### PR TITLE
[5.5] Added workaround for dd function correct output in the Chrome's network preview window

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -554,7 +554,7 @@ if (! function_exists('dd')) {
     function dd(...$args)
     {
         http_response_code(500);
-        
+
         foreach ($args as $x) {
             (new Dumper)->dump($x);
         }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -553,6 +553,8 @@ if (! function_exists('dd')) {
      */
     function dd(...$args)
     {
+        http_response_code(500);
+        
         foreach ($args as $x) {
             (new Dumper)->dump($x);
         }


### PR DESCRIPTION
Since Chrome 62.0 version the render of ``dd`` function output in the network preview window is not being displayed correctly anymore.

Before the change:
![image](https://user-images.githubusercontent.com/1407067/34462024-00ba908a-ee43-11e7-9351-483d78bd28f5.png)

After the change:
![image](https://user-images.githubusercontent.com/1407067/34462034-22546518-ee43-11e7-9199-97ded7ee8004.png)
