### PR TITLE
[5.5] Fix assertSeeText

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -246,7 +246,7 @@ class TestResponse
      */
     public function assertSeeText($value)
     {
-        PHPUnit::assertContains($value, strip_tags($this->getContent()));
+        PHPUnit::assertContains((string) $value, strip_tags($this->getContent()));
 
         return $this;
     }
@@ -272,7 +272,7 @@ class TestResponse
      */
     public function assertDontSeeText($value)
     {
-        PHPUnit::assertNotContains($value, strip_tags($this->getContent()));
+        PHPUnit::assertNotContains((string) $value, strip_tags($this->getContent()));
 
         return $this;
     }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -54,6 +54,19 @@ class FoundationTestResponseTest extends TestCase
         $response->assertSeeText('foobar');
     }
 
+    public function testAssertSeeTextNotString()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->setContent(\Mockery::mock(View::class, [
+                'render' => '<strong>12</strong>',
+            ]));
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertSeeText(12);
+    }
+
     public function testAssertHeader()
     {
         $baseResponse = tap(new Response, function ($response) {


### PR DESCRIPTION
Recently, I was outputting a Model's `id`, and, as usual, we save it as `int`. When we call it as `$model->id`, it returns in int form. 

PHPUnit's `assertContains` does not accept non string values:
```
1) Illuminate\Tests\Foundation\FoundationTestResponseTest::testAssertSeeTextNotString
PHPUnit\Framework\Exception: Argument #1 (No Value) of PHPUnit\Framework\Assert::assertContains() must be a string

/var/www/framework/src/Illuminate/Foundation/Testing/TestResponse.php:249
/var/www/framework/tests/Foundation/FoundationTestResponseTest.php:67
```

Edit: should we change `$value` type to mixed?