### PR TITLE
Update Preset Command Signature To Include Options Added Via Macro

### DIFF
--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -22,6 +22,17 @@ class PresetCommand extends Command
     protected $description = 'Swap the front-end scaffolding for the application';
 
     /**
+     * Create a new console command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->signature = 'preset { type : The preset type (' . implode(", ", $this->getPresets()) . ') }';
+        parent::__construct();
+    }
+
+    /**
      * Execute the console command.
      *
      * @return void
@@ -37,6 +48,15 @@ class PresetCommand extends Command
         }
 
         return $this->{$this->argument('type')}();
+    }
+
+    /**
+     * Get Available Presets
+     * @return array
+     */
+    protected function getPresets()
+    {
+        return array_merge(['none', 'bootstrap', 'vue', 'react'], array_keys(static::$macros));
     }
 
     /**


### PR DESCRIPTION
This allows you to see which Presets have been loaded via Macro as well as the defaults when you run
php artisan help preset. This is useful as many times you don't remember what options are available.

**Before:**
Usage:
  preset < type >

Arguments:
  type                  The preset type (none, bootstrap, vue, react)


**Now:**
Usage:
  preset < type >

Arguments:
  type                  The preset type (none, bootstrap, vue, react, bootstrap4, bootstrap4-auth)


**Using laravel-preset-bootstrap4 as an example