### PR TITLE
[5.6] Add argon helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -124,6 +124,20 @@ if (! function_exists('app_path')) {
     }
 }
 
+if (! function_exists('argon')) {
+    /**
+     * Hash the given value against the argon algorithm.
+     *
+     * @param  string  $value
+     * @param  array  $options
+     * @return string
+     */
+    function argon($value, $options = [])
+    {
+        return app('hash')->driver('argon')->make($value, $options);
+    }
+}
+
 if (! function_exists('asset')) {
     /**
      * Generate an asset path for the application.


### PR DESCRIPTION
As of version 5.6, Laravel supports Argon hash algorithm. It will be nice to have helper as in the case of Bcrypt.