### PR TITLE
[5.6] Revert "Simplify testing database connection (sqlite) to use predefined connection "testing"."

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,10 +27,9 @@
         </whitelist>
     </filter>
     <php>
-        <env name="DB_CONNECTION" value="testing" />
-        <!--
-        <env name="REDIS_HOST" value="127.0.0.1" />
-        <env name="REDIS_PORT" value="6379" />
-        -->
+      <!--
+      <env name="REDIS_HOST" value="127.0.0.1" />
+      <env name="REDIS_PORT" value="6379" />
+      -->
     </php>
 </phpunit>

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -18,6 +18,13 @@ class AuthenticationTest extends TestCase
         $app['config']->set('app.debug', 'true');
         $app['config']->set('auth.providers.users.model', AuthenticationTestUser::class);
 
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
         $app['config']->set('hashing', ['driver' => 'bcrypt']);
     }
 

--- a/tests/Integration/Database/DatabaseTestCase.php
+++ b/tests/Integration/Database/DatabaseTestCase.php
@@ -9,5 +9,13 @@ class DatabaseTestCase extends TestCase
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
     }
 }

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -14,6 +14,14 @@ class EloquentDeleteTest extends TestCase
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
     }
 
     public function setUp()

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -17,6 +17,12 @@ class EloquentFactoryBuilderTest extends TestCase
     {
         $app['config']->set('app.debug', 'true');
 
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
         $app['config']->set('database.connections.alternative-connection', [
             'driver' => 'sqlite',
             'database' => ':memory:',

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -15,6 +15,14 @@ class EloquentUpdateTest extends TestCase
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
     }
 
     public function setUp()

--- a/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
+++ b/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
@@ -14,6 +14,13 @@ class InteractsWithAuthenticationTest extends TestCase
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('auth.providers.users.model', AuthenticationTestUser::class);
+
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
     }
 
     public function setUp()

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -32,6 +32,14 @@ class SendingMailNotificationsTest extends TestCase
     {
         $app['config']->set('app.debug', 'true');
 
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
         $this->mailer = Mockery::mock(Mailer::class);
         $this->markdown = Mockery::mock(Markdown::class);
 

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -18,6 +18,8 @@ class JobChainingTest extends TestCase
     {
         $app['config']->set('app.debug', 'true');
 
+        $app['config']->set('database.default', 'testbench');
+
         $app['config']->set('queue.connections.sync1', [
             'driver' => 'sync',
         ]);

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -15,6 +15,14 @@ class ModelSerializationTest extends TestCase
     {
         $app['config']->set('app.debug', 'true');
 
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
         $app['config']->set('database.connections.custom', [
             'driver' => 'sqlite',
             'database' => ':memory:',
@@ -68,16 +76,16 @@ class ModelSerializationTest extends TestCase
 
         $unSerialized = unserialize($serialized);
 
-        $this->assertEquals('testing', $unSerialized->user->getConnectionName());
+        $this->assertEquals('testbench', $unSerialized->user->getConnectionName());
         $this->assertEquals('mohamed@laravel.com', $unSerialized->user->email);
 
-        $serialized = serialize(new ModelSerializationTestClass(ModelSerializationTestUser::on('testing')->get()));
+        $serialized = serialize(new ModelSerializationTestClass(ModelSerializationTestUser::on('testbench')->get()));
 
         $unSerialized = unserialize($serialized);
 
-        $this->assertEquals('testing', $unSerialized->user[0]->getConnectionName());
+        $this->assertEquals('testbench', $unSerialized->user[0]->getConnectionName());
         $this->assertEquals('mohamed@laravel.com', $unSerialized->user[0]->email);
-        $this->assertEquals('testing', $unSerialized->user[1]->getConnectionName());
+        $this->assertEquals('testbench', $unSerialized->user[1]->getConnectionName());
         $this->assertEquals('taylor@laravel.com', $unSerialized->user[1]->email);
     }
 


### PR DESCRIPTION
Reverts laravel/framework#22855