### PR TITLE
[5.6] More flexibility for custom log drivers

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -213,7 +213,9 @@ class LogManager implements LoggerInterface
      */
     protected function createCustomDriver(array $config)
     {
-        return $this->app->make($config['via'])->__invoke($config);
+        $f = is_callable($via = $config['via']) ? $via : $this->app->make($via);
+
+        return $f($config);
     }
 
     /**


### PR DESCRIPTION
I love the ability to have custom log drivers in config, without needing to call extend on drivers, and it reminded me of something very similar I was doing in an app as a way of specifying lazy values in config, by using callables (in particular, using the array notation since we cannot serialize closures).

So, the example at https://laravel.com/docs/5.6/logging#creating-custom-channels is great, and still works, but the following example now works also:

```php
'channels' => [
    'custom' => [
        'driver' => 'custom',
        'via' => [App\Logging\MyCustomLogger::class, 'make'],
    ],
],
```

with a **static** function:

```
<?php

namespace App\Logging;

use Monolog\Logger;

class MyCustomLogger
{
    public static function make(array $config)
    {
        return new Logger(...);
    }
}
```

This is very simple, and you don't need to go through the service container. Moreover, you don't need to create a special class with an invoke method, you can just add a static method wherever you feel, even on the logger class itself.