### PR TITLE
[5.6] Fix double firing of resolving callback

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1036,7 +1036,10 @@ class Container implements ArrayAccess, ContainerContract
         $results = [];
 
         foreach ($callbacksPerType as $type => $callbacks) {
-            if ($type === $abstract || $object instanceof $type) {
+            if ($type === $abstract ||
+                $object instanceof $type &&
+                class_exists($abstract) &&
+                ! interface_exists($type)) {
                 $results = array_merge($results, $callbacks);
             }
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1038,7 +1038,7 @@ class Container implements ArrayAccess, ContainerContract
         foreach ($callbacksPerType as $type => $callbacks) {
             if ($type === $abstract ||
                 $object instanceof $type &&
-                class_exists($abstract) &&
+                (class_exists($abstract)/* || ! interface_exists($abstract)*/) &&
                 ! interface_exists($type)) {
                 $results = array_merge($results, $callbacks);
             }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1038,7 +1038,7 @@ class Container implements ArrayAccess, ContainerContract
         foreach ($callbacksPerType as $type => $callbacks) {
             if ($type === $abstract ||
                 $object instanceof $type &&
-                (class_exists($abstract)/* || ! interface_exists($abstract)*/) &&
+                (class_exists($abstract) || ! interface_exists($abstract)) &&
                 ! interface_exists($type)) {
                 $results = array_merge($results, $callbacks);
             }


### PR DESCRIPTION
When we bind something with IoC container like this:
```php
app()->bind(Some::class, SomeAwesome::class);
```
And register resolving callback
```php
app()->resolving(Some::class, function ($some) {
    dump('Resolving Some');
});
```
After resolve this class by `resolve(Some::class)` resolving callback will fire twice. Because 1st step will be - resolve `Some::class` and 2nd step will be resolve `SomeAwesome::class` as condition in `getCallbacksForType` method is:
```php
if ($type === $abstract || $object instanceof $type) {
    $results = array_merge($results, $callbacks);
}
```
`$object instanceof $type` matches `Some` interface and also `SomeAwesome` class, because `SomeAwesome` is instanceof `Some`.
I think we should exclude cases when resolving callback registered to interface fires for class.
```php
 if ($type === $abstract ||
    $object instanceof $type &&
    (class_exists($abstract) || ! interface_exists($abstract)) &&
    ! interface_exists($type)) {
    $results = array_merge($results, $callbacks);
}
```