### PR TITLE
[5.5] Fix phpdoc for the str_is() helper match the phpdoc for the Str::is() method

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -867,7 +867,7 @@ if (! function_exists('str_is')) {
     /**
      * Determine if a given string matches a given pattern.
      *
-     * @param  string  $pattern
+     * @param  string|array  $pattern
      * @param  string  $value
      * @return bool
      */


### PR DESCRIPTION
Without specifying possible types of variables, phpStorm highlights the code as a warning.

That this change makes the phpdoc for the helper match the phpdoc for the `Str::is()` method which the `str_is` helper calls.