### PR TITLE
[5.6] Fix --force on GeneratorCommand

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -56,7 +56,7 @@ abstract class GeneratorCommand extends Command
         // First we will check to see if the class already exists. If it does, we don't want
         // to create the class and overwrite the user's code. So, we will bail out so the
         // code is untouched. Otherwise, we will continue generating this class' files.
-        if ($this->alreadyExists($this->getNameInput())) {
+        if ((! $this->hasOption('force') || ! $this->option('force')) && $this->alreadyExists($this->getNameInput())) {
             $this->error($this->type.' already exists!');
 
             return false;


### PR DESCRIPTION
When the --force option is used the command should generate and override an existing file
Before this pull request using --force has no effect, an already existing file error is thrown