### PR TITLE
[5.6] fix file name for empty extension

### DIFF
--- a/src/Illuminate/Http/FileHelpers.php
+++ b/src/Illuminate/Http/FileHelpers.php
@@ -56,7 +56,8 @@ trait FileHelpers
         }
 
         $hash = $this->hashName ?: $this->hashName = Str::random(40);
+        $extension = $this->guessExtension();
 
-        return $path.$hash.'.'.$this->guessExtension();
+        return $path . $hash . (empty($extension) ? '' : '.' . $extension);
     }
 }

--- a/src/Illuminate/Http/FileHelpers.php
+++ b/src/Illuminate/Http/FileHelpers.php
@@ -58,6 +58,6 @@ trait FileHelpers
         $hash = $this->hashName ?: $this->hashName = Str::random(40);
         $extension = $this->guessExtension();
 
-        return $path . $hash . (empty($extension) ? '' : '.' . $extension);
+        return $path.$hash.(empty($extension) ? '' : '.'.$extension);
     }
 }


### PR DESCRIPTION
on windows system php cant save file without extension