### PR TITLE
[5.6] normalize actions on route:list artisan

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -110,7 +110,7 @@ class RouteListCommand extends Command
             'method' => implode('|', $route->methods()),
             'uri'    => $route->uri(),
             'name'   => $route->getName(),
-            'action' => $route->getActionName(),
+            'action' => ltrim($route->getActionName(), '\\'),
             'middleware' => $this->getMiddleware($route),
         ]);
     }


### PR DESCRIPTION
Removes leading slash in actions. 

Change this:
![image](https://user-images.githubusercontent.com/1077520/36159007-facc49d0-10dd-11e8-8134-fb02eb6ceffb.png)

Into this:
![image](https://user-images.githubusercontent.com/1077520/36159022-058582a6-10de-11e8-880a-c3ec532d4316.png)
