### PR TITLE
Allow dynamic error view paths

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -396,7 +396,7 @@ class Handler implements ExceptionHandlerContract
         $paths = collect(config('view.paths'));
 
         view()->replaceNamespace('errors', $paths->map(function ($path) {
-            return "{$path}/errors";
+            return $this->errorsPath($path);
         })->push(__DIR__.'/views')->all());
 
         if (view()->exists($view = "errors::{$status}")) {
@@ -404,6 +404,17 @@ class Handler implements ExceptionHandlerContract
         }
 
         return $this->convertExceptionToResponse($e);
+    }
+
+    /**
+     * Determine the directory containing error views for a given path.
+     *
+     * @param string $path
+     * @return string
+     */
+    protected function errorsPath($path)
+    {
+        return "{$path}/errors";
     }
 
     /**


### PR DESCRIPTION
By extracting the error views path into a dedicated method distinct error pages can be served for various use cases by simply overriding the method, e.g.:

```php
protected function errorsPath($path) {
    // Custom error pages for backend
    if (Route::is('backend/*')) {
        return $path . '/backend/errors';
    }

    // Custom error pages for subdomain part
    if (Route::domain() === 'subdomain.example.org') {
        return $path . '/subdomain/errorpages';
    }
    
    // Default error pages
    return parent::errorsPath($path);
}
```