### PR TITLE
[5.7] Added token verification on subsequent requests to check for same or new user

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -56,7 +56,7 @@ class TokenGuard implements Guard
         // If we've already retrieved the user for the current request we can just
         // return it back immediately. We do not want to fetch the user data on
         // every call to this method because that would be tremendously slow.
-        if (! is_null($this->user)) {
+        if (! is_null($this->user) && $this->user->{$this->inputKey} == $this->getTokenForRequest()) {
             return $this->user;
         }
 


### PR DESCRIPTION
This PR tries to fix an issue with authentication when using the TokenGuard as the authorization method. 

When doing multiple requests to the server, the TokenGuard authorizes a user once and for subsequent requests, it hold a reference to the previous authenticated user. This behavior is valid until a new token is provided where the TokenGuard should run the authorization again for the new user. 

Therefore, the TokenGuard should check the authorization token on every request with the current authenticated user token before returning the user. 

This behavior was found when doing tests on the same endpoint but with different Bearer tokens. The TokenGuard always kept the first user as the authenticated user disregarding the new Bearer tokens that were sent.

Attaching images from tests output showing error reported

![image](https://user-images.githubusercontent.com/5126648/36556327-c35b4a4a-17d2-11e8-8308-055cd5045bf5.png)

![image](https://user-images.githubusercontent.com/5126648/36556294-af8304d6-17d2-11e8-896a-41c124e8991a.png)
