### PR TITLE
[5.6] Add @hasError Blade helper

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -35,4 +35,25 @@ trait CompilesHelpers
     {
         return "<?php echo method_field{$method}; ?>";
     }
+
+    /**
+     * Compile the hasError statements into valid PHP.
+     *
+     * @param  string  $field
+     * @return string
+     */
+    protected function compileHasError($field)
+    {
+        return "<?php if (\$errors->has{$field}): ?>";
+    }
+
+    /**
+     * Compile the end-hasError statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndHasError()
+    {
+        return '<?php endif; ?>';
+    }
 }

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -11,4 +11,15 @@ class BladeHelpersTest extends AbstractBladeTestCase
         $this->assertEquals('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));
         $this->assertEquals('<?php dd($var1, $var2); ?>', $this->compiler->compileString('@dd($var1, $var2)'));
     }
+
+    public function testHasSectionStatementsAreCompiled()
+    {
+        $string = '@hasError("email")
+This e-mail is incorrect
+@endhasError';
+        $expected = '<?php if ($errors->has("email")): ?>
+This e-mail is incorrect
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
Following idea of other helpers I think it's nice to have helper to verify if field has error. 
Instead of 

    @if ($errors->has('email') This e-mail is invalid @endif

we could use

    @hasError('email') This e-mail is invalid @endhasError

For me it looks cleaner. Also in cases when we apply CSS class it would be cleaner than

    {{ $errors->has('email') ? 'has-error' : '' }}

but looking at https://github.com/laravel/framework/pull/22293 I don't know if it will be approved :)