### PR TITLE
Introduce the Collection::filterIf() method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -453,6 +453,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Run a filter over each of the items if the given conditional is truthy.
+     *
+     * @param  mixed  $condition
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public function filterIf($condition, callable $callback = null)
+    {
+        return $condition ? $this->filter($callback) : $this;
+    }
+
+    /**
      * Apply the callback if the value is truthy.
      *
      * @param  bool  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -331,6 +331,17 @@ class SupportCollectionTest extends TestCase
         })->all());
     }
 
+    public function testFilterIf()
+    {
+        $c = new Collection(['foo', 'bar', 'baz']);
+        $f = function ($val) {
+            return 0 === strpos($val, 'ba');
+        };
+
+        $this->assertEquals(['foo', 'bar', 'baz'], $c->filterIf(false, $f)->values()->toArray(), 'The filter should not be applied if $condition is false.');
+        $this->assertEquals(['bar', 'baz'], $c->filterIf(true, $f)->values()->toArray(), 'The filter should be applied if $condition is true.');
+    }
+
     public function testHigherOrderKeyBy()
     {
         $c = new Collection([


### PR DESCRIPTION
This PR introduces the `Collection::filterIf()` method, which enables a filter to be conditionally applied to a collection.

For example, consider we have a Collection `$collection` and the following logic:

```php
if ($applyFilters) {
  $collection = $collection->filter(function () { /* ... */ });
}

return $collection;
```

Instead, that can be reduced to a single method call:

```php
return $collection->filterIf($applyFilters, function () { /* ... */ });
```