### PR TITLE
[5.5] Ignore VSCode IDE Local Workspace Folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 Thumbs.db
 /phpunit.xml
 /.idea
+/.vscode


### PR DESCRIPTION
VSCode creates a hidden folder called ".vscode" when storing workspace settings which we do not necessarily want to be added to our source control.