### PR TITLE
[5.5] Add option to disable wrapping Migration in transaction

### DIFF
--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -12,11 +12,11 @@ abstract class Migration
     protected $connection;
 
     /**
-     * Enables, if supported, wrapping with a transaction.
+     * Enables, if supported, wrapping the migration within a transaction.
      *
      * @var bool
      */
-    public $withTransaction = true;
+    public $withinTransaction = true;
 
     /**
      * Get the migration connection name.

--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -12,6 +12,13 @@ abstract class Migration
     protected $connection;
 
     /**
+     * Enables, if supported, wrapping with a transaction.
+     *
+     * @var bool
+     */
+    public $withTransaction = true;
+
+    /**
      * Get the migration connection name.
      *
      * @return string

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -361,7 +361,7 @@ class Migrator
         };
 
         $this->getSchemaGrammar($connection)->supportsSchemaTransactions()
-            && $migration->withTransaction
+            && $migration->withinTransaction
                     ? $connection->transaction($callback)
                     : $callback();
     }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -361,6 +361,7 @@ class Migrator
         };
 
         $this->getSchemaGrammar($connection)->supportsSchemaTransactions()
+            && $migration->withTransaction
                     ? $connection->transaction($callback)
                     : $callback();
     }


### PR DESCRIPTION
This PR provides the option to disable transactionally wrapping a migration.

In #15780 we added the ability to wrap migrations in transactions, where supported. This is awesome!

However, for exactly the same reasons expressed here: https://github.com/rails/rails/issues/9483

I propose the identical solution merged here: https://github.com/rails/rails/pull/9507

### TL;DR
Postgres and SQL Server usually do support transactional DDL, but both also have cases where they do not.  Adding this simple, passive option gives us the power to handle this when needed.