### PR TITLE
[5.5] Resolve bug Call to a member function onQueue() on string

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -84,7 +84,7 @@ class Schedule
             $job = is_string($job) ? resolve($job) : $job;
 
             if ($job instanceof ShouldQueue) {
-                dispatch($job)->onQueue($queue);
+                dispatch($job->onQueue($queue));
             } else {
                 dispatch_now($job);
             }


### PR DESCRIPTION
Method onQueue() should be applied on ShouldQueue, not on Dispatcher.