### PR TITLE
Added that subqueries related to another database work

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -47,6 +47,16 @@ trait QueriesRelationships
             $hasQuery->callScope($callback);
         }
 
+        // When query connection and subquery connection are not equals concat connection to query from
+        if ($this->getConnection() instanceof QueryBuilder && $hasQuery->getConnection() instanceof QueryBuilder) {
+            $subqueryConnection = $hasQuery->getConnection()->getDatabaseName();
+            $queryConnection = $this->getConnection()->getDatabaseName();
+            if ($queryConnection != $subqueryConnection) {
+                $queryFrom = $hasQuery->getQuery()->from.'|'.$subqueryConnection;
+                $hasQuery->from($queryFrom);
+            }
+        }
+
         return $this->addHasWhere(
             $hasQuery, $relation, $operator, $count, $boolean
         );

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -143,6 +143,7 @@ class Grammar extends BaseGrammar
         // if table contains | means that we must specify the database
         if (strpos($table, '|') !== false) {
             list($table, $database) = explode('|', $table);
+
             return 'from '.$this->wrap($database).'.'.$this->wrapTable($table);
         }
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -140,6 +140,12 @@ class Grammar extends BaseGrammar
      */
     protected function compileFrom(Builder $query, $table)
     {
+        // if table contains | means that we must specify the database
+        if (strpos($table, '|') !== false) {
+            list($table, $database) = explode('|', $table);
+            return 'from '.$this->wrap($database).'.'.$this->wrapTable($table);
+        }
+        
         return 'from '.$this->wrapTable($table);
     }
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -145,7 +145,7 @@ class Grammar extends BaseGrammar
             list($table, $database) = explode('|', $table);
             return 'from '.$this->wrap($database).'.'.$this->wrapTable($table);
         }
-        
+
         return 'from '.$this->wrapTable($table);
     }
 


### PR DESCRIPTION
Related #17624 

Added that subqueries that point another database works including database name in subquery when is different from query connection.

# ELOQUENT QUERY
`Provider::whereHas('orders')`

### NOW GENERATES

````select * from `hvp_providers` where exists (select * from `hvp_products` where `hvp_providers`.`id` = `hvp_products`.`provider_id` and `hvp_products`.`deleted_at` is null) and `hvp_providers`.`deleted_at` is null````

**Sql error:** 
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'hv_global.hvp_products' doesn't exist

### WITH THIS PULL REQUEST GENERATES

````select * from `hvp_providers` where exists (select * from `hv_warehouse`.`hvp_products` where `hvp_providers`.`id` = `hvp_products`.`provider_id` and `hvp_products`.`deleted_at` is null) and `hvp_providers`.`deleted_at` is null````