### PR TITLE
[5.7] Add nestedBindings to Implicit Route Model Binding

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlRoutable.php
+++ b/src/Illuminate/Contracts/Routing/UrlRoutable.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Contracts\Routing;
 
+use Illuminate\Routing\NestedBinding;
+
 interface UrlRoutable
 {
     /**
@@ -22,7 +24,8 @@ interface UrlRoutable
      * Retrieve the model for a bound value.
      *
      * @param  mixed  $value
+     * @param  NestedBinding|null  $nestedBinding
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    public function resolveRouteBinding($value);
+    public function resolveRouteBinding($value, NestedBinding $nestedBinding = null);
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Routing\NestedBinding;
 
 abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
@@ -1355,11 +1356,22 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * Retrieve the model for a bound value.
      *
      * @param  mixed  $value
+     * @param  NestedBinding|null  $nestedBinding
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    public function resolveRouteBinding($value)
+    public function resolveRouteBinding($value, NestedBinding $nestedBinding = null)
     {
-        return $this->where($this->getRouteKeyName(), $value)->first();
+        $query = $this->where($this->getRouteKeyName(), $value);
+
+        if (! is_null($nestedBinding)) {
+            $query = $query->whereHas($nestedBinding->getRelation(), function ($queryRelation) use ($nestedBinding){
+                $routeKeyName = $nestedBinding->getRelatedInstance()->getRouteKeyName();
+
+                return $queryRelation->where($routeKeyName, $nestedBinding->getRelatedInstance()->{$routeKeyName});
+            });
+        }
+
+        return $query->first();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -7,6 +7,7 @@ use ArrayAccess;
 use JsonSerializable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Routing\NestedBinding;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Routing\UrlRoutable;
@@ -15,7 +16,6 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
-use Illuminate\Routing\NestedBinding;
 
 abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
@@ -1364,7 +1364,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $query = $this->where($this->getRouteKeyName(), $value);
 
         if (! is_null($nestedBinding)) {
-            $query = $query->whereHas($nestedBinding->getRelation(), function ($queryRelation) use ($nestedBinding){
+            $query = $query->whereHas($nestedBinding->getRelation(), function ($queryRelation) use ($nestedBinding) {
                 $routeKeyName = $nestedBinding->getRelatedInstance()->getRouteKeyName();
 
                 return $queryRelation->where($routeKeyName, $nestedBinding->getRelatedInstance()->{$routeKeyName});

--- a/src/Illuminate/Http/Resources/DelegatesToResource.php
+++ b/src/Illuminate/Http/Resources/DelegatesToResource.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Resources;
 
 use Exception;
+use Illuminate\Routing\NestedBinding;
 
 trait DelegatesToResource
 {
@@ -29,11 +30,12 @@ trait DelegatesToResource
     /**
      * Retrieve the model for a bound value.
      *
-     * @param  mixed  $value
+     * @param  mixed $value
+     * @param NestedBinding|null $nestedBinding
      * @return void
-     * @throws \Exception
+     * @throws Exception
      */
-    public function resolveRouteBinding($value)
+    public function resolveRouteBinding($value, NestedBinding $nestedBinding = null)
     {
         throw new Exception('Resources may not be implicitly resolved from route bindings.');
     }

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -19,10 +19,12 @@ class ImplicitRouteBinding
     {
         $parameters = $route->parameters();
 
-        foreach ($route->signatureParameters(UrlRoutable::class) as $parameter) {
+        foreach ($signatureParameters = $route->signatureParameters(UrlRoutable::class) as $index => $parameter) {
             if (! $parameterName = static::getParameterName($parameter->name, $parameters)) {
                 continue;
             }
+
+            $nestedBinding = NestedBinding::setRelationshipForImplicitBinding($route, $signatureParameters, $index);
 
             $parameterValue = $parameters[$parameterName];
 
@@ -32,7 +34,7 @@ class ImplicitRouteBinding
 
             $instance = $container->make($parameter->getClass()->name);
 
-            if (! $model = $instance->resolveRouteBinding($parameterValue)) {
+            if (! $model = $instance->resolveRouteBinding($parameterValue, $nestedBinding)) {
                 throw (new ModelNotFoundException)->setModel(get_class($instance));
             }
 

--- a/src/Illuminate/Routing/NestedBinding.php
+++ b/src/Illuminate/Routing/NestedBinding.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Illuminate\Routing;
+
+class NestedBinding
+{
+    /**
+     * The relationship method name used in querying the relationship.
+     *
+     * @var string
+     */
+    protected $relation;
+
+    /**
+     * The instance that acts as the parent of the current nested parameter.
+     *
+     * @var object
+     */
+    protected $relatedInstance;
+
+    /**
+     * RelatedBinding constructor.
+     *
+     * @param  string  $relation
+     * @param  $relatedInstance
+     */
+    public function __construct(string $relation, $relatedInstance)
+    {
+        $this->relation = $relation;
+        $this->relatedInstance = $relatedInstance;
+    }
+
+    /**
+     * Gets the relationship method name used in querying the relationship.
+     *
+     * @return string
+     */
+    public function getRelation()
+    {
+        return $this->relation;
+    }
+
+    /**
+     * Gets the instance that acts as the parent of the current nested parameter.
+     *
+     * @return object
+     */
+    public function getRelatedInstance()
+    {
+        return $this->relatedInstance;
+    }
+
+    /**
+     * Sets the relationship between the parent binded parameter and the current nested parameter for implicit binding.
+     *
+     * @param  Route  $route
+     * @param  $parameters
+     * @param  $pointer
+     *
+     * @return null|$this
+     */
+    public static function setRelationshipForImplicitBinding(Route $route, $parameters, $pointer)
+    {
+        $nestedBindings = $route->nestedBindings();
+
+        // If the pointer is equal to zero, therefore it points to the first parameter, which always will be independent
+        // and cannot be nested from any parameter, therefore we skip the operation.
+        if (empty($nestedBindings) || $pointer === 0) {
+            return null;
+        }
+
+        // The pointer is shifted backwards by one step, because the $parameters array will always be ahead of
+        // the $nestedBindings array by one which is the independent parameter which is the first element in the $parameters array.
+        $pointer--;
+
+        return (new static($nestedBindings[$pointer], $route->parameter($parameters[$pointer]->name)));
+    }
+}

--- a/src/Illuminate/Routing/NestedBinding.php
+++ b/src/Illuminate/Routing/NestedBinding.php
@@ -73,6 +73,6 @@ class NestedBinding
         // the $nestedBindings array by one which is the independent parameter which is the first element in the $parameters array.
         $pointer--;
 
-        return (new static($nestedBindings[$pointer], $route->parameter($parameters[$pointer]->name)));
+        return new static($nestedBindings[$pointer], $route->parameter($parameters[$pointer]->name));
     }
 }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -886,6 +886,29 @@ class Route
     }
 
     /**
+     * Get or set the relationship methods between the related parameters.
+     *
+     * @param  array  $nestedtedBindings
+     * @return $this
+     */
+    public function nestedBindings($nestedtedBindings = null)
+    {
+        if (is_null($nestedtedBindings)) {
+            return (array) ($this->action['nestedtedBindings'] ?? []);
+        }
+
+        if (is_string($nestedtedBindings)) {
+            $nestedtedBindings = func_get_args();
+        }
+
+        $this->action['nestedtedBindings'] = array_merge(
+            (array) ($this->action['nestedtedBindings'] ?? []), $nestedtedBindings
+        );
+
+        return $this;
+    }
+
+    /**
      * Dynamically access route parameters.
      *
      * @param  string  $key

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Routing;
 
 use Illuminate\Http\Request;
+use Illuminate\Routing\NestedBinding;
 use Illuminate\Routing\Route;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Routing\UrlGenerator;
@@ -466,7 +467,7 @@ class RoutableInterfaceStub implements UrlRoutable
         return 'key';
     }
 
-    public function resolveRouteBinding($routeKey)
+    public function resolveRouteBinding($routeKey, \Illuminate\Routing\NestedBinding $nestedBinding = null)
     {
         //
     }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Routing;
 
 use Illuminate\Http\Request;
-use Illuminate\Routing\NestedBinding;
 use Illuminate\Routing\Route;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Routing\UrlGenerator;


### PR DESCRIPTION
The problem:
I have a defined route as follows..
`"companies/{company}/departments/{department}/supervisors/{supervisor}"`
currently RMB will retrieve each model separately, but if i want to strict the binding so that the supervisor is nested from department and the department is nested from the company, I will go to the RouteServiceProvider and explicitly write the binding for each (the department & the supervisor).

Imagine that i have 5+ parameters each nested from the previous parameter that requires a lot of code that mostly has duplicated logic.

Therefore the idea is to introduce a nestedBindings list that guides the Implicit RMB when binding the model to the parameter, simply it will tell the IRMB to query the relationship between parameter1 & parameter2 (department,supervisor)

Solution:

We have the following models:

```
...Department.php
class Department extends Model {

     public function company(){
        return $this->belongsTo(Company::class);
     }
}
```

```
....Supervisor.php
class Supervisor extends Model {

    public function department(){
        return $this->belongsTo(Department::class);
    }
}
```

We will define the route as follows

`Route::get('companies/{company}/departments/{department}/supervisors/{supervisor}', 'SupervisorsController@show')->name('showSupervisor')->nestedBindings(['company','department']);`

Here we give the nestedBindings() an array containing the relationship method names built inside the models: 'company' relationship method inside a Department Model and 'department' relationship method inside Supervisor model, and take into consideration that the first parameter will always be independent.

Also, We can apply the nestedBindings on RouteGroups as follows
```

Route::group(['prefix' => 'companies/{company}'], function(){

Route::group(['prefix' => 'departments/{department}', 'nestedBindings' => ['company']], function(){

Route::group(['prefix' => 'supervisors/{supervisor}', 'nestedBindings' => ['department']], function(){});

});

});
```

OR

```

Route::group(['prefix' => 'companies/{company}'], function(){

Route::group(['prefix' => 'departments/{department}/supervisors/{supervisor}', 'nestedBindings' => ['company', 'department']], function(){});

});

```

I think the next step, we can add a default behavior to the nestedBindings() if given an empty array to try to guess the relationship method between the parameters and then we can push forward to include this idea on the Route::model();




