### PR TITLE
[5.6] Default attributes for pivot table during fetching and creating rows

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -76,6 +76,13 @@ class BelongsToMany extends Relation
     protected $pivotWhereIns = [];
 
     /**
+     * Default values for the pivot columns.
+     *
+     * @var array
+     */
+    protected $pivotValues = [];
+
+    /**
      * Indicates if timestamps are available on the pivot table.
      *
      * @var bool
@@ -345,6 +352,32 @@ class BelongsToMany extends Relation
     public function orWherePivot($column, $operator = null, $value = null)
     {
         return $this->wherePivot($column, $operator, $value, 'or');
+    }
+
+    /**
+     * Sets default value when querying or creating a new row in the pivot table.
+     *
+     * @param  string  $column
+     * @param  mixed   $value
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function withPivotValues($column, $value = null)
+    {
+        if (is_array($column)) {
+            foreach ($column as $name => $value) {
+                $this->withPivotValues($name, $value);
+            }
+
+            return $this;
+        }
+
+        if (is_null($value)) {
+            throw new \InvalidArgumentException('$value cannot be null.');
+        }
+
+        $this->pivotValues[] = func_get_args();
+
+        return $this->wherePivot($column, '=', $value);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -300,6 +300,12 @@ trait InteractsWithPivotTable
             $record = $this->addTimestampsToAttachment($record);
         }
 
+        // Adding the default pivot values (if there is any) to the record.
+        foreach ($this->pivotValues as $arguments) {
+            list($name, $value) = $arguments;
+            $record[$name] = $value;
+        }
+
         return $record;
     }
 

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Query\Builder;
+
+class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testWithPivotValuesMethodSetsWhereConditionsForFetching()
+    {
+        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation->withPivotValues(['is_admin' => 1]);
+    }
+
+    public function testWithPivotValuesMethodSetsDefaultArgumentsForInsertion()
+    {
+        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation->withPivotValues(['is_admin' => 1]);
+
+        $query = m::mock('stdClass');
+        $query->shouldReceive('from')->once()->with('club_user')->andReturn($query);
+        $query->shouldReceive('insert')->once()->with([['club_id' => 1, 'user_id' => 1, 'is_admin' => 1]])->andReturn(true);
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+
+        $relation->attach(1);
+    }
+
+    public function getRelationArguments()
+    {
+        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent->shouldReceive('getKey')->andReturn(1);
+        $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
+        $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $builder->shouldReceive('getModel')->andReturn($related);
+
+        $related->shouldReceive('getTable')->andReturn('users');
+        $related->shouldReceive('getKeyName')->andReturn('id');
+
+        $builder->shouldReceive('join')->once()->with('club_user', 'users.id', '=', 'club_user.user_id');
+        $builder->shouldReceive('where')->once()->with('club_user.club_id', '=', 1);
+        $builder->shouldReceive('where')->once()->with('club_user.is_admin', '=', 1, 'and');
+
+        return [$builder, $parent, 'club_user', 'club_id', 'user_id', 'id', 'id', null, false];
+    }
+}

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Database;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Database\Query\Builder;
 
 class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
 {


### PR DESCRIPTION
As per the proposal: https://github.com/laravel/internals/issues/872.

Added a new method so that default pivot values can be set during fetching and creating rows.
This version also includes tests.