### PR TITLE
[5.5] Fixed parameter type of tagged method in Container contract

### DIFF
--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -36,7 +36,7 @@ interface Container extends ContainerInterface
     /**
      * Resolve all of the bindings for a given tag.
      *
-     * @param  array  $tag
+     * @param  string  $tag
      * @return array
      */
     public function tagged($tag);


### PR DESCRIPTION
This PR fixes the parameter type of `\Illuminate\Contracts\Container\Container::tagged($tag)` defined in the docblock. The `$tag` parameter should have a `string` type, not `array` (see [implementation](https://github.com/laravel/framework/blob/d6db20a571b0a966886d083c477ce82f77c367c3/src/Illuminate/Container/Container.php#L431)).