### PR TITLE
[5.7] [WIP] Replace Fluent in Schema builder for columns

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -24,7 +24,7 @@ class Blueprint
     /**
      * The columns that should be added to the table.
      *
-     * @var Columns\Column[]
+     * @var \Illuminate\Database\Schema\Columns\Column[]
      */
     protected $columns = [];
 
@@ -152,7 +152,7 @@ class Blueprint
     /**
      * Add the commands that are implied by the blueprint's state.
      *
-     * @param Grammar $grammar
+     * @param \Illuminate\Database\Schema\Grammars\Grammar $grammar
      * @return void
      */
     protected function addImpliedCommands(Grammar $grammar)
@@ -485,7 +485,7 @@ class Blueprint
      * Create a new auto-incrementing integer (4-byte) column on the table.
      *
      * @param  string  $column
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function increments($column)
     {
@@ -496,7 +496,7 @@ class Blueprint
      * Create a new auto-incrementing tiny integer (1-byte) column on the table.
      *
      * @param  string  $column
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function tinyIncrements($column)
     {
@@ -507,7 +507,7 @@ class Blueprint
      * Create a new auto-incrementing small integer (2-byte) column on the table.
      *
      * @param  string  $column
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function smallIncrements($column)
     {
@@ -518,7 +518,7 @@ class Blueprint
      * Create a new auto-incrementing medium integer (3-byte) column on the table.
      *
      * @param  string  $column
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function mediumIncrements($column)
     {
@@ -529,7 +529,7 @@ class Blueprint
      * Create a new auto-incrementing big integer (8-byte) column on the table.
      *
      * @param  string  $column
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function bigIncrements($column)
     {
@@ -541,13 +541,13 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $length
-     * @return Columns\CharString
+     * @return \Illuminate\Database\Schema\Columns\VariableLength
      */
     public function char($column, $length = null)
     {
         $length = $length ?: Builder::$defaultStringLength;
 
-        return $this->addColumn(new Columns\CharString('char', $column, $length));
+        return $this->addColumn(new Columns\VariableLength('char', $column, $length));
     }
 
     /**
@@ -555,20 +555,20 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $length
-     * @return Columns\CharString
+     * @return \Illuminate\Database\Schema\Columns\VariableLength
      */
     public function string($column, $length = null)
     {
         $length = $length ?: Builder::$defaultStringLength;
 
-        return $this->addColumn(new Columns\CharString('string', $column, $length));
+        return $this->addColumn(new Columns\VariableLength('string', $column, $length));
     }
 
     /**
      * Create a new text column on the table.
      *
      * @param  string  $column
-     * @return Columns\Text
+     * @return \Illuminate\Database\Schema\Columns\Text
      */
     public function text($column)
     {
@@ -579,7 +579,7 @@ class Blueprint
      * Create a new medium text column on the table.
      *
      * @param  string  $column
-     * @return Columns\Text
+     * @return \Illuminate\Database\Schema\Columns\Text
      */
     public function mediumText($column)
     {
@@ -590,7 +590,7 @@ class Blueprint
      * Create a new long text column on the table.
      *
      * @param  string  $column
-     * @return Columns\Text
+     * @return \Illuminate\Database\Schema\Columns\Text
      */
     public function longText($column)
     {
@@ -603,7 +603,7 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function integer($column, $autoIncrement = false, $unsigned = false)
     {
@@ -616,7 +616,7 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function tinyInteger($column, $autoIncrement = false, $unsigned = false)
     {
@@ -629,7 +629,7 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function smallInteger($column, $autoIncrement = false, $unsigned = false)
     {
@@ -642,7 +642,7 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function mediumInteger($column, $autoIncrement = false, $unsigned = false)
     {
@@ -655,7 +655,7 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function bigInteger($column, $autoIncrement = false, $unsigned = false)
     {
@@ -667,7 +667,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function unsignedInteger($column, $autoIncrement = false)
     {
@@ -679,7 +679,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function unsignedTinyInteger($column, $autoIncrement = false)
     {
@@ -691,7 +691,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function unsignedSmallInteger($column, $autoIncrement = false)
     {
@@ -703,7 +703,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function unsignedMediumInteger($column, $autoIncrement = false)
     {
@@ -715,7 +715,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
-     * @return Columns\Integer
+     * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function unsignedBigInteger($column, $autoIncrement = false)
     {
@@ -728,7 +728,7 @@ class Blueprint
      * @param  string  $column
      * @param  int  $total
      * @param  int  $places
-     * @return Columns\Decimal
+     * @return \Illuminate\Database\Schema\Columns\Decimal
      */
     public function float($column, $total = 8, $places = 2)
     {
@@ -741,7 +741,7 @@ class Blueprint
      * @param  string  $column
      * @param  int|null  $total
      * @param  int|null  $places
-     * @return Columns\Decimal
+     * @return \Illuminate\Database\Schema\Columns\Decimal
      */
     public function double($column, $total = null, $places = null)
     {
@@ -754,7 +754,7 @@ class Blueprint
      * @param  string  $column
      * @param  int  $total
      * @param  int  $places
-     * @return Columns\Decimal
+     * @return \Illuminate\Database\Schema\Columns\Decimal
      */
     public function decimal($column, $total = 8, $places = 2)
     {
@@ -767,7 +767,7 @@ class Blueprint
      * @param  string  $column
      * @param  int  $total
      * @param  int  $places
-     * @return Columns\Decimal
+     * @return \Illuminate\Database\Schema\Columns\Decimal
      */
     public function unsignedDecimal($column, $total = 8, $places = 2)
     {
@@ -781,7 +781,7 @@ class Blueprint
      * Create a new boolean column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function boolean($column)
     {
@@ -793,7 +793,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  array  $allowed
-     * @return Columns\Enum
+     * @return \Illuminate\Database\Schema\Columns\Enum
      */
     public function enum($column, array $allowed)
     {
@@ -804,7 +804,7 @@ class Blueprint
      * Create a new json column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function json($column)
     {
@@ -815,7 +815,7 @@ class Blueprint
      * Create a new jsonb column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function jsonb($column)
     {
@@ -826,7 +826,7 @@ class Blueprint
      * Create a new date column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function date($column)
     {
@@ -838,7 +838,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $precision
-     * @return Columns\Time
+     * @return \Illuminate\Database\Schema\Columns\Time
      */
     public function dateTime($column, $precision = 0)
     {
@@ -850,7 +850,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $precision
-     * @return Columns\Time
+     * @return \Illuminate\Database\Schema\Columns\Time
      */
     public function dateTimeTz($column, $precision = 0)
     {
@@ -862,7 +862,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $precision
-     * @return Columns\Time
+     * @return \Illuminate\Database\Schema\Columns\Time
      */
     public function time($column, $precision = 0)
     {
@@ -874,7 +874,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $precision
-     * @return Columns\Time
+     * @return \Illuminate\Database\Schema\Columns\Time
      */
     public function timeTz($column, $precision = 0)
     {
@@ -886,7 +886,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $precision
-     * @return Columns\Timestamp
+     * @return \Illuminate\Database\Schema\Columns\Timestamp
      */
     public function timestamp($column, $precision = 0)
     {
@@ -898,7 +898,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $precision
-     * @return Columns\Timestamp
+     * @return \Illuminate\Database\Schema\Columns\Timestamp
      */
     public function timestampTz($column, $precision = 0)
     {
@@ -949,7 +949,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $precision
-     * @return Columns\Timestamp
+     * @return \Illuminate\Database\Schema\Columns\Timestamp
      */
     public function softDeletes($column = 'deleted_at', $precision = 0)
     {
@@ -960,7 +960,7 @@ class Blueprint
      * Add a "deleted at" timestampTz for the table.
      *
      * @param  int  $precision
-     * @return Columns\Timestamp
+     * @return \Illuminate\Database\Schema\Columns\Timestamp
      */
     public function softDeletesTz($precision = 0)
     {
@@ -971,7 +971,7 @@ class Blueprint
      * Create a new year column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function year($column)
     {
@@ -982,7 +982,7 @@ class Blueprint
      * Create a new binary column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function binary($column)
     {
@@ -993,7 +993,7 @@ class Blueprint
      * Create a new uuid column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function uuid($column)
     {
@@ -1004,7 +1004,7 @@ class Blueprint
      * Create a new IP address column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function ipAddress($column)
     {
@@ -1015,7 +1015,7 @@ class Blueprint
      * Create a new MAC address column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function macAddress($column)
     {
@@ -1026,7 +1026,7 @@ class Blueprint
      * Create a new geometry column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function geometry($column)
     {
@@ -1037,7 +1037,7 @@ class Blueprint
      * Create a new point column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function point($column)
     {
@@ -1048,7 +1048,7 @@ class Blueprint
      * Create a new linestring column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function lineString($column)
     {
@@ -1059,7 +1059,7 @@ class Blueprint
      * Create a new polygon column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function polygon($column)
     {
@@ -1070,7 +1070,7 @@ class Blueprint
      * Create a new geometrycollection column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function geometryCollection($column)
     {
@@ -1081,7 +1081,7 @@ class Blueprint
      * Create a new multipoint column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function multiPoint($column)
     {
@@ -1092,7 +1092,7 @@ class Blueprint
      * Create a new multilinestring column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function multiLineString($column)
     {
@@ -1103,7 +1103,7 @@ class Blueprint
      * Create a new multipolygon column on the table.
      *
      * @param  string  $column
-     * @return Columns\Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function multiPolygon($column)
     {
@@ -1145,7 +1145,7 @@ class Blueprint
     /**
      * Adds the `remember_token` column to the table.
      *
-     * @return Columns\CharString
+     * @return \Illuminate\Database\Schema\Columns\VariableLength
      */
     public function rememberToken()
     {
@@ -1214,8 +1214,8 @@ class Blueprint
     /**
      * Add a new column to the blueprint.
      *
-     * @param  Columns\Column $column
-     * @return Columns\Column|Columns\CharString|Columns\Integer|Columns\Decimal|Columns\Enum|Columns\Time|Columns\Timestamp|Columns\Text
+     * @param  \Illuminate\Database\Schema\Columns\Column $column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function addColumn(Columns\Column $column)
     {
@@ -1278,7 +1278,7 @@ class Blueprint
     /**
      * Get the columns on the blueprint.
      *
-     * @return Columns\Column[]
+     * @return \Illuminate\Database\Schema\Columns\Column[]
      */
     public function getColumns()
     {
@@ -1298,7 +1298,7 @@ class Blueprint
     /**
      * Get the columns on the blueprint that should be added.
      *
-     * @return Columns\Column[]
+     * @return \Illuminate\Database\Schema\Columns\Column[]
      */
     public function getAddedColumns()
     {
@@ -1310,7 +1310,7 @@ class Blueprint
     /**
      * Get the columns on the blueprint that should be changed.
      *
-     * @return Columns\Column[]
+     * @return \Illuminate\Database\Schema\Columns\Column[]
      */
     public function getChangedColumns()
     {

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -24,7 +24,7 @@ class Blueprint
     /**
      * The columns that should be added to the table.
      *
-     * @var \Illuminate\Support\Fluent[]
+     * @var Columns\Column[]
      */
     protected $columns = [];
 
@@ -152,7 +152,7 @@ class Blueprint
     /**
      * Add the commands that are implied by the blueprint's state.
      *
-     * @param  \Illuminate\Database\Grammar  $grammer
+     * @param Grammar $grammar
      * @return void
      */
     protected function addImpliedCommands(Grammar $grammar)
@@ -203,7 +203,7 @@ class Blueprint
     /**
      * Add the fluent commands specified on any columns.
      *
-     * @param  \Illuminate\Database\Grammar  $grammer
+     * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @param
      */
     public function addFluentCommands(Grammar $grammar)
@@ -485,7 +485,7 @@ class Blueprint
      * Create a new auto-incrementing integer (4-byte) column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function increments($column)
     {
@@ -496,7 +496,7 @@ class Blueprint
      * Create a new auto-incrementing tiny integer (1-byte) column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function tinyIncrements($column)
     {
@@ -507,7 +507,7 @@ class Blueprint
      * Create a new auto-incrementing small integer (2-byte) column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function smallIncrements($column)
     {
@@ -518,7 +518,7 @@ class Blueprint
      * Create a new auto-incrementing medium integer (3-byte) column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function mediumIncrements($column)
     {
@@ -529,7 +529,7 @@ class Blueprint
      * Create a new auto-incrementing big integer (8-byte) column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function bigIncrements($column)
     {
@@ -541,13 +541,13 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $length
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\CharString
      */
     public function char($column, $length = null)
     {
         $length = $length ?: Builder::$defaultStringLength;
 
-        return $this->addColumn('char', $column, compact('length'));
+        return $this->addColumn(new Columns\CharString('char', $column, $length));
     }
 
     /**
@@ -555,46 +555,46 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $length
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\CharString
      */
     public function string($column, $length = null)
     {
         $length = $length ?: Builder::$defaultStringLength;
 
-        return $this->addColumn('string', $column, compact('length'));
+        return $this->addColumn(new Columns\CharString('string', $column, $length));
     }
 
     /**
      * Create a new text column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Text
      */
     public function text($column)
     {
-        return $this->addColumn('text', $column);
+        return $this->addColumn(new Columns\Text('text', $column));
     }
 
     /**
      * Create a new medium text column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Text
      */
     public function mediumText($column)
     {
-        return $this->addColumn('mediumText', $column);
+        return $this->addColumn(new Columns\Text('mediumText', $column));
     }
 
     /**
      * Create a new long text column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Text
      */
     public function longText($column)
     {
-        return $this->addColumn('longText', $column);
+        return $this->addColumn(new Columns\Text('longText', $column));
     }
 
     /**
@@ -603,11 +603,11 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function integer($column, $autoIncrement = false, $unsigned = false)
     {
-        return $this->addColumn('integer', $column, compact('autoIncrement', 'unsigned'));
+        return $this->addColumn(new Columns\Integer('integer', $column, $autoIncrement, $unsigned));
     }
 
     /**
@@ -616,11 +616,11 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function tinyInteger($column, $autoIncrement = false, $unsigned = false)
     {
-        return $this->addColumn('tinyInteger', $column, compact('autoIncrement', 'unsigned'));
+        return $this->addColumn(new Columns\Integer('tinyInteger', $column, $autoIncrement, $unsigned));
     }
 
     /**
@@ -629,11 +629,11 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function smallInteger($column, $autoIncrement = false, $unsigned = false)
     {
-        return $this->addColumn('smallInteger', $column, compact('autoIncrement', 'unsigned'));
+        return $this->addColumn(new Columns\Integer('smallInteger', $column, $autoIncrement, $unsigned));
     }
 
     /**
@@ -642,11 +642,11 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function mediumInteger($column, $autoIncrement = false, $unsigned = false)
     {
-        return $this->addColumn('mediumInteger', $column, compact('autoIncrement', 'unsigned'));
+        return $this->addColumn(new Columns\Integer('mediumInteger', $column, $autoIncrement, $unsigned));
     }
 
     /**
@@ -655,11 +655,11 @@ class Blueprint
      * @param  string  $column
      * @param  bool  $autoIncrement
      * @param  bool  $unsigned
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function bigInteger($column, $autoIncrement = false, $unsigned = false)
     {
-        return $this->addColumn('bigInteger', $column, compact('autoIncrement', 'unsigned'));
+        return $this->addColumn(new Columns\Integer('bigInteger', $column, $autoIncrement, $unsigned));
     }
 
     /**
@@ -667,7 +667,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function unsignedInteger($column, $autoIncrement = false)
     {
@@ -679,7 +679,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function unsignedTinyInteger($column, $autoIncrement = false)
     {
@@ -691,7 +691,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function unsignedSmallInteger($column, $autoIncrement = false)
     {
@@ -703,7 +703,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function unsignedMediumInteger($column, $autoIncrement = false)
     {
@@ -715,7 +715,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Integer
      */
     public function unsignedBigInteger($column, $autoIncrement = false)
     {
@@ -728,11 +728,11 @@ class Blueprint
      * @param  string  $column
      * @param  int  $total
      * @param  int  $places
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Decimal
      */
     public function float($column, $total = 8, $places = 2)
     {
-        return $this->addColumn('float', $column, compact('total', 'places'));
+        return $this->addColumn(new Columns\Decimal('float', $column, $total, $places));
     }
 
     /**
@@ -741,11 +741,11 @@ class Blueprint
      * @param  string  $column
      * @param  int|null  $total
      * @param  int|null  $places
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Decimal
      */
     public function double($column, $total = null, $places = null)
     {
-        return $this->addColumn('double', $column, compact('total', 'places'));
+        return $this->addColumn(new Columns\Decimal('double', $column, $total, $places));
     }
 
     /**
@@ -754,11 +754,11 @@ class Blueprint
      * @param  string  $column
      * @param  int  $total
      * @param  int  $places
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Decimal
      */
     public function decimal($column, $total = 8, $places = 2)
     {
-        return $this->addColumn('decimal', $column, compact('total', 'places'));
+        return $this->addColumn(new Columns\Decimal('decimal', $column, $total, $places));
     }
 
     /**
@@ -767,24 +767,25 @@ class Blueprint
      * @param  string  $column
      * @param  int  $total
      * @param  int  $places
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Decimal
      */
     public function unsignedDecimal($column, $total = 8, $places = 2)
     {
-        return $this->addColumn('decimal', $column, [
-            'total' => $total, 'places' => $places, 'unsigned' => true,
-        ]);
+        $column = (new Columns\Decimal('decimal', $column, $total, $places))
+            ->unsigned();
+
+        return $this->addColumn($column);
     }
 
     /**
      * Create a new boolean column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function boolean($column)
     {
-        return $this->addColumn('boolean', $column);
+        return $this->addColumn(new Columns\Column('boolean', $column));
     }
 
     /**
@@ -792,44 +793,44 @@ class Blueprint
      *
      * @param  string  $column
      * @param  array  $allowed
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Enum
      */
     public function enum($column, array $allowed)
     {
-        return $this->addColumn('enum', $column, compact('allowed'));
+        return $this->addColumn(new Columns\Enum('enum', $column, $allowed));
     }
 
     /**
      * Create a new json column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function json($column)
     {
-        return $this->addColumn('json', $column);
+        return $this->addColumn(new Columns\Column('json', $column));
     }
 
     /**
      * Create a new jsonb column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function jsonb($column)
     {
-        return $this->addColumn('jsonb', $column);
+        return $this->addColumn(new Columns\Column('jsonb', $column));
     }
 
     /**
      * Create a new date column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function date($column)
     {
-        return $this->addColumn('date', $column);
+        return $this->addColumn(new Columns\Column('date', $column));
     }
 
     /**
@@ -837,11 +838,11 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $precision
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Time
      */
     public function dateTime($column, $precision = 0)
     {
-        return $this->addColumn('dateTime', $column, compact('precision'));
+        return $this->addColumn(new Columns\Time('dateTime', $column, $precision));
     }
 
     /**
@@ -849,11 +850,11 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $precision
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Time
      */
     public function dateTimeTz($column, $precision = 0)
     {
-        return $this->addColumn('dateTimeTz', $column, compact('precision'));
+        return $this->addColumn(new Columns\Time('dateTimeTz', $column, $precision));
     }
 
     /**
@@ -861,11 +862,11 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $precision
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Time
      */
     public function time($column, $precision = 0)
     {
-        return $this->addColumn('time', $column, compact('precision'));
+        return $this->addColumn(new Columns\Time('time', $column, $precision));
     }
 
     /**
@@ -873,11 +874,11 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $precision
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Time
      */
     public function timeTz($column, $precision = 0)
     {
-        return $this->addColumn('timeTz', $column, compact('precision'));
+        return $this->addColumn(new Columns\Time('timeTz', $column, $precision));
     }
 
     /**
@@ -885,11 +886,11 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $precision
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Timestamp
      */
     public function timestamp($column, $precision = 0)
     {
-        return $this->addColumn('timestamp', $column, compact('precision'));
+        return $this->addColumn(new Columns\Timestamp('timestamp', $column, $precision));
     }
 
     /**
@@ -897,11 +898,11 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $precision
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Timestamp
      */
     public function timestampTz($column, $precision = 0)
     {
-        return $this->addColumn('timestampTz', $column, compact('precision'));
+        return $this->addColumn(new Columns\Timestamp('timestampTz', $column, $precision));
     }
 
     /**
@@ -948,7 +949,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int  $precision
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Timestamp
      */
     public function softDeletes($column = 'deleted_at', $precision = 0)
     {
@@ -959,7 +960,7 @@ class Blueprint
      * Add a "deleted at" timestampTz for the table.
      *
      * @param  int  $precision
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Timestamp
      */
     public function softDeletesTz($precision = 0)
     {
@@ -970,143 +971,143 @@ class Blueprint
      * Create a new year column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function year($column)
     {
-        return $this->addColumn('year', $column);
+        return $this->addColumn(new Columns\Column('year', $column));
     }
 
     /**
      * Create a new binary column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function binary($column)
     {
-        return $this->addColumn('binary', $column);
+        return $this->addColumn(new Columns\Column('binary', $column));
     }
 
     /**
      * Create a new uuid column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function uuid($column)
     {
-        return $this->addColumn('uuid', $column);
+        return $this->addColumn(new Columns\Column('uuid', $column));
     }
 
     /**
      * Create a new IP address column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function ipAddress($column)
     {
-        return $this->addColumn('ipAddress', $column);
+        return $this->addColumn(new Columns\Column('ipAddress', $column));
     }
 
     /**
      * Create a new MAC address column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function macAddress($column)
     {
-        return $this->addColumn('macAddress', $column);
+        return $this->addColumn(new Columns\Column('macAddress', $column));
     }
 
     /**
      * Create a new geometry column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function geometry($column)
     {
-        return $this->addColumn('geometry', $column);
+        return $this->addColumn(new Columns\Column('geometry', $column));
     }
 
     /**
      * Create a new point column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function point($column)
     {
-        return $this->addColumn('point', $column);
+        return $this->addColumn(new Columns\Column('point', $column));
     }
 
     /**
      * Create a new linestring column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function lineString($column)
     {
-        return $this->addColumn('linestring', $column);
+        return $this->addColumn(new Columns\Column('linestring', $column));
     }
 
     /**
      * Create a new polygon column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function polygon($column)
     {
-        return $this->addColumn('polygon', $column);
+        return $this->addColumn(new Columns\Column('polygon', $column));
     }
 
     /**
      * Create a new geometrycollection column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function geometryCollection($column)
     {
-        return $this->addColumn('geometrycollection', $column);
+        return $this->addColumn(new Columns\Column('geometrycollection', $column));
     }
 
     /**
      * Create a new multipoint column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function multiPoint($column)
     {
-        return $this->addColumn('multipoint', $column);
+        return $this->addColumn(new Columns\Column('multipoint', $column));
     }
 
     /**
      * Create a new multilinestring column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function multiLineString($column)
     {
-        return $this->addColumn('multilinestring', $column);
+        return $this->addColumn(new Columns\Column('multilinestring', $column));
     }
 
     /**
      * Create a new multipolygon column on the table.
      *
      * @param  string  $column
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\Column
      */
     public function multiPolygon($column)
     {
-        return $this->addColumn('multipolygon', $column);
+        return $this->addColumn(new Columns\Column('multipolygon', $column));
     }
 
     /**
@@ -1144,7 +1145,7 @@ class Blueprint
     /**
      * Adds the `remember_token` column to the table.
      *
-     * @return \Illuminate\Support\Fluent
+     * @return Columns\CharString
      */
     public function rememberToken()
     {
@@ -1213,16 +1214,12 @@ class Blueprint
     /**
      * Add a new column to the blueprint.
      *
-     * @param  string  $type
-     * @param  string  $name
-     * @param  array  $parameters
-     * @return \Illuminate\Support\Fluent
+     * @param  Columns\Column $column
+     * @return Columns\Column|Columns\CharString|Columns\Integer|Columns\Decimal|Columns\Enum|Columns\Time|Columns\Timestamp|Columns\Text
      */
-    public function addColumn($type, $name, array $parameters = [])
+    public function addColumn(Columns\Column $column)
     {
-        $this->columns[] = $column = new Fluent(
-            array_merge(compact('type', 'name'), $parameters)
-        );
+        $this->columns[] = $column;
 
         return $column;
     }
@@ -1235,8 +1232,8 @@ class Blueprint
      */
     public function removeColumn($name)
     {
-        $this->columns = array_values(array_filter($this->columns, function ($c) use ($name) {
-            return $c['attributes']['name'] != $name;
+        $this->columns = array_values(array_filter($this->columns, function (Columns\Column $c) use ($name) {
+            return $c->name != $name;
         }));
 
         return $this;
@@ -1281,7 +1278,7 @@ class Blueprint
     /**
      * Get the columns on the blueprint.
      *
-     * @return \Illuminate\Support\Fluent[]
+     * @return Columns\Column[]
      */
     public function getColumns()
     {
@@ -1301,7 +1298,7 @@ class Blueprint
     /**
      * Get the columns on the blueprint that should be added.
      *
-     * @return \Illuminate\Support\Fluent[]
+     * @return Columns\Column[]
      */
     public function getAddedColumns()
     {
@@ -1313,7 +1310,7 @@ class Blueprint
     /**
      * Get the columns on the blueprint that should be changed.
      *
-     * @return \Illuminate\Support\Fluent[]
+     * @return Columns\Column[]
      */
     public function getChangedColumns()
     {

--- a/src/Illuminate/Database/Schema/Columns/CharString.php
+++ b/src/Illuminate/Database/Schema/Columns/CharString.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Database\Schema\Columns;
+
+/**
+ * Class CharString
+ *
+ * @property-read int $length
+ */
+class CharString extends Text
+{
+    /**
+     * @var int
+     */
+    protected $length;
+
+    /**
+     * CharString constructor.
+     *
+     * @param string $type
+     * @param string $name
+     * @param int $length
+     */
+    public function __construct(string $type, string $name, int $length)
+    {
+        parent::__construct($type, $name);
+
+        $this->length = $length;
+    }
+}

--- a/src/Illuminate/Database/Schema/Columns/Column.php
+++ b/src/Illuminate/Database/Schema/Columns/Column.php
@@ -239,10 +239,10 @@ class Column
     /**
      * Adds a primary key.
      *
-     * @param null|string $name
+     * @param string $name
      * @return \Illuminate\Database\Schema\Columns\Column
      */
-    public function primary(?string $name = null): Column
+    public function primary(string $name = null): Column
     {
         $this->primary = is_null($name) ? true : $name;
         return $this;
@@ -251,10 +251,10 @@ class Column
     /**
      * Adds a unique index.
      *
-     * @param null|string $name
+     * @param string $name
      * @return \Illuminate\Database\Schema\Columns\Column
      */
-    public function unique(?string $name = null): Column
+    public function unique(string $name = null): Column
     {
         $this->unique = is_null($name) ? true : $name;
         return $this;
@@ -263,10 +263,10 @@ class Column
     /**
      * Adds a plain index.
      *
-     * @param null|string $name
+     * @param string $name
      * @return \Illuminate\Database\Schema\Columns\Column
      */
-    public function index(?string $name = null): Column
+    public function index(string $name = null): Column
     {
         $this->index = is_null($name) ? true : $name;
         return $this;
@@ -275,10 +275,10 @@ class Column
     /**
      * Adds a spatial index. (except SQLite)
      *
-     * @param null|string $name
+     * @param string $name
      * @return \Illuminate\Database\Schema\Columns\Column
      */
-    public function spatialIndex(?string $name = null): Column
+    public function spatialIndex(string $name = null): Column
     {
         $this->spatialIndex = is_null($name) ? true : $name;
         return $this;

--- a/src/Illuminate/Database/Schema/Columns/Column.php
+++ b/src/Illuminate/Database/Schema/Columns/Column.php
@@ -49,12 +49,12 @@ class Column
     /**
      * @var bool
      */
-    private $first = false;
+    private $first;
 
     /**
      * @var bool
      */
-    private $nullable = false;
+    private $nullable;
 
     /**
      * @var string
@@ -69,7 +69,7 @@ class Column
     /**
      * @var bool
      */
-    private $change = false;
+    private $change;
 
     /**
      * @var string|true

--- a/src/Illuminate/Database/Schema/Columns/Column.php
+++ b/src/Illuminate/Database/Schema/Columns/Column.php
@@ -143,7 +143,7 @@ class Column
      * Place the column "after" another column (MySQL)
      *
      * @param string $column
-     * @return Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function after(string $column): Column
     {
@@ -155,7 +155,7 @@ class Column
      * Add a comment to a column (MySQL)
      *
      * @param string $comment
-     * @return Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function comment(string $comment): Column
     {
@@ -167,7 +167,7 @@ class Column
      * Specify a "default" value for the column
      *
      * @param mixed $default
-     * @return Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function default($default): Column
     {
@@ -178,7 +178,7 @@ class Column
     /**
      * Place the column "first" in the table (MySQL)
      *
-     * @return Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function first(): Column
     {
@@ -190,7 +190,7 @@ class Column
      * Allows (by default) NULL values to be inserted into the column
      *
      * @param bool $value
-     * @return Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function nullable(bool $value = true): Column
     {
@@ -202,7 +202,7 @@ class Column
      * Create a stored generated column (MySQL)
      *
      * @param string $expression
-     * @return Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function storedAs(string $expression): Column
     {
@@ -214,7 +214,7 @@ class Column
      * Create a virtual generated column (MySQL)
      *
      * @param string $expression
-     * @return Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function virtualAs(string $expression): Column
     {
@@ -228,7 +228,7 @@ class Column
      * bigInteger, binary, boolean, date, dateTime, dateTimeTz, decimal, integer, json, longText, mediumText,
      * smallInteger, string, text, time, unsignedBigInteger, unsignedInteger and unsignedSmallInteger.
      *
-     * @return Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function change(): Column
     {
@@ -240,7 +240,7 @@ class Column
      * Adds a primary key.
      *
      * @param null|string $name
-     * @return Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function primary(?string $name = null): Column
     {
@@ -252,7 +252,7 @@ class Column
      * Adds a unique index.
      *
      * @param null|string $name
-     * @return Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function unique(?string $name = null): Column
     {
@@ -264,7 +264,7 @@ class Column
      * Adds a plain index.
      *
      * @param null|string $name
-     * @return Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function index(?string $name = null): Column
     {
@@ -276,7 +276,7 @@ class Column
      * Adds a spatial index. (except SQLite)
      *
      * @param null|string $name
-     * @return Column
+     * @return \Illuminate\Database\Schema\Columns\Column
      */
     public function spatialIndex(?string $name = null): Column
     {

--- a/src/Illuminate/Database/Schema/Columns/Column.php
+++ b/src/Illuminate/Database/Schema/Columns/Column.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Illuminate\Database\Schema\Columns;
+
+/**
+ * Class Column
+ *
+ * @property-read string $type
+ * @property-read string $name
+ * @property-read string $after
+ * @property-read string $comment
+ * @property-read mixed $default
+ * @property-read bool $first
+ * @property-read bool $nullable
+ * @property-read string $storedAs
+ * @property-read string $virtualAs
+ * @property-read string|true $primary
+ * @property-read string|true $unique
+ * @property-read string|true $index
+ * @property-read string|true $spatialIndex
+ */
+class Column
+{
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $after;
+
+    /**
+     * @var string
+     */
+    private $comment;
+
+    /**
+     * @var mixed
+     */
+    private $default;
+
+    /**
+     * @var bool
+     */
+    private $first = false;
+
+    /**
+     * @var bool
+     */
+    private $nullable = false;
+
+    /**
+     * @var string
+     */
+    private $storedAs;
+
+    /**
+     * @var string
+     */
+    private $virtualAs;
+
+    /**
+     * @var bool
+     */
+    private $change = false;
+
+    /**
+     * @var string|true
+     */
+    private $primary;
+
+    /**
+     * @var string|true
+     */
+    private $unique;
+
+    /**
+     * @var string|true
+     */
+    private $index;
+
+    /**
+     * @var string|true
+     */
+    private $spatialIndex;
+
+    /**
+     * Column constructor.
+     *
+     * @param string $type
+     * @param string $name
+     */
+    public function __construct(string $type, string $name)
+    {
+        $this->type = $type;
+        $this->name = $name;
+    }
+
+    /**
+     * @param string $name
+     * @return mixed
+     */
+    public function __get(string $name)
+    {
+        return $this->{$name};
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $value
+     */
+    public function __set(string $name, $value)
+    {
+        // make all properties read only
+        throw new \RuntimeException("Trying to write to read only property '$name'");
+    }
+
+    /**
+     * @param string $name
+     * @return bool
+     */
+    public function __isset(string $name): bool
+    {
+        return isset($this->{$name});
+    }
+
+    /**
+     * @return array
+     */
+    public function getAttributes(): array
+    {
+        return get_object_vars($this);
+    }
+
+    /**
+     * @param string $column
+     * @return Column
+     */
+    public function after(string $column): Column
+    {
+        $this->after = $column;
+        return $this;
+    }
+
+    /**
+     * @param string $comment
+     * @return Column
+     */
+    public function comment(string $comment): Column
+    {
+        $this->comment = $comment;
+        return $this;
+    }
+
+    /**
+     * @param mixed $default
+     * @return Column
+     */
+    public function default($default): Column
+    {
+        $this->default = $default;
+        return $this;
+    }
+
+    /**
+     * @return Column
+     */
+    public function first(): Column
+    {
+        $this->first = true;
+        return $this;
+    }
+
+    /**
+     * @param bool $value
+     * @return Column
+     */
+    public function nullable(bool $value = true): Column
+    {
+        $this->nullable = $value;
+        return $this;
+    }
+
+    /**
+     * @param string $expression
+     * @return Column
+     */
+    public function storedAs(string $expression): Column
+    {
+        $this->storedAs = $expression;
+        return $this;
+    }
+
+    /**
+     * @param string $expression
+     * @return Column
+     */
+    public function virtualAs(string $expression): Column
+    {
+        $this->virtualAs = $expression;
+        return $this;
+    }
+
+    /**
+     * @return Column
+     */
+    public function change(): Column
+    {
+        $this->change = true;
+        return $this;
+    }
+
+    /**
+     * @param null|string $name
+     * @return Column
+     */
+    public function primary(?string $name = null): Column
+    {
+        $this->primary = is_null($name) ? true : $name;
+        return $this;
+    }
+
+    /**
+     * @param null|string $name
+     * @return Column
+     */
+    public function unique(?string $name = null): Column
+    {
+        $this->unique = is_null($name) ? true : $name;
+        return $this;
+    }
+
+    /**
+     * @param null|string $name
+     * @return Column
+     */
+    public function index(?string $name = null): Column
+    {
+        $this->index = is_null($name) ? true : $name;
+        return $this;
+    }
+
+    /**
+     * @param null|string $name
+     * @return Column
+     */
+    public function spatialIndex(?string $name = null): Column
+    {
+        $this->spatialIndex = is_null($name) ? true : $name;
+        return $this;
+    }
+}

--- a/src/Illuminate/Database/Schema/Columns/Column.php
+++ b/src/Illuminate/Database/Schema/Columns/Column.php
@@ -140,6 +140,8 @@ class Column
     }
 
     /**
+     * Place the column "after" another column (MySQL)
+     *
      * @param string $column
      * @return Column
      */
@@ -150,6 +152,8 @@ class Column
     }
 
     /**
+     * Add a comment to a column (MySQL)
+     *
      * @param string $comment
      * @return Column
      */
@@ -160,6 +164,8 @@ class Column
     }
 
     /**
+     * Specify a "default" value for the column
+     *
      * @param mixed $default
      * @return Column
      */
@@ -170,6 +176,8 @@ class Column
     }
 
     /**
+     * Place the column "first" in the table (MySQL)
+     *
      * @return Column
      */
     public function first(): Column
@@ -179,6 +187,8 @@ class Column
     }
 
     /**
+     * Allows (by default) NULL values to be inserted into the column
+     *
      * @param bool $value
      * @return Column
      */
@@ -189,6 +199,8 @@ class Column
     }
 
     /**
+     * Create a stored generated column (MySQL)
+     *
      * @param string $expression
      * @return Column
      */
@@ -199,6 +211,8 @@ class Column
     }
 
     /**
+     * Create a virtual generated column (MySQL)
+     *
      * @param string $expression
      * @return Column
      */
@@ -209,6 +223,11 @@ class Column
     }
 
     /**
+     * The change method allows you to modify some existing column types to a new type or modify the column's attributes
+     * Only the following column types can be "changed":
+     * bigInteger, binary, boolean, date, dateTime, dateTimeTz, decimal, integer, json, longText, mediumText,
+     * smallInteger, string, text, time, unsignedBigInteger, unsignedInteger and unsignedSmallInteger.
+     *
      * @return Column
      */
     public function change(): Column
@@ -218,6 +237,8 @@ class Column
     }
 
     /**
+     * Adds a primary key.
+     *
      * @param null|string $name
      * @return Column
      */
@@ -228,6 +249,8 @@ class Column
     }
 
     /**
+     * Adds a unique index.
+     *
      * @param null|string $name
      * @return Column
      */
@@ -238,6 +261,8 @@ class Column
     }
 
     /**
+     * Adds a plain index.
+     *
      * @param null|string $name
      * @return Column
      */
@@ -248,6 +273,8 @@ class Column
     }
 
     /**
+     * Adds a spatial index. (except SQLite)
+     *
      * @param null|string $name
      * @return Column
      */

--- a/src/Illuminate/Database/Schema/Columns/Decimal.php
+++ b/src/Illuminate/Database/Schema/Columns/Decimal.php
@@ -16,10 +16,10 @@ namespace Illuminate\Database\Schema\Columns;
  * @method \Illuminate\Database\Schema\Columns\Decimal storedAs(string $expression)
  * @method \Illuminate\Database\Schema\Columns\Decimal virtualAs(string $expression)
  * @method \Illuminate\Database\Schema\Columns\Decimal change()
- * @method \Illuminate\Database\Schema\Columns\Decimal primary(?string $name = null)
- * @method \Illuminate\Database\Schema\Columns\Decimal unique(?string $name = null)
- * @method \Illuminate\Database\Schema\Columns\Decimal index(?string $name = null)
- * @method \Illuminate\Database\Schema\Columns\Decimal spatialIndex(?string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Decimal primary(string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Decimal unique(string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Decimal index(string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Decimal spatialIndex(string $name = null)
  */
 class Decimal extends Column
 {
@@ -43,10 +43,10 @@ class Decimal extends Column
      *
      * @param string $type
      * @param string $name
-     * @param int|null $total
-     * @param int|null $places
+     * @param int $total
+     * @param int $places
      */
-    public function __construct(string $type, string $name, ?int $total = null, ?int $places = null)
+    public function __construct(string $type, string $name, int $total = null, int $places = null)
     {
         parent::__construct($type, $name);
 

--- a/src/Illuminate/Database/Schema/Columns/Decimal.php
+++ b/src/Illuminate/Database/Schema/Columns/Decimal.php
@@ -8,18 +8,18 @@ namespace Illuminate\Database\Schema\Columns;
  * @property-read int|null $total
  * @property-read int|null $places
  * @property-read bool $unsigned
- * @method Decimal after(string $column)
- * @method Decimal comment(string $comment)
- * @method Decimal default(mixed $default)
- * @method Decimal first()
- * @method Decimal nullable(bool $value = true)
- * @method Decimal storedAs(string $expression)
- * @method Decimal virtualAs(string $expression)
- * @method Decimal change()
- * @method Decimal primary(?string $name = null)
- * @method Decimal unique(?string $name = null)
- * @method Decimal index(?string $name = null)
- * @method Decimal spatialIndex(?string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Decimal after(string $column)
+ * @method \Illuminate\Database\Schema\Columns\Decimal comment(string $comment)
+ * @method \Illuminate\Database\Schema\Columns\Decimal default(mixed $default)
+ * @method \Illuminate\Database\Schema\Columns\Decimal first()
+ * @method \Illuminate\Database\Schema\Columns\Decimal nullable(bool $value = true)
+ * @method \Illuminate\Database\Schema\Columns\Decimal storedAs(string $expression)
+ * @method \Illuminate\Database\Schema\Columns\Decimal virtualAs(string $expression)
+ * @method \Illuminate\Database\Schema\Columns\Decimal change()
+ * @method \Illuminate\Database\Schema\Columns\Decimal primary(?string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Decimal unique(?string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Decimal index(?string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Decimal spatialIndex(?string $name = null)
  */
 class Decimal extends Column
 {
@@ -57,7 +57,7 @@ class Decimal extends Column
     /**
      * Set INTEGER columns as UNSIGNED (MySQL)
      *
-     * @return Decimal
+     * @return \Illuminate\Database\Schema\Columns\Decimal
      */
     public function unsigned(): Decimal
     {

--- a/src/Illuminate/Database/Schema/Columns/Decimal.php
+++ b/src/Illuminate/Database/Schema/Columns/Decimal.php
@@ -56,6 +56,8 @@ class Decimal extends Column
     }
 
     /**
+     * Set INTEGER columns as UNSIGNED (MySQL)
+     *
      * @return Decimal
      */
     public function unsigned(): Decimal

--- a/src/Illuminate/Database/Schema/Columns/Decimal.php
+++ b/src/Illuminate/Database/Schema/Columns/Decimal.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Database\Schema\Columns;
+
+/**
+ * Class Decimal
+ *
+ * @property-read int|null $total
+ * @property-read int|null $places
+ * @property-read bool $unsigned
+ * @method Decimal after(string $column)
+ * @method Decimal collation(string $value)
+ * @method Decimal comment(string $comment)
+ * @method Decimal default(mixed $default)
+ * @method Decimal first()
+ * @method Decimal nullable(bool $value = true)
+ * @method Decimal storedAs(string $expression)
+ * @method Decimal virtualAs(string $expression)
+ * @method Decimal change()
+ * @method Decimal primary(?string $name = null)
+ * @method Decimal unique(?string $name = null)
+ * @method Decimal index(?string $name = null)
+ * @method Decimal spatialIndex(?string $name = null)
+ */
+class Decimal extends Column
+{
+    /**
+     * @var int|null
+     */
+    protected $total;
+
+    /**
+     * @var int|null
+     */
+    protected $places;
+
+    /**
+     * @var bool
+     */
+    protected $unsigned = false;
+
+    /**
+     * Decimal constructor.
+     *
+     * @param string $type
+     * @param string $name
+     * @param int|null $total
+     * @param int|null $places
+     */
+    public function __construct(string $type, string $name, ?int $total = null, ?int $places = null)
+    {
+        parent::__construct($type, $name);
+
+        $this->total = $total;
+        $this->places = $places;
+    }
+
+    /**
+     * @return Decimal
+     */
+    public function unsigned(): Decimal
+    {
+        $this->unsigned = true;
+        return $this;
+    }
+}

--- a/src/Illuminate/Database/Schema/Columns/Decimal.php
+++ b/src/Illuminate/Database/Schema/Columns/Decimal.php
@@ -9,7 +9,6 @@ namespace Illuminate\Database\Schema\Columns;
  * @property-read int|null $places
  * @property-read bool $unsigned
  * @method Decimal after(string $column)
- * @method Decimal collation(string $value)
  * @method Decimal comment(string $comment)
  * @method Decimal default(mixed $default)
  * @method Decimal first()

--- a/src/Illuminate/Database/Schema/Columns/Enum.php
+++ b/src/Illuminate/Database/Schema/Columns/Enum.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Database\Schema\Columns;
+
+/**
+ * Class Enum
+ *
+ * @property-read string[] $allowed
+ */
+class Enum extends Text
+{
+    /**
+     * @var string[]
+     */
+    protected $allowed;
+
+    /**
+     * Enum constructor.
+     *
+     * @param string $type
+     * @param string $name
+     * @param string[] $allowed
+     */
+    public function __construct(string $type, string $name, array $allowed)
+    {
+        parent::__construct($type, $name);
+
+        $this->allowed = $allowed;
+    }
+}

--- a/src/Illuminate/Database/Schema/Columns/Integer.php
+++ b/src/Illuminate/Database/Schema/Columns/Integer.php
@@ -8,7 +8,6 @@ namespace Illuminate\Database\Schema\Columns;
  * @property-read bool $autoIncrement
  * @property-read bool $unsigned
  * @method \Illuminate\Database\Schema\Columns\Integer after(string $column)
- * @method \Illuminate\Database\Schema\Columns\Integer collation(string $value)
  * @method \Illuminate\Database\Schema\Columns\Integer comment(string $comment)
  * @method \Illuminate\Database\Schema\Columns\Integer default(mixed $default)
  * @method \Illuminate\Database\Schema\Columns\Integer first()

--- a/src/Illuminate/Database/Schema/Columns/Integer.php
+++ b/src/Illuminate/Database/Schema/Columns/Integer.php
@@ -15,10 +15,10 @@ namespace Illuminate\Database\Schema\Columns;
  * @method \Illuminate\Database\Schema\Columns\Integer storedAs(string $expression)
  * @method \Illuminate\Database\Schema\Columns\Integer virtualAs(string $expression)
  * @method \Illuminate\Database\Schema\Columns\Integer change()
- * @method \Illuminate\Database\Schema\Columns\Integer primary(?string $name = null)
- * @method \Illuminate\Database\Schema\Columns\Integer unique(?string $name = null)
- * @method \Illuminate\Database\Schema\Columns\Integer index(?string $name = null)
- * @method \Illuminate\Database\Schema\Columns\Integer spatialIndex(?string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Integer primary(string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Integer unique(string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Integer index(string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Integer spatialIndex(string $name = null)
  */
 class Integer extends Column
 {

--- a/src/Illuminate/Database/Schema/Columns/Integer.php
+++ b/src/Illuminate/Database/Schema/Columns/Integer.php
@@ -53,7 +53,7 @@ class Integer extends Column
      *
      * @return \Illuminate\Database\Schema\Columns\Integer
      */
-    public function autoIncrement(): \Illuminate\Database\Schema\Columns\Integer
+    public function autoIncrement(): Integer
     {
         $this->autoIncrement = true;
         return $this;
@@ -64,7 +64,7 @@ class Integer extends Column
      *
      * @return \Illuminate\Database\Schema\Columns\Integer
      */
-    public function unsigned(): \Illuminate\Database\Schema\Columns\Integer
+    public function unsigned(): Integer
     {
         $this->unsigned = true;
         return $this;

--- a/src/Illuminate/Database/Schema/Columns/Integer.php
+++ b/src/Illuminate/Database/Schema/Columns/Integer.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Database\Schema\Columns;
+
+/**
+ * Class Integer
+ *
+ * @property-read bool $autoIncrement
+ * @property-read bool $unsigned
+ * @method \Illuminate\Database\Schema\Columns\Integer after(string $column)
+ * @method \Illuminate\Database\Schema\Columns\Integer collation(string $value)
+ * @method \Illuminate\Database\Schema\Columns\Integer comment(string $comment)
+ * @method \Illuminate\Database\Schema\Columns\Integer default(mixed $default)
+ * @method \Illuminate\Database\Schema\Columns\Integer first()
+ * @method \Illuminate\Database\Schema\Columns\Integer nullable(bool $value = true)
+ * @method \Illuminate\Database\Schema\Columns\Integer storedAs(string $expression)
+ * @method \Illuminate\Database\Schema\Columns\Integer virtualAs(string $expression)
+ * @method \Illuminate\Database\Schema\Columns\Integer change()
+ * @method \Illuminate\Database\Schema\Columns\Integer primary(?string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Integer unique(?string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Integer index(?string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Integer spatialIndex(?string $name = null)
+ */
+class Integer extends Column
+{
+    /**
+     * @var bool
+     */
+    protected $autoIncrement = false;
+
+    /**
+     * @var bool
+     */
+    protected $unsigned = false;
+
+    /**
+     * Integer constructor.
+     *
+     * @param string $type
+     * @param string $name
+     * @param bool $autoIncrement
+     * @param bool $unsigned
+     */
+    public function __construct(string $type, string $name, bool $autoIncrement = false, bool $unsigned = false)
+    {
+        parent::__construct($type, $name);
+
+        $this->autoIncrement = $autoIncrement;
+        $this->unsigned = $unsigned;
+    }
+
+    /**
+     * @return \Illuminate\Database\Schema\Columns\Integer
+     */
+    public function autoIncrement(): \Illuminate\Database\Schema\Columns\Integer
+    {
+        $this->autoIncrement = true;
+        return $this;
+    }
+
+    /**
+     * @return \Illuminate\Database\Schema\Columns\Integer
+     */
+    public function unsigned(): \Illuminate\Database\Schema\Columns\Integer
+    {
+        $this->unsigned = true;
+        return $this;
+    }
+}

--- a/src/Illuminate/Database/Schema/Columns/Integer.php
+++ b/src/Illuminate/Database/Schema/Columns/Integer.php
@@ -50,6 +50,8 @@ class Integer extends Column
     }
 
     /**
+     * Set INTEGER columns as auto-increment (primary key)
+     *
      * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function autoIncrement(): \Illuminate\Database\Schema\Columns\Integer
@@ -59,6 +61,8 @@ class Integer extends Column
     }
 
     /**
+     * Set INTEGER columns as UNSIGNED (MySQL)
+     *
      * @return \Illuminate\Database\Schema\Columns\Integer
      */
     public function unsigned(): \Illuminate\Database\Schema\Columns\Integer

--- a/src/Illuminate/Database/Schema/Columns/Text.php
+++ b/src/Illuminate/Database/Schema/Columns/Text.php
@@ -33,6 +33,8 @@ class Text extends Column
     private $collation;
 
     /**
+     * Specify a character set for the column (MySQL)
+     *
      * @param string $charset
      * @return Text
      */
@@ -43,6 +45,8 @@ class Text extends Column
     }
 
     /**
+     * Specify a collation for the column (MySQL/SQL Server)
+     *
      * @param string $value
      * @return Text
      */

--- a/src/Illuminate/Database/Schema/Columns/Text.php
+++ b/src/Illuminate/Database/Schema/Columns/Text.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Database\Schema\Columns;
+
+/**
+ * Class Text
+ *
+ * @property-read string $charset
+ * @property-read string $collation
+ * @method Text after(string $column)
+ * @method Text comment(string $comment)
+ * @method Text default(mixed $default)
+ * @method Text first()
+ * @method Text nullable(bool $value = true)
+ * @method Text storedAs(string $expression)
+ * @method Text virtualAs(string $expression)
+ * @method Text change()
+ * @method Text primary(?string $name = null)
+ * @method Text unique(?string $name = null)
+ * @method Text index(?string $name = null)
+ * @method Text spatialIndex(?string $name = null)
+ */
+class Text extends Column
+{
+    /**
+     * @var string
+     */
+    protected $charset;
+
+    /**
+     * @var string
+     */
+    private $collation;
+
+    /**
+     * @param string $charset
+     * @return Text
+     */
+    public function charset(string $charset): Text
+    {
+        $this->charset = $charset;
+        return $this;
+    }
+
+    /**
+     * @param string $value
+     * @return Text
+     */
+    public function collation(string $value): Text
+    {
+        $this->collation = $value;
+        return $this;
+    }
+}

--- a/src/Illuminate/Database/Schema/Columns/Text.php
+++ b/src/Illuminate/Database/Schema/Columns/Text.php
@@ -7,18 +7,18 @@ namespace Illuminate\Database\Schema\Columns;
  *
  * @property-read string $charset
  * @property-read string $collation
- * @method Text after(string $column)
- * @method Text comment(string $comment)
- * @method Text default(mixed $default)
- * @method Text first()
- * @method Text nullable(bool $value = true)
- * @method Text storedAs(string $expression)
- * @method Text virtualAs(string $expression)
- * @method Text change()
- * @method Text primary(?string $name = null)
- * @method Text unique(?string $name = null)
- * @method Text index(?string $name = null)
- * @method Text spatialIndex(?string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Text after(string $column)
+ * @method \Illuminate\Database\Schema\Columns\Text comment(string $comment)
+ * @method \Illuminate\Database\Schema\Columns\Text default(mixed $default)
+ * @method \Illuminate\Database\Schema\Columns\Text first()
+ * @method \Illuminate\Database\Schema\Columns\Text nullable(bool $value = true)
+ * @method \Illuminate\Database\Schema\Columns\Text storedAs(string $expression)
+ * @method \Illuminate\Database\Schema\Columns\Text virtualAs(string $expression)
+ * @method \Illuminate\Database\Schema\Columns\Text change()
+ * @method \Illuminate\Database\Schema\Columns\Text primary(?string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Text unique(?string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Text index(?string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Text spatialIndex(?string $name = null)
  */
 class Text extends Column
 {
@@ -36,7 +36,7 @@ class Text extends Column
      * Specify a character set for the column (MySQL)
      *
      * @param string $charset
-     * @return Text
+     * @return \Illuminate\Database\Schema\Columns\Text
      */
     public function charset(string $charset): Text
     {
@@ -48,7 +48,7 @@ class Text extends Column
      * Specify a collation for the column (MySQL/SQL Server)
      *
      * @param string $value
-     * @return Text
+     * @return \Illuminate\Database\Schema\Columns\Text
      */
     public function collation(string $value): Text
     {

--- a/src/Illuminate/Database/Schema/Columns/Text.php
+++ b/src/Illuminate/Database/Schema/Columns/Text.php
@@ -30,7 +30,7 @@ class Text extends Column
     /**
      * @var string
      */
-    private $collation;
+    protected $collation;
 
     /**
      * Specify a character set for the column (MySQL)

--- a/src/Illuminate/Database/Schema/Columns/Text.php
+++ b/src/Illuminate/Database/Schema/Columns/Text.php
@@ -15,10 +15,10 @@ namespace Illuminate\Database\Schema\Columns;
  * @method \Illuminate\Database\Schema\Columns\Text storedAs(string $expression)
  * @method \Illuminate\Database\Schema\Columns\Text virtualAs(string $expression)
  * @method \Illuminate\Database\Schema\Columns\Text change()
- * @method \Illuminate\Database\Schema\Columns\Text primary(?string $name = null)
- * @method \Illuminate\Database\Schema\Columns\Text unique(?string $name = null)
- * @method \Illuminate\Database\Schema\Columns\Text index(?string $name = null)
- * @method \Illuminate\Database\Schema\Columns\Text spatialIndex(?string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Text primary(string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Text unique(string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Text index(string $name = null)
+ * @method \Illuminate\Database\Schema\Columns\Text spatialIndex(string $name = null)
  */
 class Text extends Column
 {

--- a/src/Illuminate/Database/Schema/Columns/Time.php
+++ b/src/Illuminate/Database/Schema/Columns/Time.php
@@ -5,6 +5,8 @@ namespace Illuminate\Database\Schema\Columns;
 /**
  * Class Time
  *
+ * This class is used to store params of columns containing time and created by
+ * Blueprint::time, Blueprint::timeTz, Blueprint::dateTime, Blueprint::dateTimeTz methods
  * @property-read int $precision
  */
 class Time extends Column

--- a/src/Illuminate/Database/Schema/Columns/Time.php
+++ b/src/Illuminate/Database/Schema/Columns/Time.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Database\Schema\Columns;
+
+/**
+ * Class Time
+ *
+ * @property-read int $precision
+ */
+class Time extends Column
+{
+    /**
+     * @var int
+     */
+    protected $precision;
+
+    /**
+     * Time constructor.
+     *
+     * @param string $type
+     * @param string $name
+     * @param int $precision
+     */
+    public function __construct(string $type, string $name, int $precision)
+    {
+        parent::__construct($type, $name);
+
+        $this->precision = $precision;
+    }
+}

--- a/src/Illuminate/Database/Schema/Columns/Timestamp.php
+++ b/src/Illuminate/Database/Schema/Columns/Timestamp.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Database\Schema\Columns;
+
+/**
+ * Class Timestamp
+ *
+ * @property-read bool $useCurrent
+ */
+class Timestamp extends Time
+{
+    /**
+     * @var bool
+     */
+    protected $useCurrent = false;
+
+    /**
+     * @return Timestamp
+     */
+    public function useCurrent(): Timestamp
+    {
+        $this->useCurrent = true;
+        return $this;
+    }
+}

--- a/src/Illuminate/Database/Schema/Columns/Timestamp.php
+++ b/src/Illuminate/Database/Schema/Columns/Timestamp.php
@@ -17,7 +17,7 @@ class Timestamp extends Time
     /**
      * Set TIMESTAMP columns to use CURRENT_TIMESTAMP as default value
      *
-     * @return Timestamp
+     * @return \Illuminate\Database\Schema\Columns\Timestamp
      */
     public function useCurrent(): Timestamp
     {

--- a/src/Illuminate/Database/Schema/Columns/Timestamp.php
+++ b/src/Illuminate/Database/Schema/Columns/Timestamp.php
@@ -15,6 +15,8 @@ class Timestamp extends Time
     protected $useCurrent = false;
 
     /**
+     * Set TIMESTAMP columns to use CURRENT_TIMESTAMP as default value
+     *
      * @return Timestamp
      */
     public function useCurrent(): Timestamp

--- a/src/Illuminate/Database/Schema/Columns/VariableLength.php
+++ b/src/Illuminate/Database/Schema/Columns/VariableLength.php
@@ -3,11 +3,12 @@
 namespace Illuminate\Database\Schema\Columns;
 
 /**
- * Class CharString
+ * Class VariableLength
  *
+ * This class is used to store params of columns created by Blueprint::char and Blueprint::string methods
  * @property-read int $length
  */
-class CharString extends Text
+class VariableLength extends Text
 {
     /**
      * @var int
@@ -15,7 +16,7 @@ class CharString extends Text
     protected $length;
 
     /**
-     * CharString constructor.
+     * VariableLength constructor.
      *
      * @param string $type
      * @param string $name

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Illuminate\Database\Schema\Columns\Column;
 use RuntimeException;
 use Doctrine\DBAL\Types\Type;
 use Illuminate\Support\Fluent;
@@ -23,6 +24,7 @@ class ChangeColumn
      * @return array
      *
      * @throws \RuntimeException
+     * @throws \Doctrine\DBAL\DBALException
      */
     public static function compile($grammar, Blueprint $blueprint, Fluent $command, Connection $connection)
     {
@@ -67,6 +69,7 @@ class ChangeColumn
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Doctrine\DBAL\Schema\Table  $table
      * @return \Doctrine\DBAL\Schema\Table
+     * @throws \Doctrine\DBAL\Schema\SchemaException
      */
     protected static function getTableWithColumnChanges(Blueprint $blueprint, Table $table)
     {
@@ -93,29 +96,30 @@ class ChangeColumn
     /**
      * Get the Doctrine column instance for a column change.
      *
-     * @param  \Doctrine\DBAL\Schema\Table  $table
-     * @param  \Illuminate\Support\Fluent  $fluent
+     * @param  \Doctrine\DBAL\Schema\Table $table
+     * @param  Column $column
      * @return \Doctrine\DBAL\Schema\Column
+     * @throws \Doctrine\DBAL\Schema\SchemaException
      */
-    protected static function getDoctrineColumn(Table $table, Fluent $fluent)
+    protected static function getDoctrineColumn(Table $table, Column $column)
     {
         return $table->changeColumn(
-            $fluent['name'], static::getDoctrineColumnChangeOptions($fluent)
-        )->getColumn($fluent['name']);
+            $column->name, static::getDoctrineColumnChangeOptions($column)
+        )->getColumn($column->name);
     }
 
     /**
      * Get the Doctrine column change options.
      *
-     * @param  \Illuminate\Support\Fluent  $fluent
+     * @param  Column  $column
      * @return array
      */
-    protected static function getDoctrineColumnChangeOptions(Fluent $fluent)
+    protected static function getDoctrineColumnChangeOptions(Column $column)
     {
-        $options = ['type' => static::getDoctrineColumnType($fluent['type'])];
+        $options = ['type' => static::getDoctrineColumnType($column->type)];
 
-        if (in_array($fluent['type'], ['text', 'mediumText', 'longText'])) {
-            $options['length'] = static::calculateDoctrineTextLength($fluent['type']);
+        if (in_array($column->type, ['text', 'mediumText', 'longText'])) {
+            $options['length'] = static::calculateDoctrineTextLength($column->type);
         }
 
         return $options;

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -97,7 +97,7 @@ class ChangeColumn
      * Get the Doctrine column instance for a column change.
      *
      * @param  \Doctrine\DBAL\Schema\Table $table
-     * @param  Column $column
+     * @param  \Illuminate\Database\Schema\Columns\Column $column
      * @return \Doctrine\DBAL\Schema\Column
      * @throws \Doctrine\DBAL\Schema\SchemaException
      */
@@ -111,7 +111,7 @@ class ChangeColumn
     /**
      * Get the Doctrine column change options.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return array
      */
     protected static function getDoctrineColumnChangeOptions(Column $column)

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Illuminate\Database\Schema\Columns\Column;
 use Illuminate\Support\Fluent;
 use Doctrine\DBAL\Schema\TableDiff;
 use Illuminate\Database\Connection;
@@ -108,7 +109,7 @@ abstract class Grammar extends BaseGrammar
             // Each of the column types have their own compiler functions which are tasked
             // with turning the column definition into its SQL format for this platform
             // used by the connection. The column's modifiers are compiled and added.
-            $sql = $this->wrap($column).' '.$this->getType($column);
+            $sql = $this->wrap($column->name).' '.$this->getType($column);
 
             $columns[] = $this->addModifiers($sql, $blueprint, $column);
         }
@@ -119,10 +120,10 @@ abstract class Grammar extends BaseGrammar
     /**
      * Get the SQL for the column data type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function getType(Fluent $column)
+    protected function getType(Column $column)
     {
         return $this->{'type'.ucfirst($column->type)}($column);
     }
@@ -132,10 +133,10 @@ abstract class Grammar extends BaseGrammar
      *
      * @param  string  $sql
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function addModifiers($sql, Blueprint $blueprint, Fluent $column)
+    protected function addModifiers($sql, Blueprint $blueprint, Column $column)
     {
         foreach ($this->modifiers as $modifier) {
             if (method_exists($this, $method = "modify{$modifier}")) {

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema\Grammars;
 
 use Illuminate\Database\Schema\Columns\Column;
+use Illuminate\Database\Schema\Columns\Integer;
 use Illuminate\Support\Fluent;
 use Doctrine\DBAL\Schema\TableDiff;
 use Illuminate\Database\Connection;
@@ -28,12 +29,20 @@ abstract class Grammar extends BaseGrammar
     protected $fluentCommands = [];
 
     /**
+     * The possible column serials.
+     *
+     * @var string[]
+     */
+    protected $serials = [];
+
+    /**
      * Compile a rename column command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
      * @param  \Illuminate\Database\Connection  $connection
      * @return array
+     * @throws \Doctrine\DBAL\DBALException
      */
     public function compileRenameColumn(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
@@ -45,10 +54,11 @@ abstract class Grammar extends BaseGrammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @param  \Illuminate\Database\Connection $connection
+     * @param  \Illuminate\Database\Connection  $connection
      * @return array
      *
      * @throws \RuntimeException
+     * @throws \Doctrine\DBAL\DBALException
      */
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
@@ -120,7 +130,7 @@ abstract class Grammar extends BaseGrammar
     /**
      * Get the SQL for the column data type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function getType(Column $column)
@@ -133,7 +143,7 @@ abstract class Grammar extends BaseGrammar
      *
      * @param  string  $sql
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function addModifiers($sql, Blueprint $blueprint, Column $column)
@@ -233,6 +243,15 @@ abstract class Grammar extends BaseGrammar
         return is_bool($value)
                     ? "'".(int) $value."'"
                     : "'".(string) $value."'";
+    }
+
+    /**
+     * @param \Illuminate\Database\Schema\Columns\Column $column
+     * @return bool
+     */
+    protected function isColumnSerial(Column $column): bool
+    {
+        return $column instanceof Integer && in_array($column->type, $this->serials);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
-use Illuminate\Database\Schema\Columns\CharString;
+use Illuminate\Database\Schema\Columns\VariableLength;
 use Illuminate\Database\Schema\Columns\Column;
 use Illuminate\Database\Schema\Columns\Decimal;
 use Illuminate\Database\Schema\Columns\Enum;
-use Illuminate\Database\Schema\Columns\Integer as IntegerColumn;
+use Illuminate\Database\Schema\Columns\Integer;
 use Illuminate\Database\Schema\Columns\Text;
 use Illuminate\Database\Schema\Columns\Time;
 use Illuminate\Database\Schema\Columns\Timestamp;
@@ -394,10 +394,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a char type.
      *
-     * @param  CharString  $column
+     * @param  \Illuminate\Database\Schema\Columns\VariableLength  $column
      * @return string
      */
-    protected function typeChar(CharString $column)
+    protected function typeChar(VariableLength $column)
     {
         return "char({$column->length})";
     }
@@ -405,10 +405,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a string type.
      *
-     * @param  CharString  $column
+     * @param  \Illuminate\Database\Schema\Columns\VariableLength  $column
      * @return string
      */
-    protected function typeString(CharString $column)
+    protected function typeString(VariableLength $column)
     {
         return "varchar({$column->length})";
     }
@@ -416,7 +416,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a text type.
      *
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Text  $column
      * @return string
      */
     protected function typeText(Text $column)
@@ -427,7 +427,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a medium text type.
      *
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Text  $column
      * @return string
      */
     protected function typeMediumText(Text $column)
@@ -438,7 +438,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a long text type.
      *
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Text  $column
      * @return string
      */
     protected function typeLongText(Text $column)
@@ -449,10 +449,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a big integer type.
      *
-     * @param  IntegerColumn  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeBigInteger(IntegerColumn $column)
+    protected function typeBigInteger(Integer $column)
     {
         return 'bigint';
     }
@@ -460,10 +460,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for an integer type.
      *
-     * @param  IntegerColumn  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeInteger(IntegerColumn $column)
+    protected function typeInteger(Integer $column)
     {
         return 'int';
     }
@@ -471,10 +471,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a medium integer type.
      *
-     * @param  IntegerColumn  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeMediumInteger(IntegerColumn $column)
+    protected function typeMediumInteger(Integer $column)
     {
         return 'mediumint';
     }
@@ -482,10 +482,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a tiny integer type.
      *
-     * @param  IntegerColumn  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeTinyInteger(IntegerColumn $column)
+    protected function typeTinyInteger(Integer $column)
     {
         return 'tinyint';
     }
@@ -493,10 +493,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a small integer type.
      *
-     * @param  IntegerColumn  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeSmallInteger(IntegerColumn $column)
+    protected function typeSmallInteger(Integer $column)
     {
         return 'smallint';
     }
@@ -504,7 +504,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a float type.
      *
-     * @param  Decimal  $column
+     * @param  \Illuminate\Database\Schema\Columns\Decimal  $column
      * @return string
      */
     protected function typeFloat(Decimal $column)
@@ -515,7 +515,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a double type.
      *
-     * @param  Decimal  $column
+     * @param  \Illuminate\Database\Schema\Columns\Decimal  $column
      * @return string
      */
     protected function typeDouble(Decimal $column)
@@ -530,7 +530,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a decimal type.
      *
-     * @param  Decimal  $column
+     * @param  \Illuminate\Database\Schema\Columns\Decimal  $column
      * @return string
      */
     protected function typeDecimal(Decimal $column)
@@ -541,7 +541,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a boolean type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeBoolean(Column $column)
@@ -552,7 +552,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for an enumeration type.
      *
-     * @param  Enum  $column
+     * @param  \Illuminate\Database\Schema\Columns\Enum  $column
      * @return string
      */
     protected function typeEnum(Enum $column)
@@ -563,7 +563,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a json type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeJson(Column $column)
@@ -574,7 +574,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a jsonb type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeJsonb(Column $column)
@@ -585,7 +585,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a date type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeDate(Column $column)
@@ -596,7 +596,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a date-time type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeDateTime(Time $column)
@@ -607,7 +607,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a date-time (with time zone) type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeDateTimeTz(Time $column)
@@ -618,7 +618,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a time type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeTime(Time $column)
@@ -629,7 +629,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a time (with time zone) type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeTimeTz(Time $column)
@@ -640,7 +640,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a timestamp type.
      *
-     * @param  Timestamp  $column
+     * @param  \Illuminate\Database\Schema\Columns\Timestamp  $column
      * @return string
      */
     protected function typeTimestamp(Timestamp $column)
@@ -653,7 +653,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a timestamp (with time zone) type.
      *
-     * @param  Timestamp  $column
+     * @param  \Illuminate\Database\Schema\Columns\Timestamp  $column
      * @return string
      */
     protected function typeTimestampTz(Timestamp $column)
@@ -664,7 +664,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a year type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeYear(Column $column)
@@ -675,7 +675,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a binary type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeBinary(Column $column)
@@ -686,7 +686,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a uuid type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeUuid(Column $column)
@@ -697,7 +697,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for an IP address type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeIpAddress(Column $column)
@@ -708,7 +708,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a MAC address type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeMacAddress(Column $column)
@@ -719,7 +719,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial Geometry type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeGeometry(Column $column)
@@ -730,7 +730,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial Point type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typePoint(Column $column)
@@ -741,7 +741,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial LineString type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeLineString(Column $column)
@@ -752,7 +752,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial Polygon type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typePolygon(Column $column)
@@ -763,7 +763,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial GeometryCollection type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeGeometryCollection(Column $column)
@@ -774,7 +774,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPoint type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeMultiPoint(Column $column)
@@ -785,7 +785,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiLineString type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeMultiLineString(Column $column)
@@ -796,7 +796,7 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPolygon type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeMultiPolygon(Column $column)
@@ -808,7 +808,7 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a generated virtual column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
     protected function modifyVirtualAs(Blueprint $blueprint, Column $column)
@@ -822,7 +822,7 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a generated stored column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
     protected function modifyStoredAs(Blueprint $blueprint, Column $column)
@@ -836,7 +836,7 @@ class MySqlGrammar extends Grammar
      * Get the SQL for an unsigned column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  IntegerColumn|Decimal|Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer|\Illuminate\Database\Schema\Columns\Decimal|\Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
     protected function modifyUnsigned(Blueprint $blueprint, Column $column)
@@ -850,12 +850,12 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a character set column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
-    protected function modifyCharset(Blueprint $blueprint, Text $column)
+    protected function modifyCharset(Blueprint $blueprint, Column $column)
     {
-        if (! is_null($column->charset)) {
+        if ($column instanceof Text && ! is_null($column->charset)) {
             return ' character set '.$column->charset;
         }
     }
@@ -864,12 +864,12 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a collation column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
-    protected function modifyCollate(Blueprint $blueprint, Text $column)
+    protected function modifyCollate(Blueprint $blueprint, Column $column)
     {
-        if (! is_null($column->collation)) {
+        if ($column instanceof Text && ! is_null($column->collation)) {
             return ' collate '.$column->collation;
         }
     }
@@ -878,7 +878,7 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a nullable column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
     protected function modifyNullable(Blueprint $blueprint, Column $column)
@@ -892,7 +892,7 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a default column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
     protected function modifyDefault(Blueprint $blueprint, Column $column)
@@ -906,12 +906,12 @@ class MySqlGrammar extends Grammar
      * Get the SQL for an auto-increment column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  IntegerColumn  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
-    protected function modifyIncrement(Blueprint $blueprint, IntegerColumn $column)
+    protected function modifyIncrement(Blueprint $blueprint, Column $column)
     {
-        if (in_array($column->type, $this->serials) && $column->autoIncrement) {
+        if ($this->isColumnSerial($column) && $column->autoIncrement) {
             return ' auto_increment primary key';
         }
     }
@@ -920,7 +920,7 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a "first" column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
     protected function modifyFirst(Blueprint $blueprint, Column $column)
@@ -934,7 +934,7 @@ class MySqlGrammar extends Grammar
      * Get the SQL for an "after" column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
     protected function modifyAfter(Blueprint $blueprint, Column $column)
@@ -948,7 +948,7 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a "comment" column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
     protected function modifyComment(Blueprint $blueprint, Column $column)

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -2,6 +2,14 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Illuminate\Database\Schema\Columns\CharString;
+use Illuminate\Database\Schema\Columns\Column;
+use Illuminate\Database\Schema\Columns\Decimal;
+use Illuminate\Database\Schema\Columns\Enum;
+use Illuminate\Database\Schema\Columns\Integer as IntegerColumn;
+use Illuminate\Database\Schema\Columns\Text;
+use Illuminate\Database\Schema\Columns\Time;
+use Illuminate\Database\Schema\Columns\Timestamp;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
@@ -386,10 +394,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a char type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  CharString  $column
      * @return string
      */
-    protected function typeChar(Fluent $column)
+    protected function typeChar(CharString $column)
     {
         return "char({$column->length})";
     }
@@ -397,10 +405,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a string type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  CharString  $column
      * @return string
      */
-    protected function typeString(Fluent $column)
+    protected function typeString(CharString $column)
     {
         return "varchar({$column->length})";
     }
@@ -408,10 +416,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string
      */
-    protected function typeText(Fluent $column)
+    protected function typeText(Text $column)
     {
         return 'text';
     }
@@ -419,10 +427,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a medium text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string
      */
-    protected function typeMediumText(Fluent $column)
+    protected function typeMediumText(Text $column)
     {
         return 'mediumtext';
     }
@@ -430,10 +438,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a long text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string
      */
-    protected function typeLongText(Fluent $column)
+    protected function typeLongText(Text $column)
     {
         return 'longtext';
     }
@@ -441,10 +449,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a big integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  IntegerColumn  $column
      * @return string
      */
-    protected function typeBigInteger(Fluent $column)
+    protected function typeBigInteger(IntegerColumn $column)
     {
         return 'bigint';
     }
@@ -452,10 +460,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for an integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  IntegerColumn  $column
      * @return string
      */
-    protected function typeInteger(Fluent $column)
+    protected function typeInteger(IntegerColumn $column)
     {
         return 'int';
     }
@@ -463,10 +471,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a medium integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  IntegerColumn  $column
      * @return string
      */
-    protected function typeMediumInteger(Fluent $column)
+    protected function typeMediumInteger(IntegerColumn $column)
     {
         return 'mediumint';
     }
@@ -474,10 +482,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a tiny integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  IntegerColumn  $column
      * @return string
      */
-    protected function typeTinyInteger(Fluent $column)
+    protected function typeTinyInteger(IntegerColumn $column)
     {
         return 'tinyint';
     }
@@ -485,10 +493,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a small integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  IntegerColumn  $column
      * @return string
      */
-    protected function typeSmallInteger(Fluent $column)
+    protected function typeSmallInteger(IntegerColumn $column)
     {
         return 'smallint';
     }
@@ -496,10 +504,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a float type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Decimal  $column
      * @return string
      */
-    protected function typeFloat(Fluent $column)
+    protected function typeFloat(Decimal $column)
     {
         return $this->typeDouble($column);
     }
@@ -507,10 +515,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a double type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Decimal  $column
      * @return string
      */
-    protected function typeDouble(Fluent $column)
+    protected function typeDouble(Decimal $column)
     {
         if ($column->total && $column->places) {
             return "double({$column->total}, {$column->places})";
@@ -522,10 +530,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a decimal type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Decimal  $column
      * @return string
      */
-    protected function typeDecimal(Fluent $column)
+    protected function typeDecimal(Decimal $column)
     {
         return "decimal({$column->total}, {$column->places})";
     }
@@ -533,10 +541,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a boolean type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeBoolean(Fluent $column)
+    protected function typeBoolean(Column $column)
     {
         return 'tinyint(1)';
     }
@@ -544,10 +552,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for an enumeration type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Enum  $column
      * @return string
      */
-    protected function typeEnum(Fluent $column)
+    protected function typeEnum(Enum $column)
     {
         return sprintf('enum(%s)', $this->quoteString($column->allowed));
     }
@@ -555,10 +563,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a json type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeJson(Fluent $column)
+    protected function typeJson(Column $column)
     {
         return 'json';
     }
@@ -566,10 +574,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a jsonb type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeJsonb(Fluent $column)
+    protected function typeJsonb(Column $column)
     {
         return 'json';
     }
@@ -577,10 +585,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a date type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeDate(Fluent $column)
+    protected function typeDate(Column $column)
     {
         return 'date';
     }
@@ -588,10 +596,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a date-time type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeDateTime(Fluent $column)
+    protected function typeDateTime(Time $column)
     {
         return $column->precision ? "datetime($column->precision)" : 'datetime';
     }
@@ -599,10 +607,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a date-time (with time zone) type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeDateTimeTz(Fluent $column)
+    protected function typeDateTimeTz(Time $column)
     {
         return $this->typeDateTime($column);
     }
@@ -610,10 +618,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a time type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeTime(Fluent $column)
+    protected function typeTime(Time $column)
     {
         return $column->precision ? "time($column->precision)" : 'time';
     }
@@ -621,10 +629,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a time (with time zone) type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeTimeTz(Fluent $column)
+    protected function typeTimeTz(Time $column)
     {
         return $this->typeTime($column);
     }
@@ -632,10 +640,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a timestamp type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Timestamp  $column
      * @return string
      */
-    protected function typeTimestamp(Fluent $column)
+    protected function typeTimestamp(Timestamp $column)
     {
         $columnType = $column->precision ? "timestamp($column->precision)" : 'timestamp';
 
@@ -645,10 +653,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a timestamp (with time zone) type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Timestamp  $column
      * @return string
      */
-    protected function typeTimestampTz(Fluent $column)
+    protected function typeTimestampTz(Timestamp $column)
     {
         return $this->typeTimestamp($column);
     }
@@ -656,10 +664,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a year type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeYear(Fluent $column)
+    protected function typeYear(Column $column)
     {
         return 'year';
     }
@@ -667,10 +675,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a binary type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeBinary(Fluent $column)
+    protected function typeBinary(Column $column)
     {
         return 'blob';
     }
@@ -678,10 +686,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a uuid type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeUuid(Fluent $column)
+    protected function typeUuid(Column $column)
     {
         return 'char(36)';
     }
@@ -689,10 +697,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for an IP address type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeIpAddress(Fluent $column)
+    protected function typeIpAddress(Column $column)
     {
         return 'varchar(45)';
     }
@@ -700,10 +708,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a MAC address type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeMacAddress(Fluent $column)
+    protected function typeMacAddress(Column $column)
     {
         return 'varchar(17)';
     }
@@ -711,10 +719,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial Geometry type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeGeometry(Fluent $column)
+    public function typeGeometry(Column $column)
     {
         return 'geometry';
     }
@@ -722,10 +730,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial Point type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typePoint(Fluent $column)
+    public function typePoint(Column $column)
     {
         return 'point';
     }
@@ -733,10 +741,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial LineString type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeLineString(Fluent $column)
+    public function typeLineString(Column $column)
     {
         return 'linestring';
     }
@@ -744,10 +752,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial Polygon type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typePolygon(Fluent $column)
+    public function typePolygon(Column $column)
     {
         return 'polygon';
     }
@@ -755,10 +763,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial GeometryCollection type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeGeometryCollection(Fluent $column)
+    public function typeGeometryCollection(Column $column)
     {
         return 'geometrycollection';
     }
@@ -766,10 +774,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPoint type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeMultiPoint(Fluent $column)
+    public function typeMultiPoint(Column $column)
     {
         return 'multipoint';
     }
@@ -777,10 +785,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiLineString type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeMultiLineString(Fluent $column)
+    public function typeMultiLineString(Column $column)
     {
         return 'multilinestring';
     }
@@ -788,10 +796,10 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPolygon type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeMultiPolygon(Fluent $column)
+    public function typeMultiPolygon(Column $column)
     {
         return 'multipolygon';
     }
@@ -800,10 +808,10 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a generated virtual column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string|null
      */
-    protected function modifyVirtualAs(Blueprint $blueprint, Fluent $column)
+    protected function modifyVirtualAs(Blueprint $blueprint, Column $column)
     {
         if (! is_null($column->virtualAs)) {
             return " as ({$column->virtualAs})";
@@ -814,10 +822,10 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a generated stored column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string|null
      */
-    protected function modifyStoredAs(Blueprint $blueprint, Fluent $column)
+    protected function modifyStoredAs(Blueprint $blueprint, Column $column)
     {
         if (! is_null($column->storedAs)) {
             return " as ({$column->storedAs}) stored";
@@ -828,10 +836,10 @@ class MySqlGrammar extends Grammar
      * Get the SQL for an unsigned column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  IntegerColumn|Decimal|Column  $column
      * @return string|null
      */
-    protected function modifyUnsigned(Blueprint $blueprint, Fluent $column)
+    protected function modifyUnsigned(Blueprint $blueprint, Column $column)
     {
         if ($column->unsigned) {
             return ' unsigned';
@@ -842,10 +850,10 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a character set column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string|null
      */
-    protected function modifyCharset(Blueprint $blueprint, Fluent $column)
+    protected function modifyCharset(Blueprint $blueprint, Text $column)
     {
         if (! is_null($column->charset)) {
             return ' character set '.$column->charset;
@@ -856,10 +864,10 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a collation column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string|null
      */
-    protected function modifyCollate(Blueprint $blueprint, Fluent $column)
+    protected function modifyCollate(Blueprint $blueprint, Text $column)
     {
         if (! is_null($column->collation)) {
             return ' collate '.$column->collation;
@@ -870,10 +878,10 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a nullable column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string|null
      */
-    protected function modifyNullable(Blueprint $blueprint, Fluent $column)
+    protected function modifyNullable(Blueprint $blueprint, Column $column)
     {
         if (is_null($column->virtualAs) && is_null($column->storedAs)) {
             return $column->nullable ? ' null' : ' not null';
@@ -884,10 +892,10 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a default column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string|null
      */
-    protected function modifyDefault(Blueprint $blueprint, Fluent $column)
+    protected function modifyDefault(Blueprint $blueprint, Column $column)
     {
         if (! is_null($column->default)) {
             return ' default '.$this->getDefaultValue($column->default);
@@ -898,10 +906,10 @@ class MySqlGrammar extends Grammar
      * Get the SQL for an auto-increment column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  IntegerColumn  $column
      * @return string|null
      */
-    protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
+    protected function modifyIncrement(Blueprint $blueprint, IntegerColumn $column)
     {
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
             return ' auto_increment primary key';
@@ -912,10 +920,10 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a "first" column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string|null
      */
-    protected function modifyFirst(Blueprint $blueprint, Fluent $column)
+    protected function modifyFirst(Blueprint $blueprint, Column $column)
     {
         if (! is_null($column->first)) {
             return ' first';
@@ -926,10 +934,10 @@ class MySqlGrammar extends Grammar
      * Get the SQL for an "after" column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string|null
      */
-    protected function modifyAfter(Blueprint $blueprint, Fluent $column)
+    protected function modifyAfter(Blueprint $blueprint, Column $column)
     {
         if (! is_null($column->after)) {
             return ' after '.$this->wrap($column->after);
@@ -940,10 +948,10 @@ class MySqlGrammar extends Grammar
      * Get the SQL for a "comment" column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string|null
      */
-    protected function modifyComment(Blueprint $blueprint, Fluent $column)
+    protected function modifyComment(Blueprint $blueprint, Column $column)
     {
         if (! is_null($column->comment)) {
             return " comment '".addslashes($column->comment)."'";

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -841,7 +841,8 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyUnsigned(Blueprint $blueprint, Column $column)
     {
-        if ($column->unsigned) {
+        $isNumeric = ($column instanceof Decimal) || ($column instanceof Integer);
+        if ($isNumeric && $column->unsigned) {
             return ' unsigned';
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -2,6 +2,14 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Illuminate\Database\Schema\Columns\CharString;
+use Illuminate\Database\Schema\Columns\Column;
+use Illuminate\Database\Schema\Columns\Decimal;
+use Illuminate\Database\Schema\Columns\Enum;
+use Illuminate\Database\Schema\Columns\Integer as ColumnInteger;
+use Illuminate\Database\Schema\Columns\Text;
+use Illuminate\Database\Schema\Columns\Time;
+use Illuminate\Database\Schema\Columns\Timestamp;
 use RuntimeException;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Schema\Blueprint;
@@ -349,10 +357,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a char type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  CharString  $column
      * @return string
      */
-    protected function typeChar(Fluent $column)
+    protected function typeChar(CharString $column)
     {
         return "char({$column->length})";
     }
@@ -360,10 +368,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a string type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  CharString  $column
      * @return string
      */
-    protected function typeString(Fluent $column)
+    protected function typeString(CharString $column)
     {
         return "varchar({$column->length})";
     }
@@ -371,10 +379,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string
      */
-    protected function typeText(Fluent $column)
+    protected function typeText(Text $column)
     {
         return 'text';
     }
@@ -382,10 +390,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a medium text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string
      */
-    protected function typeMediumText(Fluent $column)
+    protected function typeMediumText(Text $column)
     {
         return 'text';
     }
@@ -393,10 +401,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a long text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string
      */
-    protected function typeLongText(Fluent $column)
+    protected function typeLongText(Text $column)
     {
         return 'text';
     }
@@ -404,10 +412,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for an integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeInteger(Fluent $column)
+    protected function typeInteger(ColumnInteger $column)
     {
         return $column->autoIncrement ? 'serial' : 'integer';
     }
@@ -415,10 +423,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a big integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeBigInteger(Fluent $column)
+    protected function typeBigInteger(ColumnInteger $column)
     {
         return $column->autoIncrement ? 'bigserial' : 'bigint';
     }
@@ -426,10 +434,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a medium integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeMediumInteger(Fluent $column)
+    protected function typeMediumInteger(ColumnInteger $column)
     {
         return $column->autoIncrement ? 'serial' : 'integer';
     }
@@ -437,10 +445,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a tiny integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeTinyInteger(Fluent $column)
+    protected function typeTinyInteger(ColumnInteger $column)
     {
         return $column->autoIncrement ? 'smallserial' : 'smallint';
     }
@@ -448,10 +456,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a small integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeSmallInteger(Fluent $column)
+    protected function typeSmallInteger(ColumnInteger $column)
     {
         return $column->autoIncrement ? 'smallserial' : 'smallint';
     }
@@ -459,10 +467,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a float type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Decimal  $column
      * @return string
      */
-    protected function typeFloat(Fluent $column)
+    protected function typeFloat(Decimal $column)
     {
         return $this->typeDouble($column);
     }
@@ -470,10 +478,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a double type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Decimal  $column
      * @return string
      */
-    protected function typeDouble(Fluent $column)
+    protected function typeDouble(Decimal $column)
     {
         return 'double precision';
     }
@@ -481,10 +489,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a real type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeReal(Fluent $column)
+    protected function typeReal(Column $column)
     {
         return 'real';
     }
@@ -492,10 +500,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a decimal type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Decimal  $column
      * @return string
      */
-    protected function typeDecimal(Fluent $column)
+    protected function typeDecimal(Decimal $column)
     {
         return "decimal({$column->total}, {$column->places})";
     }
@@ -503,10 +511,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a boolean type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeBoolean(Fluent $column)
+    protected function typeBoolean(Column $column)
     {
         return 'boolean';
     }
@@ -514,10 +522,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for an enumeration type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Enum  $column
      * @return string
      */
-    protected function typeEnum(Fluent $column)
+    protected function typeEnum(Enum $column)
     {
         return sprintf(
             'varchar(255) check ("%s" in (%s))',
@@ -529,10 +537,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a json type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeJson(Fluent $column)
+    protected function typeJson(Column $column)
     {
         return 'json';
     }
@@ -540,10 +548,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a jsonb type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeJsonb(Fluent $column)
+    protected function typeJsonb(Column $column)
     {
         return 'jsonb';
     }
@@ -551,10 +559,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a date type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeDate(Fluent $column)
+    protected function typeDate(Column $column)
     {
         return 'date';
     }
@@ -562,10 +570,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a date-time type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeDateTime(Fluent $column)
+    protected function typeDateTime(Time $column)
     {
         return "timestamp($column->precision) without time zone";
     }
@@ -573,10 +581,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a date-time (with time zone) type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeDateTimeTz(Fluent $column)
+    protected function typeDateTimeTz(Time $column)
     {
         return "timestamp($column->precision) with time zone";
     }
@@ -584,10 +592,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a time type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeTime(Fluent $column)
+    protected function typeTime(Time $column)
     {
         return "time($column->precision) without time zone";
     }
@@ -595,10 +603,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a time (with time zone) type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeTimeTz(Fluent $column)
+    protected function typeTimeTz(Time $column)
     {
         return "time($column->precision) with time zone";
     }
@@ -606,10 +614,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a timestamp type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Timestamp  $column
      * @return string
      */
-    protected function typeTimestamp(Fluent $column)
+    protected function typeTimestamp(Timestamp $column)
     {
         $columnType = "timestamp($column->precision) without time zone";
 
@@ -619,10 +627,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a timestamp (with time zone) type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Timestamp  $column
      * @return string
      */
-    protected function typeTimestampTz(Fluent $column)
+    protected function typeTimestampTz(Timestamp $column)
     {
         $columnType = "timestamp($column->precision) with time zone";
 
@@ -632,21 +640,21 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a year type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeYear(Fluent $column)
+    protected function typeYear(Column $column)
     {
-        return $this->typeInteger($column);
+        return 'integer';
     }
 
     /**
      * Create the column definition for a binary type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeBinary(Fluent $column)
+    protected function typeBinary(Column $column)
     {
         return 'bytea';
     }
@@ -654,10 +662,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a uuid type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeUuid(Fluent $column)
+    protected function typeUuid(Column $column)
     {
         return 'uuid';
     }
@@ -665,10 +673,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for an IP address type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeIpAddress(Fluent $column)
+    protected function typeIpAddress(Column $column)
     {
         return 'inet';
     }
@@ -676,10 +684,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a MAC address type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeMacAddress(Fluent $column)
+    protected function typeMacAddress(Column $column)
     {
         return 'macaddr';
     }
@@ -687,10 +695,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial Geometry type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @throws \RuntimeException
      */
-    protected function typeGeometry(Fluent $column)
+    protected function typeGeometry(Column $column)
     {
         throw new RuntimeException('The database driver in use does not support the Geometry spatial column type.');
     }
@@ -698,10 +706,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial Point type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typePoint(Fluent $column)
+    protected function typePoint(Column $column)
     {
         return $this->formatPostGisType('point');
     }
@@ -709,10 +717,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial LineString type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeLineString(Fluent $column)
+    protected function typeLineString(Column $column)
     {
         return $this->formatPostGisType('linestring');
     }
@@ -720,10 +728,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial Polygon type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typePolygon(Fluent $column)
+    protected function typePolygon(Column $column)
     {
         return $this->formatPostGisType('polygon');
     }
@@ -731,10 +739,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial GeometryCollection type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeGeometryCollection(Fluent $column)
+    protected function typeGeometryCollection(Column $column)
     {
         return $this->formatPostGisType('geometrycollection');
     }
@@ -742,10 +750,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPoint type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeMultiPoint(Fluent $column)
+    protected function typeMultiPoint(Column $column)
     {
         return $this->formatPostGisType('multipoint');
     }
@@ -753,10 +761,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiLineString type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeMultiLineString(Fluent $column)
+    public function typeMultiLineString(Column $column)
     {
         return $this->formatPostGisType('multilinestring');
     }
@@ -764,10 +772,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPolygon type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeMultiPolygon(Fluent $column)
+    protected function typeMultiPolygon(Column $column)
     {
         return $this->formatPostGisType('multipolygon');
     }
@@ -787,10 +795,10 @@ class PostgresGrammar extends Grammar
      * Get the SQL for a nullable column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string|null
      */
-    protected function modifyNullable(Blueprint $blueprint, Fluent $column)
+    protected function modifyNullable(Blueprint $blueprint, Column $column)
     {
         return $column->nullable ? ' null' : ' not null';
     }
@@ -799,10 +807,10 @@ class PostgresGrammar extends Grammar
      * Get the SQL for a default column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string|null
      */
-    protected function modifyDefault(Blueprint $blueprint, Fluent $column)
+    protected function modifyDefault(Blueprint $blueprint, Column $column)
     {
         if (! is_null($column->default)) {
             return ' default '.$this->getDefaultValue($column->default);
@@ -813,10 +821,10 @@ class PostgresGrammar extends Grammar
      * Get the SQL for an auto-increment column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string|null
      */
-    protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
+    protected function modifyIncrement(Blueprint $blueprint, ColumnInteger $column)
     {
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
             return ' primary key';

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
-use Illuminate\Database\Schema\Columns\CharString;
+use Illuminate\Database\Schema\Columns\VariableLength;
 use Illuminate\Database\Schema\Columns\Column;
 use Illuminate\Database\Schema\Columns\Decimal;
 use Illuminate\Database\Schema\Columns\Enum;
-use Illuminate\Database\Schema\Columns\Integer as ColumnInteger;
+use Illuminate\Database\Schema\Columns\Integer;
 use Illuminate\Database\Schema\Columns\Text;
 use Illuminate\Database\Schema\Columns\Time;
 use Illuminate\Database\Schema\Columns\Timestamp;
@@ -357,10 +357,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a char type.
      *
-     * @param  CharString  $column
+     * @param  \Illuminate\Database\Schema\Columns\VariableLength  $column
      * @return string
      */
-    protected function typeChar(CharString $column)
+    protected function typeChar(VariableLength $column)
     {
         return "char({$column->length})";
     }
@@ -368,10 +368,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a string type.
      *
-     * @param  CharString  $column
+     * @param  \Illuminate\Database\Schema\Columns\VariableLength  $column
      * @return string
      */
-    protected function typeString(CharString $column)
+    protected function typeString(VariableLength $column)
     {
         return "varchar({$column->length})";
     }
@@ -379,7 +379,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a text type.
      *
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Text  $column
      * @return string
      */
     protected function typeText(Text $column)
@@ -390,7 +390,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a medium text type.
      *
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Text  $column
      * @return string
      */
     protected function typeMediumText(Text $column)
@@ -401,7 +401,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a long text type.
      *
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Text  $column
      * @return string
      */
     protected function typeLongText(Text $column)
@@ -412,10 +412,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for an integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeInteger(ColumnInteger $column)
+    protected function typeInteger(Integer $column)
     {
         return $column->autoIncrement ? 'serial' : 'integer';
     }
@@ -423,10 +423,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a big integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeBigInteger(ColumnInteger $column)
+    protected function typeBigInteger(Integer $column)
     {
         return $column->autoIncrement ? 'bigserial' : 'bigint';
     }
@@ -434,10 +434,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a medium integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeMediumInteger(ColumnInteger $column)
+    protected function typeMediumInteger(Integer $column)
     {
         return $column->autoIncrement ? 'serial' : 'integer';
     }
@@ -445,10 +445,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a tiny integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeTinyInteger(ColumnInteger $column)
+    protected function typeTinyInteger(Integer $column)
     {
         return $column->autoIncrement ? 'smallserial' : 'smallint';
     }
@@ -456,10 +456,10 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a small integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeSmallInteger(ColumnInteger $column)
+    protected function typeSmallInteger(Integer $column)
     {
         return $column->autoIncrement ? 'smallserial' : 'smallint';
     }
@@ -467,7 +467,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a float type.
      *
-     * @param  Decimal  $column
+     * @param  \Illuminate\Database\Schema\Columns\Decimal  $column
      * @return string
      */
     protected function typeFloat(Decimal $column)
@@ -478,7 +478,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a double type.
      *
-     * @param  Decimal  $column
+     * @param  \Illuminate\Database\Schema\Columns\Decimal  $column
      * @return string
      */
     protected function typeDouble(Decimal $column)
@@ -489,7 +489,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a real type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeReal(Column $column)
@@ -500,7 +500,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a decimal type.
      *
-     * @param  Decimal  $column
+     * @param  \Illuminate\Database\Schema\Columns\Decimal  $column
      * @return string
      */
     protected function typeDecimal(Decimal $column)
@@ -511,7 +511,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a boolean type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeBoolean(Column $column)
@@ -522,7 +522,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for an enumeration type.
      *
-     * @param  Enum  $column
+     * @param  \Illuminate\Database\Schema\Columns\Enum  $column
      * @return string
      */
     protected function typeEnum(Enum $column)
@@ -537,7 +537,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a json type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeJson(Column $column)
@@ -548,7 +548,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a jsonb type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeJsonb(Column $column)
@@ -559,7 +559,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a date type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeDate(Column $column)
@@ -570,7 +570,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a date-time type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeDateTime(Time $column)
@@ -581,7 +581,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a date-time (with time zone) type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeDateTimeTz(Time $column)
@@ -592,7 +592,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a time type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeTime(Time $column)
@@ -603,7 +603,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a time (with time zone) type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeTimeTz(Time $column)
@@ -614,7 +614,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a timestamp type.
      *
-     * @param  Timestamp  $column
+     * @param  \Illuminate\Database\Schema\Columns\Timestamp  $column
      * @return string
      */
     protected function typeTimestamp(Timestamp $column)
@@ -627,7 +627,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a timestamp (with time zone) type.
      *
-     * @param  Timestamp  $column
+     * @param  \Illuminate\Database\Schema\Columns\Timestamp  $column
      * @return string
      */
     protected function typeTimestampTz(Timestamp $column)
@@ -640,7 +640,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a year type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeYear(Column $column)
@@ -651,7 +651,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a binary type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeBinary(Column $column)
@@ -662,7 +662,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a uuid type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeUuid(Column $column)
@@ -673,7 +673,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for an IP address type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeIpAddress(Column $column)
@@ -684,7 +684,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a MAC address type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeMacAddress(Column $column)
@@ -695,7 +695,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial Geometry type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @throws \RuntimeException
      */
     protected function typeGeometry(Column $column)
@@ -706,7 +706,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial Point type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typePoint(Column $column)
@@ -717,7 +717,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial LineString type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeLineString(Column $column)
@@ -728,7 +728,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial Polygon type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typePolygon(Column $column)
@@ -739,7 +739,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial GeometryCollection type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeGeometryCollection(Column $column)
@@ -750,7 +750,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPoint type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeMultiPoint(Column $column)
@@ -761,7 +761,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiLineString type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeMultiLineString(Column $column)
@@ -772,7 +772,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPolygon type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeMultiPolygon(Column $column)
@@ -795,7 +795,7 @@ class PostgresGrammar extends Grammar
      * Get the SQL for a nullable column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
     protected function modifyNullable(Blueprint $blueprint, Column $column)
@@ -807,7 +807,7 @@ class PostgresGrammar extends Grammar
      * Get the SQL for a default column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
     protected function modifyDefault(Blueprint $blueprint, Column $column)
@@ -821,12 +821,12 @@ class PostgresGrammar extends Grammar
      * Get the SQL for an auto-increment column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
-    protected function modifyIncrement(Blueprint $blueprint, ColumnInteger $column)
+    protected function modifyIncrement(Blueprint $blueprint, Column $column)
     {
-        if (in_array($column->type, $this->serials) && $column->autoIncrement) {
+        if ($this->isColumnSerial($column) && $column->autoIncrement) {
             return ' primary key';
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/RenameColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/RenameColumn.php
@@ -19,6 +19,7 @@ class RenameColumn
      * @param  \Illuminate\Support\Fluent  $command
      * @param  \Illuminate\Database\Connection  $connection
      * @return array
+     * @throws \Doctrine\DBAL\DBALException
      */
     public static function compile(Grammar $grammar, Blueprint $blueprint, Fluent $command, Connection $connection)
     {

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
-use Illuminate\Database\Schema\Columns\CharString;
+use Illuminate\Database\Schema\Columns\VariableLength;
 use Illuminate\Database\Schema\Columns\Column;
 use Illuminate\Database\Schema\Columns\Decimal;
 use Illuminate\Database\Schema\Columns\Enum;
-use Illuminate\Database\Schema\Columns\Integer as ColumnInteger;
+use Illuminate\Database\Schema\Columns\Integer;
 use Illuminate\Database\Schema\Columns\Text;
 use Illuminate\Database\Schema\Columns\Time;
 use Illuminate\Database\Schema\Columns\Timestamp;
@@ -358,10 +358,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a char type.
      *
-     * @param  CharString  $column
+     * @param  \Illuminate\Database\Schema\Columns\VariableLength  $column
      * @return string
      */
-    protected function typeChar(CharString $column)
+    protected function typeChar(VariableLength $column)
     {
         return 'varchar';
     }
@@ -369,10 +369,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a string type.
      *
-     * @param  CharString  $column
+     * @param  \Illuminate\Database\Schema\Columns\VariableLength  $column
      * @return string
      */
-    protected function typeString(CharString $column)
+    protected function typeString(VariableLength $column)
     {
         return 'varchar';
     }
@@ -380,7 +380,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a text type.
      *
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Text  $column
      * @return string
      */
     protected function typeText(Text $column)
@@ -391,7 +391,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a medium text type.
      *
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Text  $column
      * @return string
      */
     protected function typeMediumText(Text $column)
@@ -402,7 +402,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a long text type.
      *
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Text  $column
      * @return string
      */
     protected function typeLongText(Text $column)
@@ -413,10 +413,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeInteger(ColumnInteger $column)
+    protected function typeInteger(Integer $column)
     {
         return 'integer';
     }
@@ -424,10 +424,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a big integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeBigInteger(ColumnInteger $column)
+    protected function typeBigInteger(Integer $column)
     {
         return 'integer';
     }
@@ -435,10 +435,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a medium integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeMediumInteger(ColumnInteger $column)
+    protected function typeMediumInteger(Integer $column)
     {
         return 'integer';
     }
@@ -446,10 +446,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a tiny integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeTinyInteger(ColumnInteger $column)
+    protected function typeTinyInteger(Integer $column)
     {
         return 'integer';
     }
@@ -457,10 +457,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a small integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeSmallInteger(ColumnInteger $column)
+    protected function typeSmallInteger(Integer $column)
     {
         return 'integer';
     }
@@ -468,7 +468,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a float type.
      *
-     * @param  Decimal  $column
+     * @param  \Illuminate\Database\Schema\Columns\Decimal  $column
      * @return string
      */
     protected function typeFloat(Decimal $column)
@@ -479,7 +479,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a double type.
      *
-     * @param  Decimal  $column
+     * @param  \Illuminate\Database\Schema\Columns\Decimal  $column
      * @return string
      */
     protected function typeDouble(Decimal $column)
@@ -490,7 +490,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a decimal type.
      *
-     * @param  Decimal  $column
+     * @param  \Illuminate\Database\Schema\Columns\Decimal  $column
      * @return string
      */
     protected function typeDecimal(Decimal $column)
@@ -501,7 +501,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a boolean type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeBoolean(Column $column)
@@ -512,7 +512,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for an enumeration type.
      *
-     * @param  Enum  $column
+     * @param  \Illuminate\Database\Schema\Columns\Enum  $column
      * @return string
      */
     protected function typeEnum(Enum $column)
@@ -527,7 +527,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a json type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeJson(Column $column)
@@ -538,7 +538,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a jsonb type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeJsonb(Column $column)
@@ -549,7 +549,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a date type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeDate(Column $column)
@@ -560,7 +560,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a date-time type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeDateTime(Time $column)
@@ -574,7 +574,7 @@ class SQLiteGrammar extends Grammar
      * Note: "SQLite does not have a storage class set aside for storing dates and/or times."
      * @link https://www.sqlite.org/datatype3.html
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeDateTimeTz(Time $column)
@@ -585,7 +585,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a time type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeTime(Time $column)
@@ -596,7 +596,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a time (with time zone) type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeTimeTz(Time $column)
@@ -607,7 +607,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a timestamp type.
      *
-     * @param  Timestamp  $column
+     * @param  \Illuminate\Database\Schema\Columns\Timestamp  $column
      * @return string
      */
     protected function typeTimestamp(Timestamp $column)
@@ -618,7 +618,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a timestamp (with time zone) type.
      *
-     * @param  Timestamp  $column
+     * @param  \Illuminate\Database\Schema\Columns\Timestamp  $column
      * @return string
      */
     protected function typeTimestampTz(Timestamp $column)
@@ -629,7 +629,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a year type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeYear(Column $column)
@@ -640,7 +640,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a binary type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeBinary(Column $column)
@@ -651,7 +651,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a uuid type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeUuid(Column $column)
@@ -662,7 +662,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for an IP address type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeIpAddress(Column $column)
@@ -673,7 +673,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a MAC address type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeMacAddress(Column $column)
@@ -684,7 +684,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial Geometry type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeGeometry(Column $column)
@@ -695,7 +695,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial Point type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typePoint(Column $column)
@@ -706,7 +706,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial LineString type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeLineString(Column $column)
@@ -717,7 +717,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial Polygon type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typePolygon(Column $column)
@@ -728,7 +728,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial GeometryCollection type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeGeometryCollection(Column $column)
@@ -739,7 +739,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPoint type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeMultiPoint(Column $column)
@@ -750,7 +750,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiLineString type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeMultiLineString(Column $column)
@@ -761,7 +761,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPolygon type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeMultiPolygon(Column $column)
@@ -773,7 +773,7 @@ class SQLiteGrammar extends Grammar
      * Get the SQL for a nullable column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
     protected function modifyNullable(Blueprint $blueprint, Column $column)
@@ -785,7 +785,7 @@ class SQLiteGrammar extends Grammar
      * Get the SQL for a default column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
     protected function modifyDefault(Blueprint $blueprint, Column $column)
@@ -799,12 +799,12 @@ class SQLiteGrammar extends Grammar
      * Get the SQL for an auto-increment column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
-    protected function modifyIncrement(Blueprint $blueprint, ColumnInteger $column)
+    protected function modifyIncrement(Blueprint $blueprint, Column $column)
     {
-        if (in_array($column->type, $this->serials) && $column->autoIncrement) {
+        if ($this->isColumnSerial($column) && $column->autoIncrement) {
             return ' primary key autoincrement';
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -2,6 +2,14 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Illuminate\Database\Schema\Columns\CharString;
+use Illuminate\Database\Schema\Columns\Column;
+use Illuminate\Database\Schema\Columns\Decimal;
+use Illuminate\Database\Schema\Columns\Enum;
+use Illuminate\Database\Schema\Columns\Integer as ColumnInteger;
+use Illuminate\Database\Schema\Columns\Text;
+use Illuminate\Database\Schema\Columns\Time;
+use Illuminate\Database\Schema\Columns\Timestamp;
 use RuntimeException;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Connection;
@@ -350,10 +358,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a char type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  CharString  $column
      * @return string
      */
-    protected function typeChar(Fluent $column)
+    protected function typeChar(CharString $column)
     {
         return 'varchar';
     }
@@ -361,10 +369,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a string type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  CharString  $column
      * @return string
      */
-    protected function typeString(Fluent $column)
+    protected function typeString(CharString $column)
     {
         return 'varchar';
     }
@@ -372,10 +380,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string
      */
-    protected function typeText(Fluent $column)
+    protected function typeText(Text $column)
     {
         return 'text';
     }
@@ -383,10 +391,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a medium text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string
      */
-    protected function typeMediumText(Fluent $column)
+    protected function typeMediumText(Text $column)
     {
         return 'text';
     }
@@ -394,10 +402,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a long text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string
      */
-    protected function typeLongText(Fluent $column)
+    protected function typeLongText(Text $column)
     {
         return 'text';
     }
@@ -405,10 +413,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeInteger(Fluent $column)
+    protected function typeInteger(ColumnInteger $column)
     {
         return 'integer';
     }
@@ -416,10 +424,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a big integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeBigInteger(Fluent $column)
+    protected function typeBigInteger(ColumnInteger $column)
     {
         return 'integer';
     }
@@ -427,10 +435,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a medium integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeMediumInteger(Fluent $column)
+    protected function typeMediumInteger(ColumnInteger $column)
     {
         return 'integer';
     }
@@ -438,10 +446,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a tiny integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeTinyInteger(Fluent $column)
+    protected function typeTinyInteger(ColumnInteger $column)
     {
         return 'integer';
     }
@@ -449,10 +457,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a small integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeSmallInteger(Fluent $column)
+    protected function typeSmallInteger(ColumnInteger $column)
     {
         return 'integer';
     }
@@ -460,10 +468,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a float type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Decimal  $column
      * @return string
      */
-    protected function typeFloat(Fluent $column)
+    protected function typeFloat(Decimal $column)
     {
         return 'float';
     }
@@ -471,10 +479,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a double type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Decimal  $column
      * @return string
      */
-    protected function typeDouble(Fluent $column)
+    protected function typeDouble(Decimal $column)
     {
         return 'float';
     }
@@ -482,10 +490,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a decimal type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Decimal  $column
      * @return string
      */
-    protected function typeDecimal(Fluent $column)
+    protected function typeDecimal(Decimal $column)
     {
         return 'numeric';
     }
@@ -493,10 +501,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a boolean type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeBoolean(Fluent $column)
+    protected function typeBoolean(Column $column)
     {
         return 'tinyint(1)';
     }
@@ -504,10 +512,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for an enumeration type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Enum  $column
      * @return string
      */
-    protected function typeEnum(Fluent $column)
+    protected function typeEnum(Enum $column)
     {
         return sprintf(
             'varchar check ("%s" in (%s))',
@@ -519,10 +527,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a json type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeJson(Fluent $column)
+    protected function typeJson(Column $column)
     {
         return 'text';
     }
@@ -530,10 +538,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a jsonb type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeJsonb(Fluent $column)
+    protected function typeJsonb(Column $column)
     {
         return 'text';
     }
@@ -541,10 +549,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a date type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeDate(Fluent $column)
+    protected function typeDate(Column $column)
     {
         return 'date';
     }
@@ -552,10 +560,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a date-time type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeDateTime(Fluent $column)
+    protected function typeDateTime(Time $column)
     {
         return 'datetime';
     }
@@ -566,10 +574,10 @@ class SQLiteGrammar extends Grammar
      * Note: "SQLite does not have a storage class set aside for storing dates and/or times."
      * @link https://www.sqlite.org/datatype3.html
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeDateTimeTz(Fluent $column)
+    protected function typeDateTimeTz(Time $column)
     {
         return $this->typeDateTime($column);
     }
@@ -577,10 +585,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a time type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeTime(Fluent $column)
+    protected function typeTime(Time $column)
     {
         return 'time';
     }
@@ -588,10 +596,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a time (with time zone) type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeTimeTz(Fluent $column)
+    protected function typeTimeTz(Time $column)
     {
         return $this->typeTime($column);
     }
@@ -599,10 +607,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a timestamp type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Timestamp  $column
      * @return string
      */
-    protected function typeTimestamp(Fluent $column)
+    protected function typeTimestamp(Timestamp $column)
     {
         return $column->useCurrent ? 'datetime default CURRENT_TIMESTAMP' : 'datetime';
     }
@@ -610,10 +618,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a timestamp (with time zone) type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Timestamp  $column
      * @return string
      */
-    protected function typeTimestampTz(Fluent $column)
+    protected function typeTimestampTz(Timestamp $column)
     {
         return $this->typeTimestamp($column);
     }
@@ -621,21 +629,21 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a year type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeYear(Fluent $column)
+    protected function typeYear(Column $column)
     {
-        return $this->typeInteger($column);
+        return 'integer';
     }
 
     /**
      * Create the column definition for a binary type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeBinary(Fluent $column)
+    protected function typeBinary(Column $column)
     {
         return 'blob';
     }
@@ -643,10 +651,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a uuid type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeUuid(Fluent $column)
+    protected function typeUuid(Column $column)
     {
         return 'varchar';
     }
@@ -654,10 +662,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for an IP address type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeIpAddress(Fluent $column)
+    protected function typeIpAddress(Column $column)
     {
         return 'varchar';
     }
@@ -665,10 +673,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a MAC address type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeMacAddress(Fluent $column)
+    protected function typeMacAddress(Column $column)
     {
         return 'varchar';
     }
@@ -676,10 +684,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial Geometry type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeGeometry(Fluent $column)
+    public function typeGeometry(Column $column)
     {
         return 'geometry';
     }
@@ -687,10 +695,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial Point type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typePoint(Fluent $column)
+    public function typePoint(Column $column)
     {
         return 'point';
     }
@@ -698,10 +706,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial LineString type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeLineString(Fluent $column)
+    public function typeLineString(Column $column)
     {
         return 'linestring';
     }
@@ -709,10 +717,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial Polygon type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typePolygon(Fluent $column)
+    public function typePolygon(Column $column)
     {
         return 'polygon';
     }
@@ -720,10 +728,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial GeometryCollection type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeGeometryCollection(Fluent $column)
+    public function typeGeometryCollection(Column $column)
     {
         return 'geometrycollection';
     }
@@ -731,10 +739,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPoint type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeMultiPoint(Fluent $column)
+    public function typeMultiPoint(Column $column)
     {
         return 'multipoint';
     }
@@ -742,10 +750,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiLineString type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeMultiLineString(Fluent $column)
+    public function typeMultiLineString(Column $column)
     {
         return 'multilinestring';
     }
@@ -753,10 +761,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPolygon type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeMultiPolygon(Fluent $column)
+    public function typeMultiPolygon(Column $column)
     {
         return 'multipolygon';
     }
@@ -765,10 +773,10 @@ class SQLiteGrammar extends Grammar
      * Get the SQL for a nullable column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string|null
      */
-    protected function modifyNullable(Blueprint $blueprint, Fluent $column)
+    protected function modifyNullable(Blueprint $blueprint, Column $column)
     {
         return $column->nullable ? ' null' : ' not null';
     }
@@ -777,10 +785,10 @@ class SQLiteGrammar extends Grammar
      * Get the SQL for a default column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string|null
      */
-    protected function modifyDefault(Blueprint $blueprint, Fluent $column)
+    protected function modifyDefault(Blueprint $blueprint, Column $column)
     {
         if (! is_null($column->default)) {
             return ' default '.$this->getDefaultValue($column->default);
@@ -791,10 +799,10 @@ class SQLiteGrammar extends Grammar
      * Get the SQL for an auto-increment column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string|null
      */
-    protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
+    protected function modifyIncrement(Blueprint $blueprint, ColumnInteger $column)
     {
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
             return ' primary key autoincrement';

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
-use Illuminate\Database\Schema\Columns\CharString;
+use Illuminate\Database\Schema\Columns\VariableLength;
 use Illuminate\Database\Schema\Columns\Column;
 use Illuminate\Database\Schema\Columns\Decimal;
 use Illuminate\Database\Schema\Columns\Enum;
-use Illuminate\Database\Schema\Columns\Integer as ColumnInteger;
+use Illuminate\Database\Schema\Columns\Integer;
 use Illuminate\Database\Schema\Columns\Text;
 use Illuminate\Database\Schema\Columns\Time;
 use Illuminate\Database\Schema\Columns\Timestamp;
@@ -308,10 +308,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a char type.
      *
-     * @param  CharString  $column
+     * @param  \Illuminate\Database\Schema\Columns\VariableLength  $column
      * @return string
      */
-    protected function typeChar(CharString $column)
+    protected function typeChar(VariableLength $column)
     {
         return "nchar({$column->length})";
     }
@@ -319,10 +319,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a string type.
      *
-     * @param  CharString  $column
+     * @param  \Illuminate\Database\Schema\Columns\VariableLength  $column
      * @return string
      */
-    protected function typeString(CharString $column)
+    protected function typeString(VariableLength $column)
     {
         return "nvarchar({$column->length})";
     }
@@ -330,7 +330,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a text type.
      *
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Text  $column
      * @return string
      */
     protected function typeText(Text $column)
@@ -341,7 +341,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a medium text type.
      *
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Text  $column
      * @return string
      */
     protected function typeMediumText(Text $column)
@@ -352,7 +352,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a long text type.
      *
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Text  $column
      * @return string
      */
     protected function typeLongText(Text $column)
@@ -363,10 +363,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for an integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeInteger(ColumnInteger $column)
+    protected function typeInteger(Integer $column)
     {
         return 'int';
     }
@@ -374,10 +374,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a big integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeBigInteger(ColumnInteger $column)
+    protected function typeBigInteger(Integer $column)
     {
         return 'bigint';
     }
@@ -385,10 +385,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a medium integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeMediumInteger(ColumnInteger $column)
+    protected function typeMediumInteger(Integer $column)
     {
         return 'int';
     }
@@ -396,10 +396,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a tiny integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeTinyInteger(ColumnInteger $column)
+    protected function typeTinyInteger(Integer $column)
     {
         return 'tinyint';
     }
@@ -407,10 +407,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a small integer type.
      *
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Integer  $column
      * @return string
      */
-    protected function typeSmallInteger(ColumnInteger $column)
+    protected function typeSmallInteger(Integer $column)
     {
         return 'smallint';
     }
@@ -418,7 +418,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a float type.
      *
-     * @param  Decimal  $column
+     * @param  \Illuminate\Database\Schema\Columns\Decimal  $column
      * @return string
      */
     protected function typeFloat(Decimal $column)
@@ -429,7 +429,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a double type.
      *
-     * @param  Decimal  $column
+     * @param  \Illuminate\Database\Schema\Columns\Decimal  $column
      * @return string
      */
     protected function typeDouble(Decimal $column)
@@ -440,7 +440,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a decimal type.
      *
-     * @param  Decimal  $column
+     * @param  \Illuminate\Database\Schema\Columns\Decimal  $column
      * @return string
      */
     protected function typeDecimal(Decimal $column)
@@ -451,7 +451,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a boolean type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeBoolean(Column $column)
@@ -462,7 +462,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for an enumeration type.
      *
-     * @param  Enum  $column
+     * @param  \Illuminate\Database\Schema\Columns\Enum  $column
      * @return string
      */
     protected function typeEnum(Enum $column)
@@ -477,7 +477,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a json type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeJson(Column $column)
@@ -488,7 +488,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a jsonb type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeJsonb(Column $column)
@@ -499,7 +499,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a date type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeDate(Column $column)
@@ -510,7 +510,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a date-time type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeDateTime(Time $column)
@@ -521,7 +521,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a date-time (with time zone) type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeDateTimeTz(Time $column)
@@ -532,7 +532,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a time type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeTime(Time $column)
@@ -543,7 +543,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a time (with time zone) type.
      *
-     * @param  Time  $column
+     * @param  \Illuminate\Database\Schema\Columns\Time  $column
      * @return string
      */
     protected function typeTimeTz(Time $column)
@@ -554,7 +554,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a timestamp type.
      *
-     * @param  Timestamp  $column
+     * @param  \Illuminate\Database\Schema\Columns\Timestamp  $column
      * @return string
      */
     protected function typeTimestamp(Timestamp $column)
@@ -569,7 +569,7 @@ class SqlServerGrammar extends Grammar
      *
      * @link https://msdn.microsoft.com/en-us/library/bb630289(v=sql.120).aspx
      *
-     * @param  Timestamp  $column
+     * @param  \Illuminate\Database\Schema\Columns\Timestamp  $column
      * @return string
      */
     protected function typeTimestampTz(Timestamp $column)
@@ -586,7 +586,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a year type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeYear(Column $column)
@@ -597,7 +597,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a binary type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeBinary(Column $column)
@@ -608,7 +608,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a uuid type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeUuid(Column $column)
@@ -619,7 +619,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for an IP address type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeIpAddress(Column $column)
@@ -630,7 +630,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a MAC address type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     protected function typeMacAddress(Column $column)
@@ -641,7 +641,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial Geometry type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeGeometry(Column $column)
@@ -652,7 +652,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial Point type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typePoint(Column $column)
@@ -663,7 +663,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial LineString type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeLineString(Column $column)
@@ -674,7 +674,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial Polygon type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typePolygon(Column $column)
@@ -685,7 +685,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial GeometryCollection type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeGeometryCollection(Column $column)
@@ -696,7 +696,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPoint type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeMultiPoint(Column $column)
@@ -707,7 +707,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiLineString type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeMultiLineString(Column $column)
@@ -718,7 +718,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPolygon type.
      *
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string
      */
     public function typeMultiPolygon(Column $column)
@@ -730,12 +730,12 @@ class SqlServerGrammar extends Grammar
      * Get the SQL for a collation column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Text  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
-    protected function modifyCollate(Blueprint $blueprint, Text $column)
+    protected function modifyCollate(Blueprint $blueprint, Column $column)
     {
-        if (! is_null($column->collation)) {
+        if ($column instanceof Text && ! is_null($column->collation)) {
             return ' collate '.$column->collation;
         }
     }
@@ -744,7 +744,7 @@ class SqlServerGrammar extends Grammar
      * Get the SQL for a nullable column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
     protected function modifyNullable(Blueprint $blueprint, Column $column)
@@ -756,7 +756,7 @@ class SqlServerGrammar extends Grammar
      * Get the SQL for a default column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  Column  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
     protected function modifyDefault(Blueprint $blueprint, Column $column)
@@ -770,12 +770,12 @@ class SqlServerGrammar extends Grammar
      * Get the SQL for an auto-increment column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  ColumnInteger  $column
+     * @param  \Illuminate\Database\Schema\Columns\Column  $column
      * @return string|null
      */
-    protected function modifyIncrement(Blueprint $blueprint, ColumnInteger $column)
+    protected function modifyIncrement(Blueprint $blueprint, Column $column)
     {
-        if (in_array($column->type, $this->serials) && $column->autoIncrement) {
+        if ($this->isColumnSerial($column) && $column->autoIncrement) {
             return ' identity primary key';
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -2,6 +2,14 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Illuminate\Database\Schema\Columns\CharString;
+use Illuminate\Database\Schema\Columns\Column;
+use Illuminate\Database\Schema\Columns\Decimal;
+use Illuminate\Database\Schema\Columns\Enum;
+use Illuminate\Database\Schema\Columns\Integer as ColumnInteger;
+use Illuminate\Database\Schema\Columns\Text;
+use Illuminate\Database\Schema\Columns\Time;
+use Illuminate\Database\Schema\Columns\Timestamp;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -300,10 +308,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a char type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  CharString  $column
      * @return string
      */
-    protected function typeChar(Fluent $column)
+    protected function typeChar(CharString $column)
     {
         return "nchar({$column->length})";
     }
@@ -311,10 +319,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a string type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  CharString  $column
      * @return string
      */
-    protected function typeString(Fluent $column)
+    protected function typeString(CharString $column)
     {
         return "nvarchar({$column->length})";
     }
@@ -322,10 +330,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string
      */
-    protected function typeText(Fluent $column)
+    protected function typeText(Text $column)
     {
         return 'nvarchar(max)';
     }
@@ -333,10 +341,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a medium text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string
      */
-    protected function typeMediumText(Fluent $column)
+    protected function typeMediumText(Text $column)
     {
         return 'nvarchar(max)';
     }
@@ -344,10 +352,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a long text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string
      */
-    protected function typeLongText(Fluent $column)
+    protected function typeLongText(Text $column)
     {
         return 'nvarchar(max)';
     }
@@ -355,10 +363,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for an integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeInteger(Fluent $column)
+    protected function typeInteger(ColumnInteger $column)
     {
         return 'int';
     }
@@ -366,10 +374,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a big integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeBigInteger(Fluent $column)
+    protected function typeBigInteger(ColumnInteger $column)
     {
         return 'bigint';
     }
@@ -377,10 +385,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a medium integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeMediumInteger(Fluent $column)
+    protected function typeMediumInteger(ColumnInteger $column)
     {
         return 'int';
     }
@@ -388,10 +396,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a tiny integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeTinyInteger(Fluent $column)
+    protected function typeTinyInteger(ColumnInteger $column)
     {
         return 'tinyint';
     }
@@ -399,10 +407,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a small integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string
      */
-    protected function typeSmallInteger(Fluent $column)
+    protected function typeSmallInteger(ColumnInteger $column)
     {
         return 'smallint';
     }
@@ -410,10 +418,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a float type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Decimal  $column
      * @return string
      */
-    protected function typeFloat(Fluent $column)
+    protected function typeFloat(Decimal $column)
     {
         return 'float';
     }
@@ -421,10 +429,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a double type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Decimal  $column
      * @return string
      */
-    protected function typeDouble(Fluent $column)
+    protected function typeDouble(Decimal $column)
     {
         return 'float';
     }
@@ -432,10 +440,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a decimal type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Decimal  $column
      * @return string
      */
-    protected function typeDecimal(Fluent $column)
+    protected function typeDecimal(Decimal $column)
     {
         return "decimal({$column->total}, {$column->places})";
     }
@@ -443,10 +451,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a boolean type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeBoolean(Fluent $column)
+    protected function typeBoolean(Column $column)
     {
         return 'bit';
     }
@@ -454,10 +462,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for an enumeration type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Enum  $column
      * @return string
      */
-    protected function typeEnum(Fluent $column)
+    protected function typeEnum(Enum $column)
     {
         return sprintf(
             'nvarchar(255) check ("%s" in (%s))',
@@ -469,10 +477,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a json type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeJson(Fluent $column)
+    protected function typeJson(Column $column)
     {
         return 'nvarchar(max)';
     }
@@ -480,10 +488,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a jsonb type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeJsonb(Fluent $column)
+    protected function typeJsonb(Column $column)
     {
         return 'nvarchar(max)';
     }
@@ -491,10 +499,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a date type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeDate(Fluent $column)
+    protected function typeDate(Column $column)
     {
         return 'date';
     }
@@ -502,10 +510,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a date-time type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeDateTime(Fluent $column)
+    protected function typeDateTime(Time $column)
     {
         return $column->precision ? "datetime2($column->precision)" : 'datetime';
     }
@@ -513,10 +521,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a date-time (with time zone) type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeDateTimeTz(Fluent $column)
+    protected function typeDateTimeTz(Time $column)
     {
         return $column->precision ? "datetimeoffset($column->precision)" : 'datetimeoffset';
     }
@@ -524,10 +532,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a time type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeTime(Fluent $column)
+    protected function typeTime(Time $column)
     {
         return $column->precision ? "time($column->precision)" : 'time';
     }
@@ -535,10 +543,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a time (with time zone) type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Time  $column
      * @return string
      */
-    protected function typeTimeTz(Fluent $column)
+    protected function typeTimeTz(Time $column)
     {
         return $this->typeTime($column);
     }
@@ -546,10 +554,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a timestamp type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Timestamp  $column
      * @return string
      */
-    protected function typeTimestamp(Fluent $column)
+    protected function typeTimestamp(Timestamp $column)
     {
         $columnType = $column->precision ? "datetime2($column->precision)" : 'datetime';
 
@@ -561,10 +569,10 @@ class SqlServerGrammar extends Grammar
      *
      * @link https://msdn.microsoft.com/en-us/library/bb630289(v=sql.120).aspx
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Timestamp  $column
      * @return string
      */
-    protected function typeTimestampTz(Fluent $column)
+    protected function typeTimestampTz(Timestamp $column)
     {
         if ($column->useCurrent) {
             $columnType = $column->precision ? "datetimeoffset($column->precision)" : 'datetimeoffset';
@@ -578,21 +586,21 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a year type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeYear(Fluent $column)
+    protected function typeYear(Column $column)
     {
-        return $this->typeInteger($column);
+        return 'int';
     }
 
     /**
      * Create the column definition for a binary type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeBinary(Fluent $column)
+    protected function typeBinary(Column $column)
     {
         return 'varbinary(max)';
     }
@@ -600,10 +608,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a uuid type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeUuid(Fluent $column)
+    protected function typeUuid(Column $column)
     {
         return 'uniqueidentifier';
     }
@@ -611,10 +619,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for an IP address type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeIpAddress(Fluent $column)
+    protected function typeIpAddress(Column $column)
     {
         return 'nvarchar(45)';
     }
@@ -622,10 +630,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a MAC address type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    protected function typeMacAddress(Fluent $column)
+    protected function typeMacAddress(Column $column)
     {
         return 'nvarchar(17)';
     }
@@ -633,10 +641,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial Geometry type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeGeometry(Fluent $column)
+    public function typeGeometry(Column $column)
     {
         return 'geography';
     }
@@ -644,10 +652,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial Point type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typePoint(Fluent $column)
+    public function typePoint(Column $column)
     {
         return 'geography';
     }
@@ -655,10 +663,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial LineString type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeLineString(Fluent $column)
+    public function typeLineString(Column $column)
     {
         return 'geography';
     }
@@ -666,10 +674,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial Polygon type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typePolygon(Fluent $column)
+    public function typePolygon(Column $column)
     {
         return 'geography';
     }
@@ -677,10 +685,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial GeometryCollection type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeGeometryCollection(Fluent $column)
+    public function typeGeometryCollection(Column $column)
     {
         return 'geography';
     }
@@ -688,10 +696,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPoint type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeMultiPoint(Fluent $column)
+    public function typeMultiPoint(Column $column)
     {
         return 'geography';
     }
@@ -699,10 +707,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiLineString type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeMultiLineString(Fluent $column)
+    public function typeMultiLineString(Column $column)
     {
         return 'geography';
     }
@@ -710,10 +718,10 @@ class SqlServerGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPolygon type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string
      */
-    public function typeMultiPolygon(Fluent $column)
+    public function typeMultiPolygon(Column $column)
     {
         return 'geography';
     }
@@ -722,10 +730,10 @@ class SqlServerGrammar extends Grammar
      * Get the SQL for a collation column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Text  $column
      * @return string|null
      */
-    protected function modifyCollate(Blueprint $blueprint, Fluent $column)
+    protected function modifyCollate(Blueprint $blueprint, Text $column)
     {
         if (! is_null($column->collation)) {
             return ' collate '.$column->collation;
@@ -736,10 +744,10 @@ class SqlServerGrammar extends Grammar
      * Get the SQL for a nullable column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string|null
      */
-    protected function modifyNullable(Blueprint $blueprint, Fluent $column)
+    protected function modifyNullable(Blueprint $blueprint, Column $column)
     {
         return $column->nullable ? ' null' : ' not null';
     }
@@ -748,10 +756,10 @@ class SqlServerGrammar extends Grammar
      * Get the SQL for a default column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  Column  $column
      * @return string|null
      */
-    protected function modifyDefault(Blueprint $blueprint, Fluent $column)
+    protected function modifyDefault(Blueprint $blueprint, Column $column)
     {
         if (! is_null($column->default)) {
             return ' default '.$this->getDefaultValue($column->default);
@@ -762,10 +770,10 @@ class SqlServerGrammar extends Grammar
      * Get the SQL for an auto-increment column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param  ColumnInteger  $column
      * @return string|null
      */
-    protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
+    protected function modifyIncrement(Blueprint $blueprint, ColumnInteger $column)
     {
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
             return ' identity primary key';

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -89,7 +89,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
     public function testUnsignedDecimalTable()
     {
         $base = new Blueprint('users', function ($table) {
-            $table->unsignedDecimal('money', 10, 2)->useCurrent();
+            $table->unsignedDecimal('money', 10, 2);
         });
 
         $connection = m::mock('Illuminate\Database\Connection');


### PR DESCRIPTION
_This is early preview pull request to show main idea and get feedback. If it looks good I can finish it._

The main idea of changes is to improve Schema builder with explicitly defined classes for column building instead of usage of Fluent. So code is easier to understand because new classes explicitly define possible functionality.

Also IDE can autocomplete possible methods:
![autocomplete1](https://user-images.githubusercontent.com/3708309/35478006-28818938-03e3-11e8-8ee1-ef2533fb72c0.png)

For example text specific methods like charset and collation will be autocompleted only for text column types:
![autocomplete2](https://user-images.githubusercontent.com/3708309/35478013-5e7b57a8-03e3-11e8-93b3-afe659a39c85.png)

For example for integer column type IDE can warn that method does not exist:
![autocomplete3](https://user-images.githubusercontent.com/3708309/35478019-7a01ea00-03e3-11e8-85ba-da3a757bb60a.png)

Because of usage of Fluent for now it is impossible to get such static analyze of code to predict some errors.
