### PR TITLE
[5.6] Add sortByPredicate method and its test

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1428,6 +1428,39 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Sort the collection using the given predicate.
+     *
+     * @param  predicate  $predicate
+     * @return static
+     */
+    public function sortByPredicate($predicate)
+    {
+        $results = $this->items;
+        return new static($this->quickSort($results, $predicate));
+    }
+
+    protected function quickSort($arr, $predicate) 
+    {
+        if(sizeof($arr) < 2) return $arr;
+        $leftArr = [];
+        $rightArr = [];
+        $pivotKey  = key($arr);
+        $pivotValue = array_shift($arr);
+        foreach( $arr as $key => $value ) {
+            if($predicate($value, $pivotValue, $key, $pivotKey)) {
+                $leftArr[$key] = $value;
+            } else {
+                $rightArr[$key] = $value;
+            }
+        }
+        return array_merge(
+            $this->quickSort($leftArr, $predicate), 
+            [$pivotKey => $pivotValue], 
+            $this->quickSort($rightArr, $predicate)
+        );
+    }
+
+    /**
      * Sort the collection in descending order using the given callback.
      *
      * @param  callable|string  $callback

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1439,23 +1439,25 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         return new static($this->quickSort($results, $predicate));
     }
 
-    protected function quickSort($arr, $predicate) 
+    protected function quickSort($arr, $predicate)
     {
-        if(sizeof($arr) < 2) return $arr;
+        if (sizeof($arr) < 2) {
+            return $arr;
+        }
         $leftArr = [];
         $rightArr = [];
-        $pivotKey  = key($arr);
+        $pivotKey = key($arr);
         $pivotValue = array_shift($arr);
         foreach( $arr as $key => $value ) {
-            if($predicate($value, $pivotValue, $key, $pivotKey)) {
+            if ($predicate($value, $pivotValue, $key, $pivotKey)) {
                 $leftArr[$key] = $value;
             } else {
                 $rightArr[$key] = $value;
             }
         }
         return array_merge(
-            $this->quickSort($leftArr, $predicate), 
-            [$pivotKey => $pivotValue], 
+            $this->quickSort($leftArr, $predicate),
+            [$pivotKey => $pivotValue],
             $this->quickSort($rightArr, $predicate)
         );
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1436,6 +1436,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function sortByPredicate($predicate)
     {
         $results = $this->items;
+
         return new static($this->quickSort($results, $predicate));
     }
 
@@ -1448,13 +1449,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $rightArr = [];
         $pivotKey = key($arr);
         $pivotValue = array_shift($arr);
-        foreach( $arr as $key => $value ) {
+        foreach ($arr as $key => $value) {
             if ($predicate($value, $pivotValue, $key, $pivotKey)) {
                 $leftArr[$key] = $value;
             } else {
                 $rightArr[$key] = $value;
             }
         }
+        
         return array_merge(
             $this->quickSort($leftArr, $predicate),
             [$pivotKey => $pivotValue],

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1456,7 +1456,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 $rightArr[$key] = $value;
             }
         }
-        
+
         return array_merge(
             $this->quickSort($leftArr, $predicate),
             [$pivotKey => $pivotValue],

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -878,6 +878,112 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['taylor', 'dayle'], array_values($data->all()));
     }
 
+    public function testSortByPredicate()
+    {
+        $data = new Collection([
+            'a' => [
+                'name' => 'a',
+                'startTime' => strtotime("2018-02-15"),
+                'endTime' => strtotime("2018-02-18")
+            ], 
+            'b' => [
+                'name' => 'b',
+                'startTime' => strtotime("2018-02-15"),
+                'endTime' => strtotime("2018-02-17")
+            ],
+            'c' => [
+                'name' => 'c',
+                'startTime' => strtotime("2018-02-12"),
+                'endTime' => strtotime("2018-02-13")
+            ],
+            'd' => [
+                'name' => 'd',
+                'startTime' => strtotime("2018-02-10"),
+                'endTime' => strtotime("2018-02-17")
+            ]
+        ]);
+        $data = $data->sortByPredicate(function ($value, $pivotValue) {
+            return $value['startTime'] != $pivotValue['startTime'] ? 
+                $value['startTime'] < $pivotValue['startTime'] : 
+                $value['endTime'] < $pivotValue['endTime'];
+        });
+        $this->assertEquals([
+            0 => [
+                'name' => 'd',
+                'startTime' => strtotime("2018-02-10"),
+                'endTime' => strtotime("2018-02-17")
+            ],
+            1 => [
+                'name' => 'c',
+                'startTime' => strtotime("2018-02-12"),
+                'endTime' => strtotime("2018-02-13")
+            ],
+            2 => [
+                'name' => 'b',
+                'startTime' => strtotime("2018-02-15"),
+                'endTime' => strtotime("2018-02-17")
+            ],
+            3 => [
+                'name' => 'a',
+                'startTime' => strtotime("2018-02-15"),
+                'endTime' => strtotime("2018-02-18")
+            ]
+        ], array_values($data->all()));
+    }
+
+    public function testSortByPredicateWithKey()
+    {
+        $data = new Collection([
+            'a' => [
+                'name' => 'a',
+                'startTime' => strtotime("2018-02-15"),
+                'endTime' => strtotime("2018-02-18")
+            ], 
+            'b' => [
+                'name' => 'b',
+                'startTime' => strtotime("2018-02-15"),
+                'endTime' => strtotime("2018-02-17")
+            ],
+            'c' => [
+                'name' => 'c',
+                'startTime' => strtotime("2018-02-12"),
+                'endTime' => strtotime("2018-02-13")
+            ],
+            'd' => [
+                'name' => 'd',
+                'startTime' => strtotime("2018-02-10"),
+                'endTime' => strtotime("2018-02-17")
+            ]
+        ]);
+        $data = $data->sortByPredicate(function ($value, $pivotValue, $key, $pivotKey) {
+            return $value['startTime'] != $pivotValue['startTime'] ? 
+                $value['startTime'] < $pivotValue['startTime'] : 
+                $key < $pivotKey;
+        });
+        $this->assertEquals([
+            0 => [
+                'name' => 'd',
+                'startTime' => strtotime("2018-02-10"),
+                'endTime' => strtotime("2018-02-17")
+            ],
+            1 => [
+                'name' => 'c',
+                'startTime' => strtotime("2018-02-12"),
+                'endTime' => strtotime("2018-02-13")
+            ],
+            2 => [
+                'name' => 'a',
+                'startTime' => strtotime("2018-02-15"),
+                'endTime' => strtotime("2018-02-18")
+            ],
+            3 => [
+                'name' => 'b',
+                'startTime' => strtotime("2018-02-15"),
+                'endTime' => strtotime("2018-02-17")
+            ]
+        ], array_values($data->all()));
+    }
+
     public function testSortByString()
     {
         $data = new Collection([['name' => 'taylor'], ['name' => 'dayle']]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -884,26 +884,26 @@ class SupportCollectionTest extends TestCase
             'a' => [
                 'name' => 'a',
                 'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-18")
+                'endTime' => strtotime("2018-02-18"),
             ], 
             'b' => [
                 'name' => 'b',
                 'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-17")
+                'endTime' => strtotime("2018-02-17"),
             ],
             'c' => [
                 'name' => 'c',
                 'startTime' => strtotime("2018-02-12"),
-                'endTime' => strtotime("2018-02-13")
+                'endTime' => strtotime("2018-02-13"),
             ],
             'd' => [
                 'name' => 'd',
                 'startTime' => strtotime("2018-02-10"),
-                'endTime' => strtotime("2018-02-17")
+                'endTime' => strtotime("2018-02-17"),
             ]
         ]);
         $data = $data->sortByPredicate(function ($value, $pivotValue) {
-            return $value['startTime'] != $pivotValue['startTime'] ? 
+            return $value['startTime'] != $pivotValue['startTime'] ?
                 $value['startTime'] < $pivotValue['startTime'] : 
                 $value['endTime'] < $pivotValue['endTime'];
         });
@@ -911,22 +911,22 @@ class SupportCollectionTest extends TestCase
             0 => [
                 'name' => 'd',
                 'startTime' => strtotime("2018-02-10"),
-                'endTime' => strtotime("2018-02-17")
+                'endTime' => strtotime("2018-02-17"),
             ],
             1 => [
                 'name' => 'c',
                 'startTime' => strtotime("2018-02-12"),
-                'endTime' => strtotime("2018-02-13")
+                'endTime' => strtotime("2018-02-13"),
             ],
             2 => [
                 'name' => 'b',
                 'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-17")
+                'endTime' => strtotime("2018-02-17"),
             ],
             3 => [
                 'name' => 'a',
                 'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-18")
+                'endTime' => strtotime("2018-02-18"),
             ]
         ], array_values($data->all()));
     }
@@ -937,26 +937,26 @@ class SupportCollectionTest extends TestCase
             'a' => [
                 'name' => 'a',
                 'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-18")
+                'endTime' => strtotime("2018-02-18"),
             ], 
             'b' => [
                 'name' => 'b',
                 'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-17")
+                'endTime' => strtotime("2018-02-17"),
             ],
             'c' => [
                 'name' => 'c',
                 'startTime' => strtotime("2018-02-12"),
-                'endTime' => strtotime("2018-02-13")
+                'endTime' => strtotime("2018-02-13"),
             ],
             'd' => [
                 'name' => 'd',
                 'startTime' => strtotime("2018-02-10"),
-                'endTime' => strtotime("2018-02-17")
+                'endTime' => strtotime("2018-02-17"),
             ]
         ]);
         $data = $data->sortByPredicate(function ($value, $pivotValue, $key, $pivotKey) {
-            return $value['startTime'] != $pivotValue['startTime'] ? 
+            return $value['startTime'] != $pivotValue['startTime'] ?
                 $value['startTime'] < $pivotValue['startTime'] : 
                 $key < $pivotKey;
         });
@@ -964,22 +964,22 @@ class SupportCollectionTest extends TestCase
             0 => [
                 'name' => 'd',
                 'startTime' => strtotime("2018-02-10"),
-                'endTime' => strtotime("2018-02-17")
+                'endTime' => strtotime("2018-02-17"),
             ],
             1 => [
                 'name' => 'c',
                 'startTime' => strtotime("2018-02-12"),
-                'endTime' => strtotime("2018-02-13")
+                'endTime' => strtotime("2018-02-13"),
             ],
             2 => [
                 'name' => 'a',
                 'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-18")
+                'endTime' => strtotime("2018-02-18"),
             ],
             3 => [
                 'name' => 'b',
                 'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-17")
+                'endTime' => strtotime("2018-02-17"),
             ]
         ], array_values($data->all()));
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -883,51 +883,51 @@ class SupportCollectionTest extends TestCase
         $data = new Collection([
             'a' => [
                 'name' => 'a',
-                'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-18"),
-            ], 
+                'startTime' => strtotime('2018-02-15'),
+                'endTime' => strtotime('2018-02-18'),
+            ],
             'b' => [
                 'name' => 'b',
-                'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-17"),
+                'startTime' => strtotime('2018-02-15'),
+                'endTime' => strtotime('2018-02-17'),
             ],
             'c' => [
                 'name' => 'c',
-                'startTime' => strtotime("2018-02-12"),
-                'endTime' => strtotime("2018-02-13"),
+                'startTime' => strtotime('2018-02-12'),
+                'endTime' => strtotime('2018-02-13'),
             ],
             'd' => [
                 'name' => 'd',
-                'startTime' => strtotime("2018-02-10"),
-                'endTime' => strtotime("2018-02-17"),
-            ]
+                'startTime' => strtotime('2018-02-10'),
+                'endTime' => strtotime('2018-02-17'),
+            ],
         ]);
         $data = $data->sortByPredicate(function ($value, $pivotValue) {
             return $value['startTime'] != $pivotValue['startTime'] ?
-                $value['startTime'] < $pivotValue['startTime'] : 
+                $value['startTime'] < $pivotValue['startTime'] :
                 $value['endTime'] < $pivotValue['endTime'];
         });
         $this->assertEquals([
             0 => [
                 'name' => 'd',
-                'startTime' => strtotime("2018-02-10"),
-                'endTime' => strtotime("2018-02-17"),
+                'startTime' => strtotime('2018-02-10'),
+                'endTime' => strtotime('2018-02-17'),
             ],
             1 => [
                 'name' => 'c',
-                'startTime' => strtotime("2018-02-12"),
-                'endTime' => strtotime("2018-02-13"),
+                'startTime' => strtotime('2018-02-12'),
+                'endTime' => strtotime('2018-02-13'),
             ],
             2 => [
                 'name' => 'b',
-                'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-17"),
+                'startTime' => strtotime('2018-02-15'),
+                'endTime' => strtotime('2018-02-17'),
             ],
             3 => [
                 'name' => 'a',
-                'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-18"),
-            ]
+                'startTime' => strtotime('2018-02-15'),
+                'endTime' => strtotime('2018-02-18'),
+            ],
         ], array_values($data->all()));
     }
 
@@ -936,51 +936,51 @@ class SupportCollectionTest extends TestCase
         $data = new Collection([
             'a' => [
                 'name' => 'a',
-                'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-18"),
-            ], 
+                'startTime' => strtotime('2018-02-15'),
+                'endTime' => strtotime('2018-02-18'),
+            ],
             'b' => [
                 'name' => 'b',
-                'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-17"),
+                'startTime' => strtotime('2018-02-15'),
+                'endTime' => strtotime('2018-02-17'),
             ],
             'c' => [
                 'name' => 'c',
-                'startTime' => strtotime("2018-02-12"),
-                'endTime' => strtotime("2018-02-13"),
+                'startTime' => strtotime('2018-02-12'),
+                'endTime' => strtotime('2018-02-13'),
             ],
             'd' => [
                 'name' => 'd',
-                'startTime' => strtotime("2018-02-10"),
-                'endTime' => strtotime("2018-02-17"),
-            ]
+                'startTime' => strtotime('2018-02-10'),
+                'endTime' => strtotime('2018-02-17'),
+            ],
         ]);
         $data = $data->sortByPredicate(function ($value, $pivotValue, $key, $pivotKey) {
             return $value['startTime'] != $pivotValue['startTime'] ?
-                $value['startTime'] < $pivotValue['startTime'] : 
+                $value['startTime'] < $pivotValue['startTime'] :
                 $key < $pivotKey;
         });
         $this->assertEquals([
             0 => [
                 'name' => 'd',
-                'startTime' => strtotime("2018-02-10"),
-                'endTime' => strtotime("2018-02-17"),
+                'startTime' => strtotime('2018-02-10'),
+                'endTime' => strtotime('2018-02-17'),
             ],
             1 => [
                 'name' => 'c',
-                'startTime' => strtotime("2018-02-12"),
-                'endTime' => strtotime("2018-02-13"),
+                'startTime' => strtotime('2018-02-12'),
+                'endTime' => strtotime('2018-02-13'),
             ],
             2 => [
                 'name' => 'a',
-                'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-18"),
+                'startTime' => strtotime('2018-02-15'),
+                'endTime' => strtotime('2018-02-18'),
             ],
             3 => [
                 'name' => 'b',
-                'startTime' => strtotime("2018-02-15"),
-                'endTime' => strtotime("2018-02-17"),
-            ]
+                'startTime' => strtotime('2018-02-15'),
+                'endTime' => strtotime('2018-02-17'),
+            ],
         ], array_values($data->all()));
     }
 


### PR DESCRIPTION
Add a method that sort by a predicate
Inspired by swift's sort
https://developer.apple.com/documentation/swift/array/2296815-sorted
「sorted using the given predicate as the comparison between elements」

in the test i create some array that have srartTime and endTime

in test one(testSortByPredicate), compare them with srartTime
if srartTime is equal, then compare them with endTime

in test two(testSortByPredicateWithKey), compare them with srartTime
if srartTime is equal, then compare them with their key

this method is useful for me, i was implementation at my other project, i hope everyone can use it so i open a pull request.

thanks