### PR TITLE
[5.6] Use implode instead of alias

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -484,7 +484,7 @@ class Grammar extends BaseGrammar
     {
         $values = $this->parameterize($where['values']);
 
-        return '('.join(', ', $where['columns']).') '.$where['operator'].' ('.$values.')';
+        return '('.implode(', ', $where['columns']).') '.$where['operator'].' ('.$values.')';
     }
 
     /**


### PR DESCRIPTION
No need to use `join` in one place when in all the others `implode` is used