### PR TITLE
[5.6] Add "cookware" to uncountable list

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -17,6 +17,7 @@ class Pluralizer
         'cattle',
         'chassis',
         'compensation',
+        'cookware',
         'coreopsis',
         'data',
         'deer',


### PR DESCRIPTION
Cookware is usually uncountable. Google has 142 million results for "cookware", and only 0.5 million for "cookwares".