### PR TITLE
[5.6] 1071 Specified key was too long; max key length is 767 bytes

### DIFF
--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -14,7 +14,7 @@ class CreateSessionsTable extends Migration
     public function up()
     {
         Schema::create('sessions', function (Blueprint $table) {
-            $table->string('id')->unique();
+            $table->string('id', 191)->unique();
             $table->unsignedInteger('user_id')->nullable();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();


### PR DESCRIPTION
#### SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes
Getting this Error when using utf8mb4 charset
this is a solution of this error
changed column size to 191