### PR TITLE
[5.6] brpoplpush for redis queues

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -74,7 +74,7 @@ class RedisQueue extends Queue implements QueueContract
         $queue = $this->getQueue($queue);
 
         return $this->getConnection()->eval(
-            LuaScripts::size(), 3, $queue, $queue.':delayed', $queue.':reserved'
+            LuaScripts::size(), 4, $queue, $queue.':front', $queue.':delayed', $queue.':reserved'
         );
     }
 
@@ -101,7 +101,7 @@ class RedisQueue extends Queue implements QueueContract
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        $this->getConnection()->rpush($this->getQueue($queue), $payload);
+        $this->getConnection()->lpush($this->getQueue($queue), $payload);
 
         return json_decode($payload, true)['id'] ?? null;
     }
@@ -209,41 +209,41 @@ class RedisQueue extends Queue implements QueueContract
      */
     protected function retrieveNextJob($queue)
     {
-        if (! is_null($this->blockFor)) {
-            return $this->blockingPop($queue);
+        $job = $this->nonBlockingPop($queue);
+        if ($job[0]) {
+            return $job;
         }
 
+        if (! is_null($this->blockFor) && $this->block($queue)) {
+            return $this->nonBlockingPop($queue);
+        }
+
+        return [null, null];
+    }
+
+    /**
+     * Retrieve the next job without blocking.
+     *
+     * @param $queue
+     * @return mixed
+     */
+    protected function nonBlockingPop($queue)
+    {
         return $this->getConnection()->eval(
-            LuaScripts::pop(), 2, $queue, $queue.':reserved',
+            LuaScripts::pop(), 3, $queue, $queue.':front', $queue.':reserved',
             $this->availableAt($this->retryAfter)
         );
     }
 
     /**
-     * Retrieve the next job by blocking-pop.
+     * Block for the next job.
      *
      * @param  string  $queue
-     * @return array
+     * @return string|null
      */
-    protected function blockingPop($queue)
+    protected function block($queue)
     {
-        $rawBody = $this->getConnection()->blpop($queue, $this->blockFor);
-
-        if (! is_null($rawBody)) {
-            $payload = json_decode($rawBody[1], true);
-
-            $payload['attempts']++;
-
-            $reserved = json_encode($payload);
-
-            $this->getConnection()->zadd($queue.':reserved', [
-                $reserved => $this->availableAt($this->retryAfter),
-            ]);
-
-            return [$rawBody[1], $reserved];
-        }
-
-        return [null, null];
+        return $this->getConnection()->brpoplpush($queue, $queue.':front', $this->blockFor);
     }
 
     /**

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -224,7 +224,7 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * Retrieve the next job without blocking.
      *
-     * @param $queue
+     * @param  string  $queue
      * @return mixed
      */
     protected function nonBlockingPop($queue)

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -17,7 +17,7 @@ class QueueRedisQueueTest extends TestCase
         $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
-        $redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]));
+        $redis->shouldReceive('lpush')->once()->with('queues:default', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]));
 
         $id = $queue->push('foo', ['data']);
         $this->assertEquals('foo', $id);

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -68,7 +68,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param $driver
+     * @param  string  $driver
      */
     public function testMigrateMoreThan100Jobs($driver)
     {
@@ -86,7 +86,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param $driver
+     * @param  string  $driver
      *
      * @throws \Exception
      */

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -68,6 +68,49 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
+     * @param $driver
+     */
+    public function testMigrateMoreThan100Jobs($driver)
+    {
+        $this->setQueue($driver);
+
+        for ($i = -1; $i >= -201; $i--) {
+            $this->queue->later($i, new RedisQueueIntegrationTestJob($i));
+        }
+
+        for ($i = -201; $i <= -1; $i++) {
+            $this->assertEquals($i, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command)->i);
+        }
+    }
+
+    /**
+     * @dataProvider redisDriverProvider
+     *
+     * @param $driver
+     *
+     * @throws \Exception
+     */
+    public function testBlockingPop($driver)
+    {
+        $this->tearDownRedis();
+        if ($pid = pcntl_fork() > 0) {
+            $this->setUpRedis();
+            $this->setQueue($driver, 10);
+            $this->assertEquals(12, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command)->i);
+        } elseif ($pid == 0) {
+            $this->setUpRedis();
+            $this->setQueue('predis');
+            sleep(1);
+            $this->queue->push(new RedisQueueIntegrationTestJob(12));
+            die;
+        } else {
+            $this->fail('Cannot fork');
+        }
+    }
+
+    /**
+     * @dataProvider redisDriverProvider
+     *
      * @param string $driver
      */
     public function testPopProperlyPopsJobOffOfRedis($driver)
@@ -335,10 +378,11 @@ class RedisQueueIntegrationTest extends TestCase
 
     /**
      * @param string $driver
+     * @param null $blockFor
      */
-    private function setQueue($driver)
+    private function setQueue($driver, $blockFor = null)
     {
-        $this->queue = new RedisQueue($this->redis[$driver]);
+        $this->queue = new RedisQueue($this->redis[$driver], 'default', null, 60, $blockFor);
         $this->queue->setContainer(m::mock(Container::class));
     }
 }


### PR DESCRIPTION
Fixing #22939
### Changes:
1. The order of jobs in Redis queue is reversed.
2. A new Redis list is added for each queue, prefiex ':front'.
3. brpoplpush command is used for blocking pop.
4. `LuaScripts::migrateExpiredJobs()` Migrates up to 100 jobs from reserved and delayed queues. It is not a good to eval lua scripts that are possible to take super-linear time. I think a PR may be sent to previous versions of Laravel with this regard.
### Tests:
1. I added a test for migrating more than 100 jobs, since the ordering was a bit confusing to me.
2. A test is added for blocking pop. It requires `pcntl_fork()`.
