### PR TITLE
[5.5] fixes Scheduler between for time frame before and after midnight

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -52,6 +52,10 @@ trait ManagesFrequencies
      */
     private function inTimeInterval($startTime, $endTime)
     {
+        if ($this->endTimeGreater($startTime, $endTime)) {
+            $endTime .= ' +1 day';
+        }
+
         return function () use ($startTime, $endTime) {
             return Carbon::now($this->timezone)->between(
                 Carbon::parse($startTime, $this->timezone),
@@ -59,6 +63,18 @@ trait ManagesFrequencies
                 true
             );
         };
+    }
+
+    /**
+     * Check if endTime is considered greater for humans.
+     *
+     * @param string $startTime
+     * @param string $endTime
+     * @return bool
+     */
+    private function endTimeGreater($startTime, $endTime)
+    {
+        return explode(':', $startTime)[0] > explode(':', $endTime)[0];
     }
 
     /**


### PR DESCRIPTION
If I expect a Task to be run between 10:00 PM and 03:00 AM
```
$schedule->command('route:call import/start')
            ->everyFifteenMinutes()
            ->between('22:00', '03:00')
```

Instead the Task will be run between 03:00 AM and 10:00PM, because 03:00 is considered smaller than 22:00, they get flipped around.

This PR now allows to have the task run as expected between, 10:00PM and 03:AM, and fixes #22723 
