### PR TITLE
[5.6] Update the list of removed packages when installing the "none" preset

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/None.php
+++ b/src/Illuminate/Foundation/Console/Presets/None.php
@@ -34,8 +34,9 @@ class None extends Preset
     protected static function updatePackageArray(array $packages)
     {
         unset(
-            $packages['bootstrap-sass'],
+            $packages['bootstrap'],
             $packages['jquery'],
+            $packages['popper.js'],
             $packages['vue'],
             $packages['babel-preset-react'],
             $packages['react'],


### PR DESCRIPTION
At the moment when running `php artisan preset none` the `bootstrap` and `popper.js` dependencies are not removed from `package.json`.

The current "none" preset removes `bootstrap-sass` which is not a dependency anymore.

`popper.js` seems to be a Bootstrap dependency and is added when running `php artisan preset bootstrap` so keeping it is not required.