### PR TITLE
[5.5] add fullUrl wildcards to except array in VerifyCsrfToken

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -104,7 +104,7 @@ class VerifyCsrfToken
                 $except = trim($except, '/');
             }
 
-            if ($request->url() === $except || $request->is($except)) {
+            if ($request->fullUrlIs($except) || $request->is($except)) {
                 return true;
             }
         }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -157,6 +157,18 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->is('/'));
     }
 
+    public function testFullUrlIsMethod()
+    {
+        $request = Request::create('http://example.com/foo/bar', 'GET');
+
+        $this->assertTrue($request->fullUrlIs('http://example.com/foo/bar'));
+        $this->assertFalse($request->fullUrlIs('example.com*'));
+        $this->assertTrue($request->fullUrlIs('http://*'));
+        $this->assertTrue($request->fullUrlIs('*foo*'));
+        $this->assertTrue($request->fullUrlIs('*bar'));
+        $this->assertTrue($request->fullUrlIs('*'));
+    }
+
     public function testRouteIsMethod()
     {
         $request = Request::create('/foo/bar', 'GET');

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptStub.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptStub.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+
+class VerifyCsrfTokenExceptStub extends VerifyCsrfToken
+{
+    public function checkInExceptArray($request){
+        return $this->inExceptArray($request);
+    }
+
+    public function setExcept(array $except)
+    {
+        $this->except = $except;
+
+        return $this;
+    }
+}

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptStub.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptStub.php
@@ -6,7 +6,8 @@ use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 
 class VerifyCsrfTokenExceptStub extends VerifyCsrfToken
 {
-    public function checkInExceptArray($request){
+    public function checkInExceptArray($request)
+    {
         return $this->inExceptArray($request);
     }
 

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Middleware;
+
+use Mockery as m;
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+use Orchestra\Testbench\TestCase;
+
+class VerifyCsrfTokenExceptTest extends TestCase
+{
+    private $stub;
+    private $request;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->stub = new VerifyCsrfTokenExceptStub(app(), new Encrypter(Encrypter::generateKey('AES-128-CBC')));
+        $this->request = Request::create('http://example.com/foo/bar', 'POST');
+    }
+
+    public function testItCanExceptPaths()
+    {
+        $this->assertMatchingExcept(['/foo/bar']);
+        $this->assertMatchingExcept(['foo/bar']);
+        $this->assertNonMatchingExcept(['/bar/foo']);
+    }
+
+    public function testItCanExceptWildcardPaths()
+    {
+        $this->assertMatchingExcept(['/foo/*']);
+        $this->assertNonMatchingExcept(['/bar*']);
+    }
+
+    public function testItCanExceptFullUrlPaths()
+    {
+        $this->assertMatchingExcept(['http://example.com/foo/bar']);
+        $this->assertMatchingExcept(['http://example.com/foo/bar/']);
+
+        $this->assertNonMatchingExcept(['https://example.com/foo/bar/']);
+        $this->assertNonMatchingExcept(['http://foobar.com/']);
+    }
+
+    public function testItCanExceptFullUrlWildcardPaths()
+    {
+        $this->assertMatchingExcept(['http://example.com/*']);
+        $this->assertMatchingExcept(['*example.com*']);
+
+        $this->request = Request::create('https://example.com', 'POST');
+        $this->assertMatchingExcept(['*example.com']);
+    }
+
+    private function assertMatchingExcept(array $except, $bool = true)
+    {
+        $this->assertSame($bool, $this->stub->setExcept($except)->checkInExceptArray($this->request));
+    }
+
+    private function assertNonMatchingExcept(array $except)
+    {
+        return $this->assertMatchingExcept($except, false);
+    }
+
+}

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -2,11 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Http\Middleware;
 
-use Mockery as m;
-use Illuminate\Encryption\Encrypter;
-use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Orchestra\Testbench\TestCase;
+use Illuminate\Encryption\Encrypter;
 
 class VerifyCsrfTokenExceptTest extends TestCase
 {
@@ -61,5 +59,4 @@ class VerifyCsrfTokenExceptTest extends TestCase
     {
         return $this->assertMatchingExcept($except, false);
     }
-
 }


### PR DESCRIPTION
This is an improvement on the following PR that is already merged into 5.5.
https://github.com/laravel/framework/pull/22619

The former PR made sure full URLs could be passed in the `except` array of the VerifyCsrfToken middleware. This PR adds wildcard support for full URLs as well. It is fully compatible with existing behaviour: both paths and full URLs can be added, with or without the `*` wildcard. e.g.

```php
protected $except = [
    '/foo/bar',
    '/foo/*',
    'http://example.com/foo/bar', // Now possible to add full url with except matching
    'http://example.com/foo/*',   // or with wildcard
];
```

This PR contains tests on both the matching logic as well as for the request::fullUrlIs() method, which is used in the VerifyCsrfToken middleware.