### PR TITLE
[5.3] Avoid counting nulls (fatal in PHP 7.2)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1274,7 +1274,7 @@ class Builder
      */
     protected function shouldNestWheresForScope(QueryBuilder $query, $originalWhereCount)
     {
-        return count($query->wheres) > $originalWhereCount;
+        return count((array) $query->wheres) > $originalWhereCount;
     }
 
     /**


### PR DESCRIPTION
This a sibling to laravel#22567
Already taken care of in 5.4 and later.