### PR TITLE
[5.5] Parse $id when updating existing pivot

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -188,7 +188,7 @@ trait InteractsWithPivotTable
             $attributes = $this->addTimestampsToAttachment($attributes, true);
         }
 
-        $updated = $this->newPivotStatementForId($id)->update(
+        $updated = $this->newPivotStatementForId($this->parseIds($id))->update(
             $this->castAttributes($attributes)
         );
 


### PR DESCRIPTION
Use of the `parseIds` method to get a correct id when updating an existing pivot using the `updateExistingPivot` method.