### PR TITLE
[5.6] Add reference to model in MassAssignmentException

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -230,8 +230,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             if ($this->isFillable($key)) {
                 $this->setAttribute($key, $value);
             } elseif ($totallyGuarded) {
+                $model = get_class($this);
                 throw new MassAssignmentException(
-                    "Add [{$key}] to fillable property to allow mass assignment."
+                    "Add [{$key}] to fillable property to allow mass assignment on {$model}."
                 );
             }
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -230,7 +230,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             if ($this->isFillable($key)) {
                 $this->setAttribute($key, $value);
             } elseif ($totallyGuarded) {
-                $model = get_class($this);
+                $model = static::class;
                 throw new MassAssignmentException(
                     "Add [{$key}] to fillable property to allow mass assignment on {$model}."
                 );


### PR DESCRIPTION
[This pull request](https://github.com/laravel/framework/pull/22565) and [this commit](https://github.com/laravel/framework/commit/6c1bc1eda7f1d666fc8aa324db4e5e6f13104690) updated mass assignment exception wording. I think we could improve it a bit more by giving the model class name.

So replacing:

```
Add [name] to fillable property to allow mass assignment.
```

By:

```
Add [name] to fillable property to allow mass assignment on App\User.
```

Errors on models are sometimes confusing, because there is no explicit reference to the actual model in backtrace. This PR could be a one step more to make errors more understandable in Laravel.