### PR TITLE
Should not exit on multiarray cookies (better ignore them)

### DIFF
--- a/src/Illuminate/Cookie/Guard.php
+++ b/src/Illuminate/Cookie/Guard.php
@@ -99,6 +99,9 @@ class Guard implements HttpKernelInterface {
 
 		foreach ($cookie as $key => $value)
 		{
+			if (!is_string($value)) {
+				throw new DecryptException("Unexpected cookie type " . gettype($value) . " of $key");
+			}
 			$decrypted[$key] = $this->encrypter->decrypt($value);
 		}
 


### PR DESCRIPTION
Users could crash framework by setting specific cookies:

`setcookie('dummy[foo][bar]', 'value1' , time()+3600);`

the next request will fail, with msg "string expected"