### PR TITLE
[5.5] Cache table name in eloquent model getTable()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1170,7 +1170,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function getTable()
     {
         if (! isset($this->table)) {
-            return str_replace(
+            $this->table = str_replace(
                 '\\', '', Str::snake(Str::plural(class_basename($this)))
             );
         }


### PR DESCRIPTION
It seems unnecessary to generate the table name on every call to getTable() on the Eloquent Model class.

This change caches the table name within the $table property.