### PR TITLE
[5.6] Blade component aliases

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -425,6 +425,30 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Register a component alias.
+     *
+     * @param  string  $path
+     * @param  string  $alias
+     * @return void
+     */
+    public function component($path, $alias = null)
+    {
+        $alias = $alias ?: array_last(explode('.', $path));
+
+        $this->directive($alias, function ($expression) use ($path) {
+            if ($expression) {
+                return "<?php \$__env->startComponent('{$path}', {$expression}); ?>";
+            } else {
+                return "<?php \$__env->startComponent('{$path}'); ?>";
+            }
+        });
+
+        $this->directive('end'.$alias, function ($expression) use ($path) {
+            return '<?php echo $__env->renderComponent(); ?>';
+        });
+    }
+
+    /**
      * Register a handler for custom directives.
      *
      * @param  string  $name

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -90,4 +90,37 @@ class BladeCustomTest extends AbstractBladeTestCase
 <?php endif; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testCustomComponents()
+    {
+        $this->compiler->component('app.components.alert', 'alert');
+
+        $string = '@alert
+@endalert';
+        $expected = '<?php $__env->startComponent(\'app.components.alert\'); ?>
+<?php echo $__env->renderComponent(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testCustomComponentsWithSlots()
+    {
+        $this->compiler->component('app.components.alert', 'alert');
+
+        $string = '@alert([\'type\' => \'danger\'])
+@endalert';
+        $expected = '<?php $__env->startComponent(\'app.components.alert\', [\'type\' => \'danger\']); ?>
+<?php echo $__env->renderComponent(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testCustomComponentsDefaultAlias()
+    {
+        $this->compiler->component('app.components.alert');
+
+        $string = '@alert
+@endalert';
+        $expected = '<?php $__env->startComponent(\'app.components.alert\'); ?>
+<?php echo $__env->renderComponent(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
This PR adds a `component` method to Blade for registering component aliases. Blade components are one of my favorite additions to Laravel, but the syntax can be quite verbose sometimes. This adds an easy way to create component directives, for components that you're going to use all over your app.

```php
Blade::component('app.components.alert', 'alert');
```

```blade
@alert(['type' => 'danger'])
    @slot('title')
        Forbidden
    @endslot

    You are not allowed to access this resource!
@endalert
```

This PR also adds a shorter syntax, that assumes that you'll want to alias your component to the last part of the component path. This allows you to omit the second argument.

```php
Blade::component('app.components.alert');
```

You lose explicitness though, so I could drop that from the PR if it's in the way.