### PR TITLE
[5.6] Channel classes

### DIFF
--- a/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Input\InputOption;
 
 class ChannelMakeCommand extends GeneratorCommand
 {

--- a/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class ChannelMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:channel';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new channel class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Broadcasting Channel';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/channel.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Broadcasting';
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/channel.stub
+++ b/src/Illuminate/Foundation/Console/stubs/channel.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace DummyNamespace;
+
+class DummyClass
+{
+    /**
+     * Create a new broadcasting channel instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Authenticates the channel.
+     *
+     * @return mixed
+     */
+    public function join()
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -28,6 +28,7 @@ use Illuminate\Foundation\Console\PolicyMakeCommand;
 use Illuminate\Foundation\Console\RouteCacheCommand;
 use Illuminate\Foundation\Console\RouteClearCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
+use Illuminate\Foundation\Console\ChannelMakeCommand;
 use Illuminate\Foundation\Console\ConfigCacheCommand;
 use Illuminate\Foundation\Console\ConfigClearCommand;
 use Illuminate\Foundation\Console\ConsoleMakeCommand;
@@ -129,6 +130,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'AppName' => 'command.app.name',
         'AuthMake' => 'command.auth.make',
         'CacheTable' => 'command.cache.table',
+        'ChannelMake' => 'command.channel.make',
         'ConsoleMake' => 'command.console.make',
         'ControllerMake' => 'command.controller.make',
         'EventGenerate' => 'command.event.generate',
@@ -397,6 +399,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.job.make', function ($app) {
             return new JobMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerChannelMakeCommand()
+    {
+        $this->app->singleton('command.channel.make', function ($app) {
+            return new ChannelMakeCommand($app['files']);
         });
     }
 

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -57,6 +57,33 @@ class BroadcasterTest extends TestCase
         Container::setInstance(new Container);
     }
 
+    public function testCanUseChannelClasses()
+    {
+        $broadcaster = new FakeBroadcaster;
+
+        $parameters = $broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', DummyBroadcastingChannel::class);
+        $this->assertEquals(['model.1.instance', 'something'], $parameters);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Unknown channel handler type.
+     */
+    public function testUnknownChannelAuthHandlerTypeThrowsException()
+    {
+        $broadcaster = new FakeBroadcaster;
+
+        $broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', 123);
+    }
+
+    public function testCanRegisterChannelsAsClasses()
+    {
+        $broadcaster = new FakeBroadcaster;
+
+        $broadcaster->channel('something', function () {});
+        $broadcaster->channel('somethingelse', DummyBroadcastingChannel::class);
+    }
+
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
      * @expectedExceptionMessage
@@ -127,5 +154,13 @@ class BroadcasterTestEloquentModelNotFoundStub extends Model
     public function first()
     {
         //
+    }
+}
+
+class DummyBroadcastingChannel
+{
+    public function join($user, BroadcasterTestEloquentModelStub $model, $nonModel)
+    {
+
     }
 }

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -80,7 +80,8 @@ class BroadcasterTest extends TestCase
     {
         $broadcaster = new FakeBroadcaster;
 
-        $broadcaster->channel('something', function () {});
+        $broadcaster->channel('something', function () {
+        });
         $broadcaster->channel('somethingelse', DummyBroadcastingChannel::class);
     }
 
@@ -161,6 +162,6 @@ class DummyBroadcastingChannel
 {
     public function join($user, BroadcasterTestEloquentModelStub $model, $nonModel)
     {
-
+        //
     }
 }


### PR DESCRIPTION
### Added

- Artisan command to generate the channel classes

### Changed

- Allow passing channel authentication classes to clean up the channels file in the routes.

---

I have a demo app that uses the broadcasting feature and the [channels file](https://github.com/tonysm/slackish-laravel/blob/master/routes/channels.php) got a bit bloated. I figured we could a similar approach as the Phoenix version [here](https://github.com/tonysm/slackish-phoenix/blob/master/lib/slackishphx_web/channels/user_socket.ex#L4-L5) and [here](https://github.com/tonysm/slackish-phoenix/blob/master/lib/slackishphx_web/channels/room_channel.ex#L7-L9).

This allowed me to convert this:

```php
<?php

Broadcast::channel('App.User.{id}', function ($user, $id) {
    return (int) $user->id === (int) $id;
});

Broadcast::channel('channels.{channel}', function (\App\User $user, \App\Channel $channel) {
    if (!$channel->exists || !$user->canJoin($channel)) {
        return false;
    }

    $user->joinChannel($channel);

    return [
        'id' => $user->id,
        'name' => $user->name,
        'avatar_path' => $user->avatar_path,
    ];
});

Broadcast::channel('companies.{company}', function (\App\User $user, \App\Company $company) {
    if (!$user->currentCompany || !$user->currentCompany->is($company)) {
        return false;
    }

    return [
        'id' => $user->id,
        'name' => $user->name,
        'avatar_path' => $user->avatar_path,
    ];
});
```

Into this:

```php
<?php

Broadcast::channel('App.User.{id}', function ($user, $id) {
    return (int) $user->id === (int) $id;
});

Broadcast::channel('channels.{channel}', \App\Broadcasting\ChatRoomChannel::class);
Broadcast::channel('companies.{company}', \App\Broadcasting\CompanyChannel::class);
```

And an example of the channel class:

```php
<?php

namespace App\Broadcasting;

use App\User;
use App\Channel;

class ChatRoomChannel
{
    /**
     * Authenticates the channel.
     *
     * @param User $user
     * @param Channel $channel
     *
     * @return array|bool
     */
    public function join(User $user, Channel $channel)
    {
        if (!$channel->exists || !$user->canJoin($channel)) {
            return false;
        }

        $user->joinChannel($channel);

        return [
            'id' => $user->id,
            'name' => $user->name,
            'avatar_path' => $user->avatar_path,
        ];
    }
}
```

The idea is to allow the channels file to look more like the routes files (web and api) where we register the channel classes that will handle the channels authentication.