### PR TITLE
[5.6] Use Bootstrap 4 in the preset

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/Bootstrap.php
+++ b/src/Illuminate/Foundation/Console/Presets/Bootstrap.php
@@ -25,8 +25,9 @@ class Bootstrap extends Preset
     protected static function updatePackageArray(array $packages)
     {
         return [
-            'bootstrap-sass' => '^3.3.7',
-            'jquery' => '^3.1.1',
+            'bootstrap' => '^4.0.0-beta.3',
+            'jquery' => '^3.2',
+            'popper.js' => '^1.12',
         ] + $packages;
     }
 

--- a/src/Illuminate/Foundation/Console/Presets/bootstrap-stubs/_variables.scss
+++ b/src/Illuminate/Foundation/Console/Presets/bootstrap-stubs/_variables.scss
@@ -2,24 +2,9 @@
 // Body
 $body-bg: #f5f8fa;
 
-// Borders
-$laravel-border-color: darken($body-bg, 10%);
-$list-group-border: $laravel-border-color;
-$navbar-default-border: $laravel-border-color;
-$panel-default-border: $laravel-border-color;
-$panel-inner-border: $laravel-border-color;
-
-// Brands
-$brand-primary: #3097D1;
-$brand-info: #8eb4cb;
-$brand-success: #2ab27b;
-$brand-warning: #cbb956;
-$brand-danger: #bf5329;
-
 // Typography
-$icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
 $font-family-sans-serif: "Raleway", sans-serif;
-$font-size-base: 14px;
+$font-size-base: 0.9rem;
 $line-height-base: 1.6;
 $text-color: #636b6f;
 
@@ -28,11 +13,6 @@ $navbar-default-bg: #fff;
 
 // Buttons
 $btn-default-color: $text-color;
-
-// Inputs
-$input-border: lighten($text-color, 40%);
-$input-border-focus: lighten($brand-primary, 25%);
-$input-color-placeholder: lighten($text-color, 30%);
 
 // Panels
 $panel-default-heading-bg: #fff;

--- a/src/Illuminate/Foundation/Console/Presets/bootstrap-stubs/app.scss
+++ b/src/Illuminate/Foundation/Console/Presets/bootstrap-stubs/app.scss
@@ -6,4 +6,9 @@
 @import "variables";
 
 // Bootstrap
-@import "~bootstrap-sass/assets/stylesheets/bootstrap";
+@import '~bootstrap/scss/bootstrap';
+
+.navbar-laravel {
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.04);
+}


### PR DESCRIPTION
With the auth scaffolding being updated to Bootstrap 4 and the `laravel/laravel` repo also using it, I'd suggest the preset should now use Bootstrap 4 also.