### PR TITLE
[5.5] Make assertJsonCount able to use nested keys

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -461,9 +461,8 @@ class TestResponse
     public function assertJsonCount(int $count, $key = null)
     {
         if ($key) {
-            $items = data_get($this->json(), $key);
-            PHPUnit::assertCount($count,
-                $items,
+            PHPUnit::assertCount(
+                $count, data_get($this->json(), $key),
                 "Failed to assert that the response count matched the expected {$count}"
             );
 

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -461,8 +461,9 @@ class TestResponse
     public function assertJsonCount(int $count, $key = null)
     {
         if ($key) {
+            $items = data_get($this->json(), $key);
             PHPUnit::assertCount($count,
-                $this->json()[$key],
+                $items,
                 "Failed to assert that the response count matched the expected {$count}"
             );
 

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -148,7 +148,6 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonCount(4);
     }
 
-
     public function testMacroable()
     {
         TestResponse::macro('foo', function () {

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -132,6 +132,23 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonStructure(['*' => ['foo', 'bar', 'foobar']]);
     }
 
+    public function testAssertJsonCount()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        // With simple key
+        $response->assertJsonCount(3, 'bars');
+
+        // With nested key
+        $response->assertJsonCount(2, 'baz.*.bar');
+
+        // Without structure
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+
+        $response->assertJsonCount(4);
+    }
+
+
     public function testMacroable()
     {
         TestResponse::macro('foo', function () {


### PR DESCRIPTION
Enhanced testing helper with assertJsonCount to be able to use nested keys for checking count more than just one level deep.

Added some tests that illustrate it pretty well.