### PR TITLE
[5.6] Rewrite BadMethodCallException messages for consistency and always include the FQN of the class that throws the exception

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1304,7 +1304,8 @@ class Builder
         }
 
         if (! isset(static::$macros[$method])) {
-            throw new BadMethodCallException("Method {$method} does not exist.");
+            $className = static::class;
+            throw new BadMethodCallException("Method {$className}::{$method} does not exist.");
         }
 
         if (static::$macros[$method] instanceof Closure) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2508,7 +2508,6 @@ class Builder
         }
 
         $className = static::class;
-
-        throw new BadMethodCallException("Call to undefined method {$className}::{$method}()");
+        throw new BadMethodCallException("Method {$className}::{$method} does not exist.");
     }
 }

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -231,8 +231,7 @@ class RedirectResponse extends BaseRedirectResponse
             return $this->with(Str::snake(substr($method, 4)), $parameters[0]);
         }
 
-        throw new BadMethodCallException(
-            "Method [$method] does not exist on Redirect."
-        );
+        $className = static::class;
+        throw new BadMethodCallException("Method {$className}::{$method} does not exist.");
     }
 }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -718,6 +718,7 @@ class Mailable implements MailableContract, Renderable
             return $this->with(Str::snake(substr($method, 4)), $parameters[0]);
         }
 
-        throw new BadMethodCallException("Method [$method] does not exist on mailable.");
+        $className = static::class;
+        throw new BadMethodCallException("Method {$className}::{$method} does not exist.");
     }
 }

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -65,6 +65,7 @@ abstract class Controller
      */
     public function __call($method, $parameters)
     {
-        throw new BadMethodCallException("Method [{$method}] does not exist on [".get_class($this).'].');
+        $className = static::class;
+        throw new BadMethodCallException("Method {$className}::{$method} does not exist.");
     }
 }

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -175,6 +175,7 @@ class RouteRegistrar
             return $this->attribute($method, $parameters[0]);
         }
 
-        throw new BadMethodCallException("Method [{$method}] does not exist.");
+        $className = static::class;
+        throw new BadMethodCallException("Method {$className}::{$method} does not exist.");
     }
 }

--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -71,7 +71,8 @@ trait Macroable
     public static function __callStatic($method, $parameters)
     {
         if (! static::hasMacro($method)) {
-            throw new BadMethodCallException("Method {$method} does not exist.");
+            $className = static::class;
+            throw new BadMethodCallException("Method {$className}::{$method} does not exist.");
         }
 
         if (static::$macros[$method] instanceof Closure) {
@@ -93,7 +94,8 @@ trait Macroable
     public function __call($method, $parameters)
     {
         if (! static::hasMacro($method)) {
-            throw new BadMethodCallException("Method {$method} does not exist.");
+            $className = static::class;
+            throw new BadMethodCallException("Method {$className}::{$method} does not exist.");
         }
 
         $macro = static::$macros[$method];

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1137,6 +1137,7 @@ class Validator implements ValidatorContract
             return $this->callExtension($rule, $parameters);
         }
 
-        throw new BadMethodCallException("Method [$method] does not exist.");
+        $className = static::class;
+        throw new BadMethodCallException("Method {$className}::{$method} does not exist.");
     }
 }

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -396,7 +396,8 @@ class View implements ArrayAccess, ViewContract
     public function __call($method, $parameters)
     {
         if (! Str::startsWith($method, 'with')) {
-            throw new BadMethodCallException("Method [$method] does not exist on view.");
+            $className = static::class;
+            throw new BadMethodCallException("Method {$className}::{$method} does not exist.");
         }
 
         return $this->with(Str::camel(substr($method, 4)), $parameters[0]);

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -121,7 +121,7 @@ class HttpRedirectResponseTest extends TestCase
 
     /**
      * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method [doesNotExist] does not exist on Redirect.
+     * @expectedExceptionMessage Method Illuminate\Http\RedirectResponse::doesNotExist does not exist.
      */
     public function testMagicCallException()
     {

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -189,7 +189,7 @@ class HttpResponseTest extends TestCase
 
     /**
      * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method [doesNotExist] does not exist on Redirect.
+     * @expectedExceptionMessage Method Illuminate\Http\RedirectResponse::doesNotExist does not exist.
      */
     public function testMagicCallException()
     {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -201,7 +201,7 @@ class RouteRegistrarTest extends TestCase
 
     /**
      * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method [missing] does not exist.
+     * @expectedExceptionMessage Method Illuminate\Routing\RouteRegistrar::missing does not exist.
      */
     public function testRegisteringNonApprovedAttributesThrows()
     {

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -58,7 +58,7 @@ class SupportCarbonTest extends TestCase
 
     /**
      * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method nonExistingStaticMacro does not exist.
+     * @expectedExceptionMessage Method Illuminate\Support\Carbon::nonExistingStaticMacro does not exist.
      */
     public function testCarbonRaisesExceptionWhenStaticMacroIsNotFound()
     {
@@ -67,7 +67,7 @@ class SupportCarbonTest extends TestCase
 
     /**
      * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method nonExistingMacro does not exist.
+     * @expectedExceptionMessage Method Illuminate\Support\Carbon::nonExistingMacro does not exist.
      */
     public function testCarbonRaisesExceptionWhenMacroIsNotFound()
     {

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -165,7 +165,7 @@ class ViewTest extends TestCase
 
     /**
      * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method [badMethodCall] does not exist on view.
+     * @expectedExceptionMessage Method Illuminate\View\View::badMethodCall does not exist.
      */
     public function testViewBadMethod()
     {


### PR DESCRIPTION
The objective of the proposed changes is to make the messages of the `BadMethodCallException` exceptions more consistent in the framework, always including the FQN of the class where the exceptions is thrown, since in many cases the exception is thrown by a trait (ex: `Macroable`) making the debugging more complicated.

This way, what would previously generate an error by console with this message:
```
BadMethodCallException: Method hello does not exist.
/.../vendor/laravel/framework/src/Illuminate/Support/Traits/Macroable.php:75
...
```

Now it generates the following message:
```
BadMethodCallException: Method Illuminate\Database\Eloquent\Collection::hello does not exist.
/.../vendor/laravel/framework/src/Illuminate/Support/Traits/Macroable.php:75
....
```

The tests have also been updated to reflect the changes.