### PR TITLE
[5.6] Fix BelongsToMany pivot relation wakeup

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -429,7 +429,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function getQueueableRelations()
     {
-        return $this->isNotEmpty() ? $this->first()->getRelations() : [];
+        return $this->isNotEmpty() ? $this->first()->getQueueableRelations() : [];
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1303,11 +1303,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $relations = [];
 
         foreach ($this->getRelations() as $key => $relation) {
-            $relations[] = $key;
+            if (method_exists($this, $key)) {
+                $relations[] = $key;
+            }
 
             if ($relation instanceof QueueableCollection) {
-                foreach ($relation->getQueueableRelations() as $collectionKey => $collectionValue) {
-                    $relations[] = $key.'.'.$collectionKey;
+                foreach ($relation->getQueueableRelations() as $collectionValue) {
+                    $relations[] = $key.'.'.$collectionValue;
                 }
             }
 

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -146,7 +146,9 @@ class ModelSerializationTest extends TestCase
      */
     public function it_reloads_relationships()
     {
-        $order = Order::create();
+        $order = tap(Order::create(), function (Order $order) {
+            $order->wasRecentlyCreated = false;
+        });
 
         $product1 = Product::create();
         $product2 = Product::create();
@@ -154,7 +156,7 @@ class ModelSerializationTest extends TestCase
         Line::create(['order_id' => $order->id, 'product_id' => $product1->id]);
         Line::create(['order_id' => $order->id, 'product_id' => $product2->id]);
 
-        $order->load('line', 'lines');
+        $order->load('line', 'lines', 'products');
 
         $serialized = serialize(new ModelRelationSerializationTestClass($order));
         $unSerialized = unserialize($serialized);
@@ -167,7 +169,9 @@ class ModelSerializationTest extends TestCase
      */
     public function it_reloads_nested_relationships()
     {
-        $order = Order::create();
+        $order = tap(Order::create(), function (Order $order) {
+            $order->wasRecentlyCreated = false;
+        });
 
         $product1 = Product::create();
         $product2 = Product::create();
@@ -175,7 +179,7 @@ class ModelSerializationTest extends TestCase
         Line::create(['order_id' => $order->id, 'product_id' => $product1->id]);
         Line::create(['order_id' => $order->id, 'product_id' => $product2->id]);
 
-        $order->load('line.product', 'lines', 'lines.product');
+        $order->load('line.product', 'lines', 'lines.product', 'products');
 
         $nestedSerialized = serialize(new ModelRelationSerializationTestClass($order));
         $nestedUnSerialized = unserialize($nestedSerialized);
@@ -214,6 +218,11 @@ class Order extends Model
     public function lines()
     {
         return $this->hasMany(Line::class);
+    }
+
+    public function products()
+    {
+        return $this->belongsToMany(Product::class, 'lines');
     }
 }
 


### PR DESCRIPTION
As described in issue #23068 when a model with a BelongsToMany relation is unserialized, the pivot relation fails to reload as it does not have an explicit relation method in the Model.

This PR tries to fix this issue by verifying if an explicit relation method exists before serializing that relation.

Some tests were changed to reflect this updates.

P.S.: I am not sure if this is the best approach, and if calling `getQueueableRelations` from the first model in a collection could lead to a circular reference problem when serializing.

But as this issue is preventing me to migrate to Laravel 5.6 I tried to fix it in the most reasonable way. Any further help is appreciated.