### PR TITLE
[5.6] Change session default driver key

### DIFF
--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -199,7 +199,7 @@ class SessionManager extends Manager
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['session.driver'];
+        return $this->app['config']['session.default'];
     }
 
     /**
@@ -210,6 +210,6 @@ class SessionManager extends Manager
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['session.driver'] = $name;
+        $this->app['config']['session.default'] = $name;
     }
 }


### PR DESCRIPTION
I'm not sure if that's the only place. For sure to make it pass also `orchestra/testbench-core` should be updated.

The reason of this change is that in almost all other places default driver has `default` key. 

Key `default` is used for:
- https://github.com/laravel/laravel/blob/master/config/broadcasting.php
- https://github.com/laravel/laravel/blob/master/config/cache.php
- https://github.com/laravel/laravel/blob/master/config/database.php
- https://github.com/laravel/laravel/blob/master/config/filesystems.php
- https://github.com/laravel/laravel/blob/master/config/queue.php

And key `driver` is used only for session and for: 
- https://github.com/laravel/laravel/blob/master/config/mail.php 

If approved I would suggest similar update for Mail to have consistency and use `default` as key for all drivers.