### PR TITLE
[5.6] Make sure transaction won't be started twice for RefreshDatabase

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -108,7 +108,7 @@ abstract class TestCase extends BaseTestCase
             $this->runDatabaseMigrations();
         }
 
-        if (isset($uses[DatabaseTransactions::class])) {
+        if (isset($uses[DatabaseTransactions::class]) && !isset($uses[RefreshDatabase::class])) {
             $this->beginDatabaseTransaction();
         }
 


### PR DESCRIPTION
This should fix the issue introduced in https://github.com/laravel/framework/pull/22596 with starting transaction twice for RefreshDatabase class.

@skollro and @a-komarev can you confirm this will fix the issue? I really don't like code duplication but maybe it should be moved to other trait