### PR TITLE
[5.5] Check for --no-interaction flag on command calls

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -194,10 +194,10 @@ class Command extends SymfonyCommand
     {
         $arguments['command'] = $command;
         $input = new ArrayInput($arguments);
-        if($input->hasParameterOption(array('--no-interaction'), true)) {
+        if ($input->hasParameterOption(['--no-interaction'], true)) {
             $input->setInteractive(false);
         }
-        
+
         return $this->getApplication()->find($command)->run(
             $input, $this->output
         );
@@ -214,10 +214,10 @@ class Command extends SymfonyCommand
     {
         $arguments['command'] = $command;
         $input = new ArrayInput($arguments);
-        if($input->hasParameterOption(array('--no-interaction'), true)) {
+        if ($input->hasParameterOption(['--no-interaction'], true)) {
             $input->setInteractive(false);
         }
-        
+
         return $this->getApplication()->find($command)->run(
             $input, new NullOutput
         );

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -193,10 +193,11 @@ class Command extends SymfonyCommand
     public function call($command, array $arguments = [])
     {
         $arguments['command'] = $command;
-		$input = new ArrayInput($arguments);
-		if($input->hasParameterOption(array('--no-interaction'), true)) {
-			$input->setInteractive(false);
+        $input = new ArrayInput($arguments);
+        if($input->hasParameterOption(array('--no-interaction'), true)) {
+            $input->setInteractive(false);
         }
+        
         return $this->getApplication()->find($command)->run(
             $input, $this->output
         );
@@ -212,10 +213,11 @@ class Command extends SymfonyCommand
     public function callSilent($command, array $arguments = [])
     {
         $arguments['command'] = $command;
-		$input = new ArrayInput($arguments);
-		if($input->hasParameterOption(array('--no-interaction'), true)) {
-			$input->setInteractive(false);
+        $input = new ArrayInput($arguments);
+        if($input->hasParameterOption(array('--no-interaction'), true)) {
+            $input->setInteractive(false);
         }
+        
         return $this->getApplication()->find($command)->run(
             $input, new NullOutput
         );

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -193,9 +193,12 @@ class Command extends SymfonyCommand
     public function call($command, array $arguments = [])
     {
         $arguments['command'] = $command;
-
+		$input = new ArrayInput($arguments);
+		if($input->hasParameterOption(array('--no-interaction'), true)) {
+			$input->setInteractive(false);
+        }
         return $this->getApplication()->find($command)->run(
-            new ArrayInput($arguments), $this->output
+            $input, $this->output
         );
     }
 
@@ -209,9 +212,12 @@ class Command extends SymfonyCommand
     public function callSilent($command, array $arguments = [])
     {
         $arguments['command'] = $command;
-
+		$input = new ArrayInput($arguments);
+		if($input->hasParameterOption(array('--no-interaction'), true)) {
+			$input->setInteractive(false);
+        }
         return $this->getApplication()->find($command)->run(
-            new ArrayInput($arguments), new NullOutput
+            $input, new NullOutput
         );
     }
 


### PR DESCRIPTION
Currently, calling an artisan command from another artisan command as described in the docs (`$this->call(...)`) does not allow the `--no-interaction` flag to be set on the command (or rather, you can set it, but it won't have any effect unless the called command specifically checks for it).
The current workaround is to use the `Artisan` facade. 

This was raised in the Adldap2-Laravel repo: 
https://github.com/Adldap2/Adldap2-Laravel/issues/441#issuecomment-353542978

This PR solves the issue by explicitly checking for the `--no-interaction` flag (but not the shorthand `-n` flag) to set the interactive mode of the new input in the same manner symfony/application sets it in `Application::configureIO`: 
https://github.com/symfony/symfony/blob/07766b39052b6ba294dc6ddf85e38ee61a8e0bcb/src/Symfony/Component/Console/Application.php#L791-L792

An alternative would be to check if the current command is being run in non-interactive mode, but I think that would have a higher chance of breaking existing code. This way, the only way to break existing code is if someone is using the `--no-interaction` argument in a command call and somehow still expecting interaction.  
Avoiding BC breaks is also the reason I've omitted the `-n` short syntax, as it is plausible that people may have developed commands that are being called exclusively by other commands and have their own meaning for `-n` without knowing it's intended purpose.