### PR TITLE
[5.5] Modify except collection method to have a single dimension collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -391,7 +391,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function except($keys)
     {
         if ($keys instanceof self) {
-            $keys = $keys->keys()->all();
+            $keys = $keys->all();
         } elseif (! is_array($keys)) {
             $keys = func_get_args();
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -973,11 +973,11 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(['first' => 'Taylor'], $data->except(['last', 'email', 'missing'])->all());
         $this->assertEquals(['first' => 'Taylor'], $data->except('last', 'email', 'missing')->all());
-        $this->assertEquals(['first' => 'Taylor'], $data->except(collect(['last' => 'Otwell', 'email' => 'taylorotwell@gmail.com', 'missing']))->all());
+        $this->assertEquals(['first' => 'Taylor'], $data->except(collect(['last', 'email', 'missing']))->all());
 
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->except(['last'])->all());
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->except('last')->all());
-        $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->except(collect(['last' => 'Otwell']))->all());
+        $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->except(collect(['last']))->all());
     }
 
     public function testPluckWithArrayAndObjectValues()


### PR DESCRIPTION
this **PR** reverts #22399 , the reason is to make the method **API** consistent

in the documentation [except()](https://laravel.com/docs/5.5/collections#method-except) method accepts **single dimension** array of **keys** , not **multi dimension array** 

```php
$collection = collect(['product_id' => 1, 'price' => 100, 'discount' => false]);

//will return all the $collection which is wrong
$collection->except(['price'  => 50, 'discount' => true]);

//same will happen if we do this
 $collection->except(collect(['price' ,'discount' ]));
```
so in my opinion if we are passing **array of keys** , we should also pass **collection of keys**

```php

$collection->except(['price' ,'discount']);

$collection->except(collect(['price' ,'discount']));
```