### PR TITLE
[5.6] Include $columns in getCountForPagination call

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -705,7 +705,7 @@ class Builder
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = ($total = $this->toBase()->getCountForPagination())
+        $results = ($total = $this->toBase()->getCountForPagination($columns))
                                     ? $this->forPage($page, $perPage)->get($columns)
                                     : $this->model->newCollection();
 


### PR DESCRIPTION
This PR intends to include the $columns variable in all calls of getCountForPagination.

Currently it is already passed on Illuminate/Database/Query/Builder.php, but it is not on Illuminate/Database/Eloquent/Builder.php, in both cases it is used when paginating an model.

Problem:
- Wrong total being returned from the paginate method

When Issue was found:
- I'm building a search page for an eCommerce, and it has multiple relationships. When I try to get the paginate, it returns the wrong total, since Laravel needs that $columns to be passed into the getCountForPagination to a count into a distinct column, instead of the default '*'.

Note: I would be good to update the version 5.5 as well, since it affects old versions.