### PR TITLE
[5.6] Integration test to avoid repetitive pagination PR with columns

### DIFF
--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentPaginateTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentPaginateTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function ($table) {
+            $table->increments('id');
+            $table->string('title')->nullable();
+            $table->timestamps();
+        });
+    }
+    
+    public function test_pagination_on_top_of_columns()
+    {
+        for ($i = 1; $i <= 50; $i++) {
+            Post::create([
+                'title' => 'Title ' . $i,
+            ]);
+        }
+
+        $this->assertCount(15, Post::paginate(15, ['id', 'title']));
+    }
+}
+
+class Post extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentPaginateTest;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 /**
@@ -21,7 +21,7 @@ class EloquentPaginateTest extends DatabaseTestCase
             $table->timestamps();
         });
     }
-    
+
     public function test_pagination_on_top_of_columns()
     {
         for ($i = 1; $i <= 50; $i++) {


### PR DESCRIPTION
As Taylor recently said, in the last week 3 people already tried PRing a change to the Builder that passes the `$columns` into the `getCountForPagination()`. Unfortunately, that doesn't work when you use more than one column and it breaks the SQL being generated.

This is an attempt to avoid people from trying that again in the future. They'll be able to see for themselves that their change breaks on TravisCI. If somebody can apply a change that doesn't break this test, maybe that would be a PR worth looking into.

References: 
https://github.com/laravel/framework/pull/23255, https://github.com/laravel/framework/pull/23214, https://github.com/laravel/framework/pull/23209

Edit: StyleCI is failing but I don't know what is the issue as it's failing to analyze. ping @GrahamCampbell 