### PR TITLE
[5.5] Make sure string is passed to hash_equals

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -68,7 +68,7 @@ class EloquentUserProvider implements UserProvider
             return null;
         }
 
-        $rememberToken = $model->getRememberToken();
+        $rememberToken = (string) $model->getRememberToken();
 
         return $rememberToken && hash_equals($rememberToken, $token) ? $model : null;
     }

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -43,6 +43,22 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertEquals($mockUser, $user);
     }
 
+    public function testRetrieveByTokenReturnsNullWhenRememberTokenReturnsTrue()
+    {
+        $mockUser = m::mock('stdClass');
+        $mockUser->shouldReceive('getRememberToken')->once()->andReturn(true);
+
+        $provider = $this->getProviderMock();
+        $mock = m::mock('stdClass');
+        $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
+        $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
+        $mock->shouldReceive('first')->once()->andReturn($mockUser);
+        $provider->expects($this->once())->method('createModel')->will($this->returnValue($mock));
+        $user = $provider->retrieveByToken(1, 'a');
+
+        $this->assertNull($user);
+    }
+
     public function testRetrieveTokenWithBadIdentifierReturnsNull()
     {
         $provider = $this->getProviderMock();


### PR DESCRIPTION
As mentioned in https://github.com/laravel/framework/issues/22717 if `hash_equals` get non-string we might get for example:

> hash_equals(): Expected known_string to be a string, boolean given

so it's better to cast token to string here