### PR TITLE
Adds ability to pass a timestamp to the constructor

### DIFF
--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -17,7 +17,7 @@ class Carbon extends BaseCarbon implements JsonSerializable
      */
     protected static $serializer;
 
-     /**
+    /**
      * Create a new Carbon instance.
      *
      * @param string|int|null           $time

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -17,6 +17,22 @@ class Carbon extends BaseCarbon implements JsonSerializable
      */
     protected static $serializer;
 
+     /**
+     * Create a new Carbon instance.
+     *
+     * @param string|int|null           $time
+     * @param \DateTimeZone|string|null $tz
+     */
+    public function __construct($time = null, $tz = null)
+    {
+        // Convert timestamp to date string
+        if (is_int($time)) {
+            $time = date('Y-m-d H:i:s', $time);
+        }
+
+        parent::__construct($time, $tz);
+    }
+
     /**
      * Prepare the object for JSON serialization.
      *


### PR DESCRIPTION
Seeing the main Carbon/Carbon project seems dead in the water (no PRs being accepted since more than a year), I figure it is easier/faster to just build extra functionality on top of it via the Laravel Carbon class.
So here goes:

This makes it possible to pass a timestamp to the Carbon class, like:
```
$date = new Carbon(1518358828);
```
This way you don't have to do extra checks to see what format the date is in before passing it to Carbon.

PS: PR on main Carbon/Carbon: https://github.com/briannesbitt/Carbon/pull/1084