### PR TITLE
[5.5] Prettify PHPUnit results

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,8 @@
         "phpunit/phpunit": "~6.0",
         "predis/predis": "^1.1.1",
         "symfony/css-selector": "~3.3",
-        "symfony/dom-crawler": "~3.3"
+        "symfony/dom-crawler": "~3.3",
+        "srmklive/phpunit-prettify": "~0.1"
     },
     "autoload": {
         "files": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
          stopOnFailure="false"
          syntaxCheck="true"
          verbose="true"
+         printerClass="Srmklive\PHPUnitPrettify\Printer"
 >
     <testsuites>
         <testsuite name="Laravel Test Suite">


### PR DESCRIPTION
Through this [mikeerickson/phpunit-pretty-result-printer](https://github.com/mikeerickson/phpunit-pretty-result-printer) package, we can prettify the output for PHPUnit tests as shown here.

https://github.com/mikeerickson/phpunit-pretty-result-printer/blob/master/sample.png

The issue with this package is that it doesn't work properly with PHPUnit 6+. I authored the PR #22545 but it was showing errors for PHP 7 & above. 

To make it work with PHPUnit 6+, i forked the [mikeerickson/phpunit-pretty-result-printer](https://github.com/mikeerickson/phpunit-pretty-result-printer) package & published my own [package](https://github.com/srmklive/phpunit-prettify) with PHPUnit 6+ support. Following is the output when i run Laravel framework tests locally.

https://github.com/srmklive/phpunit-prettify/blob/master/sample.png