### PR TITLE
[5.5] set null as default value for optional() helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -720,7 +720,7 @@ if (! function_exists('optional')) {
      * @param  mixed  $value
      * @return mixed
      */
-    function optional($value)
+    function optional($value = null)
     {
         return new Optional($value);
     }


### PR DESCRIPTION
This PR allows you to quickly create an object that always returns null using `$mock = optional();`. 