### PR TITLE
[5.6] Ability to cast model attributes to a specific date format

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -190,7 +190,7 @@ trait HasAttributes
                 $attributes[$key] = $this->serializeDate($attributes[$key]);
             }
 
-            if ($attributes[$key] && Str::startsWith($value, 'date:')) {
+            if ($attributes[$key] && Str::startsWith($value, ['date:', 'datetime:'])) {
                 $attributes[$key] = $attributes[$key]->format(explode(':', $value, 2)[1]);
             }
         }
@@ -509,7 +509,7 @@ trait HasAttributes
      */
     protected function getCastType($key)
     {
-        if (Str::startsWith($this->getCasts()[$key], 'date:')) {
+        if (Str::startsWith($this->getCasts()[$key], ['date:', 'datetime:'])) {
             return 'custom_datetime';
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -189,6 +189,10 @@ trait HasAttributes
                 ($value === 'date' || $value === 'datetime')) {
                 $attributes[$key] = $this->serializeDate($attributes[$key]);
             }
+
+            if ($attributes[$key] && Str::startsWith($value, 'date:')) {
+                $attributes[$key] = $attributes[$key]->format(explode(':', $value, 2)[1]);
+            }
         }
 
         return $attributes;
@@ -488,6 +492,7 @@ trait HasAttributes
             case 'date':
                 return $this->asDate($value);
             case 'datetime':
+            case 'custom_datetime':
                 return $this->asDateTime($value);
             case 'timestamp':
                 return $this->asTimestamp($value);
@@ -504,6 +509,10 @@ trait HasAttributes
      */
     protected function getCastType($key)
     {
+        if (Str::startsWith($this->getCasts()[$key], 'date:')) {
+            return 'custom_datetime';
+        }
+
         return trim(strtolower($this->getCasts()[$key]));
     }
 

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -46,6 +46,6 @@ class TestModel1 extends Model
 
     public $casts = [
         'date_field' => 'date:Y-m',
-        'datetime_field' => 'date:Y-m H:i',
+        'datetime_field' => 'datetime:Y-m H:i',
     ];
 }

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelDateCastingTest;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentModelDateCastingTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('test_model1', function ($table) {
+            $table->increments('id');
+            $table->date('date_field')->nullable();
+            $table->datetime('datetime_field')->nullable();
+        });
+    }
+
+    public function test_user_can_update_nullable_date()
+    {
+        $user = TestModel1::create([
+            'date_field' => '2019-10-01',
+            'datetime_field' => '2019-10-01 10:15:20',
+        ]);
+
+        $this->assertEquals('2019-10', $user->toArray()['date_field']);
+        $this->assertEquals('2019-10 10:15', $user->toArray()['datetime_field']);
+        $this->assertInstanceOf(Carbon::class, $user->date_field);
+        $this->assertInstanceOf(Carbon::class, $user->datetime_field);
+    }
+}
+
+class TestModel1 extends Model
+{
+    public $table = 'test_model1';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+    protected $dates = ['date_field', 'datetime_field'];
+
+    public $casts = [
+        'date_field' => 'date:Y-m',
+        'datetime_field' => 'date:Y-m H:i',
+    ];
+}


### PR DESCRIPTION
Given the following casts:

```php
public $casts = [
    'birthdate' => 'date:Y-m-d',
    'joined_at' => 'datetime:Y-m-d H:00',
];
```

When the model is casted to JSON or array output the attributes will be formatted to the date formats provided by the developer:

```
birthdate: 2000-10-15
joined_at: 2017-10-15 05:00
```