### PR TITLE
[5.6] Pass missed level to log method

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -557,7 +557,7 @@ class LogManager implements LoggerInterface
      */
     public function log($level, $message, array $context = [])
     {
-        return $this->driver()->log($message, $context);
+        return $this->driver()->log($level, $message, $context);
     }
 
     /**


### PR DESCRIPTION
- Laravel Version: 5.6-dev

### Description:
I just pass the missed $level argument into the log method.
`php
public function log($level, $message, array $context = [])
{
    return $this->driver()->log($message, $context); // Missing the $level argument
}
`
