### PR TITLE
[5.5] Adds method `abort` to Application Contract

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -40,8 +40,8 @@ interface Application extends Container
      * @return bool
      */
     public function isDownForMaintenance();
-    
-     /**
+
+    /**
      * Throw an HttpException with the given data.
      *
      * @param  int     $code

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -40,6 +40,18 @@ interface Application extends Container
      * @return bool
      */
     public function isDownForMaintenance();
+    
+     /**
+     * Throw an HttpException with the given data.
+     *
+     * @param  int     $code
+     * @param  string  $message
+     * @param  array   $headers
+     * @return void
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function abort($code, $message = '', array $headers = []);
 
     /**
      * Register all of the configured providers.


### PR DESCRIPTION
This PR addresses the addition of a method `abort` to the `Illuminate\Contracts\Foundation\Application`  interface.