### PR TITLE
Singular migration name on pivot model command

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -80,7 +80,9 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function createMigration()
     {
-        $table = Str::plural(Str::snake(class_basename($this->argument('name'))));
+        $table = $this->option('pivot') ?
+            Str::snake(class_basename($this->argument('name'))) :
+            Str::plurar(Str::snake(class_basename($this->argument('name'))));
 
         $this->call('make:migration', [
             'name' => "create_{$table}_table",


### PR DESCRIPTION
Migration table on pivot should be singular not plural, based on Model [Pivot.php#L143](https://github.com/laravel/framework/blob/5.5/src/Illuminate/Database/Eloquent/Relations/Pivot.php#L143)

or if Pivot model should be a Model, then we should not override getTable() method on [Pivot.php#L139](https://github.com/laravel/framework/blob/5.5/src/Illuminate/Database/Eloquent/Relations/Pivot.php#L139)