### PR TITLE
[5.6] add diff as custom date casting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -191,7 +191,11 @@ trait HasAttributes
             }
 
             if ($attributes[$key] && $this->isCustomDateTimeCast($value)) {
-                $attributes[$key] = $attributes[$key]->format(explode(':', $value, 2)[1]);
+                $format = explode(':', $value, 2)[1];
+
+                $attributes[$key] = $format === 'diff' ?
+                    $attributes[$key]->diffForHumans() :
+                    $attributes[$key]->format($format);
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -193,7 +193,7 @@ trait HasAttributes
             if ($attributes[$key] && $this->isCustomDateTimeCast($value)) {
                 $format = explode(':', $value, 2)[1];
 
-                $attributes[$key] = $format === 'diff' ?
+                $attributes[$key] = $format === 'diff_for_humans' ?
                     $attributes[$key]->diffForHumans() :
                     $attributes[$key]->format($format);
             }

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -20,6 +20,7 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
             $table->increments('id');
             $table->date('date_field')->nullable();
             $table->datetime('datetime_field')->nullable();
+            $table->datetime('datetime_diff_field')->nullable();
         });
     }
 
@@ -35,6 +36,17 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         $this->assertInstanceOf(Carbon::class, $user->date_field);
         $this->assertInstanceOf(Carbon::class, $user->datetime_field);
     }
+
+    public function test_dates_are_diff_castable()
+    {
+        $user = TestModel1::create([
+            'datetime_diff_field' => '2019-10-01 10:15:20',
+        ]);
+
+        Carbon::setTestNow(Carbon::parse('2019-10-01 10:16:20'));
+
+        $this->assertEquals('1 minute ago', $user->toArray()['datetime_diff_field']);
+    }
 }
 
 class TestModel1 extends Model
@@ -47,5 +59,6 @@ class TestModel1 extends Model
     public $casts = [
         'date_field' => 'date:Y-m',
         'datetime_field' => 'datetime:Y-m H:i',
+        'datetime_diff_field' => 'datetime:diff',
     ];
 }

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -59,6 +59,6 @@ class TestModel1 extends Model
     public $casts = [
         'date_field' => 'date:Y-m',
         'datetime_field' => 'datetime:Y-m H:i',
-        'datetime_diff_field' => 'datetime:diff',
+        'datetime_diff_field' => 'datetime:diff_for_humans',
     ];
 }


### PR DESCRIPTION
This would add the ability for someone to use a date casting like this

```
$casts = [
    'created_at' => 'datetime:diff_for_humans',
];
```

and receive the equivalent to doing `$model->created_at->diffForHumans()`