### PR TITLE
[5.6] Add MailableContract alias for docblocks in Mailer interfaces

### DIFF
--- a/src/Illuminate/Contracts/Mail/MailQueue.php
+++ b/src/Illuminate/Contracts/Mail/MailQueue.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Contracts\Mail;
 
+use Illuminate\Contracts\Mail\Mailable as MailableContract;
+
 interface MailQueue
 {
     /**

--- a/src/Illuminate/Contracts/Mail/Mailer.php
+++ b/src/Illuminate/Contracts/Mail/Mailer.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Contracts\Mail;
 
+use Illuminate\Contracts\Mail\Mailable as MailableContract;
+
 interface Mailer
 {
     /**


### PR DESCRIPTION
The class aliases were missing in these interfaces, making the usages of `MailableContract` in proceeding docblocks incorrect.