### PR TITLE
[5.7] Set Redis connection names

### DIFF
--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -19,6 +19,13 @@ abstract class Connection
     protected $client;
 
     /**
+     * The Redis connection name.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
      * Subscribe to a set of given channels for messages.
      *
      * @param  array|string  $channels
@@ -94,6 +101,27 @@ abstract class Connection
     public function command($method, array $parameters = [])
     {
         return $this->client->{$method}(...$parameters);
+    }
+
+    /**
+     * Get the connection name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set the connections name.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
     }
 
     /**

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -58,7 +58,10 @@ class RedisManager implements Factory
             return $this->connections[$name];
         }
 
-        return $this->connections[$name] = $this->resolve($name);
+        $this->connections[$name] = $this->resolve($name);
+        $this->connections[$name]->setName($name);
+
+        return $this->connections[$name];
     }
 
     /**


### PR DESCRIPTION
It would be handy to have to connection name on the actual Redis connection.

I went with the getter/setter approach, because it doesn't change/break anything. Alternatively we could pass the connection name to the connector and the connection constructor.