### PR TITLE
[5.6] Add whereLike and whereNotLike query builder methods

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -958,6 +958,56 @@ class Builder
     }
 
     /**
+     * Add a "where like" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed   $value
+     * @param  string  $boolean
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function whereLike($column, $value, $boolean = 'and')
+    {
+        return $this->where($column, 'like', '%'.addcslashes($value, '%').'%', $boolean);
+    }
+
+    /**
+     * Add a "where not like" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed   $value
+     * @param  string  $boolean
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function whereNotLike($column, $value, $boolean = 'and')
+    {
+        return $this->where($column, 'not like', '%'.addcslashes($value, '%').'%', $boolean);
+    }
+
+    /**
+     * Add an "or where like" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed   $value
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function orWhereLike($column, $value)
+    {
+        return $this->whereLike($column, $value, 'or');
+    }
+
+    /**
+     * Add an "or where not like" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed   $value
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function orWhereNotLike($column, $value)
+    {
+        return $this->whereNotLike($column, $value, 'or');
+    }
+
+    /**
      * Add a "where date" statement to the query.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -542,6 +542,54 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([], $builder->getBindings());
     }
 
+    public function testWhereLike()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereLike('email', '@');
+        $this->assertEquals('select * from [users] where [email] like ?', $builder->toSql());
+        $this->assertEquals([0 => '%@%'], $builder->getBindings());
+    }
+
+    public function testWhereNotLike()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereNotLike('email', '@');
+        $this->assertEquals('select * from [users] where [email] not like ?', $builder->toSql());
+        $this->assertEquals([0 => '%@%'], $builder->getBindings());
+    }
+
+    public function testWhereLikeWithPercent()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereLike('email', '%');
+        $this->assertEquals('select * from [users] where [email] like ?', $builder->toSql());
+        $this->assertEquals([0 => '%\%%'], $builder->getBindings());
+    }
+
+    public function testWhereNotLikeWithPercent()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereNotLike('email', '%');
+        $this->assertEquals('select * from [users] where [email] not like ?', $builder->toSql());
+        $this->assertEquals([0 => '%\%%'], $builder->getBindings());
+    }
+
+    public function testOrWhereLike()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->where('id', 1)->orWhereLike('email', '@');
+        $this->assertEquals('select * from [users] where [id] = ? or [email] like ?', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => '%@%'], $builder->getBindings());
+    }
+
+    public function testOrWhereNotLike()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->where('id', 1)->orWhereNotLike('email', '@');
+        $this->assertEquals('select * from [users] where [id] = ? or [email] not like ?', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => '%@%'], $builder->getBindings());
+    }
+
     public function testArrayWhereColumn()
     {
         $conditions = [


### PR DESCRIPTION
This adds 4 new QueryBuilder methods:

    public function whereLike($column, $value, $boolean = 'and')
    public function whereNotLike($column, $value, $boolean = 'and')
    public function orWhereLike($column, $value)
    public function orWhereNotLike($column, $value)

and relative tests.