### PR TITLE
[5.6] Added static method to get Model's table name

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1194,6 +1194,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         return $this;
     }
 
+	/**
+	 * Get the table associated with the model.
+	 *
+	 * @return string
+	 */
+	public static function table()
+	{
+		return (new static)->getTable();
+	}
+
     /**
      * Get the primary key for the model.
      *


### PR DESCRIPTION
Adding this method to base Model allows us to use it statically in such cases as validation 
ie. `Rule::exists(User::table(), 'id')` 
or in queries to prevent ambiguous columns ie. `where(Post::table() . '.user_id', $id)`

This is IMHO more convenient than writing `(new User)->getTable()` each time.