### PR TITLE
Make sure framework does not exit when there's a problem decrypting cookies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravel/framework",
+    "name": "juliusza/framework",
     "description": "The Laravel Framework.",
     "keywords": ["framework", "laravel"],
     "license": "MIT",

--- a/src/Illuminate/Cookie/Guard.php
+++ b/src/Illuminate/Cookie/Guard.php
@@ -65,7 +65,7 @@ class Guard implements HttpKernelInterface {
 			{
 				$request->cookies->set($key, $this->decryptCookie($c));
 			}
-			catch (DecryptException $e)
+			catch (\Throwable $e)
 			{
 				$request->cookies->set($key, null);
 			}


### PR DESCRIPTION
Reproduce with 

`setcookie('dummy[foo][bar]', 'value1' , time()+3600);`

the next request will fail, with msg "string expected"

