### PR TITLE
[5.5] Fix missing table prefix in SQLiteGrammar compileDropColumn()

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -245,7 +245,7 @@ class SQLiteGrammar extends Grammar
         );
 
         foreach ($command->columns as $name) {
-            $column = $connection->getDoctrineColumn($blueprint->getTable(), $name);
+            $column = $connection->getDoctrineColumn($this->getTablePrefix().$blueprint->getTable(), $name);
 
             $tableDiff->removedColumns[$name] = $column;
         }

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -90,6 +90,31 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('drop index "foo"', $statements[0]);
     }
 
+    public function testDropColumn()
+    {
+        if (! class_exists('Doctrine\DBAL\Schema\SqliteSchemaManager')) {
+            $this->markTestSkipped('Doctrine should be installed to run dropColumn tests');
+        }
+
+        $db = new \Illuminate\Database\Capsule\Manager;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => 'prefix_',
+        ]);
+
+        $schema_builder = $db->getConnection()->getSchemaBuilder();
+
+        $schema_builder->create('users', function (Blueprint $table) {
+            $table->string('email');
+            $table->string('name');
+        });
+
+        $schema_builder->table('users', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+    }
+
     /**
      * @expectedException \RuntimeException
      * @expectedExceptionMessage The database driver in use does not support spatial indexes.


### PR DESCRIPTION
Fixes #22741