### PR TITLE
[5.5] Supporting Laravel-Mix PR #1246, HMR w/ different Hosts and Ports

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -555,6 +555,12 @@ if (! function_exists('mix')) {
         }
 
         if (file_exists(public_path($manifestDirectory.'/hot'))) {
+            $url = file_get_contents(public_path($manifestDirectory.'/hot'));
+
+            if(Str::startsWith($url, 'http://') || Str::startsWith($url, 'https://')) {
+                return new HtmlString(Str::after($url, ':') . $path);
+            }
+
             return new HtmlString("//localhost:8080{$path}");
         }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -557,8 +557,8 @@ if (! function_exists('mix')) {
         if (file_exists(public_path($manifestDirectory.'/hot'))) {
             $url = file_get_contents(public_path($manifestDirectory.'/hot'));
 
-            if(Str::startsWith($url, 'http://') || Str::startsWith($url, 'https://')) {
-                return new HtmlString(Str::after($url, ':') . $path);
+            if (Str::startsWith($url, 'http://') || Str::startsWith($url, 'https://')) {
+                return new HtmlString(Str::after($url, ':').$path);
             }
 
             return new HtmlString("//localhost:8080{$path}");


### PR DESCRIPTION
Part One: #21545

This PR changes the 'mix' helper function to take URLs coming from the `hot` file. This feature should be fully backwards compatible with older Laravel Mix & Laravel installs.

Supporting Laravel-Mix Pull Request JeffreyWay/laravel-mix#1246, allowing Hot Module Reloading with custom hosts and ports, allowing hot-module reloading across networks.

~~Please don't merge straight away, I'm awaiting a reply to JeffreyWay/laravel-mix#1246~~

JefferyWay merged JeffreyWay/laravel-mix#1246. Should be good to go 

Let me know if you require tests for this code change,

Edit: Just realised that there's no other use of `Str::` in the class. Let me know if you want me to use the native php string functions.