### PR TITLE
[5.5] Fix typo Query/Builder::where

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -480,7 +480,7 @@ class Builder
      * Add a basic where clause to the query.
      *
      * @param  string|array|\Closure  $column
-     * @param  string|null  $operator
+     * @param  mixed   $operator
      * @param  mixed   $value
      * @param  string  $boolean
      * @return $this


### PR DESCRIPTION
From the documentation:
> For convenience, if you simply want to verify that a column is equal to a given value, you may pass `the value` directly as the second argument to the where method:

We can't predict `the value`, right?