### PR TITLE
[5.6] Support useCurrent in datetime types

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -593,7 +593,17 @@ class MySqlGrammar extends Grammar
      */
     protected function typeDateTime(Fluent $column)
     {
-        return $column->precision ? "datetime($column->precision)" : 'datetime';
+        $definition = $column->precision ? "datetime($column->precision)" : 'datetime';
+
+        if ($column->useCurrent) {
+            $definition = "$definition default CURRENT_TIMESTAMP";
+        }
+
+        if ($column->updateCurrent) {
+            $definition = "$definition on update CURRENT_TIMESTAMP";
+        }
+
+        return $definition;
     }
 
     /**
@@ -637,9 +647,17 @@ class MySqlGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        $columnType = $column->precision ? "timestamp($column->precision)" : 'timestamp';
+        $definition = $column->precision ? "timestamp($column->precision)" : 'timestamp';
 
-        return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
+        if ($column->useCurrent) {
+            $definition = "$definition default CURRENT_TIMESTAMP";
+        }
+
+        if ($column->updateCurrent) {
+            $definition = "$definition on update CURRENT_TIMESTAMP";
+        }
+
+        return $definition;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -544,7 +544,13 @@ class PostgresGrammar extends Grammar
      */
     protected function typeDateTime(Fluent $column)
     {
-        return "timestamp($column->precision) without time zone";
+        $definition = "timestamp($column->precision) without time zone";
+
+        if ($column->useCurrent) {
+            $definition = "$definition default CURRENT_TIMESTAMP";
+        }
+
+        return $definition;
     }
 
     /**
@@ -555,7 +561,13 @@ class PostgresGrammar extends Grammar
      */
     protected function typeDateTimeTz(Fluent $column)
     {
-        return "timestamp($column->precision) with time zone";
+        $definition = "timestamp($column->precision) with time zone";
+
+        if ($column->useCurrent) {
+            $definition = "$definition default CURRENT_TIMESTAMP";
+        }
+
+        return $definition;
     }
 
     /**
@@ -588,9 +600,13 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        $columnType = "timestamp($column->precision) without time zone";
+        $definition = "timestamp($column->precision) without time zone";
 
-        return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
+        if ($column->useCurrent) {
+            $definition = "$definition default CURRENT_TIMESTAMP";
+        }
+
+        return $definition;
     }
 
     /**
@@ -601,9 +617,13 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTimestampTz(Fluent $column)
     {
-        $columnType = "timestamp($column->precision) with time zone";
+        $definition = "timestamp($column->precision) with time zone";
 
-        return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
+        if ($column->useCurrent) {
+            $definition = "$definition default CURRENT_TIMESTAMP";
+        }
+
+        return $definition;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -553,7 +553,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeDateTime(Fluent $column)
     {
-        return 'datetime';
+        return $column->useCurrent ? 'datetime default CURRENT_TIMESTAMP' : 'datetime';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -503,7 +503,13 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeDateTime(Fluent $column)
     {
-        return $column->precision ? "datetime2($column->precision)" : 'datetime';
+        $definition = $column->precision ? "datetime2($column->precision)" : 'datetime';
+
+        if ($column->useCurrent) {
+            $definition = "$definition default CURRENT_TIMESTAMP";
+        }
+
+        return $definition;
     }
 
     /**
@@ -514,7 +520,13 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeDateTimeTz(Fluent $column)
     {
-        return $column->precision ? "datetimeoffset($column->precision)" : 'datetimeoffset';
+        $definition = $column->precision ? "datetimeoffset($column->precision)" : 'datetimeoffset';
+
+        if ($column->useCurrent) {
+            $definition = "$definition default CURRENT_TIMESTAMP";
+        }
+
+        return $definition;
     }
 
     /**
@@ -547,9 +559,13 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        $columnType = $column->precision ? "datetime2($column->precision)" : 'datetime';
+        $definition = $column->precision ? "datetime2($column->precision)" : 'datetime';
 
-        return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
+        if ($column->useCurrent) {
+            $definition = "$definition default CURRENT_TIMESTAMP";
+        }
+
+        return $definition;
     }
 
     /**
@@ -562,13 +578,13 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTimestampTz(Fluent $column)
     {
-        if ($column->useCurrent) {
-            $columnType = $column->precision ? "datetimeoffset($column->precision)" : 'datetimeoffset';
+        $definition = $column->precision ? "datetimeoffset($column->precision)" : 'datetimeoffset';
 
-            return "$columnType default CURRENT_TIMESTAMP";
+        if ($column->useCurrent) {
+            $definition = "$definition default CURRENT_TIMESTAMP";
         }
 
-        return "datetimeoffset($column->precision)";
+        return $definition;
     }
 
     /**

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -587,7 +587,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetimeoffset(0) not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetimeoffset not null', $statements[0]);
     }
 
     public function testAddingTimestampTzWithPrecision()
@@ -614,7 +614,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestampsTz();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetimeoffset(0) null, "updated_at" datetimeoffset(0) null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetimeoffset null, "updated_at" datetimeoffset null', $statements[0]);
     }
 
     public function testAddingRememberToken()


### PR DESCRIPTION
- Supports useCurrent in datetime types.
- Supports updateCurrent in MySQL ( timestamp ON UPDATE CURRENT_TIMESTAMP ).