### PR TITLE
[5.6] Add sortKeys and sortKeysDesc methods to Collection.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1476,6 +1476,33 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Sort the collection keys.
+     *
+     * @param int $options
+     * @param bool $descending
+     * @return static
+     */
+    public function sortKeys($options = SORT_REGULAR, $descending = false)
+    {
+        $items = $this->items;
+
+        $descending ? krsort($items, $options) : ksort($items, $options);
+
+        return new static($items);
+    }
+
+    /**
+     * Sort the collection keys in descending order.
+     *
+     * @param int $options
+     * @return static
+     */
+    public function sortKeysDesc($options = SORT_REGULAR)
+    {
+        return $this->sortKeys($options, true);
+    }
+
+    /**
      * Splice a portion of the underlying collection array.
      *
      * @param  int  $offset

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -943,6 +943,20 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => 'dayle', 0 => 'taylor'], $data->all());
     }
 
+    public function testSortKeys()
+    {
+        $data = new Collection(['b' => 'dayle', 'a' => 'taylor']);
+
+        $this->assertEquals(['a' => 'taylor', 'b' => 'dayle'], $data->sortKeys()->all());
+    }
+
+    public function testSortKeysDesc()
+    {
+        $data = new Collection(['a' => 'taylor', 'b' => 'dayle']);
+
+        $this->assertEquals(['b' => 'dayle', 'a' => 'taylor'], $data->sortKeys()->all());
+    }
+
     public function testReverse()
     {
         $data = new Collection(['zaeed', 'alan']);


### PR DESCRIPTION
This PR adds two convenience methods to `Collection` to allow sorting keys of the collection, or sorting the collection by the key if you wish.

 - `sortKeys`
 - `sortKeysDesc`

One of the use cases that I find myself a lot lately is grabbing an object via an API and rendering it's properties in a sorted fashion. 

This PR allows to do something along the lines of

```php
$this->renderLead(collect($this->getLeadViaAPI($id))->sortKeys());
```

instead of

```php
$leadData = get_object_vars($this->getLeadViaAPI($id));
ksort($leadData);

$this->renderLead(collect($leadData));
```

or doing some unnatural combination of `map` and `sort`.