### PR TITLE
[5.7] Make route group namespaces absolute if they start with '\'

### DIFF
--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -40,7 +40,7 @@ class RouteGroup
     protected static function formatNamespace($new, $old)
     {
         if (isset($new['namespace'])) {
-            return isset($old['namespace'])
+            return isset($old['namespace']) && strpos($new['namespace'], '\\') !== 0
                     ? trim($old['namespace'], '\\').'\\'.trim($new['namespace'], '\\')
                     : trim($new['namespace'], '\\');
         }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -882,6 +882,25 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foo', $routes[0]->getPrefix());
     }
 
+    public function testRouteGroupingOutsideOfInheritedNamespace()
+    {
+        $router = $this->getRouter();
+
+        $router->group(['namespace' => 'App\Http\Controllers'], function ($router) {
+            $router->group(['namespace' => '\Foo\Bar'], function ($router) {
+                $router->get('users', 'UsersController@index');
+            });
+        });
+
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals(
+            'Foo\Bar\UsersController@index',
+            $routes[0]->getAction()['uses']
+        );
+    }
+
     public function testCurrentRouteUses()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
Clone of #23066 - Pushing to the `master` branch because it's a breaking change.

Currently, you can register routes to point to a fully qualified class name if it starts with a '\\' - which will ignore the namespace that would otherwise be inherited from the route group stack:

```php
Route::get('users', '\Foo\Bar\UsersController@index')
```

This PR adds the same functionality for route groups:

```php
Route::namespace('App\Http\Controllers')->group(function () {
    Route::namespace('\Foo\Bar')->group(function () {
        Route::get('users', 'UsersController@index'); // Foo\Bar\UsersController@index
    });
});
```

An example use case for this functionality would be for route macros provided by a package. For example:

```php
Route::macro('packageResources', function () {
    Route::namespace('\Vendor\Namespace')->group(function () {
        Route::get('resources', 'ResourcesController@index');
        // Long list of other routes.
    });
});
```

This means you can use the above macro in your applications main routes file without the namespace being inherited.