### PR TITLE
[5.5] Add functionality that will load json lang files from within a directory

### DIFF
--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -144,7 +144,7 @@ class FileLoader implements Loader
                 if ($this->files->exists($full = "{$localePath}.json")) {
                     $files = [$full];
                 } elseif ($this->files->exists($localePath)) {
-                    $files = $this->files->glob($localePath . "/*.json");
+                    $files = $this->files->glob("{$localePath}/*.json");
                 }
 
                 foreach ($files as $file) {

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -138,11 +138,20 @@ class FileLoader implements Loader
     {
         return collect(array_merge($this->jsonPaths, [$this->path]))
             ->reduce(function ($output, $path) use ($locale) {
-                if ($this->files->exists($full = "{$path}/{$locale}.json")) {
-                    $decoded = json_decode($this->files->get($full), true);
+                $localePath = "{$path}/{$locale}";
+
+                $files = [];
+                if ($this->files->exists($full = "{$localePath}.json")) {
+                    $files = [$full];
+                } elseif ($this->files->exists($localePath)) {
+                    $files = $this->files->glob($localePath . "/*.json");
+                }
+
+                foreach ($files as $file) {
+                    $decoded = json_decode($this->files->get($file), true);
 
                     if (is_null($decoded) || json_last_error() !== JSON_ERROR_NONE) {
-                        throw new RuntimeException("Translation file [{$full}] contains an invalid JSON structure.");
+                        throw new RuntimeException("Translation file [{$file}] contains an invalid JSON structure.");
                     }
 
                     $output = array_merge($output, $decoded);

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -13,6 +13,36 @@ class TranslationFileLoaderTest extends TestCase
         m::close();
     }
 
+    public function testLoadMethodForJSONWillGetAllJsonFilesUnderDirectory()
+    {
+        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en.json')->andReturn(false);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en')->andReturn(true);
+        $files->shouldReceive('glob')->once()->with(__DIR__ . '/en/*.json')->andReturn([
+            __DIR__ . '/en/general.json',
+            __DIR__ . '/en/users.json'
+        ]);
+        $files->shouldReceive('get')->twice()
+            ->andReturn('{"foo":"bar"}', '{"user":"test"}'); // Loads both
+
+        $this->assertEquals(['foo' => 'bar', 'user' => 'test'], $loader->load('en', '*', '*'));
+    }
+
+    public function testLoadMethodForJSONWillGetJsonFilesUnderDirectory()
+    {
+        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en.json')->andReturn(false);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en')->andReturn(true);
+        $files->shouldReceive('glob')->once()->with(__DIR__ . '/en/*.json')->andReturn([
+            __DIR__ . '/en/general.json',
+        ]);
+        $files->shouldReceive('get')->once()
+            ->with(__DIR__.'/en/general.json')
+            ->andReturn('{"foo":"bar"}');
+
+        $this->assertEquals(['foo' => 'bar'], $loader->load('en', '*', '*'));
+    }
+
     public function testLoadMethodWithoutNamespacesProperlyCallsLoader()
     {
         $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -20,7 +20,7 @@ class TranslationFileLoaderTest extends TestCase
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en')->andReturn(true);
         $files->shouldReceive('glob')->once()->with(__DIR__.'/en/*.json')->andReturn([
             __DIR__.'/en/general.json',
-            __DIR__.'/en/users.json'
+            __DIR__.'/en/users.json',
         ]);
         $files->shouldReceive('get')->twice()
             ->andReturn('{"foo":"bar"}', '{"user":"test"}'); // Loads both

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -18,9 +18,9 @@ class TranslationFileLoaderTest extends TestCase
         $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en.json')->andReturn(false);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en')->andReturn(true);
-        $files->shouldReceive('glob')->once()->with(__DIR__ . '/en/*.json')->andReturn([
-            __DIR__ . '/en/general.json',
-            __DIR__ . '/en/users.json'
+        $files->shouldReceive('glob')->once()->with(__DIR__.'/en/*.json')->andReturn([
+            __DIR__.'/en/general.json',
+            __DIR__.'/en/users.json'
         ]);
         $files->shouldReceive('get')->twice()
             ->andReturn('{"foo":"bar"}', '{"user":"test"}'); // Loads both
@@ -33,8 +33,8 @@ class TranslationFileLoaderTest extends TestCase
         $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en.json')->andReturn(false);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en')->andReturn(true);
-        $files->shouldReceive('glob')->once()->with(__DIR__ . '/en/*.json')->andReturn([
-            __DIR__ . '/en/general.json',
+        $files->shouldReceive('glob')->once()->with(__DIR__.'/en/*.json')->andReturn([
+            __DIR__.'/en/general.json',
         ]);
         $files->shouldReceive('get')->once()
             ->with(__DIR__.'/en/general.json')


### PR DESCRIPTION
This was created from the internals issue here: https://github.com/laravel/internals/issues/951

If you have a json lang file in the route, e.g resources/lang/es.json it will load that, however if you have resources/lang/es/general.json (and more), it will load all the files under the directory to allow for breaking down json lang files into logical parts.