### PR TITLE
[5.5] Remove wrong reference in changelog

### DIFF
--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -3,7 +3,7 @@
 ## v5.5.31 (2018-01-16)
 
 ### Fixed
-- Reverted [#22804](https://github.com/laravel/framework/pull/22804) ([d8a8368](https://github.com/laravel/framework/commit/d8a8368e15e73de50b91b903f6b933c7d05b0e28), [f34926c](https://github.com/laravel/framework/commit/f34926c52ba282ff67f4be3e9afc8d0ddc885c3f), [#22817](https://github.com/laravel/framework/pull/22817))
+- Reverted [#22804](https://github.com/laravel/framework/pull/22804) ([d8a8368](https://github.com/laravel/framework/commit/d8a8368e15e73de50b91b903f6b933c7d05b0e28), [f34926c](https://github.com/laravel/framework/commit/f34926c52ba282ff67f4be3e9afc8d0ddc885c3f))
 
 
 ## v5.5.30 (2018-01-16)


### PR DESCRIPTION
Follow-up to https://github.com/laravel/framework/commit/3f422993c69a053d7fd3094dd8a40f945b0b326d#commitcomment-26894521.