### PR TITLE
[5.6] Fix an issue where delayed jobs in L5.5 fail to run in L5.6

### DIFF
--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -82,7 +82,7 @@ trait SerializesAndRestoresModelIdentifiers
     {
         return $this->getQueryForModelRestoration(
             (new $value->class)->setConnection($value->connection), $value->id
-        )->useWritePdo()->firstOrFail()->load($value->relations);
+        )->useWritePdo()->firstOrFail()->load($value->relations ?? []);
     }
 
     /**


### PR DESCRIPTION
Due to the new relations method introduced in commit 230eeef when jobs got queued in L5.5, the `relations` didn't exist in the serialized payload of the queued job so when the queue tries to run those old L5.5 queued jobs in L5.6, it throws an exception of `parseWithRelations() must be of type array, boolean given`. This problem only affects jobs that were queued in L5.5 for a later date and are now trying to be dispatched in L5.6.

In a production environment where jobs have been sitting in the queue waiting to be dispatched by the queue worker, it fails to run the jobs. 

With this commit those jobs that have a false for the `relations` property, it will default to an empty array.