### PR TITLE
[5.6] Reorder message customization callbacks

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -128,8 +128,8 @@ class Mailable implements MailableContract, Renderable
             $this->buildFrom($message)
                  ->buildRecipients($message)
                  ->buildSubject($message)
-                 ->buildAttachments($message)
-                 ->runCallbacks($message);
+                 ->runCallbacks($message)
+                 ->buildAttachments($message);
         });
     }
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -225,12 +225,12 @@ class Mailer implements MailerContract, MailQueueContract
 
         $data['message'] = $message = $this->createMessage();
 
+        call_user_func($callback, $message);
+        
         // Once we have retrieved the view content for the e-mail we will set the body
         // of this message using the HTML type, which will provide a simple wrapper
         // to creating view based emails that are able to receive arrays of data.
         $this->addContent($message, $view, $plain, $raw, $data);
-
-        call_user_func($callback, $message);
 
         // If a global "to" address has been set, we will set that address on the mail
         // message. This is primarily useful during local development in which each


### PR DESCRIPTION
Call developer-supplied callbacks in `Mailer` and `Mailable` a bit earlier, to allow customization of created message body and attachments.

Body and attachments of SwiftMailer messages are opaque encoded blobs, which makes them hard to customize after creation. This PR ensures that callbacks, registered by  `withSwiftMessage`, are executed at earlier point, before SwiftMailer message emits it's body. This enables setting email encoder (8bit/base64 etc.) and other customization of message body.

The change isn't particularly disrupting, because current implementation does not allow to modify the message at all, aside from setting headers. While it's theoretically possible to interact with message from the callback by breaking encapsulation and/or converting full message to string, a brief look at uses of `withSwiftMessage` in public Github project and Laravel documentation shows that all of them are limited to fiddling with email headers and adding attachments.

Fixes #22982 