### PR TITLE
[5.5] Filter routes by method in insensitive case

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -163,7 +163,7 @@ class RouteListCommand extends Command
     {
         if (($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
              $this->option('path') && ! Str::contains($route['uri'], $this->option('path')) ||
-             $this->option('method') && ! Str::contains($route['method'], $this->option('method'))) {
+             $this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) {
             return;
         }
 


### PR DESCRIPTION
Added an ability to filter routes by a method in insensitive case. Small change, but I will be grateful if I can filter routes with `php artisan:route:list --method=post` not `php artisan:route:list --method=POST`