### PR TITLE
[5.6] Keep same string format and avoid potential test failure

### DIFF
--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -96,7 +96,7 @@ class Listener
     {
         return defined('ARTISAN_BINARY')
                         ? ProcessUtils::escapeArgument(ARTISAN_BINARY)
-                        : "'artisan'";
+                        : ProcessUtils::escapeArgument('artisan');
     }
 
     /**

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -96,7 +96,7 @@ class Listener
     {
         return defined('ARTISAN_BINARY')
                         ? ProcessUtils::escapeArgument(ARTISAN_BINARY)
-                        : 'artisan';
+                        : "'artisan'";
     }
 
     /**


### PR DESCRIPTION
Sorry, last PR #23047  sent to wrong branch.

------

`ProcessUtils::escapeArgument` will return a string wrapped by single quote `'artisan'` (on macOS, but other OS should have same issue), but `artisan` is not wrapped. when `ARTISAN_BINARY` is not defined, unit test will error.

This PR make them in a same style. 

Previous code could lead some potential test issue when running the test specifically in phpstorm targeting on one function `testMakeProcessCorrectlyFormatsCommandLine` in `tests/Queue/QueuePoolTest.php`. (might be a setup issue, but still should keep them in same style.)

This could be seen as a breaking change so targeting 5.6 branch

Attached output dump with phpunit script
```
/usr/local/Cellar/php71/7.1.8_20/bin/php /Users/project/path/framework/vendor/bin/phpunit --configuration /Users/project/path/framework/phpunit.xml.dist --filter "/::testMakeProcessCorrectlyFormatsCommandLine( .*)?$/" Illuminate\Tests\Queue\QueueListenerTest /Users/project/path/framework/tests/Queue/QueueListenerTest.php --teamcity
PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.8 with Xdebug 2.5.5
Configuration: /Users/project/path/framework/phpunit.xml.dist


Failed asserting that two strings are equal.
Expected :''/usr/local/Cellar/php71/7.1.8_20/bin/php' 'artisan' queue:work 'connection' --once --queue='queue' --delay=1 --memory=2 --sleep=3 --tries=0'
Actual   :''/usr/local/Cellar/php71/7.1.8_20/bin/php' artisan queue:work 'connection' --once --queue='queue' --delay=1 --memory=2 --sleep=3 --tries=0'
 <Click to see difference>

 /Users/project/path/framework/tests/Queue/QueueListenerTest.php:49
 
Time: 211 ms, Memory: 6.00MB
```