### PR TITLE
[5.6] [WIP] Add notification database channel custom types

### DIFF
--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -18,10 +18,25 @@ class DatabaseChannel
     {
         return $notifiable->routeNotificationFor('database', $notification)->create([
             'id' => $notification->id,
-            'type' => get_class($notification),
+            'type' => $this->getType($notification),
             'data' => $this->getData($notifiable, $notification),
             'read_at' => null,
         ]);
+    }
+
+    /**
+     * Get the type of the notification.
+     *
+     * @param  \Illuminate\Notifications\Notification  $notification
+     * @return array
+     */
+    protected function getType(Notification $notification)
+    {
+        if (method_exists($notification, 'broadcastType')) {
+            return $notification->broadcastType();
+        }
+
+        return get_class($notification);
     }
 
     /**

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -31,6 +31,23 @@ class NotificationDatabaseChannelTest extends TestCase
         $channel = new DatabaseChannel;
         $channel->send($notifiable, $notification);
     }
+
+    public function testDatabaseChannelCreatesDatabaseRecordWithCustomType()
+    {
+        $notification = new NotificationDatabaseChannelWithCustomTypeTestNotification;
+        $notification->id = 1;
+        $notifiable = Mockery::mock();
+
+        $notifiable->shouldReceive('routeNotificationFor->create')->with([
+            'id' => 1,
+            'type' => 'custom.type',
+            'data' => ['invoice_id' => 1],
+            'read_at' => null,
+        ]);
+
+        $channel = new DatabaseChannel;
+        $channel->send($notifiable, $notification);
+    }
 }
 
 class NotificationDatabaseChannelTestNotification extends Notification
@@ -38,5 +55,18 @@ class NotificationDatabaseChannelTestNotification extends Notification
     public function toDatabase($notifiable)
     {
         return new DatabaseMessage(['invoice_id' => 1]);
+    }
+}
+
+class NotificationDatabaseChannelWithCustomTypeTestNotification extends Notification
+{
+    public function toDatabase($notifiable)
+    {
+        return new DatabaseMessage(['invoice_id' => 1]);
+    }
+
+    public function broadcastType()
+    {
+        return 'custom.type';
     }
 }


### PR DESCRIPTION
Related to: #23236

This PR introduces the same behavior to the database notification channel to keep notification channels data consistency.

Use case: I'm adding notification to database and broadcasting them to the user. But if user has missed notifications - he can call `GET /notifications` later and get the same data which was broadcasted earlier. Otherwise notification type will be mismatch and there will be issues with data merge.

The only thing I don't like in this implementation is method naming. Type resolver checks if `broadcastType()` method exists in `Notification`. Earlier I suggested name `broadcastAs()` inspired from Broadcasting Event. Taylor's name `broadcastType()` is way better, but still coupled with broadcasting. Maybe it's better to rename it to more generic `getType()`?