### PR TITLE
[5.5] groupBy method in collection to support multiple levels

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -654,6 +654,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function groupBy($groupBy, $preserveKeys = false)
     {
+        if (is_array($groupBy)) {
+            $nextLevelGroups = $groupBy;
+
+            $groupBy = array_shift($nextLevelGroups);
+        }
         $groupBy = $this->valueRetriever($groupBy);
 
         $results = [];
@@ -676,7 +681,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             }
         }
 
-        return new static($results);
+        $result = new static($results);
+        if (! empty($nextLevelGroups)) {
+            return $result->map->groupBy($nextLevelGroups, $preserveKeys);
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1601,6 +1601,48 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected_result, $result->toArray());
     }
 
+    public function testGroupByMultiLevelAndClosurePreservingKeys()
+    {
+        $data = new Collection([
+            10 => ['user' => 1, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_3']],
+            20 => ['user' => 2, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_2']],
+            30 => ['user' => 3, 'skilllevel' => 2, 'roles' => ['Role_1']],
+            40 => ['user' => 4, 'skilllevel' => 2, 'roles' => ['Role_2']],
+        ]);
+
+        $result = $data->groupBy([
+            'skilllevel',
+            function ($item) {
+                return $item['roles'];
+            }
+        ], true);
+
+        $expected_result = [
+            1 => [
+                'Role_1' => [
+                    10 => ['user' => 1, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_3']],
+                    20 => ['user' => 2, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_2']],
+                ],
+                'Role_3' => [
+                    10 => ['user' => 1, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_3']],
+                ],
+                'Role_2' => [
+                    20 => ['user' => 2, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_2']],
+                ],
+            ],
+            2 => [
+                'Role_1' => [
+                    30 => ['user' => 3, 'skilllevel' => 2, 'roles' => ['Role_1']],
+                ],
+                'Role_2' => [
+                    40 => ['user' => 4, 'skilllevel' => 2, 'roles' => ['Role_2']],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected_result, $result->toArray());
+    }
+
     public function testKeyByAttribute()
     {
         $data = new Collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => '2'], ['rating' => 3, 'name' => '3']]);


### PR DESCRIPTION
Ever wanted to groupBy multiple levels? Simply specify the groupBy-criteria(s) as an array. Each array element will applied for the particular level within a multidimensional tree structure. For each level, the groupBy method works exactly the way before, so you can still use a callback for any level for example.

No clue what I'm talking about? Then take a look at the corresponding test helps maybe:

```php
public function testGroupByMultiLevelAndClosurePreservingKeys()
{
    $data = new Collection([
        10 => ['user' => 1, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_3']],
        20 => ['user' => 2, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_2']],
        30 => ['user' => 3, 'skilllevel' => 2, 'roles' => ['Role_1']],
        40 => ['user' => 4, 'skilllevel' => 2, 'roles' => ['Role_2']],
    ]);

    $result = $data->groupBy([
        'skilllevel',
        function ($item) {
            return $item['roles'];
        },
    ], true);

    $expected_result = [
        1 => [
            'Role_1' => [
                10 => ['user' => 1, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_3']],
                20 => ['user' => 2, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_2']],
            ],
            'Role_3' => [
                10 => ['user' => 1, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_3']],
            ],
            'Role_2' => [
                20 => ['user' => 2, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_2']],
            ],
        ],
        2 => [
            'Role_1' => [
                30 => ['user' => 3, 'skilllevel' => 2, 'roles' => ['Role_1']],
            ],
            'Role_2' => [
                40 => ['user' => 4, 'skilllevel' => 2, 'roles' => ['Role_2']],
            ],
        ],
    ];

    $this->assertEquals($expected_result, $result->toArray());
}
``` 

Even cooler if you can combine that with dot-syntax of `array_get()`:

```php
$user40 = array_get($result, '2.Role_2')->first();
```