### PR TITLE
[5.5] Fix incorrect League Filesystem interface docblock

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -252,7 +252,7 @@ class FilesystemManager implements FactoryContract
      *
      * @param  \League\Flysystem\AdapterInterface  $adapter
      * @param  array  $config
-     * @return \League\Flysystem\FlysystemInterface
+     * @return \League\Flysystem\FilesystemInterface
      */
     protected function createFlysystem(AdapterInterface $adapter, array $config)
     {


### PR DESCRIPTION
Fixes a docblock return value to the correct `League\Flysystem\FilesystemInterface` inside `FilesystemManager::createFlysystem()`.