### PR TITLE
[5.5] Unnecessary temporary variable

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -391,8 +391,6 @@ class Handler implements ExceptionHandlerContract
      */
     protected function renderHttpException(HttpException $e)
     {
-        $status = $e->getStatusCode();
-
         $paths = collect(config('view.paths'));
 
         view()->replaceNamespace('errors', $paths->map(function ($path) {
@@ -400,7 +398,7 @@ class Handler implements ExceptionHandlerContract
         })->push(__DIR__.'/views')->all());
 
         if (view()->exists($view = "errors::{$status}")) {
-            return response()->view($view, ['exception' => $e], $status, $e->getHeaders());
+            return response()->view($view, ['exception' => $e], $e->getStatusCode(), $e->getHeaders());
         }
 
         return $this->convertExceptionToResponse($e);


### PR DESCRIPTION
- Laravel Version: 5.5

### Description:
I think it is unnecessary to place the $status variable this case.
```php
protected function renderHttpException(HttpException $e)
{
    $status = $e->getStatusCode(); // unnecessary variable

    $paths = collect(config('view.paths'));

    view()->replaceNamespace('errors', $paths->map(function ($path) {
        return "{$path}/errors";
    })->push(__DIR__.'/views')->all());

    if (view()->exists($view = "errors::{$status}")) {
        return response()->view($view, ['exception' => $e], $status, $e->getHeaders());
    }

    return $this->convertExceptionToResponse($e);
}
```
