### PR TITLE
[5.5] Remove the integer key check in assertSessionHasErrors assertion

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -692,11 +692,7 @@ class TestResponse
         $errors = app('session.store')->get('errors')->getBag($errorBag);
 
         foreach ($keys as $key => $value) {
-            if (is_int($key)) {
-                PHPUnit::assertTrue($errors->has($value), "Session missing error: $value");
-            } else {
-                PHPUnit::assertContains($value, $errors->get($key, $format));
-            }
+            PHPUnit::assertContains($value, $errors->get($key, $format));
         }
 
         return $this;


### PR DESCRIPTION
## Description

In the `TestResponse::assertSessionHasErrors`, if the error key is an integer, the error value is sent to the message bag to determine if any message exists for it, which is incorrect because the message bag uses the key to determine if any message exist for it.

With this changes, the numeric key can be used to fetch the error messages and determine if the given value is contained in them.

## Example:

If at any point in your application you do:

```php
return redirect()->back()->withErrors('Some random string');
```

you will have a message bag that is similar to this one, which will hold the error in the key `0`:

```php
$errors = new Illuminate\Support\MessageBag('Some random string');
```

then, you have this assertion in a test:

```php
$this->get('/somewhere');
     ->assertSessionHasErrors('Some random string');
```

With the current implementation the assertion will try:

```php
PHPUnit::assertTrue($errors->has('Some random string'));
```

which will return false (because the error value was used instead of the key) and throw:

```
Session missing error: Some random string
```

With the changes in this PR, the assertion will try the key:

```php
PHPUnit::assertContains('Some random string', $errors->get(0))
```
and then the error message will be found, causing the assertion to pass.