### PR TITLE
[5.5] Assume join default arguments when only the table is provided.

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -333,14 +333,14 @@ class Builder
      * Add a join clause to the query.
      *
      * @param  string  $table
-     * @param  string  $first
+     * @param  string|null  $first
      * @param  string|null  $operator
      * @param  string|null  $second
      * @param  string  $type
      * @param  bool    $where
      * @return $this
      */
-    public function join($table, $first, $operator = null, $second = null, $type = 'inner', $where = false)
+    public function join($table, $first = null, $operator = null, $second = null, $type = 'inner', $where = false)
     {
         $join = new JoinClause($this, $type, $table);
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1174,6 +1174,21 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['1', true], $builder->getBindings());
     }
 
+    public function testJoinOnlyProvidesTable()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('posts')->join('users');
+        $this->assertEquals('select * from "posts" inner join "users" on "users"."id" = "posts"."user_id"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->from('posts')->join('users')->join('attachments');
+        $this->assertEquals('select * from "posts" inner join "users" on "users"."id" = "posts"."user_id" inner join "attachments" on "attachments"."id" = "posts"."attachment_id"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->from('posts')->join('no_s_at_end');
+        $this->assertEquals('select * from "posts" inner join "no_s_at_end" on "no_s_at_end"."id" = "posts"."no_s_at_end_id"', $builder->toSql());
+    }
+
     public function testRawExpressionsInSelect()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Proposal: https://github.com/laravel/internals/issues/931

Iff your builder use-case is the 99% case where the name of the primary key and the remote column key can be inferred with simple rules:
- the primary key of the joined table is `id`
- the foreign column is the singular (only the `s` is stripped) of the joined table and `_id` appended

then you can use this new shorter way to describe inner joins:
```php
$users = DB::table('users')
    ->join('contacts')
    ->join('orders')
    ->select('users.*', 'contacts.phone', 'orders.price')
    ->toSql();
```
and you get back this:
```sql
SELECT
  "users".*
  , "contacts"."phone"
  , "orders"."price"
FROM "users"
  INNER JOIN "contacts" ON "contacts"."id" = "users"."contact_id"
  INNER JOIN "orders" ON "orders"."id" = "users"."order_id";
```

If your case does not meet these rules, then you've to fill in the information as usual.

### Implementation
Possible approaches were discussed in https://github.com/laravel/internals/issues/931 , a TL;DR:
- 100% coverage would only be possible by having "knowledge" of the models and their relations, which isn't possible from the query builder (knows nothing about models)
- it was brought up to use `\Illuminate\Support\Pluralizer::singular` but [it has been pointed out](https://github.com/laravel/internals/issues/931#issuecomment-352526409) this may break over time when the list of words gets adjusted.
- so the most common case would to just strip of the `s`, which this PR implements

I may quote https://github.com/laravel/internals/issues/931#issuecomment-352736057 : 
> zero intelligence, zero risk.