### PR TITLE
[5.6] Fix pivot serialization

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent;
 
 use LogicException;
 use Illuminate\Support\Arr;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Support\Collection as BaseCollection;
 
@@ -407,6 +408,14 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function getQueueableIds()
     {
+        if ($this->isEmpty()) {
+            return [];
+        }
+
+        if ($this->first() instanceof Pivot) {
+            return $this->map->getQueueableId()->all();
+        }
+
         return $this->modelKeys();
     }
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -412,11 +412,9 @@ class Collection extends BaseCollection implements QueueableCollection
             return [];
         }
 
-        if ($this->first() instanceof Pivot) {
-            return $this->map->getQueueableId()->all();
-        }
-
-        return $this->modelKeys();
+        return $this->first() instanceof Pivot
+                    ? $this->map->getQueueableId()->all()
+                    : $this->modelKeys();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Builder;
 
 class MorphPivot extends Pivot
@@ -75,5 +76,75 @@ class MorphPivot extends Pivot
         $this->morphClass = $morphClass;
 
         return $this;
+    }
+
+    /**
+     * Get the queueable identity for the entity.
+     *
+     * @return mixed
+     */
+    public function getQueueableId()
+    {
+        if (isset($this->attributes[$this->getKeyName()])) {
+            return $this->getKey();
+        }
+
+        return sprintf(
+            '%s:%s:%s:%s:%s:%s',
+            $this->foreignKey, $this->getAttribute($this->foreignKey),
+            $this->relatedKey, $this->getAttribute($this->relatedKey),
+            $this->morphType, $this->morphClass
+        );
+    }
+
+    /**
+     * Get a new query to restore one or more models by their queueable IDs.
+     *
+     * @param  array|int  $ids
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function newQueryForRestoration($ids)
+    {
+        if (is_array($ids)) {
+            return $this->newQueryForCollectionRestoration($ids);
+        }
+
+        if (! Str::contains($ids, ':')) {
+            return parent::newQueryForRestoration($ids);
+        }
+
+        $segments = explode(':', $ids);
+
+        return $this->newQueryWithoutScopes()
+                        ->where($segments[0], $segments[1])
+                        ->where($segments[2], $segments[3])
+                        ->where($segments[4], $segments[5]);
+    }
+
+    /**
+     * Get a new query to restore multiple models by their queueable IDs.
+     *
+     * @param  array|int  $ids
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function newQueryForCollectionRestoration(array $ids)
+    {
+        if (! Str::contains($ids[0], ':')) {
+            return parent::newQueryForRestoration($ids);
+        }
+
+        $query = $this->newQueryWithoutScopes();
+
+        foreach ($ids as $id) {
+            $segments = explode(':', $id);
+
+            $query->orWhere(function ($query) use ($segments) {
+                return $query->where($segments[0], $segments[1])
+                             ->where($segments[2], $segments[3])
+                             ->where($segments[4], $segments[5]);
+            });
+        }
+
+        return $query;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -147,6 +147,22 @@ class MorphToMany extends BelongsToMany
     }
 
     /**
+     * Get the pivot columns for the relation.
+     *
+     * "pivot_" is prefixed ot each column for easy removal later.
+     *
+     * @return array
+     */
+    protected function aliasedPivotColumns()
+    {
+        $defaults = [$this->foreignPivotKey, $this->relatedPivotKey, $this->morphType];
+
+        return collect(array_merge($defaults, $this->pivotColumns))->map(function ($column) {
+            return $this->table.'.'.$column.' as pivot_'.$column;
+        })->unique()->all();
+    }
+
+    /**
      * Get the foreign key "type" name.
      *
      * @return string

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -222,4 +222,71 @@ class Pivot extends Model
     {
         return $this->pivotParent->getUpdatedAtColumn();
     }
+
+    /**
+     * Get the queueable identity for the entity.
+     *
+     * @return mixed
+     */
+    public function getQueueableId()
+    {
+        if (isset($this->attributes[$this->getKeyName()])) {
+            return $this->getKey();
+        }
+
+        return sprintf(
+            '%s:%s:%s:%s',
+            $this->foreignKey, $this->getAttribute($this->foreignKey),
+            $this->relatedKey, $this->getAttribute($this->relatedKey)
+        );
+    }
+
+    /**
+     * Get a new query to restore one or more models by their queueable IDs.
+     *
+     * @param  array|int  $ids
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function newQueryForRestoration($ids)
+    {
+        if (is_array($ids)) {
+            return $this->newQueryForCollectionRestoration($ids);
+        }
+
+        if (! Str::contains($ids, ':')) {
+            return parent::newQueryForRestoration($ids);
+        }
+
+        $segments = explode(':', $ids);
+
+        return $this->newQueryWithoutScopes()
+                        ->where($segments[0], $segments[1])
+                        ->where($segments[2], $segments[3]);
+    }
+
+    /**
+     * Get a new query to restore multiple models by their queueable IDs.
+     *
+     * @param  array|int  $ids
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function newQueryForCollectionRestoration(array $ids)
+    {
+        if (! Str::contains($ids[0], ':')) {
+            return parent::newQueryForRestoration($ids);
+        }
+
+        $query = $this->newQueryWithoutScopes();
+
+        foreach ($ids as $id) {
+            $segments = explode(':', $id);
+
+            $query->orWhere(function ($query) use ($segments) {
+                return $query->where($segments[0], $segments[1])
+                             ->where($segments[2], $segments[3]);
+            });
+        }
+
+        return $query;
+    }
 }

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -62,6 +62,8 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
 
         $this->assertEquals($project->collaborators->first()->pivot->user_id, $class->pivot->user_id);
         $this->assertEquals($project->collaborators->first()->pivot->project_id, $class->pivot->project_id);
+
+        $class->pivot->save();
     }
 
 
@@ -79,6 +81,8 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
         $this->assertEquals($project->tags->first()->pivot->tag_id, $class->pivot->tag_id);
         $this->assertEquals($project->tags->first()->pivot->taggable_id, $class->pivot->taggable_id);
         $this->assertEquals($project->tags->first()->pivot->taggable_type, $class->pivot->taggable_type);
+
+        $class->pivot->save();
     }
 
 

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -49,6 +49,25 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
         $this->assertEquals($project->collaborators->first()->pivot->user_id, $class->collaborator->user_id);
         $this->assertEquals($project->collaborators->first()->pivot->project_id, $class->collaborator->project_id);
     }
+
+
+    public function test_collection_of_pivots_can_be_serialized_and_restored()
+    {
+        $user = PivotSerializationTestUser::forceCreate(['email' => 'taylor@laravel.com']);
+        $user2 = PivotSerializationTestUser::forceCreate(['email' => 'mohamed@laravel.com']);
+        $project = PivotSerializationTestProject::forceCreate(['name' => 'Test Project']);
+
+        $project->collaborators()->attach($user);
+        $project->collaborators()->attach($user2);
+
+        $project = $project->fresh();
+
+        $class = new PivotSerializationTestCollectionClass($project->collaborators->map->pivot);
+        $class = unserialize(serialize($class));
+
+        $this->assertEquals($project->collaborators[0]->pivot->user_id, $class->collaborators[0]->user_id);
+        $this->assertEquals($project->collaborators[1]->pivot->project_id, $class->collaborators[1]->project_id);
+    }
 }
 
 
@@ -61,6 +80,19 @@ class PivotSerializationTestClass
     public function __construct($collaborator)
     {
         $this->collaborator = $collaborator;
+    }
+}
+
+
+class PivotSerializationTestCollectionClass
+{
+    use SerializesModels;
+
+    public $collaborators;
+
+    public function __construct($collaborators)
+    {
+        $this->collaborators = $collaborators;
     }
 }
 

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -52,9 +52,6 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
     }
 
 
-    /**
-     * @group wow
-     */
     public function test_collection_of_pivots_can_be_serialized_and_restored()
     {
         $user = PivotSerializationTestUser::forceCreate(['email' => 'taylor@laravel.com']);

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * @group integration
+ */
+class EloquentPivotSerializationTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+            $table->timestamps();
+        });
+
+        Schema::create('projects', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('project_users', function ($table) {
+            $table->integer('user_id');
+            $table->integer('project_id');
+        });
+    }
+
+
+    public function test_pivot_can_be_serialized_and_restored()
+    {
+        $user = PivotSerializationTestUser::forceCreate(['email' => 'taylor@laravel.com']);
+        $project = PivotSerializationTestProject::forceCreate(['name' => 'Test Project']);
+        $project->collaborators()->attach($user);
+
+        $project = $project->fresh();
+
+        $class = new PivotSerializationTestClass($project->collaborators->first()->pivot);
+        $class = unserialize(serialize($class));
+
+        $this->assertEquals($project->collaborators->first()->pivot->user_id, $class->collaborator->user_id);
+        $this->assertEquals($project->collaborators->first()->pivot->project_id, $class->collaborator->project_id);
+    }
+}
+
+
+class PivotSerializationTestClass
+{
+    use SerializesModels;
+
+    public $collaborator;
+
+    public function __construct($collaborator)
+    {
+        $this->collaborator = $collaborator;
+    }
+}
+
+
+class PivotSerializationTestUser extends Model
+{
+    public $table = 'users';
+}
+
+
+class PivotSerializationTestProject extends Model
+{
+    public $table = 'projects';
+
+    public function collaborators()
+    {
+        return $this->belongsToMany(
+            PivotSerializationTestUser::class, 'project_users', 'project_id', 'user_id'
+        )->using(PivotSerializationTestCollaborator::class);
+    }
+}
+
+
+class PivotSerializationTestCollaborator extends Pivot
+{
+    public $table = 'project_users';
+}

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -6,6 +6,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\Collection as DatabaseCollection;
 
 /**
  * @group integration
@@ -51,6 +52,9 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
     }
 
 
+    /**
+     * @group wow
+     */
     public function test_collection_of_pivots_can_be_serialized_and_restored()
     {
         $user = PivotSerializationTestUser::forceCreate(['email' => 'taylor@laravel.com']);
@@ -62,7 +66,7 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
 
         $project = $project->fresh();
 
-        $class = new PivotSerializationTestCollectionClass($project->collaborators->map->pivot);
+        $class = new PivotSerializationTestCollectionClass(DatabaseCollection::make($project->collaborators->map->pivot));
         $class = unserialize(serialize($class));
 
         $this->assertEquals($project->collaborators[0]->pivot->user_id, $class->collaborators[0]->user_id);

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -48,7 +48,6 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
         });
     }
 
