### PR TITLE
[5.5] Where clauses should use original attribute values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -99,9 +99,9 @@ class Pivot extends Model
             return parent::setKeysForSaveQuery($query);
         }
 
-        $query->where($this->foreignKey, $this->getAttribute($this->foreignKey));
+        $query->where($this->foreignKey, $this->getOriginal($this->foreignKey));
 
-        return $query->where($this->relatedKey, $this->getAttribute($this->relatedKey));
+        return $query->where($this->relatedKey, $this->getOriginal($this->relatedKey));
     }
 
     /**
@@ -126,8 +126,8 @@ class Pivot extends Model
     protected function getDeleteQuery()
     {
         return $this->newQuery()->where([
-            $this->foreignKey => $this->getAttribute($this->foreignKey),
-            $this->relatedKey => $this->getAttribute($this->relatedKey),
+            $this->foreignKey => $this->getOriginal($this->foreignKey),
+            $this->relatedKey => $this->getOriginal($this->relatedKey),
         ]);
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -99,9 +99,9 @@ class Pivot extends Model
             return parent::setKeysForSaveQuery($query);
         }
 
-        $query->where($this->foreignKey, $this->getOriginal($this->foreignKey));
+        $query->where($this->foreignKey, $this->getOriginal($this->foreignKey, $this->getAttribute($this->foreignKey)));
 
-        return $query->where($this->relatedKey, $this->getOriginal($this->relatedKey));
+        return $query->where($this->relatedKey, $this->getOriginal($this->relatedKey, $this->getAttribute($this->foreignKey)));
     }
 
     /**
@@ -126,8 +126,8 @@ class Pivot extends Model
     protected function getDeleteQuery()
     {
         return $this->newQuery()->where([
-            $this->foreignKey => $this->getOriginal($this->foreignKey),
-            $this->relatedKey => $this->getOriginal($this->relatedKey),
+            $this->foreignKey => $this->getOriginal($this->foreignKey, $this->getAttribute($this->foreignKey)),
+            $this->relatedKey => $this->getOriginal($this->relatedKey, $this->getAttribute($this->foreignKey)),
         ]);
     }
 


### PR DESCRIPTION
With current implementation, it is impossible to update any of the foreign or related keys in Pivot instance, without executing raw SQL queries, as the generated query is using current attribute values instead of the original values. This PR will fix this issue.