### PR TITLE
[5.6] Change class name and method to match new Logger class

### DIFF
--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -6,7 +6,7 @@ use Mockery as m;
 use Illuminate\Log\Logger;
 use PHPUnit\Framework\TestCase;
 
-class LogWriterTest extends TestCase
+class LogLoggerTest extends TestCase
 {
     public function tearDown()
     {
@@ -21,7 +21,7 @@ class LogWriterTest extends TestCase
         $writer->error('foo');
     }
 
-    public function testWriterFiresEventsDispatcher()
+    public function testLoggerFiresEventsDispatcher()
     {
         $writer = new Logger($monolog = m::mock('Monolog\Logger'), $events = new \Illuminate\Events\Dispatcher);
         $monolog->shouldReceive('error')->once()->with('foo', []);


### PR DESCRIPTION
Make sure test class name and method match Log changes from https://github.com/laravel/framework/pull/22635