### PR TITLE
[5.6] Clean up of EncryptCookies.php

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -39,12 +39,12 @@ class EncryptCookies
     /**
      * Disable encryption for the given cookie name(s).
      *
-     * @param  string|array  $cookieName
+     * @param  string|array  $name
      * @return void
      */
-    public function disableFor($cookieName)
+    public function disableFor($name)
     {
-        $this->except = array_merge($this->except, (array) $cookieName);
+        $this->except = array_merge($this->except, (array) $name);
     }
 
     /**
@@ -67,13 +67,13 @@ class EncryptCookies
      */
     protected function decrypt(Request $request)
     {
-        foreach ($request->cookies as $key => $c) {
+        foreach ($request->cookies as $key => $cookie) {
             if ($this->isDisabled($key)) {
                 continue;
             }
 
             try {
-                $request->cookies->set($key, $this->decryptCookie($c));
+                $request->cookies->set($key, $this->decryptCookie($cookie));
             } catch (DecryptException $e) {
                 $request->cookies->set($key, null);
             }
@@ -138,16 +138,16 @@ class EncryptCookies
     /**
      * Duplicate a cookie with a new value.
      *
-     * @param  \Symfony\Component\HttpFoundation\Cookie  $c
+     * @param  \Symfony\Component\HttpFoundation\Cookie  $cookie
      * @param  mixed  $value
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    protected function duplicate(Cookie $c, $value)
+    protected function duplicate(Cookie $cookie, $value)
     {
         return new Cookie(
-            $c->getName(), $value, $c->getExpiresTime(), $c->getPath(),
-            $c->getDomain(), $c->isSecure(), $c->isHttpOnly(), $c->isRaw(),
-            $c->getSameSite()
+            $cookie->getName(), $value, $cookie->getExpiresTime(),
+            $cookie->getPath(), $cookie->getDomain(), $cookie->isSecure(), 
+            $cookie->isHttpOnly(), $cookie->isRaw(), $cookie->getSameSite()
         );
     }
 

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -146,7 +146,7 @@ class EncryptCookies
     {
         return new Cookie(
             $cookie->getName(), $value, $cookie->getExpiresTime(),
-            $cookie->getPath(), $cookie->getDomain(), $cookie->isSecure(), 
+            $cookie->getPath(), $cookie->getDomain(), $cookie->isSecure(),
             $cookie->isHttpOnly(), $cookie->isRaw(), $cookie->getSameSite()
         );
     }


### PR DESCRIPTION
Just a quick cleanup, `$c` is used when `$cookie` is better, plus `$cookieName` and `$name` are used when they should really be either `$cookieName` or `$name`.