### PR TITLE
Support Carbon in cached config

### DIFF
--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -45,4 +45,18 @@ class Carbon extends BaseCarbon implements JsonSerializable
     {
         static::$serializer = $callback;
     }
+
+    /**
+     * When a Carbon instance is exported using var_export() and reinstated using __set_state(),
+     * make sure it is reconstructed as a Carbon object instead of a DateTime object.
+     *
+     * @param  array  $properties
+     * @return static
+     */
+    public static function __set_state(array $properties)
+    {
+        return static::instance(
+            parent::__set_state($properties)
+        );
+    }
 }


### PR DESCRIPTION
Since `Carbon\Carbon` has not (re)implemented the `__set_state()` method the following class conversion happens (unwanted):

```php
use Carbon\Carbon;

$export = var_export(Carbon::now());
$date = Carbon::__set_state($export);

// $date is an instance of DateTime, NOT Carbon
```

This causes issues when a Carbon instance is defined in config and the configuration is cached:
```php
// config/app.php

use Illuminate\Support\Carbon;

return [
    ...
    'some_date' => Carbon::create(...);
    ...
];
```
```sh
php artisan config:cache
```
```php
$date = config('app.some_date')->isToday();
// 500 error - DateTime is returned from config instead of a Carbon object.
```

By redefining the `__set_state()` method in Illuminate's Carbon class and simply providing the DateTime instance to `Carbon::instance()` the expected object gets returned.