### PR TITLE
Can't get correct total record when using distinct and passing argume…

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -705,7 +705,7 @@ class Builder
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = ($total = $this->toBase()->getCountForPagination())
+        $results = ($total = $this->toBase()->getCountForPagination($columns))
                                     ? $this->forPage($page, $perPage)->get($columns)
                                     : $this->model->newCollection();
 


### PR DESCRIPTION
Can't get correct total record when using distinct and passing argument $columns.

Eg: $builder->paginate(10, ['test.id'], 'page');