### PR TITLE
[5.5] add useCurrentUpdate to MySQL to support ON UPDATE CURRENT_TIMESTAMP

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -638,8 +638,12 @@ class MySqlGrammar extends Grammar
     protected function typeTimestamp(Fluent $column)
     {
         $columnType = $column->precision ? "timestamp($column->precision)" : 'timestamp';
-
-        return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
+        if ($column->useCurrent) {
+            return "$columnType default CURRENT_TIMESTAMP";
+        } elseif ($column->useCurrentUpdate) {
+            return "$columnType default CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP";
+        }
+        return $columnType;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -643,7 +643,7 @@ class MySqlGrammar extends Grammar
         } elseif ($column->useCurrentUpdate) {
             return "$columnType default CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP";
         }
-        
+
         return $columnType;
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -643,6 +643,7 @@ class MySqlGrammar extends Grammar
         } elseif ($column->useCurrentUpdate) {
             return "$columnType default CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP";
         }
+        
         return $columnType;
     }
 


### PR DESCRIPTION
This small change allows for those using mySQL to use `useCurrentUpdate()` instead of having to do a DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP') on timestamps.