### PR TITLE
[5.6] Event wildcard listeners cache to save on string operations

### DIFF
--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -104,6 +104,23 @@ class EventsDispatcherTest extends TestCase
         $this->assertEquals('wildcard', $_SERVER['__event.test']);
     }
 
+    public function testWildcardListenersCacheFlushing()
+    {
+        unset($_SERVER['__event.test']);
+        $d = new Dispatcher;
+        $d->listen('foo.*', function () {
+            $_SERVER['__event.test'] = 'cached_wildcard';
+        });
+        $d->fire('foo.bar');
+        $this->assertEquals('cached_wildcard', $_SERVER['__event.test']);
+
+        $d->listen('foo.*', function () {
+            $_SERVER['__event.test'] = 'new_wildcard';
+        });
+        $d->fire('foo.bar');
+        $this->assertEquals('new_wildcard', $_SERVER['__event.test']);
+    }
+
     public function testListenersCanBeRemoved()
     {
         unset($_SERVER['__event.test']);


### PR DESCRIPTION
Hi!

`Str::is` is relatively expensive operation, which significantly slows down request, when goes in the number of dozens of thousand calls. Unfortunately `Dispatcher::getWildcardListeners` method calls it arbitrary number of times (depends on how many wildcard listeners of any kind you registered in your app) for every single event being fired.

It may not be significant for ordinary webpage, but it is worth the effort in the high volume & data heavy API, where simple `Database\Connection::logQuery` (without any listener registered, ie. without any action taken) may cause `Str::is` to be called thousands of times, thus slowing down API request by 5-10% in my example.

This PR introduces instance based cache, which does the following:
1. remembers all wildcard listeners for a fired event after first `getWildcardListeners` call
2. from now on uses the cache instead of calling aforementioned string operations again
3. flushes the cache whenever a new wildcard listener is being registered


Below excerpt from blackfire showing the difference in example call.


after 84ms: 
![image](https://user-images.githubusercontent.com/6928818/36674773-00c7a0dc-1b42-11e8-8b46-83b952219cd7.png)

before 364ms:
![image](https://user-images.githubusercontent.com/6928818/36674792-10ab29ce-1b42-11e8-97df-ef7f401022a1.png)
