### PR TITLE
[5.6] qualify field for route model binding

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1359,7 +1359,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function resolveRouteBinding($value)
     {
-        return $this->where($this->getRouteKeyName(), $value)->first();
+        return $this->where($this->qualifyColumn($this->getRouteKeyName()), $value)->first();
     }
 
     /**


### PR DESCRIPTION
avoids ambiguous field issue when using joins in global scopes