### PR TITLE
[5.6] Add convenient getViewData method on TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -818,6 +818,14 @@ class TestResponse
 
         dd($content);
     }
+    
+    /**
+     * @return array
+     */
+    public function getViewData()
+    {
+        return $this->getOriginalContent()->getData();
+    }
 
     /**
      * Dynamically access base response parameters.

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -253,6 +253,20 @@ class FoundationTestResponseTest extends TestCase
             $response->json()
         );
     }
+    
+    public function testGetViewData()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->setContent(\Mockery::mock(View::class, [
+                'render' => 'hello world',
+                'getData' => ['foo' => 'bar'],
+            ]));
+        });
+    
+        $response = TestResponse::fromBaseResponse($baseResponse);
+    
+        $this->assertEquals(['foo' => 'bar'], $response->getViewData());
+    }
 }
 
 class JsonSerializableMixedResourcesStub implements JsonSerializable


### PR DESCRIPTION
This PR adds a simple method to get the data passed to a view form the response.

I think this is very useful because it's a nice way to assert against some data in the view.

Example:

```
$article = factory(Article::class)->create(['title' => 'Test Title']);
        
$viewData = $this->get("/articles/{$article->id}")->getViewData();
        
$this->assertEquals('Test Title', $viewData['article']->title);
```