### PR TITLE
Small tweak to actingAs() tests, fixes bogus guard name and use "api"

### DIFF
--- a/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
+++ b/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
@@ -64,7 +64,7 @@ class InteractsWithAuthenticationTest extends TestCase
             return 'Hello '.$request->user()->username;
         })->middleware(['auth:api']);
 
-        Auth::viaRequest('basic', function ($request) {
+        Auth::viaRequest('api', function ($request) {
             return $request->user();
         });
 


### PR DESCRIPTION
Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>