### PR TITLE
Fixes count() throwing a warning on PHP 7.2 due to null being passed

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1182,7 +1182,7 @@ class Builder
         // We will keep track of how many wheres are on the query before running the
         // scope so that we can properly group the added scope constraints in the
         // query as their own isolated nested where statement and avoid issues.
-        $originalWhereCount = count($query->wheres);
+        $originalWhereCount = is_null($query->wheres) ? 0 : count($query->wheres);
 
         $result = call_user_func_array($scope, $parameters) ?: $this;
 
@@ -1228,7 +1228,7 @@ class Builder
      */
     protected function shouldNestWheresForScope(QueryBuilder $query, $originalWhereCount)
     {
-        return count($query->wheres) > $originalWhereCount;
+        return (is_null($query->wheres) ? 0 : count($query->wheres)) > $originalWhereCount;
     }
 
     /**


### PR DESCRIPTION
PHP 7.2 emits a warning when count() is passed a non-countable object or array. This fixes the issue so users can run Laravel 5.2 on PHP 7.2.