### PR TITLE
Fix sqlite exception message

### DIFF
--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -31,7 +31,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         // as the developer probably wants to know if the database exists and this
         // SQLite driver will not throw any exception if it does not by default.
         if ($path === false) {
-            throw new InvalidArgumentException("Database (${config['database']}) does not exist.");
+            throw new InvalidArgumentException("Database ({$config['database']}) does not exist.");
         }
 
         return $this->createConnection("sqlite:{$path}", $config, $options);


### PR DESCRIPTION
- Laravel Version: 5.5.28

### Description:
I just find an error of an sqlite exception message and fix it.         
`
if ($path === false) {
    throw new InvalidArgumentException("Database (${config['database']}) does not exist.");		            
}
`
`