### PR TITLE
[5.6] Add array_contains validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1390,11 +1390,11 @@ trait ValidatesAttributes
     public function validateArrayContains($attribute, $value, $parameters)
     {
         $this->requireParameterCount(1, $parameters, 'array_contains');
-        
+
         if (! in_array($parameters[0], ['email', 'file', 'image'])) {
             return false;
         }
-        
+
         $methodName = 'validate'.ucfirst(strtolower($parameters[0]));
 
         foreach ($value as $actualValue) {

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1380,6 +1380,33 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that each value of an array is of a specific type.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateArrayContains($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'array_contains');
+        
+        if (!in_array($parameters[0], ['email', 'file', 'image'])) {
+            return false;
+        }
+        
+        $methodName = 'validate' . ucfirst(strtolower($parameters[0]));
+
+        foreach ($value as $actualValue) {
+            if (!call_user_func_array([$this, $methodName], [$attribute, $actualValue])) {
+                return false;
+            }
+        }
+        
+        return true;
+    }
+
+    /**
      * Get the size of an attribute.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1402,7 +1402,7 @@ trait ValidatesAttributes
                 return false;
             }
         }
-        
+
         return true;
     }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1391,14 +1391,14 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'array_contains');
         
-        if (!in_array($parameters[0], ['email', 'file', 'image'])) {
+        if (! in_array($parameters[0], ['email', 'file', 'image'])) {
             return false;
         }
         
-        $methodName = 'validate' . ucfirst(strtolower($parameters[0]));
+        $methodName = 'validate'.ucfirst(strtolower($parameters[0]));
 
         foreach ($value as $actualValue) {
-            if (!call_user_func_array([$this, $methodName], [$attribute, $actualValue])) {
+            if (! call_user_func_array([$this, $methodName], [$attribute, $actualValue])) {
                 return false;
             }
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3827,6 +3827,29 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($rule->called);
     }
 
+    public function testArrayContainsValidation()
+    {
+        $uploadedFile = [__FILE__, '', null, null, null, true];
+        $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('guessExtension')->will($this->returnValue('png'));
+        $file->expects($this->any())->method('getClientOriginalExtension')->will($this->returnValue('png'));
+
+        $file2 = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file2->expects($this->any())->method('guessExtension')->will($this->returnValue('jpeg'));
+        $file2->expects($this->any())->method('getClientOriginalExtension')->will($this->returnValue('jpeg'));
+
+        $v = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['files' => [
+                $file,
+                $file2
+            ]],
+            ['files' => 'array_contains:file']
+        );
+
+        $this->assertTrue($v->passes());
+    }
+
     protected function getTranslator()
     {
         return m::mock('Illuminate\Contracts\Translation\Translator');

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3842,7 +3842,7 @@ class ValidationValidatorTest extends TestCase
             $this->getIlluminateArrayTranslator(),
             ['files' => [
                 $file,
-                $file2
+                $file2,
             ]],
             ['files' => 'array_contains:file']
         );


### PR DESCRIPTION
This PR adds a new validation for each value into an array, takes a second Laravel validation rule as the argument, for the moment `email`, `image` and `file` are available.

This resolve a common problem when you're working with multiple image upload, for example, this is the typical case:

[https://stackoverflow.com/questions/32716280/laravel-validation-of-multiple-images-inputs-from-html-form-array](url)

Also, the rule works with array of files or emails, this is useful when you're building dynamic frontend interfaces where the user can provide one or more email addresses.

### How to use

```php
<?php

$this->validate($request, ['files' => 'array_contains:image']);
```

Why is this rule so important?

Because you can validate your data with few lines of code and in a more readable way.

Why is not possible only implement it in my specific project?

Because **you can't** access to the built-in Laravel validation rules when you make your own via `php artisan make:rule`

I think this rule can be improved a lot! For example, adding more available options instead only files and emails, but anyway, actually resolve a very common problem.