### PR TITLE
[5.6] Tightenco/Collect should not be replaced anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,8 +67,7 @@
         "illuminate/support": "self.version",
         "illuminate/translation": "self.version",
         "illuminate/validation": "self.version",
-        "illuminate/view": "self.version",
-        "tightenco/collect": "self.version"
+        "illuminate/view": "self.version"
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",


### PR DESCRIPTION
It's now under on its own namespace to co-live with Illuminate\Collection. And this is preventing us to require it.