### PR TITLE
[5.6] Automatically map the owner model's key to the related's foreign key.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -144,11 +144,6 @@ trait GuardsAttributes
             return true;
         }
 
-        // If there's a method, chances are it's a relationship.
-        if (method_exists($this, $key)) {
-            return true;
-        }
-
         // If the attribute is explicitly listed in the "guarded" array then we can
         // return false immediately. This means this attribute is definitely not
         // fillable and there is no point in going any further in this method.

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -144,6 +144,11 @@ trait GuardsAttributes
             return true;
         }
 
+        // If there's a method, chances are it's a relationship.
+        if (method_exists($this, $key)) {
+            return true;
+        }
+
         // If the attribute is explicitly listed in the "guarded" array then we can
         // return false immediately. This means this attribute is definitely not
         // fillable and there is no point in going any further in this method.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,16 +2,16 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 
 trait HasAttributes
@@ -80,7 +80,7 @@ trait HasAttributes
     protected static $mutatorCache = [];
 
     /**
-     * Caches the keys that have been already checked for a relationship
+     * Caches the keys that have been already checked for a relationship.
      *
      * @var array
      */
@@ -541,11 +541,14 @@ trait HasAttributes
             $value = $this->fromDateTime($value);
         }
 
-        if (! in_array($key, $this->dontSetRelationValue) && method_exists($this, $key)) {
-            $this->dontSetRelationValue[] = $key;
+        if (empty($this->dontSetRelationValue[$key]) && method_exists($this, $key)) {
+            $this->dontSetRelationValue[$key] = true;
 
             try {
-                return $this->setRelationValue($key, $value);
+                $this->setRelationValue($key, $value);
+                $this->dontSetRelationValue[$key] = false;
+
+                return $this;
             } catch (LogicException $e) {
                 // ignore.
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -544,13 +544,18 @@ trait HasAttributes
         if (empty($this->dontSetRelationValue[$key]) && method_exists($this, $key)) {
             $this->dontSetRelationValue[$key] = true;
 
-            try {
-                $this->setRelationValue($key, $value);
-                $this->dontSetRelationValue[$key] = false;
+            // Here we will determine if the model base class itself contains this given key
+            // since we don't want to treat any of those methods as relationships because
+            // they are all intended as helper methods and none of these are relations.
+            if (! method_exists(self::class, $key)) {
+                try {
+                    $this->setRelationValue($key, $value);
+                    $this->dontSetRelationValue[$key] = false;
 
-                return $this;
-            } catch (LogicException $e) {
-                // ignore.
+                    return $this;
+                } catch (LogicException $e) {
+                    // ignore.
+                }
             }
         }
 
@@ -581,13 +586,6 @@ trait HasAttributes
      */
     public function setRelationValue($key, $value)
     {
-        // Here we will determine if the model base class itself contains this given key
-        // since we don't want to treat any of those methods as relationships because
-        // they are all intended as helper methods and none of these are relations.
-        if (method_exists(self::class, $key)) {
-            return $this;
-        }
-
         $relation = $this->$key();
 
         if (! $relation instanceof BelongsTo) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -563,10 +563,6 @@ trait HasAttributes
      */
     public function setRelationValue($key, $value)
     {
-        if ($value instanceof Model) {
-            $value = $value->getKey();
-        }
-
         $relation = $this->$key();
 
         if (! $relation instanceof BelongsTo) {
@@ -574,7 +570,7 @@ trait HasAttributes
             throw new LogicException(get_class($this).'::'.$key.' must return a \'belongs-to\'relationship instance.');
         }
 
-        $this->setAttribute($relation->getForeignKey(), $value);
+        $relation->associate($value);
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -581,6 +581,13 @@ trait HasAttributes
      */
     public function setRelationValue($key, $value)
     {
+        // Here we will determine if the model base class itself contains this given key
+        // since we don't want to treat any of those methods as relationships because
+        // they are all intended as helper methods and none of these are relations.
+        if (method_exists(self::class, $key)) {
+            return $this;
+        }
+
         $relation = $this->$key();
 
         if (! $relation instanceof BelongsTo) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -7,7 +7,6 @@ use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
@@ -578,10 +577,10 @@ trait HasAttributes
     /**
      * Set a given foreign model by mapping it's primary key to this model's foreign key.
      *
-     * This only works to "belongs-to" and "morphs-to" relationships.
+     * This only works with "belongs-to" and "morphs-to" relationships.
      *
      * @param  string  $key
-     * @param  Model|mixed  $value
+     * @param  mixed  $value
      * @return $this
      */
     public function setRelationValue($key, $value)

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -173,6 +173,16 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation->addEagerConstraints($models);
     }
 
+    public function testModelKeyDirectlyMapsToOwnersForeignKey()
+    {
+        $parent = new EloquentBelongsToModelStub();
+        $parent->_relation = $this->getRelation($parent, false);
+        $this->related->shouldReceive('getKey')->andReturn('another.foreign.value');
+        $parent->relation = $this->related;
+
+        $this->assertEquals('another.foreign.value', $parent->getAttribute('foreign_key'));
+    }
+
     protected function getRelation($parent = null, $incrementing = true, $keyType = 'int')
     {
         $this->builder = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -193,6 +203,13 @@ class DatabaseEloquentBelongsToTest extends TestCase
 class EloquentBelongsToModelStub extends \Illuminate\Database\Eloquent\Model
 {
     public $foreign_key = 'foreign.value';
+
+    public $_relation;
+
+    public function relation()
+    {
+        return $this->_relation;
+    }
 }
 
 class AnotherEloquentBelongsToModelStub extends \Illuminate\Database\Eloquent\Model

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -175,7 +175,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     public function testModelKeyDirectlyMapsToOwnersForeignKey()
     {
-        $parent = new EloquentBelongsToModelStub();
+        $parent = new EloquentBelongsToModelStubWithRelation();
         $parent->_relation = $this->getRelation($parent, false);
         $this->related->shouldReceive('getAttribute')->with('id')->andReturn('another.foreign.value');
         $parent->relation = $this->related;
@@ -203,13 +203,6 @@ class DatabaseEloquentBelongsToTest extends TestCase
 class EloquentBelongsToModelStub extends \Illuminate\Database\Eloquent\Model
 {
     public $foreign_key = 'foreign.value';
-
-    public $_relation;
-
-    public function relation()
-    {
-        return $this->_relation;
-    }
 }
 
 class AnotherEloquentBelongsToModelStub extends \Illuminate\Database\Eloquent\Model
@@ -225,4 +218,18 @@ class EloquentBelongsToModelStubWithZeroId extends \Illuminate\Database\Eloquent
 class MissingEloquentBelongsToModelStub extends \Illuminate\Database\Eloquent\Model
 {
     public $foreign_key;
+}
+
+class EloquentBelongsToModelStubWithRelation extends \Illuminate\Database\Eloquent\Model
+{
+    public $_relation;
+
+    protected $attributes = [
+        'foreign_key' => 'foreign.value',
+    ];
+
+    public function relation()
+    {
+        return $this->_relation;
+    }
 }

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -177,7 +177,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
     {
         $parent = new EloquentBelongsToModelStub();
         $parent->_relation = $this->getRelation($parent, false);
-        $this->related->shouldReceive('getKey')->andReturn('another.foreign.value');
+        $this->related->shouldReceive('getAttribute')->with('id')->andReturn('another.foreign.value');
         $parent->relation = $this->related;
 
         $this->assertEquals('another.foreign.value', $parent->getAttribute('foreign_key'));


### PR DESCRIPTION
## Use Case
In a scenario like this:
```yaml
users:
    - id
    ...

threads:
    - id
    - user_id
    ...
```

Every thread can have an owner, with the following relationship:
```php
public function user()
{
    return $this->belongsTo(User::class);
}
```

To set the owner of a thread, you have to do something like:
```php
$thread->user_id = $user->id;
OR
$thread->user()->associate($user);
```

With this PR, something like these are also valid:
```php
$thread->user = $user;
OR
$thread->fill(['user' => $user, ...]);
```

## Benefits
This would allow devs to write less in these kind of situation and the syntax is easily understandable.

### But Why?
If one can fetch a relation by calling `$user = $thread->user` then one would like to have the ability to set a relation by calling `$thread->user = $user`.

## Issues
Issues that might arise in situations like these:
- The foreign key's name is the same as the name of the method for the relationship.
- There's a different column whose name is the same as a method for the model.

**_Which has been patched._**