### PR TITLE
[5.6] Assert that response contains strings in a specific order

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -254,6 +254,32 @@ class TestResponse
     }
 
     /**
+     * Assert that the given strings are contained in order within the response.
+     *
+     * @param  array  $values
+     * @return $this
+     */
+    public function assertSeeInOrder(array $values)
+    {
+        $position = -1;
+
+        foreach ($values as $value) {
+            $valuePosition = mb_strpos($this->getContent(), $value);
+
+            if ($valuePosition === false || $valuePosition < $position) {
+                PHPUnit::fail(
+                    'Failed asserting that \''.$this->getContent().
+                    '\' contains "'.$value.'" in specified order.'
+                );
+            }
+
+            $position = $valuePosition;
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the given string is contained within the response text.
      *
      * @param  string  $value
@@ -262,6 +288,32 @@ class TestResponse
     public function assertSeeText($value)
     {
         PHPUnit::assertContains($value, strip_tags($this->getContent()));
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given strings are contained in order within the response text.
+     *
+     * @param  array  $values
+     * @return $this
+     */
+    public function assertSeeTextInOrder(array $values)
+    {
+        $position = -1;
+
+        foreach ($values as $value) {
+            $valuePosition = mb_strpos(strip_tags($this->getContent()), $value);
+
+            if ($valuePosition === false || $valuePosition < $position) {
+                PHPUnit::fail(
+                    'Failed asserting that \''.strip_tags($this->getContent()).
+                    '\' contains "'.$value.'" in specified order.'
+                );
+            }
+
+            $position = $valuePosition;
+        }
 
         return $this;
     }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -41,6 +41,28 @@ class FoundationTestResponseTest extends TestCase
         $response->assertViewHas('foo');
     }
 
+    public function testAssertSeeInOrder()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->setContent(\Mockery::mock(View::class, [
+                'render' => '<ul><li>foo</li><li>bar</li><li>baz</li></ul>',
+            ]));
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertSeeInOrder(['foo', 'bar', 'baz']);
+
+        try {
+            $response->assertSeeInOrder(['baz', 'bar', 'foo']);
+            $response->assertSeeInOrder(['foo', 'qux', 'bar', 'baz']);
+        } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+            return;
+        }
+
+        TestCase::fail('Assertion was expected to fail.');
+    }
+
     public function testAssertSeeText()
     {
         $baseResponse = tap(new Response, function ($response) {
@@ -52,6 +74,28 @@ class FoundationTestResponseTest extends TestCase
         $response = TestResponse::fromBaseResponse($baseResponse);
 
         $response->assertSeeText('foobar');
+    }
+
+    public function testAssertSeeTextInOrder()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->setContent(\Mockery::mock(View::class, [
+                'render' => 'foo<strong>bar</strong> baz',
+            ]));
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertSeeTextInOrder(['foobar', 'baz']);
+
+        try {
+            $response->assertSeeTextInOrder(['baz', 'foobar']);
+            $response->assertSeeTextInOrder(['foobar', 'qux', 'baz']);
+        } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+            return;
+        }
+
+        TestCase::fail('Assertion was expected to fail.');
     }
 
     public function testAssertHeader()


### PR DESCRIPTION
Submitting to 5.6 as requested in #22853

A proposed implementation for some additional assertions that can check the response for strings ensuring they appear in a particular order. This is very helpful when testing sorting functionality.

For example:

```php
$response->assertSeeInOrder(['foo', 'bar', 'baz']);
```