### PR TITLE
[5.6] Improve session errors assertions

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -692,8 +692,8 @@ class TestResponse
         $errors = app('session.store')->get('errors')->getBag($errorBag);
 
         foreach ($keys as $key => $value) {
-            if (is_int($key)) {
-                PHPUnit::assertTrue($errors->has($value), "Session missing error: $value");
+            if (is_array($value)) {
+                PHPUnit::assertArraySubset($value, $errors->get($key, $format));
             } else {
                 PHPUnit::assertContains($value, $errors->get($key, $format));
             }


### PR DESCRIPTION
In the previous implementation of `TestResponse::assertSessionHasErrors` i found that was not possible to find errors that had an integer key, for example:

```php
// If somewhere in your application you did
return redirect()->back()->withErrors('Something wrong happened.')

// You ended up with a message bag similar to this one in the session errors
$errors = new Illuminate\Support\MessageBag('Something wrong happened.');
$errors->get(0); // Returns 'Something wrong happened.'

// And the following assertion was failing, even when the error was there
$this->post('/somewhere')
     ->assertSessionHasErrors(['Something wrong happened.']);
```

This was happening because if the assertion detected that the key was an integer, it was sending the error value to the `MessageBag::has` method, which was incorrect because that method uses the key to determine if there is any messages for it.

Also, as part of the refactor i achieved the following assertion API improvements, which now allow to find:

```php
/*
 * All the messages for a given key
 */
$this->post('/somewhere', ['password' => 'abc 123'])
     ->assertSessionHasErrors([
         'password' => [
             'The password may only contain letters, numbers, and dashes.',
             'The password must be at least 8 characters.',
         ],
     ]);

/*
 * A subset of the messages for a given key
 */
$this->post('/somewhere', ['password' => 'abc 123'])
     ->assertSessionHasErrors([
         'password' => [
             'The password must be at least 8 characters.',
         ],
     ]);

/*
 * An specific message for a given key (without the need for a wrapping array).
 */
$this->post('/somewhere', ['password' => 'abc 123'])
     ->assertSessionHasErrors([
         'password' => 'The password must be at least 8 characters.',
     ]);

/*
 * Messages with integer keys
 */
$this->post('/somewhere')
     ->assertSessionHasErrors([
         'Something wrong happened.',
         'And this happened too.',
     ]);

/*
 * A subset of messages with integer keys
 */
$this->post('/somewhere')
     ->assertSessionHasErrors([
         'Something wrong happened.',
     ]);

/*
 * An specific message with an integer key (without the need for a wrapping array).
 */
$this->post('/somewhere')
     ->assertSessionHasErrors('Something wrong happened.');
```