### PR TITLE
Can't combine Route::apiResource with except

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -149,7 +149,7 @@ class ResourceRegistrar
         if (isset($options['only'])) {
             $defaults = array_intersect($defaults, (array) $options['only']);
         }
-        
+
         if (isset($options['except'])) {
             $defaults = array_diff($defaults, (array) $options['except']);
         }

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -147,9 +147,11 @@ class ResourceRegistrar
     protected function getResourceMethods($defaults, $options)
     {
         if (isset($options['only'])) {
-            return array_intersect($defaults, (array) $options['only']);
-        } elseif (isset($options['except'])) {
-            return array_diff($defaults, (array) $options['except']);
+            $defaults = array_intersect($defaults, (array) $options['only']);
+        }
+        
+        if (isset($options['except'])) {
+            $defaults = array_diff($defaults, (array) $options['except']);
         }
 
         return $defaults;


### PR DESCRIPTION
The problem is with the current implamentation you cant take an `apiResource` and use except() on it.

Like:
```php
Route::apiResource('foo', 'FooController')->except(['show']);
```

The reason for the is that an apiResource automatically has the option only set, and the methods does not check both options.