### PR TITLE
[5.5] Remove unnecessary escapeshellarg call

### DIFF
--- a/src/Illuminate/Support/ProcessUtils.php
+++ b/src/Illuminate/Support/ProcessUtils.php
@@ -23,7 +23,7 @@ class ProcessUtils
         // @see https://bugs.php.net/bug.php?id=49446
         if ('\\' === DIRECTORY_SEPARATOR) {
             if ('' === $argument) {
-                return escapeshellarg($argument);
+                return "''";
             }
 
             $escapedArgument = '';

--- a/src/Illuminate/Support/ProcessUtils.php
+++ b/src/Illuminate/Support/ProcessUtils.php
@@ -23,7 +23,7 @@ class ProcessUtils
         // @see https://bugs.php.net/bug.php?id=49446
         if ('\\' === DIRECTORY_SEPARATOR) {
             if ('' === $argument) {
-                return "''";
+                return '""';
             }
 
             $escapedArgument = '';


### PR DESCRIPTION
- As mentioned here laravel/internals#407 the escapeshellarg function is blocked by some shared hostings.
- Other occurrences of escapeshellarg function were already replaced by "'".str_replace("'", "'\\''", $argument)."'".
- Moreover the removed function call in this proposed change is unnecessary and can be replaced by a constant.