### PR TITLE
[5.6] Allow to fetch specific key when using json helper

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -500,9 +500,10 @@ class TestResponse
     /**
      * Validate and return the decoded response JSON.
      *
+     * @param  string|null  $key
      * @return array
      */
-    public function decodeResponseJson()
+    public function decodeResponseJson($key = null)
     {
         $decodedResponse = json_decode($this->getContent(), true);
 
@@ -514,17 +515,18 @@ class TestResponse
             }
         }
 
-        return $decodedResponse;
+        return data_get($decodedResponse, $key);
     }
 
     /**
      * Validate and return the decoded response JSON.
      *
+     * @param  string|null  $key
      * @return array
      */
-    public function json()
+    public function json($key = null)
     {
-        return $this->decodeResponseJson();
+        return $this->decodeResponseJson($key);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -501,7 +501,7 @@ class TestResponse
      * Validate and return the decoded response JSON.
      *
      * @param  string|null  $key
-     * @return array
+     * @return mixed
      */
     public function decodeResponseJson($key = null)
     {
@@ -522,7 +522,7 @@ class TestResponse
      * Validate and return the decoded response JSON.
      *
      * @param  string|null  $key
-     * @return array
+     * @return mixed
      */
     public function json($key = null)
     {

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -158,6 +158,17 @@ class FoundationTestResponseTest extends TestCase
 
         $files->deleteDirectory($tempDir);
     }
+
+    public function testJsonHelper()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $this->assertEquals('foo', $response->json('foobar.foobar_foo'));
+        $this->assertEquals(
+            json_decode($response->getContent(), true),
+            $response->json()
+        );
+    }
 }
 
 class JsonSerializableMixedResourcesStub implements JsonSerializable


### PR DESCRIPTION
This PR allows to fetch a specific key off of the `TestResponse` class.

Example:

```php
$title = $this->post('/posts', $data)
    ->json('data.title');
```

vs 

```php
$title = $this->post('/posts', $data)
    ->json()['data']['title'];
```

🌵 
