### PR TITLE
[5.5] Use expectation methods over annotations

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -11,12 +11,11 @@ use Illuminate\Auth\Access\HandlesAuthorization;
 
 class GateTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Callback must be a callable or a 'Class@method'
-     */
     public function test_gate_throws_exception_on_invalid_callback_type()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Callback must be a callable or a \'Class@method\'');
+
         $this->getBasicGate()->define('foo', 'foo');
     }
 
@@ -274,12 +273,11 @@ class GateTest extends TestCase
         $this->assertTrue($gate->forUser((object) ['id' => 2])->check('foo'));
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\Access\AuthorizationException
-     * @expectedExceptionMessage You are not an admin.
-     */
     public function test_authorize_throws_unauthorized_exception()
     {
+        $this->expectException(\Illuminate\Auth\Access\AuthorizationException::class);
+        $this->expectExceptionMessage('You are not an admin.');
+
         $gate = $this->getBasicGate();
 
         $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -40,11 +40,10 @@ class AuthGuardTest extends TestCase
         $guard->basic('email');
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
-     */
     public function testBasicReturnsResponseOnFailure()
     {
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException::class);
+
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = m::mock('Illuminate\Auth\SessionGuard[check,attempt]', ['default', $provider, $session]);
         $guard->shouldReceive('check')->once()->andReturn(false);
@@ -166,12 +165,11 @@ class AuthGuardTest extends TestCase
         $guard->setUser($user);
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     * @expectedExceptionMessage Unauthenticated.
-     */
     public function testAuthenticateThrowsWhenUserIsNull()
     {
+        $this->expectException(\Illuminate\Auth\AuthenticationException::class);
+        $this->expectExceptionMessage('Unauthenticated.');
+
         $guard = $this->getGuard();
         $guard->getSession()->shouldReceive('get')->once()->andReturn(null);
 

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -23,12 +23,11 @@ class AuthPasswordBrokerTest extends TestCase
         $this->assertEquals(PasswordBroker::INVALID_USER, $broker->sendResetLink(['credentials']));
     }
 
-    /**
-     * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage User must implement CanResetPassword interface.
-     */
     public function testGetUserThrowsExceptionIfUserDoesntImplementCanResetPassword()
     {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('User must implement CanResetPassword interface.');
+
         $broker = $this->getBroker($mocks = $this->getMocks());
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn('bar');
 

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -34,12 +34,11 @@ class AuthenticateMiddlewareTest extends TestCase
         });
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     * @expectedExceptionMessage Unauthenticated.
-     */
     public function testDefaultUnauthenticatedThrows()
     {
+        $this->expectException(\Illuminate\Auth\AuthenticationException::class);
+        $this->expectExceptionMessage('Unauthenticated.');
+
         $this->registerAuthDriver('default', false);
 
         $this->authenticate();
@@ -80,12 +79,11 @@ class AuthenticateMiddlewareTest extends TestCase
         $this->assertSame($secondary, $this->auth->guard());
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     * @expectedExceptionMessage Unauthenticated.
-     */
     public function testMultipleDriversUnauthenticatedThrows()
     {
+        $this->expectException(\Illuminate\Auth\AuthenticationException::class);
+        $this->expectExceptionMessage('Unauthenticated.');
+
         $this->registerAuthDriver('default', false);
 
         $this->registerAuthDriver('secondary', false);

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -54,12 +54,11 @@ class AuthorizeMiddlewareTest extends TestCase
         });
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\Access\AuthorizationException
-     * @expectedExceptionMessage This action is unauthorized.
-     */
     public function testSimpleAbilityUnauthorized()
     {
+        $this->expectException(\Illuminate\Auth\Access\AuthorizationException::class);
+        $this->expectExceptionMessage('This action is unauthorized.');
+
         $this->gate()->define('view-dashboard', function ($user, $additional = null) {
             $this->assertNull($additional);
 
@@ -94,12 +93,11 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertEquals($response->content(), 'success');
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\Access\AuthorizationException
-     * @expectedExceptionMessage This action is unauthorized.
-     */
     public function testModelTypeUnauthorized()
     {
+        $this->expectException(\Illuminate\Auth\Access\AuthorizationException::class);
+        $this->expectExceptionMessage('This action is unauthorized.');
+
         $this->gate()->define('create', function ($user, $model) {
             $this->assertEquals($model, 'App\User');
 
@@ -136,12 +134,11 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertEquals($response->content(), 'success');
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\Access\AuthorizationException
-     * @expectedExceptionMessage This action is unauthorized.
-     */
     public function testModelUnauthorized()
     {
+        $this->expectException(\Illuminate\Auth\Access\AuthorizationException::class);
+        $this->expectExceptionMessage('This action is unauthorized.');
+
         $post = new stdClass;
 
         $this->router->bind('post', function () use ($post) {

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -57,11 +57,10 @@ class BroadcasterTest extends TestCase
         Container::setInstance(new Container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
-     */
     public function testNotFoundThrowsHttpException()
     {
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+
         $broadcaster = new FakeBroadcaster;
         $callback = function ($user, BroadcasterTestEloquentModelNotFoundStub $model) {
         };

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -54,11 +54,10 @@ class ClearCommandTest extends TestCase
         $this->runCommand($command, ['store' => 'foo']);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testClearWithInvalidStoreArgument()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $command = new ClearCommandTestStub(
             $cacheManager = m::mock('Illuminate\Cache\CacheManager'),
             $files = m::mock('Illuminate\Filesystem\Filesystem')

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -430,32 +430,29 @@ class ContainerTest extends TestCase
         $this->assertFalse($_SERVER['__test.rebind']);
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Container\BindingResolutionException
-     * @expectedExceptionMessage Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class Illuminate\Tests\Container\ContainerMixedPrimitiveStub
-     */
     public function testInternalClassWithDefaultParameters()
     {
+        $this->expectException(\Illuminate\Contracts\Container\BindingResolutionException::class);
+        $this->expectExceptionMessage('Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class Illuminate\\Tests\\Container\\ContainerMixedPrimitiveStub');
+
         $container = new Container;
         $container->make('Illuminate\Tests\Container\ContainerMixedPrimitiveStub', []);
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Container\BindingResolutionException
-     * @expectedExceptionMessage Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable.
-     */
     public function testBindingResolutionExceptionMessage()
     {
+        $this->expectException(\Illuminate\Contracts\Container\BindingResolutionException::class);
+        $this->expectExceptionMessage('Target [Illuminate\\Tests\\Container\\IContainerContractStub] is not instantiable.');
+
         $container = new Container;
         $container->make('Illuminate\Tests\Container\IContainerContractStub', []);
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Container\BindingResolutionException
-     * @expectedExceptionMessage Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable while building [Illuminate\Tests\Container\ContainerTestContextInjectOne].
-     */
     public function testBindingResolutionExceptionMessageIncludesBuildStack()
     {
+        $this->expectException(\Illuminate\Contracts\Container\BindingResolutionException::class);
+        $this->expectExceptionMessage('Target [Illuminate\\Tests\\Container\\IContainerContractStub] is not instantiable while building [Illuminate\\Tests\\Container\\ContainerTestContextInjectOne].');
+
         $container = new Container;
         $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne', []);
     }
@@ -491,12 +488,11 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $result[1]);
     }
 
-    /**
-     * @expectedException \ReflectionException
-     * @expectedExceptionMessage Function ContainerTestCallStub() does not exist
-     */
     public function testCallWithAtSignBasedClassReferencesWithoutMethodThrowsException()
     {
+        $this->expectException(\ReflectionException::class);
+        $this->expectExceptionMessage('Function ContainerTestCallStub() does not exist');
+
         $container = new Container;
         $result = $container->call('ContainerTestCallStub');
     }
@@ -984,11 +980,10 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $container->get('Taylor'));
     }
 
-    /**
-     * @expectedException \Illuminate\Container\EntryNotFoundException
-     */
     public function testUnknownEntryThrowsException()
     {
+        $this->expectException(\Illuminate\Container\EntryNotFoundException::class);
+
         $container = new Container;
         $container->get('Taylor');
     }

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -71,22 +71,20 @@ class DatabaseConnectionFactoryTest extends TestCase
         $this->assertNotInstanceOf('PDO', $readPdo->getValue($connection));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage A driver must be specified.
-     */
     public function testIfDriverIsntSetExceptionIsThrown()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('A driver must be specified.');
+
         $factory = new ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
         $factory->createConnector(['foo']);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unsupported driver [foo]
-     */
     public function testExceptionIsThrownOnUnsupportedDriver()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported driver [foo]');
+
         $factory = new ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
         $container->shouldReceive('bound')->once()->andReturn(false);
         $factory->createConnector(['driver' => 'foo']);

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -223,12 +223,11 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals($mock, $result);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\QueryException
-     * @expectedExceptionMessage Deadlock found when trying to get lock (SQL: )
-     */
     public function testTransactionMethodRetriesOnDeadlock()
     {
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectExceptionMessage('Deadlock found when trying to get lock (SQL: )');
+
         $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['beginTransaction', 'commit', 'rollBack'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
         $pdo->expects($this->exactly(3))->method('beginTransaction');
@@ -255,12 +254,11 @@ class DatabaseConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Illuminate\Database\QueryException
-     * @expectedExceptionMessage server has gone away (SQL: foo)
-     */
     public function testOnLostConnectionPDOIsNotSwappedWithinATransaction()
     {
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectExceptionMessage('server has gone away (SQL: foo)');
+
         $pdo = m::mock(\PDO::class);
         $pdo->shouldReceive('beginTransaction')->once();
         $statement = m::mock(\PDOStatement::class);
@@ -309,12 +307,11 @@ class DatabaseConnectionTest extends TestCase
         }]);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\QueryException
-     * @expectedExceptionMessage  (SQL: ) (SQL: )
-     */
     public function testRunMethodNeverRetriesIfWithinTransaction()
     {
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectExceptionMessage('(SQL: ) (SQL: )');
+
         $method = (new \ReflectionClass('Illuminate\Database\Connection'))->getMethod('run');
         $method->setAccessible(true);
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -59,11 +59,10 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertInstanceOf('Illuminate\Database\Eloquent\Model', $result);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
     public function testFindOrFailMethodThrowsModelNotFoundException()
     {
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($this->getMockModel());
         $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
@@ -71,11 +70,10 @@ class DatabaseEloquentBuilderTest extends TestCase
         $result = $builder->findOrFail('bar', ['column']);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
     public function testFindOrFailMethodWithManyThrowsModelNotFoundException()
     {
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[get]', [$this->getMockQueryBuilder()]);
         $builder->setModel($this->getMockModel());
         $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', [1, 2]);
@@ -83,11 +81,10 @@ class DatabaseEloquentBuilderTest extends TestCase
         $result = $builder->findOrFail([1, 2], ['column']);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
     public function testFirstOrFailMethodThrowsModelNotFoundException()
     {
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($this->getMockModel());
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
@@ -489,11 +486,10 @@ class DatabaseEloquentBuilderTest extends TestCase
         $relation = $builder->getRelation('ordersGroups');
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\RelationNotFoundException
-     */
     public function testGetRelationThrowsException()
     {
+        $this->expectException(\Illuminate\Database\Eloquent\RelationNotFoundException::class);
+
         $builder = $this->getBuilder();
         $builder->setModel($this->getMockModel());
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -351,12 +351,11 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(TestEloquentCollectionModel::class, $c->getQueueableClass());
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Queueing collections with multiple model types is not supported.
-     */
     public function testQueueableCollectionImplementationThrowsExceptionOnMultipleModelTypes()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Queueing collections with multiple model types is not supported.');
+
         $c = new Collection([new TestEloquentCollectionModel, (object) ['id' => 'something']]);
         $c->getQueueableClass();
     }

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -119,24 +119,22 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertCount(1, $country);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].
-     */
     public function testFirstOrFailThrowsAnException()
     {
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\\Tests\\Database\\HasManyThroughTestPost].');
+
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
 
         HasManyThroughTestCountry::first()->posts()->firstOrFail();
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].
-     */
     public function testFindOrFailThrowsAnException()
     {
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\\Tests\\Database\\HasManyThroughTestPost].');
+
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
                                  ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -405,21 +405,19 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $multiple[1]);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1
-     */
     public function testFindOrFailWithSingleIdThrowsModelNotFoundException()
     {
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\\Tests\\Database\\EloquentTestUser] 1');
+
         EloquentTestUser::findOrFail(1);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1, 2
-     */
     public function testFindOrFailWithMultipleIdsThrowsModelNotFoundException()
     {
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\\Tests\\Database\\EloquentTestUser] 1, 2');
+
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::findOrFail([1, 2]);
     }
@@ -869,12 +867,11 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(['x' => 0, 'y' => 1, 'a' => ['b' => 3]], $model->json);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\QueryException
-     * @expectedExceptionMessage SQLSTATE[23000]:
-     */
     public function testSaveOrFailWithDuplicatedEntry()
     {
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectExceptionMessage('SQLSTATE[23000]:');
+
         $date = '1970-01-01';
         EloquentTestPost::create([
             'id' => 1, 'user_id' => 1, 'name' => 'Post', 'created_at' => $date, 'updated_at' => $date,
@@ -1196,11 +1193,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('2017-11-14 08:23:19.000', $model->fromDateTime($model->getAttribute('created_at')));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testTimestampsUsingOldSqlServerDateFormatFailInEdgeCases()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $model = new EloquentTestUser;
         $model->setDateFormat('Y-m-d H:i:s.000'); // Old SQL Server date format
         $model->setRawAttributes([

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -937,12 +937,11 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('bar', $model->foo);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\MassAssignmentException
-     * @expectedExceptionMessage name
-     */
     public function testGlobalGuarded()
     {
+        $this->expectException(\Illuminate\Database\Eloquent\MassAssignmentException::class);
+        $this->expectExceptionMessage('name');
+
         $model = new EloquentModelStub;
         $model->guard(['*']);
         $model->fill(['name' => 'foo', 'age' => 'bar', 'votes' => 'baz']);
@@ -1315,12 +1314,11 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNotContains('bar', $class->getObservableEvents());
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Illuminate\Tests\Database\EloquentModelStub::incorrectRelationStub must return a relationship instance.
-     */
     public function testGetModelAttributeMethodThrowsExceptionIfNotRelation()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Illuminate\\Tests\\Database\\EloquentModelStub::incorrectRelationStub must return a relationship instance.');
+
         $model = new EloquentModelStub;
         $relation = $model->incorrectRelationStub;
     }
@@ -1562,12 +1560,11 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($array['timestampAttribute']);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\JsonEncodingException
-     * @expectedExceptionMessage Unable to encode attribute [objectAttribute] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.
-     */
     public function testModelAttributeCastingFailsOnUnencodableData()
     {
+        $this->expectException(\Illuminate\Database\Eloquent\JsonEncodingException::class);
+        $this->expectExceptionMessage('Unable to encode attribute [objectAttribute] for model [Illuminate\\Tests\\Database\\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.');
+
         $model = new EloquentModelCastingStub;
         $model->objectAttribute = ['foo' => "b\xF8r"];
         $obj = new stdClass;

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -550,11 +550,10 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals($abigail->email, $comment->owner->email);
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testMorphToWithBadMethodCall()
     {
+        $this->expectException(\BadMethodCallException::class);
+
         $this->createUsers();
 
         $abigail = SoftDeletesTestUser::where('email', 'abigailotwell@gmail.com')->first();

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -50,12 +50,11 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->create('create_bar', 'foo', 'baz', true);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage A MigrationCreatorFakeMigration class already exists.
-     */
     public function testTableUpdateMigrationWontCreateDuplicateClass()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('A MigrationCreatorFakeMigration class already exists.');
+
         $creator = $this->getCreator();
 
         $creator->create('migration_creator_fake_migration', 'foo');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -668,12 +668,11 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable initially deferred', $statements[0]);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The database driver in use does not support the Geometry spatial column type.
-     */
     public function testAddingGeometry()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The database driver in use does not support the Geometry spatial column type.');
+
         $blueprint = new Blueprint('geo');
         $blueprint->geometry('coordinates');
         $blueprint->toSql($this->getConnection(), $this->getGrammar());

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1894,11 +1894,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertCount(2, $builder->wheres);
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testBuilderThrowsExpectedExceptionWithUndefinedMethod()
     {
+        $this->expectException(\BadMethodCallException::class);
+
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select');
         $builder->getProcessor()->shouldReceive('processSelect')->andReturn([]);

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -121,12 +121,11 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertFalse($schema->hasColumn('users', 'name'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The database driver in use does not support spatial indexes.
-     */
     public function testDropSpatialIndex()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
+
         $blueprint = new Blueprint('geo');
         $blueprint->dropSpatialIndex(['coordinates']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
@@ -186,23 +185,21 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The database driver in use does not support spatial indexes.
-     */
     public function testAddingSpatialIndex()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
+
         $blueprint = new Blueprint('geo');
         $blueprint->spatialIndex('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The database driver in use does not support spatial indexes.
-     */
     public function testAddingFluentSpatialIndex()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
+
         $blueprint = new Blueprint('geo');
         $blueprint->point('coordinates')->spatialIndex();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -44,60 +44,54 @@ class EncrypterTest extends TestCase
         $this->assertEquals('foo', $e->decrypt($encrypted));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
-     */
     public function testDoNoAllowLongerKey()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+
         new Encrypter(str_repeat('z', 32));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
-     */
     public function testWithBadKeyLength()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+
         new Encrypter(str_repeat('a', 5));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
-     */
     public function testWithBadKeyLengthAlternativeCipher()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+
         new Encrypter(str_repeat('a', 16), 'AES-256-CFB8');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
-     */
     public function testWithUnsupportedCipher()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+
         new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Encryption\DecryptException
-     * @expectedExceptionMessage The payload is invalid.
-     */
     public function testExceptionThrownWhenPayloadIsInvalid()
     {
+        $this->expectException(\Illuminate\Contracts\Encryption\DecryptException::class);
+        $this->expectExceptionMessage('The payload is invalid.');
+
         $e = new Encrypter(str_repeat('a', 16));
         $payload = $e->encrypt('foo');
         $payload = str_shuffle($payload);
         $e->decrypt($payload);
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Encryption\DecryptException
-     * @expectedExceptionMessage The MAC is invalid.
-     */
     public function testExceptionThrownWithDifferentKey()
     {
+        $this->expectException(\Illuminate\Contracts\Encryption\DecryptException::class);
+        $this->expectExceptionMessage('The MAC is invalid.');
+
         $a = new Encrypter(str_repeat('a', 16));
         $b = new Encrypter(str_repeat('b', 16));
         $b->decrypt($a->encrypt('baz'));

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -195,11 +195,10 @@ class FilesystemTest extends TestCase
         $this->assertFalse(is_dir($this->tempDir.'/tmp'));
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Filesystem\FileNotFoundException
-     */
     public function testGetThrowsExceptionNonexisitingFile()
     {
+        $this->expectException(\Illuminate\Contracts\Filesystem\FileNotFoundException::class);
+
         $files = new Filesystem;
         $files->get($this->tempDir.'/unknown-file.txt');
     }
@@ -211,11 +210,10 @@ class FilesystemTest extends TestCase
         $this->assertEquals('Howdy?', $files->getRequire($this->tempDir.'/file.php'));
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Filesystem\FileNotFoundException
-     */
     public function testGetRequireThrowsExceptionNonexisitingFile()
     {
+        $this->expectException(\Illuminate\Contracts\Filesystem\FileNotFoundException::class);
+
         $files = new Filesystem;
         $files->getRequire($this->tempDir.'/file.php');
     }

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -29,12 +29,11 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
         $this->assertTrue($_SERVER['_test.authorizes.trait']);
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\Access\AuthorizationException
-     * @expectedExceptionMessage This action is unauthorized.
-     */
     public function test_exception_is_thrown_if_gate_check_fails()
     {
+        $this->expectException(\Illuminate\Auth\Access\AuthorizationException::class);
+        $this->expectExceptionMessage('This action is unauthorized.');
+
         $gate = $this->getBasicGate();
 
         $gate->define('baz', function () {

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -34,11 +34,10 @@ class FoundationFormRequestTest extends TestCase
         $this->assertEquals(['name' => 'specified'], $request->validated());
     }
 
-    /**
-     * @expectedException \Illuminate\Validation\ValidationException
-     */
     public function test_validate_throws_when_validation_fails()
     {
+        $this->expectException(\Illuminate\Validation\ValidationException::class);
+
         $request = $this->createRequest(['no' => 'name']);
 
         $this->mocks['redirect']->shouldReceive('withInput->withErrors');
@@ -46,12 +45,11 @@ class FoundationFormRequestTest extends TestCase
         $request->validate();
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\Access\AuthorizationException
-     * @expectedExceptionMessage This action is unauthorized.
-     */
     public function test_validate_method_throws_when_authorization_fails()
     {
+        $this->expectException(\Illuminate\Auth\Access\AuthorizationException::class);
+        $this->expectExceptionMessage('This action is unauthorized.');
+
         $this->createRequest([], FoundationTestFormRequestForbiddenStub::class)->validate();
     }
 

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -34,12 +34,11 @@ class FoundationHelpersTest extends TestCase
         $this->assertEquals('default', cache('baz', 'default'));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage You must specify an expiration time when setting a value in the cache.
-     */
     public function testCacheThrowsAnExceptionIfAnExpirationIsNotProvided()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('You must specify an expiration time when setting a value in the cache.');
+
         cache(['foo' => 'bar']);
     }
 

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -35,12 +35,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The table is empty.
-     */
     public function testSeeInDatabaseDoesNotFindResults()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The table is empty.');
+
         $builder = $this->mockCountBuilder(0);
 
         $builder->shouldReceive('get')->andReturn(collect());
@@ -48,11 +47,10 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
-     */
     public function testSeeInDatabaseFindsNotMatchingResults()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+
         $this->expectExceptionMessage('Found: '.json_encode([['title' => 'Forge']], JSON_PRETTY_PRINT));
 
         $builder = $this->mockCountBuilder(0);
@@ -63,11 +61,10 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
-     */
     public function testSeeInDatabaseFindsManyNotMatchingResults()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+
         $this->expectExceptionMessage('Found: '.json_encode(['data', 'data', 'data'], JSON_PRETTY_PRINT).' and 2 others.');
 
         $builder = $this->mockCountBuilder(0);
@@ -87,11 +84,10 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseMissing($this->table, $this->data);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
-     */
     public function testDontSeeInDatabaseFindsResults()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+
         $builder = $this->mockCountBuilder(1);
 
         $builder->shouldReceive('take')->andReturnSelf();
@@ -107,12 +103,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertSoftDeleted($this->table, $this->data);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The table is empty.
-     */
     public function testSeeSoftDeletedInDatabaseDoesNotFindResults()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The table is empty.');
+
         $builder = $this->mockCountBuilder(0);
 
         $builder->shouldReceive('get')->andReturn(collect());

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -74,12 +74,11 @@ class HttpJsonResponseTest extends TestCase
         $this->assertSame(404, $response->getStatusCode());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Type is not supported
-     */
     public function testJsonErrorResource()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Type is not supported');
+
         $resource = tmpfile();
         $response = new \Illuminate\Http\JsonResponse(['resource' => $resource]);
     }

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -119,12 +119,11 @@ class HttpRedirectResponseTest extends TestCase
         $response->withFoo('bar');
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method [doesNotExist] does not exist on Redirect.
-     */
     public function testMagicCallException()
     {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Method [doesNotExist] does not exist on Redirect.');
+
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -706,12 +706,11 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->accepts('text/html'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Session store not set on request.
-     */
     public function testSessionMethod()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Session store not set on request.');
+
         $request = Request::create('/', 'GET');
         $request->session();
     }
@@ -738,12 +737,11 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(40, mb_strlen($request->fingerprint()));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unable to generate fingerprint. Route unavailable.
-     */
     public function testFingerprintWithoutRoute()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to generate fingerprint. Route unavailable.');
+
         $request = Request::create('/', 'GET', [], [], [], []);
         $request->fingerprint();
     }

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -187,12 +187,11 @@ class HttpResponseTest extends TestCase
         $response->withFoo('bar');
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method [doesNotExist] does not exist on Redirect.
-     */
     public function testMagicCallException()
     {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Method [doesNotExist] does not exist on Redirect.');
+
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');
     }

--- a/tests/Integration/Cache/CacheLockTest.php
+++ b/tests/Integration/Cache/CacheLockTest.php
@@ -84,11 +84,10 @@ class CacheLockTest extends TestCase
         }));
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Cache\LockTimeoutException
-     */
     public function test_locks_throw_timeout_if_block_expires()
     {
+        $this->expectException(\Illuminate\Contracts\Cache\LockTimeoutException::class);
+
         Carbon::setTestNow();
 
         Cache::store('memcached')->lock('foo')->release();

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -244,10 +244,11 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     /**
      * @test
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function firstOrFail_method()
     {
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
         $post = Post::create(['title' => str_random()]);
 
         $post->tags()->firstOrFail(['id' => 10]);
@@ -271,10 +272,11 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     /**
      * @test
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function findOrFail_method()
     {
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
         $post = Post::create(['title' => str_random()]);
 
         $tag = Tag::create(['name' => str_random()]);

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -107,11 +107,12 @@ class ModelSerializationTest extends TestCase
 
     /**
      * @test
-     * @expectedException \LogicException
-     * @expectedExceptionMessage  Queueing collections with multiple model connections is not supported.
      */
     public function it_fails_if_models_on_multi_connections()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Queueing collections with multiple model connections is not supported.');
+
         $user = ModelSerializationTestUser::on('custom')->create([
             'email' => 'mohamed@laravel.com',
         ]);

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -65,12 +65,11 @@ class LogWriterTest extends TestCase
         unset($_SERVER['__log.context']);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Events dispatcher has not been set.
-     */
     public function testListenShortcutFailsWithNoDispatcher()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Events dispatcher has not been set.');
+
         $writer = new Writer($monolog = m::mock('Monolog\Logger'));
         $writer->listen(function () {
         });

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -131,12 +131,11 @@ class PipelineTest extends TestCase
         $this->assertEquals('data', $result);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage A container instance has not been passed to the Pipeline.
-     */
     public function testPipelineThrowsExceptionOnResolveWithoutContainer()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('A container instance has not been passed to the Pipeline.');
+
         (new Pipeline)->send('data')
             ->through('Illuminate\Tests\Pipeline\PipelineTestPipeOne')
             ->then(function ($piped) {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -199,12 +199,11 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals('api.users', $this->getRoute()->getName());
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method [missing] does not exist.
-     */
     public function testRegisteringNonApprovedAttributesThrows()
     {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Method [missing] does not exist.');
+
         $this->router->domain('foo')->missing('bar')->group(function ($router) {
             //
         });

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -211,12 +211,11 @@ class RoutingRouteTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Route for [foo/bar] has no action.
-     */
     public function testFluentRouting()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Route for [foo/bar] has no action.');
+
         $router = $this->getRouter();
         $router->get('foo/bar')->uses(function () {
             return 'hello';
@@ -524,11 +523,10 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foo/bar/baz', $router->dispatch(Request::create('/foo/bar/baz', 'GET'))->getContent());
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
     public function testRoutesDontMatchNonMatchingPathsWithLeadingOptionals()
     {
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+
         $router = $this->getRouter();
         $router->get('{baz?}', function ($age = 25) {
             return $age;
@@ -536,11 +534,10 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('25', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
     public function testRoutesDontMatchNonMatchingDomain()
     {
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+
         $router = $this->getRouter();
         $router->get('foo/bar', ['domain' => 'api.foo.bar', function () {
             return 'hello';
@@ -776,12 +773,11 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Routing\RouteModelBindingNullStub].
-     */
     public function testModelBindingWithNullReturn()
     {
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\\Tests\\Routing\\RouteModelBindingNullStub].');
+
         $router = $this->getRouter();
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
@@ -1048,12 +1044,11 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('Namespace\\Controller@action', $action['controller']);
     }
 
-    /**
-     * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage Invalid route action: [Illuminate\Tests\Routing\RouteTestControllerStub].
-     */
     public function testInvalidActionException()
     {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Invalid route action: [Illuminate\\Tests\\Routing\\RouteTestControllerStub].');
+
         $router = $this->getRouter();
         $router->get('/', ['uses' => 'Illuminate\Tests\Routing\RouteTestControllerStub']);
 
@@ -1364,11 +1359,10 @@ class RoutingRouteTest extends TestCase
         $router->dispatch(Request::create('foo', 'GET'))->getContent();
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
     public function testImplicitBindingsWithOptionalParameterWithNonExistingKeyInUri()
     {
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
         $phpunit = $this;
         $router = $this->getRouter();
         $router->get('foo/{bar?}', [

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -386,11 +386,10 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('http://sub.foo.com/foo/bar', $url->route('foo'));
     }
 
-    /**
-     * @expectedException \Illuminate\Routing\Exceptions\UrlGenerationException
-     */
     public function testUrlGenerationForControllersRequiresPassingOfRequiredParameters()
     {
+        $this->expectException(\Illuminate\Routing\Exceptions\UrlGenerationException::class);
+
         $url = new UrlGenerator(
             $routes = new RouteCollection,
             $request = Request::create('http://www.foo.com:8080/')

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -56,21 +56,19 @@ class SupportCarbonTest extends TestCase
         $this->assertSame('2017-06-25 12:00:00', Carbon::twoDaysAgoAtNoon()->toDateTimeString());
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method nonExistingStaticMacro does not exist.
-     */
     public function testCarbonRaisesExceptionWhenStaticMacroIsNotFound()
     {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Method nonExistingStaticMacro does not exist.');
+
         Carbon::nonExistingStaticMacro();
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method nonExistingMacro does not exist.
-     */
     public function testCarbonRaisesExceptionWhenMacroIsNotFound()
     {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Method nonExistingMacro does not exist.');
+
         Carbon::now()->nonExistingMacro();
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2101,11 +2101,10 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRandomThrowsAnExceptionUsingAmountBiggerThanCollectionSize()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $data = new Collection([1, 2, 3]);
         $data->random(4);
     }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -740,11 +740,10 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals($mock, tap($mock)->foo());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testThrow()
     {
+        $this->expectException(\RuntimeException::class);
+
         throw_if(true, new RuntimeException);
     }
 
@@ -753,12 +752,11 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('foo', throw_unless('foo', new RuntimeException));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Test Message
-     */
     public function testThrowWithString()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Test Message');
+
         throw_if(true, RuntimeException::class, 'Test Message');
     }
 

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -22,12 +22,11 @@ class SupportTestingEventFakeTest extends TestCase
         $this->fake->assertDispatched(EventStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\EventStub] event was dispatched 2 times instead of 1 times.
-     */
     public function testAssertDispatchedWithCallbackInt()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [Illuminate\\Tests\\Support\\EventStub] event was dispatched 2 times instead of 1 times.');
+
         $this->fake->dispatch(EventStub::class);
         $this->fake->dispatch(EventStub::class);
 
@@ -35,12 +34,11 @@ class SupportTestingEventFakeTest extends TestCase
         $this->fake->assertDispatched(EventStub::class, 1);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\EventStub] event was dispatched 2 times instead of 1 times.
-     */
     public function testAssertDispatchedTimes()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [Illuminate\\Tests\\Support\\EventStub] event was dispatched 2 times instead of 1 times.');
+
         $this->fake->dispatch(EventStub::class);
         $this->fake->dispatch(EventStub::class);
 
@@ -48,12 +46,11 @@ class SupportTestingEventFakeTest extends TestCase
         $this->fake->assertDispatchedTimes(EventStub::class, 1);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The unexpected [Illuminate\Tests\Support\EventStub] event was dispatched.
-     */
     public function testAssertNotDispatched()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The unexpected [Illuminate\\Tests\\Support\\EventStub] event was dispatched.');
+
         $this->fake->dispatch(EventStub::class);
 
         $this->fake->assertNotDispatched(EventStub::class);

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -16,12 +16,11 @@ class MailFakeTest extends TestCase
         $this->mailable = new MailableStub;
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\MailableStub] mailable was not sent.
-     */
     public function testAssertSent()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [Illuminate\\Tests\\Support\\MailableStub] mailable was not sent.');
+
         $this->fake->assertSent(MailableStub::class);
 
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
@@ -29,12 +28,11 @@ class MailFakeTest extends TestCase
         $this->fake->assertSent(MailableStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The unexpected [Illuminate\Tests\Support\MailableStub] mailable was sent.
-     */
     public function testAssertNotSent()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The unexpected [Illuminate\\Tests\\Support\\MailableStub] mailable was sent.');
+
         $this->fake->assertNotSent(MailableStub::class);
 
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
@@ -42,12 +40,11 @@ class MailFakeTest extends TestCase
         $this->fake->assertNotSent(MailableStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\MailableStub] mailable was sent 2 times instead of 1 times.
-     */
     public function testAssertSentTimes()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [Illuminate\\Tests\\Support\\MailableStub] mailable was sent 2 times instead of 1 times.');
+
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
@@ -55,12 +52,11 @@ class MailFakeTest extends TestCase
         $this->fake->assertSent(MailableStub::class, 2);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\MailableStub] mailable was not queued.
-     */
     public function testAssertQueued()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [Illuminate\\Tests\\Support\\MailableStub] mailable was not queued.');
+
         $this->fake->assertQueued(MailableStub::class);
 
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
@@ -68,12 +64,11 @@ class MailFakeTest extends TestCase
         $this->fake->assertQueued(MailableStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\MailableStub] mailable was queued 2 times instead of 1 times.
-     */
     public function testAssertQueuedTimes()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [Illuminate\\Tests\\Support\\MailableStub] mailable was queued 2 times instead of 1 times.');
+
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
 
@@ -81,24 +76,22 @@ class MailFakeTest extends TestCase
         $this->fake->assertQueued(MailableStub::class, 2);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\QueueableMailableStub] mailable was not sent.
-     */
     public function testSendQueuesAMailableThatShouldBeQueued()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [Illuminate\\Tests\\Support\\QueueableMailableStub] mailable was not sent.');
+
         $this->fake->to('taylor@laravel.com')->send(new QueueableMailableStub);
 
         $this->fake->assertSent(QueueableMailableStub::class);
         $this->fake->assertQueued(QueueableMailableStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage Mailables were sent unexpectedly.
-     */
     public function testAssertNothingSent()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('Mailables were sent unexpectedly.');
+
         $this->fake->assertNothingSent();
 
         $this->fake->to('taylor@laravel.com')->send($this->mailable);

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -17,12 +17,11 @@ class NotificationFakeTest extends TestCase
         $this->user = new UserStub;
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\NotificationStub] notification was not sent.
-     */
     public function testAssertSentTo()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [Illuminate\\Tests\\Support\\NotificationStub] notification was not sent.');
+
         $this->fake->assertSentTo($this->user, NotificationStub::class);
 
         $this->fake->send($this->user, new NotificationStub);
@@ -30,12 +29,11 @@ class NotificationFakeTest extends TestCase
         $this->fake->assertSentTo($this->user, NotificationStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The unexpected [Illuminate\Tests\Support\NotificationStub] notification was sent.
-     */
     public function testAssertNotSentTo()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The unexpected [Illuminate\\Tests\\Support\\NotificationStub] notification was sent.');
+
         $this->fake->assertNotSentTo($this->user, NotificationStub::class);
 
         $this->fake->send($this->user, new NotificationStub);

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -15,12 +15,11 @@ class QueueFakeTest extends TestCase
         $this->job = new JobStub;
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\JobStub] job was not pushed.
-     */
     public function testAssertPushed()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [Illuminate\\Tests\\Support\\JobStub] job was not pushed.');
+
         $this->fake->assertPushed(JobStub::class);
 
         $this->fake->push($this->job);
@@ -28,12 +27,11 @@ class QueueFakeTest extends TestCase
         $this->fake->assertPushed(JobStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The unexpected [Illuminate\Tests\Support\JobStub] job was pushed.
-     */
     public function testAssertNotPushed()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The unexpected [Illuminate\\Tests\\Support\\JobStub] job was pushed.');
+
         $this->fake->assertNotPushed(JobStub::class);
 
         $this->fake->push($this->job);
@@ -41,12 +39,11 @@ class QueueFakeTest extends TestCase
         $this->fake->assertNotPushed(JobStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\JobStub] job was not pushed.
-     */
     public function testAssertPushedOn()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [Illuminate\\Tests\\Support\\JobStub] job was not pushed.');
+
         $this->fake->push($this->job, '', 'foo');
 
         $this->fake->assertPushedOn('bar', JobStub::class);
@@ -54,12 +51,11 @@ class QueueFakeTest extends TestCase
         $this->fake->assertPushedOn('foo', JobStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\JobStub] job was pushed 2 times instead of 1 times.
-     */
     public function testAssertPushedTimes()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [Illuminate\\Tests\\Support\\JobStub] job was pushed 2 times instead of 1 times.');
+
         $this->fake->push($this->job);
         $this->fake->push($this->job);
 
@@ -68,12 +64,11 @@ class QueueFakeTest extends TestCase
         $this->fake->assertPushed(JobStub::class, 2);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage Jobs were pushed unexpectedly.
-     */
     public function testAssertNothingPushed()
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->expectExceptionMessage('Jobs were pushed unexpectedly.');
+
         $this->fake->assertNothingPushed();
 
         $this->fake->push($this->job);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -65,11 +65,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    /**
-     * @expectedException \Illuminate\Validation\ValidationException
-     */
     public function testValidateThrowsOnFail()
     {
+        $this->expectException(\Illuminate\Validation\ValidationException::class);
+
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar'], ['baz' => 'required']);
 
@@ -2868,12 +2867,11 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Validation rule required_if requires at least 2 parameters.
-     */
     public function testExceptionThrownOnIncorrectParameterCount()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Validation rule required_if requires at least 2 parameters.');
+
         $trans = $this->getTranslator();
         $v = new Validator($trans, [], ['foo' => 'required_if:foo']);
         $v->passes();

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -20,12 +20,11 @@ class ViewBladeCompilerTest extends TestCase
         $this->assertTrue($compiler->isExpired('foo'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Please provide a valid cache path.
-     */
     public function testCannotConstructWithBadCachePath()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide a valid cache path.');
+
         new BladeCompiler($this->getFiles(), null);
     }
 

--- a/tests/View/ViewEngineResolverTest.php
+++ b/tests/View/ViewEngineResolverTest.php
@@ -18,11 +18,10 @@ class ViewEngineResolverTest extends TestCase
         $this->assertEquals(spl_object_hash($result), spl_object_hash($resolver->resolve('foo')));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testResolverThrowsExceptionOnUnknownEngine()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $resolver = new \Illuminate\View\Engines\EngineResolver;
         $resolver->resolve('foo');
     }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -67,11 +67,10 @@ class ViewFactoryTest extends TestCase
         unset($_SERVER['__test.view']);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testFirstThrowsInvalidArgumentExceptionIfNoneFound()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->once()->with('view')->andThrow('InvalidArgumentException');
         $factory->getFinder()->shouldReceive('find')->once()->with('bar')->andThrow('InvalidArgumentException');
@@ -461,22 +460,20 @@ class ViewFactoryTest extends TestCase
         $factory->make('vendor/package::foo.bar');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testExceptionIsThrownForUnknownExtension()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->once()->with('view')->andReturn('view.foo');
         $factory->make('view');
     }
 
-    /**
-     * @expectedException \ErrorException
-     * @expectedExceptionMessage section exception message
-     */
     public function testExceptionsInSectionsAreThrown()
     {
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionMessage('section exception message');
+
         $engine = new \Illuminate\View\Engines\CompilerEngine(m::mock(\Illuminate\View\Compilers\CompilerInterface::class));
         $engine->getCompiler()->shouldReceive('getCompiledPath')->andReturnUsing(function ($path) {
             return $path;
@@ -491,12 +488,11 @@ class ViewFactoryTest extends TestCase
         $factory->make('view')->render();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Cannot end a section without first starting one.
-     */
     public function testExtraStopSectionCallThrowsException()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot end a section without first starting one.');
+
         $factory = $this->getFactory();
         $factory->startSection('foo');
         $factory->stopSection();
@@ -504,12 +500,11 @@ class ViewFactoryTest extends TestCase
         $factory->stopSection();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Cannot end a section without first starting one.
-     */
     public function testExtraAppendSectionCallThrowsException()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot end a section without first starting one.');
+
         $factory = $this->getFactory();
         $factory->startSection('foo');
         $factory->stopSection();

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -72,11 +72,10 @@ class ViewFinderTest extends TestCase
         $this->assertEquals(__DIR__.'/bar/bar/baz.blade.php', $finder->find('foo::bar.baz'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testExceptionThrownWhenViewNotFound()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $finder = $this->getFinder();
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(false);
@@ -85,22 +84,20 @@ class ViewFinderTest extends TestCase
         $finder->find('foo');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage No hint path defined for [name].
-     */
     public function testExceptionThrownOnInvalidViewName()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No hint path defined for [name].');
+
         $finder = $this->getFinder();
         $finder->find('name::');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage No hint path defined for [name].
-     */
     public function testExceptionThrownWhenNoHintPathIsRegistered()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No hint path defined for [name].');
+
         $finder = $this->getFinder();
         $finder->find('name::foo');
     }

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -163,12 +163,11 @@ class ViewTest extends TestCase
         $this->assertFalse($view->offsetExists('foo'));
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method [badMethodCall] does not exist on view.
-     */
     public function testViewBadMethod()
     {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Method [badMethodCall] does not exist on view.');
+
         $view = $this->getView();
         $view->badMethodCall();
     }


### PR DESCRIPTION
As final continuation of #22792 and #22798 .

To follow official best practices to set exception via methods, not code.