### PR TITLE
[5.5] Disconnect from the database when refresh is done

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -75,7 +75,10 @@ trait RefreshDatabase
 
         $this->beforeApplicationDestroyed(function () use ($database) {
             foreach ($this->connectionsToTransact() as $name) {
-                $database->connection($name)->rollBack();
+                $connection = $database->connection($name);
+
+                $connection->rollBack();
+                $connection->disconnect();
             }
         });
     }


### PR DESCRIPTION
[As noticed](https://github.com/laravel/framework/issues/18471#issuecomment-352216254) by @GuidoHendriks, the `RefreshDatabase` trait isn't closing the database connection. This PR solves this issue and resolves #18471.