### PR TITLE
[5.6] allow collect() to create nested collections

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -416,11 +416,18 @@ if (! function_exists('collect')) {
      * Create a collection from the given value.
      *
      * @param  mixed  $value
+     * @param bool $nested
      * @return \Illuminate\Support\Collection
      */
-    function collect($value = null)
+    function collect($value = null, $nested=false)
     {
-        return new Collection($value);
+        $collection = new Collection($value);
+        if ($value && $nested) {
+            $collection->transform(function ($item) {
+                return is_array($item) ? collect($item,true) : $item;
+            });
+        }
+        return $collection;
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -419,12 +419,12 @@ if (! function_exists('collect')) {
      * @param bool $nested
      * @return \Illuminate\Support\Collection
      */
-    function collect($value = null, $nested=false)
+    function collect($value = null, $nested = false)
     {
         $collection = new Collection($value);
         if ($value && $nested) {
             $collection->transform(function ($item) {
-                return is_array($item) ? collect($item,true) : $item;
+                return is_array($item) ? collect($item, true) : $item;
             });
         }
         return $collection;

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -427,6 +427,7 @@ if (! function_exists('collect')) {
                 return is_array($item) ? collect($item, true) : $item;
             });
         }
+        
         return $collection;
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -422,12 +422,13 @@ if (! function_exists('collect')) {
     function collect($value = null, $nested = false)
     {
         $collection = new Collection($value);
+
         if ($value && $nested) {
             $collection->transform(function ($item) {
                 return is_array($item) ? collect($item, true) : $item;
             });
         }
-        
+
         return $collection;
     }
 }


### PR DESCRIPTION
collect(array) becomes collect(array,bool) where bool recursively creates nested collections. 

```
collect([1,2,3,4=>['test'=>[7,8,9]]],true)
```
produces
```
Illuminate\Support\Collection {#896
     all: [
       0 => 1,
       1 => 2,
       2 => 3,
       4 => Illuminate\Support\Collection {#861
         all: [
           "test" => Illuminate\Support\Collection {#893
             all: [
               7,
               8,
               9,
             ],
           },
         ],
       },
     ],
   }
```