### PR TITLE
[5.5] Add an argument to withTrashed

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -82,7 +82,11 @@ class SoftDeletingScope implements Scope
      */
     protected function addWithTrashed(Builder $builder)
     {
-        $builder->macro('withTrashed', function (Builder $builder) {
+        $builder->macro('withTrashed', function (Builder $builder, $withTrashed = true) {
+            if (!$withTrashed) {
+                return $builder->withoutTrashed();
+            }
+
             return $builder->withoutGlobalScope($this);
         });
     }

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -83,7 +83,7 @@ class SoftDeletingScope implements Scope
     protected function addWithTrashed(Builder $builder)
     {
         $builder->macro('withTrashed', function (Builder $builder, $withTrashed = true) {
-            if (!$withTrashed) {
+            if (! $withTrashed) {
                 return $builder->withoutTrashed();
             }
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -150,6 +150,14 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertInstanceOf(Eloquent::class, SoftDeletesTestUser::withTrashed()->find(1));
     }
 
+    public function testWithTrashedAcceptsAnArgument()
+    {
+        $this->createUsers();
+
+        $this->assertCount(1, SoftDeletesTestUser::withTrashed(false)->get());
+        $this->assertCount(2, SoftDeletesTestUser::withTrashed(true)->get());
+    }
+
     public function testDeleteSetsDeletedColumn()
     {
         $this->createUsers();


### PR DESCRIPTION
This adds an option to pass an argument to `withTrashed` which decides whether or not to include the trashed records.
```php
Model::withTrashed(true)->get(); // Retrieves trashed records
Model::withTrashed(false)->get(); // Does not retrieve trashed records
```
I believe this doesn't introduce any breaking changes, hence the 5.5 branch.

Use case:
```php
public function index(Request $request)
{
    return User::withTrashed($request->showDeleted)->get();
}
```
instead of:
```php
public function index(Request $request)
{
    $query = User::query();

    if ($request->showDeleted) {
        $query->withTrashed();
    }

    return $query->get();
}
```