### PR TITLE
[5.5] Create assertion to determine if a header is missing

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -126,6 +126,21 @@ class TestResponse
     }
 
     /**
+     * Asserts that the response does not contains the given header.
+     *
+     * @param  string  $headerName
+     * @return $this
+     */
+    protected function assertHeaderMissing($headerName)
+    {
+        PHPUnit::assertFalse(
+            $this->headers->has($headerName), "Header [{$headerName}] is present on response."
+        );
+
+        return $this;
+    }
+
+    /**
      * Asserts that the response contains the given cookie and equals the optional value.
      *
      * @param  string  $cookieName


### PR DESCRIPTION
This `assertHeaderMissing` assertion is the counterpart of the `\Illuminate\Foundation\Testing\TestResponse::assertHeader` and will make the test fail if the given header name is present in the response.

It's naming is also consistent with the assertions `assertCookie` and `assertCookieMissing`.