### PR TITLE
[5.5] Fixes Scheduler between for time frame before and after midnight 

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -52,6 +52,10 @@ trait ManagesFrequencies
      */
     private function inTimeInterval($startTime, $endTime)
     {
+        if ($this->endTimeGreater($startTime, $endTime)) {
+            $endTime .= ' +1 day';
+        }
+
         return function () use ($startTime, $endTime) {
             return Carbon::now($this->timezone)->between(
                 Carbon::parse($startTime, $this->timezone),
@@ -59,6 +63,18 @@ trait ManagesFrequencies
                 true
             );
         };
+    }
+
+    /**
+     * Check if endTime is considered greater for humans.
+     *
+     * @param string $startTime
+     * @param string $endTime
+     * @return bool
+     */
+    private function endTimeGreater($startTime, $endTime)
+    {
+        return explode(':', $startTime)[0] > explode(':', $endTime)[0];
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -52,7 +52,7 @@ trait ManagesFrequencies
      */
     private function inTimeInterval($startTime, $endTime)
     {
-        if ($this->endTimeGreater($startTime, $endTime)) {
+        if ($this->isMidnightBetween($startTime, $endTime)) {
             $endTime .= ' +1 day';
         }
 
@@ -66,15 +66,15 @@ trait ManagesFrequencies
     }
 
     /**
-     * Check if endTime is considered greater for humans.
+     * Check if startTime and endTime are before and after midnight
      *
      * @param string $startTime
      * @param string $endTime
      * @return bool
      */
-    private function endTimeGreater($startTime, $endTime)
+    private function isMidnightBetween($startTime, $endTime)
     {
-        return explode(':', $startTime)[0] > explode(':', $endTime)[0];
+        return strtotime($startTime) > strtotime($endTime);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -66,7 +66,7 @@ trait ManagesFrequencies
     }
 
     /**
-     * Check if startTime and endTime are before and after midnight
+     * Check if startTime and endTime are before and after midnight.
      *
      * @param string $startTime
      * @param string $endTime


### PR DESCRIPTION
# Steps to reproduce
Schedule a task to run between 10:00 PM and 03:00 AM (a time frame of 5 hours)
```
$schedule->command('route:call import/start')
            ->everyFifteenMinutes()
            ->between('22:00', '03:00')
```

# Expected result
Have the task to be run between 10:00 PM and 03:00 AM according to the frequency.

# Actual result
The task will run between 03:00 AM and 10:00 PM (a time frame of 19 hours)

---
This PR fixes #22723  