### PR TITLE
[5.6]  Added new methods that accepts callable for collection diff, diffAssoc and diffKeys

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -306,6 +306,20 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the items in the collection that are not present in the given items using a user defined function
+     * as the comparator
+     *
+     * @param  mixed   $items
+     * @param callable $callback
+     *
+     * @return static
+     */
+    public function udiff($items, callable $callback)
+    {
+        return new static(array_udiff($this->items, $this->getArrayableItems($items),$callback));
+    }
+
+    /**
      * Get the items in the collection whose keys and values are not present in the given items.
      *
      * @param  mixed  $items
@@ -317,6 +331,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the items in the collection whose keys and values are not present in the given items.
+     *
+     * @param  mixed   $items
+     * @param callable $callback
+     *
+     * @return static
+     */
+    public function diffUAssoc($items, callable $callback)
+    {
+        return new static(array_diff_uassoc($this->items, $this->getArrayableItems($items), $callback));
+    }
+
+    /**
      * Get the items in the collection whose keys are not present in the given items.
      *
      * @param  mixed  $items
@@ -325,6 +352,20 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function diffKeys($items)
     {
         return new static(array_diff_key($this->items, $this->getArrayableItems($items)));
+    }
+
+    /**
+     * Get the items in the collection whose keys are not present in the given items using a user defined function
+     * as the comparator.
+     *
+     * @param  mixed   $items
+     * @param callable $callback
+     *
+     * @return static
+     */
+    public function diffUKeys($items, callable $callback)
+    {
+        return new static(array_diff_ukey($this->items, $this->getArrayableItems($items), $callback));
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -314,7 +314,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @return static
      */
-    public function udiff($items, callable $callback)
+    public function diffUsing($items, callable $callback)
     {
         return new static(array_udiff($this->items, $this->getArrayableItems($items),$callback));
     }
@@ -338,7 +338,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @return static
      */
-    public function diffUAssoc($items, callable $callback)
+    public function diffAssocUsing($items, callable $callback)
     {
         return new static(array_diff_uassoc($this->items, $this->getArrayableItems($items), $callback));
     }
@@ -363,7 +363,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @return static
      */
-    public function diffUKeys($items, callable $callback)
+    public function diffKeysUsing($items, callable $callback)
     {
         return new static(array_diff_ukey($this->items, $this->getArrayableItems($items), $callback));
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -629,18 +629,18 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['id' => 1], $c->diff(new Collection(['first_word' => 'Hello', 'last_word' => 'World']))->all());
     }
 
-    public function testUDiffCollection()
+    public function testDiffUsingWithCollection()
     {
         $c = new Collection(['en_GB', 'fr', 'HR']);
         // demonstrate that diffKeys wont support case insensitivity
         $this->assertEquals(['en_GB', 'fr', 'HR'], $c->diff(new Collection(['en_gb' , 'hr']))->values()->toArray());
         // allow for case insensitive difference
-        $this->assertEquals(['fr'], $c->udiff(new Collection(['en_gb' , 'hr']), 'strcasecmp')->values()->toArray());
+        $this->assertEquals(['fr'], $c->diffUsing(new Collection(['en_gb' , 'hr']), 'strcasecmp')->values()->toArray());
     }
-    public function testUDiffNull()
+    public function testDiffUsingWithNull()
     {
         $c = new Collection(['en_GB', 'fr', 'HR']);
-        $this->assertEquals(['en_GB', 'fr', 'HR'], $c->udiff(null, 'strcasecmp')->values()->toArray());
+        $this->assertEquals(['en_GB', 'fr', 'HR'], $c->diffUsing(null, 'strcasecmp')->values()->toArray());
     }
 
     public function testDiffNull()
@@ -656,14 +656,14 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first_word' => 'Hello'], $c1->diffKeys($c2)->all());
     }
 
-    public function testDiffUKeys()
+    public function testDiffKeysUsing()
     {
         $c1 = new Collection(['id' => 1, 'first_word' => 'Hello']);
         $c2 = new Collection(['ID' => 123, 'foo_bar' => 'Hello']);
         // demonstrate that diffKeys wont support case insensitivity
         $this->assertEquals(['id'=>1, 'first_word'=> 'Hello'], $c1->diffKeys($c2)->all());
         // allow for case insensitive difference
-        $this->assertEquals(['first_word' => 'Hello'], $c1->diffUKeys($c2, 'strcasecmp')->all());
+        $this->assertEquals(['first_word' => 'Hello'], $c1->diffKeysUsing($c2, 'strcasecmp')->all());
     }
 
     public function testDiffAssoc()
