### PR TITLE
[5.5] Fix parameter usage in RedirectController

### DIFF
--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -9,12 +9,13 @@ class RedirectController extends Controller
     /**
      * Invoke the controller method.
      *
-     * @param  string  $destination
-     * @param  int  $status
+     * @param  array  $args
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function __invoke($destination, $status = 301)
+    public function __invoke(...$args)
     {
+        list($destination, $status) = array_slice($args, -2);
+
         return new RedirectResponse($destination, $status);
     }
 }


### PR DESCRIPTION
If route parameters are present in registered _redirect_ routes, they are passed to the controller method previous to _$destination_ and _$status_, which results in invalid responses. This PR makes this controller handle these cases, just as it's handled in ViewController.