### PR TITLE
[5.5] PR to merge for `Resource` class with User's preference to pass the method name, customize link url and meta.

### DIFF
--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -37,12 +37,24 @@ class PaginatedResourceResponse extends ResourceResponse
      */
     protected function paginationInformation($request)
     {
-        $paginated = $this->resource->resource->toArray();
+        $paginatedResource = $this->resource;
+        if (method_exists($paginatedResource, 'links')) {
+            $paginationLinks = $paginatedResource->links($request);
+        } else {
+            $paginationLinks = $this->paginationLinks($this->resource->resource->toArray());
+        }
+        $information['links'] = $paginationLinks;
 
-        return [
-            'links' => $this->paginationLinks($paginated),
-            'meta' => $this->meta($paginated),
-        ];
+        if (method_exists($paginatedResource, 'meta')) {
+            // do not include meta if user returns null from "meta" method
+            if (!is_null($paginatedResource->meta)) {
+                $information['meta'] = $paginatedResource->meta;
+            }
+        } else {
+            $information['meta'] = $this->meta($this->resource->resource->toArray());
+        }
+
+        return $information;
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -30,6 +30,13 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
      */
     public $with = [];
 
+	/**
+	 * The callback which will be called when resolving.
+	 *
+	 * @var string | default 'toArray'
+	 */
+	protected $callback;
+
     /**
      * The additional meta data that should be added to the resource response.
      *
@@ -46,15 +53,16 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
      */
     public static $wrap = 'data';
 
-    /**
-     * Create a new resource instance.
-     *
-     * @param  mixed  $resource
-     * @return void
-     */
-    public function __construct($resource)
+	/**
+	 * Create a new resource instance.
+	 *
+	 * @param  mixed $resource
+	 * @param string $callback
+	 */
+    public function __construct($resource, $callback = 'toArray')
     {
         $this->resource = $resource;
+        $this->callback = $callback;
     }
 
     /**
@@ -87,7 +95,7 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
      */
     public function resolve($request = null)
     {
-        $data = $this->toArray(
+        $data = $this->{$this->callback}(
             $request = $request ?: Container::getInstance()->make('request')
         );
 

--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -35,7 +35,7 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
 	 *
 	 * @var string | default 'toArray'
 	 */
-	protected $callback;
+	protected $callback = "toArray";
 
     /**
      * The additional meta data that should be added to the resource response.
@@ -62,7 +62,9 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
     public function __construct($resource, $callback = 'toArray')
     {
         $this->resource = $resource;
-        $this->callback = $callback;
+        if(is_string($callback)){
+            $this->callback = $callback;
+        }
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -24,15 +24,15 @@ class ResourceCollection extends Resource implements IteratorAggregate
      */
     public $collection;
 
-    /**
-     * Create a new resource instance.
-     *
-     * @param  mixed  $resource
-     * @return void
-     */
-    public function __construct($resource)
+	/**
+	 * Create a new resource instance.
+	 *
+	 * @param  mixed $resource
+	 * @param string $callback
+	 */
+    public function __construct($resource, $callback = 'toArray')
     {
-        parent::__construct($resource);
+        parent::__construct($resource, $callback);
 
         $this->resource = $this->collectResource($resource);
     }


### PR DESCRIPTION
After merging this PR, the users of the framework will be able to achieve the following facilities.
1.  Previously, For a `Resource` or `ResourceCollection` class, the user had to write his transformations inside the `toArray` method. If the user wanted to shrink the object, he had to create another class. Now, they can pass the *method name* when creating the objects. like 
`return new UserResource(User::find(10), 'shortInfo');` . short info **SHOULD BE** present inside the `UserResource` class. The same can be done for the `ResourceCollection` too.
2. After merging the code, User will have the ability to customize their `links`. The `links` method must be present inside the **extension** of `ResourceCollection` class.
3. If the user wants to remove the `meta` key from his collection, he __can NOW__ return `null` from `ResourceCollection::meta` method. Meta method doesn't exist in the `ResourceCollection` class. If he wants to **override** the default meta-data, he can set his own inside the `meta` method of his own class. In other cases, the frameworks metadata will be loaded.