### PR TITLE
[5.5] Fix tests for assertHeader and assertHeaderMissing

### DIFF
--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -64,12 +64,17 @@ class FoundationTestResponseTest extends TestCase
 
         try {
             $response->assertHeader('Location', '/bar');
+            $this->fail('No exception was thrown');
         } catch (\PHPUnit\Framework\ExpectationFailedException $e) {
             $this->assertEquals('/bar', $e->getComparisonFailure()->getExpected());
             $this->assertEquals('/foo', $e->getComparisonFailure()->getActual());
         }
     }
 
+    /**
+     * @expectedException \PHPUnit\Framework\ExpectationFailedException
+     * @expectedExceptionMessage Unexpected header [Location] is present on response.
+     */
     public function testAssertHeaderMissing()
     {
         $baseResponse = tap(new Response, function ($response) {
@@ -78,14 +83,7 @@ class FoundationTestResponseTest extends TestCase
 
         $response = TestResponse::fromBaseResponse($baseResponse);
 
-        try {
-            $response->assertHeaderMissing('Location');
-        } catch (\PHPUnit\Framework\ExpectationFailedException $e) {
-            $this->assertContains(
-                'Unexpected header [Location] is present on response.',
-                $e->getMessage()
-            );
-        }
+        $response->assertHeaderMissing('Location');
     }
 
     public function testAssertJsonWithArray()


### PR DESCRIPTION
Previous implementation of tests was wrong (including new test added in https://github.com/laravel/framework/pull/22866). If you commented out the whole code from `assertHeader` and `assertHeaderMissing` from `Illuminate\Foundation\Testing\TestResponse` both tests passed without any problem in current tests implementation. 

After change both tests would fail in such case - now they really test if exception was thrown.