### PR TITLE
assertSessionHasErrors support to check keys fix.

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -748,7 +748,7 @@ class TestResponse
         foreach ($keys as $key => $value) {
             if (is_array($value)) {
                 PHPUnit::assertArraySubset($value, $errors->get($key, $format));
-            } else if (is_int($key)) {
+            } elseif (is_int($key)) {
 				PHPUnit::assertTrue($errors->has($value), "Session missing error: $value");
 			} else {
                 PHPUnit::assertContains($value, $errors->get($key, $format));

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -748,7 +748,9 @@ class TestResponse
         foreach ($keys as $key => $value) {
             if (is_array($value)) {
                 PHPUnit::assertArraySubset($value, $errors->get($key, $format));
-            } else {
+            } else if (is_int($key)) {
+				PHPUnit::assertTrue($errors->has($value), "Session missing error: $value");
+			} else {
                 PHPUnit::assertContains($value, $errors->get($key, $format));
             }
         }


### PR DESCRIPTION
Returned the support to check keys without value to the assertSessionHasErrors function.
Fixes issue #23085