### PR TITLE
[5.2] Update Builder.php

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -769,7 +769,7 @@ class Builder
      */
     public function addNestedWhereQuery($query, $boolean = 'and')
     {
-        if (count($query->wheres)) {
+        if (isset($query->wheres)&&count($query->wheres)) {
             $type = 'Nested';
 
             $this->wheres[] = compact('type', 'query', 'boolean');


### PR DESCRIPTION
in php 7.2.0     count() will now yield a warning on invalid countable types passed to the array_or_countable parameter.