### PR TITLE
[5.6] Keep host order in database failover

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -176,7 +176,14 @@ class ConnectionFactory
     protected function createPdoResolverWithHosts(array $config)
     {
         return function () use ($config) {
-            foreach (Arr::shuffle($hosts = $this->parseHosts($config)) as $key => $host) {
+            $hosts = $this->parseHosts($config);
+
+            // Shuffle hosts by default or if expicitly configured to shuffle
+            if (!array_key_exists('shuffle_hosts', $config) || $config['shuffle_hosts']) {
+                $hosts = Arr::shuffle($hosts);
+            }
+
+            foreach ($hosts as $key => $host) {
                 $config['host'] = $host;
 
                 try {

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -179,7 +179,7 @@ class ConnectionFactory
             $hosts = $this->parseHosts($config);
 
             // Shuffle hosts by default or if expicitly configured to shuffle
-            if (!array_key_exists('shuffle_hosts', $config) || $config['shuffle_hosts']) {
+            if (! array_key_exists('shuffle_hosts', $config) || $config['shuffle_hosts']) {
                 $hosts = Arr::shuffle($hosts);
             }
 


### PR DESCRIPTION
Added support for attempting connecting to database hosts in specified order instead of random order.

By adding 'shuffle_hosts' => false in your database driver config, the framework will not attempt to connect to the database hosts in the order specified in your driver config instead of always shuffling.