### PR TITLE
[5.5] Make sure getRememberToken returns string

### DIFF
--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -44,12 +44,12 @@ trait Authenticatable
     /**
      * Get the token value for the "remember me" session.
      *
-     * @return string
+     * @return string|null
      */
     public function getRememberToken()
     {
         if (! empty($this->getRememberTokenName())) {
-            return $this->{$this->getRememberTokenName()};
+            return (string) $this->{$this->getRememberTokenName()};
         }
     }
 

--- a/tests/Auth/AuthenticatableTest.php
+++ b/tests/Auth/AuthenticatableTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Auth;
 
-use Illuminate\Foundation\Auth\User;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Auth\User;
 
 class AuthenticatableTest extends TestCase
 {
@@ -13,7 +13,7 @@ class AuthenticatableTest extends TestCase
         $user->setRememberToken('sample_token');
         $this->assertSame('sample_token', $user->getRememberToken());
     }
-    
+
     public function testItReturnsStringAsRememberTokenWhenItWasSetToTrue()
     {
         $user = new User();

--- a/tests/Auth/AuthenticatableTest.php
+++ b/tests/Auth/AuthenticatableTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Tests\Auth;
+
+use Illuminate\Foundation\Auth\User;
+use PHPUnit\Framework\TestCase;
+
+class AuthenticatableTest extends TestCase
+{
+    public function testItReturnsSameRememberTokenForString()
+    {
+        $user = new User();
+        $user->setRememberToken('sample_token');
+        $this->assertSame('sample_token', $user->getRememberToken());
+    }
+    
+    public function testItReturnsStringAsRememberTokenWhenItWasSetToTrue()
+    {
+        $user = new User();
+        $user->setRememberToken(true);
+        $this->assertSame('1', $user->getRememberToken());
+    }
+
+    public function testItReturnsNullWhenRememberTokenNameWasSetToEmpty()
+    {
+        $user = new class extends User {
+            public function getRememberTokenName()
+            {
+                return '';
+            }
+        };
+        $user->setRememberToken(true);
+        $this->assertNull($user->getRememberToken());
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/laravel/framework/pull/22718 make sure that string is returned from here