### PR TITLE
[5.6] Enable relationship unsetting 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -720,6 +720,19 @@ trait HasRelationships
     }
 
     /**
+     * Unset the specific relationship in the model.
+     *
+     * @param  string  $relation
+     * @return $this
+     */
+    public function unsetRelation($relation)
+    {
+        unset($this->relations[$relation]);
+
+        return $this;
+    }
+
+    /**
      * Get the relationships that are touched on save.
      *
      * @return array

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -25,6 +25,16 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertArrayNotHasKey('foo', $parent->toArray());
     }
 
+    public function testUnsetRelationForgetsLoadedRelationship()
+    {
+        $model = new EloquentRelationResetModelStub;
+
+        $model->setRelation('foo', 'value');
+        $this->assertTrue($model->relationLoaded('foo'));
+        $model->unsetRelation('foo');
+        $this->assertFalse($model->relationLoaded('foo'));
+    }
+
     public function testTouchMethodUpdatesRelatedTimestamps()
     {
         $builder = m::mock(Builder::class);


### PR DESCRIPTION
This PR introduces a conveniece method for _unsetting_ already loaded relationships.

Consider the following: You have a `User` class which has `articles` relationship. You may want to provide an `addArticle()` method on the User class.

```php
class User extends Model
{
    public function articles()
    {
        return $this->hasMany(Article::class);
    }

    public functiona addArticle($attributes)
    {
        return $this->articles()->create($attributes);
    }
}
```

Then, your tests would look like this:

```php
/** @test */
public function it_creates_new_article()
{
    $user = factory(User::class)->create();

    $this->assertCount(0, $user->articles);

    $user->addArticle([
        'title' => 'Frying pan.',
    ]);

    // This assertion would fail, as the `articles` relationship
    // has already been loaded and is cached.
    //
    // In order to make it pass, we would need to either refresh
    // the user model, or query the articles relationship manually.
    $this->assertCount(1, $user->articles);
}
```

The solution this PR proposes is to provide a `Model::unsetRelation()` method to enable _"forgetting"_ already loaded relationships.

```php
class User extends Model
{
    public function addArticle($attributes)
    {
        $article = $this->articles()->create($attribute);

        $this->unsetRelation('articles');

        return $article;
    }
}
```

Then the test would pass without having to refresh the relationship manually.

By using this approach, we hide the complexity of re-fetching the relationships manually inside convenience methods like `addArticle()`. An alternative approach would be to reload the relationship inside the `addArticle()` method but that would fire off one more query, even when not necessary.

---

The question now is wether you would consider aliasing this method to `$model->forget()` as that reads a bit nicer.