### PR TITLE
[5.6] Add 'next' and 'prev' methods to Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -231,6 +231,31 @@ class Builder
         return $this;
     }
 
+
+    /**
+     * Find the next record after the given value and column.
+     *
+     * @param  mixed  $value
+     * @param  string  $column
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function next($value, $column)
+    {
+        return $this->where($column , '>', $value)->orderBy($column, 'asc')->first();
+    }
+
+    /**
+     * Find the previous record before the given value and column.
+     *
+     * @param  mixed  $value
+     * @param  string  $column
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function prev($value, $column)
+    {
+        return $this->where($column , '<', $value)->orderBy($column, 'desc')->first();
+    }
+
     /**
      * Add an "or where" clause to the query.
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -443,6 +443,46 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Retrieve the next or previous model according to the given column.
+     *
+     * @param  string  $column
+     * @param  string  $method
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    protected function nextOrPrev($column, $method)
+    {
+        $query = $this->newQuery();
+
+        if (! $this->exists) {
+            return null;
+        }
+
+        return $query->{$method}($this->{$column}, $column);
+    }
+
+    /**
+     * Find the next model according to the given column.
+     *
+     * @param  string|null  $column
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    protected function next($column = null)
+    {
+        return $this->nextOrPrev($column ?: $this->getKeyName(), 'next');
+    }
+
+    /**
+     * Find the previous model according to the given column.
+     *
+     * @param  string|null  $column
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    protected function prev($column = null)
+    {
+        return $this->nextOrPrev($column ?: $this->getKeyName(), 'prev');
+    }
+
+    /**
      * Increment the underlying attribute value and sync with original.
      *
      * @param  string  $column
@@ -1477,7 +1517,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function __call($method, $parameters)
     {
-        if (in_array($method, ['increment', 'decrement'])) {
+        if (in_array($method, ['increment', 'decrement', 'next', 'prev'])) {
             return $this->$method(...$parameters);
         }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1123,6 +1123,41 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertNull($freshNotStoredUser);
     }
 
+    public function testNextMethodOnModel()
+    {
+        // emails order is reversed: 4@gmail, 3@gmail..
+        EloquentTestUser::insert([['id' => 1, 'email' => '4@gmail.com'], ['id' => 2, 'email' => '3@gmail.com'] , ['id' => 3, 'email' => '2@gmail.com'], ['id' => 4, 'email'=> '1@gmail.com'],['id'=> 8, 'email'=>'foo@gmail.com']]);
+
+        $thirdUser =  EloquentTestUser::find(3);
+
+        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $thirdUser->next());
+        $this->assertEquals(4, $thirdUser->next()->id);
+        $this->assertEquals(2, $thirdUser->next('email')->id);
+        $this->assertNull( EloquentTestUser::find(8)->next());
+        $this->assertEquals(8, EloquentTestUser::find(4)->next()->id);
+
+        $notStoredUser = new EloquentTestUser();
+        $this->assertNull( $notStoredUser->next());
+    }
+
+
+    public function testPrevMethodOnModel()
+    {
+        // emails order is reversed: 4@gmail, 3@gmail..
+        EloquentTestUser::insert([['id' => 1, 'email' => '4@gmail.com'], ['id' => 2, 'email' => '3@gmail.com'] , ['id' => 3, 'email' => '2@gmail.com'], ['id' => 4, 'email'=> '1@gmail.com'],['id'=> 8, 'email'=>'foo@gmail.com']]);
+
+        $thirdUser =  EloquentTestUser::find(3);
+
+        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $thirdUser->prev());
+        $this->assertEquals(2, $thirdUser->prev()->id);
+        $this->assertEquals(4, $thirdUser->prev('email')->id);
+        $this->assertNull(EloquentTestUser::find(1)->prev());
+        $this->assertEquals(4, EloquentTestUser::find(8)->prev()->id);
+
+        $notStoredUser = new EloquentTestUser();
+        $this->assertNull( $notStoredUser->prev());
+    }
+
     public function testFreshMethodOnCollection()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
This PR introduces two new methods (next, prev) to Eloquent's `Model` and `Builder`.

Using this methods, we can retrieve a Model instance from it's previous or following record. By simply calling `$model->next()`, if the key is not passed, then it will call the Model's `getKeyName` method to compare according to the primary key.

Usage Example:
``` php
Order::insert([ ['id'=>1, 'total' => 100, 'id' => 2, 'total' => 50], ['id' => 3, 'total' => 40]]);

$secondOrder = Order::find(2);

$secondOrder->next(); // returns the third Order
$secondOrder->prev(); // returns the first Order 

$secondOrder->next('total'); // returns the first Order, since the second order's total is 50, and the 100 total at the first order is the closest higher value
```

The underlying implementation on the `Builder` part is a simple where clause and order by, then picking and returning the first result. The logic of `next` and `prev` is applied in the construction of the where call and the sorting type.

The implementation on the `Model` part is similar to the implemntation of `increment/decrement` methods.