### PR TITLE
[5.6] Optimize DB query numericAggregate method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2085,22 +2085,15 @@ class Builder
     {
         $result = $this->aggregate($function, $columns);
 
-        // If there is no result, we can obviously just return 0 here. Next, we will check
-        // if the result is an integer or float. If it is already one of these two data
-        // types we can just return the result as-is, otherwise we will convert this.
+        // If there is no result, we can obviously just return 0 here.
         if (! $result) {
             return 0;
         }
 
-        if (is_int($result) || is_float($result)) {
-            return $result;
-        }
-
-        // If the result doesn't contain a decimal place, we will assume it is an int then
-        // cast it to one. When it does we will cast it to a float since it needs to be
-        // cast to the expected data type for the developers out of pure convenience.
-        return strpos((string) $result, '.') === false
-                ? (int) $result : (float) $result;
+        // PHP automatically tries to coerce $result to a number if you try to add 0 to it.
+        // If the result contain a decimal place, it will be converted to float.
+        // If the result doesn't contain a decimal place, it will be converted to integer.
+        return $result + 0;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2091,8 +2091,7 @@ class Builder
         }
 
         // PHP automatically tries to coerce $result to a number if you try to add 0 to it.
-        // If the result contain a decimal place, it will be converted to float.
-        // If the result doesn't contain a decimal place, it will be converted to integer.
+        // If the result contain a decimal place, it will be converted to float, otherwise to integer.
         return $result + 0;
     }
 


### PR DESCRIPTION
This trick looks a bit magical, but it is working like a charm in PHP for a long time.

When you are trying to add `0` to string - PHP will try to convert it to `float` if there is decimal place, or to `int` if there is none.

So we can simplify this code:
```php
return strpos((string) $result, '.') === false ? (int) $result : (float) $result;
```

To this:
```php
return $result + 0;
```

It will help us to improve performance because we have removed:
1. Casting to `(string)`
2. Search in string for the `.` character
3. Ternary operator
4. Casting to `(int)` or `(float)`.

*I suppose it's doing the same thing, but on lower language level.*

Additionally we don't need checks `is_int` and `is_float` anymore, because I'm sure adding zero to integer or float is much cheaper then checking of the type. Especially 2 checks.
```php
if (is_int($result) || is_float($result)) {
    return $result;
}
````

Is there is a way object or something else except `string`, `int` or `float` can be in `$result`?
  