### PR TITLE
[5.7] Factory states through methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent;
 
-use BadMethodCallException;
 use Faker\Generator as Faker;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -352,14 +351,6 @@ class FactoryBuilder
             return $this->macroCall($method, $parameters);
         }
 
-        if (Str::startsWith($method, 'with')) {
-            return $this->withState(Str::camel(Str::after($method, 'with')));
-        }
-
-        $className = static::class;
-
-        throw new BadMethodCallException("Call to undefined method {$className}::{$method}()");
+        return $this->withState(Str::camel($method));
     }
-
-
 }

--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -32,8 +32,9 @@ trait Macroable
     /**
      * Mix another object into the class.
      *
-     * @param  object  $mixin
+     * @param  object $mixin
      * @return void
+     * @throws \ReflectionException
      */
     public static function mixin($mixin)
     {

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -159,9 +159,9 @@ class EloquentFactoryBuilderTest extends TestCase
     {
         $server = factory(FactoryBuildableServer::class)->create();
 
-        $inlineServer = factory(FactoryBuildableServer::class)->withInline()->create();
+        $inlineServer = factory(FactoryBuildableServer::class)->inline()->create();
 
-        $callableServer = \factory(FactoryBuildableServer::class)->withInline()->withCallable()->create();
+        $callableServer = \factory(FactoryBuildableServer::class)->inline()->callable()->create();
 
         $this->assertEquals('active', $server->status);
         $this->assertEquals('inline', $inlineServer->status);
@@ -173,7 +173,7 @@ class EloquentFactoryBuilderTest extends TestCase
      */
     public function creating_models_with_multiple_method_states()
     {
-        $server = \factory(FactoryBuildableServer::class)->withCallable()->withMainServer()->create();
+        $server = \factory(FactoryBuildableServer::class)->callable()->mainServer()->create();
 
         $this->assertEquals('callable', $server->status);
         $this->assertEquals('main', $server->name);
@@ -186,7 +186,7 @@ class EloquentFactoryBuilderTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        factory(FactoryBuildableServer::class)->withUnknown()->create();
+        factory(FactoryBuildableServer::class)->unknown()->create();
     }
 
     /**

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -56,6 +56,8 @@ class EloquentFactoryBuilderTest extends TestCase
 
         $factory->state(FactoryBuildableServer::class, 'inline', ['status' => 'inline']);
 
+        $factory->state(FactoryBuildableServer::class, 'mainServer', ['name' => 'main']);
+
         $app->singleton(Factory::class, function ($app) use ($factory) {
             return $factory;
         });
@@ -164,6 +166,17 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertEquals('active', $server->status);
         $this->assertEquals('inline', $inlineServer->status);
         $this->assertEquals('callable', $callableServer->status);
+    }
+
+    /**
+     * @test
+     */
+    public function creating_models_with_multiple_method_states()
+    {
+        $server = \factory(FactoryBuildableServer::class)->withCallable()->withMainServer()->create();
+
+        $this->assertEquals('callable', $server->status);
+        $this->assertEquals('main', $server->name);
     }
 
     /**

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -153,6 +153,32 @@ class EloquentFactoryBuilderTest extends TestCase
     /**
      * @test
      */
+    public function creating_models_with_method_states()
+    {
+        $server = factory(FactoryBuildableServer::class)->create();
+
+        $inlineServer = factory(FactoryBuildableServer::class)->withInline()->create();
+
+        $callableServer = \factory(FactoryBuildableServer::class)->withInline()->withCallable()->create();
+
+        $this->assertEquals('active', $server->status);
+        $this->assertEquals('inline', $inlineServer->status);
+        $this->assertEquals('callable', $callableServer->status);
+    }
+
+    /**
+     * @test
+     */
+    public function fails_if_state_does_not_exist()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        factory(FactoryBuildableServer::class)->withUnknown()->create();
+    }
+
+    /**
+     * @test
+     */
     public function creating_models_with_relationships()
     {
         factory(FactoryBuildableUser::class, 2)


### PR DESCRIPTION
Added factory states through methods with prefix `with`.

Which means this
```
$users = factory(App\User::class, 5)->states('premium', 'delinquent')->make();
```
can be converted to 
```
$users = factory(App\User::class, 5)->withPremium()->withDelinquent()->make();
```

UPDATE 1:
- Removed `with` prefix.
```
$users = factory(App\User::class, 5)->premium()->delinquent()->make();
```