### PR TITLE
[5.6] Revert return type of sendFailedLoginResponse

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -123,7 +123,7 @@ trait AuthenticatesUsers
      * Get the failed login response instance.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return void
+     * @return \Symfony\Component\HttpFoundation\Response
      *
      * @throws \Illuminate\Validation\ValidationException
      */


### PR DESCRIPTION
This reverts the change of return type of sendFailedLoginResponse that was introduced in https://github.com/laravel/framework/pull/23274. Changing the return type of void is a breaking change for everyone that has overridden sendFailedLoginResponse to return a custom response.