### PR TITLE
[5.5] Allow StudlyCase and snake_case migration names

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Console\Migrations;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Composer;
 use Illuminate\Database\Migrations\MigrationCreator;
 
@@ -63,7 +64,7 @@ class MigrateMakeCommand extends BaseCommand
         // It's possible for the developer to specify the tables to modify in this
         // schema operation. The developer may also specify if this table needs
         // to be freshly created so we can create the appropriate migrations.
-        $name = trim($this->input->getArgument('name'));
+        $name = Str::snake(trim($this->input->getArgument('name')));
 
         $table = $this->input->getOption('table');
 

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -42,6 +42,20 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $this->runCommand($command, ['name' => 'create_foo']);
     }
 
+    public function testBasicCreateGivesCreatorProperArgumentsWhenNameIsStudlyCase()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
+            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing()
+        );
+        $app = new \Illuminate\Foundation\Application;
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', null, false);
+
+        $this->runCommand($command, ['name' => 'CreateFoo']);
+    }
+
     public function testBasicCreateGivesCreatorProperArgumentsWhenTableIsSet()
     {
         $command = new MigrateMakeCommand(


### PR DESCRIPTION
This includes a small change to allow the developer to use a `StudlyCase` migration name for consistency with conventions used by other artisan commands.

This was previously with the new additions in #20760. However, since that was closed, I wanted to separate this as I believe it has value in core. 