### PR TITLE
[5.5] Fix file upload testing bug with nested arrays

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -334,7 +334,7 @@ trait MakesHttpRequests
     {
         $kernel = $this->app->make(HttpKernel::class);
 
-        $files = array_merge($files, $this->extractFilesFromDataArray($parameters));
+        $files = array_merge_recursive($files, $this->extractFilesFromDataArray($parameters));
 
         $symfonyRequest = SymfonyRequest::create(
             $this->prepareUrlForRequest($uri), $method, $parameters,


### PR DESCRIPTION
This fixes a bug occurring when `$parameters` and `$files` share nested keys (`'foo'`):

```php
$this->call('POST', '/', ['foo' => ['name' => '']], [], ['foo' => ['file' => UploadedFile::fake()->image('image.jpg')]]);
```

In that case the uploaded files accidentally get removed from the request.