### PR TITLE
[5.5] Adds default string value to Artisan line method

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -437,7 +437,7 @@ class Command extends SymfonyCommand
      * @param  null|int|string  $verbosity
      * @return void
      */
-    public function line($string, $style = null, $verbosity = null)
+    public function line($string = '', $style = null, $verbosity = null)
     {
         $styled = $style ? "<$style>$string</$style>" : $string;
 


### PR DESCRIPTION
This PR gives the possibility of put an empty line on an Artisan command without having to put an empty string as parameter.

**Before**:

```php
        $this->line(''); // <-- We have to put an empty string in order to add a new empty line.
```
**After**:

```php
        $this->line();
    }
```

The result is still the same, an empty line:
<img width="100%" alt="empty line" src="https://user-images.githubusercontent.com/5457236/34917418-7cae29aa-f946-11e7-87e7-3a8b33f32c7a.png">
