### PR TITLE
[5.5] Simplify Arr::wrap

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -605,6 +605,6 @@ class Arr
      */
     public static function wrap($value)
     {
-        return ! is_array($value) ? [$value] : $value;
+        return (array) $value;
     }
 }


### PR DESCRIPTION
If we just cast as `array`, PHP handles it for us.

Reference: https://3v4l.org/Egsi3