### PR TITLE
[5.5]  Fix parameter usage in RedirectController (with tests)

### DIFF
--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -9,12 +9,13 @@ class RedirectController extends Controller
     /**
      * Invoke the controller method.
      *
-     * @param  string  $destination
-     * @param  int  $status
+     * @param  array  $args
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function __invoke($destination, $status = 301)
+    public function __invoke(...$args)
     {
+        list($destination, $status) = array_slice($args, -2);
+
         return new RedirectResponse($destination, $status);
     }
 }

--- a/tests/Integration/Routing/RouteRedirectTest.php
+++ b/tests/Integration/Routing/RouteRedirectTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * @group integration
+ */
+class RouteRedirectTest extends TestCase
+{
+    public function test_route_redirect()
+    {
+        Route::redirect('from', 'to', 301);
+
+        $response = $this->get('/from');
+        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals('to', $response->headers->get('Location'));
+    }
+
+    public function test_route_redirect_with_params()
+    {
+        Route::redirect('from/{param}/{param2?}', 'to', 301);
+
+        $response = $this->get('/from/value1/value2');
+        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals('to', $response->headers->get('Location'));
+
+        $response = $this->get('/from/value1');
+        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals('to', $response->headers->get('Location'));
+    }
+}


### PR DESCRIPTION
If route parameters are present in registered _redirect_ routes, they are passed to the controller method previous to _$destination_ and _$status_, which results in invalid responses. This PR makes this controller handle these cases, just as it's handled in ViewController.