### PR TITLE
[5.6] Add IteractsWithConsole::artisanOutput method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -17,4 +17,14 @@ trait InteractsWithConsole
     {
         return $this->app[Kernel::class]->call($command, $parameters);
     }
+
+    /**
+     * Get the output for the last run command.
+     *
+     * @return string
+     */
+    public function artisanOutput()
+    {
+        return $this->app[Kernel::class]->output();
+    }
 }


### PR DESCRIPTION
Often times I want to get the output of the command I am testing, and have to resort to

```php
$output = $this->app[Kernel::class]->output();
```

I think this would make a great addition to testing artisan commands.

I couldn't find any tests for the `artisan` method unfortunately, not sure where to put tests for this addition.