### PR TITLE
[5.6] Added 'rules' method to SendsPasswordResetEmails class

### DIFF
--- a/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
+++ b/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
@@ -40,14 +40,24 @@ trait SendsPasswordResetEmails
     }
 
     /**
-     * Validate the email for the given request.
+     * Validate the email for the given request and the provided set of rules.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return void
      */
     protected function validateEmail(Request $request)
     {
-        $this->validate($request, ['email' => 'required|email']);
+        $this->validate($request, $this->rules());
+    }
+
+    /**
+     * Get the password reset requests validation rules.
+     *
+     * @return array
+     */
+    protected function rules()
+    {
+        return ['email' => 'required|email'];
     }
 
     /**


### PR DESCRIPTION
Implemented a rules() method that returns an array of rules for the email validation.

Utilized the new rules() method in the validateEmail() method.

The intention is to simplify rules extension in this trait, by simply overriding the rules() method in the controller, while maintaining the current funcionality stable.