### PR TITLE
[5.5] Add support for custom validation messages for custom, developer provided rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Validation\Concerns;
 
 use Closure;
-use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Contracts\Validation\Rule;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 trait FormatsMessages

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -534,7 +534,7 @@ class Validator implements ValidatorContract
             $this->failedRules[$attribute][get_class($rule)] = [];
 
             $this->messages->add($attribute, $this->makeReplacements(
-                $rule->message(), $attribute, get_class($rule), []
+                $this->getMessage($attribute, $rule), $attribute, get_class($rule), []
             ));
         }
     }


### PR DESCRIPTION
At the moment, I don't think it is possible to add validation error messages when using custom rules. It only seems to be possible to have a single, generic error message, which is determined by `\Illuminate\Contracts\Validation\Rule::message()`.

This PR adds the possibility for developers to specify custom validation messages for custom rules, using the class name of the rule as its identifier. For example:

A custom rule:

    <?php

    namespace App\Rules;

    class CustomRule implements \Illuminate\Contracts\Validation\Rule
    {
        public function passes($attribute, $rule)
        {
            return false;
        }

        public function message()
        {
            return 'Default message goes here';
        }
    }

A form request:

    <?php

    namespace App\Http\Requests;

    use Illuminate\Foundation\Http\FormRequest;
    use App\Rules\CustomRule;

    class TestRequest extends FormRequest
    {
        public function rules()
        {
            return [
                'field_one' => [new CustomRule()]
            ];
        }

        public function messages()
        {
            return [
                'field_one.' . CustomRule::class => 'This is the new validation message'
            ];
        }
    }
