### PR TITLE
[5.5] allows array or multiple params for hasAny helper

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -94,15 +94,17 @@ trait InteractsWithInput
     /**
      * Determine if the request contains any of the given inputs.
      *
-     * @param  dynamic  $key
+     * @param  string|array  $key
      * @return bool
      */
-    public function hasAny(...$keys)
+    public function hasAny($key)
     {
+        $keys = is_array($key) ? $key : func_get_args();
+
         $input = $this->all();
 
-        foreach ($keys as $key) {
-            if (Arr::has($input, $key)) {
+        foreach ($keys as $value) {
+            if (Arr::has($input, $value)) {
                 return true;
             }
         }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -262,15 +262,25 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->hasAny('city'));
         $this->assertFalse($request->hasAny('foo'));
         $this->assertTrue($request->hasAny('name', 'email'));
+        $this->assertTrue($request->hasAny(['name']));
+        $this->assertTrue($request->hasAny(['age']));
+        $this->assertTrue($request->hasAny(['city']));
+        $this->assertFalse($request->hasAny(['foo']));
+        $this->assertTrue($request->hasAny(['name', 'email']));
 
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
         $this->assertTrue($request->hasAny('name', 'email'));
         $this->assertFalse($request->hasAny('surname', 'password'));
+        $this->assertTrue($request->hasAny(['name', 'email']));
+        $this->assertFalse($request->hasAny(['surname', 'password']));
 
         $request = Request::create('/', 'GET', ['foo' => ['bar' => null, 'baz' => '']]);
         $this->assertTrue($request->hasAny('foo.bar'));
         $this->assertTrue($request->hasAny('foo.baz'));
         $this->assertFalse($request->hasAny('foo.bax'));
+        $this->assertTrue($request->hasAny(['foo.bar']));
+        $this->assertTrue($request->hasAny(['foo.baz']));
+        $this->assertFalse($request->hasAny(['foo.bax']));
     }
 
     public function testFilledMethod()


### PR DESCRIPTION
Make this the same as `has()` allowing array or params

Closes https://github.com/laravel/framework/issues/22917