### PR TITLE
Add $only to  `Modal::toArray()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -965,11 +965,18 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Convert the model instance to an array.
      *
+     * @param array|null $only
      * @return array
      */
-    public function toArray()
+    public function toArray($only = null)
     {
-        return array_merge($this->attributesToArray(), $this->relationsToArray());
+        $attributes = array_merge($this->attributesToArray(), $this->relationsToArray());
+
+        if (is_array($only)) {
+            return array_only($attributes, $only);
+        }
+
+        return $attributes;
     }
 
     /**


### PR DESCRIPTION
As a shortcut to get only selected attributes when getting a model as an array.

So instead of `array_only($model->toArray(), [...])` we can just do `$model->toArray([...])`