### PR TITLE
[5.6] Use and document new Blade directives

### DIFF
--- a/CHANGELOG-5.6.md
+++ b/CHANGELOG-5.6.md
@@ -14,6 +14,9 @@
 - Show job id in `queue:work` output ([#21204](https://github.com/laravel/framework/pull/21204))
 - Show batch number in `migrate:status` output ([#21391](https://github.com/laravel/framework/pull/21391))
 
+### Blade Templates
+- Added `@csrf` and `@method` directives ([5f19844](https://github.com/laravel/framework/commit/5f1984421af096ef21b7d2011949a233849d4ee3))
+
 ### Database
 - ⚠️ Swap the index order of morph type and id ([#21693](https://github.com/laravel/framework/pull/21693))
 

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/login.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/login.stub
@@ -9,7 +9,7 @@
 
                 <div class="card-body">
                     <form method="POST" action="{{ route('login') }}">
-                        {{ csrf_field() }}
+                        @csrf
 
                         <div class="form-group row">
                             <label for="email" class="col-sm-4 col-form-label text-md-right">E-Mail Address</label>

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/email.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/email.stub
@@ -15,7 +15,7 @@
                     @endif
 
                     <form method="POST" action="{{ route('password.email') }}">
-                        {{ csrf_field() }}
+                        @csrf
 
                         <div class="form-group row">
                             <label for="email" class="col-md-4 col-form-label text-md-right">E-Mail Address</label>

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
@@ -9,7 +9,7 @@
 
                 <div class="card-body">
                     <form method="POST" action="{{ route('password.request') }}">
-                        {{ csrf_field() }}
+                        @csrf
 
                         <input type="hidden" name="token" value="{{ $token }}">
 

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/register.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/register.stub
@@ -9,7 +9,7 @@
 
                 <div class="card-body">
                     <form method="POST" action="{{ route('register') }}">
-                        {{ csrf_field() }}
+                        @csrf
 
                         <div class="form-group row">
                             <label for="name" class="col-md-4 col-form-label text-md-right">Name</label>

--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -49,7 +49,7 @@
                                     </a>
 
                                     <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
-                                        {{ csrf_field() }}
+                                        @csrf
                                     </form>
                                 </div>
                             </li>


### PR DESCRIPTION
In https://github.com/laravel/framework/commit/5f1984421af096ef21b7d2011949a233849d4ee3 we had two new blade directives: `@csrf` and `@method`. This PR both add to the `CHANGELOG-5.6.md` and use them.