### PR TITLE
[5.6] Queue::bulk() fake now properly pushes expected jobs

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -240,7 +240,7 @@ class QueueFake extends QueueManager implements Queue
     public function bulk($jobs, $data = '', $queue = null)
     {
         foreach ($jobs as $job) {
-            $this->push($job);
+            $this->push($job, $data, $queue);
         }
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -239,7 +239,7 @@ class QueueFake extends QueueManager implements Queue
      */
     public function bulk($jobs, $data = '', $queue = null)
     {
-        foreach ($this->jobs as $job) {
+        foreach ($jobs as $job) {
             $this->push($job);
         }
     }

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -95,7 +95,7 @@ class QueueFakeTest extends TestCase
         $queue = 'my-test-queue';
         $this->fake->bulk([
             $this->job,
-            new JobStub()
+            new JobStub(),
         ], null, $queue);
 
         $this->fake->assertPushedOn($queue, JobStub::class);

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -87,6 +87,20 @@ class QueueFakeTest extends TestCase
             $this->assertThat($e, new ExceptionMessage('Jobs were pushed unexpectedly.'));
         }
     }
+
+    public function testAssertPushedUsingBulk()
+    {
+        $this->fake->assertNothingPushed();
+
+        $queue = 'my-test-queue';
+        $this->fake->bulk([
+            $this->job,
+            new JobStub()
+        ], null, $queue);
+
+        $this->fake->assertPushedOn($queue, JobStub::class);
+        $this->fake->assertPushed(JobStub::class, 2);
+    }
 }
 
 class JobStub


### PR DESCRIPTION
Currently Laravel is unable to perform assertions on work pushed to the queue in a bulk fashion because the fake queue does not actually push the given jobs.  This PR enables work (when using the Fake) to actually be pushed to the queue, allowing tests to perform assertions.