### PR TITLE
[5.6] Allow the use of component('alias') as mentioned in the documentation

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -4,6 +4,7 @@ namespace Illuminate\View\Compilers;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\View;
 
 class BladeCompiler extends Compiler implements CompilerInterface
 {
@@ -434,6 +435,8 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function component($path, $alias = null)
     {
         $alias = $alias ?: array_last(explode('.', $path));
+
+        View::setComponentAlias($path, $alias);
 
         $this->directive($alias, function ($expression) use ($path) {
             return $expression

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -77,7 +77,7 @@ trait ManagesComponents
     public function renderComponent()
     {
         $name = array_pop($this->componentStack);
-        
+
         return $this->make($name, $this->componentData($name))->render();
     }
 

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -35,6 +35,23 @@ trait ManagesComponents
     protected $slotStack = [];
 
     /**
+     * The component aliases.
+     */
+    protected $componentAliases = [];
+
+    /**
+     * Set a component alias.
+     *
+     * @param  string  $path
+     * @param  string  $alias
+     * @return void
+     */
+    public function setComponentAlias($path, $alias)
+    {
+        $this->componentAliases[$alias] = $path;
+    }
+
+    /**
      * Start a component rendering process.
      *
      * @param  string  $name
@@ -44,7 +61,7 @@ trait ManagesComponents
     public function startComponent($name, array $data = [])
     {
         if (ob_start()) {
-            $this->componentStack[] = $name;
+            $this->componentStack[] = $this->componentAliases[$name] ?? $name;
 
             $this->componentData[$this->currentComponent()] = $data;
 
@@ -60,7 +77,6 @@ trait ManagesComponents
     public function renderComponent()
     {
         $name = array_pop($this->componentStack);
-
         return $this->make($name, $this->componentData($name))->render();
     }
 

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -77,6 +77,7 @@ trait ManagesComponents
     public function renderComponent()
     {
         $name = array_pop($this->componentStack);
+        
         return $this->make($name, $this->componentData($name))->render();
     }
 

--- a/tests/View/Blade/AbstractBladeTestCase.php
+++ b/tests/View/Blade/AbstractBladeTestCase.php
@@ -4,15 +4,22 @@ namespace Illuminate\Tests\View\Blade;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Facades\View;
 use Illuminate\View\Compilers\BladeCompiler;
 
 abstract class AbstractBladeTestCase extends TestCase
 {
     protected $compiler;
+    protected $viewFactory;
 
     public function setUp()
     {
         $this->compiler = new BladeCompiler(m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+
+        $this->viewFactory = m::mock('Illuminate\View\Factory');
+
+        View::swap($this->viewFactory);
+
         parent::setUp();
     }
 

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Tests\View\Blade;
 
-use Illuminate\Support\Facades\View;
-
 class BladeCustomTest extends AbstractBladeTestCase
 {
     public function testCustomPhpCodeIsCorrectlyHandled()

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\View\Blade;
 
+use Illuminate\Support\Facades\View;
+
 class BladeCustomTest extends AbstractBladeTestCase
 {
     public function testCustomPhpCodeIsCorrectlyHandled()
@@ -93,6 +95,8 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testCustomComponents()
     {
+        $this->viewFactory->shouldReceive('setComponentAlias')->with('app.components.alert', 'alert');
+
         $this->compiler->component('app.components.alert', 'alert');
 
         $string = '@alert
@@ -104,6 +108,8 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testCustomComponentsWithSlots()
     {
+        $this->viewFactory->shouldReceive('setComponentAlias')->with('app.components.alert', 'alert');
+
         $this->compiler->component('app.components.alert', 'alert');
 
         $string = '@alert([\'type\' => \'danger\'])
@@ -115,6 +121,8 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testCustomComponentsDefaultAlias()
     {
+        $this->viewFactory->shouldReceive('setComponentAlias')->with('app.components.alert', 'alert');
+
         $this->compiler->component('app.components.alert');
 
         $string = '@alert

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -336,6 +336,23 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('title<hr> component Taylor laravel.com', $contents);
     }
 
+    public function testComponentHandlingWithAlias()
+    {
+        $factory = $this->getFactory();
+        $factory->getFinder()->shouldReceive('find')->with('component-path')->andReturn(__DIR__.'/fixtures/component.php');
+        $factory->getEngineResolver()->shouldReceive('resolve')->andReturn(new \Illuminate\View\Engines\PhpEngine);
+        $factory->getDispatcher()->shouldReceive('dispatch');
+        $factory->setComponentAlias('component-path', 'component-alias');
+        $factory->startComponent('component-alias', ['name' => 'Taylor']);
+        $factory->slot('title');
+        $factory->slot('website', 'laravel.com');
+        echo 'title<hr>';
+        $factory->endSlot();
+        echo 'component';
+        $contents = $factory->renderComponent();
+        $this->assertEquals('title<hr> component Taylor laravel.com', $contents);
+    }
+
     public function testTranslation()
     {
         $container = new \Illuminate\Container\Container;


### PR DESCRIPTION
The documentation says that after using `Blade::component('components.alert', 'alert')` you can call the component like: `@component('alert')`. That wasn't working for me, this is a possible fix.

Although I'm not happy with using the `View` facade in BladeCompiler (or maybe it doesn't matter?), especially because that made the tests more complicated. Other than that this might be fine.