### PR TITLE
[5.6] Fix assertRedirect

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -94,7 +94,9 @@ class TestResponse
         );
 
         if (! is_null($uri)) {
-            PHPUnit::assertEquals(app('url')->to($uri), $this->headers->get('Location'));
+            PHPUnit::assertEquals(
+                app('url')->to($uri), app('url')->to($this->headers->get('Location'))
+            );
         }
 
         return $this;

--- a/tests/Integration/Routing/RouteRedirectTest.php
+++ b/tests/Integration/Routing/RouteRedirectTest.php
@@ -24,10 +24,14 @@ class RouteRedirectTest extends TestCase
         Route::redirect('from/{param}/{param2?}', 'to', 301);
 
         $response = $this->get('/from/value1/value2');
+        $response->assertRedirect('to');
+
         $this->assertEquals(301, $response->getStatusCode());
         $this->assertEquals('to', $response->headers->get('Location'));
 
         $response = $this->get('/from/value1');
+        $response->assertRedirect('to');
+
         $this->assertEquals(301, $response->getStatusCode());
         $this->assertEquals('to', $response->headers->get('Location'));
     }


### PR DESCRIPTION
This is a follow to #23170 :

> assertRedirect doesn't behave correctly when asserting redirect routes since it retains the headers format while converting the given URI to URL if necessary.

but this retains the original tests.
However `assertRedirect` is operating an equal behavior to original tests and even better by asserting any redirect type, not just 301 one. Plus, accepting both urls and uris equally.