### PR TITLE
[5.5] Update Vue Preset version to match laravel/laravel@c2259a2.

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/Vue.php
+++ b/src/Illuminate/Foundation/Console/Presets/Vue.php
@@ -30,7 +30,7 @@ class Vue extends Preset
      */
     protected static function updatePackageArray(array $packages)
     {
-        return ['vue' => '^2.1.10'] + Arr::except($packages, [
+        return ['vue' => '^2.5.7'] + Arr::except($packages, [
             'babel-preset-react',
             'react',
             'react-dom',


### PR DESCRIPTION
In package.json for laravel/laravel, the "default" Vue dependency got bumped from 2.1.10 to 2.5.7. The Vue Preset has not been updated to match, so after installing a clean install of laravel, `php artisan preset vue` downgrades Vue. This simply moves the Vue Preset in line with the laravel/laravel default install.