### PR TITLE
[5.6] Allow nullable method injection

### DIFF
--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -43,10 +43,10 @@ trait RouteDependencyResolverTrait
 
         foreach ($reflector->getParameters() as $key => $parameter) {
             $instance = $this->transformDependency(
-                $parameter, $parameters
+                $parameter, $parameters, $transformed
             );
 
-            if (! is_null($instance)) {
+            if ($transformed) {
                 $instanceCount++;
 
                 $this->spliceIntoParameters($parameters, $key, $instance);
@@ -64,9 +64,10 @@ trait RouteDependencyResolverTrait
      *
      * @param  \ReflectionParameter  $parameter
      * @param  array  $parameters
+     * @param  bool  $transformed
      * @return mixed
      */
-    protected function transformDependency(ReflectionParameter $parameter, $parameters)
+    protected function transformDependency(ReflectionParameter $parameter, $parameters, &$transformed)
     {
         $class = $parameter->getClass();
 
@@ -74,6 +75,8 @@ trait RouteDependencyResolverTrait
         // the list of parameters. If it is we will just skip it as it is probably a model
         // binding and we do not want to mess with those; otherwise, we resolve it here.
         if ($class && ! $this->alreadyInParameters($class->name, $parameters)) {
+            $transformed = true;
+
             return $parameter->isDefaultValueAvailable()
                 ? $parameter->getDefaultValue()
                 : $this->container->make($class->name);


### PR DESCRIPTION
I wrote the following controller action that can accept multiple routes. Some of injected arguments are nullable.

```php
Route::get('articles/{article}/comments', 'CommentController@index');
Route::get('events/{event}/comments', 'CommentController@index');
```

```php
class CommentController
{
    public function index(Request $request, Article $article = null, Event $event = null)
    {
        $commentable = $article ?: $event;
        return $commentable->comments();
    }
}
```

However, Laravel currently cannot handle null value injection. This PR makes it possible.

----

Related: [【Laravel】Route Model Binding と Policy だけで認可処理を完結させるための Resourceful ルーティングの工夫 - Qiita](https://qiita.com/mpyw/items/13b04f80f6355b30215a#%E3%82%B3%E3%83%B3%E3%83%88%E3%83%AD%E3%83%BC%E3%83%A9)