### PR TITLE
Add queue worker pool feature

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -51,6 +51,7 @@ use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Foundation\Console\NotificationMakeCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
 use Illuminate\Queue\Console\WorkCommand as QueueWorkCommand;
+use Illuminate\Queue\Console\PoolCommand as QueuePoolCommand;
 use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
 use Illuminate\Notifications\Console\NotificationTableCommand;
 use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
@@ -109,6 +110,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'QueueRestart' => 'command.queue.restart',
         'QueueRetry' => 'command.queue.retry',
         'QueueWork' => 'command.queue.work',
+        'QueuePool' => 'command.queue.pool',
         'RouteCache' => 'command.route.cache',
         'RouteClear' => 'command.route.clear',
         'RouteList' => 'command.route.list',
@@ -704,6 +706,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.queue.work', function ($app) {
             return new QueueWorkCommand($app['queue.worker']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerQueuePoolCommand()
+    {
+        $this->app->singleton('command.queue.pool', function ($app) {
+            return new QueuePoolCommand($app['queue.pool']);
         });
     }
 

--- a/src/Illuminate/Queue/Console/PoolCommand.php
+++ b/src/Illuminate/Queue/Console/PoolCommand.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Illuminate\Queue\Pool;
+use Illuminate\Console\Command;
+use Illuminate\Queue\PoolOption;
+
+class PoolCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'queue:pool
+                            {connection? : The name of the queue connection to work}
+                            {--workers= : The amount of the workers to start}
+                            {--queue= : The names of the queues to work}
+                            {--delay=0 : The number of seconds to delay failed jobs}
+                            {--force : Force the worker to run even in maintenance mode}
+                            {--memory=128 : The memory limit in megabytes}
+                            {--sleep=3 : Number of seconds to sleep when no job is available}
+                            {--timeout=60 : The number of seconds a child process can run}
+                            {--tries=0 : Number of times to attempt a job before logging it failed}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Start a pool of workers to process the queue';
+
+    /**
+     * The queue pool instance.
+     *
+     * @var \Illuminate\Queue\Pool
+     */
+    protected $pool;
+
+    /**
+     * Create a new queue work command.
+     *
+     * @param  \Illuminate\Queue\Pool  $pool
+     * @return void
+     */
+    public function __construct(Pool $pool)
+    {
+        parent::__construct();
+
+        $this->setOutputHandler($this->pool = $pool);
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // We need to get the right queue for the connection which is set in the queue
+        // configuration file for the application. We will pull it based on the set
+        // connection being run for the queue operation currently being executed.
+        $queue = $this->getQueue(
+            $connection = $this->input->getArgument('connection')
+        );
+
+        $this->pool->start(
+            $connection, $queue, $this->gatherOptions()
+        );
+    }
+
+    /**
+     * Get the name of the queue connection to listen on.
+     *
+     * @param  string  $connection
+     * @return string
+     */
+    protected function getQueue($connection)
+    {
+        $connection = $connection ?: $this->laravel['config']['queue.default'];
+
+        return $this->input->getOption('queue') ?: $this->laravel['config']->get(
+            "queue.connections.{$connection}.queue", 'default'
+        );
+    }
+
+    /**
+     * Get the listener options for the command.
+     *
+     * @return \Illuminate\Queue\PoolOption
+     */
+    protected function gatherOptions()
+    {
+        return new PoolOption(
+            $this->option('workers'), $this->option('env'),
+            $this->option('delay'), $this->option('memory'),
+            $this->option('timeout'), $this->option('sleep'),
+            $this->option('tries'), $this->option('force')
+        );
+    }
+
+    /**
+     * Set the options on the queue listener.
+     *
+     * @param  \Illuminate\Queue\Pool  $pool
+     * @return void
+     */
+    protected function setOutputHandler(Pool $pool)
+    {
+        $pool->setOutputHandler(function ($type, $line) {
+            $this->output->write($line);
+        });
+    }
+}

