### PR TITLE
[5.6] Make some Manager class extend \Illuminate\Support\Manager

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Broadcasting;
 
-use Closure;
 use Pusher\Pusher;
 use Psr\Log\LoggerInterface;
 use InvalidArgumentException;

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -6,6 +6,7 @@ use Closure;
 use Pusher\Pusher;
 use Psr\Log\LoggerInterface;
 use InvalidArgumentException;
+use Illuminate\Support\Manager;
 use Illuminate\Broadcasting\Broadcasters\LogBroadcaster;
 use Illuminate\Broadcasting\Broadcasters\NullBroadcaster;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
@@ -16,40 +17,8 @@ use Illuminate\Contracts\Broadcasting\Factory as FactoryContract;
 /**
  * @mixin \Illuminate\Contracts\Broadcasting\Broadcaster
  */
-class BroadcastManager implements FactoryContract
+class BroadcastManager extends Manager implements FactoryContract
 {
-    /**
-     * The application instance.
-     *
-     * @var \Illuminate\Foundation\Application
-     */
-    protected $app;
-
-    /**
-     * The array of resolved broadcast drivers.
-     *
-     * @var array
-     */
-    protected $drivers = [];
-
-    /**
-     * The registered custom driver creators.
-     *
-     * @var array
-     */
-    protected $customCreators = [];
-
-    /**
-     * Create a new manager instance.
-     *
-     * @param  \Illuminate\Foundation\Application  $app
-     * @return void
-     */
-    public function __construct($app)
-    {
-        $this->app = $app;
-    }
-
     /**
      * Register the routes for handling broadcast authentication and sockets.
      *
@@ -138,70 +107,6 @@ class BroadcastManager implements FactoryContract
     }
 
     /**
-     * Get a driver instance.
-     *
-     * @param  string  $name
-     * @return mixed
-     */
-    public function driver($name = null)
-    {
-        $name = $name ?: $this->getDefaultDriver();
-
-        return $this->drivers[$name] = $this->get($name);
-    }
-
-    /**
-     * Attempt to get the connection from the local cache.
-     *
-     * @param  string  $name
-     * @return \Illuminate\Contracts\Broadcasting\Broadcaster
-     */
-    protected function get($name)
-    {
-        return $this->drivers[$name] ?? $this->resolve($name);
-    }
-
-    /**
-     * Resolve the given store.
-     *
-     * @param  string  $name
-     * @return \Illuminate\Contracts\Broadcasting\Broadcaster
-     *
-     * @throws \InvalidArgumentException
-     */
-    protected function resolve($name)
-    {
-        $config = $this->getConfig($name);
-
-        if (is_null($config)) {
-            throw new InvalidArgumentException("Broadcaster [{$name}] is not defined.");
-        }
-
-        if (isset($this->customCreators[$config['driver']])) {
-            return $this->callCustomCreator($config);
-        }
-
-        $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
-
-        if (! method_exists($this, $driverMethod)) {
-            throw new InvalidArgumentException("Driver [{$config['driver']}] is not supported.");
-        }
-
-        return $this->{$driverMethod}($config);
-    }
-
-    /**
-     * Call a custom driver creator.
-     *
-     * @param  array  $config
-     * @return mixed
-     */
-    protected function callCustomCreator(array $config)
-    {
-        return $this->customCreators[$config['driver']]($this->app, $config);
-    }
-
-    /**
      * Create an instance of the driver.
      *
      * @param  array  $config
@@ -260,7 +165,13 @@ class BroadcastManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        return $this->app['config']["broadcasting.connections.{$name}"];
+        $config = $this->app['config']["broadcasting.connections.{$name}"];
+
+        if (is_null($config)) {
+            throw new InvalidArgumentException("Broadcaster [{$name}] is not defined.");
+        }
+
+        return $config;
     }
 
     /**
@@ -282,31 +193,5 @@ class BroadcastManager implements FactoryContract
     public function setDefaultDriver($name)
     {
         $this->app['config']['broadcasting.default'] = $name;
-    }
-
-    /**
-     * Register a custom driver creator Closure.
-     *
-     * @param  string    $driver
-     * @param  \Closure  $callback
-     * @return $this
-     */
-    public function extend($driver, Closure $callback)
-    {
-        $this->customCreators[$driver] = $callback;
-
-        return $this;
-    }
-
-    /**
-     * Dynamically call the default driver instance.
-     *
-     * @param  string  $method
-     * @param  array   $parameters
-     * @return mixed
-     */
-    public function __call($method, $parameters)
-    {
-        return $this->driver()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Cache;
 
-use Closure;
 use InvalidArgumentException;
 use Illuminate\Support\Manager;
 use Illuminate\Contracts\Cache\Store;

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -4,6 +4,7 @@ namespace Illuminate\Cache;
 
 use Closure;
 use InvalidArgumentException;
+use Illuminate\Support\Manager;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Contracts\Cache\Factory as FactoryContract;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
@@ -11,40 +12,8 @@ use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 /**
  * @mixin \Illuminate\Contracts\Cache\Repository
  */
-class CacheManager implements FactoryContract
+class CacheManager extends Manager implements FactoryContract
 {
-    /**
-     * The application instance.
-     *
-     * @var \Illuminate\Foundation\Application
-     */
-    protected $app;
-
-    /**
-     * The array of resolved cache stores.
-     *
-     * @var array
-     */
-    protected $stores = [];
-
-    /**
-     * The registered custom driver creators.
-     *
-     * @var array
-     */
-    protected $customCreators = [];
-
-    /**
-     * Create a new Cache manager instance.
-     *
-     * @param  \Illuminate\Foundation\Application  $app
-     * @return void
-     */
-    public function __construct($app)
-    {
-        $this->app = $app;
-    }
-
     /**
      * Get a cache store instance by name.
      *
@@ -53,71 +22,7 @@ class CacheManager implements FactoryContract
      */
     public function store($name = null)
     {
-        $name = $name ?: $this->getDefaultDriver();
-
-        return $this->stores[$name] = $this->get($name);
-    }
-
-    /**
-     * Get a cache driver instance.
-     *
-     * @param  string  $driver
-     * @return mixed
-     */
-    public function driver($driver = null)
-    {
-        return $this->store($driver);
-    }
-
-    /**
-     * Attempt to get the store from the local cache.
-     *
-     * @param  string  $name
-     * @return \Illuminate\Contracts\Cache\Repository
-     */
-    protected function get($name)
-    {
-        return $this->stores[$name] ?? $this->resolve($name);
-    }
-
-    /**
-     * Resolve the given store.
-     *
-     * @param  string  $name
-     * @return \Illuminate\Contracts\Cache\Repository
-     *
-     * @throws \InvalidArgumentException
-     */
-    protected function resolve($name)
-    {
-        $config = $this->getConfig($name);
-
-        if (is_null($config)) {
-            throw new InvalidArgumentException("Cache store [{$name}] is not defined.");
-        }
-
-        if (isset($this->customCreators[$config['driver']])) {
-            return $this->callCustomCreator($config);
-        } else {
-            $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
-
-            if (method_exists($this, $driverMethod)) {
-                return $this->{$driverMethod}($config);
-            } else {
-                throw new InvalidArgumentException("Driver [{$config['driver']}] is not supported.");
-            }
-        }
-    }
-
-    /**
-     * Call a custom driver creator.
-     *
-     * @param  array  $config
-     * @return mixed
-     */
-    protected function callCustomCreator(array $config)
-    {
-        return $this->customCreators[$config['driver']]($this->app, $config);
+        return $this->driver($name);
     }
 
     /**
@@ -254,7 +159,13 @@ class CacheManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        return $this->app['config']["cache.stores.{$name}"];
+        $config = $this->app['config']["cache.stores.{$name}"];
+
+        if (is_null($config)) {
+            throw new InvalidArgumentException("Cache store [{$name}] is not defined.");
+        }
+
+        return $config;
     }
 
     /**
@@ -276,31 +187,5 @@ class CacheManager implements FactoryContract
     public function setDefaultDriver($name)
     {
         $this->app['config']['cache.default'] = $name;
-    }
-
-    /**
-     * Register a custom driver creator Closure.
-     *
-     * @param  string    $driver
-     * @param  \Closure  $callback
-     * @return $this
-     */
-    public function extend($driver, Closure $callback)
-    {
-        $this->customCreators[$driver] = $callback->bindTo($this, $this);
-
-        return $this;
-    }
-
-    /**
-     * Dynamically call the default driver instance.
-     *
-     * @param  string  $method
-     * @param  array   $parameters
-     * @return mixed
-     */
-    public function __call($method, $parameters)
-    {
-        return $this->store()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -7,6 +7,7 @@ use Aws\S3\S3Client;
 use OpenCloud\Rackspace;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
+use Illuminate\Support\Manager;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\FilesystemInterface;
 use League\Flysystem\Cached\CachedAdapter;
@@ -21,51 +22,8 @@ use Illuminate\Contracts\Filesystem\Factory as FactoryContract;
 /**
  * @mixin \Illuminate\Contracts\Filesystem\Filesystem
  */
-class FilesystemManager implements FactoryContract
+class FilesystemManager extends Manager implements FactoryContract
 {
-    /**
-     * The application instance.
-     *
-     * @var \Illuminate\Contracts\Foundation\Application
-     */
-    protected $app;
-
-    /**
-     * The array of resolved filesystem drivers.
-     *
-     * @var array
-     */
-    protected $disks = [];
-
-    /**
-     * The registered custom driver creators.
-     *
-     * @var array
-     */
-    protected $customCreators = [];
-
-    /**
-     * Create a new filesystem manager instance.
-     *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return void
-     */
-    public function __construct($app)
-    {
-        $this->app = $app;
-    }
-
-    /**
-     * Get a filesystem instance.
-     *
-     * @param  string  $name
-     * @return \Illuminate\Contracts\Filesystem\Filesystem
-     */
-    public function drive($name = null)
-    {
-        return $this->disk($name);
-    }
-
     /**
      * Get a filesystem instance.
      *
@@ -74,9 +32,7 @@ class FilesystemManager implements FactoryContract
      */
     public function disk($name = null)
     {
-        $name = $name ?: $this->getDefaultDriver();
-
-        return $this->disks[$name] = $this->get($name);
+        return $this->driver($name);
     }
 
     /**
@@ -88,54 +44,19 @@ class FilesystemManager implements FactoryContract
     {
         $name = $this->getDefaultCloudDriver();
 
-        return $this->disks[$name] = $this->get($name);
-    }
-
-    /**
-     * Attempt to get the disk from the local cache.
-     *
-     * @param  string  $name
-     * @return \Illuminate\Contracts\Filesystem\Filesystem
-     */
-    protected function get($name)
-    {
-        return $this->disks[$name] ?? $this->resolve($name);
-    }
-
-    /**
-     * Resolve the given disk.
-     *
-     * @param  string  $name
-     * @return \Illuminate\Contracts\Filesystem\Filesystem
-     *
-     * @throws \InvalidArgumentException
-     */
-    protected function resolve($name)
-    {
-        $config = $this->getConfig($name);
-
-        if (isset($this->customCreators[$config['driver']])) {
-            return $this->callCustomCreator($config);
-        }
-
-        $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
-
-        if (method_exists($this, $driverMethod)) {
-            return $this->{$driverMethod}($config);
-        } else {
-            throw new InvalidArgumentException("Driver [{$config['driver']}] is not supported.");
-        }
+        return $this->driver($name);
     }
 
     /**
      * Call a custom driver creator.
      *
+     * @param  string $name
      * @param  array  $config
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
-    protected function callCustomCreator(array $config)
+    protected function callCustomCreator($name, array $config)
     {
-        $driver = $this->customCreators[$config['driver']]($this->app, $config);
+        $driver = $this->customCreators[$name]($this->app, $config);
 
         if ($driver instanceof FilesystemInterface) {
             return $this->adapt($driver);
@@ -308,7 +229,7 @@ class FilesystemManager implements FactoryContract
      */
     public function set($name, $disk)
     {
-        $this->disks[$name] = $disk;
+        $this->drivers[$name] = $disk;
     }
 
     /**
@@ -340,31 +261,5 @@ class FilesystemManager implements FactoryContract
     public function getDefaultCloudDriver()
     {
         return $this->app['config']['filesystems.cloud'];
-    }
-
-    /**
-     * Register a custom driver creator Closure.
-     *
-     * @param  string    $driver
-     * @param  \Closure  $callback
-     * @return $this
-     */
-    public function extend($driver, Closure $callback)
-    {
-        $this->customCreators[$driver] = $callback;
-
-        return $this;
-    }
-
-    /**
-     * Dynamically call the default driver instance.
-     *
-     * @param  string  $method
-     * @param  array   $parameters
-     * @return mixed
-     */
-    public function __call($method, $parameters)
-    {
-        return $this->disk()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -2,11 +2,9 @@
 
 namespace Illuminate\Filesystem;
 
-use Closure;
 use Aws\S3\S3Client;
 use OpenCloud\Rackspace;
 use Illuminate\Support\Arr;
-use InvalidArgumentException;
 use Illuminate\Support\Manager;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\FilesystemInterface;

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -121,14 +121,15 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      * Create a new driver instance.
      *
      * @param  string  $driver
+     * @param  array|null   $config
      * @return mixed
      *
      * @throws \InvalidArgumentException
      */
-    protected function createDriver($driver)
+    protected function createDriver($driver, $config = null)
     {
         try {
-            return parent::createDriver($driver);
+            return parent::createDriver($driver, $config);
         } catch (InvalidArgumentException $e) {
             if (class_exists($driver)) {
                 return $this->app->make($driver);

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -10,11 +10,12 @@ class SessionManager extends Manager
      * Call a custom driver creator.
      *
      * @param  string  $driver
+     * @param  array $config
      * @return mixed
      */
-    protected function callCustomCreator($driver)
+    protected function callCustomCreator($driver, array $config)
     {
-        return $this->buildSession(parent::callCustomCreator($driver));
+        return $this->buildSession(parent::callCustomCreator($driver, $config));
     }
 
     /**


### PR DESCRIPTION
This is a PR trying to resolve the situation that many Manager class have many duplicate code that `\Illuminate\Support\Manager` have.
ref: #22574 and laravel/internals#938

Those classes that not inherit `\Illuminate\Support\Manager` mostly because they have `config` need to pass to `createDriver` methods and they have "validation" on if the config is null or not, so that we can't just use `$this->app['config']['foo']['bar']` to get the value like some manager that inherit from `\Illuminate\Support\Manager`, for example `createNexmoDriver` method in `Illuminate\Notifications\ChannelManager` .
so the first approach would be do the "validation" in each `createDriver` methods, not sure if it's best so this PR use another approach that make `config` available from parent class `\Illuminate\Support\Manager`, this way those drivers that don't need config can working as usual, and those drivers that need config can now pass configuration and inherit `\Illuminate\Support\Manager` at same time, it also add the support if someone want use this Manager abstract class and want some config to be able to pass to drivers, but this is a **break change**.

This PR updated all managers except `Illuminate\Redis\RedisManager`, `Illuminate\Database\DatabaseManager` and `Illuminate\Queue\QueueManager`. these 3 manager have some unique implementation so I'd like to know if this PR have meanings or we shouldn't do this change at all first.