### PR TITLE
[5.6] Change Resource name away from soft-reserved name

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Resources\DelegatesToResource;
 use Illuminate\Http\Resources\ConditionallyLoadsAttributes;
 
-class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutable
+class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutable
 {
     use ConditionallyLoadsAttributes, DelegatesToResource;
 

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -6,7 +6,7 @@ use IteratorAggregate;
 use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Http\Resources\CollectsResources;
 
-class ResourceCollection extends Resource implements IteratorAggregate
+class ResourceCollection extends JsonResource implements IteratorAggregate
 {
     use CollectsResources;
 

--- a/tests/Integration/Http/Fixtures/AuthorResource.php
+++ b/tests/Integration/Http/Fixtures/AuthorResource.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Http\Fixtures;
 
-use Illuminate\Http\Resources\Json\Resource;
+use Illuminate\Http\Resources\Json\JsonResource;
 
-class AuthorResource extends Resource
+class AuthorResource extends JsonResource
 {
     public function toArray($request)
     {

--- a/tests/Integration/Http/Fixtures/PostResource.php
+++ b/tests/Integration/Http/Fixtures/PostResource.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Http\Fixtures;
 
-use Illuminate\Http\Resources\Json\Resource;
+use Illuminate\Http\Resources\Json\JsonResource;
 
-class PostResource extends Resource
+class PostResource extends JsonResource
 {
     public function toArray($request)
     {

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalData.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalData.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Http\Fixtures;
 
-use Illuminate\Http\Resources\Json\Resource;
+use Illuminate\Http\Resources\Json\JsonResource;
 
-class PostResourceWithOptionalData extends Resource
+class PostResourceWithOptionalData extends JsonResource
 {
     public function toArray($request)
     {

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalMerging.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalMerging.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Http\Fixtures;
 
-use Illuminate\Http\Resources\Json\Resource;
+use Illuminate\Http\Resources\Json\JsonResource;
 
-class PostResourceWithOptionalMerging extends Resource
+class PostResourceWithOptionalMerging extends JsonResource
 {
     public function toArray($request)
     {

--- a/tests/Integration/Http/Fixtures/ReallyEmptyPostResource.php
+++ b/tests/Integration/Http/Fixtures/ReallyEmptyPostResource.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Http\Fixtures;
 
-use Illuminate\Http\Resources\Json\Resource;
+use Illuminate\Http\Resources\Json\JsonResource;
 
-class ReallyEmptyPostResource extends Resource
+class ReallyEmptyPostResource extends JsonResource
 {
     //
 }

--- a/tests/Integration/Http/Fixtures/SerializablePostResource.php
+++ b/tests/Integration/Http/Fixtures/SerializablePostResource.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Http\Fixtures;
 
-use Illuminate\Http\Resources\Json\Resource;
+use Illuminate\Http\Resources\Json\JsonResource;
 
-class SerializablePostResource extends Resource
+class SerializablePostResource extends JsonResource
 {
     public function toArray($request)
     {


### PR DESCRIPTION
This is an issue that was identified by @joshuanoyes in an Internals post here: https://github.com/laravel/internals/issues/966

Essentially `Resource` is actually a soft-reserved name by PHP and its use is "highly discouraged" as documented here: http://php.net/manual/en/reserved.other-reserved-words.php

So at the moment there is no issue. Laravel 5.6 will run happily on PHP7.2.

The problem is, at short notice, an RFC might be added to PHP that includes the use of `Resource`, switching it to a full reserved name. If/when that occurs, `5.6` will stop working and will not be compatible with that new PHP version, effectively providing an artificial upper ceiling on what PHP version it can run on.

Unlike some of the backporting we did to allow older versions of Laravel to run on PHP7.2 with the `count()` issue; this fix would be a "breaking change", so you wouldnt really be able to fix it in any older versions (unless you allow a breaking change on a point release which will send Reddit into meltdown).

So I think the best option is just do the change now, place it as part of the 5.6 upgrade guide - especially while it is still a relavitely new feature and not in heavy use, and avoid any future issues.

Otherwise we leave it as is - and risk problems in the future that will be more difficult to resolve (especially if the feature is used more often).

p.s. this doesnt solve the issue for `5.5` which has LTS - so that might be affected by this at a later stage. But I guess we can cross that bridge if we come to it.