### PR TITLE
[5.5] Add mail markdown parse as line

### DIFF
--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -95,7 +95,7 @@ class Markdown
     public static function parse($text, $line = false)
     {
         $parsedown = new Parsedown;
-        
+
         $html = $line ? $parsedown->line($text) : $parsedown->text($text);
 
         return new HtmlString($html);

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -89,13 +89,16 @@ class Markdown
      * Parse the given Markdown text into HTML.
      *
      * @param  string  $text
+     * @param  bool  $line
      * @return \Illuminate\Support\HtmlString
      */
-    public static function parse($text)
+    public static function parse($text, $line = false)
     {
         $parsedown = new Parsedown;
+        
+        $html = $line ? $parsedown->line($text) : $parsedown->text($text);
 
-        return new HtmlString($parsedown->text($text));
+        return new HtmlString($html);
     }
 
     /**

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -65,4 +65,14 @@ class MailMarkdownTest extends TestCase
 
         $this->assertEquals('<h1>Something</h1>', $result);
     }
+
+    public function testParseReturnsParsedMarkdownLine()
+    {
+        $viewFactory = \Mockery::mock('Illuminate\View\Factory');
+        $markdown = new \Illuminate\Mail\Markdown($viewFactory);
+
+        $result = $markdown->parse('Something', $line = true);
+
+        $this->assertEquals('Something', $result);
+    }
 }


### PR DESCRIPTION
Currently if you want to parse something like image in markdown mail it will wrap image to p tag. I added flag to parse method that will give possibility to parse markdown as it is without wrapping it to p tag.

```
Illuminate\Mail\Markdown::parse('Hello _Parsedown_!')

# Output:
# <p>Hello <em>Parsedown</em>!</p>
```

```
Illuminate\Mail\Markdown::parse('Hello _Parsedown_!', $line = true)

# Output:
# Hello <em>Parsedown</em>!
```
[Parsedown docs](https://github.com/erusev/parsedown/wiki/Tutorial:-Get-Started)

Not sure about implementation maybe better to make separate method for it or another way...