--- a/src/Illuminate/Queue/Pool.php
+++ b/src/Illuminate/Queue/Pool.php
@@ -1,0 +1,302 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use Closure;
+use Illuminate\Support\ProcessUtils;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\PhpExecutableFinder;
+
+class Pool
+{
+    /**
+     * The command working path.
+     *
+     * @var string
+     */
+    protected $commandPath;
+
+    /**
+     * The environment the workers should run under.
+     *
+     * @var string
+     */
+    protected $environment;
+
+    /**
+     * The worker processes that started.
+     *
+     * @var array
+     */
+    protected $processes;
+
+    /**
+     * The amount of seconds to wait before polling the queue.
+     *
+     * @var int
+     */
+    protected $sleep = 3;
+
+    /**
+     * The amount of times to try a job before logging it failed.
+     *
+     * @var int
+     */
+    protected $maxTries = 0;
+
+    /**
+     * The queue worker command line.
+     *
+     * @var string
+     */
+    protected $workerCommand;
+
+    /**
+     * The output handler callback.
+     *
+     * @var \Closure|null
+     */
+    protected $outputHandler;
+
+    /**
+     * Create a new queue listener.
+     *
+     * @param  string  $commandPath
+     * @return void
+     */
+    public function __construct($commandPath)
+    {
+        $this->commandPath = $commandPath;
+        $this->workerCommand = $this->buildCommandTemplate();
+    }
+
+    /**
+     * Build the environment specific worker command.
+     *
+     * @return string
+     */
+    protected function buildCommandTemplate()
+    {
+        $command = 'queue:work %s --queue=%s --delay=%s --memory=%s --sleep=%s --tries=%s';
+
+        return "{$this->phpBinary()} {$this->artisanBinary()} {$command}";
+    }
+
+    /**
+     * Get the PHP binary.
+     *
+     * @return string
+     */
+    protected function phpBinary()
+    {
+        return ProcessUtils::escapeArgument(
+            (new PhpExecutableFinder)->find(false)
+        );
+    }
+
+    /**
+     * Get the Artisan binary.
+     *
+     * @return string
+     */
+    protected function artisanBinary()
+    {
+        return defined('ARTISAN_BINARY')
+            ? ProcessUtils::escapeArgument(ARTISAN_BINARY)
+            : 'artisan';
+    }
+
+    /**
+     * Start workers.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @param  \Illuminate\Queue\PoolOption  $options
+     * @return void
+     */
+    public function start($connection, $queue, PoolOption $options)
+    {
+        $processes = $this->makeProcesses($connection, $queue, $options);
+
+        $this->setProcesses($processes);
+
+        while (true) {
+            $this->runProcesses($options->memory);
+        }
+    }
+
+    /**
+     * Create an array of Symfony processes.
+     *
+     * @param $connection
+     * @param $queue
+     * @param \Illuminate\Queue\PoolOption $options
+     * @return array
+     */
+    public function makeProcesses($connection, $queue, PoolOption $options)
+    {
+        $processes = [];
+
+        foreach(range(1, $options->workers) as $key) {
+            $processes[$key] = $this->makeProcess($connection, $queue, $options);
+        }
+
+        return $processes;
+    }
+
+    /**
+     * Create a new Symfony process for the worker.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @param  \Illuminate\Queue\PoolOption  $options
+     * @return \Symfony\Component\Process\Process
+     */
+    public function makeProcess($connection, $queue, PoolOption $options)
+    {
+        $command = $this->workerCommand;
+
+        // If the environment is set, we will append it to the command string so the
+        // workers will run under the specified environment. Otherwise, they will
+        // just run under the production environment which is not always right.
+        if (isset($options->environment)) {
+            $command = $this->addEnvironment($command, $options);
+        }
+
+        // Next, we will just format out the worker commands with all of the various
+        // options available for the command. This will produce the final command
+        // line that we will pass into a Symfony process object for processing.
+        $command = $this->formatCommand(
+            $command, $connection, $queue, $options
+        );
+
+        return new Process(
+            $command, $this->commandPath, null, null, $options->timeout
+        );
+    }
+
+    /**
+     * Add the environment option to the given command.
+     *
+     * @param  string  $command
+     * @param  \Illuminate\Queue\PoolOption  $options
+     * @return string
+     */
+    protected function addEnvironment($command, PoolOption $options)
+    {
+        return $command.' --env='.ProcessUtils::escapeArgument($options->environment);
+    }
+
+    /**
+     * Format the given command with the listener options.
+     *
+     * @param  string  $command
+     * @param  string  $connection
+     * @param  string  $queue
+     * @param  \Illuminate\Queue\PoolOption  $options
+     * @return string
+     */
+    protected function formatCommand($command, $connection, $queue, PoolOption $options)
+    {
+        return sprintf(
+            $command,
+            ProcessUtils::escapeArgument($connection),
+            ProcessUtils::escapeArgument($queue),
+            $options->delay, $options->memory,
+            $options->sleep, $options->maxTries
+        );
+    }
+
+    /**
+     * Run worker processes.
+     *
+     * @param  int  $memory
+     * @return void
+     */
+    public function runProcesses($memory)
+    {
+        $processes = $this->getProcesses();
+
+        array_walk( $processes, function ($process, $key) {
+            if (!$process->isRunning()) {
+                $process->start(function ($type, $line) use ($key) {
+                    $line = "[Worker $key]: $line";
+                    $this->handleWorkerOutput($type, $line);
+                });
+            }
+        });
+
+        // Once we have run the job we'll go check if the memory limit has been exceeded
+        // for the script. If it has, we will kill this script so the process manager
+        // will restart this with a clean slate of memory automatically on exiting.
+        if ($this->memoryExceeded($memory)) {
+            $this->stop();
+        }
+    }
+
+    /**
+     * Get processes.
+     *
+     * @return array
+     */
+    public function getProcesses()
+    {
+        return $this->processes;
+    }
+
+    /**
+     * Set processes.
+     *
+     * @param array $processes
+     */
+    public function setProcesses($processes)
+    {
+        $this->processes = $processes;
+    }
+
+    /**
+     * Handle output from the worker process.
+     *
+     * @param  int  $type
+     * @param  string  $line
+     * @return void
+     */
+    protected function handleWorkerOutput($type, $line)
+    {
+        if (isset($this->outputHandler)) {
+            call_user_func($this->outputHandler, $type, $line);
+        }
+    }
+
+    /**
+     * Determine if the memory limit has been exceeded.
+     *
+     * @param  int  $memoryLimit
+     * @return bool
+     */
+    public function memoryExceeded($memoryLimit)
+    {
+        return (memory_get_usage() / 1024 / 1024) >= $memoryLimit;
+    }
+
+    /**
+     * Stop listening and bail out of the script.
+     *
+     * @return void
+     */
+    public function stop()
+    {
+        die;
+    }
+
+    /**
+     * Set the output handler callback.
+     *
+     * @param  \Closure  $outputHandler
+     * @return void
+     */
+    public function setOutputHandler(Closure $outputHandler)
+    {
+        $this->outputHandler = $outputHandler;
+    }
+}

