### PR TITLE
Add more options to toArray() and reverse() functions in Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1262,13 +1262,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Reverse items order.
+     * Reverse items order and keep the original index or not.
      *
+     * @param bool $preserve
      * @return static
      */
-    public function reverse()
+    public function reverse($preserve = true)
     {
-        return new static(array_reverse($this->items, true));
+        return new static(array_reverse($this->items, $preserve));
     }
 
     /**
@@ -1611,15 +1612,22 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Get the collection of items as a plain array.
+     * Get the collection of items as a plain array or an array which each element is instance of the original class.
      *
+     * @param bool $preserveElementClass
      * @return array
      */
-    public function toArray()
+    public function toArray($preserveElementClass = false)
     {
-        return array_map(function ($value) {
-            return $value instanceof Arrayable ? $value->toArray() : $value;
-        }, $this->items);
+        if (!$preserveElementClass)
+            return array_map(function ($value) {
+                return $value instanceof Arrayable ? $value->toArray() : $value;
+            }, $this->items);
+
+        $modifier = function ($value) {
+            return $value;
+        };
+        return array_map($modifier, $this->items);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1619,14 +1619,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function toArray($preserveElementClass = false)
     {
-        if (!$preserveElementClass)
+        if (! $preserveElementClass) {
             return array_map(function ($value) {
                 return $value instanceof Arrayable ? $value->toArray() : $value;
             }, $this->items);
-
+        }
+        
         $modifier = function ($value) {
             return $value;
         };
+        
         return array_map($modifier, $this->items);
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1624,11 +1624,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 return $value instanceof Arrayable ? $value->toArray() : $value;
             }, $this->items);
         }
-        
+
         $modifier = function ($value) {
             return $value;
         };
-        
+
         return array_map($modifier, $this->items);
     }
 


### PR DESCRIPTION
When I work with Laravel Collection, I usually have to deal with many problems like that:

1. Reversing the order of the collection, then the reversed collection is displayed in view as a table with the unordered keys.
2. Calling `toArray()` function for the collection but it makes the collection completely change to a new array of arrays. Means that, each old element in the collection is changed from an object of class to an array of attributes, then it can no longer be used as an object like it was.

Therefore, I want to add more options for developers to be able to use these functions in more cases. Meanwhile, no change affects the existing projects and the developers.