### PR TITLE
[5.5] Improved error handling consistency for unhandled HTTP status codes

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -399,7 +399,7 @@ class Handler implements ExceptionHandlerContract
             return "{$path}/errors";
         })->push(__DIR__.'/views')->all());
 
-        if (view()->exists($view = "errors::{$status}")) {
+        if (view()->exists($view = "errors::{$status}") || (! config('app.debug') && view()->exists($view = "errors::unhandled"))) {
             return response()->view($view, ['exception' => $e], $status, $e->getHeaders());
         }
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -399,7 +399,7 @@ class Handler implements ExceptionHandlerContract
             return "{$path}/errors";
         })->push(__DIR__.'/views')->all());
 
-        if (view()->exists($view = "errors::{$status}") || (! config('app.debug') && view()->exists($view = "errors::unhandled"))) {
+        if (view()->exists($view = "errors::{$status}") || (! config('app.debug') && view()->exists($view = 'errors::unhandled'))) {
             return response()->view($view, ['exception' => $e], $status, $e->getHeaders());
         }
 

--- a/src/Illuminate/Foundation/Exceptions/views/unhandled.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/unhandled.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::layout')
+
+@section('title', 'Error')
+
+@section('message', 'Whoops, looks like something went wrong.')


### PR DESCRIPTION
Based on the discussion in PR https://github.com/laravel/framework/pull/22820, I decided to create a new PR to solve a slightly different problem.

When handing `HttpException`s there's the possibility to create custom views for any status. By default there are views for the status codes 404, 419, 429, 500 and 503. When in debug other statuses will either use `Whoops` or `SymfonyExceptionHandler` as a fallback, which makes sense.

If not in debug it will currently fallback to `SymfonyExceptionHandler`. This PR changes this to fallback to a separate view called `unhandled.blade.php`, which uses the same layout as predefined views (`{status}.blade.php`). This way all errors are shown consistently in production and could easily be customised to match the application's layout.

I noticed that any exception that's not a `HTTPException` are handled in a similar way: In debug it's shown by `Whoops` or `SymfonyExceptionHandler`, otherwise it's handled as a HTTP 500 which uses `500.blade.php`.

It didn't make sense to also use `500.blade.php` for this, that's why I went with `unhandled.blade.php`. In the other PR the suggested name was `default.blade.php` which could also work, but this is less likely to cause confusion in my opinion.

In short, when handling HTTP status codes that don't have an error view, the shown error will in debug change from:

<img width="1137" alt="screen shot 2018-01-17 at 02 10 19" src="https://user-images.githubusercontent.com/5393965/35042480-2e04b5a4-fb89-11e7-9164-0b19de1fd0fc.png">

To:

<img width="829" alt="screen shot 2018-01-17 at 13 20 33" src="https://user-images.githubusercontent.com/5393965/35042496-3fa1381e-fb89-11e7-9271-5199f8901d9a.png">

And will be customisable like all other HTTP errors.