### PR TITLE
[5.6] Enhance retry helper function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -751,25 +751,30 @@ if (! function_exists('retry')) {
      * @param  int  $times
      * @param  callable  $callback
      * @param  int  $sleep
+     * @param  int  $factor
+     * @param  int  $jitter
      * @return mixed
      *
      * @throws \Exception
      */
-    function retry($times, callable $callback, $sleep = 0)
+    function retry($times, callable $callback, $sleep = 0, $factor = 1, $jitter = 0.0)
     {
-        $times--;
+        $attempts = 0;
 
         beginning:
         try {
             return $callback();
         } catch (Exception $e) {
-            if (! $times) {
+            if (++$attempts >= $times) {
                 throw $e;
             }
 
-            $times--;
-
             if ($sleep) {
+                $j = $jitter * 2 * mt_rand() / mt_getrandmax() - $jitter;
+                $f = $attempts > 1 ? $factor + $j : 1 + abs($j);
+
+                $sleep *= $f;
+
                 usleep($sleep * 1000);
             }
 


### PR DESCRIPTION
I often find an exponential retry function is preferred over a constant rate - perhaps others does as well.

These minor changes give the opportunity for both use cases by increasing the `sleep` and `factor` parameter.

I believe this change is a non-breaking change but I might be wrong. The default values give the same result as the current retry function.