### PR TITLE
[5.5] Add `notifyNow` shortcut to `AnonymousNotifiable`

### DIFF
--- a/src/Illuminate/Notifications/AnonymousNotifiable.php
+++ b/src/Illuminate/Notifications/AnonymousNotifiable.php
@@ -39,6 +39,17 @@ class AnonymousNotifiable
     }
 
     /**
+     * Send the given notification immediately.
+     *
+     * @param  mixed  $notification
+     * @return void
+     */
+    public function notifyNow($notification)
+    {
+        app(Dispatcher::class)->sendNow($this, $notification);
+    }
+
+    /**
      * Get the notification routing information for the given driver.
      *
      * @param  string  $driver


### PR DESCRIPTION
This allows you to do:

```php
Notification::route('mail', 'me@alexbouma.me')
    ->notifyNow(new UserNotification($message));
```

Very useful for making sure a notification gets sent immediately (for testing notifications).

Not sure where and if to add tests... any directions for this are appreciated!

(FWIW: I did test it in a application ofcourse 😄)