### PR TITLE
[5.5] Update docblock render() method to return a string, rather than View

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -177,7 +177,7 @@ class Mailer implements MailerContract, MailQueueContract
      *
      * @param  string|array  $view
      * @param  array  $data
-     * @return \Illuminate\View\View
+     * @return string
      */
     public function render($view, array $data = [])
     {


### PR DESCRIPTION
Update docblock, fixes #22633