### PR TITLE
Pass basic authentication field parameter to the auth.basic middleware

### DIFF
--- a/CHANGELOG-5.6.md
+++ b/CHANGELOG-5.6.md
@@ -1,5 +1,15 @@
 # Release Notes for 5.6.x
 
+## [Unreleased]
+
+### Changed
+- Moved clone logic from `FormRequestServiceProvider` to `Request` ([b0c2459](https://github.com/laravel/framework/commit/b0c2459d7e55519d1c61927ab526e489a3a52eaf))
+
+### Fixed
+- Returns same `Logger` instance from `LogManager` ([#23118](https://github.com/laravel/framework/pull/23118))
+- Register missing `hash.driver` DI ([#23114](https://github.com/laravel/framework/pull/23114))
+
+
 ## v5.6.3 (2018-02-09)
 
 ### Fixed

--- a/CHANGELOG-5.6.md
+++ b/CHANGELOG-5.6.md
@@ -4,10 +4,18 @@
 
 ### Changed
 - Moved clone logic from `FormRequestServiceProvider` to `Request` ([b0c2459](https://github.com/laravel/framework/commit/b0c2459d7e55519d1c61927ab526e489a3a52eaf))
+- Changed pagination arrow symbols ([#23127](https://github.com/laravel/framework/pull/23127))
+- Update React version in preset ([#23134](https://github.com/laravel/framework/pull/23134))
+- Added an empty error bag when rendering HTTP exception views ([#23139](https://github.com/laravel/framework/pull/23139))
 
 ### Fixed
 - Returns same `Logger` instance from `LogManager` ([#23118](https://github.com/laravel/framework/pull/23118))
 - Register missing `hash.driver` DI ([#23114](https://github.com/laravel/framework/pull/23114))
+- Fixed an issue with starting two database transactions in tests ([#23132](https://github.com/laravel/framework/pull/23132))
+- Don't replace `tightenco/collect` ([#23147](https://github.com/laravel/framework/pull/23147))
+
+### Removed
+- Removed unnecessary `.card-default` classes from views ([#23129](https://github.com/laravel/framework/pull/23129))
 
 
 ## v5.6.3 (2018-02-09)

--- a/CHANGELOG-5.6.md
+++ b/CHANGELOG-5.6.md
@@ -2,20 +2,27 @@
 
 ## [Unreleased]
 
+### Added
+- Added the ability to set message ID right hand side ([#23181](https://github.com/laravel/framework/pull/23181))
+- Support callbacks as custom log drivers ([#23184](https://github.com/laravel/framework/pull/23184))
+
 ### Changed
 - Moved clone logic from `FormRequestServiceProvider` to `Request` ([b0c2459](https://github.com/laravel/framework/commit/b0c2459d7e55519d1c61927ab526e489a3a52eaf))
 - Changed pagination arrow symbols ([#23127](https://github.com/laravel/framework/pull/23127))
 - Update React version in preset ([#23134](https://github.com/laravel/framework/pull/23134))
 - Added an empty error bag when rendering HTTP exception views ([#23139](https://github.com/laravel/framework/pull/23139))
+- Normalized actions when using `route:list` command ([#23148](https://github.com/laravel/framework/pull/23148))
 
 ### Fixed
 - Returns same `Logger` instance from `LogManager` ([#23118](https://github.com/laravel/framework/pull/23118))
 - Register missing `hash.driver` DI ([#23114](https://github.com/laravel/framework/pull/23114))
 - Fixed an issue with starting two database transactions in tests ([#23132](https://github.com/laravel/framework/pull/23132))
-- Don't replace `tightenco/collect` ([#23147](https://github.com/laravel/framework/pull/23147))
+- Don't replace `tightenco/collect` ([#23147](https://github.com/laravel/framework/pull/23147), [#23153](https://github.com/laravel/framework/pull/23153), [#23160](https://github.com/laravel/framework/pull/23160))
+- Catch `InvalidFileException` when loading invalid environment file ([#23149](https://github.com/laravel/framework/pull/23149), [5695079](https://github.com/laravel/framework/commit/569507941594075c36893445dd22374efbe48305))
+- Fixed an issue with `assertRedirect()` ([#23176](https://github.com/laravel/framework/pull/23176))
 
 ### Removed
-- Removed unnecessary `.card-default` classes from views ([#23129](https://github.com/laravel/framework/pull/23129))
+- Removed Bootstrap 3 leftovers ([#23129](https://github.com/laravel/framework/pull/23129), [#23173](https://github.com/laravel/framework/pull/23173))
 
 
 ## v5.6.3 (2018-02-09)

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
         "illuminate/support": "self.version",
         "illuminate/translation": "self.version",
         "illuminate/validation": "self.version",
-        "illuminate/view": "self.version"
+        "illuminate/view": "self.version",
+        "tightenco/collect": "<5.5.33"
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",

--- a/composer.json
+++ b/composer.json
@@ -67,8 +67,7 @@
         "illuminate/support": "self.version",
         "illuminate/translation": "self.version",
         "illuminate/validation": "self.version",
-        "illuminate/view": "self.version",
-        "tightenco/collect": "self.version"
+        "illuminate/view": "self.version"
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/login.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/login.stub
@@ -4,7 +4,7 @@
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-md-8">
-            <div class="card card-default">
+            <div class="card">
                 <div class="card-header">Login</div>
 
                 <div class="card-body">

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/email.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/email.stub
@@ -4,7 +4,7 @@
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-md-8">
-            <div class="card card-default">
+            <div class="card">
                 <div class="card-header">Reset Password</div>
 
                 <div class="card-body">

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
@@ -4,7 +4,7 @@
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-md-8">
-            <div class="card card-default">
+            <div class="card">
                 <div class="card-header">Reset Password</div>
 
                 <div class="card-body">

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/register.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/register.stub
@@ -4,7 +4,7 @@
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-md-8">
-            <div class="card card-default">
+            <div class="card">
                 <div class="card-header">Register</div>
 
                 <div class="card-body">

--- a/src/Illuminate/Auth/Console/stubs/make/views/home.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/home.stub
@@ -4,7 +4,7 @@
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-md-8">
-            <div class="card card-default">
+            <div class="card">
                 <div class="card-header">Dashboard</div>
 
                 <div class="card-body">

--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -38,9 +38,10 @@
                             <li><a class="nav-link" href="{{ route('register') }}">Register</a></li>
                         @else
                             <li class="nav-item dropdown">
-                                <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                     {{ Auth::user()->name }} <span class="caret"></span>
                                 </a>
+
                                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                                     <a class="dropdown-item" href="{{ route('logout') }}"
                                        onclick="event.preventDefault();

--- a/src/Illuminate/Auth/Middleware/AuthenticateWithBasicAuth.php
+++ b/src/Illuminate/Auth/Middleware/AuthenticateWithBasicAuth.php
@@ -31,10 +31,11 @@ class AuthenticateWithBasicAuth
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @param  string|null  $guard
+     * @param  string|null  $field
      * @return mixed
      */
-    public function handle($request, Closure $next, $guard = null)
+    public function handle($request, Closure $next, $guard = null, $field = null)
     {
-        return $this->auth->guard($guard)->basic() ?: $next($request);
+        return $this->auth->guard($guard)->basic($field) ?: $next($request);
     }
 }

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Bootstrap;
 
 use Dotenv\Dotenv;
 use Dotenv\Exception\InvalidPathException;
+use Dotenv\Exception\InvalidFileException;
 use Symfony\Component\Console\Input\ArgvInput;
 use Illuminate\Contracts\Foundation\Application;
 
@@ -25,7 +26,7 @@ class LoadEnvironmentVariables
 
         try {
             (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
-        } catch (InvalidPathException $e) {
+        } catch (InvalidPathException | InvalidFileException $e) {
             //
         }
     }

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Foundation\Bootstrap;
 
 use Dotenv\Dotenv;
-use Dotenv\Exception\InvalidPathException;
 use Dotenv\Exception\InvalidFileException;
+use Dotenv\Exception\InvalidPathException;
 use Symfony\Component\Console\Input\ArgvInput;
 use Illuminate\Contracts\Foundation\Application;
 

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -26,8 +26,10 @@ class LoadEnvironmentVariables
 
         try {
             (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
-        } catch (InvalidPathException | InvalidFileException $e) {
+        } catch (InvalidPathException $e) {
             //
+        } catch (InvalidFileException $e) {
+            dd('Fatal Error: Values in .env containing spaces must be surrounded by quotes.');
         }
     }
 

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -29,7 +29,7 @@ class LoadEnvironmentVariables
         } catch (InvalidPathException $e) {
             //
         } catch (InvalidFileException $e) {
-            dd('Fatal Error: Values in .env containing spaces must be surrounded by quotes.');
+            die('The environment file is invalid: '.$e->getMessage());
         }
     }
 

--- a/src/Illuminate/Foundation/Console/Presets/React.php
+++ b/src/Illuminate/Foundation/Console/Presets/React.php
@@ -32,8 +32,8 @@ class React extends Preset
     {
         return [
             'babel-preset-react' => '^6.23.0',
-            'react' => '^15.4.2',
-            'react-dom' => '^15.4.2',
+            'react' => '^16.2.0',
+            'react-dom' => '^16.2.0',
         ] + Arr::except($packages, ['vue']);
     }
 

--- a/src/Illuminate/Foundation/Console/Presets/bootstrap-stubs/_variables.scss
+++ b/src/Illuminate/Foundation/Console/Presets/bootstrap-stubs/_variables.scss
@@ -6,13 +6,3 @@ $body-bg: #f5f8fa;
 $font-family-sans-serif: "Raleway", sans-serif;
 $font-size-base: 0.9rem;
 $line-height-base: 1.6;
-$text-color: #636b6f;
-
-// Navbar
-$navbar-default-bg: #fff;
-
-// Buttons
-$btn-default-color: $text-color;
-
-// Panels
-$panel-default-heading-bg: #fff;

--- a/src/Illuminate/Foundation/Console/Presets/react-stubs/Example.js
+++ b/src/Illuminate/Foundation/Console/Presets/react-stubs/Example.js
@@ -7,7 +7,7 @@ export default class Example extends Component {
             <div className="container">
                 <div className="row justify-content-center">
                     <div className="col-md-8">
-                        <div className="card card-default">
+                        <div className="card">
                             <div className="card-header">Example Component</div>
 
                             <div className="card-body">

--- a/src/Illuminate/Foundation/Console/Presets/vue-stubs/ExampleComponent.vue
+++ b/src/Illuminate/Foundation/Console/Presets/vue-stubs/ExampleComponent.vue
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="row justify-content-center">
             <div class="col-md-8">
-                <div class="card card-default">
+                <div class="card">
                     <div class="card-header">Example Component</div>
 
                     <div class="card-body">

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -110,7 +110,7 @@ class RouteListCommand extends Command
             'method' => implode('|', $route->methods()),
             'uri'    => $route->uri(),
             'name'   => $route->getName(),
-            'action' => $route->getActionName(),
+            'action' => ltrim($route->getActionName(), '\\'),
             'middleware' => $this->getMiddleware($route),
         ]);
     }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Response;
 use Illuminate\Routing\Router;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\ViewErrorBag;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\RedirectResponse;
 use Whoops\Handler\PrettyPageHandler;
@@ -400,7 +401,7 @@ class Handler implements ExceptionHandlerContract
         })->push(__DIR__.'/views')->all());
 
         if (view()->exists($view = "errors::{$status}")) {
-            return response()->view($view, ['exception' => $e], $status, $e->getHeaders());
+            return response()->view($view, ['exception' => $e, 'errors' => new ViewErrorBag], $status, $e->getHeaders());
         }
 
         return $this->convertExceptionToResponse($e);

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -402,7 +402,7 @@ class Handler implements ExceptionHandlerContract
 
         if (view()->exists($view = "errors::{$status}")) {
             return response()->view($view, [
-                'exception' => $e, 'errors' => new ViewErrorBag
+                'exception' => $e, 'errors' => new ViewErrorBag,
             ], $status, $e->getHeaders());
         }
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -401,7 +401,9 @@ class Handler implements ExceptionHandlerContract
         })->push(__DIR__.'/views')->all());
 
         if (view()->exists($view = "errors::{$status}")) {
-            return response()->view($view, ['exception' => $e, 'errors' => new ViewErrorBag], $status, $e->getHeaders());
+            return response()->view($view, [
+                'exception' => $e, 'errors' => new ViewErrorBag
+            ], $status, $e->getHeaders());
         }
 
         return $this->convertExceptionToResponse($e);

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -94,7 +94,9 @@ class TestResponse
         );
 
         if (! is_null($uri)) {
-            PHPUnit::assertEquals(app('url')->to($uri), $this->headers->get('Location'));
+            PHPUnit::assertEquals(
+                app('url')->to($uri), app('url')->to($this->headers->get('Location'))
+            );
         }
 
         return $this;

--- a/src/Illuminate/Hashing/HashServiceProvider.php
+++ b/src/Illuminate/Hashing/HashServiceProvider.php
@@ -36,6 +36,6 @@ class HashServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return ['hash'];
+        return ['hash', 'hash.driver'];
     }
 }

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -113,7 +113,7 @@ class LogManager implements LoggerInterface
     {
         try {
             return $this->channels[$name] ?? with($this->resolve($name), function ($logger) use ($name) {
-                return $this->tap($name, new Logger($logger, $this->app['events']));
+                return $this->channels[$name] = $this->tap($name, new Logger($logger, $this->app['events']));
             });
         } catch (Throwable $e) {
             return tap($this->createEmergencyLogger(), function ($logger) use ($e) {

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -213,9 +213,9 @@ class LogManager implements LoggerInterface
      */
     protected function createCustomDriver(array $config)
     {
-        $f = is_callable($via = $config['via']) ? $via : $this->app->make($via);
+        $factory = is_callable($via = $config['via']) ? $via : $this->app->make($via);
 
-        return $f($config);
+        return $factory($config);
     }
 
     /**

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -213,7 +213,9 @@ class LogManager implements LoggerInterface
      */
     protected function createCustomDriver(array $config)
     {
-        return $this->app->make($config['via'])->__invoke($config);
+        $f = is_callable($via = $config['via']) ? $via : $this->app->make($via);
+
+        return $f($config);
     }
 
     /**

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -93,10 +93,10 @@ class MailServiceProvider extends ServiceProvider
         // mailer instance, passing in the transport instances, which allows us to
         // override this transporter instances during app start-up if necessary.
         $this->app->singleton('swift.mailer', function ($app) {
-            if ($mailDomain = $app->make('config')->get('mail.domain')) {
+            if ($domain = $app->make('config')->get('mail.domain')) {
                 Swift_DependencyContainer::getInstance()
                                 ->register('mime.idgenerator.idright')
-                                ->asValue($mailDomain);
+                                ->asValue($domain);
             }
 
             return new Swift_Mailer($app['swift.transport']->driver());

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -5,6 +5,7 @@ namespace Illuminate\Mail;
 use Swift_Mailer;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Swift_DependencyContainer;
 use Illuminate\Support\ServiceProvider;
 
 class MailServiceProvider extends ServiceProvider
@@ -87,6 +88,10 @@ class MailServiceProvider extends ServiceProvider
     public function registerSwiftMailer()
     {
         $this->registerSwiftTransport();
+
+        Swift_DependencyContainer::getInstance()
+            ->register('mime.idgenerator.idright')
+            ->asValue($this->app->make('config')->get('mail.domain', 'swift.generated'));
 
         // Once we have the transporter registered, we will register the actual Swift
         // mailer instance, passing in the transport instances, which allows us to

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -89,14 +89,16 @@ class MailServiceProvider extends ServiceProvider
     {
         $this->registerSwiftTransport();
 
-        Swift_DependencyContainer::getInstance()
-            ->register('mime.idgenerator.idright')
-            ->asValue($this->app->make('config')->get('mail.domain', 'swift.generated'));
-
         // Once we have the transporter registered, we will register the actual Swift
         // mailer instance, passing in the transport instances, which allows us to
         // override this transporter instances during app start-up if necessary.
         $this->app->singleton('swift.mailer', function ($app) {
+            if ($mailDomain = $app->make('config')->get('mail.domain')) {
+                Swift_DependencyContainer::getInstance()
+                                ->register('mime.idgenerator.idright')
+                                ->asValue($mailDomain);
+            }
+
             return new Swift_Mailer($app['swift.transport']->driver());
         });
     }

--- a/src/Illuminate/Pagination/resources/views/bootstrap-4.blade.php
+++ b/src/Illuminate/Pagination/resources/views/bootstrap-4.blade.php
@@ -2,9 +2,9 @@
     <ul class="pagination">
         {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
-            <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+            <li class="page-item disabled"><span class="page-link">&lsaquo;</span></li>
         @else
-            <li class="page-item"><a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
+            <li class="page-item"><a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">&lsaquo;</a></li>
         @endif
 
         {{-- Pagination Elements --}}
@@ -28,9 +28,9 @@
 
         {{-- Next Page Link --}}
         @if ($paginator->hasMorePages())
-            <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
+            <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">&rsaquo;</a></li>
         @else
-            <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+            <li class="page-item disabled"><span class="page-link">&rsaquo;</span></li>
         @endif
     </ul>
 @endif

--- a/src/Illuminate/Pagination/resources/views/default.blade.php
+++ b/src/Illuminate/Pagination/resources/views/default.blade.php
@@ -2,9 +2,9 @@
     <ul class="pagination">
         {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
-            <li class="disabled"><span>&laquo;</span></li>
+            <li class="disabled"><span>&lsaquo;</span></li>
         @else
-            <li><a href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
+            <li><a href="{{ $paginator->previousPageUrl() }}" rel="prev">&lsaquo;</a></li>
         @endif
 
         {{-- Pagination Elements --}}
@@ -28,9 +28,9 @@
 
         {{-- Next Page Link --}}
         @if ($paginator->hasMorePages())
-            <li><a href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
+            <li><a href="{{ $paginator->nextPageUrl() }}" rel="next">&rsaquo;</a></li>
         @else
-            <li class="disabled"><span>&raquo;</span></li>
+            <li class="disabled"><span>&rsaquo;</span></li>
         @endif
     </ul>
 @endif

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -21,7 +21,7 @@
         "nesbot/carbon": "^1.20"
     },
     "replace": {
-        "tightenco/collect": "self.version"
+        "tightenco/collect": "<5.5.33"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Integration/Routing/RouteRedirectTest.php
+++ b/tests/Integration/Routing/RouteRedirectTest.php
@@ -24,10 +24,14 @@ class RouteRedirectTest extends TestCase
         Route::redirect('from/{param}/{param2?}', 'to', 301);
 
         $response = $this->get('/from/value1/value2');
+        $response->assertRedirect('to');
+
         $this->assertEquals(301, $response->getStatusCode());
         $this->assertEquals('to', $response->headers->get('Location'));
 
         $response = $this->get('/from/value1');
+        $response->assertRedirect('to');
+
         $this->assertEquals(301, $response->getStatusCode());
         $this->assertEquals('to', $response->headers->get('Location'));
     }

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\Log;
+
+use Illuminate\Log\LogManager;
+use Orchestra\Testbench\TestCase;
+
+class LogManagerTest extends TestCase
+{
+    public function testLogManagerCachesLoggerInstances()
+    {
+        $manager = new LogManager($this->app);
+
+        $logger1 = $manager->channel('single')->getLogger();
+        $logger2 = $manager->channel('single')->getLogger();
+
+        $this->assertSame($logger1, $logger2);
+    }
+}


### PR DESCRIPTION
This is fully backward compatible.
Allow customizing the authentication field easily:
```php
$this->middleware('auth.basic:guardians,username')
```