### PR TITLE
[5.5] Add a "qualifyColumn" method to the Eloquent Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1223,6 +1223,17 @@ class Builder
     }
 
     /**
+     * Qualify the given column name by the model's table.
+     *
+     * @param  string  $column
+     * @return string
+     */
+    public function qualify($column)
+    {
+        return $this->model->qualify($column);
+    }
+
+    /**
      * Get the given macro by name.
      *
      * @param  string  $name

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1228,9 +1228,9 @@ class Builder
      * @param  string  $column
      * @return string
      */
-    public function qualify($column)
+    public function qualifyColumn($column)
     {
-        return $this->model->qualify($column);
+        return $this->model->qualifyColumn($column);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -250,6 +250,21 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Qualify the given column name by the model's table.
+     *
+     * @param  string  $column
+     * @return string
+     */
+    public function qualify($column)
+    {
+        if (Str::contains($column, '.')) {
+            return $column;
+        }
+
+        return $this->getTable().'.'.$column;
+    }
+
+    /**
      * Remove the table name from a given key.
      *
      * @param  string  $key
@@ -1206,7 +1221,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getQualifiedKeyName()
     {
-        return $this->getTable().'.'.$this->getKeyName();
+        return $this->qualify($this->getKeyName());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -255,7 +255,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $column
      * @return string
      */
-    public function qualify($column)
+    public function qualifyColumn($column)
     {
         if (Str::contains($column, '.')) {
             return $column;
@@ -1221,7 +1221,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getQualifiedKeyName()
     {
-        return $this->qualify($this->getKeyName());
+        return $this->qualifyColumn($this->getKeyName());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -253,7 +253,7 @@ class BelongsTo extends Relation
         }
 
         return $query->select($columns)->whereColumn(
-            $this->getQualifiedForeignKey(), '=', $query->qualify($this->ownerKey)
+            $this->getQualifiedForeignKey(), '=', $query->qualifyColumn($this->ownerKey)
         );
     }
 
@@ -327,7 +327,7 @@ class BelongsTo extends Relation
      */
     public function getQualifiedForeignKey()
     {
-        return $this->child->qualify($this->foreignKey);
+        return $this->child->qualifyColumn($this->foreignKey);
     }
 
     /**
@@ -347,7 +347,7 @@ class BelongsTo extends Relation
      */
     public function getQualifiedOwnerKeyName()
     {
-        return $this->related->qualify($this->ownerKey);
+        return $this->related->qualifyColumn($this->ownerKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -253,7 +253,7 @@ class BelongsTo extends Relation
         }
 
         return $query->select($columns)->whereColumn(
-            $this->getQualifiedForeignKey(), '=', $query->getModel()->getTable().'.'.$this->ownerKey
+            $this->getQualifiedForeignKey(), '=', $query->qualify($this->ownerKey)
         );
     }
 
@@ -327,7 +327,7 @@ class BelongsTo extends Relation
      */
     public function getQualifiedForeignKey()
     {
-        return $this->child->getTable().'.'.$this->foreignKey;
+        return $this->child->qualify($this->foreignKey);
     }
 
     /**
@@ -347,7 +347,7 @@ class BelongsTo extends Relation
      */
     public function getQualifiedOwnerKeyName()
     {
-        return $this->related->getTable().'.'.$this->ownerKey;
+        return $this->related->qualify($this->ownerKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -959,7 +959,7 @@ class BelongsToMany extends Relation
      */
     public function getQualifiedParentKeyName()
     {
-        return $this->parent->getTable().'.'.$this->parentKey;
+        return $this->parent->qualify($this->parentKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -959,7 +959,7 @@ class BelongsToMany extends Relation
      */
     public function getQualifiedParentKeyName()
     {
-        return $this->parent->qualify($this->parentKey);
+        return $this->parent->qualifyColumn($this->parentKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -125,7 +125,7 @@ class HasManyThrough extends Relation
      */
     public function getQualifiedParentKeyName()
     {
-        return $this->parent->qualify($this->secondLocalKey);
+        return $this->parent->qualifyColumn($this->secondLocalKey);
     }
 
     /**
@@ -495,7 +495,7 @@ class HasManyThrough extends Relation
      */
     public function getQualifiedFirstKeyName()
     {
-        return $this->throughParent->qualify($this->firstKey);
+        return $this->throughParent->qualifyColumn($this->firstKey);
     }
 
     /**
@@ -505,7 +505,7 @@ class HasManyThrough extends Relation
      */
     public function getQualifiedForeignKeyName()
     {
-        return $this->related->qualify($this->secondKey);
+        return $this->related->qualifyColumn($this->secondKey);
     }
 
     /**
@@ -515,6 +515,6 @@ class HasManyThrough extends Relation
      */
     public function getQualifiedLocalKeyName()
     {
-        return $this->farParent->qualify($this->localKey);
+        return $this->farParent->qualifyColumn($this->localKey);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -125,7 +125,7 @@ class HasManyThrough extends Relation
      */
     public function getQualifiedParentKeyName()
     {
-        return $this->parent->getTable().'.'.$this->secondLocalKey;
+        return $this->parent->qualify($this->secondLocalKey);
     }
 
     /**
@@ -495,7 +495,7 @@ class HasManyThrough extends Relation
      */
     public function getQualifiedFirstKeyName()
     {
-        return $this->throughParent->getTable().'.'.$this->firstKey;
+        return $this->throughParent->qualify($this->firstKey);
     }
 
     /**
@@ -505,7 +505,7 @@ class HasManyThrough extends Relation
      */
     public function getQualifiedForeignKeyName()
     {
-        return $this->related->getTable().'.'.$this->secondKey;
+        return $this->related->qualify($this->secondKey);
     }
 
     /**
@@ -515,6 +515,6 @@ class HasManyThrough extends Relation
      */
     public function getQualifiedLocalKeyName()
     {
-        return $this->farParent->getTable().'.'.$this->localKey;
+        return $this->farParent->qualify($this->localKey);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -396,7 +396,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function getQualifiedParentKeyName()
     {
-        return $this->parent->getTable().'.'.$this->localKey;
+        return $this->parent->qualify($this->localKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -396,7 +396,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function getQualifiedParentKeyName()
     {
-        return $this->parent->qualify($this->localKey);
+        return $this->parent->qualifyColumn($this->localKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -164,6 +164,6 @@ trait SoftDeletes
      */
     public function getQualifiedDeletedAtColumn()
     {
-        return $this->getTable().'.'.$this->getDeletedAtColumn();
+        return $this->qualify($this->getDeletedAtColumn());
     }
 }

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -164,6 +164,6 @@ trait SoftDeletes
      */
     public function getQualifiedDeletedAtColumn()
     {
-        return $this->qualify($this->getDeletedAtColumn());
+        return $this->qualifyColumn($this->getDeletedAtColumn());
     }
 }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -127,14 +127,14 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('bar', $result);
     }
 
-    public function testQualify()
+    public function testQualifyColumn()
     {
         $builder = new Builder(m::mock(BaseBuilder::class));
         $builder->shouldReceive('from')->with('stub');
 
         $builder->setModel(new EloquentModelStub);
 
-        $this->assertEquals('stub.column', $builder->qualify('column'));
+        $this->assertEquals('stub.column', $builder->qualifyColumn('column'));
     }
 
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Database\Query\Builder as BaseBuilder;
 
 class DatabaseEloquentBuilderTest extends TestCase
 {
@@ -124,6 +125,16 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->first();
         $this->assertEquals('bar', $result);
+    }
+
+    public function testQualify()
+    {
+        $builder = new Builder(m::mock(BaseBuilder::class));
+        $builder->shouldReceive('from')->with('stub');
+
+        $builder->setModel(new EloquentModelStub);
+
+        $this->assertEquals('stub.column', $builder->qualify('column'));
     }
 
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()
@@ -366,7 +377,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testLocalMacrosAreCalledOnBuilder()
     {
         unset($_SERVER['__test.builder']);
-        $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
+        $builder = new Builder(new BaseBuilder(
             m::mock('Illuminate\Database\ConnectionInterface'),
             m::mock('Illuminate\Database\Query\Grammars\Grammar'),
             m::mock('Illuminate\Database\Query\Processors\Processor')
@@ -987,7 +998,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     protected function getMockQueryBuilder()
     {
-        $query = m::mock('Illuminate\Database\Query\Builder');
+        $query = m::mock(BaseBuilder::class);
         $query->shouldReceive('from')->with('foo_table');
 
         return $query;

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -175,7 +175,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $builder->shouldReceive('getQuery')->once()->andReturn($parentQuery);
 
         $builder->shouldReceive('select')->once()->with(m::type('Illuminate\Database\Query\Expression'))->andReturnSelf();
-        $relation->getParent()->shouldReceive('getTable')->andReturn('table');
+        $relation->getParent()->shouldReceive('qualify')->andReturn('table.id');
         $builder->shouldReceive('whereColumn')->once()->with('table.id', '=', 'table.foreign_key')->andReturn($baseQuery);
         $baseQuery->shouldReceive('setBindings')->once()->with([], 'select');
 

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -175,7 +175,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $builder->shouldReceive('getQuery')->once()->andReturn($parentQuery);
 
         $builder->shouldReceive('select')->once()->with(m::type('Illuminate\Database\Query\Expression'))->andReturnSelf();
-        $relation->getParent()->shouldReceive('qualify')->andReturn('table.id');
+        $relation->getParent()->shouldReceive('qualifyColumn')->andReturn('table.id');
         $builder->shouldReceive('whereColumn')->once()->with('table.id', '=', 'table.foreign_key')->andReturn($baseQuery);
         $baseQuery->shouldReceive('setBindings')->once()->with([], 'select');
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -866,11 +866,11 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('bar', $model->age);
     }
 
-    public function testQualify()
+    public function testQualifyColumn()
     {
         $model = new EloquentModelStub;
 
-        $this->assertEquals('stub.column', $model->qualify('column'));
+        $this->assertEquals('stub.column', $model->qualifyColumn('column'));
     }
 
     public function testForceFillMethodFillsGuardedAttributes()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -866,6 +866,13 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('bar', $model->age);
     }
 
+    public function testQualify()
+    {
+        $model = new EloquentModelStub;
+
+        $this->assertEquals('stub.column', $model->qualify('column'));
+    }
+
     public function testForceFillMethodFillsGuardedAttributes()
     {
         $model = (new EloquentModelSaveStub)->forceFill(['id' => 21]);


### PR DESCRIPTION
Useful in complex queries where you need to qualify the column name to avoid collision:

```php
function addSomeComplexSubquery($query, $model)
{
    $query->where($model->qualifyColumn('column'), $someValue);
}
````