### PR TITLE
[5.5] Add __set_state() method to Carbon, return correct type when loading from config cache

### DIFF
--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -45,4 +45,15 @@ class Carbon extends BaseCarbon implements JsonSerializable
     {
         static::$serializer = $callback;
     }
+
+    /**
+     * The __set_state handler.
+     *
+     * @param  array  $array
+     * @return static
+     */
+    public static function __set_state($array)
+    {
+        return static::instance(parent::__set_state($array));
+    }
 }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -93,4 +93,15 @@ class SupportCarbonTest extends TestCase
             'timezone' => 'UTC',
         ], $this->now->jsonSerialize());
     }
+
+    public function testSetStateReturnsCorrectType()
+    {
+        $carbon = Carbon::__set_state(array(
+            'date' => '2017-06-27 13:14:15.000000',
+            'timezone_type' => 3,
+            'timezone' => 'UTC',
+        ));
+
+        $this->assertInstanceOf(Carbon::class, $carbon);
+    }
 }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -96,11 +96,11 @@ class SupportCarbonTest extends TestCase
 
     public function testSetStateReturnsCorrectType()
     {
-        $carbon = Carbon::__set_state(array(
+        $carbon = Carbon::__set_state([
             'date' => '2017-06-27 13:14:15.000000',
             'timezone_type' => 3,
             'timezone' => 'UTC',
-        ));
+        ]);
 
         $this->assertInstanceOf(Carbon::class, $carbon);
     }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -104,4 +104,13 @@ class SupportCarbonTest extends TestCase
 
         $this->assertInstanceOf(Carbon::class, $carbon);
     }
+
+    public function testDeserializationOccursCorrectly()
+    {
+        $carbon = new Carbon('2017-06-27 13:14:15.000000');
+        $serialized = 'return '.var_export($carbon, true).';';
+        $deserialized = eval($serialized);
+
+        $this->assertInstanceOf(Carbon::class, $deserialized);
+    }
 }


### PR DESCRIPTION
Currently Carbon itself does not implement the `__set_state()` method, instead deferring to `DateTime::__set_state()` which returns an instance of `DateTime` not `Carbon`.

The Laravel config cache functionality uses `var_export()` to produce a string representation of a variable (see [here](https://github.com/laravel/framework/blob/da3d25051ebf8ebdaec23f366a3bd274c1e6bf1d/src/Illuminate/Foundation/Console/ConfigCacheCommand.php#L57)).

```php
var_export(Illuminate\Support\Carbon::now());

// Will output (as a string):
Illuminate\Support\Carbon::__set_state(array(
   'date' => '2018-01-08 15:56:34.340900',
   'timezone_type' => 3,
   'timezone' => 'UTC',
))

// But when executed, this produces:
// => DateTime @1515426994 {#848
//     date: 2018-01-08 15:56:34.340900 UTC (+00:00),
//    }
```

Ideally this would be fixed on Carbon itself, but the [PR I submitted](https://github.com/briannesbitt/Carbon/pull/950) hasn't received a response in 7 months. Since Carbon plays such a fundamental role in a lot of Laravel applications and config caching is a great feature, I feel that it would be beneficial to fix here. 