### PR TITLE
Stringable value objects as router actions

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -460,13 +460,13 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Determine if the action is routing to a controller.
      *
-     * @param  array  $action
+     * @param  \Closure|array|string|object $action
      * @return bool
      */
     protected function actionReferencesController($action)
     {
         if (! $action instanceof Closure) {
-            return is_string($action) || (isset($action['uses']) && is_string($action['uses']));
+            return is_stringable($action) || (isset($action['uses']) && is_stringable($action['uses']));
         }
 
         return false;
@@ -480,7 +480,7 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     protected function convertToControllerAction($action)
     {
-        if (is_string($action)) {
+        if (is_stringable($action)) {
             $action = ['uses' => $action];
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -532,11 +532,12 @@ class Str
     }
 
     /**
-     * Return true if the param is a string, or an object that maybe treated as string
+     * Return true if the param is a string, or an object that maybe treated as string.
      * @param $value
      * @return bool
      */
-    public static function isStringable($value) {
+    public static function isStringable($value)
+    {
         return is_string($value) ||
             (is_object($value) && is_callable([$value, '__toString']));
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -532,6 +532,16 @@ class Str
     }
 
     /**
+     * Return true if the param is a string, or an object that maybe treated as string
+     * @param $value
+     * @return bool
+     */
+    public static function isStringable($value) {
+        return is_string($value) ||
+            (is_object($value) && is_callable([$value, '__toString']));
+    }
+
+    /**
      * Generate a time-ordered UUID (version 4).
      *
      * @return \Ramsey\Uuid\Uuid

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -660,6 +660,19 @@ if (! function_exists('head')) {
     }
 }
 
+if (! function_exists('is_stringable')) {
+    /**
+     * Return true if the param is a string or an object that maybe treated as string
+     * @param $value
+     * @return bool
+     */
+    function is_stringable($value)
+    {
+        return Str::isStringable($value);
+    }
+
+}
+
 if (! function_exists('kebab_case')) {
     /**
      * Convert a string to kebab case.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -662,7 +662,7 @@ if (! function_exists('head')) {
 
 if (! function_exists('is_stringable')) {
     /**
-     * Return true if the param is a string or an object that maybe treated as string
+     * Return true if the param is a string or an object that maybe treated as string.
      * @param $value
      * @return bool
      */

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -670,7 +670,6 @@ if (! function_exists('is_stringable')) {
     {
         return Str::isStringable($value);
     }
-
 }
 
 if (! function_exists('kebab_case')) {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -249,6 +249,15 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('App\\Illuminate\Tests\Routing\RouteTestControllerStub@index', $action['controller']);
     }
 
+    public function testActionSpecifiedByAStringableObject()
+    {
+        $router = $this->getRouter();
+        $actionObject = new StringableObject('App\\Illuminate\Tests\Routing\RouteTestControllerStub@index');
+        $router->get('foo/bar')->uses($actionObject);
+        $action = $router->getRoutes()->getRoutes()[0]->getAction();
+        $this->assertEquals('App\\Illuminate\Tests\Routing\RouteTestControllerStub@index', $action['controller']);
+    }
+
     public function testMiddlewareGroups()
     {
         unset($_SERVER['__middleware.group']);
@@ -1761,5 +1770,21 @@ class ActionStub
     public function __invoke()
     {
         return 'hello';
+    }
+}
+
+
+class StringableObject
+{
+    private $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString()
+    {
+        return $this->value;
     }
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1773,7 +1773,6 @@ class ActionStub
     }
 }
 
-
 class StringableObject
 {
     private $value;


### PR DESCRIPTION
**Current situation:** When creating routes, the action must be a string.
With this pull requests we'll be able to pass a value object.

**Reason:** Working  on several DDD projects I try to use, when it may enrich the domain, ValueObjects as an alternative to simple types. This in order to make [implicit concepts more explicit](http://www.markhneedham.com/blog/2009/04/23/ddd-making-implicit-concepts-explicit/).
In my project, action is not a string, its an Action which simply correspond to a value object with the __toString method.