### PR TITLE
[5.5] Fixes blade compiler for having 'or' inside a string when starting with '$'

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -100,6 +100,6 @@ trait CompilesEchos
      */
     public function compileEchoDefaults($value)
     {
-        return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/si', 'isset($1) ? $1 : $2', $value);
+        return preg_replace('/^((\|")[^(\'|")]*(\'|")|[^(\'|")]*)(?=\sor)(?:\s+or\s+)(.+?)$/si', 'isset($1) ? $1 : $4', $value);
     }
 }

--- a/tests/View/Blade/BladeEchoTest.php
+++ b/tests/View/Blade/BladeEchoTest.php
@@ -49,13 +49,16 @@ class BladeEchoTest extends AbstractBladeTestCase
             $age or 90
         }}'));
 
-        $this->assertEquals('<?php echo e("Hello world or foo"); ?>',
-            $this->compiler->compileString('{{ "Hello world or foo" }}'));
-        $this->assertEquals('<?php echo e("Hello world or foo"); ?>',
-            $this->compiler->compileString('{{"Hello world or foo"}}'));
-        $this->assertEquals('<?php echo e($foo + $or + $baz); ?>', $this->compiler->compileString('{{$foo + $or + $baz}}'));
-        $this->assertEquals('<?php echo e("Hello world or foo"); ?>', $this->compiler->compileString('{{
-            "Hello world or foo"
+        $this->assertEquals('<?php echo e($object->method(\'foo or bar\')); ?>', $this->compiler->compileString('{{ $object->method(\'foo or bar\') }}'));
+        $this->assertEquals('<?php echo e($object->method(\'foo or bar\')); ?>', $this->compiler->compileString('{{$object->method(\'foo or bar\')}}'));
+        $this->assertEquals('<?php echo e($object->method(\'foo or bar\')); ?>', $this->compiler->compileString('{{
+            $object->method(\'foo or bar\')
+        }}'));
+
+        $this->assertEquals('<?php echo e($callback(\'foo or bar\')); ?>', $this->compiler->compileString('{{ $callback(\'foo or bar\') }}'));
+        $this->assertEquals('<?php echo e($callback(\'foo or bar\')); ?>', $this->compiler->compileString('{{$callback(\'foo or bar\')}}'));
+        $this->assertEquals('<?php echo e($callback(\'foo or bar\')); ?>', $this->compiler->compileString('{{
+            $callback(\'foo or bar\')
         }}'));
 
         $this->assertEquals('<?php echo e(\'Hello world or foo\'); ?>',


### PR DESCRIPTION
Fixes `{{ $object->method('foo or bar') }}` from being formatted as `<?php echo e(isset($object->method('foo or bar') ? $object->method('foo or bar')); ?>`