### PR TITLE
[5.5] Drop empty expectedExceptionMessage annotations

### DIFF
--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -42,7 +42,6 @@ class AuthGuardTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
-     * @expectedExceptionMessage
      */
     public function testBasicReturnsResponseOnFailure()
     {

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -59,7 +59,6 @@ class BroadcasterTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
-     * @expectedExceptionMessage
      */
     public function testNotFoundThrowsHttpException()
     {

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -56,7 +56,6 @@ class ClearCommandTest extends TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage
      */
     public function testClearWithInvalidStoreArgument()
     {

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -986,7 +986,6 @@ class ContainerTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Container\EntryNotFoundException
-     * @expectedExceptionMessage
      */
     public function testUnknownEntryThrowsException()
     {

--- a/tests/Integration/Cache/CacheLockTest.php
+++ b/tests/Integration/Cache/CacheLockTest.php
@@ -86,7 +86,6 @@ class CacheLockTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Contracts\Cache\LockTimeoutException
-     * @expectedExceptionMessage
      */
     public function test_locks_throw_timeout_if_block_expires()
     {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -526,7 +526,6 @@ class RoutingRouteTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @expectedExceptionMessage
      */
     public function testRoutesDontMatchNonMatchingPathsWithLeadingOptionals()
     {
@@ -539,7 +538,6 @@ class RoutingRouteTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @expectedExceptionMessage
      */
     public function testRoutesDontMatchNonMatchingDomain()
     {
@@ -1368,7 +1366,6 @@ class RoutingRouteTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     * @expectedExceptionMessage
      */
     public function testImplicitBindingsWithOptionalParameterWithNonExistingKeyInUri()
     {


### PR DESCRIPTION
This empty assertion brings no effect as it's ignored by PHPUnit