### PR TITLE
[5.5] Use path helpers for Console commands

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -224,7 +224,7 @@ class AppNameCommand extends Command
     protected function setDatabaseFactoryNamespaces()
     {
         $files = Finder::create()
-                            ->in($this->laravel->databasePath().'/factories')
+                            ->in(database_path('factories'))
                             ->contains($this->currentRoot)
                             ->name('*.php');
 
@@ -268,7 +268,7 @@ class AppNameCommand extends Command
      */
     protected function getComposerPath()
     {
-        return $this->laravel->basePath().'/composer.json';
+        return base_path('composer.json');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -32,7 +32,7 @@ class DownCommand extends Command
     public function handle()
     {
         file_put_contents(
-            $this->laravel->storagePath().'/framework/down',
+            storage_path('framework/down'),
             json_encode($this->getDownFilePayload(), JSON_PRETTY_PRINT)
         );
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -32,7 +32,7 @@ class ServeCommand extends Command
      */
     public function handle()
     {
-        chdir($this->laravel->publicPath());
+        chdir(public_path());
 
         $this->line("<info>Laravel development server started:</info> <http://{$this->host()}:{$this->port()}>");
 
@@ -50,7 +50,7 @@ class ServeCommand extends Command
             ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false)),
             $this->host(),
             $this->port(),
-            ProcessUtils::escapeArgument($this->laravel->basePath())
+            ProcessUtils::escapeArgument(base_path())
         );
     }
 

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -52,7 +52,7 @@ class TestMakeCommand extends GeneratorCommand
     {
         $name = Str::replaceFirst($this->rootNamespace(), '', $name);
 
-        return $this->laravel->basePath().'/tests'.str_replace('\\', '/', $name).'.php';
+        return base_path('tests').str_replace('\\', '/', $name).'.php';
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -27,7 +27,7 @@ class UpCommand extends Command
      */
     public function handle()
     {
-        @unlink($this->laravel->storagePath().'/framework/down');
+        @unlink(storage_path('framework/down'));
 
         $this->info('Application is now live.');
     }


### PR DESCRIPTION
When trying to use a custom public path, the Op of issue #18550 was advised to override the `path.public` binding. I did the same for my application, however I was then unable to use the `artisan serve` command, because that just uses the hardcoded value in `publicPath()`, instead of the bindings.

The error message I received was this:
```
$ php artisan serve
In ServeCommand.php line 35:

  chdir(): No such file or directory (errno 2)
```

StorageLinkCommand.php already uses the `public_path()` helper (although with the argument `'storage'`), so it seems this commit doesn't introduce a new dependency on these helpers that wasn't there before.

If there was a specific reason to not use these helper functions, maybe we can find some other solution.