### PR TITLE
[5.5] Allow to disable CREATED_AT

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -42,7 +42,7 @@ trait HasTimestamps
             $this->setUpdatedAt($time);
         }
 
-        if (! is_null(static::CREATED_AT) && ! $this->exists && ! $this->isDirty(static::CREATED_AT) ) {
+        if (! is_null(static::CREATED_AT) && ! $this->exists && ! $this->isDirty(static::CREATED_AT)) {
             $this->setCreatedAt($time);
         }
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -42,7 +42,7 @@ trait HasTimestamps
             $this->setUpdatedAt($time);
         }
 
-        if (! $this->exists && ! $this->isDirty(static::CREATED_AT)) {
+        if (! is_null(static::CREATED_AT) && ! $this->exists && ! $this->isDirty(static::CREATED_AT) ) {
             $this->setCreatedAt($time);
         }
     }


### PR DESCRIPTION
Exactly as we allowed to disable UPDATED_AT https://github.com/laravel/framework/pull/21178/commits/b4758e212c2ca89edfa590d91d0534151fac4d86
I'm allowing to disable CREATED_AT by setting
`const CREATED_AT = false;`
in the model
