### PR TITLE
[5.7] Pass basic authentication field parameter to the auth.basic middleware

### DIFF
--- a/src/Illuminate/Auth/Middleware/AuthenticateWithBasicAuth.php
+++ b/src/Illuminate/Auth/Middleware/AuthenticateWithBasicAuth.php
@@ -31,10 +31,11 @@ class AuthenticateWithBasicAuth
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @param  string|null  $guard
+     * @param  string|null  $field
      * @return mixed
      */
-    public function handle($request, Closure $next, $guard = null)
+    public function handle($request, Closure $next, $guard = null, $field = null)
     {
-        return $this->auth->guard($guard)->basic() ?: $next($request);
+        return $this->auth->guard($guard)->basic($field) ?: $next($request);
     }
 }


### PR DESCRIPTION
Ref #23216 

This is fully backward compatible.
Allow customizing the authentication field easily:
```php
$this->middleware('auth.basic:guardians,username')
```