### PR TITLE
[5.6] Carbon Helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -384,7 +384,7 @@ if (! function_exists('carbon')) {
      */
     function carbon($time = null, $tz = null)
     {
-        return new Carbon($time = null, $tz = null);
+        return new Carbon($time, $tz);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Debug\Dumper;
@@ -370,6 +371,20 @@ if (! function_exists('camel_case')) {
     function camel_case($value)
     {
         return Str::camel($value);
+    }
+}
+
+if (! function_exists('carbon')) {
+    /**
+     * Create a new Carbon instance.
+     *
+     * @param  string|null                $time
+     * @param  \DateTimeZone|string|null  $tz
+     * @return \Illuminate\Support\Carbon
+     */
+    function carbon($time = null, $tz = null)
+    {
+        return new Carbon($time = null, $tz = null);
     }
 }
 


### PR DESCRIPTION
Add a `carbon()` helper to create an `Illuminate\Support\Carbon` instance. It accepts the same method parameters as Carbon's constructor.

```
>>> carbon()->now()
=> Illuminate\Support\Carbon @1513807944 {#1536
     date: 2017-12-21 09:12:24.0 Australia/Sydney (+11:00),
   }
```