### PR TITLE
[5.5] Add the power of Arr::get() to Collection get()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -642,11 +642,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function get($key, $default = null)
     {
-        if ($this->offsetExists($key)) {
-            return $this->items[$key];
-        }
-
-        return value($default);
+        return Arr::get($this->items, $key, $default);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2422,6 +2422,27 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
+    
+    public function testGetNestedValue()
+    {
+        $collection = new Collection([
+            'foo' => [
+                'bar' => 'baz',
+                'books' => [
+                    'Book 1',
+                    'Book 2',
+                ],
+                'todos' => [
+                    'first' => 'Todo 1',
+                    'second' => 'Todo 2',
+                ],
+            ],
+        );
+            
+        $this->assertEquals('baz', $collection->get('foo.bar'));
+        $this->assertEquals('Book 1', $collection->get('foo.books.0'));
+        $this->assertEquals('Todo 2', $collection->get('foo.todos.second'));
+    }
 }
 
 class TestSupportCollectionHigherOrderItem

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2422,7 +2422,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
-    
+
     public function testGetNestedValue()
     {
         $collection = new Collection([
@@ -2438,7 +2438,7 @@ class SupportCollectionTest extends TestCase
                 ],
             ],
         ]);
-            
+
         $this->assertEquals('baz', $collection->get('foo.bar'));
         $this->assertEquals('Book 1', $collection->get('foo.books.0'));
         $this->assertEquals('Todo 2', $collection->get('foo.todos.second'));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2437,7 +2437,7 @@ class SupportCollectionTest extends TestCase
                     'second' => 'Todo 2',
                 ],
             ],
-        );
+        ]);
             
         $this->assertEquals('baz', $collection->get('foo.bar'));
         $this->assertEquals('Book 1', $collection->get('foo.books.0'));


### PR DESCRIPTION
By using `Arr::get()`, now It's possible to get nested value using collection get().