### PR TITLE
[5.6] Update 503.blade.php

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/503.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/503.blade.php
@@ -2,4 +2,8 @@
 
 @section('title', 'Service Unavailable')
 
-@section('message', 'Be right back.')
+@if ($message = $exception->getMessage())
+    @section('message', $message)
+@else
+    @section('message', 'Be right back.')
+@endif


### PR DESCRIPTION
When an application is put in maintenance mode with `php artisan down --message "Some info"`
the 503.blade.php now shows the message the user provide. If none, it uses the default "Be right back." message.