### PR TITLE
[5.5] Remove unused variables in Closures

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2297,7 +2297,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->once()->with($page, $perPage)->andReturnSelf();
         $builder->shouldReceive('get')->once()->andReturn($results);
 
-        Paginator::currentPageResolver(function () use ($path) {
+        Paginator::currentPageResolver(function () {
             return 1;
         });
 
@@ -2328,7 +2328,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldNotReceive('forPage');
         $builder->shouldNotReceive('get');
 
-        Paginator::currentPageResolver(function () use ($path) {
+        Paginator::currentPageResolver(function () {
             return 1;
         });
 

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -153,14 +153,14 @@ class EventsDispatcherTest extends TestCase
     public function testEventPassedFirstToWildcards()
     {
         $d = new Dispatcher;
-        $d->listen('foo.*', function ($event, $data) use ($d) {
+        $d->listen('foo.*', function ($event, $data) {
             $this->assertEquals('foo.bar', $event);
             $this->assertEquals(['first', 'second'], $data);
         });
         $d->fire('foo.bar', ['first', 'second']);
 
         $d = new Dispatcher;
-        $d->listen('foo.bar', function ($first, $second) use ($d) {
+        $d->listen('foo.bar', function ($first, $second) {
             $this->assertEquals('first', $first);
             $this->assertEquals('second', $second);
         });


### PR DESCRIPTION
PS: I have restart `Travis CI` two times already due time out :-1: 