### PR TITLE
[5.5] Modify find eloquent collection method to accept collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -22,7 +22,7 @@ class Collection extends BaseCollection implements QueueableCollection
             $key = $key->getKey();
         }
 
-        if($key instanceof BaseCollection) {
+        if ($key instanceof BaseCollection) {
             $key = $key->toArray();
         }
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -22,6 +22,10 @@ class Collection extends BaseCollection implements QueueableCollection
             $key = $key->getKey();
         }
 
+        if($key instanceof BaseCollection) {
+            $key = $key->toArray();
+        }
+
         if (is_array($key)) {
             if ($this->isEmpty()) {
                 return new static;

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent;
 
 use LogicException;
 use Illuminate\Support\Arr;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Support\Collection as BaseCollection;
 
@@ -22,7 +23,7 @@ class Collection extends BaseCollection implements QueueableCollection
             $key = $key->getKey();
         }
 
-        if ($key instanceof BaseCollection) {
+        if ($key instanceof Arrayable) {
             $key = $key->toArray();
         }
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -148,6 +148,8 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertCount(1, $c->find([2]));
         $this->assertEquals(2, $c->find([2])->first()->id);
         $this->assertCount(2, $c->find([2, 3, 4]));
+        $this->assertCount(2, $c->find(collect([2, 3, 4])));
+        $this->assertEquals([2, 3], $c->find(collect([2, 3, 4]))->pluck('id')->all());
         $this->assertEquals([2, 3], $c->find([2, 3, 4])->pluck('id')->all());
     }
 


### PR DESCRIPTION
this **PR** will allows eloquent collection **find()** method to accept **collection**

```php

$users = User::get()->find(collect([20,40,30]))

```