### PR TITLE
[5.6] Ability to set mail message ID right hand side using a config value

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -5,6 +5,7 @@ namespace Illuminate\Mail;
 use Swift_Mailer;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Swift_DependencyContainer;
 use Illuminate\Support\ServiceProvider;
 
 class MailServiceProvider extends ServiceProvider
@@ -87,6 +88,10 @@ class MailServiceProvider extends ServiceProvider
     public function registerSwiftMailer()
     {
         $this->registerSwiftTransport();
+
+        Swift_DependencyContainer::getInstance()
+            ->register('mime.idgenerator.idright')
+            ->asValue($this->app->make('config')->get('mail.domain', 'swift.generated'));
 
         // Once we have the transporter registered, we will register the actual Swift
         // mailer instance, passing in the transport instances, which allows us to

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -89,14 +89,16 @@ class MailServiceProvider extends ServiceProvider
     {
         $this->registerSwiftTransport();
 
-        Swift_DependencyContainer::getInstance()
-            ->register('mime.idgenerator.idright')
-            ->asValue($this->app->make('config')->get('mail.domain', 'swift.generated'));
-
         // Once we have the transporter registered, we will register the actual Swift
         // mailer instance, passing in the transport instances, which allows us to
         // override this transporter instances during app start-up if necessary.
         $this->app->singleton('swift.mailer', function ($app) {
+            if ($mailDomain = $app->make('config')->get('mail.domain')) {
+                Swift_DependencyContainer::getInstance()
+                                ->register('mime.idgenerator.idright')
+                                ->asValue($mailDomain);
+            }
+
             return new Swift_Mailer($app['swift.transport']->driver());
         });
     }


### PR DESCRIPTION
<img width="565" alt="screen shot 2018-02-15 at 9 26 21 pm" src="https://user-images.githubusercontent.com/4332182/36276458-b9492342-1296-11e8-9ab1-008988f47bd6.png">

This PR adds the ability to set the right hand side of the Message-id header to a specific domain.

To do this, you need to set the `mail.domain` config value to a valid domain.