### PR TITLE
[5.5] Fix validation of RFC3339 date format string

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -361,7 +361,7 @@ trait ValidatesAttributes
         $format = $parameters[0];
 
         $date = DateTime::createFromFormat('!'.$format, $value);
-        
+
         /*
          * RFC3339 date format fix.
          */

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -361,6 +361,13 @@ trait ValidatesAttributes
         $format = $parameters[0];
 
         $date = DateTime::createFromFormat('!'.$format, $value);
+        
+        /*
+         * RFC3339 date format fix.
+         */
+        if ($format == \DateTime::RFC3339 && substr($value, -1) == 'Z') {
+            $value = str_replace('Z', '+00:00', $value);
+        }
 
         return $date && $date->format($format) == $value;
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2394,6 +2394,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => '2000-01-01T00:00:00+00:30'], ['x' => 'date_format:Y-m-d\TH:i:sP']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['x' => '2000-01-01T00:00:00Z'], ['x' => 'date_format:Y-m-d\TH:i:sP']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['x' => '2000-01-01 17:43:59'], ['x' => 'date_format:Y-m-d H:i:s']);
         $this->assertTrue($v->passes());
 


### PR DESCRIPTION
Validate RFC3339 formatted dates that ends with 'Z'

Follwing is a valid RFC3339 date but this was not validated properly
2018-01-29T00:30:00Z