### PR TITLE
[5.6] Updated mass assignment exception wording

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -229,7 +229,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             if ($this->isFillable($key)) {
                 $this->setAttribute($key, $value);
             } elseif ($totallyGuarded) {
-                throw new MassAssignmentException($key);
+                throw new MassAssignmentException('Model is guarded. Add key ['.$key.'] to $fillable to allow mass assignment.');
             }
         }
 


### PR DESCRIPTION
Updated mass assignment exception wording for clarity; nominating the key alone is a little vague.

I was finding when running `firstOrCreate()` on a model where I neglected to update the `$fillable` array was returning an exception with the first key name in it each time. The fix itself was obvious and simple (ie updating `$fillable`), but I thought adding a couple of breadcrumbs for folks new to Laravel might help.