### PR TITLE
[5.6] As per MySQL utf8mb4

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -34,7 +34,7 @@ class Builder
      *
      * @var int
      */
-    public static $defaultStringLength = 255;
+    public static $defaultStringLength = 191;
 
     /**
      * Create a new database Schema manager.


### PR DESCRIPTION
For utf8mb4 191 should be default to consider it to be indexed and avoid all kinds of problems.
https://dev.mysql.com/doc/refman/5.7/en/charset-unicode-conversion.html