### PR TITLE
[5.6] Add `explode` static constructor on Support\Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -49,6 +49,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Create a new collection instance with the result of an explode operation.
+     *
+     * @param  string  $delimiter
+     * @param  string  $string
+     * @param  int  $limit
+     * @return static
+     */
+    public static function explode($delimiter, $string, $limit = PHP_INT_MAX)
+    {
+        return new static(explode(...func_get_args()));
+    }
+
+    /**
      * Create a new collection instance if the value isn't one already.
      *
      * @param  mixed  $items

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1100,6 +1100,12 @@ class SupportCollectionTest extends TestCase
         $this->assertSame([['age' => 18], ['age' => 56]], $c->adults->age->values()->all());
     }
 
+    public function testExplodeMethod()
+    {
+        $collection = Collection::explode(',', 'foo,bar');
+        $this->assertEquals(['foo', 'bar'], $collection->all());
+    }
+
     public function testMakeMethod()
     {
         $collection = Collection::make('foo');


### PR DESCRIPTION
What?

```php
Collection::explode(',', $tags)->chainy()->mcChainFace();
```

---

I've found myself in a few places wanting this - making a collection from the result of an `explode`. Previously you'd have to do something like...

```php
$tags = explode(',', $request->tags);

Collection::make($tags)->map(function ($tag) {
    return trim($tag);
});

// or inline

Collection::make(explode(',', $request->tags))->map(function ($tag) {
    return trim($tag);
});

// now

Collection::explode(',', $request->tags)->map(function ($tag) {
    return trim($tag);
});

```

The explode method is a way to create arrays. *Collections are #life* - but are also smart arrays - so it makes sense that our smart arrays can be made via an explode method directly on the class.

I can see real world use cases for this through my project codebases - but the Framework itself also could utilise this - [here is this idea of creating a collection from an `explode` in the codebase](https://github.com/laravel/framework/blob/bd352a0d2ca93775fce8ef02365b03fc4fb8cbb0/src/Illuminate/Database/Grammar.php#L62). Might not be the best example - was just the first I came across.

I'm not sure what people's thoughts are on this also being available on the `Eloquent\Collection` and if that is an issue as it's inherently string dependent and not related to models at all 🤔