### PR TITLE
[5.6] A cache key that can be used to identify a model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1383,11 +1383,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $this->getTable().'/new';
         }
 
-        if (! $this->getAttribute('updated_at')) {
-            return $this->getTable().'/'.$this->getKey();
+        $updatedAt = $this->getAttribute($this->getUpdatedAtColumn());
+
+        if ($this->usesTimestamps() && ! is_null($updatedAt)) {
+            return $this->getTable().'/'.$this->getKey().'-'.$updatedAt->timestamp;
         }
 
-        return $this->getTable().'/'.$this->getKey().'-'.$this->updated_at->timestamp;
+        return $this->getTable().'/'.$this->getKey();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1373,6 +1373,24 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Returns a stable cache key that can be used to identify the record.
+     *
+     * @return string
+     */
+    public function cacheKey()
+    {
+        if (! $this->exists) {
+            return $this->getTable().'/new';
+        }
+
+        if (! $this->getAttribute('updated_at')) {
+            return $this->getTable().'/'.$this->getKey();
+        }
+
+        return $this->getTable().'/'.$this->getKey().'-'.$this->updated_at->timestamp;
+    }
+
+    /**
      * Get the number of models to return per page.
      *
      * @return int

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1701,21 +1701,45 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testCacheKey()
     {
+        // New model
         $new = new EloquentDateModelStub();
         $this->assertEquals('stub/new', $new->cacheKey());
 
-        $withoutDates = new EloquentModelStub(['id' => 1]);
-        $withoutDates->exists = true;
-        $this->assertEquals('stub/1', $withoutDates->cacheKey());
+        // A model that doesn't use timestamps
+        $withoutTimestamps = new EloquentModelStub(['id' => 1]);
+        $withoutTimestamps->exists = true;
+        $withoutTimestamps->timestamps = false;
+        $this->assertEquals('stub/1', $withoutTimestamps->cacheKey());
 
-        $withDates = new class(['id' => 1, 'updated_at' => Carbon::now()]) extends EloquentDateModelStub {
+        // Null timestamp
+        $nullTimestamp = new EloquentModelStub(['id' => 2, 'updated_at' => null]);
+        $nullTimestamp->exists = true;
+        $this->assertEquals('stub/2', $nullTimestamp->cacheKey());
+
+        // Default model with an updated_at column
+        $withTimestamps = new class(['id' => 3, 'updated' => Carbon::now()]) extends EloquentDateModelStub {
+            const UPDATED_AT = 'updated';
+
             public function getDateFormat()
             {
                 return 'Y-m-d H:i:s';
             }
         };
-        $withDates->exists = true;
-        $this->assertEquals('stub/1-'.Carbon::now()->timestamp, $withDates->cacheKey());
+        $withTimestamps->exists = true;
+        $this->assertEquals('stub/3-'.Carbon::now()->timestamp, $withTimestamps->cacheKey());
+
+        // Custom updated_at column
+        $customUpdatedAt = new class(['id' => 4, 'updated' => Carbon::now()]) extends EloquentDateModelStub {
+            const UPDATED_AT = 'updated';
+
+            public function getDateFormat()
+            {
+                return 'Y-m-d H:i:s';
+            }
+        };
+
+        $customUpdatedAt->exists = true;
+        $this->assertEquals('stub/4-'.Carbon::now()->timestamp, $customUpdatedAt->cacheKey());
     }
 
     protected function addMockConnection($model)

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1699,6 +1699,25 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testCacheKey()
+    {
+        $new = new EloquentDateModelStub();
+        $this->assertEquals('stub/new', $new->cacheKey());
+
+        $withoutDates = new EloquentModelStub(['id' => 1]);
+        $withoutDates->exists = true;
+        $this->assertEquals('stub/1', $withoutDates->cacheKey());
+
+        $withDates = new class(['id' => 1, 'updated_at' => Carbon::now()]) extends EloquentDateModelStub {
+            public function getDateFormat()
+            {
+                return 'Y-m-d H:i:s';
+            }
+        };
+        $withDates->exists = true;
+        $this->assertEquals('stub/1-'.Carbon::now()->timestamp, $withDates->cacheKey());
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1717,9 +1717,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('stub/2', $nullTimestamp->cacheKey());
 
         // Default model with an updated_at column
-        $withTimestamps = new class(['id' => 3, 'updated' => Carbon::now()]) extends EloquentDateModelStub {
-            const UPDATED_AT = 'updated';
-
+        $withTimestamps = new class(['id' => 3, 'updated_at' => Carbon::now()]) extends EloquentDateModelStub {
             public function getDateFormat()
             {
                 return 'Y-m-d H:i:s';


### PR DESCRIPTION
__Originally submitted in #22744, this is now based off of 5.6__ 🍸 

Based on [ActiveRecord](https://github.com/rails/rails/blob/15ef55efb591e5379486ccf53dd3e13f416564f6/activerecord/lib/active_record/integration.rb#L64), adds a `Model::cacheKey()` method that gets a stable cache key used to identify a model.

This can be used to build model cache that gets invalidated:

```php
class Article extends Model
{
    public function getCachedCommentsCountAttribute()
    {
        return Cache::rememberForever($this->cacheKey() . ':comments_count', function () {
            return $this->comments->count();
        });
    }
}
```

The `cacheKey()` method would produce the following if the model had the `updated_at` date attribute:

```
articles/1-1515693922
```

Models without an `updated_at`:

```
articles/1
```

New models:

```
articles/new
```

For more info, I [wrote about it](https://laravel-news.com/laravel-model-caching) using `Model::touch()` to invalidate cache on a model.