### PR TITLE
Make route group namespaces absolute if they begin with a '\'

### DIFF
--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -40,7 +40,7 @@ class RouteGroup
     protected static function formatNamespace($new, $old)
     {
         if (isset($new['namespace'])) {
-            return isset($old['namespace'])
+            return isset($old['namespace']) && strpos($new['namespace'], '\\') !== 0
                     ? trim($old['namespace'], '\\').'\\'.trim($new['namespace'], '\\')
                     : trim($new['namespace'], '\\');
         }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -882,6 +882,25 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foo', $routes[0]->getPrefix());
     }
 
+    public function testRouteGroupingOutsideOfInheritedNamespace()
+    {
+        $router = $this->getRouter();
+
+        $router->group(['namespace' => 'App\Http\Controllers'], function ($router) {
+            $router->group(['namespace' => '\Foo\Bar'], function ($router) {
+                $router->get('users', 'UsersController@index');
+            });
+        });
+
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals(
+            'Foo\Bar\UsersController@index',
+            $routes[0]->getAction()['uses']
+        );
+    }
+
     public function testCurrentRouteUses()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
Currently, you can register routes to point to a fully qualified class name if it starts with a '\\' - which will ignore the namespace that would otherwise be inherited from the route group stack:

`Route::get('users', '\Foo\Bar\UsersController@index')`

This PR adds the same functionality for route groups:

```
Route::namespace('\Foo\Bar')->group(function () {
    Route::get('users', 'UsersController@index'); // Foo\Bar\UsersController@index
});
```