### PR TITLE
[5.5] Make sure deleteDirectory method was really executed

### DIFF
--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -213,7 +213,7 @@ class FilesystemTest extends TestCase
         mkdir($this->tempDir.'/tmp2', 0777, true);
 
         $files = m::mock(Filesystem::class)->makePartial();
-        $files->shouldReceive('deleteDirectory')->andReturn(false);
+        $files->shouldReceive('deleteDirectory')->once()->andReturn(false);
         $this->assertFalse($files->moveDirectory($this->tempDir.'/tmp', $this->tempDir.'/tmp2', true));
     }
 


### PR DESCRIPTION
This fixes test added in https://github.com/laravel/framework/pull/22874

When using `shouldReceive` there should be always quantifier - once, never, times, atLeast.

If we removed:

```
if (! $this->deleteDirectory($to)) {
   return false;
}
```

from `Filesystem@moveDirectory` method in current state this test would pass and it shouldn't.