### PR TITLE
Use HTTP Status constant

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -122,7 +122,7 @@ class ThrottleRequests
         );
 
         return new HttpException(
-            429, 'Too Many Attempts.', null, $headers
+            Response::HTTP_TOO_MANY_REQUESTS, 'Too Many Attempts.', null, $headers
         );
     }
 


### PR DESCRIPTION
This is a simple clean-up that caught my eye: The `ThrottleRequests` middleware currently uses the HTTP status code `429` directly. However, Symfony's `Request` has many handy constants for this purpose.