### PR TITLE
[5.5] Fix abundant table-prefix in SQLite grammar

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -41,7 +41,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileColumnListing($table)
     {
-        return 'pragma table_info('.str_replace('.', '__', $table).')';
+        return 'pragma table_info('.$this->wrap(str_replace('.', '__', $table)).')';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -41,7 +41,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileColumnListing($table)
     {
-        return 'pragma table_info('.$this->wrapTable(str_replace('.', '__', $table)).')';
+        return 'pragma table_info('.str_replace('.', '__', $table).')';
     }
 
     /**

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -112,10 +112,13 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         });
 
         $this->assertTrue($schema->hasTable('users'));
+        $this->assertTrue($schema->hasColumn('users','name'));
 
         $schema->table('users', function (Blueprint $table) {
             $table->dropColumn('name');
         });
+
+        $this->assertFalse($schema->hasColumn('users','name'));
     }
 
     /**

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -112,13 +112,13 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         });
 
         $this->assertTrue($schema->hasTable('users'));
-        $this->assertTrue($schema->hasColumn('users','name'));
+        $this->assertTrue($schema->hasColumn('users', 'name'));
 
         $schema->table('users', function (Blueprint $table) {
             $table->dropColumn('name');
         });
 
-        $this->assertFalse($schema->hasColumn('users','name'));
+        $this->assertFalse($schema->hasColumn('users', 'name'));
     }
 
     /**


### PR DESCRIPTION
There is a prefixing issue when using SQLite driver as discussed in #22741. 
I introduced some additional tests (@victorlap) which showed there is a prefixing issue in another method of SQLiteGrammar as well: `compileColumnListing`. 
`compileColumnListing` is not responsible for adding table prefixes as this is already done by `Schema\Builder`
This changes the behavior of `compileColumnListing` when prefixes are used. 