### PR TITLE
[5.6] Added options to paginator function to allow for param injection.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -695,11 +695,12 @@ class Builder
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  array  $options
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      *
      * @throws \InvalidArgumentException
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $options = [])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
@@ -709,10 +710,12 @@ class Builder
                                     ? $this->forPage($page, $perPage)->get($columns)
                                     : $this->model->newCollection();
 
-        return $this->paginator($results, $total, $perPage, $page, [
+        $options = array_merge($options, [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
         ]);
+
+        return $this->paginator($results, $total, $perPage, $page, $options);
     }
 
     /**
@@ -722,9 +725,10 @@ class Builder
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  array  $options
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
-    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $options = [])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
@@ -735,10 +739,12 @@ class Builder
         // paginator instances for these results with the given page and per page.
         $this->skip(($page - 1) * $perPage)->take($perPage + 1);
 
-        return $this->simplePaginator($this->get($columns), $perPage, $page, [
+        $options = array_merge($options, [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
         ]);
+
+        return $this->simplePaginator($this->get($columns), $perPage, $page, $options);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -590,13 +590,14 @@ class BelongsToMany extends Relation
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  array  $options
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $options = [])
     {
         $this->query->addSelect($this->shouldSelect($columns));
 
-        return tap($this->query->paginate($perPage, $columns, $pageName, $page), function ($paginator) {
+        return tap($this->query->paginate($perPage, $columns, $pageName, $page, $options), function ($paginator) {
             $this->hydratePivotRelation($paginator->items());
         });
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -382,13 +382,14 @@ class HasManyThrough extends Relation
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int  $page
+     * @param  array  $options
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $options = [])
     {
         $this->query->addSelect($this->shouldSelect($columns));
 
-        return $this->query->paginate($perPage, $columns, $pageName, $page);
+        return $this->query->paginate($perPage, $columns, $pageName, $page, $options);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1756,9 +1756,10 @@ class Builder
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  array  $options
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null, $options = [])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
@@ -1766,10 +1767,12 @@ class Builder
 
         $results = $total ? $this->forPage($page, $perPage)->get($columns) : collect();
 
-        return $this->paginator($results, $total, $perPage, $page, [
+        $options = array_merge($options, [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
         ]);
+
+        return $this->paginator($results, $total, $perPage, $page, $options);
     }
 
     /**
@@ -1781,18 +1784,21 @@ class Builder
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  array  $options
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
-    public function simplePaginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null)
+    public function simplePaginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null, $options = [])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
         $this->skip(($page - 1) * $perPage)->take($perPage + 1);
 
-        return $this->simplePaginator($this->get($columns), $perPage, $page, [
+        $options = array_merge($options, [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
         ]);
+
+        return $this->simplePaginator($this->get($columns), $perPage, $page, $options);
     }
 
     /**


### PR DESCRIPTION
See: #22736 

Thanks for the previous feedback.

To give a direct use case:
```
$data = (new Model())->sortable()->paginate(
  \Input::get('i', 25), ['*'], 'page', null, [ 'query' => \Input::all([ 'sort', 'order', 'i' ]) ]
);
```
* above is the simplified code without any input checking.

sortable is a helper to allow for table sorting. This works through query params.
Query param 'i' is the rows on a page.

By giving the query params to the pagination function, they get feeded back into [Illuminate\Pagination\AbstractPaginator](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Pagination/AbstractPaginator.php) and are then used to compile the new pagination links.

Another use case for this patch is to set 'defaultView'. That would allow one to have a different paginator for that model (not sure where that would be use full though).


To give my own opinion:
I think its a bit of a dirty hack, as it misuses the options injector ([Illuminate\Pagination\Paginator:36](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Pagination/Paginator.php#L36)).
But I have found no other flexible enough option where I could have done this.
