### PR TITLE
[5.6] Allow set cookie secure option when session secure default is true

### DIFF
--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -1,6 +1,6 @@
 # Release Notes for 5.5.x
 
-## [Unreleased]
+## v5.5.29 (2018-01-15)
 
 ### Added
 - Added `Model::qualifyColumn()` method ([#22577](https://github.com/laravel/framework/pull/22577))
@@ -23,6 +23,7 @@
 - Set `null` as default value for `optional()` helper ([#22699](https://github.com/laravel/framework/pull/22699))
 - Make sure `getRememberToken()` returns a string ([#22724](https://github.com/laravel/framework/pull/22724))
 - Updated Vue preset version ([#22732](https://github.com/laravel/framework/pull/22732))
+- Accept `Arrayable` items in `Collection::find()` ([#22787](https://github.com/laravel/framework/pull/22787))
 
 ### Fixed
 - Close database connection when using `RefreshDatabase` trait ([#22569](https://github.com/laravel/framework/pull/22569))
@@ -30,6 +31,9 @@
 - Fixed parameter usage in `RedirectController` ([#22657](https://github.com/laravel/framework/pull/22657))
 - Added `__set_state()` method to `Support/Carbon` ([#22689](https://github.com/laravel/framework/pull/22689))
 - Do not continue checking `APP_ENV` if environment file path being set successfully with `--env` option ([#22753](https://github.com/laravel/framework/pull/22753))
+- Fixed missing table prefix in `SQLiteGrammar::compileDropColumn()` ([#22745](https://github.com/laravel/framework/pull/22745), [c13322c](https://github.com/laravel/framework/commit/c13322c54a20de1417d7bf53e348a601c526bf54))
+- Fixed prefixing in `SQLiteGrammar::compileColumnListing()` ([#22781](https://github.com/laravel/framework/pull/22781))
+
 
 ## v5.5.28 (2017-12-26)
 

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -54,13 +54,13 @@ class CookieJar implements JarContract
      * @param  int          $minutes
      * @param  string       $path
      * @param  string       $domain
-     * @param  bool         $secure
+     * @param  bool|null    $secure
      * @param  bool         $httpOnly
      * @param  bool         $raw
      * @param  string|null  $sameSite
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = null)
+    public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = null, $httpOnly = true, $raw = false, $sameSite = null)
     {
         list($path, $domain, $secure, $sameSite) = $this->getPathAndDomain($path, $domain, $secure, $sameSite);
 
@@ -76,13 +76,13 @@ class CookieJar implements JarContract
      * @param  string       $value
      * @param  string       $path
      * @param  string       $domain
-     * @param  bool         $secure
+     * @param  bool|null    $secure
      * @param  bool         $httpOnly
      * @param  bool         $raw
      * @param  string|null  $sameSite
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    public function forever($name, $value, $path = null, $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = null)
+    public function forever($name, $value, $path = null, $domain = null, $secure = null, $httpOnly = true, $raw = false, $sameSite = null)
     {
         return $this->make($name, $value, 2628000, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
     }
@@ -154,15 +154,15 @@ class CookieJar implements JarContract
     /**
      * Get the path and domain, or the default values.
      *
-     * @param  string  $path
-     * @param  string  $domain
-     * @param  bool    $secure
-     * @param  string  $sameSite
+     * @param  string    $path
+     * @param  string    $domain
+     * @param  bool|null $secure
+     * @param  string    $sameSite
      * @return array
      */
-    protected function getPathAndDomain($path, $domain, $secure = false, $sameSite = null)
+    protected function getPathAndDomain($path, $domain, $secure = null, $sameSite = null)
     {
-        return [$path ?: $this->path, $domain ?: $this->domain, $secure ?: $this->secure, $sameSite ?: $this->sameSite];
+        return [$path ?: $this->path, $domain ?: $this->domain, is_bool($secure) ? $secure : $this->secure, $sameSite ?: $this->sameSite];
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1062,6 +1062,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return new static($this->items);
         }
 
+        if ($keys instanceof self) {
+            $keys = $keys->all();
+        }
+
         $keys = is_array($keys) ? $keys : func_get_args();
 
         return new static(Arr::only($this->items, $keys));

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -271,6 +271,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function dd(...$args)
     {
+        http_response_code(500);
+
         call_user_func_array([$this, 'dump'], $args);
 
         die(1);

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -51,6 +51,18 @@ class CookieTest extends TestCase
         $this->assertEquals('lax', $c->getSameSite());
     }
 
+    public function testCookiesCanSetSecureOptionUsingDefaultPathAndDomain()
+    {
+        $cookie = $this->getCreator();
+        $cookie->setDefaultPathAndDomain('/path', '/domain', true, 'lax');
+        $c = $cookie->make('color', 'blue', 10, null, null, false);
+        $this->assertEquals('blue', $c->getValue());
+        $this->assertFalse($c->isSecure());
+        $this->assertEquals('/domain', $c->getDomain());
+        $this->assertEquals('/path', $c->getPath());
+        $this->assertEquals('lax', $c->getSameSite());
+    }
+
     public function testQueuedCookies()
     {
         $cookie = $this->getCreator();

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1970,9 +1970,11 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($data->all(), $data->only(null)->all());
         $this->assertEquals(['first' => 'Taylor'], $data->only(['first', 'missing'])->all());
         $this->assertEquals(['first' => 'Taylor'], $data->only('first', 'missing')->all());
+        $this->assertEquals(['first' => 'Taylor'], $data->only(collect(['first', 'missing']))->all());
 
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->only(['first', 'email'])->all());
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->only('first', 'email')->all());
+        $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->only(collect(['first', 'email']))->all());
     }
 
     public function testGettingAvgItemsFromCollection()


### PR DESCRIPTION
When setting `secure` on `sessions.php` all cookies are forced to be secure even if you queue a cookie with the `$secure` option set to false. 