### PR TITLE
[5.6] Add Nested Joins to Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -152,10 +152,11 @@ class Grammar extends BaseGrammar
      */
     protected function compileJoins(Builder $query, $joins)
     {
-        return collect($joins)->map(function ($join) {
+        return collect($joins)->map(function ($join) use ($query) {
             $table = $this->wrapTable($join->table);
+            $nestedJoins = is_null($join->joins) ? '' : ' '.$this->compileJoins($query, $join->joins);
 
-            return trim("{$join->type} join {$table} {$this->compileWheres($join)}");
+            return trim("{$join->type} join {$table}{$nestedJoins} {$this->compileWheres($join)}");
         })->implode(' ');
     }
 


### PR DESCRIPTION
Sometimes left joined tables should only show up if they can join to another table.  The following query is a basic example and was used in one of the tests.

SELECT "users"."id", 
       "contacts"."id", 
       "contact_types"."id" 
FROM   "users" 
       LEFT JOIN "contacts" 
              INNER JOIN "contact_types" 
              ON "contacts"."contact_type_id" = "contact_types"."id" 
       ON "users"."id" = "contacts"."id" 