### PR TITLE
[5.6] Fix assertSessionHasErrors

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -746,7 +746,7 @@ class TestResponse
         $errors = app('session.store')->get('errors')->getBag($errorBag);
 
         foreach ($keys as $key => $value) {
-            if (is_int($value)) {
+            if (is_int($key)) {
                 PHPUnit::assertTrue($errors->has($value), "Session missing error: $value");
             } else {
                 PHPUnit::assertContains($value, $errors->get($key, $format));


### PR DESCRIPTION
Here the variable used with `is_int` should be `$key` no `$value` (same as in Laravel 5.5). 