### PR TITLE
ConnectionManager support class

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -12,8 +12,9 @@ use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SqlServerConnection;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Support\ConnectionFactoryInterface;
 
-class ConnectionFactory
+class ConnectionFactory implements ConnectionFactoryInterface
 {
     /**
      * The IoC container instance.
@@ -36,13 +37,13 @@ class ConnectionFactory
     /**
      * Establish a PDO connection based on the configuration.
      *
+     * @param  string  $driver
      * @param  array   $config
-     * @param  string  $name
      * @return \Illuminate\Database\Connection
      */
-    public function make(array $config, $name = null)
+    public function make($driver, array $config)
     {
-        $config = $this->parseConfig($config, $name);
+        $config = $this->parseConfig($config, $driver);
 
         if (isset($config['read'])) {
             return $this->createReadWriteConnection($config);
@@ -55,12 +56,12 @@ class ConnectionFactory
      * Parse and prepare the database configuration.
      *
      * @param  array   $config
-     * @param  string  $name
+     * @param  string  $driver
      * @return array
      */
-    protected function parseConfig(array $config, $name)
+    protected function parseConfig(array $config, $driver)
     {
-        return Arr::add(Arr::add($config, 'prefix', ''), 'name', $name);
+        return Arr::add(Arr::add($config, 'prefix', ''), 'driver', $driver);
     }
 
     /**

--- a/src/Illuminate/Support/ConnectionFactoryInterface.php
+++ b/src/Illuminate/Support/ConnectionFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Support;
+
+interface ConnectionFactoryInterface
+{
+    /**
+     * Make a driver instance using the provided configuration.
+     *
+     * @param  string  $driver
+     * @param  array   $config
+     * @return mixed
+     */
+    public function make($driver, array $config);
+}

--- a/src/Illuminate/Support/ConnectionManager.php
+++ b/src/Illuminate/Support/ConnectionManager.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Illuminate\Support;
+
+use RuntimeException;
+use Illuminate\Support\ConnectionFactoryInterface as ConnectionFactory;
+
+abstract class ConnectionManager
+{
+    /**
+     * The application instance.
+     *
+     * @var \Illuminate\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * The driver factory instance.
+     *
+     * @var \Illuminate\Support\ConnectionFactoryInterface
+     */
+    protected $factory;
+
+    /**
+     * The active connection instances.
+     *
+     * @var array
+     */
+    protected $connections = [];
+
+    /**
+     * The custom connection resolvers.
+     *
+     * @var array
+     */
+    protected $extensions = [];
+
+    /**
+     * Create a new manager instance.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @param  \Illuminate\Support\ConnectionFactoryInterface   $factory
+     * @return void
+     */
+    public function __construct($app, ConnectionFactory $factory)
+    {
+        $this->app = $app;
+        $this->factory = $factory;
+    }
+
+    /**
+     * Get the default connection name.
+     *
+     * @return string
+     */
+    abstract public function getDefaultConnection();
+
+    /**
+     * Get the configuration for a connection.
+     *
+     * @param  string  $name
+     * @return array
+     */
+    abstract protected function configuration($name);
+
+    /**
+     * Get a connection instance.
+     *
+     * @param  string|null  $name
+     * @return mixed
+     */
+    public function connection($name = null)
+    {
+        $name = $name ?: $this->getDefaultConnection();
+
+        // If we haven't created this connection, we'll create it
+        // based on the config provided in the application.
+        if (! isset($this->connections[$name])) {
+            $this->connections[$name] = $this->makeConnection($name);
+        }
+
+        return $this->connections[$name];
+    }
+
+    /**
+     * Make the connection instance.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    protected function makeConnection($name)
+    {
+        $config = $this->configuration($name);
+
+        // First we will check by the connection name to see if an extension has been
+        // registered specifically for that connection. If it has we will call the
+        // Closure and pass it the config allowing it to resolve the connection.
+        if (isset($this->extensions[$name])) {
+            return call_user_func($this->extensions[$name], $config, $name);
+        }
+
+        $driver = $this->parseDriverName($name, $config);
+
+        // Next we will check to see if an extension has been registered for a driver
+        // and will call the Closure if so, which allows us to have a more generic
+        // resolver for the drivers themselves which applies to all connections.
+        if (isset($this->extensions[$driver])) {
+            return call_user_func($this->extensions[$driver], $config, $name);
+        }
+
+        return $this->factory->make($driver, $config);
+    }
+
+    /**
+     * Get the driver for a connection.
+     *
+     * @param  string  $name
+     * @param  array   $config
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    protected function parseDriverName($name, $config)
+    {
+        if (isset($config['driver'])) {
+            return $config['driver'];
+        }
+
+        throw new RuntimeException("Unable to determine driver for connection [$name]");
+    }
+
+    /**
+     * Register an extension connection resolver.
+     *
+     * @param  string    $name
+     * @param  callable  $resolver
+     * @return void
+     */
+    public function extend($name, callable $resolver)
+    {
+        $this->extensions[$name] = $resolver;
+    }
+
+    /**
+     * Return all of the created connections.
+     *
+     * @return array
+     */
+    public function getConnections()
+    {
+        return $this->connections;
+    }
+
+    /**
+     * Dynamically pass methods to the default connection.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->connection()->$method(...$parameters);
+    }
+}


### PR DESCRIPTION
Intermediate PR in preparation of [#23183 (Multiple Mail connections)](https://github.com/laravel/framework/pull/23183) based on [this comment](https://github.com/laravel/framework/pull/23183#issuecomment-366160993).

----
This PR adds an additional `Manager` support class for managing "connections" instead of drivers. Since I consider a "connection" to be a driver+config combination I chose to not couple the regular Manager class as built driver instances get cached.

I refactored the `DatabaseManager` as an example. Other possible candidates could be `BroadcastManager`, `CacheManager` and `QueueManager`.

Note: to comply to the newly introduced `ConnectionFactoryInterface` I had to relocate the addition of the database's connection name to the config array to another part in code.

I look forward to suggestions.