### PR TITLE
Migrations which create indexes on many columns could fail with an error

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -215,6 +215,10 @@ class MySqlGrammar extends Grammar
      */
     protected function compileKey(Blueprint $blueprint, Fluent $command, $type)
     {
+        if ($type === 'index' && strlen($command->index) > 64) {
+            $command->index = substr($command->index, 0, 64);
+        }
+
         return sprintf('alter table %s add %s %s%s(%s)',
             $this->wrapTable($blueprint),
             $type,

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -215,7 +215,7 @@ class MySqlGrammar extends Grammar
      */
     protected function compileKey(Blueprint $blueprint, Fluent $command, $type)
     {
-        if ($type === 'index' && strlen($command->index) > 64) {
+        if (strlen($command->index) > 64) {
             $command->index = substr($command->index, 0, 64);
         }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -126,6 +126,10 @@ class PostgresGrammar extends Grammar
      */
     public function compileIndex(Blueprint $blueprint, Fluent $command)
     {
+        if (strlen($command->index) > 63) {
+            $command->index = substr($command->index, 0, 63);
+        }
+
         return sprintf('create index %s on %s%s (%s)',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -318,6 +318,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add index `baz` using hash(`foo`, `bar`)', $statements[0]);
     }
 
+    public function testAddingLongIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo', 'bar', 'baz', 'quux', 'thud', 'grunt', 'fum', 'corge', 'grault', 'flarp', 'zxc', 'spqr', 'wombat']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add index `users_foo_bar_baz_quux_thud_grunt_fum_corge_grault_flarp_zxc_spq`(`foo`, `bar`, `baz`, `quux`, `thud`, `grunt`, `fum`, `corge`, `grault`, `flarp`, `zxc`, `spqr`, `wombat`)', $statements[0]);
+    }
+
     public function testAddingSpatialIndex()
     {
         $blueprint = new Blueprint('geo');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -213,6 +213,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
+    public function testAddingLongIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo', 'bar', 'baz', 'quux', 'thud', 'grunt', 'fum', 'corge', 'grault', 'flarp', 'zxc', 'spqr', 'wombat']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('create index "users_foo_bar_baz_quux_thud_grunt_fum_corge_grault_flarp_zxc_sp" on "users" ("foo", "bar", "baz", "quux", "thud", "grunt", "fum", "corge", "grault", "flarp", "zxc", "spqr", "wombat")', $statements[0]);
+    }
+
     public function testAddingIndexWithAlgorithm()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
MySql and Postgres have built in limits on the number of characters that can be used for an index name. This checks for index names that are longer than those limits and truncates the name of the index to those limits.

Tests included.