### PR TITLE
[5.6] Add slack attachment pretext attribute

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -85,6 +85,7 @@ class SlackWebhookChannel
                 'author_icon' => $attachment->authorIcon,
                 'author_link' => $attachment->authorLink,
                 'author_name' => $attachment->authorName,
+                'pretext' => $attachment->pretext,
                 'color' => $attachment->color ?: $message->color(),
                 'fallback' => $attachment->fallback,
                 'fields' => $this->fields($attachment),

--- a/src/Illuminate/Notifications/Messages/SlackAttachment.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachment.php
@@ -30,6 +30,13 @@ class SlackAttachment
     public $content;
 
     /**
+     * The attachment's pre-text.
+     *
+     * @var string
+     */
+    public $pretext;
+
+    /**
      * A plain-text summary of the attachment.
      *
      * @var string
@@ -137,6 +144,19 @@ class SlackAttachment
     public function content($content)
     {
         $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * Set the Pre-text of the attachment.
+     *
+     * @param  string  $pretext
+     * @return $this
+     */
+    public function pretext($pretext)
+    {
+        $this->pretext = $pretext;
 
         return $this;
     }


### PR DESCRIPTION
<img width="786" alt="screen shot 2018-02-08 at 2 12 59 pm" src="https://user-images.githubusercontent.com/4332182/35972348-26e50082-0cda-11e8-877c-579439eca48d.png">
