### PR TITLE
[5.6] Math DB functions should return numeric type

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2024,31 +2024,29 @@ class Builder
      * Retrieve the sum of the values of a given column.
      *
      * @param  string  $column
-     * @return mixed
+     * @return float|int
      */
     public function sum($column)
     {
-        $result = $this->aggregate(__FUNCTION__, [$column]);
-
-        return $result ?: 0;
+        return $this->numericAggregate(__FUNCTION__, [$column]);
     }
 
     /**
      * Retrieve the average of the values of a given column.
      *
      * @param  string  $column
-     * @return mixed
+     * @return float|int
      */
     public function avg($column)
     {
-        return $this->aggregate(__FUNCTION__, [$column]);
+        return $this->numericAggregate(__FUNCTION__, [$column]);
     }
 
     /**
      * Alias for the "avg" method.
      *
      * @param  string  $column
-     * @return mixed
+     * @return float|int
      */
     public function average($column)
     {


### PR DESCRIPTION
I've found one interesting thing when started to declare static types in one of my packages. Maybe I'm missing something, but it's not right that database query math functions like `avg` and `sum` returns `string` instead of `float` or `int`.

I understand that `min` & `max` functions are math too, but they could be used to get `DATE` & `TIMESTAMP` types. Is there any use cases for `avg` or `sum` functions where string could be returned?

Average dates are getting by converting them to Unix timestamps, calculating average value and then converting them to date value back.
 
Notice that we don't need this check: `return $result ?: 0;`. It's done in `numericAggregate` method.