### PR TITLE
[5.5] Use inheritdoc for NullQueue instead of copying docblocks

### DIFF
--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -7,10 +7,7 @@ use Illuminate\Contracts\Queue\Queue as QueueContract;
 class NullQueue extends Queue implements QueueContract
 {
     /**
-     * Get the size of the queue.
-     *
-     * @param  string  $queue
-     * @return int
+     * {@inheritdoc}
      */
     public function size($queue = null)
     {
@@ -18,12 +15,7 @@ class NullQueue extends Queue implements QueueContract
     }
 
     /**
-     * Push a new job onto the queue.
-     *
-     * @param  string  $job
-     * @param  mixed   $data
-     * @param  string  $queue
-     * @return mixed
+     * {@inheritdoc}
      */
     public function push($job, $data = '', $queue = null)
     {
@@ -31,12 +23,7 @@ class NullQueue extends Queue implements QueueContract
     }
 
     /**
-     * Push a raw payload onto the queue.
-     *
-     * @param  string  $payload
-     * @param  string  $queue
-     * @param  array   $options
-     * @return mixed
+     * {@inheritdoc}
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
@@ -44,13 +31,7 @@ class NullQueue extends Queue implements QueueContract
     }
 
     /**
-     * Push a new job onto the queue after a delay.
-     *
-     * @param  \DateTimeInterface|\DateInterval|int  $delay
-     * @param  string  $job
-     * @param  mixed   $data
-     * @param  string  $queue
-     * @return mixed
+     * {@inheritdoc}
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
@@ -58,10 +39,7 @@ class NullQueue extends Queue implements QueueContract
     }
 
     /**
-     * Pop the next job off of the queue.
-     *
-     * @param  string  $queue
-     * @return \Illuminate\Contracts\Queue\Job|null
+     * {@inheritdoc}
      */
     public function pop($queue = null)
     {


### PR DESCRIPTION
As pointed out in https://github.com/laravel/framework/pull/22609 params should match interface contract. There is no additional info in them so we an use `{@inheritdoc}`  instead of copying them.