### PR TITLE
[5.6] Container alias accept array

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -466,14 +466,16 @@ class Container implements ArrayAccess, ContainerContract
      * Alias a type to a different name.
      *
      * @param  string  $abstract
-     * @param  string  $alias
+     * @param  string|array  $aliases
      * @return void
      */
-    public function alias($abstract, $alias)
+    public function alias($abstract, $aliases)
     {
-        $this->aliases[$alias] = $abstract;
+        foreach ((array) $aliases as $alias) {
+            $this->aliases[$alias] = $abstract;
 
-        $this->abstractAliases[$abstract][] = $alias;
+            $this->abstractAliases[$abstract][] = $alias;
+        }
     }
 
     /**

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -19,10 +19,10 @@ interface Container extends ContainerInterface
      * Alias a type to a different name.
      *
      * @param  string  $abstract
-     * @param  string  $alias
+     * @param  string|array  $aliases
      * @return void
      */
-    public function alias($abstract, $alias);
+    public function alias($abstract, $aliases);
 
     /**
      * Assign a set of tags to a given binding.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1156,9 +1156,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'validator'            => [\Illuminate\Validation\Factory::class, \Illuminate\Contracts\Validation\Factory::class],
             'view'                 => [\Illuminate\View\Factory::class, \Illuminate\Contracts\View\Factory::class],
         ] as $key => $aliases) {
-            foreach ($aliases as $alias) {
-                $this->alias($key, $alias);
-            }
+            $this->alias($key, $aliases);
         }
     }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -131,6 +131,10 @@ class ContainerTest extends TestCase
         $this->assertEquals('bar', $container->make('foo'));
         $this->assertEquals('bar', $container->make('baz'));
         $this->assertEquals('bar', $container->make('bat'));
+
+        $container->alias('foo', ['foo1', 'foo2']);
+        $this->assertEquals('bar', $container->make('foo1'));
+        $this->assertEquals('bar', $container->make('foo2'));
     }
 
     public function testAliasesWithArrayOfParameters()


### PR DESCRIPTION
- Laravel Version: *
- PHP Version: *
- Database Driver & Version: *

### Description:
I think if the container alias method accepts the second argument as an array, it will be more convenient for registering an alias service. Of course, everything works normally with a single string as it has done before.

### Steps To Reproduce:
As the current way framework is using:
```php
// Illuminate\Foundation\Application::registerCoreContainerAliases
foreach ($services as $key => $aliases) {
    foreach ($aliases as $alias) {
        $this->alias($key, $alias);
    }
}
```
We can use this way instead:
```php
foreach ($services as $key => $aliases) {
    $this->alias($key, $aliases);
}
```