### PR TITLE
[5.6] Change typehint

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -411,7 +411,7 @@ class Handler implements ExceptionHandlerContract
      *
      * @param  \Symfony\Component\HttpFoundation\Response  $response
      * @param  \Exception  $e
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     protected function toIlluminateResponse($response, Exception $e)
     {


### PR DESCRIPTION
~~This reverts #22517.~~ EDIT: GC - it actually doesn't revert this at all

That change was based on phpstan (static code analysis) which didn't take into account that this is a shared framework where, even if we return our own response in this particular implementation, anyone could have returned their own Response (based of Symfony's Response class). There's no functional requirement presented for removing this capability.