### PR TITLE
[5.5] class_uses_recursive() return parent class's trait first

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -403,7 +403,7 @@ if (! function_exists('class_uses_recursive')) {
 
         $results = [];
 
-        foreach (array_merge([$class => $class], class_parents($class)) as $class) {
+        foreach (array_reverse(class_parents($class)) + [$class => $class] as $class) {
             $results += trait_uses_recursive($class);
         }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -699,20 +699,27 @@ class SupportHelpersTest extends TestCase
 
     public function testClassUsesRecursiveShouldReturnTraitsOnParentClasses()
     {
-        $this->assertEquals([
-            'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
+        $this->assertTrue([
             'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
-        ],
-        class_uses_recursive('Illuminate\Tests\Support\SupportTestClassTwo'));
+            'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
+        ] === class_uses_recursive('Illuminate\Tests\Support\SupportTestClassTwo'));
     }
 
     public function testClassUsesRecursiveAcceptsObject()
     {
-        $this->assertEquals([
-            'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
+        $this->assertTrue([
             'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
-        ],
-        class_uses_recursive(new SupportTestClassTwo));
+            'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
+        ] === class_uses_recursive(new SupportTestClassTwo));
+    }
+
+    public function testClassUsesRecursiveParentFirst()
+    {
+        $this->assertTrue([
+            'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
+            'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
+            'Illuminate\Tests\Support\SupportTestTraitThree' => 'Illuminate\Tests\Support\SupportTestTraitThree',
+        ] === class_uses_recursive(SupportTestClassThree::class));
     }
 
     public function testArrayAdd()
@@ -843,6 +850,15 @@ class SupportTestClassOne
 
 class SupportTestClassTwo extends SupportTestClassOne
 {
+}
+
+trait SupportTestTraitThree
+{
+}
+
+class SupportTestClassThree extends SupportTestClassTwo
+{
+    use SupportTestTraitThree;
 }
 
 class SupportTestArrayAccess implements ArrayAccess

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -699,27 +699,30 @@ class SupportHelpersTest extends TestCase
 
     public function testClassUsesRecursiveShouldReturnTraitsOnParentClasses()
     {
-        $this->assertTrue([
+        $this->assertSame([
             'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
             'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
-        ] === class_uses_recursive('Illuminate\Tests\Support\SupportTestClassTwo'));
+        ],
+        class_uses_recursive('Illuminate\Tests\Support\SupportTestClassTwo'));
     }
 
     public function testClassUsesRecursiveAcceptsObject()
     {
-        $this->assertTrue([
+        $this->assertSame([
             'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
             'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
-        ] === class_uses_recursive(new SupportTestClassTwo));
+        ],
+        class_uses_recursive(new SupportTestClassTwo));
     }
 
-    public function testClassUsesRecursiveParentFirst()
+    public function testClassUsesRecursiveReturnParentTraitsFirst()
     {
-        $this->assertTrue([
+        $this->assertSame([
             'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
             'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
             'Illuminate\Tests\Support\SupportTestTraitThree' => 'Illuminate\Tests\Support\SupportTestTraitThree',
-        ] === class_uses_recursive(SupportTestClassThree::class));
+        ],
+        class_uses_recursive(SupportTestClassThree::class));
     }
 
     public function testArrayAdd()


### PR DESCRIPTION
**Reason** 

when Model booting traits, subclass's trait will boot before parent's trait, It is quite different from dev's expectation.

---

**Changed**

- This PR will make `class_uses_recursive()` return traits order by `use` order.
- PHPUnit `assertEquals` does not validate the order of array elements , so i change to `assertSame`