### PR TITLE
Allow dynamic error view paths

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -396,7 +396,7 @@ class Handler implements ExceptionHandlerContract
         $paths = collect(config('view.paths'));
 
         view()->replaceNamespace('errors', $paths->map(function ($path) {
-            return "{$path}/errors";
+            return $this->errorsPath($path);
         })->push(__DIR__.'/views')->all());
 
         if (view()->exists($view = "errors::{$status}")) {
@@ -404,6 +404,17 @@ class Handler implements ExceptionHandlerContract
         }
 
         return $this->convertExceptionToResponse($e);
+    }
+
+    /**
+     * Determine the directory containing error views for a given path.
+     *
+     * @param string $path
+     * @return string
+     */
+    protected function errorsPath($path)
+    {
+        return "{$path}/errors";
     }
 
     /**


### PR DESCRIPTION
In response to https://github.com/laravel/framework/pull/23001#issuecomment-362592230:

The framework's logic for determining the location where error views can be found is currently rather hardcoded in `Illuminate\Foundation\Exceptions\Handler`. In essence, all view paths defined in config are taken and `/errors` is simply appended as a sensible default.

```php
/**
 * Render the given HttpException.
 *
 * @param  \Symfony\Component\HttpKernel\Exception\HttpException  $e
 * @return \Symfony\Component\HttpFoundation\Response
 */
protected function renderHttpException(HttpException $e)
{
    $status = $e->getStatusCode();

    $paths = collect(config('view.paths'));

    view()->replaceNamespace('errors', $paths->map(function ($path) {
        return "{$path}/errors";
    })->push(__DIR__.'/views')->all());

    if (view()->exists($view = "errors::{$status}")) {
        return response()->view($view, ['exception' => $e], $status, $e->getHeaders());
    }

    return $this->convertExceptionToResponse($e);
}
```

Yet this scenario becomes rather cumbersome if one would like to serve distinct error pages for different environments. Let's say we have a `frontend` and `backend` environment. Error pages for these environments should blend in in their own theme, and additionally the errors on the frontend would (in my case) ideally present some useful links to guide the user what to do.

Suppose the views folder is set up like this:
* /views/backend
    * /errors
        * 404.blade.php
        * ...
    * ...
* /views/frontend
    * /errors
        * 404.blade.php
        * ...
    * ...

Following the current implementation, Laravel would only search for an error view in `views/errors`. You could say to add the `frontend` and `backend` folders explicitly in the configuration file, but still this doesn't seem like a viable option: what if `backend` is defined before `frontend`, both have a 404 view and we stumble upon a 404 in the frontend? The current implementation just takes the first one it finds, being the 404 of the backend. So it seems the only way to circumvent this default behavior is by fully overriding the `renderHttpException()`method...

By giving the developer a chance to dynamically calculate where the views should be fetched from, a much cleaner way can be introduced. All paths in configuration are processed to increase chances of hitting an existing one.

```php
protected function errorsPath($path) {
    // Logic to determine if we're in the backend
    if (...) {
        return $path . '/backend/errors';
    }

    // Logic to determine if we're in the frontend
    if (...) {
        return $path . '/frontend/errors';
    }
    
    // Default error pages
    return parent::errorsPath($path);
}
```

I don't expect any breaking changes since the default hardcoded calculation is still available. It's up to the developer to override when necessary...

On the tests side: I'm not quite sure if this change requires testing as it's only an extraction to a method. If you think testing is appropriate, please advise as I'm unsure how the test should look like.