### PR TITLE
Assign permissions to a directory in recursive mode.

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -153,12 +153,17 @@ class Filesystem
     /**
      * Get or set UNIX mode of a file or directory.
      *
-     * @param  string  $path
-     * @param  int  $mode
+     * @param  string $path
+     * @param  int    $mode
+     * @param bool    $recursive
      * @return mixed
      */
-    public function chmod($path, $mode = null)
+    public function chmod($path, $mode = null, $recursive = false)
     {
+        if ($recursive){
+            return $this->chmod_r($path,$mode);
+        }
+
         if ($mode) {
             return chmod($path, $mode);
         }
@@ -562,5 +567,32 @@ class Filesystem
     public function cleanDirectory($directory)
     {
         return $this->deleteDirectory($directory, true);
+    }
+
+    /**
+     * Assign permissions in recursive mode.
+     *
+     * @param $directory
+     * @param $mode
+     * @return bool
+     */
+    private function chmod_r($directory, $mode)
+    {
+        if(!is_dir($directory)) {
+            return false;
+        }
+
+        $dir = new FilesystemIterator($directory);
+
+        foreach ($dir as $item) {
+
+            if ($item->isDir() && !$item->isLink()) {
+                $this->chmod_r($item->getPathname(),$mode);
+            }else{
+                $this->chmod($item->getPathname(), $mode);
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -47,6 +47,21 @@ class FilesystemTest extends TestCase
         $this->assertEquals('0755', $filePermission);
     }
 
+    public function testSetChmodRecursive()
+    {
+        $files = new Filesystem;
+        $files->makeDirectory($this->tempDir.'/temp2');
+        $files->makeDirectory($this->tempDir.'/temp2/temp3');
+        $files->put($this->tempDir.'/temp2/file1.txt','recursive1');
+        $files->put($this->tempDir.'/temp2/temp3/file2.txt','recursive2');
+        $files->chmod($this->tempDir.'/temp2', 0777, true);
+        $file1Permission = substr(sprintf('%o', fileperms($this->tempDir.'/temp2/file1.txt')), -4);
+        $file2Permission = substr(sprintf('%o', fileperms($this->tempDir.'/temp2/temp3/file2.txt')), -4);
+
+        $this->assertEquals('0777', $file1Permission);
+        $this->assertEquals('0777', $file2Permission);
+    }
+
     public function testGetChmod()
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');


### PR DESCRIPTION
I need this, maybe some of you too. Currently to apply permissions to some files in the same directory:

```
$fs->chmod('/temp/temp2/file1.txt', 0777);
$fs->chmod('/temp/temp2/temp3/file2.txt', 0777);
```

With this modification:

`$fs->chmod('/temp/temp2', 0777, true);`