### PR TITLE
[5.6] Fix inOrder assertions

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -261,10 +261,10 @@ class TestResponse
      */
     public function assertSeeInOrder(array $values)
     {
-        $position = -1;
+        $position = 0;
 
         foreach ($values as $value) {
-            $valuePosition = mb_strpos($this->getContent(), $value);
+            $valuePosition = mb_strpos($this->getContent(), $value, $position);
 
             if ($valuePosition === false || $valuePosition < $position) {
                 PHPUnit::fail(
@@ -273,7 +273,7 @@ class TestResponse
                 );
             }
 
-            $position = $valuePosition;
+            $position = $valuePosition + mb_strlen($value);
         }
 
         return $this;
@@ -300,10 +300,10 @@ class TestResponse
      */
     public function assertSeeTextInOrder(array $values)
     {
-        $position = -1;
+        $position = 0;
 
         foreach ($values as $value) {
-            $valuePosition = mb_strpos(strip_tags($this->getContent()), $value);
+            $valuePosition = mb_strpos(strip_tags($this->getContent()), $value, $position);
 
             if ($valuePosition === false || $valuePosition < $position) {
                 PHPUnit::fail(
@@ -312,7 +312,7 @@ class TestResponse
                 );
             }
 
-            $position = $valuePosition;
+            $position = $valuePosition + mb_strlen($value);
         }
 
         return $this;

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -45,22 +45,26 @@ class FoundationTestResponseTest extends TestCase
     {
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(\Mockery::mock(View::class, [
-                'render' => '<ul><li>foo</li><li>bar</li><li>baz</li></ul>',
+                'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
             ]));
         });
 
         $response = TestResponse::fromBaseResponse($baseResponse);
 
         $response->assertSeeInOrder(['foo', 'bar', 'baz']);
+        $response->assertSeeInOrder(['foo', 'bar', 'baz', 'foo']);
 
         try {
             $response->assertSeeInOrder(['baz', 'bar', 'foo']);
-            $response->assertSeeInOrder(['foo', 'qux', 'bar', 'baz']);
+            TestCase::fail('Assertion was expected to fail.');
         } catch (\PHPUnit\Framework\AssertionFailedError $e) {
-            return;
         }
 
-        TestCase::fail('Assertion was expected to fail.');
+        try {
+            $response->assertSeeInOrder(['foo', 'qux', 'bar', 'baz']);
+            TestCase::fail('Assertion was expected to fail.');
+        } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+        }
     }
 
     public function testAssertSeeText()
@@ -80,22 +84,26 @@ class FoundationTestResponseTest extends TestCase
     {
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(\Mockery::mock(View::class, [
-                'render' => 'foo<strong>bar</strong> baz',
+                'render' => 'foo<strong>bar</strong> baz <strong>foo</strong>',
             ]));
         });
 
         $response = TestResponse::fromBaseResponse($baseResponse);
 
         $response->assertSeeTextInOrder(['foobar', 'baz']);
+        $response->assertSeeTextInOrder(['foobar', 'baz', 'foo']);
 
         try {
             $response->assertSeeTextInOrder(['baz', 'foobar']);
-            $response->assertSeeTextInOrder(['foobar', 'qux', 'baz']);
+            TestCase::fail('Assertion was expected to fail.');
         } catch (\PHPUnit\Framework\AssertionFailedError $e) {
-            return;
         }
-
-        TestCase::fail('Assertion was expected to fail.');
+        
+        try {
+            $response->assertSeeTextInOrder(['foobar', 'qux', 'baz']);
+            TestCase::fail('Assertion was expected to fail.');
+        } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+        }
     }
 
     public function testAssertHeader()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -98,7 +98,7 @@ class FoundationTestResponseTest extends TestCase
             TestCase::fail('Assertion was expected to fail.');
         } catch (\PHPUnit\Framework\AssertionFailedError $e) {
         }
-        
+
         try {
             $response->assertSeeTextInOrder(['foobar', 'qux', 'baz']);
             TestCase::fail('Assertion was expected to fail.');


### PR DESCRIPTION
This fixes @helmut  https://github.com/laravel/framework/pull/22915 

In previous implementation when response contained `foo bar foo` and you ran:
```php
$response->assertSeeInOrder(['foo', 'bar', 'foo']);
```

it failed and now it will pass.

Also tests updated a bit just to make sure both assertions fail as expected in tests.