### PR TITLE
[5.7] Don’t call Redis clients directly

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -29,7 +29,7 @@ class PhpRedisConnection extends Connection
      */
     public function get($key)
     {
-        $result = $this->client->get($key);
+        $result = $this->command('get', [$key]);
 
         return $result !== false ? $result : null;
     }
@@ -44,7 +44,7 @@ class PhpRedisConnection extends Connection
     {
         return array_map(function ($value) {
             return $value !== false ? $value : null;
-        }, $this->client->mget($keys));
+        }, $this->command('mget', $keys));
     }
 
     /**
@@ -90,7 +90,7 @@ class PhpRedisConnection extends Connection
      */
     public function setnx($key, $value)
     {
-        return (int) $this->client->setnx($key, $value);
+        return (int) $this->command('setnx', [$key, $value]);
     }
 
     /**
@@ -139,7 +139,7 @@ class PhpRedisConnection extends Connection
      */
     public function hsetnx($hash, $key, $value)
     {
-        return (int) $this->client->hsetnx($hash, $key, $value);
+        return (int) $this->command('hsetnx', [$hash, $key, $value]);
     }
 
     /**
@@ -240,10 +240,10 @@ class PhpRedisConnection extends Connection
      */
     public function zinterstore($output, $keys, $options = [])
     {
-        return $this->zInter($output, $keys,
+        return $this->command('zInter', [$output, $keys,
             $options['weights'] ?? null,
-            $options['aggregate'] ?? 'sum'
-        );
+            $options['aggregate'] ?? 'sum',
+        ]);
     }
 
     /**
@@ -256,10 +256,10 @@ class PhpRedisConnection extends Connection
      */
     public function zunionstore($output, $keys, $options = [])
     {
-        return $this->zUnion($output, $keys,
+        return $this->command('zUnion', [$output, $keys,
             $options['weights'] ?? null,
-            $options['aggregate'] ?? 'sum'
-        );
+            $options['aggregate'] ?? 'sum',
+        ]);
     }
 
     /**
@@ -317,7 +317,7 @@ class PhpRedisConnection extends Connection
      */
     public function eval($script, $numberOfKeys, ...$arguments)
     {
-        return $this->client->eval($script, $arguments, $numberOfKeys);
+        return $this->command('eval', [$script, $arguments, $numberOfKeys]);
     }
 
     /**
@@ -404,8 +404,6 @@ class PhpRedisConnection extends Connection
      */
     public function __call($method, $parameters)
     {
-        $method = strtolower($method);
-
-        return parent::__call($method, $parameters);
+        return parent::__call(strtolower($method), $parameters);
     }
 }

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -91,9 +91,10 @@ class ConcurrencyLimiter
             return $this->name.$i;
         }, range(1, $this->maxLocks));
 
-        return $this->redis->eval($this->luaScript(), count($slots),
-            ...array_merge($slots, [$this->name, $this->releaseAfter])
-        );
+        return $this->redis->command('eval', array_merge(
+            [$this->luaScript(), count($slots)],
+            array_merge($slots, [$this->name, $this->releaseAfter])
+        ));
     }
 
     /**
@@ -125,6 +126,6 @@ LUA;
      */
     protected function release($key)
     {
-        $this->redis->del($key);
+        $this->redis->command('del', [$key]);
     }
 }

--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -99,9 +99,9 @@ class DurationLimiter
      */
     public function acquire()
     {
-        $results = $this->redis->eval($this->luaScript(), 1,
-            $this->name, microtime(true), time(), $this->decay, $this->maxLocks
-        );
+        $results = $this->redis->command('eval', [
+            $this->luaScript(), 1, $this->name, microtime(true), time(), $this->decay, $this->maxLocks,
+        ]);
 
         $this->decaysAt = $results[1];
 


### PR DESCRIPTION
To move one step closer to #22961, stop calling PhpRedis/Predis methods directly and pass everything through `command()`. This is happening for most calls anyhow via `Connection::__call()`.