### PR TITLE
Added a command make:observer to create observer easily

### DIFF
--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class ObserverMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:observer';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new observer class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Observer';
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = parent::buildClass($name);
+
+        $model = $this->option('model');
+
+        return $model ? $this->replaceModel($stub, $model) : $stub;
+    }
+
+    /**
+     * Replace the model for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $model
+     * @return string
+     */
+    protected function replaceModel($stub, $model)
+    {
+        $model = str_replace('/', '\\', $model);
+
+        $namespaceModel = $this->laravel->getNamespace().$model;
+
+        if (Str::startsWith($model, '\\')) {
+            $stub = str_replace('NamespacedDummyModel', trim($model, '\\'), $stub);
+        } else {
+            $stub = str_replace('NamespacedDummyModel', $namespaceModel, $stub);
+        }
+
+        $stub = str_replace(
+            "use {$namespaceModel};\nuse {$namespaceModel};", "use {$namespaceModel};", $stub
+        );
+
+        $model = class_basename(trim($model, '\\'));
+
+        $stub = str_replace('DummyModel', $model, $stub);
+
+        $dummyModel = Str::camel($model);
+
+        return str_replace('dummyModel', $dummyModel, $stub);
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->option('model')
+                    ? __DIR__ . '/stubs/observer.stub'
+                    : __DIR__.'/stubs/observer.plain.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Observers';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the observer applies to.'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/observer.plain.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.plain.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace DummyNamespace;
+
+class DummyClass
+{
+    //
+}

--- a/src/Illuminate/Foundation/Console/stubs/observer.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.stub
@@ -1,0 +1,129 @@
+<?php
+
+namespace DummyNamespace;
+
+use NamespacedDummyModel;
+
+class DummyClass
+{
+    /**
+     * Listen to the DummyModel retrieved event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function retrieved(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel creating event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function creating(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel created event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function created(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel updating event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function updating(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel updated event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function updated(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel saving event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function saving(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel saved event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function saved(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel deleting event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function deleting(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel deleted event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function deleted(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel restoring event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function restoring(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel restored event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function restored(DummyModel $dummyModel)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -38,6 +38,7 @@ use Illuminate\Foundation\Console\StorageLinkCommand;
 use Illuminate\Routing\Console\ControllerMakeCommand;
 use Illuminate\Routing\Console\MiddlewareMakeCommand;
 use Illuminate\Foundation\Console\ListenerMakeCommand;
+use Illuminate\Foundation\Console\ObserverMakeCommand;
 use Illuminate\Foundation\Console\ProviderMakeCommand;
 use Illuminate\Foundation\Console\ResourceMakeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
@@ -143,6 +144,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'ModelMake' => 'command.model.make',
         'NotificationMake' => 'command.notification.make',
         'NotificationTable' => 'command.notification.table',
+        'ObserverMake' => 'command.observer.make',
         'PolicyMake' => 'command.policy.make',
         'ProviderMake' => 'command.provider.make',
         'QueueFailedTable' => 'command.queue.failed-table',
@@ -572,6 +574,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.notification.make', function ($app) {
             return new NotificationMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerObserverMakeCommand()
+    {
+        $this->app->singleton('command.observer.make', function ($app) {
+            return new ObserverMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
This PR added a command `make:observer` to create observers easily under `app/Observers` folder.

When running `php artisan make:observer` an empty class will be generated, when running `php artisan make:observer -m Post`, an observer class with all possible event for `Post` will be generated.

without `-m`, we can create the `Observers` folder easily, with `-m`, all possible event will be there, and developers can delete unnecessary events or just leave it there and then code for needed model events. 

final class of `php artisan make:observer -m User` looks like this
```
<?php

namespace App\Observers;

use App\User;

class UserObserver
{
    /**
     * Listen to the User retrieved event.
     *
     * @param  \App\User  $user
     * @return void
     */
    public function retrieved(User $user)
    {
        //
    }

    /**
     * Listen to the User creating event.
     *
     * @param  \App\User  $user
     * @return void
     */
    public function creating(User $user)
    {
        //
    }

    /**
     * Listen to the User created event.
     *
     * @param  \App\User  $user
     * @return void
     */
    public function created(User $user)
    {
        //
    }

    /**
     * Listen to the User updating event.
     *
     * @param  \App\User  $user
     * @return void
     */
    public function updating(User $user)
    {
        //
    }

    /**
     * Listen to the User updated event.
     *
     * @param  \App\User  $user
     * @return void
     */
    public function updated(User $user)
    {
        //
    }

    /**
     * Listen to the User saving event.
     *
     * @param  \App\User  $user
     * @return void
     */
    public function saving(User $user)
    {
        //
    }

    /**
     * Listen to the User saved event.
     *
     * @param  \App\User  $user
     * @return void
     */
    public function saved(User $user)
    {
        //
    }

    /**
     * Listen to the User deleting event.
     *
     * @param  \App\User  $user
     * @return void
     */
    public function deleting(User $user)
    {
        //
    }

    /**
     * Listen to the User deleted event.
     *
     * @param  \App\User  $user
     * @return void
     */
    public function deleted(User $user)
    {
        //
    }

    /**
     * Listen to the User restoring event.
     *
     * @param  \App\User  $user
     * @return void
     */
    public function restoring(User $user)
    {
        //
    }

    /**
     * Listen to the User restored event.
     *
     * @param  \App\User  $user
     * @return void
     */
    public function restored(User $user)
    {
        //
    }
}
```