### PR TITLE
[5.5] Add Hash::fake() for even faster tests and future proofing for Argon

### DIFF
--- a/src/Illuminate/Support/Facades/Hash.php
+++ b/src/Illuminate/Support/Facades/Hash.php
@@ -2,11 +2,23 @@
 
 namespace Illuminate\Support\Facades;
 
+use Illuminate\Support\Testing\Fakes\HashFake;
+
 /**
  * @see \Illuminate\Hashing\BcryptHasher
  */
 class Hash extends Facade
 {
+    /**
+     * Replace the bound instance with a fake.
+     *
+     * @return void
+     */
+    public static function fake()
+    {
+        static::swap(new HashFake);
+    }
+
     /**
      * Get the registered name of the component.
      *

--- a/src/Illuminate/Support/Testing/Fakes/HashFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/HashFake.php
@@ -26,7 +26,7 @@ class HashFake implements Hasher
      */
     public function make($value, array $options = [])
     {
-        return crc32($value);
+        return md5($value);
     }
 
     /**
@@ -39,7 +39,7 @@ class HashFake implements Hasher
      */
     public function check($value, $hashedValue, array $options = [])
     {
-        return crc32($value) == $hashedValue;
+        return md5($value) === $hashedValue;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/HashFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/HashFake.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Support\Testing\Fakes;
+
+use PHPUnit\Framework\Assert as PHPUnit;
+use Illuminate\Contracts\Hashing\Hasher;
+
+class HashFake implements Hasher
+{
+    /**
+     * The value to be hashed.
+     *
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * Assert if a hash was pushed based on a truth-test callback.
+     *
+     * @param  string  $value
+     * @return void
+     */
+    public function assertValueWasHashed($value)
+    {
+        PHPUnit::assertEquals($this->value, $value, "The expected [{$value}] value was not hashed.");
+    }
+
+    /**
+     * Get information about the given hashed value.
+     *
+     * @param  string  $hashedValue
+     * @return array
+     */
+    public function info($hashedValue)
+    {
+        return password_get_info($hashedValue);
+    }
+
+    /**
+     * Hash the given value.
+     *
+     * @param  string  $value
+     * @param  array   $options
+     * @return string
+     */
+    public function make($value, array $options = [])
+    {
+        $this->value = $value;
+
+        return $value;
+    }
+
+    /**
+     * Check the given plain value against a hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array   $options
+     * @return bool
+     */
+    public function check($value, $hashedValue, array $options = [])
+    {
+        return $value === $hashedValue;
+    }
+
+    /**
+     * Check if the given hash has been hashed using the given options.
+     *
+     * @param  string  $hashedValue
+     * @param  array   $options
+     * @return bool
+     */
+    public function needsRehash($hashedValue, array $options = [])
+    {
+        return false;
+    }
+}

--- a/src/Illuminate/Support/Testing/Fakes/HashFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/HashFake.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
-use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Hashing\Hasher;
+use PHPUnit\Framework\Assert as PHPUnit;
 
 class HashFake implements Hasher
 {

--- a/src/Illuminate/Support/Testing/Fakes/HashFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/HashFake.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
-use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Hashing\Hasher;
 
 class HashFake implements Hasher

--- a/src/Illuminate/Support/Testing/Fakes/HashFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/HashFake.php
@@ -2,29 +2,11 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
-use Illuminate\Contracts\Hashing\Hasher;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Illuminate\Contracts\Hashing\Hasher;
 
 class HashFake implements Hasher
 {
-    /**
-     * The value to be hashed.
-     *
-     * @var string
-     */
-    protected $value;
-
-    /**
-     * Assert if a hash was pushed based on a truth-test callback.
-     *
-     * @param  string  $value
-     * @return void
-     */
-    public function assertValueWasHashed($value)
-    {
-        PHPUnit::assertEquals($this->value, $value, "The expected [{$value}] value was not hashed.");
-    }
-
     /**
      * Get information about the given hashed value.
      *
@@ -45,9 +27,7 @@ class HashFake implements Hasher
      */
     public function make($value, array $options = [])
     {
-        $this->value = $value;
-
-        return $value;
+        return crc32($value);
     }
 
     /**
@@ -60,7 +40,7 @@ class HashFake implements Hasher
      */
     public function check($value, $hashedValue, array $options = [])
     {
-        return $value === $hashedValue;
+        return crc32($value) == $hashedValue;
     }
 
     /**

--- a/tests/Hashing/FakeHasherTest.php
+++ b/tests/Hashing/FakeHasherTest.php
@@ -11,18 +11,9 @@ class FakeHasherTest extends TestCase
     {
         Hash::fake();
 
-        $this->assertEquals('test', Hash::make('test'));
+        $this->assertEquals(crc32('test'), Hash::make('test'));
         $this->assertTrue(Hash::check('test', Hash::make('test')));
         $this->assertFalse(Hash::check('wrong', Hash::make('test')));
         $this->assertTrue(is_array(Hash::info('example')));
-    }
-
-    public function testHashAssertions()
-    {
-        Hash::fake();
-
-        Hash::make('value');
-
-        Hash::assertValueWasHashed('value');
     }
 }

--- a/tests/Hashing/FakeHasherTest.php
+++ b/tests/Hashing/FakeHasherTest.php
@@ -11,7 +11,7 @@ class FakeHasherTest extends TestCase
     {
         Hash::fake();
 
-        $this->assertEquals(crc32('test'), Hash::make('test'));
+        $this->assertEquals(md5('test'), Hash::make('test'));
         $this->assertTrue(Hash::check('test', Hash::make('test')));
         $this->assertFalse(Hash::check('wrong', Hash::make('test')));
         $this->assertTrue(is_array(Hash::info('example')));

--- a/tests/Hashing/FakeHasherTest.php
+++ b/tests/Hashing/FakeHasherTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Hashing;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Facades\Hash;
+
+class FakeHasherTest extends TestCase
+{
+    public function testHashCanBeFaked()
+    {
+        Hash::fake();
+
+        $this->assertEquals('test', Hash::make('test'));
+        $this->assertTrue(Hash::check('test', Hash::make('test')));
+        $this->assertFalse(Hash::check('wrong', Hash::make('test')));
+        $this->assertTrue(is_array(Hash::info('example')));
+    }
+
+    public function testHashAssertions()
+    {
+        Hash::fake();
+
+        Hash::make('value');
+
+        Hash::assertValueWasHashed('value');
+    }
+}


### PR DESCRIPTION
I was suprised at the level of performance gains discussed on Twitter with the recent PR to Laravel that `Hash::setRounds(4)` gave: https://twitter.com/taylorotwell/status/943135617466105856

I was already toying around with the idea of a `Hash::fake()` option - and a few people also mentioned it on Twitter and Github (@adamwathan @sebastiandedeyne @m1guelpf) - so I decided to play around with it some more.

I got about another 5% improvement in my test suite by using a faked hasher. Performance results are likely to very amgonst different test suites, so that alone is probably not worth it.

But I realised it does future proof us for Laravel 5.6 / PHP 7.2 when Argon hashing comes in. This way you can switch to Argon without slowing your tests, because you cant use `setRounds()` there.

To use you would just do `Hash::fake()` in your `CreatesApplicaiton` trait (instead of doing `Hash::setRounds(4)`).

~~While I was at it I also added a hash assertion which might be useful in tests~~ (removed - see below).

I've sent to 5.5 as it is non-breaking. I've also tested against master/5.6 to confirm it works as expected.

Tests included.