### PR TITLE
[5.5] Allow chaining of the $request->merge() method

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -287,22 +287,26 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * Merge new input into the current request's input array.
      *
      * @param  array  $input
-     * @return void
+     * @return \Illuminate\Http\Request
      */
     public function merge(array $input)
     {
         $this->getInputSource()->add($input);
+        
+        return $this;
     }
 
     /**
      * Replace the input for the current request.
      *
      * @param  array  $input
-     * @return void
+     * @return \Illuminate\Http\Request
      */
     public function replace(array $input)
     {
         $this->getInputSource()->replace($input);
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
I found that it would be nice to be able to chain methods on the request. eg. `$request->merge([])->only()`, but it is not possible to do this currently and I cannot see a reason why this should not be allowed?