### PR TITLE
[5.5] Add "notExists" method to query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1947,6 +1947,16 @@ class Builder
     }
 
     /**
+     * Determine if no rows exist for the current query.
+     *
+     * @return bool
+     */
+    public function notExists()
+    {
+        return ! $this->exists();
+    }
+
+    /**
      * Retrieve the "count" result of the query.
      *
      * @param  string  $columns

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1268,6 +1268,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($results);
 
         $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select exists(select * from "users") as "exists"', [], true)->andReturn([['exists' => 0]]);
+        $results = $builder->from('users')->notExists();
+        $this->assertTrue($results);
+
+        $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select max("id") as aggregate from "users"', [], true)->andReturn([['aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
             return $results;


### PR DESCRIPTION
I use the `$query->exists()` method a lot on the query builder. However, quite often I'm looking for the inverse. This PR adds `notExists()` to the query builder for those situations.

Naming here is tricky because you could do `empty()`, `none()`, `doesNotExist()` or even something else. I chose `notExists()` because it follows how you would write the SQL (ie. `NOT EXISTS`).