### PR TITLE
[5.5] Improve tests of test Fakes

### DIFF
--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -3,11 +3,11 @@
 namespace Illuminate\Tests\Support;
 
 use Mockery as m;
-use PHPUnit\Framework\Constraint\ExceptionMessage;
-use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Testing\Fakes\EventFake;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\Constraint\ExceptionMessage;
 
 class SupportTestingEventFakeTest extends TestCase
 {

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Support;
 
 use Mockery as m;
+use PHPUnit\Framework\Constraint\ExceptionMessage;
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Testing\Fakes\EventFake;
@@ -17,46 +19,60 @@ class SupportTestingEventFakeTest extends TestCase
 
     public function testAssertDispacthed()
     {
+        try {
+            $this->fake->assertDispatched(EventStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\EventStub] event was not dispatched.'));
+        }
+
         $this->fake->dispatch(EventStub::class);
 
         $this->fake->assertDispatched(EventStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\EventStub] event was dispatched 2 times instead of 1 times.
-     */
     public function testAssertDispatchedWithCallbackInt()
     {
         $this->fake->dispatch(EventStub::class);
         $this->fake->dispatch(EventStub::class);
 
+        try {
+            $this->fake->assertDispatched(EventStub::class, 1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\EventStub] event was dispatched 2 times instead of 1 times.'));
+        }
+
         $this->fake->assertDispatched(EventStub::class, 2);
-        $this->fake->assertDispatched(EventStub::class, 1);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\EventStub] event was dispatched 2 times instead of 1 times.
-     */
     public function testAssertDispatchedTimes()
     {
         $this->fake->dispatch(EventStub::class);
         $this->fake->dispatch(EventStub::class);
 
+        try {
+            $this->fake->assertDispatchedTimes(EventStub::class, 1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\EventStub] event was dispatched 2 times instead of 1 times.'));
+        }
+
         $this->fake->assertDispatchedTimes(EventStub::class, 2);
-        $this->fake->assertDispatchedTimes(EventStub::class, 1);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The unexpected [Illuminate\Tests\Support\EventStub] event was dispatched.
-     */
     public function testAssertNotDispatched()
     {
+        $this->fake->assertNotDispatched(EventStub::class);
+
         $this->fake->dispatch(EventStub::class);
 
-        $this->fake->assertNotDispatched(EventStub::class);
+        try {
+            $this->fake->assertNotDispatched(EventStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\EventStub] event was dispatched.'));
+        }
     }
 }
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -6,6 +6,8 @@ use Illuminate\Mail\Mailable;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Testing\Fakes\MailFake;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\Constraint\ExceptionMessage;
 
 class MailFakeTest extends TestCase
 {
@@ -16,94 +18,104 @@ class MailFakeTest extends TestCase
         $this->mailable = new MailableStub;
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\MailableStub] mailable was not sent.
-     */
     public function testAssertSent()
     {
-        $this->fake->assertSent(MailableStub::class);
+        try {
+            $this->fake->assertSent(MailableStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\MailableStub] mailable was not sent.'));
+        }
 
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
         $this->fake->assertSent(MailableStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The unexpected [Illuminate\Tests\Support\MailableStub] mailable was sent.
-     */
     public function testAssertNotSent()
     {
         $this->fake->assertNotSent(MailableStub::class);
 
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
-        $this->fake->assertNotSent(MailableStub::class);
+        try {
+            $this->fake->assertNotSent(MailableStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\MailableStub] mailable was sent.'));
+        }
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\MailableStub] mailable was sent 2 times instead of 1 times.
-     */
     public function testAssertSentTimes()
     {
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
-        $this->fake->assertSent(MailableStub::class, 1);
+        try {
+            $this->fake->assertSent(MailableStub::class, 1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\MailableStub] mailable was sent 2 times instead of 1 times.'));
+        }
+
         $this->fake->assertSent(MailableStub::class, 2);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\MailableStub] mailable was not queued.
-     */
     public function testAssertQueued()
     {
-        $this->fake->assertQueued(MailableStub::class);
+        try {
+            $this->fake->assertQueued(MailableStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\MailableStub] mailable was not queued.'));
+        }
 
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
 
         $this->fake->assertQueued(MailableStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\MailableStub] mailable was queued 2 times instead of 1 times.
-     */
     public function testAssertQueuedTimes()
     {
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
 
-        $this->fake->assertQueued(MailableStub::class, 1);
+        try {
+            $this->fake->assertQueued(MailableStub::class, 1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\MailableStub] mailable was queued 2 times instead of 1 times.'));
+        }
+
         $this->fake->assertQueued(MailableStub::class, 2);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\QueueableMailableStub] mailable was not sent.
-     */
     public function testSendQueuesAMailableThatShouldBeQueued()
     {
         $this->fake->to('taylor@laravel.com')->send(new QueueableMailableStub);
 
-        $this->fake->assertSent(QueueableMailableStub::class);
         $this->fake->assertQueued(QueueableMailableStub::class);
+
+        try {
+            $this->fake->assertSent(QueueableMailableStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\QueueableMailableStub] mailable was not sent.'));
+        }
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage Mailables were sent unexpectedly.
-     */
     public function testAssertNothingSent()
     {
         $this->fake->assertNothingSent();
 
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
-        $this->fake->assertNothingSent();
+        try {
+            $this->fake->assertNothingSent();
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('Mailables were sent unexpectedly.'));
+        }
     }
 }
 

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Support;
 
-use PHPUnit\Framework\Constraint\ExceptionMessage;
-use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Notifications\Notification;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\Constraint\ExceptionMessage;
 use Illuminate\Support\Testing\Fakes\NotificationFake;
 
 class NotificationFakeTest extends TestCase

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Support;
 
+use PHPUnit\Framework\Constraint\ExceptionMessage;
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Notifications\Notification;
@@ -17,30 +19,32 @@ class NotificationFakeTest extends TestCase
         $this->user = new UserStub;
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\NotificationStub] notification was not sent.
-     */
     public function testAssertSentTo()
     {
-        $this->fake->assertSentTo($this->user, NotificationStub::class);
+        try {
+            $this->fake->assertSentTo($this->user, NotificationStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\NotificationStub] notification was not sent.'));
+        }
 
         $this->fake->send($this->user, new NotificationStub);
 
         $this->fake->assertSentTo($this->user, NotificationStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The unexpected [Illuminate\Tests\Support\NotificationStub] notification was sent.
-     */
     public function testAssertNotSentTo()
     {
         $this->fake->assertNotSentTo($this->user, NotificationStub::class);
 
         $this->fake->send($this->user, new NotificationStub);
 
-        $this->fake->assertNotSentTo($this->user, NotificationStub::class);
+        try {
+            $this->fake->assertNotSentTo($this->user, NotificationStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\NotificationStub] notification was sent.'));
+        }
     }
 }
 

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Support;
 
-use PHPUnit\Framework\Constraint\ExceptionMessage;
-use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Testing\Fakes\QueueFake;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\Constraint\ExceptionMessage;
 
 class QueueFakeTest extends TestCase
 {

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Support;
 
+use PHPUnit\Framework\Constraint\ExceptionMessage;
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Testing\Fakes\QueueFake;
@@ -15,70 +17,75 @@ class QueueFakeTest extends TestCase
         $this->job = new JobStub;
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\JobStub] job was not pushed.
-     */
     public function testAssertPushed()
     {
-        $this->fake->assertPushed(JobStub::class);
+        try {
+            $this->fake->assertPushed(JobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\JobStub] job was not pushed.'));
+        }
 
         $this->fake->push($this->job);
 
         $this->fake->assertPushed(JobStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The unexpected [Illuminate\Tests\Support\JobStub] job was pushed.
-     */
     public function testAssertNotPushed()
     {
         $this->fake->assertNotPushed(JobStub::class);
 
         $this->fake->push($this->job);
 
-        $this->fake->assertNotPushed(JobStub::class);
+        try {
+            $this->fake->assertNotPushed(JobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\JobStub] job was pushed.'));
+        }
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\JobStub] job was not pushed.
-     */
     public function testAssertPushedOn()
     {
         $this->fake->push($this->job, '', 'foo');
 
-        $this->fake->assertPushedOn('bar', JobStub::class);
+        try {
+            $this->fake->assertPushedOn('bar', JobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\JobStub] job was not pushed.'));
+        }
 
         $this->fake->assertPushedOn('foo', JobStub::class);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\JobStub] job was pushed 2 times instead of 1 times.
-     */
     public function testAssertPushedTimes()
     {
         $this->fake->push($this->job);
         $this->fake->push($this->job);
 
-        $this->fake->assertPushed(JobStub::class, 1);
+        try {
+            $this->fake->assertPushed(JobStub::class, 1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\JobStub] job was pushed 2 times instead of 1 times.'));
+        }
 
         $this->fake->assertPushed(JobStub::class, 2);
     }
 
-    /**
-     * @expectedException PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage Jobs were pushed unexpectedly.
-     */
     public function testAssertNothingPushed()
     {
         $this->fake->assertNothingPushed();
 
         $this->fake->push($this->job);
 
-        $this->fake->assertNothingPushed();
+        try {
+            $this->fake->assertNothingPushed();
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('Jobs were pushed unexpectedly.'));
+        }
     }
 }
 


### PR DESCRIPTION
The current implementation for `Illuminate\Tests\Support\MailFakeTest::testAssertSent` is

```php
/**
 * @expectedException PHPUnit\Framework\ExpectationFailedException
 * @expectedExceptionMessage The expected [Illuminate\Tests\Support\MailableStub] mailable was not sent.
 */
public function testAssertSent()
{
    $this->fake->assertSent(MailableStub::class);

    $this->fake->to('taylor@laravel.com')->send($this->mailable);

    $this->fake->assertSent(MailableStub::class);
}
```

This implementation fails to test the path where the assertion passes, since the first line will fail, which will satisfy the annotated expected exception. The remaining lines are always unreachable code, they serve no purpose but confusing the reader of the test.

Furthermore, it is not possible for the reader of the test to tell if the exception was thrown in line 1 or 3 of the method.

Using these annotations, in my opinion, doesn't give enough control for testing both the passing and failing scenarios in the same test.

Compare with

```php
public function testAssertSent()
{
    try {
        $this->fake->assertSent(MailableStub::class);
        $this->fail();
    } catch (ExpectationFailedException $e) {
        $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\MailableStub] mailable was not sent.'));
    }

    $this->fake->to('taylor@laravel.com')->send($this->mailable);

    $this->fake->assertSent(MailableStub::class);
}
```

where `try` / `catch`, together with the explicit call to `fail()`, will ensure that the exception is thrown at the expected place, allowing the execution of the rest of the method.

The same idea is applied in

- `Illuminate\Tests\Support\MailFakeTest`
- `Illuminate\Tests\Support\NotificationFakeTest`
- `Illuminate\Tests\Support\QueueFakeTest`
- `Illuminate\Tests\Support\SupportTestingEventFakeTest`
