### PR TITLE
When calling each(fn(), 1) iterate result set instead of sending multiple queries

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -74,7 +74,7 @@ trait BuildsQueries
 
         $results->setFetchMode(\PDO::FETCH_CLASS, get_class($this->getModel()));
         while ($row = $results->fetch()) {
-            if ($callback($row, 1) === false) {
+            if ($callback($row, 0) === false) {
                 return false;
             }
         }

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -78,6 +78,7 @@ trait BuildsQueries
                 return false;
             }
         }
+
         return true;
     }
 

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -57,13 +57,28 @@ trait BuildsQueries
      */
     public function each(callable $callback, $count = 1000)
     {
-        return $this->chunk($count, function ($results) use ($callback) {
-            foreach ($results as $key => $value) {
-                if ($callback($value, $key) === false) {
-                    return false;
+        if ($count > 1) {
+            return $this->chunk($count, function ($results) use ($callback) {
+                foreach ($results as $key => $value) {
+                    if ($callback($value, $key) === false) {
+                        return false;
+                    }
                 }
+            });
+        }
+
+        $results = app('db')->getPdo()->query($this->toSql());
+        if ($results === false) {
+            return false;
+        }
+
+        $results->setFetchMode(\PDO::FETCH_CLASS, get_class($this->getModel()));
+        while ($row = $results->fetch()) {
+            if ($callback($row, 1) === false) {
+                return false;
             }
-        });
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
When count = 1, use getPdo() in conjunction with PDO::FETCH_CLASS (hydrate wasn't playing along as well) while iterating fetch(), to avoid sending multiple LIMIT OFFSET queries

Re: https://github.com/laravel/internals/issues/882

Here's a basic test script that I used

```
php artisan make:model Test

php artisan tinker

app('db')->statement('create table tests(id,value);');

app('db')->statement('insert into tests(id,value) values (1,\'A\'),(2,\'B\'),(3,\'C\');');

\DB::listen(function($sql) { echo $sql->sql."\n";});

App\Test::each(function($item){echo(json_encode($item))."\n";if(is_object($item)) echo get_class($item)."\n";}, 1)
// before
    select * from "tests" order by "tests"."id" asc limit 1 offset 0
    {"id":1,"value":"A"}
    App\Test
    select * from "tests" order by "tests"."id" asc limit 1 offset 1
    {"id":2,"value":"B"}
    App\Test
    select * from "tests" order by "tests"."id" asc limit 1 offset 2
    {"id":3,"value":"C"}
    App\Test
    select * from "tests" order by "tests"."id" asc limit 1 offset 3
    => true
    >>> 
// after
    {"id":1,"value":"A"}
    App\Test
    {"id":2,"value":"B"}
    App\Test
    {"id":3,"value":"C"}
    App\Test
    => true
    >>> 
```