### PR TITLE
[5.7] add `handler` option when defining route and route group

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -643,6 +643,16 @@ class Route
     }
 
     /**
+     * Get the handler class name of the route instance.
+     *
+     * @return string
+     */
+    public function getHandler()
+    {
+        return $this->action['handler'] ?? null;
+    }
+
+    /**
      * Determine whether the route's name matches the given patterns.
      *
      * @param  dynamic  $patterns

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -105,6 +105,4 @@ class RouteGroup
     {
         return isset($new['handler']) ? $new['handler'] : (isset($old['handler']) ? $old['handler'] : null);
     }
-
-
 }

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -23,10 +23,11 @@ class RouteGroup
             'namespace' => static::formatNamespace($new, $old),
             'prefix' => static::formatPrefix($new, $old),
             'where' => static::formatWhere($new, $old),
+            'handler' => static::formatHandler($new, $old),
         ]);
 
         return array_merge_recursive(Arr::except(
-            $old, ['namespace', 'prefix', 'where', 'as']
+            $old, ['namespace', 'prefix', 'where', 'handler', 'as']
         ), $new);
     }
 
@@ -92,4 +93,18 @@ class RouteGroup
 
         return $new;
     }
+
+    /**
+     * Format the "handler" clause of the new group attributes.
+     *
+     * @param  array  $new
+     * @param  array  $old
+     * @return string|null
+     */
+    protected static function formatHandler($new, $old)
+    {
+        return isset($new['handler']) ? $new['handler'] : (isset($old['handler']) ? $old['handler'] : null);
+    }
+
+
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -631,7 +631,7 @@ class Router implements RegistrarContract, BindingRegistrar
         });
 
         $routeExceptionHandler = $route->getHandler();
-        if (!is_null($routeExceptionHandler)) {
+        if (! is_null($routeExceptionHandler)) {
             app()->singleton('Illuminate\Contracts\Debug\ExceptionHandler', $routeExceptionHandler);
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -631,7 +631,7 @@ class Router implements RegistrarContract, BindingRegistrar
         });
 
         $routeExceptionHandler = $route->getHandler();
-        if(!is_null($routeExceptionHandler)) {
+        if (!is_null($routeExceptionHandler)) {
             app()->singleton('Illuminate\Contracts\Debug\ExceptionHandler', $routeExceptionHandler);
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -630,6 +630,11 @@ class Router implements RegistrarContract, BindingRegistrar
             return $route;
         });
 
