### PR TITLE
[5.7] Fix Cookie factory to match implementation

### DIFF
--- a/src/Illuminate/Contracts/Cookie/Factory.php
+++ b/src/Illuminate/Contracts/Cookie/Factory.php
@@ -12,13 +12,13 @@ interface Factory
      * @param  int     $minutes
      * @param  string  $path
      * @param  string  $domain
-     * @param  bool    $secure
+     * @param  bool|null    $secure
      * @param  bool    $httpOnly
      * @param  bool         $raw
      * @param  string|null  $sameSite
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = null);
+    public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = null, $httpOnly = true, $raw = false, $sameSite = null);
 
     /**
      * Create a cookie that lasts "forever" (five years).
@@ -27,13 +27,13 @@ interface Factory
      * @param  string  $value
      * @param  string  $path
      * @param  string  $domain
-     * @param  bool    $secure
+     * @param  bool|null    $secure
      * @param  bool    $httpOnly
      * @param  bool         $raw
      * @param  string|null  $sameSite
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    public function forever($name, $value, $path = null, $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = null);
+    public function forever($name, $value, $path = null, $domain = null, $secure = null, $httpOnly = true, $raw = false, $sameSite = null);
 
     /**
      * Expire the given cookie.


### PR DESCRIPTION
There was a change to how the cookie implementation was done a few weeks ago: https://github.com/laravel/framework/commit/530a83542c648d6961567cdf2b4734fb868a933d#diff-f6e87ec3ac94fefcef2f7979a80a91b1

This implementation has now seperated from the factory interface, and the two are no longer aligned.

This PR brings the factory in line with the required implementation. I've targetted 5.7, because I guess techically this is a change in the interface, so it's a "breaking change"?

Solves https://github.com/laravel/framework/issues/23196.