### PR TITLE
[5.5] Fix Validator not handling properly inline messages for size rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -20,9 +20,7 @@ trait FormatsMessages
      */
     protected function getMessage($attribute, $rule)
     {
-        $inlineMessage = $this->getFromLocalArray(
-            $attribute, $lowerRule = Str::snake($rule)
-        );
+        $inlineMessage = $this->getInlineMessage($attribute, $rule);
 
         // First we will retrieve the custom message for the validation rule if one
         // exists. If a custom validation message is being used we'll return the
@@ -30,6 +28,8 @@ trait FormatsMessages
         if (! is_null($inlineMessage)) {
             return $inlineMessage;
         }
+
+        $lowerRule = Str::snake($rule);
 
         $customMessage = $this->getCustomMessageFromTranslator(
             $customKey = "validation.custom.{$attribute}.{$lowerRule}"
@@ -151,6 +151,28 @@ trait FormatsMessages
         $key = "validation.{$lowerRule}.{$type}";
 
         return $this->translator->trans($key);
+    }
+
+    /**
+     * Get the proper inline error message for standard and size rules.
+     *
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @return string|null
+     */
+    protected function getInlineMessage($attribute, $rule)
+    {
+        $inlineEntry = $this->getFromLocalArray($attribute, Str::snake($rule));
+
+        // If the entry is an array and the rule is a size rule, it is necessary
+        // to extract the message corresponding to the type of the attribute
+        if (is_array($inlineEntry) && in_array($rule, $this->sizeRules)) {
+            $type = $this->getAttributeType($attribute);
+
+            return $inlineEntry[$type];
+        }
+
+        return $inlineEntry;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -562,6 +562,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('require it please!', $v->messages()->first('name'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['name' => 'foobarba'], ['name' => 'size:9'], ['size' => ['string' => ':attribute should be of length :size']]);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('name should be of length 9', $v->messages()->first('name'));
     }
 
     public function testInlineValidationMessagesAreRespectedWithAsterisks()


### PR DESCRIPTION
This PR attempts to fix the following issue https://github.com/laravel/framework/issues/20754

When passing a custom message object to a Validator, size rules (`size`, `between`, `min`, `max`) are not handled correctly:
```php
 [
    // ...
    'size' => [
        'numeric' => 'Hey the :attribute must be :size.',
        'file'    => 'Hey the :attribute must be :size kilobytes.',
        'string'  => 'Hey the :attribute must be :size characters.',
        'array'   => 'Hey the :attribute must contain :size items.',
    ],
    // ...
];
```

Take the following example route:
```php
<?php

use Illuminate\Http\Request;

Route::get('/', function (Request $request) {
    $rules = [
        'foo' => 'required|numeric|size:3',
        'bar' => 'required',
    ];

    $messages = [
        'size' => [
            'numeric' => 'Hey the :attribute must be :size.',
            'file'    => 'Hey the :attribute must be :size kilobytes.',
            'string'  => 'Hey the :attribute must be :size characters.',
            'array'   => 'Hey the :attribute must contain :size items.',
        ],
        'required' => 'Hey, you forgot to fill :attribute :(',
    ];

    $validator = Validator::make($request->all(), $rules, $messages);

    if ($validator->fails()) {
        dd($validator->errors()->all());
    }

    echo 'ok';
});
```

Loading `domain.tld/?foo=3` properly displays:
```
array:1 [▼
  0 => "Hey, you forgot to fill bar :("
]
```

But loading `domain.tld/?bar=random-string` throws an `Array to string error` exception.

This is because, when specifying inline messages, the method `getFromLocalArray()` doesn't perform any check on what is returned, and in the case of the `size` rule, it returns an array.

What I suggest we do, is check what is returned by `getFromLocalArray()`, and if an array is returned, attempt to extract the correct message depending on the type of the attribute.

Please feel free to tell me if this is intended behavior, or if you have any remark about this PR