### PR TITLE
[5.6] Improves name for factory when creating with model make command.

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -68,7 +68,7 @@ class ModelMakeCommand extends GeneratorCommand
     protected function createFactory()
     {
         $this->call('make:factory', [
-            'name' => $this->argument('name').'Factory',
+            'name' => Str::singular(Str::studly(class_basename($this->argument('name')))).'Factory',
             '--model' => $this->argument('name'),
         ]);
     }


### PR DESCRIPTION
Improves the factory name when creating from make:model command with -f flag.

For example: when you run:

php artisan make:model Models/Car -f

a ModelsCarFactory.php is created instead of CarFactory.php.

this PR is an effort to achieve a better name for the factory.