-
     public function test_pivot_can_be_serialized_and_restored()
     {
         $user = PivotSerializationTestUser::forceCreate(['email' => 'taylor@laravel.com']);
@@ -63,7 +62,6 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
         $this->assertEquals($project->collaborators->first()->pivot->user_id, $class->pivot->user_id);
         $this->assertEquals($project->collaborators->first()->pivot->project_id, $class->pivot->project_id);
     }
-
 
     public function test_morph_pivot_can_be_serialized_and_restored()
     {
@@ -80,7 +78,6 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
         $this->assertEquals($project->tags->first()->pivot->taggable_id, $class->pivot->taggable_id);
         $this->assertEquals($project->tags->first()->pivot->taggable_type, $class->pivot->taggable_type);
     }
-
 
     public function test_collection_of_pivots_can_be_serialized_and_restored()
     {
@@ -99,7 +96,6 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
         $this->assertEquals($project->collaborators[0]->pivot->user_id, $class->pivots[0]->user_id);
         $this->assertEquals($project->collaborators[1]->pivot->project_id, $class->pivots[1]->project_id);
     }
-
 
     public function test_collection_of_morph_pivots_can_be_serialized_and_restored()
     {
@@ -125,7 +121,6 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
     }
 }
 
-
 class PivotSerializationTestClass
 {
     use SerializesModels;
@@ -137,7 +132,6 @@ class PivotSerializationTestClass
         $this->pivot = $pivot;
     }
 }
-
 
 class PivotSerializationTestCollectionClass
 {
@@ -151,12 +145,10 @@ class PivotSerializationTestCollectionClass
     }
 }
 
-
 class PivotSerializationTestUser extends Model
 {
     public $table = 'users';
 }
-
 
 class PivotSerializationTestProject extends Model
 {
@@ -176,7 +168,6 @@ class PivotSerializationTestProject extends Model
     }
 }
 
-
 class PivotSerializationTestTag extends Model
 {
     public $table = 'tags';
@@ -187,7 +178,6 @@ class PivotSerializationTestTag extends Model
                     ->using(PivotSerializationTestTagAttachment::class);
     }
 }
-
 
 class PivotSerializationTestCollaborator extends Pivot
 {


### PR DESCRIPTION
Currently, passing a custom pivot model to a queued job will cause errors when pulling the job back off the queue. This correct the storage of pivot model and morphed pivot model queueable IDs and also adjusts the restoration queries to use the new format.