### PR TITLE
Easier custom error messages for Rule Objects

### DIFF
--- a/src/Illuminate/Contracts/Validation/Rule.php
+++ b/src/Illuminate/Contracts/Validation/Rule.php
@@ -19,4 +19,11 @@ interface Rule
      * @return string
      */
     public function message();
+    
+    /**
+     * Get the validation rule's name.
+     * 
+     * @return string
+     */
+    public function name();
 }

--- a/src/Illuminate/Contracts/Validation/Rule.php
+++ b/src/Illuminate/Contracts/Validation/Rule.php
@@ -14,15 +14,15 @@ interface Rule
     public function passes($attribute, $value);
 
     /**
-     * Get the validation error message.
+     * Get the default validation error message.
      *
      * @return string
      */
     public function message();
-    
+
     /**
      * Get the validation rule's name.
-     * 
+     *
      * @return string
      */
     public function name();

--- a/src/Illuminate/Foundation/Console/stubs/rule.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Validation\Rules\Rule;
 
 class DummyClass implements Rule
 {

--- a/src/Illuminate/Foundation/Console/stubs/rule.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.stub
@@ -29,7 +29,7 @@ class DummyClass implements Rule
     }
 
     /**
-     * Get the validation error message.
+     * Get the fallback validation error message.
      *
      * @return string
      */

--- a/src/Illuminate/Validation/ClosureValidationRule.php
+++ b/src/Illuminate/Validation/ClosureValidationRule.php
@@ -52,9 +52,8 @@ class ClosureValidationRule extends Rule
         $this->callback->__invoke($attribute, $value, function ($message, $rule = '') {
             $this->failed = true;
 
-            $this->message = $message;
-            
             $this->rule = $rule;
+            $this->message = $message;
         });
 
         return ! $this->failed;

--- a/src/Illuminate/Validation/ClosureValidationRule.php
+++ b/src/Illuminate/Validation/ClosureValidationRule.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Validation;
 
-use Illuminate\Contracts\Validation\Rule as RuleContract;
+use Illuminate\Validation\Rules\Rule;
 
