### PR TITLE
Fix To setGlobalAddress Method

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -75,7 +75,7 @@ class MailServiceProvider extends ServiceProvider
         $address = Arr::get($config, $type);
 
         if (is_array($address) && isset($address['address'])) {
-            $mailer->{'always'.Str::studly($type)}($address['address'], $address['name']);
+            $mailer->{'always'.Str::studly($type)}($address['address'], isset($address['name']) ? $address['name'] : NULL);
         }
     }
 

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -75,7 +75,8 @@ class MailServiceProvider extends ServiceProvider
         $address = Arr::get($config, $type);
 
         if (is_array($address) && isset($address['address'])) {
-            $mailer->{'always'.Str::studly($type)}($address['address'], isset($address['name']) ? $address['name'] : NULL);
+            $name = isset($address['name']) ? $address['name'] : NULL;
+            $mailer->{'always'.Str::studly($type)}($address['address'], $name);
         }
     }
 


### PR DESCRIPTION
This fixes a break using the Notification::route() method when sending
a notification to a single email address.  Currently this breaks
because it is looking for a ‘name’ index in the $address array, but it
doesn’t exist when using Notification::(‘mail’,
‘emailaddress’)->notify().