### PR TITLE
ArrayCacheStore to return values, not references of objects. Resolves #23079

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -16,7 +16,7 @@ class ArrayStore extends TaggableStore implements Store
     protected $storage = [];
 
     /**
-     * Retrieve an item from the cache by key.
+     * Retrieve an item (by value) from the cache by key.
      *
      * @param  string|array  $key
      * @return mixed
@@ -24,7 +24,7 @@ class ArrayStore extends TaggableStore implements Store
     public function get($key)
     {
         if (array_key_exists($key, $this->storage)) {
-            return $this->storage[$key];
+            return unserialize(serialize($this->storage[$key]));
         }
     }
 

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -84,4 +84,17 @@ class CacheArrayStoreTest extends TestCase
         $store = new ArrayStore;
         $this->assertEmpty($store->getPrefix());
     }
+
+    public function testGettingBackCachedObjectsByValueNotByReference() {
+        $cacheKey = 'testKey';
+        $store = new ArrayStore;
+
+        $store->put($cacheKey, new \Illuminate\Support\Collection([1,2,3]), 60);
+
+        $collection1 = $store->get($cacheKey)->push(4);
+        $collection2 = $store->get($cacheKey)->push(5);
+
+        $this->assertEquals(4, $collection1->last());
+        $this->assertEquals(5, $collection2->last());
+    }
 }


### PR DESCRIPTION
An cached object needs to get back from Array CacheStore as value, not by reference