### PR TITLE
[5.7] Redis events

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -28,7 +28,7 @@ trait InteractsWithRedis
      */
     public function setUpRedis()
     {
-        $app = new Application;
+        $app = $this->app ?? new Application;
         $host = getenv('REDIS_HOST') ?: '127.0.0.1';
         $port = getenv('REDIS_PORT') ?: 6379;
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Redis\RedisManager;
+use Illuminate\Foundation\Application;
 
 trait InteractsWithRedis
 {
@@ -27,6 +28,7 @@ trait InteractsWithRedis
      */
     public function setUpRedis()
     {
+        $app = new Application;
         $host = getenv('REDIS_HOST') ?: '127.0.0.1';
         $port = getenv('REDIS_PORT') ?: 6379;
 
@@ -37,7 +39,7 @@ trait InteractsWithRedis
         }
 
         foreach ($this->redisDriverProvider() as $driver) {
-            $this->redis[$driver[0]] = new RedisManager($driver[0], [
+            $this->redis[$driver[0]] = new RedisManager($app, $driver[0], [
                 'cluster' => false,
                 'default' => [
                     'host' => $host,

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -19,6 +19,13 @@ abstract class Connection
     protected $client;
 
     /**
+     * The Redis connection name.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
      * Subscribe to a set of given channels for messages.
      *
      * @param  array|string  $channels
@@ -94,6 +101,27 @@ abstract class Connection
     public function command($method, array $parameters = [])
     {
         return $this->client->{$method}(...$parameters);
+    /**
+     * Get the connection name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set the connections name.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -187,6 +187,16 @@ abstract class Connection
     }
 
     /**
+     * Unset the event dispatcher instance on the connection.
+     *
+     * @return void
+     */
+    public function unsetEventDispatcher()
+    {
+        $this->events = null;
+    }
+
+    /**
      * Pass other method calls down to the underlying client.
      *
      * @param  string  $method

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -109,7 +109,14 @@ abstract class Connection
      */
     public function command($method, array $parameters = [])
     {
-        return $this->client->{$method}(...$parameters);
+        $start = microtime(true);
+        $result = $this->client->{$method}(...$parameters);
+        $time = round((microtime(true) - $start) * 1000, 2);
+
+        $this->event(new QueryExecuted($method, $parameters, $time, $this));
+
+        return $result;
+    }
 
     /**
      * Fire the given event if possible.

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -113,7 +113,9 @@ abstract class Connection
         $result = $this->client->{$method}(...$parameters);
         $time = round((microtime(true) - $start) * 1000, 2);
 
-        $this->event(new QueryExecuted($method, $parameters, $time, $this));
+        if (isset($this->events)) {
+            $this->event(new QueryExecuted($method, $parameters, $time, $this));
+        }
 
         return $result;
     }

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -404,8 +404,6 @@ class PhpRedisConnection extends Connection
      */
     public function __call($method, $parameters)
     {
-        $method = strtolower($method);
-
-        return parent::__call($method, $parameters);
+        return parent::__call(strtolower($method), $parameters);
     }
 }

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -29,7 +29,7 @@ class PhpRedisConnection extends Connection
      */
     public function get($key)
     {
-        $result = $this->client->get($key);
+        $result = $this->command('get', [$key]);
 
         return $result !== false ? $result : null;
     }
@@ -44,7 +44,7 @@ class PhpRedisConnection extends Connection
     {
         return array_map(function ($value) {
             return $value !== false ? $value : null;
-        }, $this->client->mget($keys));
+        }, $this->command('mget', $keys));
     }
 
     /**
@@ -90,7 +90,7 @@ class PhpRedisConnection extends Connection
      */
     public function setnx($key, $value)
     {
-        return (int) $this->client->setnx($key, $value);
+        return (int) $this->command('setnx', [$key, $value]);
     }
 
     /**
@@ -139,7 +139,7 @@ class PhpRedisConnection extends Connection
      */
     public function hsetnx($hash, $key, $value)
     {
-        return (int) $this->client->hsetnx($hash, $key, $value);
+        return (int) $this->command('hsetnx', [$hash, $key, $value]);
     }
 
     /**
@@ -240,10 +240,10 @@ class PhpRedisConnection extends Connection
      */
     public function zinterstore($output, $keys, $options = [])
     {
-        return $this->zInter($output, $keys,
+        return $this->command('zInter', [$output, $keys,
             $options['weights'] ?? null,
-            $options['aggregate'] ?? 'sum'
-        );
+            $options['aggregate'] ?? 'sum',
+        ]);
     }
 
     /**
@@ -256,10 +256,10 @@ class PhpRedisConnection extends Connection
      */
     public function zunionstore($output, $keys, $options = [])
     {
-        return $this->zUnion($output, $keys,
+        return $this->command('zUnion', [$output, $keys,
             $options['weights'] ?? null,
-            $options['aggregate'] ?? 'sum'
-        );
+            $options['aggregate'] ?? 'sum',
+        ]);
     }
 
     /**
@@ -317,7 +317,7 @@ class PhpRedisConnection extends Connection
      */
     public function eval($script, $numberOfKeys, ...$arguments)
     {
-        return $this->client->eval($script, $arguments, $numberOfKeys);
+        return $this->command('eval', [$script, $arguments, $numberOfKeys]);
     }
 
     /**

--- a/src/Illuminate/Redis/Events/QueryExecuted.php
+++ b/src/Illuminate/Redis/Events/QueryExecuted.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Redis\Events;
+
+class QueryExecuted
+{
+    /**
+     * The Redis command that was executed.
+     *
+     * @var string
+     */
+    public $command;
+
+    /**
+     * The array of query parameters.
+     *
+     * @var array
+     */
+    public $parameters;
+
+    /**
+     * The number of milliseconds it took to execute the query.
+     *
+     * @var float
+     */
+    public $time;
+
+    /**
+     * The Redis connection instance.
+     *
+     * @var \Illuminate\Redis\Connections\Connection
+     */
+    public $connection;
+
+    /**
+     * The Redis connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $command
+     * @param  array  $parameters
+     * @param  float|null  $time
+     * @param  \Illuminate\Redis\Connections\Connection  $connection
+     * @return void
+     */
+    public function __construct($command, $parameters, $time, $connection)
+    {
+        $this->time = $time;
+        $this->command = $command;
+        $this->parameters = $parameters;
+        $this->connection = $connection;
+        $this->connectionName = $connection->getName();
+    }
+}

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -91,9 +91,10 @@ class ConcurrencyLimiter
             return $this->name.$i;
         }, range(1, $this->maxLocks));
 
-        return $this->redis->eval($this->luaScript(), count($slots),
-            ...array_merge($slots, [$this->name, $this->releaseAfter])
-        );
+        return $this->redis->command('eval', array_merge(
+            [$this->luaScript(), count($slots)],
+            array_merge($slots, [$this->name, $this->releaseAfter])
+        ));
     }
 
     /**
@@ -125,6 +126,6 @@ LUA;
      */
     protected function release($key)
     {
-        $this->redis->del($key);
+        $this->redis->command('del', [$key]);
     }
 }

