### PR TITLE
[5.6] Remove monologConfigurator infrastructure completely

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -95,13 +95,6 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected $deferredServices = [];
 
     /**
-     * A custom callback used to configure Monolog.
-     *
-     * @var callable|null
-     */
-    protected $monologConfigurator;
-
-    /**
      * The custom database path defined by the developer.
      *
      * @var string
@@ -1042,39 +1035,6 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function provideFacades($namespace)
     {
         AliasLoader::setFacadeNamespace($namespace);
-    }
-
-    /**
-     * Define a callback to be used to configure Monolog.
-     *
-     * @param  callable  $callback
-     * @return $this
-     */
-    public function configureMonologUsing(callable $callback)
-    {
-        $this->monologConfigurator = $callback;
-
-        return $this;
-    }
-
-    /**
-     * Determine if the application has a custom Monolog configurator.
-     *
-     * @return bool
-     */
-    public function hasMonologConfigurator()
-    {
-        return ! is_null($this->monologConfigurator);
-    }
-
-    /**
-     * Get the custom Monolog configurator for the application.
-     *
-     * @return callable
-     */
-    public function getMonologConfigurator()
-    {
-        return $this->monologConfigurator;
     }
 
     /**


### PR DESCRIPTION
This was made obsolete with the overhaul of the new logger in 5.6
and isn't applied anymore (i.e. dead code).

It was used in `\Illuminate\Log\LogServiceProvider` but is gone now (the removal happened in https://github.com/laravel/framework/pull/22635 ).

### Note
Applying this PR is a "hard break".

So far in 5.6 it's a "soft break", as in: even if you have used `configureMonologUsing`, it's not called anymore but you wouldn't notice until later.  After merging this, anyone using it would immediately see a hard break in the application.

As I assume it's not coming back anymore, I additionally suggest to note this in the upgrade guide as a breaking change to 5.5