### PR TITLE
Add Builder::hasView('view_name') to check for existence of views

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -75,6 +75,21 @@ class Builder
     }
 
     /**
+     * Determine if the given view exists.
+     *
+     * @param  string  $view
+     * @return bool
+     */
+    public function hasView($view)
+    {
+        $view = $this->connection->getTablePrefix().$view;
+
+        return count($this->connection->select(
+            $this->grammar->compileViewExists(), [$view]
+        )) > 0;
+    }
+
+    /**
      * Determine if the given table has a given column.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -36,6 +36,16 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine if a view exists.
+     *
+     * @return string
+     */
+    public function compileViewExists()
+    {
+        return $this->compileTableExists();
+    }
+
+    /**
      * Compile the query to determine the list of columns.
      *
      * @return string

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -47,6 +47,16 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine if a view exists.
+     *
+     * @return string
+     */
+    public function compileViewExists()
+    {
+        return $this->compileTableExists();
+    }
+
+    /**
      * Compile the query to determine the list of columns.
      *
      * @return string

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -34,6 +34,16 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine if a view exists.
+     *
+     * @return string
+     */
+    public function compileViewExists()
+    {
+        return "select * from sqlite_master where type = 'view' and name = ?";
+    }
+
+    /**
      * Compile the query to determine the list of columns.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -39,6 +39,16 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine if a view exists.
+     *
+     * @return string
+     */
+    public function compileViewExists()
+    {
+        return "select * from sysobjects where type = 'V' and name = ?";
+    }
+
+    /**
      * Compile the query to determine the list of columns.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -20,6 +20,21 @@ class MySqlBuilder extends Builder
     }
 
     /**
+     * Determine if the given view exists.
+     *
+     * @param  string  $view
+     * @return bool
+     */
+    public function hasView($view)
+    {
+        $view = $this->connection->getTablePrefix().$view;
+
+        return count($this->connection->select(
+            $this->grammar->compileViewExists(), [$this->connection->getDatabaseName(), $view]
+        )) > 0;
+    }
+
+    /**
      * Get the column listing for a given table.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -22,6 +22,23 @@ class PostgresBuilder extends Builder
     }
 
     /**
+     * Determine if the given view exists.
+     *
+     * @param  string  $view
+     * @return bool
+     */
+    public function hasView($view)
+    {
+        list($schema, $view) = $this->parseSchemaAndTable($view);
+
+        $view = $this->connection->getTablePrefix().$view;
+
+        return count($this->connection->select(
+            $this->grammar->compileTableExists(), [$schema, $view]
+        )) > 0;
+    }
+
+    /**
      * Drop all tables from the database.
      *
      * @return void

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -26,6 +26,19 @@ class DatabaseSchemaBuilderTest extends TestCase
         $this->assertTrue($builder->hasTable('table'));
     }
 
+    public function testHasViewCorrectlyCallsGrammar()
+    {
+        $connection = m::mock('Illuminate\Database\Connection');
+        $grammar = m::mock('stdClass');
+        $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
+        $builder = new Builder($connection);
+        $grammar->shouldReceive('compileViewExists')->once()->andReturn('sql');
+        $connection->shouldReceive('getTablePrefix')->once()->andReturn('prefix_');
+        $connection->shouldReceive('select')->once()->with('sql', ['prefix_view'])->andReturn(['prefix_view']);
+
+        $this->assertTrue($builder->hasView('view'));
+    }
+
     public function testTableHasColumns()
     {
         $connection = m::mock('Illuminate\Database\Connection');


### PR DESCRIPTION
Sometimes it is quite convenient to check for the existence of something before actually executing code in a migration. We already may do that in our migrations for tables like so
```php
public function up()
{
    if (!Schema::hasTable('users')) {
        Schema::create('users', function (Blueprint $table) {
            $table->increments('id');
            $table->string('email');
            $table->string('password');
        });
    }
}
```

As there is no counterpart that works for views (consistently across all supported DBMS) at the moment, this PR introduces a new function called `Builder::hasView($viewName)` which does exactly the same as `Builder::hasTable($tableName)` but for views. In some database grammars it just uses the query of `compileTableExists()` as fallback, but for SQL Server and SQLite it introduces a new query.

#### Table prefix
In the current implementation, a design decision has been made by me which utilizes the existing `$this->connection->getTablePrefix()` also for views. I'm not really sure if this makes sense as there are no methods on the schema builder which allow us to create views fluently yet. Therefore views may follow some different naming conventions which we are not yet aware of. I would suggest a change in this regard when going down the route to implement schema builder methods for view creation, though. Or maybe the introduction of such methods would solve this issue anyway as the normal table prefix could be used also for views.

#### Tested code base

The code has not yet been tested and I'm happy to receive reviews and feedback from the CI.

#### Why views anyway?
Because we need them for third-party systems and we like to maintain them with our existing code base.