### PR TITLE
[5.6] Allow to set opposite relation automatically

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/Relations/SetsOppositeRelations.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/Relations/SetsOppositeRelations.php
@@ -18,5 +18,5 @@ interface SetsOppositeRelations
      *
      * @param \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|null $models
      */
-    public function setOppositeRelation($models);    
+    public function setOppositeRelation($models);
 }

--- a/src/Illuminate/Contracts/Database/Eloquent/Relations/SetsOppositeRelations.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/Relations/SetsOppositeRelations.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Eloquent\Relations;
+
+interface SetsOppositeRelations
+{
+    /**
+     * Specify that opposite relationship with given name should be set with parent model.
+     *
+     * @param string $relation
+     *
+     * @return $this
+     */
+    public function withOpposite($relation);
+
+    /**
+     * Set opposite relationship for given model/models with parent model.
+     *
+     * @param \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|null $models
+     */
+    public function setOppositeRelation($models);    
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use Illuminate\Contracts\Database\Eloquent\Relations\SetsOppositeRelations as SetsOppositeRelationsContract;
 use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
@@ -383,7 +384,8 @@ trait HasAttributes
         // relationship has already been loaded, so we'll just return it out of
         // here because there is no need to query within the relations twice.
         if ($this->relationLoaded($key)) {
-            $this->$key()->setOppositeRelation($this->relations[$key]);
+            $this->setOppositeRelation($key);
+
             return $this->relations[$key];
         }
 
@@ -392,6 +394,19 @@ trait HasAttributes
         // and hydrate the relationship's value on the "relationships" array.
         if (method_exists($this, $key)) {
             return $this->getRelationshipFromMethod($key);
+        }
+    }
+
+    /**
+     * Set an opposite relationship.
+     *
+     * @param  string  $relation
+     * @return void
+     */
+    protected function setOppositeRelation($relation) 
+    {
+        if ($this->$relation() instanceof SetsOppositeRelationsContract) {
+            $this->$relation()->setOppositeRelation($this->relations[$relation]);
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use Illuminate\Contracts\Database\Eloquent\Relations\SetsOppositeRelations as SetsOppositeRelationsContract;
 use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
@@ -12,6 +11,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\JsonEncodingException;
+use Illuminate\Contracts\Database\Eloquent\Relations\SetsOppositeRelations as SetsOppositeRelationsContract;
 
 trait HasAttributes
 {
@@ -403,7 +403,7 @@ trait HasAttributes
      * @param  string  $relation
      * @return void
      */
-    protected function setOppositeRelation($relation) 
+    protected function setOppositeRelation($relation)
     {
         if (method_exists($this, $relation) && $this->$relation() instanceof SetsOppositeRelationsContract) {
             $this->$relation()->setOppositeRelation($this->relations[$relation]);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -383,6 +383,7 @@ trait HasAttributes
         // relationship has already been loaded, so we'll just return it out of
         // here because there is no need to query within the relations twice.
         if ($this->relationLoaded($key)) {
+            $this->$key()->setOppositeRelation($this->relations[$key]);
             return $this->relations[$key];
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -405,7 +405,7 @@ trait HasAttributes
      */
     protected function setOppositeRelation($relation) 
     {
-        if ($this->$relation() instanceof SetsOppositeRelationsContract) {
+        if (method_exists($this, $relation) && $this->$relation() instanceof SetsOppositeRelationsContract) {
             $this->$relation()->setOppositeRelation($this->relations[$relation]);
         }
     }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Contracts\Database\Eloquent\Relations\SetsOppositeRelations as SetsOppositeRelationsContract;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -11,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 /**
  * @mixin \Illuminate\Database\Eloquent\Builder
  */
-class BelongsTo extends Relation
+class BelongsTo extends Relation implements SetsOppositeRelationsContract
 {
     use SupportsDefaultModels, SetsOppositeRelations;
 
@@ -83,7 +84,7 @@ class BelongsTo extends Relation
 
         $this->setOppositeRelation($model);
 
-        return $model;        
+        return $model;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
-use Illuminate\Contracts\Database\Eloquent\Relations\SetsOppositeRelations as SetsOppositeRelationsContract;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Concerns\SetsOppositeRelations;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
+use Illuminate\Contracts\Database\Eloquent\Relations\SetsOppositeRelations as SetsOppositeRelationsContract;
 
 /**
  * @mixin \Illuminate\Database\Eloquent\Builder

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Concerns\SetsOppositeRelations;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
 /**
@@ -12,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
  */
 class BelongsTo extends Relation
 {
-    use SupportsDefaultModels;
+    use SupportsDefaultModels, SetsOppositeRelations;
 
     /**
      * The child model instance of the relation.
@@ -78,7 +79,11 @@ class BelongsTo extends Relation
      */
     public function getResults()
     {
-        return $this->query->first() ?: $this->getDefaultFor($this->parent);
+        $model = $this->query->first() ?: $this->getDefaultFor($this->parent);
+
+        $this->setOppositeRelation($model);
+
+        return $model;        
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SetsOppositeRelations.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SetsOppositeRelations.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait SetsOppositeRelations
+{
+    /**
+     * @var string|null
+     */
+    protected $oppositeRelationName;
+
+    /**
+     * @var bool
+     */
+    protected $oppositeRelationLoaded = false;
+
+    /**
+     * Specify that opposite relationship with given name should be set with parent model.
+     *
+     * @param string $relation
+     *
+     * @return $this
+     */
+    public function withOpposite($relation)
+    {
+        $this->oppositeRelationName = $relation;
+
+        return $this;
+    }
+
+    /**
+     * Set opposite relationship for given model/models with parent model.
+     *
+     * @param \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|null $models
+     */
+    public function setOppositeRelation($models)
+    {
+        $parent = $this->getParent();
+        
+        if ($this->oppositeRelationLoaded || !$this->oppositeRelationName || !$parent->exists) {
+            return;
+        }
+
+        $this->oppositeRelationLoaded = true;
+
+        if ($models instanceof Model) {
+            $models->setRelation($this->oppositeRelationName, $parent);
+            return;
+        }
+
+        foreach ($models as $model) {
+            $model->setRelation($this->oppositeRelationName, $parent);
+        }
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SetsOppositeRelations.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SetsOppositeRelations.php
@@ -38,8 +38,8 @@ trait SetsOppositeRelations
     public function setOppositeRelation($models)
     {
         $parent = $this->getParent();
-        
-        if ($this->oppositeRelationLoaded || !$this->oppositeRelationName || !$parent->exists) {
+
+        if ($this->oppositeRelationLoaded || ! $this->oppositeRelationName || ! $parent->exists) {
             return;
         }
 
@@ -47,6 +47,7 @@ trait SetsOppositeRelations
 
         if ($models instanceof Model) {
             $models->setRelation($this->oppositeRelationName, $parent);
+
             return;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
-use Illuminate\Contracts\Database\Eloquent\Relations\SetsOppositeRelations as SetsOppositeRelationsContract;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Concerns\SetsOppositeRelations;
+use Illuminate\Contracts\Database\Eloquent\Relations\SetsOppositeRelations as SetsOppositeRelationsContract;
 
 class HasMany extends HasOneOrMany implements SetsOppositeRelationsContract
 {

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -3,9 +3,12 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Concerns\SetsOppositeRelations;
 
 class HasMany extends HasOneOrMany
 {
+    use SetsOppositeRelations;
+    
     /**
      * Get the results of the relationship.
      *
@@ -13,7 +16,11 @@ class HasMany extends HasOneOrMany
      */
     public function getResults()
     {
-        return $this->query->get();
+        $model = $this->query->get();
+
+        $this->setOppositeRelation($model);
+
+        return $model;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -2,13 +2,14 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Contracts\Database\Eloquent\Relations\SetsOppositeRelations as SetsOppositeRelationsContract;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Concerns\SetsOppositeRelations;
 
-class HasMany extends HasOneOrMany
+class HasMany extends HasOneOrMany implements SetsOppositeRelationsContract
 {
     use SetsOppositeRelations;
-    
+
     /**
      * Get the results of the relationship.
      *

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -2,12 +2,13 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Contracts\Database\Eloquent\Relations\SetsOppositeRelations as SetsOppositeRelationsContract;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Concerns\SetsOppositeRelations;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
-class HasOne extends HasOneOrMany
+class HasOne extends HasOneOrMany implements SetsOppositeRelationsContract
 {
     use SupportsDefaultModels, SetsOppositeRelations;
 
@@ -21,7 +22,7 @@ class HasOne extends HasOneOrMany
         $model = $this->query->first() ?: $this->getDefaultFor($this->parent);
 
         $this->setOppositeRelation($model);
-        
+
         return $model;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -4,11 +4,12 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Concerns\SetsOppositeRelations;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
 class HasOne extends HasOneOrMany
 {
-    use SupportsDefaultModels;
+    use SupportsDefaultModels, SetsOppositeRelations;
 
     /**
      * Get the results of the relationship.
@@ -17,7 +18,11 @@ class HasOne extends HasOneOrMany
      */
     public function getResults()
     {
-        return $this->query->first() ?: $this->getDefaultFor($this->parent);
+        $model = $this->query->first() ?: $this->getDefaultFor($this->parent);
+
+        $this->setOppositeRelation($model);
+        
+        return $model;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
-use Illuminate\Contracts\Database\Eloquent\Relations\SetsOppositeRelations as SetsOppositeRelationsContract;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Concerns\SetsOppositeRelations;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
+use Illuminate\Contracts\Database\Eloquent\Relations\SetsOppositeRelations as SetsOppositeRelationsContract;
 
 class HasOne extends HasOneOrMany implements SetsOppositeRelationsContract
 {


### PR DESCRIPTION
If approved this would give 2 benefits:

- lower number of database queries
- save memory and keep consistent object for base model and related model relation

First example - let's assume we have company and user with 1:1 relationship and run code like this:

    $company = Company::with('owner')->first();
    $ownerCompany = $company->owner->company;
    $company->delete();
    $company->name = 'Modified';
    
    dd($company->name, $ownerCompany->name, $company->exists, $ownerCompany->exists);

As a result we get:

> "Modified"
> "Mitchell-Harber"
> false
> true

what seems quite strange but this is because $company and $ownerCompany are not the same object.

Now let's assume we have 1 to many relationships (user has multiple companies) and we have code like this:

    $users = User::get();
    $users->load('companies');

    foreach ($users as $user) {
        echo $user->email."<br />";
        foreach ($user->companies as $company) {
            echo $company->name.' ( '.$company->owner->email.' )'."<br />";
        }
    }

(inner foreach might be considered as Blade partial). Assuming we have 10 users, each with 20 companies we would execute 202 queries here (200 too much). Of course in above case we could load relationship like this:

    $users->load('companies.owner');

but it still produces one not necessary query.

The idea is to add additional `withOpposite` method when defining a relationship which will cause that same model will be reused and no additional queries will be run like so:

    public function owner()
    {
        return $this->belongsTo(User::class, 'owner_id')->withOpposite('company');
    }

    public function companies()
    {
        return $this->hasMany(Company::class, 'owner_id')->withOpposite('owner');
    }

    public function company()
    {
        return $this->hasOne(Company::class, 'owner_id')->withOpposite('owner');
    }

Now running:

    $company = Company::with('owner')->first();
    $ownerCompany = $company->owner->company;
    $company->delete();
    $company->name = 'Modified';
    
    dd($company->name, $ownerCompany->name, $company->exists, $ownerCompany->exists);
    exit;


wouldn't execute an additional query and get the result:

> "Modified"
> "Modified"
> false
> false

as expected.

Also running:

    $company = Company::with('owner')->first();
    echo $company->owner->company->name;

or

    $users = User::with('companies')->get();
   
    foreach ($users as $user) {
        echo $user->email."<br />";
        foreach ($user->companies as $company) {
            echo $company->name.' ( '.$company->owner->email.' )'."<br />";
        }
    }

or


    $users = User::get();
    $users->load('companies');

    foreach ($users as $user) {
        echo $user->email."<br />";
        foreach ($user->companies as $company) {
            echo $company->name.' ( '.$company->owner->email.' )'."<br />";
        }
    }

or

    $users = User::all();

    foreach ($users as $user) {
        echo $user->email."<br />";
        foreach ($user->companies as $company) {
            echo $company->name.' ( '.$company->owner->email.' )'."<br />";
        }
    }

would execute minimum expected queries (in last code we don't use eager loading so it will produce more queries than in previous examples).

In this PR autoloading opposite relationship was introduced only into `HasMany`, `BelongsTo` and `HasOne` relationships but if approved and makes sense it could be added maybe to some more of them. Also maybe some additional code or tests should be updated. 

This mechanism is opt-in - without adding `->withOpposite(...)` to the relationship it should work as it's working now.