### PR TITLE
[5.6] Revert "allow 0 block time"

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -40,9 +40,9 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * The maximum number of seconds to block for a job.
      *
-     * @var int|null
+     * @var int
      */
-    protected $blockFor = null;
+    private $blockFor = 0;
 
     /**
      * Create a new Redis queue instance.
@@ -51,10 +51,10 @@ class RedisQueue extends Queue implements QueueContract
      * @param  string  $default
      * @param  string  $connection
      * @param  int  $retryAfter
-     * @param  int|null  $blockFor
+     * @param  int  $blockFor
      * @return void
      */
-    public function __construct(Redis $redis, $default = 'default', $connection = null, $retryAfter = 60, $blockFor = null)
+    public function __construct(Redis $redis, $default = 'default', $connection = null, $retryAfter = 60, $blockFor = 0)
     {
         $this->redis = $redis;
         $this->default = $default;
@@ -209,7 +209,7 @@ class RedisQueue extends Queue implements QueueContract
      */
     protected function retrieveNextJob($queue)
     {
-        if (! is_null($this->blockFor)) {
+        if ($this->blockFor >= 1) {
             return $this->blockingPop($queue);
         }
 


### PR DESCRIPTION
This reverts commit dbad05599b2d2059e45c480fac8817d1135d5da1.
Reasons to revert:
1. blocking for ever is in contradiction with job timeout and maybe Redis read_write_timeout.
2. It causes problems for deployment/updating code. It makes restarting the workers harder for horizon or other control systems.
3. In horizon currently the default timeout is set to zero. Which now means forever, but it used to mean no timeout at all. https://github.com/laravel/horizon/blob/1.0/src/Connectors/RedisConnector.php
4. Other implementations like SQS does not allow for long-polling/blocking for more than 30 seconds. They might have other good reasons for the restriction.