### PR TITLE
[5.6] Add driver provides

### DIFF
--- a/src/Illuminate/Hashing/HashServiceProvider.php
+++ b/src/Illuminate/Hashing/HashServiceProvider.php
@@ -36,6 +36,6 @@ class HashServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return ['hash'];
+        return ['hash', 'hash.driver'];
     }
 }


### PR DESCRIPTION
DI fails with "hash.driver" for the `Illuminate\Contracts\Hashing\Hasher` contract.

Here's an example that breaks:

```php
<?php

namespace App\Http\Controllers;

use Illuminate\Http\Request;

class HomeController extends Controller
{
    protected $hash;

    public function __construct(\Illuminate\Contracts\Hashing\Hasher $hasher)
    {
        $this->hash = $hasher->make('lance');
    }

    public function index()
    {
        return $this->hash;
    }
}
```