### PR TITLE
fix assertRedirect when asserting uri response headers

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -94,7 +94,7 @@ class TestResponse
         );
 
         if (! is_null($uri)) {
-            PHPUnit::assertEquals(app('url')->to($uri), $this->headers->get('Location'));
+            PHPUnit::assertEquals(app('url')->to($uri), url($this->headers->get('Location')));
         }
 
         return $this;

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -94,7 +94,7 @@ class TestResponse
         );
 
         if (! is_null($uri)) {
-            PHPUnit::assertEquals(app('url')->to($uri), url($this->headers->get('Location')));
+            PHPUnit::assertEquals(app('url')->to($uri), app('url')->to($this->headers->get('Location')));
         }
 
         return $this;


### PR DESCRIPTION
When defining a route using `Route::redirect()` tests are failing when asserted by `assertRedirect` because it converts the given URI to URL and compares it with the response headers which is returned as a URI in this particular case.

Example to reproduce the falsey failing test (Tested on bot: 5.5 & 5.6):
```
Route::redirect('/', '/login');

$this->get('/')
    ->assertRedirect(route('login'));
```