--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -99,9 +99,9 @@ class DurationLimiter
      */
     public function acquire()
     {
-        $results = $this->redis->eval($this->luaScript(), 1,
-            $this->name, microtime(true), time(), $this->decay, $this->maxLocks
-        );
+        $results = $this->redis->command('eval', [
+            $this->luaScript(), 1, $this->name, microtime(true), time(), $this->decay, $this->maxLocks,
+        ]);
 
         $this->decaysAt = $results[1];
 

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -11,6 +11,13 @@ use Illuminate\Contracts\Redis\Factory;
 class RedisManager implements Factory
 {
     /**
+     * The application instance.
+     *
+     * @var \Illuminate\Foundation\Application
+     */
+    protected $app;
+
+    /**
      * The name of the default driver.
      *
      * @var string
@@ -34,12 +41,14 @@ class RedisManager implements Factory
     /**
      * Create a new Redis manager instance.
      *
+     * @param  \Illuminate\Foundation\Application  $app
      * @param  string  $driver
      * @param  array  $config
      * @return void
      */
-    public function __construct($driver, array $config)
+    public function __construct($app, $driver, array $config)
     {
+        $this->app = $app;
         $this->driver = $driver;
         $this->config = $config;
     }

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -4,6 +4,7 @@ namespace Illuminate\Redis;
 
 use InvalidArgumentException;
 use Illuminate\Contracts\Redis\Factory;
+use Illuminate\Redis\Connections\Connection;
 
 /**
  * @mixin \Illuminate\Redis\Connections\Connection
@@ -67,7 +68,9 @@ class RedisManager implements Factory
             return $this->connections[$name];
         }
 
-        return $this->connections[$name] = $this->resolve($name);
+        return $this->connections[$name] = $this->configure(
+            $this->resolve($name), $name
+        );
     }
 
     /**
@@ -125,6 +128,20 @@ class RedisManager implements Factory
             case 'phpredis':
                 return new Connectors\PhpRedisConnector;
         }
+    }
+
+    /**
+     * Get the connector instance for the current driver.
+     *
+     * @param  \Illuminate\Redis\Connections\Connection  $connection
+     * @param  string  $name
+     * @return \Illuminate\Redis\Connections\Connection
+     */
+    protected function configure(Connection $connection, $name)
+    {
+        $connection->setName($name);
+
+        return $connection;
     }
 
     /**

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -141,6 +141,10 @@ class RedisManager implements Factory
     {
         $connection->setName($name);
 
+        if ($this->app->bound('events')) {
+            $connection->setEventDispatcher($this->app['events']);
+        }
+
         return $connection;
     }
 

--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -24,7 +24,7 @@ class RedisServiceProvider extends ServiceProvider
         $this->app->singleton('redis', function ($app) {
             $config = $app->make('config')->get('database.redis');
 
-            return new RedisManager(Arr::pull($config, 'client', 'predis'), $config);
+            return new RedisManager($app, Arr::pull($config, 'client', 'predis'), $config);
         });
 
         $this->app->bind('redis.connection', function ($app) {

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -32,7 +32,7 @@ class ThrottleRequestsWithRedisTest extends TestCase
         $this->ifRedisAvailable(function () {
             Carbon::setTestNow(null);
 
-            resolve('redis')->flushAll();
+            $this->app['redis']->flushAll();
 
             Route::get('/', function () {
                 return 'yes';

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Redis;
 
 use PHPUnit\Framework\TestCase;
 use Illuminate\Redis\RedisManager;
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 
 class RedisConnectionTest extends TestCase
@@ -584,7 +585,7 @@ class RedisConnectionTest extends TestCase
             $host = getenv('REDIS_HOST') ?: '127.0.0.1';
             $port = getenv('REDIS_PORT') ?: 6379;
 
-            $prefixedPhpredis = new RedisManager('phpredis', [
+            $prefixedPhpredis = new RedisManager(new Application, 'phpredis', [
                 'cluster' => false,
                 'default' => [
                     'host' => $host,


### PR DESCRIPTION
This is PR adds a `QueryExecuted` event to the Redis connections. I tried to keep this identical to what the database component is doing.

The only breaking change is that `RedisManager` constructor has changed and now requires a `Application` instance, just like `DatabaseManager` does. I thought that is more flexible than just passing in an event dispatcher.