### PR TITLE
[5.6] Add first and last pagination links

### DIFF
--- a/src/Illuminate/Pagination/resources/views/bootstrap-4.blade.php
+++ b/src/Illuminate/Pagination/resources/views/bootstrap-4.blade.php
@@ -1,5 +1,12 @@
 @if ($paginator->hasPages())
     <ul class="pagination">
+        {{-- First Page Link --}}
+        @if ($paginator->onFirstPage())
+            <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+        @else
+            <li class="page-item"><a class="page-link" href="{{ $paginator->url(1) }}" rel="first">&laquo;</a></li>
+        @endif
+
         {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
             <li class="page-item disabled"><span class="page-link">&lsaquo;</span></li>
@@ -31,6 +38,13 @@
             <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">&rsaquo;</a></li>
         @else
             <li class="page-item disabled"><span class="page-link">&rsaquo;</span></li>
+        @endif
+
+        {{-- Last Page Link --}}
+        @if ($paginator->hasMorePages())
+            <li class="page-item"><a class="page-link" href="{{ $paginator->url($paginator->lastPage()) }}" rel="last">&raquo;</a></li>
+        @else
+            <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
         @endif
     </ul>
 @endif

--- a/src/Illuminate/Pagination/resources/views/default.blade.php
+++ b/src/Illuminate/Pagination/resources/views/default.blade.php
@@ -1,5 +1,12 @@
 @if ($paginator->hasPages())
     <ul class="pagination">
+        {{-- First Page Link --}}
+        @if ($paginator->onFirstPage())
+            <li class="disabled"><span>&laquo;</span></li>
+        @else
+            <li><a href="{{ $paginator->url(1) }}" rel="first">&laquo;</a></li>
+        @endif
+
         {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
             <li class="disabled"><span>&lsaquo;</span></li>
@@ -31,6 +38,13 @@
             <li><a href="{{ $paginator->nextPageUrl() }}" rel="next">&rsaquo;</a></li>
         @else
             <li class="disabled"><span>&rsaquo;</span></li>
+        @endif
+
+        {{-- Last Page Link --}}
+        @if ($paginator->hasMorePages())
+            <li><a href="{{ $paginator->url($paginator->lastPage()) }}" rel="last">&raquo;</a></li>
+        @else
+            <li class="disabled"><span>&raquo;</span></li>
         @endif
     </ul>
 @endif

--- a/src/Illuminate/Pagination/resources/views/semantic-ui.blade.php
+++ b/src/Illuminate/Pagination/resources/views/semantic-ui.blade.php
@@ -1,10 +1,17 @@
 @if ($paginator->hasPages())
     <div class="ui pagination menu">
+        {{-- First Page Link --}}
+        @if ($paginator->onFirstPage())
+            <a class="icon item disabled"> <i class="left double angle icon"></i> </a>
+        @else
+            <a class="icon item" href="{{ $paginator->url(1) }}" rel="first"> <i class="left double angle icon"></i> </a>
+        @endif
+
         {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
-            <a class="icon item disabled"> <i class="left chevron icon"></i> </a>
+            <a class="icon item disabled"> <i class="left angle icon"></i> </a>
         @else
-            <a class="icon item" href="{{ $paginator->previousPageUrl() }}" rel="prev"> <i class="left chevron icon"></i> </a>
+            <a class="icon item" href="{{ $paginator->previousPageUrl() }}" rel="prev"> <i class="left angle icon"></i> </a>
         @endif
 
         {{-- Pagination Elements --}}
@@ -28,9 +35,16 @@
 
         {{-- Next Page Link --}}
         @if ($paginator->hasMorePages())
-            <a class="icon item" href="{{ $paginator->nextPageUrl() }}" rel="next"> <i class="right chevron icon"></i> </a>
+            <a class="icon item" href="{{ $paginator->nextPageUrl() }}" rel="next"> <i class="right angle icon"></i> </a>
         @else
-            <a class="icon item disabled"> <i class="right chevron icon"></i> </a>
+            <a class="icon item disabled"> <i class="right angle icon"></i> </a>
+        @endif
+
+        {{-- Last Page Link --}}
+        @if ($paginator->hasMorePages())
+            <a class="icon item" href="{{ $paginator->url($paginator->lastPage()) }}" rel="last"> <i class="right double angle icon"></i> </a>
+        @else
+            <a class="icon item disabled"> <i class="right double angle icon"></i> </a>
         @endif
     </div>
 @endif


### PR DESCRIPTION
The pagination would benefit from a first and last button:
![outcome](https://user-images.githubusercontent.com/12208691/36140357-50f17002-10a1-11e8-8628-3239e511deb2.png)

Which it definitely does not currently have:
![code change](https://user-images.githubusercontent.com/12208691/36561782-153cfed4-1815-11e8-8923-e96d078ff41d.png)

Changes:
* Add a first pagination link before prev
* Add a last pagination link after next
* Switch to semantic angle icons to use double chevron