+        $routeExceptionHandler = $route->getHandler();
+        if(!is_null($routeExceptionHandler)) {
+            app()->singleton('Illuminate\Contracts\Debug\ExceptionHandler', $routeExceptionHandler);
+        }
+
         $this->events->dispatch(new Events\RouteMatched($route, $request));
 
         return $this->prepareResponse($request,

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -23,7 +23,6 @@ use Illuminate\Foundation\Exceptions\Handler;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 
-
 class RoutingRouteTest extends TestCase
 {
     public function testBasicDispatchingOfRoutes()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -218,7 +218,7 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
         $router->get('foo/bar', [
-            'uses' => function() {
+            'uses' => function () {
                 return 'hello';
             },
             'handler' => 'Illuminate\Tests\Routing\RouteTestHandler',
@@ -1788,9 +1788,9 @@ class ActionStub
     }
 }
 
-class RouteTestHandler extends Handler 
+class RouteTestHandler extends Handler
 {
-    public function __construct() 
+    public function __construct()
     {
     }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Routing;
 
 use DateTime;
 use stdClass;
+use Exception;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
@@ -18,8 +19,10 @@ use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Routing\ResourceRegistrar;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Auth\Middleware\Authenticate;
+use Illuminate\Foundation\Exceptions\Handler;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Routing\Middleware\SubstituteBindings;
+
 
 class RoutingRouteTest extends TestCase
 {
@@ -208,6 +211,24 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(
             'index-foo-middleware-controller-closure',
             $router->dispatch(Request::create('foo/bar', 'GET'))->getContent()
+        );
+    }
+
+    public function testHandler()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/bar', [
+            'uses' => function() {
+                return 'hello';
+            },
+            'handler' => 'Illuminate\Tests\Routing\RouteTestHandler',
+        ]);
+
+        $router->dispatch(Request::create('foo/bar', 'GET'))->getContent();
+
+        $this->assertInstanceOf(
+            'Illuminate\Tests\Routing\RouteTestHandler',
+            app('Illuminate\Contracts\Debug\ExceptionHandler')
         );
     }
 
@@ -847,23 +868,26 @@ class RoutingRouteTest extends TestCase
     public function testGroupMerging()
     {
         $old = ['prefix' => 'foo/bar/'];
-        $this->assertEquals(['prefix' => 'foo/bar/baz', 'namespace' => null, 'where' => []], RouteGroup::merge(['prefix' => 'baz'], $old));
+        $this->assertEquals(['prefix' => 'foo/bar/baz', 'namespace' => null, 'where' => [], 'handler' => null], RouteGroup::merge(['prefix' => 'baz'], $old));
 
         $old = ['domain' => 'foo'];
-        $this->assertEquals(['domain' => 'baz', 'prefix' => null, 'namespace' => null, 'where' => []], RouteGroup::merge(['domain' => 'baz'], $old));
+        $this->assertEquals(['domain' => 'baz', 'prefix' => null, 'namespace' => null, 'where' => [], 'handler' => null], RouteGroup::merge(['domain' => 'baz'], $old));
 
         $old = ['as' => 'foo.'];
-        $this->assertEquals(['as' => 'foo.bar', 'prefix' => null, 'namespace' => null, 'where' => []], RouteGroup::merge(['as' => 'bar'], $old));
+        $this->assertEquals(['as' => 'foo.bar', 'prefix' => null, 'namespace' => null, 'where' => [], 'handler' => null], RouteGroup::merge(['as' => 'bar'], $old));
 
         $old = ['where' => ['var1' => 'foo', 'var2' => 'bar']];
         $this->assertEquals(['prefix' => null, 'namespace' => null, 'where' => [
             'var1' => 'foo', 'var2' => 'baz', 'var3' => 'qux',
-        ]], RouteGroup::merge(['where' => ['var2' => 'baz', 'var3' => 'qux']], $old));
+        ], 'handler' => null], RouteGroup::merge(['where' => ['var2' => 'baz', 'var3' => 'qux']], $old));
 
         $old = [];
         $this->assertEquals(['prefix' => null, 'namespace' => null, 'where' => [
             'var1' => 'foo', 'var2' => 'bar',
-        ]], RouteGroup::merge(['where' => ['var1' => 'foo', 'var2' => 'bar']], $old));
+        ], 'handler' => null], RouteGroup::merge(['where' => ['var1' => 'foo', 'var2' => 'bar']], $old));
+
+        $old = [];
+        $this->assertEquals(['prefix' => null, 'namespace' => null, 'where' => [], 'handler' => 'FooHandler'], RouteGroup::merge(['handler' => 'FooHandler'], $old));
     }
 
     public function testRouteGrouping()
@@ -1761,5 +1785,17 @@ class ActionStub
     public function __invoke()
     {
         return 'hello';
+    }
+}
+
+class RouteTestHandler extends Handler 
+{
+    public function __construct() 
+    {
+    }
+
+    public function render($request, Exception $exception)
+    {
+        return 'handled!';
     }
 }


### PR DESCRIPTION
This PR allows developers to have a new ```handler``` option when defining routes or route groups.
With this option they could set a custom Handler that will intercept any exceptions throw in that request cycle.

You could have something like this:

```php
//in routes/api.php
Route::group(['handler' => 'App/Exception/ApiHander', 'prefix' => 'api'], function() {
   Route::get('/api-foo-method', 'App/Http/ApiController@fooMethod');
   Route::get('/api-bar-method', 'App/Http/ApiController@barMethod');
});

//in routes/web.php
Route::get('html-foo-page', 'App/Http/HtmlController@fooMethod');
Route::get('html-bar-page', 'App/Http/HtmlController@barMethod');

//in app/Exception/Handler
public function render($request, Exception $exception)
{
    return response("I'm the HTML exception handler");
}

//in app/Exception/ApiHandler
public function render($request, Exception $exception)
{
    return response()->json(["message" => "I'm the API exception handler"]);
}
```

I think this is very useful and comfortable when applications get bigger. No more ```if``` inside handler ```render``` method to detect the type of request (if expects JSON or HTML, if urls contains '/api', etc...).