### PR TITLE
[5.7] Escape operators where possible

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -552,15 +552,11 @@ class Builder
         // will be bound to each SQL statements when it is finally executed.
         $type = 'Basic';
 
-        $where = compact(
-            'type', 'column', 'operator', 'value', 'boolean'
+        $escape = in_array($operator, $this->escapableOperators, true);
+
+        $this->wheres[] = compact(
+            'type', 'column', 'operator', 'value', 'boolean', 'escape'
         );
-
-        if (in_array($operator, $this->escapableOperators, true)) {
-            $where['escape'] = true;
-        }
-
-        $this->wheres[] = $where;
 
         if (! $value instanceof Expression) {
             $this->addBinding($value, 'where');
@@ -1173,15 +1169,11 @@ class Builder
         // in the array of where clauses for the "main" parent query instance.
         call_user_func($callback, $query = $this->forSubQuery());
 
-        $where = compact(
-            'type', 'column', 'operator', 'query', 'boolean'
+        $escape = in_array($operator, $this->escapableOperators, true);
+
+        $this->wheres[] = compact(
+            'type', 'column', 'operator', 'query', 'boolean', 'escape'
         );
-
-        if (in_array($operator, $this->escapableOperators, true)) {
-            $where['escape'] = true;
-        }
-
-        $this->wheres[] = $where;
 
         $this->addBinding($query->getBindings(), 'where');
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -193,6 +193,17 @@ class Builder
     public $useWritePdo = false;
 
     /**
+     * All of the available escapable clause operators.
+     *
+     * @var array
+     */
+    protected $escapableOperators = [
+        'like', 'like binary', 'not like',
+        'ilike',  'rlike', 'similar to',
+        'not similar to', 'not ilike',
+    ];
+
+    /**
      * Create a new query builder instance.
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection
@@ -541,9 +552,15 @@ class Builder
         // will be bound to each SQL statements when it is finally executed.
         $type = 'Basic';
 
-        $this->wheres[] = compact(
+        $where = compact(
             'type', 'column', 'operator', 'value', 'boolean'
         );
+
+        if (in_array($operator, $this->escapableOperators, true)) {
+            $where['escape'] = true;
+        }
+
+        $this->wheres[] = $where;
 
         if (! $value instanceof Expression) {
             $this->addBinding($value, 'where');
@@ -1156,9 +1173,15 @@ class Builder
         // in the array of where clauses for the "main" parent query instance.
         call_user_func($callback, $query = $this->forSubQuery());
 
-        $this->wheres[] = compact(
+        $where = compact(
             'type', 'column', 'operator', 'query', 'boolean'
         );
+
+        if (in_array($operator, $this->escapableOperators, true)) {
+            $where['escape'] = true;
+        }
+
+        $this->wheres[] = $where;
 
         $this->addBinding($query->getBindings(), 'where');
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -234,7 +234,13 @@ class Grammar extends BaseGrammar
     {
         $value = $this->parameter($where['value']);
 
-        return $this->wrap($where['column']).' '.$where['operator'].' '.$value;
+        $result = $this->wrap($where['column']).' '.$where['operator'].' '.$value;
+
+        if ($where['escape'] ?? false) {
+            $result .= ' escape "\"';
+        }
+
+        return $result;
     }
 
     /**
@@ -446,7 +452,13 @@ class Grammar extends BaseGrammar
     {
         $select = $this->compileSelect($where['query']);
 
-        return $this->wrap($where['column']).' '.$where['operator']." ($select)";
+        $result = $this->wrap($where['column']).' '.$where['operator']." ($select)";
+
+        if ($where['escape'] ?? false) {
+            $result .= ' escape "\"';
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -234,13 +234,7 @@ class Grammar extends BaseGrammar
     {
         $value = $this->parameter($where['value']);
 
-        $result = $this->wrap($where['column']).' '.$where['operator'].' '.$value;
-
-        if ($where['escape'] ?? false) {
-            $result .= ' escape "\"';
-        }
-
-        return $result;
+        return $this->escapeIfRequired($this->wrap($where['column']).' '.$where['operator'].' '.$value, $where);
     }
 
     /**
@@ -452,13 +446,7 @@ class Grammar extends BaseGrammar
     {
         $select = $this->compileSelect($where['query']);
 
-        $result = $this->wrap($where['column']).' '.$where['operator']." ($select)";
-
-        if ($where['escape'] ?? false) {
-            $result .= ' escape "\"';
-        }
-
-        return $result;
+        return $this->escapeIfRequired($this->wrap($where['column']).' '.$where['operator']." ($select)", $where);
     }
 
     /**
@@ -885,5 +873,22 @@ class Grammar extends BaseGrammar
     public function getOperators()
     {
         return $this->operators;
+    }
+
+    /**
+     * Add an ESCAPE statement to SQL if required.
+     *
+     * @param  string  $sql
+     * @param  array  $where
+     *
+     * @return string
+     */
+    protected function escapeIfRequired(string $sql, array $where): string
+    {
+        if ($where['escape'] ?? false) {
+            return $sql.' escape "\"';
+        }
+
+        return $sql;
     }
 }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -234,7 +234,10 @@ class Grammar extends BaseGrammar
     {
         $value = $this->parameter($where['value']);
 
-        return $this->escapeIfRequired($this->wrap($where['column']).' '.$where['operator'].' '.$value, $where);
+        return $this->escapeIf(
+            $this->wrap($where['column']).' '.$where['operator'].' '.$value,
+            $where['escape'] ?? false
+        );
     }
 
     /**
@@ -446,7 +449,10 @@ class Grammar extends BaseGrammar
     {
         $select = $this->compileSelect($where['query']);
 
-        return $this->escapeIfRequired($this->wrap($where['column']).' '.$where['operator']." ($select)", $where);
+        return $this->escapeIf(
+            $this->wrap($where['column']).' '.$where['operator']." ($select)",
+            $where['escape'] ?? false
+        );
     }
 
     /**
@@ -876,16 +882,16 @@ class Grammar extends BaseGrammar
     }
 
     /**
-     * Add an ESCAPE statement to SQL if required.
+     * Add an ESCAPE clause to SQL.
      *
      * @param  string  $sql
-     * @param  array  $where
+     * @param  bool  $bool
      *
      * @return string
      */
-    protected function escapeIfRequired(string $sql, array $where): string
+    protected function escapeIf($sql, $bool)
     {
-        if ($where['escape'] ?? false) {
+        if ($bool) {
             return $sql.' escape "\"';
         }
 


### PR DESCRIPTION
This is a breaking change as it will affect the SQL, and will change the behaviour when using backslashes in `LIKE` queries in SQL Server and SQLite.

Please let me know if there's anything I've missed, or I could have done better. Thanks for taking your time to review 😄 

----

# Use Case

If my app has some kind of basic searching functionality:

```php
$term = 'Foo%Bar';
Post::where('title', 'like', '%'.$term.'%')->get();
// Will return:
[
  ['title' => 'Foo%Bar'],
  ['title' => 'FooXBar'],
]

// We can escape it, but it only works on Postgres and MySQL
$term = addcslashes('Foo%Bar', '\%_');
Post::where('title', 'like', '%'.$term.'%')->get();
// Will return on Postgres and MySQL:
[
  ['title' => 'Foo%Bar'],
]
// Will return on everything else:
[]
```

This change should unify functionality across all DB engines.

# Notes

## MySQL

https://dev.mysql.com/doc/refman/5.7/en/string-comparison-functions.html#operator_like

Not required for escaping, defaults to `\` if not supplied.

## SQLite

http://sqlite.org/lang_expr.html#like

> If the optional ESCAPE clause is present, then the expression following the ESCAPE keyword must evaluate to a string consisting of a single character

Required for escaping

## SQL Server

https://docs.microsoft.com/en-us/sql/t-sql/language-elements/like-transact-sql#arguments

> escape_character is a character expression that has no default and must evaluate to only one character.

Required for escaping

## PostgreSQL

https://www.postgresql.org/docs/9.1/static/functions-matching.html

> The default escape character is the backslash

Not required for escaping, defaults to `\` if not supplied.