### PR TITLE
[5.5] Ensure Pivot models $dateFormat is used when creating a pivot record.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -313,6 +313,11 @@ trait InteractsWithPivotTable
     protected function addTimestampsToAttachment(array $record, $exists = false)
     {
         $fresh = $this->parent->freshTimestamp();
+        
+        if ($this->using) {
+            $pivotModel = new $this->using;
+            $fresh = $fresh->format($pivotModel::getDateFormat());
+        }
 
         if (! $exists && $this->hasPivotColumn($this->createdAt())) {
             $record[$this->createdAt()] = $fresh;

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -313,7 +313,7 @@ trait InteractsWithPivotTable
     protected function addTimestampsToAttachment(array $record, $exists = false)
     {
         $fresh = $this->parent->freshTimestamp();
-        
+
         if ($this->using) {
             $pivotModel = new $this->using;
             $fresh = $fresh->format($pivotModel::getDateFormat());


### PR DESCRIPTION
As with #22484 , when inserting a pivot record via `->attach()` the `InteractsWithPivotTable.php` trait doesn't check to see if the pivot table has a model representation. It' simply finds the table name and inserts a new record. Because of this, the timestamps are passed as `Carbon` instances and then turn to strings via its `toString()` method. If the consumer is using a pivot Model, it should use that models dateFormat to format by, not the `toString()` method. This simply news-up the pivot model, fetches it's dateformat and formats the `$fresh` date against it.