### PR TITLE
[5.6] Testable date validation rules when comparison has relative time

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -11,6 +11,7 @@ use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Illuminate\Support\Carbon;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Validation\ValidationData;
@@ -180,7 +181,19 @@ trait ValidatesAttributes
      */
     protected function getDateTimestamp($value)
     {
-        return $value instanceof DateTimeInterface ? $value->getTimestamp() : strtotime($value);
+        if ($value instanceof DateTimeInterface) {
+            return $value->getTimestamp();
+        }
+
+        if ($this->isTestingRelativeDateTime($value)) {
+            $date = $this->getDateTime($value);
+
+            if (! is_null($date)) {
+                return $date->getTimestamp();
+            }
+        }
+
+        return strtotime($value);
     }
 
     /**
@@ -214,11 +227,39 @@ trait ValidatesAttributes
             return $date;
         }
 
+        return $this->getDateTime($value);
+    }
+
+    /**
+     * Get a DateTime instance from a string with no format.
+     *
+     * @param  string $value
+     * @return \DateTime|null
+     */
+    protected function getDateTime($value)
+    {
         try {
+            if ($this->isTestingRelativeDateTime($value)) {
+                return new Carbon($value);
+            }
+
             return new DateTime($value);
         } catch (Exception $e) {
             //
         }
+    }
+
+    /**
+     * Check if the given value should be adjusted to Carbon::getTestNow().
+     *
+     * @param  mixed $value
+     * @return bool
+     */
+    protected function isTestingRelativeDateTime($value)
+    {
+        return Carbon::hasTestNow() && is_string($value) && (
+            $value === 'now' || Carbon::hasRelativeKeywords($value)
+        );
     }
 
     /**


### PR DESCRIPTION
Change requested by: https://github.com/laravel/framework/issues/19520

I noticed this issue recently in a feature test hitting an API endpoint and doing a HTTP request assertion equivalent to:

```php
// Now a past date.
Carbon::setTestNow('2018-02-01');

$v = validator(['starts_on' => '2018-02-02'], ['starts_on' => 'date|after:today']);

$this->assertTrue($v->passes());
```

Only `starts_on` values after 2018-02-19 would pass validation.

Date validation rule parameters containing relative time like 'today' or 'next monday' don't respect `Carbon::setTestNow()`. To get a date-adjusted value when these keywords are present in a date parameter, instantiate `Carbon` instead of  `DateTime`  or `strtotime()`.

The previous date parameter behaviour is left as-is. Only when `Carbon::hasTestNow()` and `Carbon::hasRelativeKeywords($value)` are `true` will an attempt be made to parse the string for an adjusted date.

## ~~Workaround for `Carbon` 1.20 & 1.21~~

Given `carbon\carbon` dependency of `~1.20`, this code:

```php
Carbon::setTestNow(new Carbon('last week'));
Carbon::parse('today');
```

wasn't supported until 1.22 (pull request: https://github.com/briannesbitt/Carbon/pull/634) released Jan 15, 2017. So a few  `Carbon` constructor lines were needed in `ValidatesAttributes` to support `today` as a validated relative time keyword.