### PR TITLE
[5.6] Add Blade::include for include aliases

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -470,7 +470,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         $alias = $alias ?: array_last(explode('.', $path));
 
         $this->directive($alias, function ($expression) use ($path) {
-            $expression = $this->stripParentheses($expression) ? : '[]';
+            $expression = $this->stripParentheses($expression) ?: '[]';
 
             return "<?php echo \$__env->make('{$path}', {$expression}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
         });

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -459,6 +459,24 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Register an include alias directive.
+     *
+     * @param  string  $path
+     * @param  string  $alias
+     * @return void
+     */
+    public function include($path, $alias = null)
+    {
+        $alias = $alias ?: array_last(explode('.', $path));
+
+        $this->directive($alias, function ($expression) use ($path) {
+            $expression = $this->stripParentheses($expression) ? : '[]';
+
+            return "<?php echo \$__env->make('{$path}', {$expression}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+        });
+    }
+
+    /**
      * Get the list of custom directives.
      *
      * @return array

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -124,6 +124,17 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testCustomComponentsWithExistingDirective()
+    {
+        $this->compiler->component('app.components.foreach');
+
+        $string = '@foreach
+@endforeach';
+        $expected = '<?php $__env->startComponent(\'app.components.foreach\'); ?>
+<?php echo $__env->renderComponent(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testCustomIncludes()
     {
         $this->compiler->include('app.includes.input', 'input');
@@ -148,6 +159,15 @@ class BladeCustomTest extends AbstractBladeTestCase
 
         $string = '@input';
         $expected = '<?php echo $__env->make(\'app.includes.input\', [], array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testCustomIncludesWithExistingDirective()
+    {
+        $this->compiler->include('app.includes.foreach');
+
+        $string = '@foreach';
+        $expected = '<?php echo $__env->make(\'app.includes.foreach\', [], array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -123,4 +123,31 @@ class BladeCustomTest extends AbstractBladeTestCase
 <?php echo $__env->renderComponent(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testCustomIncludes()
+    {
+        $this->compiler->include('app.includes.input', 'input');
+
+        $string = '@input';
+        $expected = '<?php echo $__env->make(\'app.includes.input\', [], array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testCustomIncludesWithData()
+    {
+        $this->compiler->include('app.includes.input', 'input');
+
+        $string = '@input([\'type\' => \'email\'])';
+        $expected = '<?php echo $__env->make(\'app.includes.input\', [\'type\' => \'email\'], array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testCustomIncludesDefaultAlias()
+    {
+        $this->compiler->include('app.includes.input');
+
+        $string = '@input';
+        $expected = '<?php echo $__env->make(\'app.includes.input\', [], array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
This does the same as #22796, but for `@include`s. Useful when you have bits of html that don't have a "slot" (self-closing parts).

```
<input type="{{ $type ?? 'text' }}">
```

```php
Blade::include('includes.input');
```

```
@input(['type' => 'email'])
```