### PR TITLE
Fix assertRedirect

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -94,7 +94,9 @@ class TestResponse
         );
 
         if (! is_null($uri)) {
-            PHPUnit::assertEquals(app('url')->to($uri), $this->headers->get('Location'));
+            PHPUnit::assertEquals(
+                app('url')->to($uri), app('url')->to($this->headers->get('Location'))
+            );
         }
 
         return $this;

--- a/tests/Integration/Routing/RouteRedirectTest.php
+++ b/tests/Integration/Routing/RouteRedirectTest.php
@@ -14,21 +14,22 @@ class RouteRedirectTest extends TestCase
     {
         Route::redirect('from', 'to', 301);
 
-        $response = $this->get('/from');
-        $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('to', $response->headers->get('Location'));
+        $this->get('/from')->assertRedirect('to');
     }
 
     public function test_route_redirect_with_params()
     {
         Route::redirect('from/{param}/{param2?}', 'to', 301);
 
-        $response = $this->get('/from/value1/value2');
-        $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('to', $response->headers->get('Location'));
+        $this->get('/from/value1/value2')->assertRedirect('to');
 
-        $response = $this->get('/from/value1');
-        $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('to', $response->headers->get('Location'));
+        $this->get('/from/value1')->assertRedirect('to');
+    }
+
+    public function test_route_redirect_to_external_location()
+    {
+        Route::redirect('from', 'https://laravel.com/');
+
+        $this->get('/from')->assertRedirect('https://laravel.com/');
     }
 }


### PR DESCRIPTION
`assertRedirect` doesn't behave correctly when asserting a redirect routes since it retains the headers format while converting the given URI to URL if necessary.