### PR TITLE
[5.6] Updating Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
 matrix:
   fast_finish: true
   include:
+    - php: 7.1.3
+    - php: 7.1.3
+      env: setup=lowest
     - php: 7.1
     - php: 7.1
       env: setup=lowest


### PR DESCRIPTION
Run tests with PHP 7.1.3 instead of the latest version of PHP 7.1