### PR TITLE
[5.3] Adds is_null check to Eloquent Builder callScope

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1228,7 +1228,7 @@ class Builder
         // We will keep track of how many wheres are on the query before running the
         // scope so that we can properly group the added scope constraints in the
         // query as their own isolated nested where statement and avoid issues.
-        $originalWhereCount = count($query->wheres);
+        $originalWhereCount = is_null($query->wheres) ? 0 : count($query->wheres);
 
         $result = $scope(...array_values($parameters)) ?: $this;
 


### PR DESCRIPTION
The issue #19381  exists also on branch 5.3 with PHP 7.2 version.

Let's fix the 5.3 branch as well.