### PR TITLE
[5.5] add assertDispatchedTimes for event fakes

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -47,14 +47,33 @@ class EventFake implements Dispatcher
      * Assert if an event was dispatched based on a truth-test callback.
      *
      * @param  string  $event
-     * @param  callable|null  $callback
+     * @param  callable|int|null  $callback
      * @return void
      */
     public function assertDispatched($event, $callback = null)
     {
+        if (is_int($callback)) {
+            return $this->assertDispatchedTimes($event, $callback);
+        }
+
         PHPUnit::assertTrue(
             $this->dispatched($event, $callback)->count() > 0,
             "The expected [{$event}] event was not dispatched."
+        );
+    }
+
+    /**
+     * Assert if a event was dispatched a number of times.
+     *
+     * @param  string  $event
+     * @param  int  $times
+     * @return void
+     */
+    public function assertDispatchedTimes($event, $times = 1)
+    {
+        PHPUnit::assertTrue(
+            ($count = $this->dispatched($event)->count()) === $times,
+            "The expected [{$event}] event was dispatched {$count} times instead of {$times} times."
         );
     }
 

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Testing\Fakes\EventFake;
+
+class SupportTestingEventFakeTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->fake = new EventFake(m::mock(Dispatcher::class));
+    }
+
+    public function testAssertDispacthed()
+    {
+        $this->fake->dispatch(EventStub::class);
+
+        $this->fake->assertDispatched(EventStub::class);
+    }
+
+    /**
+     * @expectedException PHPUnit\Framework\ExpectationFailedException
+     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\EventStub] event was dispatched 2 times instead of 1 times.
+     */
+    public function testAssertDispatchedWithCallbackInt()
+    {
+        $this->fake->dispatch(EventStub::class);
+        $this->fake->dispatch(EventStub::class);
+
+        $this->fake->assertDispatched(EventStub::class, 2);
+        $this->fake->assertDispatched(EventStub::class, 1);
+    }
+
+    /**
+     * @expectedException PHPUnit\Framework\ExpectationFailedException
+     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\EventStub] event was dispatched 2 times instead of 1 times.
+     */
+    public function testAssertDispatchedTimes()
+    {
+        $this->fake->dispatch(EventStub::class);
+        $this->fake->dispatch(EventStub::class);
+
+        $this->fake->assertDispatchedTimes(EventStub::class, 2);
+        $this->fake->assertDispatchedTimes(EventStub::class, 1);
+    }
+
+    /**
+     * @expectedException PHPUnit\Framework\ExpectationFailedException
+     * @expectedExceptionMessage The unexpected [Illuminate\Tests\Support\EventStub] event was dispatched.
+     */
+    public function testAssertNotDispatched()
+    {
+        $this->fake->dispatch(EventStub::class);
+
+        $this->fake->assertNotDispatched(EventStub::class);
+    }
+}
+
+class EventStub
+{
+}


### PR DESCRIPTION
Hey,

I find it useful to test how many times the event was dispatched. I exposed the method `assertDispatchedTimes()`, however you can pass ant _int_ to `assertDispatched()` instead of a callback, so you can use `Event::assertDispatched(SomeEvent::class, 3)`.