### PR TITLE
Code minor logic bugfix

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -414,9 +414,10 @@ trait HasAttributes
             throw new LogicException(get_class($this).'::'.$method.' must return a relationship instance.');
         }
 
-        return tap($relation->getResults(), function ($results) use ($method) {
-            $this->setRelation($method, $results);
-        });
+        $results = $relation->getResults();
+        $this->setRelation($method, $results);
+
+        return $this->relations[$method];
     }
 
     /**


### PR DESCRIPTION
the returning value must be taken from the variable it was set to. why?  we have a setRelation() setter; setters are known not only for setting a value directly, but also for modifying the value prior to setting. so if we set a value (A) to a specific property (B) via setter, but we return not the value which was 'actually' set (B), but the 'original' value (A), we are about to get bug in the code