### PR TITLE
[5.5] Avoid exposing empty string

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -510,7 +510,7 @@ class Command extends SymfonyCommand
         $this->comment('*     '.$string.'     *');
         $this->comment(str_repeat('*', strlen($string) + 12));
 
-        $this->output->newline();
+        $this->output->newLine();
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -510,7 +510,7 @@ class Command extends SymfonyCommand
         $this->comment('*     '.$string.'     *');
         $this->comment(str_repeat('*', strlen($string) + 12));
 
-        $this->output->writeln('');
+        $this->output->newline();
     }
 
     /**


### PR DESCRIPTION
Inspired by @taylorotwell tip "Avoid Exposing Booleans" :+1: 