### PR TITLE
[5.5] Fix Collection::get() on null key and specified default

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -644,7 +644,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function get($key, $default = null)
     {
-        return is_null($key) ? null : Arr::get($this->items, $key, $default);
+        return is_null($key) ? value($default) : Arr::get($this->items, $key, $default);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2486,10 +2486,14 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('Todo 2', $collection->get('foo.todos.second'));
     }
 
-    public function testGetWithNullReturnsNull()
+    public function testGetWithNullReturnsNullOrDefault()
     {
         $collection = new Collection([1, 2, 3]);
         $this->assertNull($collection->get(null));
+        $this->assertSame('default', $collection->get(null, 'default'));
+        $this->assertSame('default', $collection->get(null, function () {
+            return 'default';
+        }));
     }
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/laravel/framework/commit/6197e563fab8511ce8bf9a006444fee26f015d3a#r26919796.