### PR TITLE
[5.6] Remove old bootstrap 3 stuff from presets

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/bootstrap-stubs/_variables.scss
+++ b/src/Illuminate/Foundation/Console/Presets/bootstrap-stubs/_variables.scss
@@ -6,13 +6,3 @@ $body-bg: #f5f8fa;
 $font-family-sans-serif: "Raleway", sans-serif;
 $font-size-base: 0.9rem;
 $line-height-base: 1.6;
-$text-color: #636b6f;
-
-// Navbar
-$navbar-default-bg: #fff;
-
-// Buttons
-$btn-default-color: $text-color;
-
-// Panels
-$panel-default-heading-bg: #fff;

--- a/src/Illuminate/Foundation/Console/Presets/react-stubs/Example.js
+++ b/src/Illuminate/Foundation/Console/Presets/react-stubs/Example.js
@@ -7,7 +7,7 @@ export default class Example extends Component {
             <div className="container">
                 <div className="row justify-content-center">
                     <div className="col-md-8">
-                        <div className="card card-default">
+                        <div className="card">
                             <div className="card-header">Example Component</div>
 
                             <div className="card-body">

--- a/src/Illuminate/Foundation/Console/Presets/vue-stubs/ExampleComponent.vue
+++ b/src/Illuminate/Foundation/Console/Presets/vue-stubs/ExampleComponent.vue
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="row justify-content-center">
             <div class="col-md-8">
-                <div class="card card-default">
+                <div class="card">
                     <div class="card-header">Example Component</div>
 
                     <div class="card-body">


### PR DESCRIPTION
- remove card-default class since it does not exist in bootstrap 4
- remove sass variables which does not exist in bootstrap 4