### PR TITLE
[5.5] Add string key support to Collection@flatMap

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -932,12 +932,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Map a collection and flatten the result by a single level.
      *
-     * @param  callable  $callback
+     * @param  callable|string  $callback
      * @return static
      */
-    public function flatMap(callable $callback)
+    public function flatMap($callback)
     {
-        return $this->map($callback)->collapse();
+        if ($this->useAsCallable($callback)) {
+            return $this->map($callback)->collapse();
+        } else {
+            return $this->pluck($callback)->collapse();
+        }
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1318,10 +1318,18 @@ class SupportCollectionTest extends TestCase
             ['name' => 'taylor', 'hobbies' => ['programming', 'basketball']],
             ['name' => 'adam', 'hobbies' => ['music', 'powerlifting']],
         ]);
-        $data = $data->flatMap(function ($person) {
+
+        // Test with a callback
+        $hobbies = $data->flatMap(function ($person) {
             return $person['hobbies'];
         });
-        $this->assertEquals(['programming', 'basketball', 'music', 'powerlifting'], $data->all());
+
+        $this->assertEquals(['programming', 'basketball', 'music', 'powerlifting'], $hobbies->all());
+
+        // Test with a string key
+        $hobbies = $data->flatMap('hobbies');
+
+        $this->assertEquals(['programming', 'basketball', 'music', 'powerlifting'], $hobbies->all());
     }
 
     public function testMapToDictionary()


### PR DESCRIPTION
So you can do this:

```php
$posts = $users->flatMap('posts');
```