### PR TITLE
[5.5] Add test for the assertHeaderMissing response assertion

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -131,7 +131,7 @@ class TestResponse
      * @param  string  $headerName
      * @return $this
      */
-    protected function assertHeaderMissing($headerName)
+    public function assertHeaderMissing($headerName)
     {
         PHPUnit::assertFalse(
             $this->headers->has($headerName), "Unexpected header [{$headerName}] is present on response."

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -70,6 +70,24 @@ class FoundationTestResponseTest extends TestCase
         }
     }
 
+    public function testAssertHeaderMissing()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->header('Location', '/foo');
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        try {
+            $response->assertHeaderMissing('Location');
+        } catch (\PHPUnit\Framework\ExpectationFailedException $e) {
+            $this->assertContains(
+                'Unexpected header [Location] is present on response.',
+                $e->getMessage()
+            );
+        }
+    }
+
     public function testAssertJsonWithArray()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));


### PR DESCRIPTION
Add the missing test for the `\Illuminate\Tests\Foundation\FoundationTestResponseTest::assertHeaderMissing` assertion introduced in #22849