-class ClosureValidationRule implements RuleContract
+class ClosureValidationRule extends Rule
 {
     /**
      * The callback that validates the attribute.
@@ -49,10 +49,12 @@ class ClosureValidationRule implements RuleContract
     {
         $this->failed = false;
 
-        $this->callback->__invoke($attribute, $value, function ($message) {
+        $this->callback->__invoke($attribute, $value, function ($message, $rule = '') {
             $this->failed = true;
 
             $this->message = $message;
+            
+            $this->rule = $rule;
         });
 
         return ! $this->failed;

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -45,7 +45,7 @@ trait FormatsMessages
         // If the rule being validated is a "size" rule, we will need to gather the
         // specific error message for the type of attribute being validated such
         // as a number, file or string which all have different message types.
-        elseif (in_array($rule, $this->sizeRules)) {
+        if (in_array($rule, $this->sizeRules)) {
             return $this->getSizeMessage($attribute, $rule);
         }
 

--- a/src/Illuminate/Validation/Rules/ImplicitRule.php
+++ b/src/Illuminate/Validation/Rules/ImplicitRule.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\ImplicitRule as ImplicitRuleContract;
+
+abstract class ImplicitRule extends Rule implements ImplicitRuleContract
+{
+    //
+}

--- a/src/Illuminate/Validation/Rules/Rule.php
+++ b/src/Illuminate/Validation/Rules/Rule.php
@@ -13,8 +13,8 @@ abstract class Rule implements RuleContract
     protected $rule;
 
     /**
-     * Get the validation rule's name.
-     * 
+     * Get the default validation rule's name.
+     *
      * @return string
      */
     public function name()

--- a/src/Illuminate/Validation/Rules/Rule.php
+++ b/src/Illuminate/Validation/Rules/Rule.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Support\Str;
+use Illuminate\Contracts\Validation\Rule as RuleContract;
+
+abstract class Rule implements RuleContract
+{
+    /**
+     * The name of the rule.
+     */
+    protected $rule;
+
+    /**
+     * Get the validation rule's name.
+     * 
+     * @return string
+     */
+    public function name()
+    {
+        return $this->rule ?: Str::snake(class_basename($this));
+    }
+}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -531,10 +531,11 @@ class Validator implements ValidatorContract
     protected function validateUsingCustomRule($attribute, $value, $rule)
     {
         if (! $rule->passes($attribute, $value)) {
+            $this->fallbackMessages[] = $rule->message();
             $this->failedRules[$attribute][get_class($rule)] = [];
 
             $this->messages->add($attribute, $this->makeReplacements(
-                $rule->message(), $attribute, get_class($rule), []
+                $this->getMessage($attribute, $rule->name()), $attribute, get_class($rule), []
             ));
         }
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -531,11 +531,11 @@ class Validator implements ValidatorContract
     protected function validateUsingCustomRule($attribute, $value, $rule)
     {
         if (! $rule->passes($attribute, $value)) {
-            $this->fallbackMessages[] = $rule->message();
-            $this->failedRules[$attribute][get_class($rule)] = [];
+            $this->fallbackMessages[$rule->name()] = $rule->message();
+            $this->failedRules[$attribute][$rule->name()] = [];
 
             $this->messages->add($attribute, $this->makeReplacements(
-                $this->getMessage($attribute, $rule->name()), $attribute, get_class($rule), []
+                $this->getMessage($attribute, $rule->name()), $attribute, $rule->name(), []
             ));
         }
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -9,11 +9,11 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Validation\Validator;
+use Illuminate\Validation\Rules\Rule;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Validation\Rules\ImplicitRule;
 use Symfony\Component\HttpFoundation\File\File;
-use Illuminate\Contracts\Validation\ImplicitRule;
 
 class ValidationValidatorTest extends TestCase
 {
@@ -3699,7 +3699,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator(
             $this->getIlluminateArrayTranslator(),
             ['name' => 'taylor'],
-            ['name' => new class implements Rule {
+            ['name' => new class extends Rule {
+                protected $rule = 'must_be_taylor';
+
                 public function passes($attribute, $value)
                 {
                     return $value === 'taylor';
@@ -3718,7 +3720,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator(
             $this->getIlluminateArrayTranslator(),
             ['name' => 'adam'],
-            ['name' => [new class implements Rule {
+            ['name' => [new class extends Rule {
+                protected $rule = 'must_be_taylor';
+
                 public function passes($attribute, $value)
                 {
                     return $value === 'taylor';
@@ -3740,7 +3744,7 @@ class ValidationValidatorTest extends TestCase
             ['name' => 'taylor'],
             ['name.*' => function ($attribute, $value, $fail) {
                 if ($value !== 'taylor') {
-                    $fail(':attribute was '.$value.' instead of taylor');
+                    $fail(':attribute was '.$value.' instead of taylor', 'must_be_taylor');
                 }
             }]
         );
@@ -3753,7 +3757,7 @@ class ValidationValidatorTest extends TestCase
             ['name' => 'adam'],
             ['name' => function ($attribute, $value, $fail) {
                 if ($value !== 'taylor') {
-                    $fail(':attribute was '.$value.' instead of taylor');
+                    $fail(':attribute was '.$value.' instead of taylor', 'must_be_taylor');
                 }
             }]
         );
@@ -3766,7 +3770,9 @@ class ValidationValidatorTest extends TestCase
             $this->getIlluminateArrayTranslator(),
             ['name' => 'taylor', 'states' => ['AR', 'TX'], 'number' => 9],
             [
-                'states.*' => new class implements Rule {
+                'states.*' => new class extends Rule {
+                    protected $rule = 'must_be_ar_or_tx';
+
                     public function passes($attribute, $value)
                     {
                         return in_array($value, ['AK', 'HI']);
@@ -3779,7 +3785,7 @@ class ValidationValidatorTest extends TestCase
                 },
                 'name' => function ($attribute, $value, $fail) {
                     if ($value !== 'taylor') {
-                        $fail(':attribute must be taylor');
+                        $fail(':attribute must be taylor', 'must_be_taylor');
                     }
                 },
                 'number' => [
@@ -3787,7 +3793,7 @@ class ValidationValidatorTest extends TestCase
                     'integer',
                     function ($attribute, $value, $fail) {
                         if ($value % 4 !== 0) {
-                            $fail(':attribute must be divisible by 4');
+                            $fail(':attribute must be divisible by 4', 'must_be_divisible_by_4');
                         }
                     },
                 ],
@@ -3806,7 +3812,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator(
             $this->getIlluminateArrayTranslator(),
             ['name' => ''],
-            ['name' => $rule = new class implements ImplicitRule {
+            ['name' => $rule = new class extends ImplicitRule {
                 public $called = false;
 
                 public function passes($attribute, $value)


### PR DESCRIPTION
This PR makes it possible/easier to customise the error message from a custom Rule Object without having to edit the Rule Object itself. This is a breaking change.

## Example

Let's imagine the custom rule Uppercase:

```php
<?php

namespace App\Rules;

use Illuminate\Contracts\Validation\Rule;

class Uppercase implements Rule
{
    /**
     * Determine if the validation rule passes.
     *
     * @param  string  $attribute
     * @param  mixed  $value
     * @return bool
     */
    public function passes($attribute, $value)
    {
        return strtoupper($value) === $value;
    }

    /**
     * Get the fallback validation error message.
     *
     * @return string
     */
    public function message()
    {
        return 'The :attribute must be uppercase.';
    }
}
```

With this PR, I can customise the error message in various ways. First off, you can now add a global message for this rule in your validation translation (you could do this already previously by changing the `message` method on your Rule to use the `trans()` helper.

**lang/en/validation.php**
```php
return [
    ...
    'uploaded'             => 'The :attribute failed to upload.',
    'uppercase'            => 'The :attribute must be uppercase.',
    'url'                  => 'The :attribute format is invalid.',
    ...
];
```

Secondly, you can now add a custom validation language line, something you previously couldn't do.

**lang/en/validation.php**
```php
return [
    ...
    'custom' => [
        'name' => [
            'uppercase' => 'Your name should be entered in UPPERCASE.',
        ],
    ],
```

Lastly, you can also pass a custom error message to the validator, which you previously also couldn't do.

**In your controller**
```php
    /**
     * Update the specified resource in storage.
     *
     * @param  \Illuminate\Http\Request  $request
     * @return \Illuminate\Http\Response
     */
    public function update(Request $request)
    {
        $request->validate([
            'name' => [
                'required',
                new Uppercase,
            ],
        ],
        [
            'name.uppercase'  => 'Use UPPERCASE please!!!',
        ]);
    }
```

## The Rule name

As you can see in the examples, the rule name automatically gets parsed to `uppercase`. This uses a `name` method on the new abstract `Validation\Rules\Rule` class that custom Rule objects will now extend, rather than just implementing the `Contracts\Validation\Rule` contract. By default, it will return a snake_case version of the base classname. So `App\Rules\Uppercase` becomes `uppercase` and `App\Rules\MyCustomRule` would become `my_custom_rule`. You can also explicitly define the rule name on your `Rule` class object, by setting a value for the `$rule` property like below. You could use that to change the custom message key to something like `upper` instead, for example.

```php
<?php

namespace App\Rules;

use Illuminate\Contracts\Validation\Rule;

class Uppercase implements Rule
{
    /**
     * The name of the rule.
     * 
     * @var string
     */
    protected $rule = upper;
    
    ...
}
```

**lang/en/validation.php**
```php
return [
    ...
    'custom' => [
        'name' => [
            'upper' => 'Your name should be entered in UPPERCASE.',
        ],
    ],
```