### PR TITLE
Add Event as parameter to the before/after callbacks Scheduled Events

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -227,7 +227,7 @@ class Event
     public function callBeforeCallbacks(Container $container)
     {
         foreach ($this->beforeCallbacks as $callback) {
-            $container->call($callback);
+            $container->call($callback, [$this]);
         }
     }
 
@@ -240,7 +240,7 @@ class Event
     public function callAfterCallbacks(Container $container)
     {
         foreach ($this->afterCallbacks as $callback) {
-            $container->call($callback);
+            $container->call($callback, [$this]);
         }
     }
 

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Console;
 use Mockery as m;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
 use Illuminate\Console\Scheduling\Event;
 
 class ConsoleScheduledEventTest extends TestCase
@@ -104,5 +105,33 @@ class ConsoleScheduledEventTest extends TestCase
 
         $this->assertFalse($event->unlessBetween('8:00', '10:00')->filtersPass($app));
         $this->assertTrue($event->unlessBetween('10:00', '11:00')->isDue($app));
+    }
+
+    public function testBeforeCallbackHaveEventAsParameter()
+    {
+        $container = new Container();
+        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
+
+        $closure = function ($e) use ($event) {
+            $this->assertEquals($event, $e);
+        };
+
+        $event->before($closure);
+
+        $event->callBeforeCallbacks($container);
+    }
+
+    public function testAfterCallbackHaveEventAsParameter()
+    {
+        $container = new Container();
+        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
+
+        $closure = function ($e) use ($event) {
+            $this->assertEquals($event, $e);
+        };
+
+        $event->after($closure);
+
+        $event->callAfterCallbacks($container);
     }
 }


### PR DESCRIPTION
Add the Event as parameter for the callbacks, so that the closure can get data about the Event.

The use case is that I want to log before and after all my scheduled tasks.
Hence I would like to use the same closure, and get the description from the Event.