### PR TITLE
[5.6] Faster implementation for Collection::mapToDictionary

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -880,17 +880,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  callable  $callback
      * @return static
      */
-    
     public function mapToDictionary(callable $callback)
     {
         $dictionary = [];
 
-        $this->each(function($item, $key) use(&$dictionary, $callback) {
+        $this->each(function ($item, $key) use(&$dictionary, $callback) {
             $pair = $callback($item, $key);
             $key = key($pair);
             $value = reset($pair);
 
-            if (!isset($dictionary[$key])) {
+            if (! isset($dictionary[$key])) {
                 $dictionary[$key] = [];
             }
             $dictionary[$key][] = $value;

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -880,13 +880,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  callable  $callback
      * @return static
      */
+    
     public function mapToDictionary(callable $callback)
     {
-        $dictionary = $this->map($callback)->reduce(function ($groups, $pair) {
-            $groups[key($pair)][] = reset($pair);
+        $dictionary = [];
 
-            return $groups;
-        }, []);
+        $this->each(function($item) use(&$dictionary, $callback) {
+            $pair = $callback($item);
+            $key = key($pair);
+            $value = reset($pair);
+
+            if (!isset($dictionary[$key])) {
+                $dictionary[$key] = [];
+            }
+            $dictionary[$key][] = $value;
+        });
 
         return new static($dictionary);
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -885,8 +885,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $dictionary = [];
 
-        $this->each(function($item) use(&$dictionary, $callback) {
-            $pair = $callback($item);
+        $this->each(function($item, $key) use(&$dictionary, $callback) {
+            $pair = $callback($item, $key);
             $key = key($pair);
             $value = reset($pair);
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -884,7 +884,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $dictionary = [];
 
-        $this->each(function ($item, $key) use(&$dictionary, $callback) {
+        $this->each(function ($item, $key) use (&$dictionary, $callback) {
             $pair = $callback($item, $key);
             $key = key($pair);
             $value = reset($pair);


### PR DESCRIPTION
I just ran into huge performance problems when eager loading multiple thousand rows (~20k in my case).

I tracked it down to the Dictionary::mapToDictionary method, which somehow is very slow when dealing with this amount of data.

I rewrote the method without map-reduce and it is much faster now. Let me know what you think!

The following benchmark was taken on an i7-6700 machine. (Benchmark script attached).
[benchmap.zip](https://github.com/laravel/framework/files/1628462/benchmap.zip)
> time for 100 (current): 5.4161071777344E-5
> time for 20k (current): 17.208889961243
> time for 25k (current): 35.498338937759
> time for (new) 100: 2.5948047637939E-5
> time for 20k (new): 0.012021064758301
> time for 25k (new): 0.016914844512939

