### PR TITLE
[5.6] Extend Resource Instead of JsonResource in the stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/resource.stub
+++ b/src/Illuminate/Foundation/Console/stubs/resource.stub
@@ -2,9 +2,9 @@
 
 namespace DummyNamespace;
 
-use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\Json\Resource;
 
-class DummyClass extends JsonResource
+class DummyClass extends Resource
 {
     /**
      * Transform the resource into an array.


### PR DESCRIPTION
The examples in the docs are showing that a singular resource extends the Resource and not the JsonResource