### PR TITLE
Str::contains and str_contains optional case sensitivity

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -98,7 +98,7 @@ class Str
      * @param  bool  $caseSensitive
      * @return bool
      */
-    public static function contains($haystack, $needles, $caseSensitive=true)
+    public static function contains($haystack, $needles, $caseSensitive = true)
     {
         foreach ((array) $needles as $needle) {
             $method = $caseSensitive ? 'mb_strpos' : 'mb_stripos';

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -95,12 +95,15 @@ class Str
      *
      * @param  string  $haystack
      * @param  string|array  $needles
+     * @param  bool  $caseSensitive
      * @return bool
      */
-    public static function contains($haystack, $needles)
+    public static function contains($haystack, $needles, $caseSensitive=true)
     {
         foreach ((array) $needles as $needle) {
-            if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
+            $method = $caseSensitive ? 'mb_strpos' : 'mb_stripos';
+            
+            if ($needle !== '' && $method($haystack, $needle) !== false) {
                 return true;
             }
         }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -841,6 +841,7 @@ if (! function_exists('str_contains')) {
      *
      * @param  string  $haystack
      * @param  string|array  $needles
+     * @param  boool  $caseSensitive
      * @return bool
      */
     function str_contains($haystack, $needles, $caseSensitive=true)

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -843,9 +843,9 @@ if (! function_exists('str_contains')) {
      * @param  string|array  $needles
      * @return bool
      */
-    function str_contains($haystack, $needles)
+    function str_contains($haystack, $needles, $caseSensitive=true)
     {
-        return Str::contains($haystack, $needles);
+        return Str::contains($haystack, $needles, $caseSensitive);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -844,7 +844,7 @@ if (! function_exists('str_contains')) {
      * @param  boool  $caseSensitive
      * @return bool
      */
-    function str_contains($haystack, $needles, $caseSensitive=true)
+    function str_contains($haystack, $needles, $caseSensitive = true)
     {
         return Str::contains($haystack, $needles, $caseSensitive);
     }


### PR DESCRIPTION
This change introduces (optional) case sensitivity for the `str_contains` helper function as well as the `Str::contains` static method to which it references.

Case sensitivity is defaulted to true in order to avoid backward compatibility breaks.

Should this become part of the framework I will then update the [necessary documentation file](https://github.com/laravel/docs/blob/5.5/helpers.md) to denote that the helper method can be case in-sensitive.