### PR TITLE
[5.6] Update @trans Blade directive to call Translator#trans instead of Translator#getFromJson

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -98,7 +98,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function trans($key, array $replace = [], $locale = null)
     {
-        return $this->get($key, $replace, $locale);
+        return $this->getFromJson($key, $replace, $locale);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
@@ -18,7 +18,7 @@ trait CompilesTranslations
             return "<?php \$__env->startTranslation{$expression}; ?>";
         }
 
-        return "<?php echo app('translator')->getFromJson{$expression}; ?>";
+        return "<?php echo app('translator')->trans{$expression}; ?>";
     }
 
     /**

--- a/tests/View/Blade/BladeExpressionTest.php
+++ b/tests/View/Blade/BladeExpressionTest.php
@@ -6,13 +6,13 @@ class BladeExpressionTest extends AbstractBladeTestCase
 {
     public function testExpressionsOnTheSameLine()
     {
-        $this->assertEquals('<?php echo app(\'translator\')->getFromJson(foo(bar(baz(qux(breeze()))))); ?> space () <?php echo app(\'translator\')->getFromJson(foo(bar)); ?>', $this->compiler->compileString('@lang(foo(bar(baz(qux(breeze()))))) space () @lang(foo(bar))'));
+        $this->assertEquals('<?php echo app(\'translator\')->trans(foo(bar(baz(qux(breeze()))))); ?> space () <?php echo app(\'translator\')->trans(foo(bar)); ?>', $this->compiler->compileString('@lang(foo(bar(baz(qux(breeze()))))) space () @lang(foo(bar))'));
     }
 
     public function testExpressionWithinHTML()
     {
         $this->assertEquals('<html <?php echo e($foo); ?>>', $this->compiler->compileString('<html {{ $foo }}>'));
         $this->assertEquals('<html<?php echo e($foo); ?>>', $this->compiler->compileString('<html{{ $foo }}>'));
-        $this->assertEquals('<html <?php echo e($foo); ?> <?php echo app(\'translator\')->getFromJson(\'foo\'); ?>>', $this->compiler->compileString('<html {{ $foo }} @lang(\'foo\')>'));
+        $this->assertEquals('<html <?php echo e($foo); ?> <?php echo app(\'translator\')->trans(\'foo\'); ?>>', $this->compiler->compileString('<html {{ $foo }} @lang(\'foo\')>'));
     }
 }

--- a/tests/View/Blade/BladeLangTest.php
+++ b/tests/View/Blade/BladeLangTest.php
@@ -7,13 +7,13 @@ class BladeLangTest extends AbstractBladeTestCase
     public function testStatementThatContainsNonConsecutiveParenthesisAreCompiled()
     {
         $string = "Foo @lang(function_call('foo(blah)')) bar";
-        $expected = "Foo <?php echo app('translator')->getFromJson(function_call('foo(blah)')); ?> bar";
+        $expected = "Foo <?php echo app('translator')->trans(function_call('foo(blah)')); ?> bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testLanguageAndChoicesAreCompiled()
     {
-        $this->assertEquals('<?php echo app(\'translator\')->getFromJson(\'foo\'); ?>', $this->compiler->compileString("@lang('foo')"));
+        $this->assertEquals('<?php echo app(\'translator\')->trans(\'foo\'); ?>', $this->compiler->compileString("@lang('foo')"));
         $this->assertEquals('<?php echo app(\'translator\')->choice(\'foo\', 1); ?>', $this->compiler->compileString("@choice('foo', 1)"));
     }
 }


### PR DESCRIPTION
This PR addresses the issue raised in #23162, where the `@lang` Blade directive is unnecessarily (?) coupled with the `getFromJson` method, which isn't part of the `Illuminate\Contracts\Translation\Translator` interface.

By calling `getFromJson` instead of `get` in the `trans` method, we ensure that the fallback mechanism still works.

Feel free to discard it if there's a risk of breaking packages that depend on the old behaviour or if you can think of a way to solve this differently. ;)