### PR TITLE
Fix `active_url` validator.

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -50,7 +50,7 @@ trait ValidatesAttributes
 
         if ($url = parse_url($value, PHP_URL_HOST)) {
             try {
-                return count(dns_get_record($url, DNS_A | DNS_AAAA)) > 0;
+                return count(dns_get_record($url, DNS_A || DNS_AAAA)) > 0;
             } catch (Exception $e) {
                 return false;
             }


### PR DESCRIPTION
issue: It always returns false due to a usage of the bitwise operator (|) in numeric values, which changes the overall value, hence return false.
fix: I changed bitwise operator to logical operator (||) this fix the issue 