### PR TITLE
Use $strict param in functions that have it

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -87,7 +87,7 @@ class PasswordBrokerManager implements FactoryContract
         $key = $this->app['config']['app.key'];
 
         if (Str::startsWith($key, 'base64:')) {
-            $key = base64_decode(substr($key, 7));
+            $key = base64_decode(substr($key, 7), true);
         }
 
         $connection = $config['connection'] ?? null;

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -304,7 +304,7 @@ class Event
      */
     public function runsInEnvironment($environment)
     {
-        return empty($this->environments) || in_array($environment, $this->environments);
+        return empty($this->environments) || in_array($environment, $this->environments, true);
     }
 
     /**

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -159,6 +159,6 @@ class EncryptCookies
      */
     public function isDisabled($name)
     {
-        return in_array($name, $this->except);
+        return in_array($name, $this->except, true);
     }
 }

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -43,7 +43,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
         // First we will create the basic DSN setup as well as the port if it is in
         // in the configuration options. This will give us the basic DSN we will
         // need to establish the PDO connections and return them back for use.
-        if (in_array('dblib', $this->getAvailableDrivers())) {
+        if (in_array('dblib', $this->getAvailableDrivers(), true)) {
             return $this->getDblibDsn($config);
         } elseif ($this->prefersOdbc($config)) {
             return $this->getOdbcDsn($config);
@@ -60,7 +60,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
      */
     protected function prefersOdbc(array $config)
     {
-        return in_array('odbc', $this->getAvailableDrivers()) &&
+        return in_array('odbc', $this->getAvailableDrivers(), true) &&
                ($config['odbc'] ?? null) === true;
     }
 

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -76,7 +76,7 @@ class StatusCommand extends BaseCommand
                     ->map(function ($migration) use ($ran) {
                         $migrationName = $this->migrator->getMigrationName($migration);
 
-                        return in_array($migrationName, $ran)
+                        return in_array($migrationName, $ran, true)
                                 ? ['<info>Y</info>', $migrationName]
                                 : ['<fg=red>N</fg=red>', $migrationName];
                     });

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -679,7 +679,7 @@ class Builder
         // columns are returned as you would expect from these Eloquent models.
         if (! $this->model->hasGetMutator($column) &&
             ! $this->model->hasCast($column) &&
-            ! in_array($column, $this->model->getDates())) {
+            ! in_array($column, $this->model->getDates(), true)) {
             return $results;
         }
 
@@ -1277,7 +1277,7 @@ class Builder
             return $this->callScope([$this->model, $scope], $parameters);
         }
 
-        if (in_array($method, $this->passthru)) {
+        if (in_array($method, $this->passthru, true)) {
             return $this->toBase()->{$method}(...$parameters);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -140,7 +140,7 @@ trait GuardsAttributes
         // If the key is in the "fillable" array, we can of course assume that it's
         // a fillable attribute. Otherwise, we will check the guarded array when
         // we need to determine if the attribute is black-listed on the model.
-        if (in_array($key, $this->getFillable())) {
+        if (in_array($key, $this->getFillable(), true)) {
             return true;
         }
 
@@ -163,7 +163,7 @@ trait GuardsAttributes
      */
     public function isGuarded($key)
     {
-        return in_array($key, $this->getGuarded()) || $this->getGuarded() == ['*'];
+        return in_array($key, $this->getGuarded(), true) || $this->getGuarded() == ['*'];
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -171,7 +171,7 @@ trait HasAttributes
     protected function addCastAttributesToArray(array $attributes, array $mutatedAttributes)
     {
         foreach ($this->getCasts() as $key => $value) {
-            if (! array_key_exists($key, $attributes) || in_array($key, $mutatedAttributes)) {
+            if (! array_key_exists($key, $attributes) || in_array($key, $mutatedAttributes, true)) {
                 continue;
             }
 
@@ -350,7 +350,7 @@ trait HasAttributes
         // If the attribute is listed as a date, we will convert it to a DateTime
         // instance on retrieval, which makes it quite convenient to work with
         // date fields without having to create a mutator for each property.
-        if (in_array($key, $this->getDates()) &&
+        if (in_array($key, $this->getDates(), true) &&
             ! is_null($value)) {
             return $this->asDateTime($value);
         }
@@ -567,7 +567,7 @@ trait HasAttributes
      */
     protected function isDateAttribute($key)
     {
-        return in_array($key, $this->getDates()) ||
+        return in_array($key, $this->getDates(), true) ||
                                     $this->isDateCastable($key);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -550,7 +550,7 @@ trait HasRelationships
     protected function guessBelongsToManyRelation()
     {
         $caller = Arr::first(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), function ($trace) {
-            return ! in_array($trace['function'], Model::$manyMethods);
+            return ! in_array($trace['function'], Model::$manyMethods, true);
         });
 
         return ! is_null($caller) ? $caller['function'] : null;
@@ -588,7 +588,7 @@ trait HasRelationships
      */
     public function touches($relation)
     {
-        return in_array($relation, $this->touches);
+        return in_array($relation, $this->touches, true);
     }
 
     /**
@@ -635,7 +635,7 @@ trait HasRelationships
     {
         $morphMap = Relation::morphMap();
 
-        if (! empty($morphMap) && in_array(static::class, $morphMap)) {
+        if (! empty($morphMap) && in_array(static::class, $morphMap, true)) {
             return array_search(static::class, $morphMap, true);
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1463,7 +1463,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function __call($method, $parameters)
     {
-        if (in_array($method, ['increment', 'decrement'])) {
+        if (in_array($method, ['increment', 'decrement'], true)) {
             return $this->$method(...$parameters);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -184,7 +184,7 @@ trait InteractsWithPivotTable
      */
     public function updateExistingPivot($id, array $attributes, $touch = true)
     {
-        if (in_array($this->updatedAt(), $this->pivotColumns)) {
+        if (in_array($this->updatedAt(), $this->pivotColumns, true)) {
             $attributes = $this->addTimestampsToAttachment($attributes, true);
         }
 
@@ -333,7 +333,7 @@ trait InteractsWithPivotTable
      */
     protected function hasPivotColumn($column)
     {
-        return in_array($column, $this->pivotColumns);
+        return in_array($column, $this->pivotColumns, true);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -137,7 +137,7 @@ class HasManyThrough extends Relation
     {
         return in_array(SoftDeletes::class, class_uses_recursive(
             get_class($this->throughParent)
-        ));
+        ), true);
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -108,7 +108,7 @@ class Migrator
     {
         return Collection::make($files)
                 ->reject(function ($file) use ($ran) {
-                    return in_array($this->getMigrationName($file), $ran);
+                    return in_array($this->getMigrationName($file), $ran, true);
                 })->values()->all();
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -605,8 +605,8 @@ class Builder
      */
     protected function invalidOperatorAndValue($operator, $value)
     {
-        return is_null($value) && in_array($operator, $this->operators) &&
-             ! in_array($operator, ['=', '<>', '!=']);
+        return is_null($value) && in_array($operator, $this->operators, true) &&
+             ! in_array($operator, ['=', '<>', '!='], true);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -182,7 +182,7 @@ class MySqlGrammar extends Grammar
     {
         $values = collect($values)->reject(function ($value, $column) {
             return $this->isJsonSelector($column) &&
-                in_array(gettype($value), ['boolean', 'integer', 'double']);
+                in_array(gettype($value), ['boolean', 'integer', 'double'], true);
         })->all();
 
         return parent::prepareBindingsForUpdate($bindings, $values);

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -84,7 +84,7 @@ class Builder
     public function hasColumn($table, $column)
     {
         return in_array(
-            strtolower($column), array_map('strtolower', $this->getColumnListing($table))
+            strtolower($column), array_map('strtolower', $this->getColumnListing($table)), true
         );
     }
 
@@ -100,7 +100,7 @@ class Builder
         $tableColumns = array_map('strtolower', $this->getColumnListing($table));
 
         foreach ($columns as $column) {
-            if (! in_array(strtolower($column), $tableColumns)) {
+            if (! in_array(strtolower($column), $tableColumns, true)) {
                 return false;
             }
         }

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -114,7 +114,7 @@ class ChangeColumn
     {
         $options = ['type' => static::getDoctrineColumnType($fluent['type'])];
 
-        if (in_array($fluent['type'], ['text', 'mediumText', 'longText'])) {
+        if (in_array($fluent['type'], ['text', 'mediumText', 'longText'], true)) {
             $options['length'] = static::calculateDoctrineTextLength($fluent['type']);
         }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -903,7 +903,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
-        if (in_array($column->type, $this->serials) && $column->autoIncrement) {
+        if (in_array($column->type, $this->serials, true) && $column->autoIncrement) {
             return ' auto_increment primary key';
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -795,7 +795,7 @@ class PostgresGrammar extends Grammar
      */
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
-        if (in_array($column->type, $this->serials) && $column->autoIncrement) {
+        if (in_array($column->type, $this->serials, true) && $column->autoIncrement) {
             return ' primary key';
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -792,7 +792,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
-        if (in_array($column->type, $this->serials) && $column->autoIncrement) {
+        if (in_array($column->type, $this->serials, true) && $column->autoIncrement) {
             return ' primary key autoincrement';
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -763,7 +763,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
-        if (in_array($column->type, $this->serials) && $column->autoIncrement) {
+        if (in_array($column->type, $this->serials, true) && $column->autoIncrement) {
             return ' identity primary key';
         }
     }

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -37,7 +37,7 @@ class PostgresBuilder extends Builder
 
             $table = reset($row);
 
-            if (! in_array($table, $excludedTables)) {
+            if (! in_array($table, $excludedTables, true)) {
                 $tables[] = $table;
             }
         }
@@ -93,7 +93,7 @@ class PostgresBuilder extends Builder
         $table = explode('.', $table);
 
         if (is_array($schema = $this->connection->getConfig('schema'))) {
-            if (in_array($table[0], $schema)) {
+            if (in_array($table[0], $schema, true)) {
                 return [array_shift($table), implode('.', $table)];
             }
 

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -133,7 +133,7 @@ class Encrypter implements EncrypterContract
     {
         $payload = $this->getJsonPayload($payload);
 
-        $iv = base64_decode($payload['iv']);
+        $iv = base64_decode($payload['iv'], true);
 
         // Here we will decrypt the value. If we are able to successfully decrypt it
         // we will then unserialize it and return it out to the caller. If we are
@@ -182,7 +182,7 @@ class Encrypter implements EncrypterContract
      */
     protected function getJsonPayload($payload)
     {
-        $payload = json_decode(base64_decode($payload), true);
+        $payload = json_decode(base64_decode($payload, true), true);
 
         // If the payload is not valid JSON or does not have the proper keys set we will
         // assume it is invalid and bail out of the routine since we will not be able

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -22,7 +22,7 @@ class EncryptionServiceProvider extends ServiceProvider
             // it off to the encrypter. Keys may be base-64 encoded for presentation and we
             // want to make sure to convert them back to the raw bytes before encrypting.
             if (Str::startsWith($key = $this->key($config), 'base64:')) {
-                $key = base64_decode(substr($key, 7));
+                $key = base64_decode(substr($key, 7), true);
             }
 
             return new Encrypter($key, $config['cipher']);

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -96,7 +96,7 @@ class CallQueuedListener implements ShouldQueue
      */
     protected function setJobInstanceIfNecessary(Job $job, $instance)
     {
-        if (in_array(InteractsWithQueue::class, class_uses_recursive(get_class($instance)))) {
+        if (in_array(InteractsWithQueue::class, class_uses_recursive(get_class($instance)), true)) {
             $instance->setJob($job);
         }
 

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -87,7 +87,7 @@ trait AuthorizesRequests
         $middleware = [];
 
         foreach ($this->resourceAbilityMap() as $method => $ability) {
-            $modelName = in_array($method, $this->resourceMethodsWithoutModels()) ? $model : $parameter;
+            $modelName = in_array($method, $this->resourceMethodsWithoutModels(), true) ? $model : $parameter;
 
             $middleware["can:{$ability},{$modelName}"][] = $method;
         }

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -146,7 +146,7 @@ class HandleExceptions
      */
     protected function isFatal($type)
     {
-        return in_array($type, [E_COMPILE_ERROR, E_CORE_ERROR, E_ERROR, E_PARSE]);
+        return in_array($type, [E_COMPILE_ERROR, E_CORE_ERROR, E_ERROR, E_PARSE], true);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -32,7 +32,7 @@ class PresetCommand extends Command
             return call_user_func(static::$macros[$this->argument('type')], $this);
         }
 
-        if (! in_array($this->argument('type'), ['none', 'bootstrap', 'vue', 'react'])) {
+        if (! in_array($this->argument('type'), ['none', 'bootstrap', 'vue', 'react'], true)) {
             throw new InvalidArgumentException('Invalid preset.');
         }
 

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -260,7 +260,7 @@ class Kernel implements KernelContract
      */
     public function hasMiddleware($middleware)
     {
-        return in_array($middleware, $this->middleware);
+        return in_array($middleware, $this->middleware, true);
     }
 
     /**
@@ -271,7 +271,7 @@ class Kernel implements KernelContract
      */
     public function prependMiddleware($middleware)
     {
-        if (array_search($middleware, $this->middleware) === false) {
+        if (array_search($middleware, $this->middleware, true) === false) {
             array_unshift($this->middleware, $middleware);
         }
 
@@ -286,7 +286,7 @@ class Kernel implements KernelContract
      */
     public function pushMiddleware($middleware)
     {
-        if (array_search($middleware, $this->middleware) === false) {
+        if (array_search($middleware, $this->middleware, true) === false) {
             $this->middleware[] = $middleware;
         }
 

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -78,7 +78,7 @@ class VerifyCsrfToken
      */
     protected function isReading($request)
     {
-        return in_array($request->method(), ['HEAD', 'GET', 'OPTIONS']);
+        return in_array($request->method(), ['HEAD', 'GET', 'OPTIONS'], true);
     }
 
     /**

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -114,14 +114,14 @@ class PackageManifest
             $packages = json_decode($this->files->get($path), true);
         }
 
-        $ignoreAll = in_array('*', $ignore = $this->packagesToIgnore());
+        $ignoreAll = in_array('*', $ignore = $this->packagesToIgnore(), true);
 
         $this->write(collect($packages)->mapWithKeys(function ($package) {
             return [$this->format($package['name']) => $package['extra']['laravel'] ?? []];
         })->each(function ($configuration) use (&$ignore) {
             $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);
         })->reject(function ($configuration, $package) use ($ignore, $ignoreAll) {
-            return $ignoreAll || in_array($package, $ignore);
+            return $ignoreAll || in_array($package, $ignore, true);
         })->filter()->all());
     }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -100,7 +100,7 @@ trait InteractsWithContentTypes
         $contentTypes = (array) $contentTypes;
 
         foreach ($accepts as $accept) {
-            if (in_array($accept, ['*/*', '*'])) {
+            if (in_array($accept, ['*/*', '*'], true)) {
                 return $contentTypes[0];
             }
 

--- a/src/Illuminate/Http/Testing/MimeType.php
+++ b/src/Illuminate/Http/Testing/MimeType.php
@@ -811,7 +811,7 @@ class MimeType
      */
     public static function search($mimeType)
     {
-        return array_search($mimeType, self::$mimes) ?: null;
+        return array_search($mimeType, self::$mimes, true) ?: null;
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -85,7 +85,7 @@ class CallQueuedHandler
      */
     protected function setJobInstanceIfNecessary(Job $job, $instance)
     {
-        if (in_array(InteractsWithQueue::class, class_uses_recursive(get_class($instance)))) {
+        if (in_array(InteractsWithQueue::class, class_uses_recursive(get_class($instance)), true)) {
             $instance->setJob($job);
         }
 

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -75,7 +75,7 @@ class ControllerDispatcher implements ControllerDispatcherContract
      */
     protected static function methodExcludedByOptions($method, array $options)
     {
-        return (isset($options['only']) && ! in_array($method, (array) $options['only'])) ||
-            (! empty($options['except']) && in_array($method, (array) $options['except']));
+        return (isset($options['only']) && ! in_array($method, (array) $options['only'], true)) ||
+            (! empty($options['except']) && in_array($method, (array) $options['except'], true));
     }
 }

--- a/src/Illuminate/Routing/Matching/MethodValidator.php
+++ b/src/Illuminate/Routing/Matching/MethodValidator.php
@@ -16,6 +16,6 @@ class MethodValidator implements ValidatorInterface
      */
     public function matches(Route $route, Request $request)
     {
-        return in_array($request->getMethod(), $route->methods());
+        return in_array($request->getMethod(), $route->methods(), true);
     }
 }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -133,7 +133,7 @@ class Route
         $this->methods = (array) $methods;
         $this->action = $this->parseAction($action);
 
-        if (in_array('GET', $this->methods) && ! in_array('HEAD', $this->methods)) {
+        if (in_array('GET', $this->methods, true) && ! in_array('HEAD', $this->methods, true)) {
             $this->methods[] = 'HEAD';
         }
 

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -72,7 +72,7 @@ class RouteRegistrar
      */
     public function attribute($key, $value)
     {
-        if (! in_array($key, $this->allowedAttributes)) {
+        if (! in_array($key, $this->allowedAttributes, true)) {
             throw new InvalidArgumentException("Attribute [{$key}] does not exist.");
         }
 
@@ -163,11 +163,11 @@ class RouteRegistrar
      */
     public function __call($method, $parameters)
     {
-        if (in_array($method, $this->passthru)) {
+        if (in_array($method, $this->passthru, true)) {
             return $this->registerRoute($method, ...$parameters);
         }
 
-        if (in_array($method, $this->allowedAttributes)) {
+        if (in_array($method, $this->allowedAttributes, true)) {
             if ($method == 'middleware') {
                 return $this->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
             }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -853,7 +853,7 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function prependMiddlewareToGroup($group, $middleware)
     {
-        if (isset($this->middlewareGroups[$group]) && ! in_array($middleware, $this->middlewareGroups[$group])) {
+        if (isset($this->middlewareGroups[$group]) && ! in_array($middleware, $this->middlewareGroups[$group], true)) {
             array_unshift($this->middlewareGroups[$group], $middleware);
         }
 
@@ -875,7 +875,7 @@ class Router implements RegistrarContract, BindingRegistrar
             $this->middlewareGroups[$group] = [];
         }
 
-        if (! in_array($middleware, $this->middlewareGroups[$group])) {
+        if (! in_array($middleware, $this->middlewareGroups[$group], true)) {
             $this->middlewareGroups[$group][] = $middleware;
         }
 

--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -42,8 +42,8 @@ class SortedMiddleware extends Collection
 
             $stripped = head(explode(':', $middleware));
 
-            if (in_array($stripped, $priorityMap)) {
-                $priorityIndex = array_search($stripped, $priorityMap);
+            if (in_array($stripped, $priorityMap, true)) {
+                $priorityIndex = array_search($stripped, $priorityMap, true);
 
                 // This middleware is in the priority map. If we have encountered another middleware
                 // that was also in the priority map and was at a lower priority than the current

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -99,7 +99,7 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
         if (isset($session->payload)) {
             $this->exists = true;
 
-            return base64_decode($session->payload);
+            return base64_decode($session->payload, true);
         }
 
         return '';

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -223,7 +223,7 @@ class StartSession
     {
         $config = $config ?: $this->manager->getSessionConfig();
 
-        return ! in_array($config['driver'], [null, 'array']);
+        return ! in_array($config['driver'], [null, 'array'], true);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -223,7 +223,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 return $this->first($key, $placeholder) !== $placeholder;
             }
 
-            return in_array($key, $this->items);
+            return in_array($key, $this->items, true);
         }
 
         return $this->contains($this->operatorForWhere(...func_get_args()));
@@ -483,7 +483,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             });
 
             if (count($strings) < 2 && count(array_filter([$retrieved, $value], 'is_object')) == 1) {
-                return in_array($operator, ['!=', '<>', '!==']);
+                return in_array($operator, ['!=', '<>', '!=='], true);
             }
 
             switch ($operator) {
@@ -1779,7 +1779,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function __get($key)
     {
-        if (! in_array($key, static::$proxies)) {
+        if (! in_array($key, static::$proxies, true)) {
             throw new Exception("Property [{$key}] does not exist on this collection instance.");
         }
 

--- a/src/Illuminate/Support/Debug/Dumper.php
+++ b/src/Illuminate/Support/Debug/Dumper.php
@@ -16,7 +16,7 @@ class Dumper
     public function dump($value)
     {
         if (class_exists(CliDumper::class)) {
-            $dumper = in_array(PHP_SAPI, ['cli', 'phpdbg']) ? new CliDumper : new HtmlDumper;
+            $dumper = in_array(PHP_SAPI, ['cli', 'phpdbg'], true) ? new CliDumper : new HtmlDumper;
 
             $dumper->dump((new VarCloner)->cloneVar($value));
         } else {

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -76,7 +76,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     {
         $messages = (array) $this->messages;
 
-        return ! isset($messages[$key]) || ! in_array($message, $messages[$key]);
+        return ! isset($messages[$key]) || ! in_array($message, $messages[$key], true);
     }
 
     /**

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -94,7 +94,7 @@ class Pluralizer
      */
     protected static function uncountable($value)
     {
-        return in_array(strtolower($value), static::$uncountable);
+        return in_array(strtolower($value), static::$uncountable, true);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -222,7 +222,7 @@ class EventFake implements Dispatcher
      */
     protected function shouldFakeEvent($eventName)
     {
-        return empty($this->eventsToFake) || in_array($eventName, $this->eventsToFake);
+        return empty($this->eventsToFake) || in_array($eventName, $this->eventsToFake, true);
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -466,7 +466,7 @@ if (! function_exists('data_get')) {
 
                 $result = Arr::pluck($target, $key);
 
-                return in_array('*', $key) ? Arr::collapse($result) : $result;
+                return in_array('*', $key, true) ? Arr::collapse($result) : $result;
             }
 
             if (Arr::accessible($target) && Arr::exists($target, $segment)) {

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -45,7 +45,7 @@ trait FormatsMessages
         // If the rule being validated is a "size" rule, we will need to gather the
         // specific error message for the type of attribute being validated such
         // as a number, file or string which all have different message types.
-        elseif (in_array($rule, $this->sizeRules)) {
+        elseif (in_array($rule, $this->sizeRules, true)) {
             return $this->getSizeMessage($attribute, $rule);
         }
 
@@ -74,7 +74,7 @@ trait FormatsMessages
     {
         $inlineEntry = $this->getFromLocalArray($attribute, Str::snake($rule));
 
-        return is_array($inlineEntry) && in_array($rule, $this->sizeRules)
+        return is_array($inlineEntry) && in_array($rule, $this->sizeRules, true)
                     ? $inlineEntry[$this->getAttributeType($attribute)]
                     : $inlineEntry;
     }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -528,11 +528,11 @@ trait ValidatesAttributes
             return $key != $attribute && (bool) preg_match('#^'.$pattern.'\z#u', $key);
         });
 
-        if (in_array('ignore_case', $parameters)) {
+        if (in_array('ignore_case', $parameters, true)) {
             return empty(preg_grep('/^'.preg_quote($value, '/').'$/iu', $data));
         }
 
-        return ! in_array($value, array_values($data));
+        return ! in_array($value, array_values($data), true);
     }
 
     /**
@@ -726,7 +726,7 @@ trait ValidatesAttributes
      */
     public function guessColumnForQuery($attribute)
     {
-        if (in_array($attribute, Arr::collapse($this->implicitAttributes))
+        if (in_array($attribute, Arr::collapse($this->implicitAttributes), true)
                 && ! is_numeric($last = last(explode('.', $attribute)))) {
             return $last;
         }
@@ -813,7 +813,7 @@ trait ValidatesAttributes
             return count(array_diff($value, $parameters)) == 0;
         }
 
-        return ! is_array($value) && in_array((string) $value, $parameters);
+        return ! is_array($value) && in_array((string) $value, $parameters, true);
     }
 
     /**
@@ -836,7 +836,7 @@ trait ValidatesAttributes
             return Str::is($parameters[0], $key);
         });
 
-        return in_array($value, $otherValues);
+        return in_array($value, $otherValues, true);
     }
 
     /**
@@ -942,7 +942,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return $value->getPath() !== '' && in_array($value->guessExtension(), $parameters);
+        return $value->getPath() !== '' && in_array($value->guessExtension(), $parameters, true);
     }
 
     /**
@@ -964,8 +964,8 @@ trait ValidatesAttributes
         }
 
         return $value->getPath() !== '' &&
-                (in_array($value->getMimeType(), $parameters) ||
-                 in_array(explode('/', $value->getMimeType())[0].'/*', $parameters));
+                (in_array($value->getMimeType(), $parameters, true) ||
+                 in_array(explode('/', $value->getMimeType())[0].'/*', $parameters, true));
     }
 
     /**
@@ -977,7 +977,7 @@ trait ValidatesAttributes
      */
     protected function shouldBlockPhpUpload($value, $parameters)
     {
-        if (in_array('php', $parameters)) {
+        if (in_array('php', $parameters, true)) {
             return false;
         }
 
@@ -1111,7 +1111,7 @@ trait ValidatesAttributes
             $values = $this->convertValuesToBoolean($values);
         }
 
-        if (in_array($other, $values)) {
+        if (in_array($other, $values, true)) {
             return $this->validateRequired($attribute, $value);
         }
 
@@ -1153,7 +1153,7 @@ trait ValidatesAttributes
 
         $values = array_slice($parameters, 1);
 
-        if (! in_array($data, $values)) {
+        if (! in_array($data, $values, true)) {
             return $this->validateRequired($attribute, $value);
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -369,7 +369,7 @@ class Validator implements ValidatorContract
      */
     protected function dependsOnOtherFields($rule)
     {
-        return in_array($rule, $this->dependentRules);
+        return in_array($rule, $this->dependentRules, true);
     }
 
     /**
@@ -404,7 +404,7 @@ class Validator implements ValidatorContract
     protected function getPrimaryAttribute($attribute)
     {
         foreach ($this->implicitAttributes as $unparsed => $parsed) {
-            if (in_array($attribute, $parsed)) {
+            if (in_array($attribute, $parsed, true)) {
                 return $unparsed;
             }
         }
@@ -469,7 +469,7 @@ class Validator implements ValidatorContract
     protected function isImplicit($rule)
     {
         return $rule instanceof ImplicitRule ||
-               in_array($rule, $this->implicitRules);
+               in_array($rule, $this->implicitRules, true);
     }
 
     /**
@@ -487,7 +487,7 @@ class Validator implements ValidatorContract
         $data = ValidationData::initializeAndGatherData($attribute, $this->data);
 
         return array_key_exists($attribute, $data)
-                    || in_array($attribute, array_keys($this->data));
+                    || in_array($attribute, array_keys($this->data), true);
     }
 
     /**
@@ -517,7 +517,7 @@ class Validator implements ValidatorContract
      */
     protected function hasNotFailedPreviousRuleIfPresenceRule($rule, $attribute)
     {
-        return in_array($rule, ['Unique', 'Exists']) ? ! $this->messages->has($attribute) : true;
+        return in_array($rule, ['Unique', 'Exists'], true) ? ! $this->messages->has($attribute) : true;
     }
 
     /**
@@ -552,7 +552,7 @@ class Validator implements ValidatorContract
         }
 
         if (isset($this->failedRules[$attribute]) &&
-            in_array('uploaded', array_keys($this->failedRules[$attribute]))) {
+            in_array('uploaded', array_keys($this->failedRules[$attribute]), true)) {
             return true;
         }
 
@@ -699,7 +699,7 @@ class Validator implements ValidatorContract
         foreach ($this->rules[$attribute] as $rule) {
             list($rule, $parameters) = ValidationRuleParser::parse($rule);
 
-            if (in_array($rule, $rules)) {
+            if (in_array($rule, $rules, true)) {
                 return [$rule, $parameters];
             }
         }

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -228,7 +228,7 @@ class FileViewFinder implements ViewFinderInterface
      */
     public function addExtension($extension)
     {
-        if (($index = array_search($extension, $this->extensions)) !== false) {
+        if (($index = array_search($extension, $this->extensions, true)) !== false) {
             unset($this->extensions[$index]);
         }
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -165,7 +165,7 @@ class DatabaseConnectorTest extends TestCase
     {
         extract($config, EXTR_SKIP);
 
-        if (in_array('dblib', PDO::getAvailableDrivers())) {
+        if (in_array('dblib', PDO::getAvailableDrivers(), true)) {
             $port = isset($config['port']) ? ':'.$port : '';
             $appname = isset($config['appname']) ? ';appname='.$config['appname'] : '';
             $charset = isset($config['charset']) ? ';charset='.$config['charset'] : '';

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -53,8 +53,8 @@ class ThrottleRequestsWithRedisTest extends TestCase
                 $this->assertEquals(429, $e->getStatusCode());
                 $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
                 $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
-                $this->assertTrue(in_array($e->getHeaders()['Retry-After'], [2, 3]));
-                $this->assertTrue(in_array($e->getHeaders()['X-RateLimit-Reset'], [Carbon::now()->getTimestamp() + 2, Carbon::now()->getTimestamp() + 3]));
+                $this->assertTrue(in_array($e->getHeaders()['Retry-After'], [2, 3], true));
+                $this->assertTrue(in_array($e->getHeaders()['X-RateLimit-Reset'], [Carbon::now()->getTimestamp() + 2, Carbon::now()->getTimestamp() + 3], true));
             }
         });
     }

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -178,13 +178,13 @@ class SessionStoreTest extends TestCase
         $session->flash('foo', 'bar');
         $session->put('fu', 'baz');
         $session->put('_flash.old', ['qu']);
-        $this->assertNotFalse(array_search('foo', $session->get('_flash.new')));
-        $this->assertFalse(array_search('fu', $session->get('_flash.new')));
+        $this->assertNotFalse(array_search('foo', $session->get('_flash.new'), true));
+        $this->assertFalse(array_search('fu', $session->get('_flash.new'), true));
         $session->keep(['fu', 'qu']);
-        $this->assertNotFalse(array_search('foo', $session->get('_flash.new')));
-        $this->assertNotFalse(array_search('fu', $session->get('_flash.new')));
-        $this->assertNotFalse(array_search('qu', $session->get('_flash.new')));
-        $this->assertFalse(array_search('qu', $session->get('_flash.old')));
+        $this->assertNotFalse(array_search('foo', $session->get('_flash.new'), true));
+        $this->assertNotFalse(array_search('fu', $session->get('_flash.new'), true));
+        $this->assertNotFalse(array_search('qu', $session->get('_flash.new'), true));
+        $this->assertFalse(array_search('qu', $session->get('_flash.old'), true));
     }
 
     public function testReflash()
@@ -193,8 +193,8 @@ class SessionStoreTest extends TestCase
         $session->flash('foo', 'bar');
         $session->put('_flash.old', ['foo']);
         $session->reflash();
-        $this->assertNotFalse(array_search('foo', $session->get('_flash.new')));
-        $this->assertFalse(array_search('foo', $session->get('_flash.old')));
+        $this->assertNotFalse(array_search('foo', $session->get('_flash.new'), true));
+        $this->assertFalse(array_search('foo', $session->get('_flash.old'), true));
     }
 
     public function testReflashWithNow()
@@ -202,8 +202,8 @@ class SessionStoreTest extends TestCase
         $session = $this->getSession();
         $session->now('foo', 'bar');
         $session->reflash();
-        $this->assertNotFalse(array_search('foo', $session->get('_flash.new')));
-        $this->assertFalse(array_search('foo', $session->get('_flash.old')));
+        $this->assertNotFalse(array_search('foo', $session->get('_flash.new'), true));
+        $this->assertFalse(array_search('foo', $session->get('_flash.old'), true));
     }
 
     public function testReplace()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3761,7 +3761,7 @@ class ValidationValidatorTest extends TestCase
                 'states.*' => new class implements Rule {
                     public function passes($attribute, $value)
                     {
-                        return in_array($value, ['AK', 'HI']);
+                        return in_array($value, ['AK', 'HI'], true);
                     }
 
                     public function message()


### PR DESCRIPTION
Some functions, e.g. `in_array`, have a third param to enable strict comparison :shield: 