### PR TITLE
[5.6] Implement base Event and type hint instead of concrete class

### DIFF
--- a/src/Illuminate/Contracts/Events/Event.php
+++ b/src/Illuminate/Contracts/Events/Event.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Events;
+
+interface Event
+{
+
+}

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -47,12 +47,8 @@ class ListenerMakeCommand extends GeneratorCommand
             $event = $this->laravel->getNamespace().'Events\\'.$event;
         }
 
-        $stub = str_replace(
-            'DummyEvent', class_basename($event), parent::buildClass($name)
-        );
-
         return str_replace(
-            'DummyFullEvent', $event, $stub
+            'DummyEvent', class_basename($event), parent::buildClass($name)
         );
     }
 

--- a/src/Illuminate/Foundation/Console/stubs/event-handler-queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event-handler-queued.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use DummyFullEvent;
+use Illuminate\Contracts\Events\Event;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
@@ -23,10 +23,10 @@ class DummyClass implements ShouldQueue
     /**
      * Handle the event.
      *
-     * @param  DummyEvent  $event
+     * @param  Event  $event
      * @return void
      */
-    public function handle(DummyEvent $event)
+    public function handle(Event $event)
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/event-handler.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event-handler.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use DummyFullEvent;
+use Illuminate\Contracts\Events\Event;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
@@ -21,10 +21,10 @@ class DummyClass
     /**
      * Handle the event.
      *
-     * @param  DummyEvent  $event
+     * @param  Event  $event
      * @return void
      */
-    public function handle(DummyEvent $event)
+    public function handle(Event $event)
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/event.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event.stub
@@ -4,13 +4,14 @@ namespace DummyNamespace;
 
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Events\Event;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
-class DummyClass
+class DummyClass implements Event
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/src/Illuminate/Foundation/Console/stubs/listener-queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener-queued.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use DummyFullEvent;
+use Illuminate\Contracts\Events\Event;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
@@ -23,10 +23,10 @@ class DummyClass implements ShouldQueue
     /**
      * Handle the event.
      *
-     * @param  DummyEvent  $event
+     * @param  Event  $event
      * @return void
      */
-    public function handle(DummyEvent $event)
+    public function handle(Event $event)
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/listener.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use DummyFullEvent;
+use Illuminate\Contracts\Events\Event;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
@@ -21,10 +21,10 @@ class DummyClass
     /**
      * Handle the event.
      *
-     * @param  DummyEvent  $event
+     * @param  Event  $event
      * @return void
      */
-    public function handle(DummyEvent $event)
+    public function handle(Event $event)
     {
         //
     }


### PR DESCRIPTION
I've frequently run into the situation where I have multiple events that use the same listener. For example, maybe there's a `UserSubscribed` event and a `SyncUserMailPreferences' listener and another event named `UserUnsubscribed` event that also uses the `SyncUserMailPreferences' listener.

If I've added the events using the `event:generate` command, then the first event created will be type hinted in the listener. This poses a problem when I want to use the listener in a second event. The quickest solution is to remove the type hint in the listener's `handle()` method.

What I end up doing instead is creating an interface that all of my events implement and then I type hint that interface into the listener's `handle()` method.

Here's how it currently works:

```php
// app/Events/MyEvent.php
<?php

namespace App\Events;

class MyEvent
{
    public $foo;

    public function __construct($foo)
    {
        $this->foo = $foo;
    }
}

// app/Listeners/MyListener.php
<?php

namespace App\Listeners;

use App\Events\MyEvent;

class MyListener
{
    public function handle(MyEvent $event)
    {
        // access $event->foo here, etc.
    }
}


```

and here's how it would change with these commits:

```php
// app/Events/MyEvent.php
<?php

namespace App\Events;

use Illuminate\Contracts\Events\Event;

class MyEvent implements Event
{
    public $foo;

    public function __construct($foo)
    {
        $this->foo = $foo;
    }
}

// app/Listeners/MyListener.php
<?php

namespace App\Listeners;

use Illuminate\Contracts\Events\Event;

class MyListener
{
    public function handle(Event $event)
    {
        // access $event->foo here, etc.
    }
}
```