### PR TITLE
[5.6] Accept dot notation in Session::exists

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Session;
 
 use Closure;
+use stdClass;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use SessionHandlerInterface;
@@ -174,8 +175,10 @@ class Store implements Session
      */
     public function exists($key)
     {
-        return ! collect(is_array($key) ? $key : func_get_args())->contains(function ($key) {
-            return ! Arr::exists($this->attributes, $key);
+        $placeholder = new stdClass();
+
+        return ! collect(is_array($key) ? $key : func_get_args())->contains(function ($key) use ($placeholder) {
+            return $this->get($key, $placeholder) === $placeholder;
         });
     }
 

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -324,11 +324,14 @@ class SessionStoreTest extends TestCase
         $session->put('foo', 'bar');
         $this->assertTrue($session->exists('foo'));
         $session->put('baz', null);
+        $session->put('hulk', ['one' => true]);
         $this->assertFalse($session->has('baz'));
         $this->assertTrue($session->exists('baz'));
         $this->assertFalse($session->exists('bogus'));
         $this->assertTrue($session->exists(['foo', 'baz']));
         $this->assertFalse($session->exists(['foo', 'baz', 'bogus']));
+        $this->assertTrue($session->exists(['hulk.one']));
+        $this->assertFalse($session->exists(['hulk.two']));
     }
 
     public function testRememberMethodCallsPutAndReturnsDefault()


### PR DESCRIPTION
Since `Session::has()` accepts dot notation already, this PR makes `Session::exists()` accept it too.