### PR TITLE
[5.6] Support initial auto_increment

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -424,55 +424,60 @@ class Blueprint
      * Create a new auto-incrementing integer (4-byte) column on the table.
      *
      * @param  string  $column
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function increments($column)
+    public function increments($column, $auto_increment = 1)
     {
-        return $this->unsignedInteger($column, true);
+        return $this->unsignedInteger($column, true, $auto_increment);
     }
 
     /**
      * Create a new auto-incrementing tiny integer (1-byte) column on the table.
      *
      * @param  string  $column
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function tinyIncrements($column)
+    public function tinyIncrements($column, $auto_increment = 1)
     {
-        return $this->unsignedTinyInteger($column, true);
+        return $this->unsignedTinyInteger($column, true, $auto_increment);
     }
 
     /**
      * Create a new auto-incrementing small integer (2-byte) column on the table.
      *
      * @param  string  $column
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function smallIncrements($column)
+    public function smallIncrements($column, $auto_increment = 1)
     {
-        return $this->unsignedSmallInteger($column, true);
+        return $this->unsignedSmallInteger($column, true, $auto_increment);
     }
 
     /**
      * Create a new auto-incrementing medium integer (3-byte) column on the table.
      *
      * @param  string  $column
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function mediumIncrements($column)
+    public function mediumIncrements($column, $auto_increment = 1)
     {
-        return $this->unsignedMediumInteger($column, true);
+        return $this->unsignedMediumInteger($column, true, $auto_increment);
     }
 
     /**
      * Create a new auto-incrementing big integer (8-byte) column on the table.
      *
      * @param  string  $column
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function bigIncrements($column)
+    public function bigIncrements($column, $auto_increment = 1)
     {
-        return $this->unsignedBigInteger($column, true);
+        return $this->unsignedBigInteger($column, true, $auto_increment);
     }
 
     /**
@@ -542,11 +547,12 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function integer($column, $autoIncrement = false, $unsigned = false)
+    public function integer($column, $autoIncrement = false, $unsigned = false, $auto_increment = 1)
     {
-        return $this->addColumn('integer', $column, compact('autoIncrement', 'unsigned'));
+        return $this->addColumn('integer', $column, compact('autoIncrement', 'unsigned', 'auto_increment'));
     }
 
     /**
@@ -555,11 +561,12 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function tinyInteger($column, $autoIncrement = false, $unsigned = false)
+    public function tinyInteger($column, $autoIncrement = false, $unsigned = false, $auto_increment = 1)
     {
-        return $this->addColumn('tinyInteger', $column, compact('autoIncrement', 'unsigned'));
+        return $this->addColumn('tinyInteger', $column, compact('autoIncrement', 'unsigned', 'auto_increment'));
     }
 
     /**
@@ -568,11 +575,12 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function smallInteger($column, $autoIncrement = false, $unsigned = false)
+    public function smallInteger($column, $autoIncrement = false, $unsigned = false, $auto_increment = 1)
     {
-        return $this->addColumn('smallInteger', $column, compact('autoIncrement', 'unsigned'));
+        return $this->addColumn('smallInteger', $column, compact('autoIncrement', 'unsigned', 'auto_increment'));
     }
 
     /**
@@ -581,11 +589,12 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function mediumInteger($column, $autoIncrement = false, $unsigned = false)
+    public function mediumInteger($column, $autoIncrement = false, $unsigned = false, $auto_increment = 1)
     {
-        return $this->addColumn('mediumInteger', $column, compact('autoIncrement', 'unsigned'));
+        return $this->addColumn('mediumInteger', $column, compact('autoIncrement', 'unsigned', 'auto_increment'));
     }
 
     /**
@@ -594,11 +603,12 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function bigInteger($column, $autoIncrement = false, $unsigned = false)
+    public function bigInteger($column, $autoIncrement = false, $unsigned = false, $auto_increment = 1)
     {
-        return $this->addColumn('bigInteger', $column, compact('autoIncrement', 'unsigned'));
+        return $this->addColumn('bigInteger', $column, compact('autoIncrement', 'unsigned', 'auto_increment'));
     }
 
     /**
@@ -606,11 +616,12 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function unsignedInteger($column, $autoIncrement = false)
+    public function unsignedInteger($column, $autoIncrement = false, $auto_increment = 1)
     {
-        return $this->integer($column, $autoIncrement, true);
+        return $this->integer($column, $autoIncrement, true, $auto_increment);
     }
 
     /**
@@ -618,11 +629,12 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function unsignedTinyInteger($column, $autoIncrement = false)
+    public function unsignedTinyInteger($column, $autoIncrement = false, $auto_increment = 1)
     {
-        return $this->tinyInteger($column, $autoIncrement, true);
+        return $this->tinyInteger($column, $autoIncrement, true, $auto_increment);
     }
 
     /**
@@ -630,11 +642,12 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function unsignedSmallInteger($column, $autoIncrement = false)
+    public function unsignedSmallInteger($column, $autoIncrement = false, $auto_increment = 1)
     {
-        return $this->smallInteger($column, $autoIncrement, true);
+        return $this->smallInteger($column, $autoIncrement, true, $auto_increment);
     }
 
     /**
@@ -642,11 +655,12 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function unsignedMediumInteger($column, $autoIncrement = false)
+    public function unsignedMediumInteger($column, $autoIncrement = false, $auto_increment = 1)
     {
-        return $this->mediumInteger($column, $autoIncrement, true);
+        return $this->mediumInteger($column, $autoIncrement, true, $auto_increment);
     }
 
     /**
@@ -654,11 +668,12 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
+     * @param  int  $auto_increment
      * @return \Illuminate\Support\Fluent
      */
