### PR TITLE
[5.6] Fix missing functions in \Illuminate\Support\Testing\Fakes\BusFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -129,4 +129,37 @@ class BusFake implements Dispatcher
     {
         //
     }
+
+    /**
+     * Determine if the given command has a handler.
+     *
+     * @param  mixed $command
+     * @return bool
+     */
+    public function hasCommandHandler($command)
+    {
+        return false;
+    }
+
+    /**
+     * Retrieve the handler for a command.
+     *
+     * @param  mixed $command
+     * @return bool|mixed
+     */
+    public function getCommandHandler($command)
+    {
+        return false;
+    }
+
+    /**
+     * Map a command to a handler.
+     *
+     * @param  array $map
+     * @return $this
+     */
+    public function map(array $map)
+    {
+        return $this;
+    }
 }


### PR DESCRIPTION
Should fix error reported by @carusogabriel in https://github.com/laravel/framework/pull/22958#issuecomment-362202432