### PR TITLE
Default to 'UTC' timezone when using `date_format` validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -360,7 +360,7 @@ trait ValidatesAttributes
 
         $format = $parameters[0];
 
-        $date = DateTime::createFromFormat('!'.$format, $value);
+        $date = DateTime::createFromFormat('!'.$format, $value, new DateTimeZone('UTC'));
 
         return $date && $date->format($format) == $value;
     }


### PR DESCRIPTION
Due to daylight saving in some time zones the `date_format` validation rule can result in a `false` outcome because of the server setting.

As discussed in #23190, setting the server time to UTC would fix this, as it has no daylight saving.

Yet this would mean everybody should be aware of this (which alot aren't) and thus, in my opinion, it might be better to default the validation to UTC so we can straighten out the edge-case.