### PR TITLE
[5.5] Do not continue checking `APP_ENV` if environment file path has being set

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -39,9 +39,11 @@ class LoadEnvironmentVariables
     protected function checkForSpecificEnvironmentFile($app)
     {
         if ($app->runningInConsole() && ($input = new ArgvInput)->hasParameterOption('--env')) {
-            $this->setEnvironmentFilePath(
+            if ($this->setEnvironmentFilePath(
                 $app, $app->environmentFile().'.'.$input->getParameterOption('--env')
-            );
+            )) {
+                return;
+            }
         }
 
         if (! env('APP_ENV')) {
@@ -58,12 +60,16 @@ class LoadEnvironmentVariables
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @param  string  $file
-     * @return void
+     * @return bool
      */
     protected function setEnvironmentFilePath($app, $file)
     {
         if (file_exists($app->environmentPath().'/'.$file)) {
             $app->loadEnvironmentFrom($file);
+
+            return true;
         }
+
+        return false;
     }
 }


### PR DESCRIPTION
It is a very interesting case our team just encountered. 

There are two files, `.env.local` and `.env.testing` in the project. And in a developing server, it adds `export APP_ENV=local` in /etc/profile to define the environment.

 One of team member copied `.env.local` to `.env.testing.local`. Then another person run a command with testing environment using
```bash
php artisan XXX --env testing
```
and found the result was not as expected.

After setting environment file path `.env.testing` with `--env` option, it continued to checking the global `APP_ENV` definition and tried to set the file path `.env.testing.local` again. At last, it was the later file being loaded.

It may be a rare case, however, I think this PR is mainly meaning "--env option has higher priority than the global definition".