### PR TITLE
[5.5] Add withTrashedIf and onlyTrashedIf

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -15,7 +15,7 @@ class SoftDeletingScope implements Scope
         'WithTrashedIf',
         'WithoutTrashed',
         'OnlyTrashed',
-        'OnlyTrashedIf'
+        'OnlyTrashedIf',
     ];
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -9,7 +9,14 @@ class SoftDeletingScope implements Scope
      *
      * @var array
      */
-    protected $extensions = ['Restore', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed'];
+    protected $extensions = [
+        'Restore',
+        'WithTrashed',
+        'WithTrashedIf',
+        'WithoutTrashed',
+        'OnlyTrashed',
+        'OnlyTrashedIf'
+    ];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -82,12 +89,21 @@ class SoftDeletingScope implements Scope
      */
     protected function addWithTrashed(Builder $builder)
     {
-        $builder->macro('withTrashed', function (Builder $builder, $withTrashed = true) {
-            if (! $withTrashed) {
-                return $builder->withoutTrashed();
-            }
-
+        $builder->macro('withTrashed', function (Builder $builder) {
             return $builder->withoutGlobalScope($this);
+        });
+    }
+
+    /**
+     * Add the with-trashed extension to the builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return void
+     */
+    protected function addWithTrashedIf(Builder $builder)
+    {
+        $builder->macro('withTrashedIf', function (Builder $builder, $condition) {
+            return $condition ? $builder->withTrashed() : $builder->withoutTrashed();
         });
     }
 
@@ -126,6 +142,19 @@ class SoftDeletingScope implements Scope
             );
 
             return $builder;
+        });
+    }
+
+    /**
+     * Add the with-trashed extension to the builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return void
+     */
+    protected function addOnlyTrashedIf(Builder $builder)
+    {
+        $builder->macro('onlyTrashedIf', function (Builder $builder, $condition) {
+            return $condition ? $builder->onlyTrashed() : $builder->withoutTrashed();
         });
     }
 }

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -150,12 +150,12 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertInstanceOf(Eloquent::class, SoftDeletesTestUser::withTrashed()->find(1));
     }
 
-    public function testWithTrashedAcceptsAnArgument()
+    public function testWithTrashedIfFetchesTrashedRecordsUnderCondition()
     {
         $this->createUsers();
 
-        $this->assertCount(1, SoftDeletesTestUser::withTrashed(false)->get());
-        $this->assertCount(2, SoftDeletesTestUser::withTrashed(true)->get());
+        $this->assertCount(1, SoftDeletesTestUser::withTrashedIf(false)->get());
+        $this->assertCount(2, SoftDeletesTestUser::withTrashedIf(true)->get());
     }
 
     public function testDeleteSetsDeletedColumn()

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -203,6 +203,21 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals(1, $users->first()->id);
     }
 
+    public function testOnlyTrashedIfOnlyReturnsTrashedRecordsUnderCondition()
+    {
+        $this->createUsers();
+
+        $users = SoftDeletesTestUser::onlyTrashedIf(true)->get();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals(1, $users->first()->id);
+
+        $users = SoftDeletesTestUser::onlyTrashedIf(false)->get();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals(2, $users->first()->id);
+    }
+
     public function testOnlyWithoutTrashedOnlyReturnsTrashedRecords()
     {
         $this->createUsers();


### PR DESCRIPTION
Due to much criticism on the #22888 PR, this reverts it and instead adds `withTrashedIf` and `onlyTrashedIf` Eloquent Builder macros.

```php
Model::withTrashedIf(true)->get(); // equals Model::withTrashed()->get();
Model::withTrashedIf(false)->get(); // equals Model::get();

Model::onlyTrashedIf(true)->get(); // equals Model::onlyTrashed()->get();
Model::onlyTrashedIf(false)->get(); // equals Model::get();
```