### PR TITLE
set user provider for viaRequest guards

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -220,8 +220,12 @@ class AuthManager implements FactoryContract
      */
     public function viaRequest($driver, callable $callback)
     {
-        return $this->extend($driver, function () use ($callback) {
-            $guard = new RequestGuard($callback, $this->app['request'], $this->createUserProvider());
+        return $this->extend($driver, function ($app, $name, $config) use ($callback) {
+            $guard = new RequestGuard(
+                $callback,
+                $this->app['request'],
+                $this->createUserProvider($config['provider'] ?? null)
+            );
 
             $this->app->refresh('request', $guard, 'setRequest');
 


### PR DESCRIPTION
You may want to use the user provider in the callback:
```php
Auth::viaRequest('api', function ($request, $provider) {
    return $provider->retrieveById(1);
});
```

Together with the following `auth` configuration:
```php
    'guards' => [
        'api' => [
            'driver' => 'api',
            'provider' => 'users',
        ],
    ],
```

My fix ensures that the provider specified in `auth.api.provider` is used, i.e. `users`.

The current behavior is to use [`auth.defaults.provider`](https://github.com/laravel/framework/blob/v5.5.28/src/Illuminate/Auth/CreatesUserProviders.php#L92) for all `viaRequest` guards,
but that configuration [is not set by default](https://github.com/laravel/laravel/blob/v5.5.22/config/auth.php#L16-L19) such that `$provider` is `null`.