### PR TITLE
[5.6] Ability to set custom encryption key

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -71,6 +71,17 @@ class Encrypter implements EncrypterContract
     }
 
     /**
+     * Create a new encrypter instance with custom key.
+     * 
+     * @param  string  $key
+     * @return self
+     */
+    public function key($key)
+    {
+        return new self($key, $this->cipher);
+    }
+
+    /**
      * Encrypt the given value.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -72,7 +72,7 @@ class Encrypter implements EncrypterContract
 
     /**
      * Create a new encrypter instance with custom key.
-     * 
+     *
      * @param  string  $key
      * @return self
      */

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -15,6 +15,14 @@ class EncrypterTest extends TestCase
         $this->assertEquals('foo', $e->decrypt($encrypted));
     }
 
+    public function testEncryptionWithCustomKey()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted = $e->key(str_repeat('b', 16))->encrypt('foo');
+        $this->assertNotEquals('foo', $encrypted);
+        $this->assertEquals('foo', $e->key(str_repeat('b', 16))->decrypt($encrypted));
+    }
+
     public function testRawStringEncryption()
     {
         $e = new Encrypter(str_repeat('a', 16));


### PR DESCRIPTION
This PR will allow developers to use "external" encryption key instead of key from env file. For example developer could allow his app's users to encrypt their data by their own encryption key.

```php
$key = random_bytes(32);

$encrypted = Crypt::key($key)->encrypt('foo');
$data = Crypt::key($key)->decrypt($encrypted);
```

This is best way I found, there is no impact on people's apps.