### PR TITLE
[5.6] Use valid property when assigning threads for ArgonHasher

### DIFF
--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -139,10 +139,10 @@ class ArgonHasher implements HasherContract
     /**
      * Extract the memory cost value from the options array.
      *
-     * @param $options
+     * @param  array  $options
      * @return int
      */
-    protected function memory($options)
+    protected function memory(array $options)
     {
         return $options['memory'] ?? $this->memory;
     }
@@ -150,10 +150,10 @@ class ArgonHasher implements HasherContract
     /**
      * Extract the time cost value from the options array.
      *
-     * @param $options
+     * @param  array  $options
      * @return int
      */
-    protected function time($options)
+    protected function time(array $options)
     {
         return $options['time'] ?? $this->time;
     }
@@ -161,10 +161,10 @@ class ArgonHasher implements HasherContract
     /**
      * Extract the threads value from the options array.
      *
-     * @param $options
+     * @param  array  $options
      * @return int
      */
-    protected function threads($options)
+    protected function threads(array $options)
     {
         return $options['threads'] ?? $this->threads;
     }

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -103,7 +103,7 @@ class ArgonHasher implements HasherContract
      */
     public function setProcessors(int $threads)
     {
-        $this->threads = $threads;
+        $this->processors = $threads;
 
         return $this;
     }

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -12,7 +12,7 @@ class ArgonHasher implements HasherContract
      *
      * @var int
      */
-    protected $processors = 2;
+    protected $threads = 2;
 
     /**
      * The default memory cost factor.
@@ -51,7 +51,7 @@ class ArgonHasher implements HasherContract
         $hash = password_hash($value, PASSWORD_ARGON2I, [
             'memory_cost' => $this->memory($options),
             'time_cost' => $this->time($options),
-            'threads' => $this->processors($options),
+            'threads' => $this->threads($options),
         ]);
 
         if ($hash === false) {
@@ -90,7 +90,7 @@ class ArgonHasher implements HasherContract
         return password_needs_rehash($hashedValue, PASSWORD_ARGON2I, [
             'memory_cost' => $this->memory($options),
             'time_cost' => $this->time($options),
-            'threads' => $this->processors($options),
+            'threads' => $this->threads($options),
         ]);
     }
 
@@ -101,9 +101,9 @@ class ArgonHasher implements HasherContract
      *
      * @return $this;
      */
-    public function setProcessors(int $threads)
+    public function setThreads(int $threads)
     {
-        $this->processors = $threads;
+        $this->threads = $threads;
 
         return $this;
     }
@@ -164,8 +164,8 @@ class ArgonHasher implements HasherContract
      * @param $options
      * @return int
      */
-    protected function processors($options)
+    protected function threads($options)
     {
-        return $options['processors'] ?? $this->processors;
+        return $options['threads'] ?? $this->threads;
     }
 }

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -27,6 +27,6 @@ class HasherTest extends TestCase
         $this->assertNotSame('password', $value);
         $this->assertTrue($hasher->check('password', $value));
         $this->assertFalse($hasher->needsRehash($value));
-        $this->assertTrue($hasher->needsRehash($value, ['processors' => 1]));
+        $this->assertTrue($hasher->needsRehash($value, ['threads' => 1]));
     }
 }


### PR DESCRIPTION
I might be wrong but it seems that `setProcessors` method should use `processors` property and not unexisting `threads` property. @morloderex  You can take a look to confirm as you were creating this class in https://github.com/laravel/framework/pull/21885