### PR TITLE
[5.5] Pluralize words with float counts not equal to 1

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -58,13 +58,13 @@ class Pluralizer
     /**
      * Get the plural form of an English word.
      *
-     * @param  string  $value
-     * @param  int     $count
+     * @param  string    $value
+     * @param  int|float $count
      * @return string
      */
     public static function plural($value, $count = 2)
     {
-        if ((int) $count === 1 || static::uncountable($value)) {
+        if ((string) $count === '1' || static::uncountable($value)) {
             return $value;
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -267,8 +267,8 @@ class Str
     /**
      * Get the plural form of an English word.
      *
-     * @param  string  $value
-     * @param  int     $count
+     * @param  string    $value
+     * @param  int|float $count
      * @return string
      */
     public static function plural($value, $count = 2)

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -896,8 +896,8 @@ if (! function_exists('str_plural')) {
     /**
      * Get the plural form of an English word.
      *
-     * @param  string  $value
-     * @param  int     $count
+     * @param  string    $value
+     * @param  int|float $count
      * @return string
      */
     function str_plural($value, $count = 2)

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -17,6 +17,27 @@ class SupportPluralizerTest extends TestCase
         $this->assertEquals('children', Str::plural('child'));
     }
 
+    public function testPlural()
+    {
+        $this->assertEquals('units', Str::plural('unit', -2));
+        $this->assertEquals('units', Str::plural('unit', -1.001));
+        $this->assertEquals('units', Str::plural('unit', -1 - 0.001 + 0.001));
+        $this->assertEquals('units', Str::plural('unit', -1 + 0.001 - 0.001));
+        $this->assertEquals('units', Str::plural('unit', -1));
+        $this->assertEquals('units', Str::plural('unit', -0.9));
+        $this->assertEquals('units', Str::plural('unit', -0.5));
+        $this->assertEquals('units', Str::plural('unit', -0.1));
+        $this->assertEquals('units', Str::plural('unit', 0));
+        $this->assertEquals('units', Str::plural('unit', 0.1));
+        $this->assertEquals('units', Str::plural('unit', 0.5));
+        $this->assertEquals('units', Str::plural('unit', 0.9));
+        $this->assertEquals('unit', Str::plural('unit', 1));
+        $this->assertEquals('unit', Str::plural('unit', 1 + 0.001 - 0.001));
+        $this->assertEquals('unit', Str::plural('unit', 1 - 0.001 + 0.001));
+        $this->assertEquals('units', Str::plural('unit', 1.001));
+        $this->assertEquals('units', Str::plural('unit', 2));
+    }
+
     public function testCaseSensitiveSingularUsage()
     {
         $this->assertEquals('Child', Str::singular('Children'));


### PR DESCRIPTION
My implementation to resolve #21983.

Shamelessly taking use case example from #21973:
```php
$remaining = 1.3;
echo 'You have ' . $remaining . ' ' . str_plural('gigabyte', $remaining) . ' of space remaining on your account.';

// Current behavior:
>>> You have 1.3 gigabyte of space remaining on your account.

// After this PR:
>>> You have 1.3 gigabytes of space remaining on your account.
```

Casting to string eliminates the float inaccuracies that cause issues when comparing to integers. For example:
```php
$count = 1 + 0.001 - 0.001;
(int) $count === 1
    => false
(string) $count === '1'
    => true
```

Let me know if this is an acceptable solution and if a comment should be added to clarify why string casting is used.