### PR TITLE
[5.5] Fix SessionGuard::cycleRememberToken recreates deleted user

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -84,6 +84,10 @@ class EloquentUserProvider implements UserProvider
     {
         $user->setRememberToken($token);
 
+        if (! $user->exists) {
+            return;
+        }
+
         $timestamps = $user->timestamps;
 
         $user->timestamps = false;

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -107,6 +107,34 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertInstanceOf('Illuminate\Tests\Auth\EloquentProviderUserStub', $model);
     }
 
+    public function testUpdateRememberToken()
+    {
+        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user->exists = true;
+        $user->timestamps = true;
+        $user->shouldReceive('setRememberToken')->with('token')->once();
+        $user->shouldReceive('save')->once();
+        $provider = new EloquentUserProvider($hasher, 'foo');
+
+        $provider->updateRememberToken($user, 'token');
+
+        $this->assertTrue($user->timestamps);
+    }
+
+    public function testUpdateRememberTokenDoesntSaveUserIfItDoesntExist()
+    {
+        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user->exists = false;
+        $user->timestamps = true;
+        $user->shouldReceive('setRememberToken')->with('token')->once();
+        $user->shouldNotReceive('save');
+        $provider = new EloquentUserProvider($hasher, 'foo');
+
+        $provider->updateRememberToken($user, 'token');
+    }
+
     protected function getProviderMock()
     {
         $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');


### PR DESCRIPTION
This PR fixes the issue outlined in issue #22975 where a deleted user is recreated after calling the logout method. This is caused by the `EloquentUserProvider::updateRememberToken` method, which saves the model without checking if it exists. 

This PR adds an `exists` check *after* setting the remember token to minimize any impact that this change might have.