### PR TITLE
[5.6] Add an empty error bag for HTTP exceptions

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Response;
 use Illuminate\Routing\Router;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\ViewErrorBag;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\RedirectResponse;
 use Whoops\Handler\PrettyPageHandler;
@@ -400,7 +401,7 @@ class Handler implements ExceptionHandlerContract
         })->push(__DIR__.'/views')->all());
 
         if (view()->exists($view = "errors::{$status}")) {
-            return response()->view($view, ['exception' => $e], $status, $e->getHeaders());
+            return response()->view($view, ['exception' => $e, 'errors' => new ViewErrorBag], $status, $e->getHeaders());
         }
 
         return $this->convertExceptionToResponse($e);


### PR DESCRIPTION
Before this PR, if you had a custom HTTP error page like 404.blade.php that happens to extend a master layout which uses the errors variable, you would have an exception stating that $errors is undefined instead of the custom HTTP error page.
Here are 2 typical scenarios of $errors usage in the master layout:
- a navbar including a login form using $errors.
- a login modal available for all pages as long as the user is not signed in.

There is an open issue related to it, including steps to reproduce: https://github.com/laravel/framework/issues/23133

The goal of this PR is to add the $errors variable for all HTTP exceptions. This is a behavior which is similar to the web middleware : \Illuminate\View\Middleware\ShareErrorsFromSession. This middleware binds $errors to the session errors if the latter is defined and binds $errors to an empty view error bag otherwise because it is more convenient for the developer who doesn't have to run checks for the presence of errors.
In this HTTP exception fix, we do not have the session store set, so the errors variable is always set to an empty view error bag, again because it is more convenient for the developer.