-    public function unsignedBigInteger($column, $autoIncrement = false)
+    public function unsignedBigInteger($column, $autoIncrement = false, $auto_increment = 1)
     {
-        return $this->bigInteger($column, $autoIncrement, true);
+        return $this->bigInteger($column, $autoIncrement, true, $auto_increment);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -904,7 +904,7 @@ class MySqlGrammar extends Grammar
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
-            return ' auto_increment primary key';
+            return " auto_increment = {$column->auto_increment} primary key";
         }
     }
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -28,7 +28,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate utf8_unicode_ci', $statements[0]);
+        $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment = 1 primary key, `email` varchar(255) not null) default character set utf8 collate utf8_unicode_ci', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');
@@ -40,7 +40,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `id` int unsigned not null auto_increment primary key, add `email` varchar(255) not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `id` int unsigned not null auto_increment = 1 primary key, add `email` varchar(255) not null', $statements[0]);
     }
 
     public function testEngineCreateTable()
@@ -58,11 +58,11 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate utf8_unicode_ci engine = InnoDB', $statements[0]);
+        $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment = 1 primary key, `email` varchar(255) not null) default character set utf8 collate utf8_unicode_ci engine = InnoDB', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->create();
-        $blueprint->increments('id');
+        $blueprint->increments('id', 100);
         $blueprint->string('email');
 
         $conn = $this->getConnection();
@@ -73,7 +73,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate utf8_unicode_ci engine = InnoDB', $statements[0]);
+        $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment = 100 primary key, `email` varchar(255) not null) default character set utf8 collate utf8_unicode_ci engine = InnoDB', $statements[0]);
     }
 
     public function testCharsetCollationCreateTable()
@@ -91,7 +91,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8mb4 collate utf8mb4_unicode_ci', $statements[0]);
+        $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment = 1 primary key, `email` varchar(255) not null) default character set utf8mb4 collate utf8mb4_unicode_ci', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -106,7 +106,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) character set utf8mb4 collate utf8mb4_unicode_ci not null) default character set utf8 collate utf8_unicode_ci', $statements[0]);
+        $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment = 1 primary key, `email` varchar(255) character set utf8mb4 collate utf8mb4_unicode_ci not null) default character set utf8 collate utf8_unicode_ci', $statements[0]);
     }
 
     public function testBasicCreateTableWithPrefix()
@@ -124,7 +124,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $grammar);
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table `prefix_users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
+        $this->assertEquals('create table `prefix_users` (`id` int unsigned not null auto_increment = 1 primary key, `email` varchar(255) not null)', $statements[0]);
     }
 
     public function testCreateTemporaryTable()
@@ -141,7 +141,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create temporary table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
+        $this->assertEquals('create temporary table `users` (`id` int unsigned not null auto_increment = 1 primary key, `email` varchar(255) not null)', $statements[0]);
     }
 
     public function testDropTable()
@@ -355,7 +355,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `id` int unsigned not null auto_increment primary key', $statements[0]);
+        $this->assertEquals('alter table `users` add `id` int unsigned not null auto_increment = 1 primary key', $statements[0]);
     }
 
     public function testAddingSmallIncrementingID()
@@ -365,7 +365,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `id` smallint unsigned not null auto_increment primary key', $statements[0]);
+        $this->assertEquals('alter table `users` add `id` smallint unsigned not null auto_increment = 1 primary key', $statements[0]);
     }
 
     public function testAddingBigIncrementingID()
@@ -375,7 +375,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
+        $this->assertEquals('alter table `users` add `id` bigint unsigned not null auto_increment = 1 primary key', $statements[0]);
     }
 
     public function testAddingColumnInTableFirst()
@@ -465,7 +465,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` bigint not null auto_increment primary key', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` bigint not null auto_increment = 1 primary key', $statements[0]);
     }
 
     public function testAddingInteger()
@@ -482,7 +482,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` int not null auto_increment primary key', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` int not null auto_increment = 1 primary key', $statements[0]);
     }
 
     public function testAddingMediumInteger()
@@ -499,7 +499,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` mediumint not null auto_increment primary key', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` mediumint not null auto_increment = 1 primary key', $statements[0]);
     }
 
     public function testAddingSmallInteger()
@@ -516,7 +516,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` smallint not null auto_increment primary key', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` smallint not null auto_increment = 1 primary key', $statements[0]);
     }
 
     public function testAddingTinyInteger()
@@ -533,7 +533,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` tinyint not null auto_increment primary key', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` tinyint not null auto_increment = 1 primary key', $statements[0]);
     }
 
     public function testAddingFloat()


### PR DESCRIPTION
Inspired by @laraveldaily['s post](http://laraveldaily.com/set-auto-increment-start-laravel-migrations/) about set `auto-increment`, I've added that functionality to our `increments*` columns:
```php
$table->increments('id', 100);
```
Still working in other databases beyond `MySQL` :construction: 