### PR TITLE
Update BelongsToMany.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -295,7 +295,7 @@ class BelongsToMany extends Relation
         $this->using = $class;
 
         // pivot table name
-        $this->table = (new $class)->getTable();
+        $this->table or $this->table = (new $class)->getTable();
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -294,6 +294,9 @@ class BelongsToMany extends Relation
     {
         $this->using = $class;
 
+        // pivot table name
+        $this->table = (new $class)->getTable();
+    
         return $this;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -296,7 +296,7 @@ class BelongsToMany extends Relation
 
         // pivot table name
         $this->table = (new $class)->getTable();
-    
+
         return $this;
     }
 


### PR DESCRIPTION
A belongsToMany relation often has customized db table names. When customized pivote model is used, the name of pivot table is defined by the pivot model(customized, too). So:

$this->belongsToMany(Model, '')->using(PivotModel);

looks much better than

$this->belongsToMany(Model, 'table name')->using(PivotModel);

Thank you.