### PR TITLE
resolveRequestSignature Fix

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Routing\Middleware;
 
 use Closure;
-use RuntimeException;
 use Illuminate\Support\Str;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Support\InteractsWithTime;
@@ -83,7 +82,6 @@ class ThrottleRequests
      *
      * @param  \Illuminate\Http\Request  $request
      * @return string
-     * @throws \RuntimeException
      */
     protected function resolveRequestSignature($request)
     {

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -87,17 +87,7 @@ class ThrottleRequests
      */
     protected function resolveRequestSignature($request)
     {
-        if ($user = $request->user()) {
-            return sha1($user->getAuthIdentifier());
-        }
-
-        if ($route = $request->route()) {
-            return sha1($route->getDomain().'|'.$request->ip());
-        }
-
-        throw new RuntimeException(
-            'Unable to generate the request signature. Route unavailable.'
-        );
+        return $request->fingerprint();
     }
 
     /**


### PR DESCRIPTION
Now the throttle limit is unique per user-request. In fact with the previous version the user had the same key sha1($user->getAuthIdentifier()) for all requests. So if you wanted to restrict some routes you could not, since the rate limit was in common.