### PR TITLE
[5.5] Fix Collection dd() in browser preview window

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -271,6 +271,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function dd(...$args)
     {
+        http_response_code(500);
+
         call_user_func_array([$this, 'dump'], $args);
 
         die(1);


### PR DESCRIPTION
See https://github.com/laravel/framework/pull/22581 for the fix for the regular `dd()`. This PR applies the same fix to the `Collection`'s `dd` function.