### PR TITLE
[5.5] Fix: verify csrf token allows to except full urls

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -104,7 +104,7 @@ class VerifyCsrfToken
                 $except = trim($except, '/');
             }
 
-            if ($request->is($except)) {
+            if ($request->url() == $except || $request->is($except)) {
                 return true;
             }
         }

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -104,7 +104,7 @@ class VerifyCsrfToken
                 $except = trim($except, '/');
             }
 
-            if ($request->url() == $except || $request->is($except)) {
+            if ($request->url() === $except || $request->is($except)) {
                 return true;
             }
         }


### PR DESCRIPTION
Currently, you can leave out certain URLs from CSRF token verification by adding them to the `except` array. This is provided with an out-of-the-box laravel application. 

However, this only works if you add the paths and not the full URLs. This PR makes sure it is also possible to provide full URLs to this except array.


