### PR TITLE
[5.6] Fix prepareResponse()'s return type

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -277,7 +277,7 @@ class Handler implements ExceptionHandlerContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception $e
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response
      */
     protected function prepareResponse($request, Exception $e)
     {


### PR DESCRIPTION
As it is converted to `\Illuminate\Http\Response`
props. phpstan