### PR TITLE
Add support for translating the ValidationException's message

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -53,7 +53,7 @@ class ValidationException extends Exception
      */
     public function __construct($validator, $response = null, $errorBag = 'default')
     {
-        parent::__construct('The given data was invalid.');
+        parent::__construct(trans('validation.invalid_data'));
 
         $this->response = $response;
         $this->errorBag = $errorBag;


### PR DESCRIPTION
The `ValidationException`'s `$message` property doesn't support translation and I think it'd be great if I were able to show the validation errors in other language than English (in my case, Portuguese).

 This PR simply allows the message to be translated.