### PR TITLE
[5.6] Replace tightenco/collect before the namespace change

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -21,7 +21,7 @@
         "nesbot/carbon": "^1.20"
     },
     "replace": {
-        "tightenco/collect": "self.version"
+        "tightenco/collect": "<5.5.33"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
We should keep replacing it for versions before the namespace change, which happened in 5.5.33.

Updating Illuminate/Support/composer.json.