--- a/src/Illuminate/Queue/PoolOption.php
+++ b/src/Illuminate/Queue/PoolOption.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Queue;
+
+class PoolOption extends WorkerOptions
+{
+    /**
+     * The amount of worker need to start.
+     *
+     * @var int
+     */
+    public $workers;
+
+    /**
+     * The environment the worker should run in.
+     *
+     * @var string
+     */
+    public $environment;
+
+    /**
+     * Create a new worker options instance.
+     *
+     * @param  int  $workers
+     * @param  string $environment
+     * @param  int  $delay
+     * @param  int  $memory
+     * @param  int  $timeout
+     * @param  int  $sleep
+     * @param  int  $maxTries
+     * @param  bool  $force
+     * @return void
+     */
+    public function __construct($workers = 1, $environment = null, $delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0, $force = false)
+    {
+        $this->workers = $workers;
+        $this->environment = $environment;
+
+        parent::__construct($delay, $memory, $timeout, $sleep, $maxTries, $force);
+    }
+}

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -37,6 +37,8 @@ class QueueServiceProvider extends ServiceProvider
 
         $this->registerListener();
 
+        $this->registerPool();
+
         $this->registerFailedJobServices();
     }
 
@@ -187,6 +189,18 @@ class QueueServiceProvider extends ServiceProvider
     }
 
     /**
+     * Register the queue listener.
+     *
+     * @return void
+     */
+    protected function registerPool()
+    {
+        $this->app->singleton('queue.pool', function () {
+            return new Pool($this->app->basePath());
+        });
+    }
+
+    /**
      * Register the failed job services.
      *
      * @return void
@@ -223,7 +237,8 @@ class QueueServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'queue', 'queue.worker', 'queue.listener',
+            'queue', 'queue.worker',
+            'queue.listener', 'queue.pool',
             'queue.failer', 'queue.connection',
         ];
     }

--- a/tests/Queue/QueuePoolTest.php
+++ b/tests/Queue/QueuePoolTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class QueuePoolTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testRunProcessCallsProcess()
+    {
+        $process1 = m::mock('Symfony\Component\Process\Process')->makePartial();
+        $process1->shouldReceive('start')->once();
+        $process2 = m::mock('Symfony\Component\Process\Process')->makePartial();
+        $process2->shouldReceive('start')->once();
+
+        $pool = m::mock('Illuminate\Queue\Pool')->makePartial();
+        $pool->shouldReceive('getProcesses')->once()->andReturn([$process1, $process2]);
+        $pool->shouldReceive('memoryExceeded')->once()->with(1)->andReturn(false);
+
+        $pool->runProcesses(1);
+    }
+
+    public function testPoolCanRestartWorker()
+    {
+        $process = m::mock('Symfony\Component\Process\Process')->makePartial();
+        $process->shouldReceive('start')->once();
+        $process->shouldReceive('isRunning')->twice()->andReturn(true, false);
+
+        $pool = m::mock('Illuminate\Queue\Pool')->makePartial();
+        $pool->shouldReceive('getProcesses')->twice()->andReturn([$process]);
+        $pool->shouldReceive('memoryExceeded')->twice()->with(1)->andReturn(false);
+
+        $pool->runProcesses(1);
+        $pool->runProcesses(1);
+    }
+
+    public function testPoolStopsWhenMemoryIsExceeded()
+    {
+        $process = m::mock('Symfony\Component\Process\Process')->makePartial();
+        $process->shouldReceive('start')->once();
+
+        $pool = m::mock('Illuminate\Queue\Pool')->makePartial();
+        $pool->shouldReceive('getProcesses')->once()->andReturn([$process]);
+        $pool->shouldReceive('memoryExceeded')->once()->with(1)->andReturn(true);
+        $pool->shouldReceive('stop')->once();
+
+        $pool->runProcesses(1);
+    }
+
+    public function testMakeProcessCorrectlyFormatsCommandLine()
+    {
+        $pool = new \Illuminate\Queue\Pool(__DIR__);
+        $options = new \Illuminate\Queue\PoolOption();
+        $options->workers = 1;
+        $options->delay = 1;
+        $options->memory = 2;
+        $options->timeout = 3;
+        $processes = $pool->makeProcesses('connection', 'queue', $options);
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
+
+        $this->assertCount(1, $processes);
+        $process = array_first($processes);
+
+        $this->assertInstanceOf('Symfony\Component\Process\Process', $process);
+        $this->assertEquals(__DIR__, $process->getWorkingDirectory());
+        $this->assertEquals(3, $process->getTimeout());
+        $this->assertEquals($escape.PHP_BINARY.$escape." {$escape}artisan{$escape} queue:work {$escape}connection{$escape} --queue={$escape}queue{$escape} --delay=1 --memory=2 --sleep=3 --tries=0", $process->getCommandLine());
+    }
+}


### PR DESCRIPTION
This PR introduced a worker pool feature to easily create many workers by one command
`php artisan queue:pool --workers=3`. It could be useful in both local env to create a few workers without opening many terminals, and on production env to create workers all together without supervisord.

The pool will create workers without `--once` parameter like what inside `queue:listen` and the pool won't wait previous worker finish his job to start the next worker by using `run` instead of `start` method of Symfony `Process` class, so it's non-blocking. I tested with queueing several jobs that sleep 1 seconds each in a fresh installed laravel application, and it work as expected, several job processing event triggered one by one, and then processed event triggered one by one.

Besides that, it will check if working is still running and automatically restart the workers if necessary like supervisord, but it won't restart it self if it's dead or exceeded memory. Since it's using `queue:work` underlying, so it can receive `queue:restart` signal too to restart workers.

I added worker id before the original worker output, not sure if it's necessary or whether it should be there or not, I can remove it.

The feature is new, no existing code is being touched, so there is no breaking changes.