### PR TITLE
[5.6] Add 'encrypted' eloquent model cast

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -7,6 +7,7 @@ use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
@@ -496,6 +497,8 @@ trait HasAttributes
                 return $this->asDateTime($value);
             case 'timestamp':
                 return $this->asTimestamp($value);
+            case 'encrypted':
+                return Crypt::decrypt($value);
             default:
                 return $value;
         }
@@ -555,6 +558,10 @@ trait HasAttributes
 
         if ($this->isJsonCastable($key) && ! is_null($value)) {
             $value = $this->castAttributeAsJson($key, $value);
+        }
+
+        if ($this->hasCast($key, 'encrypted') && ! is_null($value)) {
+            $value = Crypt::encrypt($value);
         }
 
         // If this attribute contains a JSON ->, we'll set the proper value in the


### PR DESCRIPTION
Adds in a new cast option for Eloquent models: `encrypted`, which provides seamless encryption and decryption of values stored in the database. The idea is to provide a trivial way to encrypt sensitive information before it is stored and decrypt it again when it is retrieved, without the developer needing to remember in each instance. In the same way that other formats like JSON are accepted.

Using it is trivial:
```
protected $casts = ['attribute' => 'encrypted'];
```
```
$model->attribute = 'raw value';

echo $model->attribute;
// raw value
```
All the magic is contained in the model, as you would expect with a cast.

The main motivator for this is [GDPR](https://www.gdpreu.org/), which requires personal data to be properly secured. This cast type provides an easy way to add an extra layer of protection around personal data. Even if someone is able to obtain a copy of the database, they cannot read the raw values. They'd need the Laravel encryption key AND the database to obtain any personal data. Even if you're not complying with GDPR, from a security point of view being able to automatically encrypt data would be incredibly useful for many applications.

I used the Crypt facade in there, but I'm not sure what the convention is around facades within Eloquent so I'm happy to fix up the PR if there is a better way.