### PR TITLE
[5.6] Replace tightenco/collect before the namespace change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "illuminate/translation": "self.version",
         "illuminate/validation": "self.version",
         "illuminate/view": "self.version",
-        "tightenco/collect": "self.version"
+        "tightenco/collect": "<5.5.33"
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",


### PR DESCRIPTION
We should keep replacing it for versions before the namespace change, which happened in 5.5.33.