### PR TITLE
[5.5] Add support for new author fields in slack message attachment

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -82,6 +82,9 @@ class SlackWebhookChannel
     {
         return collect($message->attachments)->map(function ($attachment) use ($message) {
             return array_filter([
+                'author_icon' => $attachment->authorIcon,
+                'author_link' => $attachment->authorLink,
+                'author_name' => $attachment->authorName,
                 'color' => $attachment->color ?: $message->color(),
                 'fallback' => $attachment->fallback,
                 'fields' => $this->fields($attachment),

--- a/src/Illuminate/Notifications/Messages/SlackAttachment.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachment.php
@@ -93,6 +93,27 @@ class SlackAttachment
     public $timestamp;
 
     /**
+     * The attachment's author name.
+     *
+     * @var string
+     */
+    public $authorName;
+
+    /**
+     * The attachment's author link.
+     *
+     * @var string
+     */
+    public $authorLink;
+
+    /**
+     * The attachment's author icon.
+     *
+     * @var string
+     */
+    public $authorIcon;
+
+    /**
      * Set the title of the attachment.
      *
      * @param  string  $title
@@ -257,6 +278,23 @@ class SlackAttachment
     public function timestamp($timestamp)
     {
         $this->timestamp = $this->availableAt($timestamp);
+
+        return $this;
+    }
+
+    /**
+     * Set the author.
+     *
+     * @param  string $name
+     * @param  string $link
+     * @param  string $icon
+     * @return $this
+     */
+    public function author($name, $link = null, $icon = null)
+    {
+        $this->authorName = $name;
+        $this->authorLink = $link;
+        $this->authorIcon = $icon;
 
         return $this;
     }

--- a/src/Illuminate/Notifications/Messages/SlackAttachment.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachment.php
@@ -117,7 +117,7 @@ class SlackAttachment
      * Set the title of the attachment.
      *
      * @param  string  $title
-     * @param  string  $url
+     * @param  string|null  $url
      * @return $this
      */
     public function title($title, $url = null)
@@ -286,8 +286,8 @@ class SlackAttachment
      * Set the author.
      *
      * @param  string $name
-     * @param  string $link
-     * @param  string $icon
+     * @param  string|null $link
+     * @param  string|null $icon
      * @return $this
      */
     public function author($name, $link = null, $icon = null)

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -57,6 +57,9 @@ class NotificationSlackChannelTest extends TestCase
                             'mrkdwn_in' => ['text'],
                             'footer' => 'Laravel',
                             'footer_icon' => 'https://laravel.com/fake.png',
+                            'author_name' => 'Author',
+                            'author_link' => 'https://laravel.com/fake_author',
+                            'author_icon' => 'https://laravel.com/fake_author.png',
                             'ts' => 1234567890,
                         ],
                     ],
@@ -187,6 +190,7 @@ class NotificationSlackChannelTestNotification extends Notification
                                     ->footer('Laravel')
                                     ->footerIcon('https://laravel.com/fake.png')
                                     ->markdown(['text'])
+                                    ->author('Author', 'https://laravel.com/fake_author', 'https://laravel.com/fake_author.png')
                                     ->timestamp($timestamp);
                     });
     }


### PR DESCRIPTION
Add support for new author fields in slack message attachment mentioned in #22588 

new fields can be found in slack docs: https://api.slack.com/docs/message-attachments

