### PR TITLE
[5.6] Catches InvalidFileException when loading environment file with dotenv

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Bootstrap;
 
 use Dotenv\Dotenv;
 use Dotenv\Exception\InvalidPathException;
+use Dotenv\Exception\InvalidFileException;
 use Symfony\Component\Console\Input\ArgvInput;
 use Illuminate\Contracts\Foundation\Application;
 
@@ -25,7 +26,7 @@ class LoadEnvironmentVariables
 
         try {
             (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
-        } catch (InvalidPathException $e) {
+        } catch (InvalidPathException | InvalidFileException $e) {
             //
         }
     }

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Foundation\Bootstrap;
 
 use Dotenv\Dotenv;
-use Dotenv\Exception\InvalidPathException;
 use Dotenv\Exception\InvalidFileException;
+use Dotenv\Exception\InvalidPathException;
 use Symfony\Component\Console\Input\ArgvInput;
 use Illuminate\Contracts\Foundation\Application;
 

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -26,8 +26,10 @@ class LoadEnvironmentVariables
 
         try {
             (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
-        } catch (InvalidPathException | InvalidFileException $e) {
+        } catch (InvalidPathException $e) {
             //
+        } catch (InvalidFileException $e) {
+            dd('Fatal Error: Values in .env containing spaces must be surrounded by quotes.');
         }
     }
 


### PR DESCRIPTION
Dotenv may throw an exception when loading a `.env` file, either `InvalidPathException` or `InvalidFileException`. At present `LoadEnvironmentVariables` is only catching `InvalidPathException`. This means that when you provide an invalid `.env` file Laravel outputs an unhelpful error message, e.g:

```
APP_NAME=Laravel Framework
```

```
Fatal error: Uncaught ReflectionException: Class config does not exist in /app/vendor/laravel/framework/src/Illuminate/Container/Container.php:767 Stack trace: #0
/app/vendor/laravel/framework/src/Illuminate/Container/Container.php(767): ReflectionClass->__construct('config') #1 
/app/vendor/laravel/framework/src/Illuminate/Container/Container.php(646): Illuminate\Container\Container->build('config') #2 
[...]
```

Many are confused by this error: [1](https://github.com/laravel/dusk/issues/99), [2](https://github.com/barryvdh/laravel-dompdf/issues/192), [3](https://stackoverflow.com/questions/42025231/laravel-dusk-class-config-does-not-exist), [4](https://joelennon.com/fixing-uncaught-reflectionexception-laravel), [5](https://laracasts.com/discuss/channels/laravel/class-config-does-not-exist-in-laravel-54), [6](https://laracasts.com/discuss/channels/laravel/laravel-migration-from-52-to-55-class-config-does-not-exist).

This change captures the additional error, meaning that when invalid `.env` file is provided (usually because a value containing a space lacks quotation marks) Laravel will fall back to the default application config.

---

I think that when this error occurs Laravel should not continue executing[1] because it is a very difficult situation to debug without an error, and it's unlikely a developer will want their application to run without a `.env` — and if they do, they can create an empty `.env` file — but I haven't added it in case there is a use case I am not aware of that necessitates allowing the application run even with an invalid `.env` file provided. Any thoughts on terminating execution here?

[1] As far as I know the only way to output an error here would be `dd($e)` because the error handling functionality isn't loaded at this point in the bootstrap process.