@@ -673,14 +673,14 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['id' => 1, 'first_word' => 'Hello'], $c1->diffAssoc($c2)->all());
     }
 
-    public function testDiffUAssoc()
+    public function testDiffAssocUsing()
     {
         $c1 = new Collection(['a' => 'green', 'b' => 'brown', 'c' => 'blue', 'red']);
         $c2 = new Collection(['A' => 'green', 'yellow', 'red']);
         // demonstrate that the case of the keys will affect the output when diffAssoc is used
         $this->assertEquals(['a' => 'green', 'b' => 'brown', 'c' => 'blue', 'red'], $c1->diffAssoc($c2)->all());
         // allow for case insensitive difference
-        $this->assertEquals(['b' => 'brown', 'c' => 'blue', 'red'], $c1->diffUAssoc($c2, 'strcasecmp')->all());
+        $this->assertEquals(['b' => 'brown', 'c' => 'blue', 'red'], $c1->diffAssocUsing($c2, 'strcasecmp')->all());
     }
 
     public function testEach()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -629,6 +629,20 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['id' => 1], $c->diff(new Collection(['first_word' => 'Hello', 'last_word' => 'World']))->all());
     }
 
+    public function testUDiffCollection()
+    {
+        $c = new Collection(['en_GB', 'fr', 'HR']);
+        // demonstrate that diffKeys wont support case insensitivity
+        $this->assertEquals(['en_GB', 'fr', 'HR'], $c->diff(new Collection(['en_gb' , 'hr']))->values()->toArray());
+        // allow for case insensitive difference
+        $this->assertEquals(['fr'], $c->udiff(new Collection(['en_gb' , 'hr']), 'strcasecmp')->values()->toArray());
+    }
+    public function testUDiffNull()
+    {
+        $c = new Collection(['en_GB', 'fr', 'HR']);
+        $this->assertEquals(['en_GB', 'fr', 'HR'], $c->udiff(null, 'strcasecmp')->values()->toArray());
+    }
+
     public function testDiffNull()
     {
         $c = new Collection(['id' => 1, 'first_word' => 'Hello']);
@@ -642,11 +656,31 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first_word' => 'Hello'], $c1->diffKeys($c2)->all());
     }
 
+    public function testDiffUKeys()
+    {
+        $c1 = new Collection(['id' => 1, 'first_word' => 'Hello']);
+        $c2 = new Collection(['ID' => 123, 'foo_bar' => 'Hello']);
+        // demonstrate that diffKeys wont support case insensitivity
+        $this->assertEquals(['id'=>1, 'first_word'=> 'Hello'], $c1->diffKeys($c2)->all());
+        // allow for case insensitive difference
+        $this->assertEquals(['first_word' => 'Hello'], $c1->diffUKeys($c2, 'strcasecmp')->all());
+    }
+
     public function testDiffAssoc()
     {
         $c1 = new Collection(['id' => 1, 'first_word' => 'Hello', 'not_affected' => 'value']);
         $c2 = new Collection(['id' => 123, 'foo_bar' => 'Hello', 'not_affected' => 'value']);
         $this->assertEquals(['id' => 1, 'first_word' => 'Hello'], $c1->diffAssoc($c2)->all());
+    }
+
+    public function testDiffUAssoc()
+    {
+        $c1 = new Collection(['a' => 'green', 'b' => 'brown', 'c' => 'blue', 'red']);
+        $c2 = new Collection(['A' => 'green', 'yellow', 'red']);
+        // demonstrate that the case of the keys will affect the output when diffAssoc is used
+        $this->assertEquals(['a' => 'green', 'b' => 'brown', 'c' => 'blue', 'red'], $c1->diffAssoc($c2)->all());
+        // allow for case insensitive difference
+        $this->assertEquals(['b' => 'brown', 'c' => 'blue', 'red'], $c1->diffUAssoc($c2, 'strcasecmp')->all());
     }
 
     public function testEach()


### PR DESCRIPTION
The Collection class of the Laravel has a **diff** method which uses the array_diff php function, sometimes this method isn't sufficient, especially when you need to defined a custom function to indicate different elements in collections.

A case in point is when you wish to do **case insensitive** difference of two collections. Thankfully, PHP has methods for cases such as this. I have implemented three of such methods.

1. diffUsing (array_udiff)
2. diffAssocUsing (array_diff_uassoc)
3. diffKeysUsing (array_diff_ukeys)