### PR TITLE
[5.5] Revert PR #22222 breaking change

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1155,9 +1155,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function getTable()
     {
         if (! isset($this->table)) {
-            $this->setTable(str_replace(
+            return str_replace(
                 '\\', '', Str::snake(Str::plural(class_basename($this)))
-            ));
+            );
         }
 
         return $this->table;


### PR DESCRIPTION
This causes troubles while comparing models in tests, `assertEquals($model, $another)` where one model is recently created while the other is loaded from a relationship, the one recently created will have the `getTable` called and `setTable` will set the table, while the one retrieved will have `$table = null` causing the comparison to fail.

Original PR: https://github.com/laravel/framework/pull/22222/files

Check https://github.com/laravel/framework/issues/22409 for reference