### PR TITLE
[5.6] Add stream download response

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -59,10 +59,21 @@ interface ResponseFactory
     public function stream($callback, $status = 200, array $headers = []);
 
     /**
+     * Return a new streamed response as a file download from the application.
+     *
+     * @param  \Closure  $callback
+     * @param  string|null  $name
+     * @param  array  $headers
+     * @param  string|null  $disposition
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     */
+    public function streamDownload($callback, $name = null, array $headers = [], $disposition = 'attachment');
+
+    /**
      * Create a new file download response.
      *
      * @param  \SplFileInfo|string  $file
-     * @param  string  $name
+     * @param  string|null  $name
      * @param  array  $headers
      * @param  string|null  $disposition
      * @return \Symfony\Component\HttpFoundation\BinaryFileResponse

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -112,10 +112,36 @@ class ResponseFactory implements FactoryContract
     }
 
     /**
+     * Return a new streamed response as a file download from the application.
+     *
+     * @param  \Closure  $callback
+     * @param  string|null  $name
+     * @param  array  $headers
+     * @param  string|null  $disposition
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     */
+    public function streamDownload($callback, $name = null, array $headers = [], $disposition = 'attachment')
+    {
+        $response = new StreamedResponse($callback, 200, $headers);
+
+        if (! is_null($name)) {
+            $dispositionHeader = $response->headers->makeDisposition(
+                $disposition,
+                $name,
+                $this->fallbackName($name)
+            );
+
+            $response->headers->set('Content-Disposition', $dispositionHeader);
+        }
+
+        return $response;
+    }
+
+    /**
      * Create a new file download response.
      *
      * @param  \SplFileInfo|string  $file
-     * @param  string  $name
+     * @param  string|null  $name
      * @param  array  $headers
      * @param  string|null  $disposition
      * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
@@ -125,10 +151,21 @@ class ResponseFactory implements FactoryContract
         $response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
 
         if (! is_null($name)) {
-            return $response->setContentDisposition($disposition, $name, str_replace('%', '', Str::ascii($name)));
+            return $response->setContentDisposition($disposition, $name, $this->fallbackName($name));
         }
 
         return $response;
+    }
+
+    /**
+     * Returns a string containing only ASCII characters that is semantically equivalent to $name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function fallbackName($name)
+    {
+        return str_replace('%', '', Str::ascii($name));
     }
 
     /**


### PR DESCRIPTION
Adds the ability to respond with remote files as downloads.

```
<?php

    Route::get('/', function () {
        return response()->streamDownload(function () {
            echo file_get_contents('https://my.remote.com/file/store-12345.jpg');
        }, 'nice-name.jpg');
    });
```