### PR TITLE
[5.6] Added  default param to optional() helper

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -17,15 +17,23 @@ class Optional implements ArrayAccess
      */
     protected $value;
 
-    /**
+	/**
+	 * @var mixed|null
+	 */
+	protected $default;
+
+
+	/**
      * Create a new optional instance.
      *
      * @param  mixed  $value
+     * @param  mixed|null  $default
      * @return void
      */
-    public function __construct($value)
+    public function __construct($value, $default = null)
     {
         $this->value = $value;
+	    $this->default = $default;
     }
 
     /**
@@ -39,6 +47,8 @@ class Optional implements ArrayAccess
         if (is_object($this->value)) {
             return $this->value->{$key};
         }
+
+        return $this->default;
     }
 
     /**
@@ -57,6 +67,8 @@ class Optional implements ArrayAccess
         if (is_object($this->value)) {
             return $this->value->{$method}(...$parameters);
         }
+
+	    return $this->default;
     }
 
     /**
@@ -78,7 +90,7 @@ class Optional implements ArrayAccess
      */
     public function offsetGet($key)
     {
-        return Arr::get($this->value, $key);
+        return Arr::get($this->value, $key, $this->default);
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -718,11 +718,12 @@ if (! function_exists('optional')) {
      * Provide access to optional objects.
      *
      * @param  mixed  $value
+     * @param  mixed|null  $default
      * @return mixed
      */
-    function optional($value)
+    function optional($value, $default = null)
     {
-        return new Optional($value);
+        return new Optional($value, $default);
     }
 }
 


### PR DESCRIPTION
Added `$default` param to optional() helper. 
Now we can write `{{ optional($user->company, $user->name)->name() }}` instead of 
`{{ optional($user->company)->name() ?? $user->name }}`