### PR TITLE
[5.6] Revert #22517

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -277,7 +277,7 @@ class Handler implements ExceptionHandlerContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception $e
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     protected function prepareResponse($request, Exception $e)
     {

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -411,7 +411,7 @@ class Handler implements ExceptionHandlerContract
      *
      * @param  \Symfony\Component\HttpFoundation\Response  $response
      * @param  \Exception  $e
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response
      */
     protected function toIlluminateResponse($response, Exception $e)
     {


### PR DESCRIPTION
I am ashamed. This is the correct PR that I previously wanted to do, and a revert of my own PR.

Original: https://github.com/laravel/framework/pull/22517
My failure: https://github.com/laravel/framework/pull/22532

My original reasoning about the original PR still stands.

> That change was based on phpstan (static code analysis) which didn't take into account that this is a shared framework where, even if we return our own response in this particular implementation, anyone could have returned their own Response (based of Symfony's Response class). There's no functional requirement presented for removing this capability.