### PR TITLE
 [5.6] Enable developer to use --realpath option to migration commands

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/BaseCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/BaseCommand.php
@@ -13,12 +13,14 @@ class BaseCommand extends Command
      */
     protected function getMigrationPaths()
     {
+        $realpath = $this->input->hasOption('realpath') && $this->option('realpath');
+
         // Here, we will check to see if a path option has been defined. If it has we will
         // use the path relative to the root of the installation folder so our database
         // migrations may be run for any customized path from within the application.
         if ($this->input->hasOption('path') && $this->option('path')) {
-            return collect($this->option('path'))->map(function ($path) {
-                return $this->laravel->basePath().'/'.$path;
+            return collect($this->option('path'))->map(function ($path) use ($realpath) {
+                return $realpath ? $path : $this->laravel->basePath().'/'.$path;
             })->all();
         }
 

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -104,6 +104,8 @@ class FreshCommand extends Command
 
             ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'],
 
+            ['realpath', null, InputOption::VALUE_NONE, 'Mark the given migration path(s) as realpath.'],
+
             ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
 
             ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder.'],

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -17,6 +17,7 @@ class MigrateCommand extends BaseCommand
     protected $signature = 'migrate {--database= : The database connection to use.}
                 {--force : Force the operation to run when in production.}
                 {--path= : The path of migrations files to be executed.}
+                {--realpath : Mark the given migration path(s) as realpath.}
                 {--pretend : Dump the SQL queries that would be run.}
                 {--seed : Indicates if the seed task should be re-run.}
                 {--step : Force the migrations to be run so they can be rolled back individually.}';

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -16,7 +16,8 @@ class MigrateMakeCommand extends BaseCommand
     protected $signature = 'make:migration {name : The name of the migration.}
         {--create= : The table to be created.}
         {--table= : The table to migrate.}
-        {--path= : The location where the migration file should be created.}';
+        {--path= : The location where the migration file should be created.}
+        {--realpath : Mark the given migration path as realpath.}';
 
     /**
      * The console command description.
@@ -123,7 +124,9 @@ class MigrateMakeCommand extends BaseCommand
     protected function getMigrationPath()
     {
         if (! is_null($targetPath = $this->input->getOption('path'))) {
-            return $this->laravel->basePath().'/'.$targetPath;
+            $realpath = $this->input->hasOption('realpath') && $this->option('realpath');
+
+            return $realpath ? $targetPath : $this->laravel->basePath().'/'.$targetPath;
         }
 
         return parent::getMigrationPath();

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -144,6 +144,8 @@ class RefreshCommand extends Command
 
             ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'],
 
+            ['realpath', null, InputOption::VALUE_NONE, 'Mark the given migration path(s) as realpath.'],
+
             ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
 
             ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder.'],

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -90,6 +90,8 @@ class ResetCommand extends BaseCommand
 
             ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) of migrations files to be executed.'],
 
+            ['realpath', null, InputOption::VALUE_NONE, 'Mark the given migration path(s) as realpath.'],
+
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
         ];
     }

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -86,6 +86,8 @@ class RollbackCommand extends BaseCommand
 
             ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'],
 
+            ['realpath', null, InputOption::VALUE_NONE, 'Mark the given migration path(s) as realpath.'],
+
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
 
             ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted.'],

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -106,6 +106,8 @@ class StatusCommand extends BaseCommand
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
 
             ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to use.'],
+
+            ['realpath', null, InputOption::VALUE_NONE, 'Mark the given migration path(s) as realpath.'],
         ];
     }
 }

--- a/tests/Integration/Database/MigrateWithRealpathTest.php
+++ b/tests/Integration/Database/MigrateWithRealpathTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+
+class MigrateWithRealpathTest extends DatabaseTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->loadMigrationsFrom(realpath(__DIR__.'/stubs/'));
+    }
+
+    public function test_realpath_migration_has_properly_executed()
+    {
+        $this->assertTrue(Schema::hasTable('members'));
+    }
+
+    public function test_migrations_has_the_migrated_table()
+    {
+        $this->assertDatabaseHas('migrations', [
+            'id' => 1,
+            'migration' => '2014_10_12_000000_create_members_table',
+            'batch' => 1,
+        ]);
+    }
+
+    /**
+     * Swap Orchestra\Testbench\TestCase::loadMigrationsFrom() operation until we swap the implementation.
+     */
+    protected function loadMigrationsFrom($paths): void
+    {
+        $options = is_array($paths) ? $path : ['--path' => $paths];
+        $options['--realpath'] = true;
+
+        $this->artisan('migrate', $options);
+
+        $this->app[ConsoleKernel::class]->setArtisan(null);
+
+        $this->beforeApplicationDestroyed(function () use ($options) {
+            $this->artisan('migrate:rollback', $options);
+        });
+    }
+}

--- a/tests/Integration/Database/MigrateWithRealpathTest.php
+++ b/tests/Integration/Database/MigrateWithRealpathTest.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 
 class MigrateWithRealpathTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/MigrateWithRealpathTest.php
+++ b/tests/Integration/Database/MigrateWithRealpathTest.php
@@ -12,7 +12,16 @@ class MigrateWithRealpathTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        $this->loadMigrationsFrom(realpath(__DIR__.'/stubs/'));
+        $options = [
+            '--path' => realpath(__DIR__.'/stubs/'),
+            '--realpath' => true,
+        ];
+
+        $this->artisan('migrate', $options);
+
+        $this->beforeApplicationDestroyed(function () use ($options) {
+            $this->artisan('migrate:rollback', $options);
+        });
     }
 
     public function test_realpath_migration_has_properly_executed()
@@ -27,22 +36,5 @@ class MigrateWithRealpathTest extends DatabaseTestCase
             'migration' => '2014_10_12_000000_create_members_table',
             'batch' => 1,
         ]);
-    }
-
-    /**
-     * Swap Orchestra\Testbench\TestCase::loadMigrationsFrom() operation until we swap the implementation.
-     */
-    protected function loadMigrationsFrom($paths): void
-    {
-        $options = is_array($paths) ? $path : ['--path' => $paths];
-        $options['--realpath'] = true;
-
-        $this->artisan('migrate', $options);
-
-        $this->app[ConsoleKernel::class]->setArtisan(null);
-
-        $this->beforeApplicationDestroyed(function () use ($options) {
-            $this->artisan('migrate:rollback', $options);
-        });
     }
 }

--- a/tests/Integration/Database/stubs/2014_10_12_000000_create_members_table.php
+++ b/tests/Integration/Database/stubs/2014_10_12_000000_create_members_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateMembersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('members', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('members');
+    }
+}


### PR DESCRIPTION
This would indicate given path should be translated to realpath instead
of relative to Laravel base path.

### Benefits

You can use `php artisan migrate --path=./tests/migrations --realpath` when running integration testing on Laravel or 3rd party packages (via Testbench) without adding extra dependencies.