### PR TITLE
Use full path to server.php in artisan serve command

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -38,7 +38,7 @@ class ServeCommand extends Command {
 
 		$this->info("Laravel development server started on http://{$host}:{$port}");
 
-		passthru('"'.PHP_BINARY.'"'." -S {$host}:{$port} -t \"{$public}\" server.php");
+		passthru('"'.PHP_BINARY.'"'." -S {$host}:{$port} -t \"{$public}\" \"{$this->laravel['path.base']}/server.php\"");
 	}
 
 	/**


### PR DESCRIPTION
As of this commit to PHP: https://github.com/php/php-src/blame/654580afe5ccd0d1b9dec46f33cf68687fff06e2/sapi/cli/php_cli_server.c#L2339-L2361
For this bug: https://github.com/php/php-src/blame/654580afe5ccd0d1b9dec46f33cf68687fff06e2/sapi/cli/php_cli_server.c#L2339-L2361

The `server.php` is now looked for in the public folder provided by the document root flag `-t`, this PR uses an absolute path to the router file in order to make it work.