### PR TITLE
Add prefix to redis queue key

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -254,7 +254,7 @@ class RedisQueue extends Queue implements QueueContract
      */
     public function getQueue($queue)
     {
-        return 'queues:'.($queue ?: $this->default);
+        return config('queue.connections.redis.prefix', '').'queues:'.($queue ?: $this->default);
     }
 
     /**


### PR DESCRIPTION
Add abilities to add prefix for queue redis key.
It helps for 2 instances of laravel on same server for example.
Now prefix is possible only for phpredis library.

queue.connections.redis.prefix = 'project1:'  => redis queue key: project1:queues:...