### PR TITLE
[5.6] Fix Cache::put without $minutes nothing remembered

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -195,6 +195,8 @@ class Repository implements CacheContract, ArrayAccess
             $this->store->put($this->itemKey($key), $value, $minutes);
 
             $this->event(new KeyWritten($key, $value, $minutes));
+        } else {
+            $this->forever($key, $value);
         }
     }
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -190,13 +190,12 @@ class Repository implements CacheContract, ArrayAccess
         if (is_array($key)) {
             return $this->putMany($key, $value);
         }
-
-        if (! is_null($minutes = $this->getMinutes($minutes))) {
+        if (is_null($minutes)) {
+            $this->forever($key, $value);
+        } elseif (!is_null($minutes = $this->getMinutes($minutes))) {
             $this->store->put($this->itemKey($key), $value, $minutes);
 
             $this->event(new KeyWritten($key, $value, $minutes));
-        } else {
-            $this->forever($key, $value);
         }
     }
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -192,7 +192,7 @@ class Repository implements CacheContract, ArrayAccess
         }
         if (is_null($minutes)) {
             $this->forever($key, $value);
-        } elseif (!is_null($minutes = $this->getMinutes($minutes))) {
+        } elseif (! is_null($minutes = $this->getMinutes($minutes))) {
             $this->store->put($this->itemKey($key), $value, $minutes);
 
             $this->event(new KeyWritten($key, $value, $minutes));

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -90,7 +90,7 @@ class CacheTaggedCacheTest extends TestCase
         $conn->shouldReceive('sadd')->once()->with('prefix:bar:standard_ref', 'prefix:'.sha1('foo|bar').':key1');
         $store->shouldReceive('push')->with(sha1('foo|bar').':key1', 'key1:value');
 
-        $redis->put('key1', 'key1:value');
+        $redis->put('key1', 'key1:value', 0);
     }
 
     public function testRedisCacheTagsCanBeFlushed()


### PR DESCRIPTION
If you are calling \Cache::put method without $minutes that is not required, nothing will be saved to cache.
https://github.com/laravel/framework/blob/5.6/src/Illuminate/Cache/Repository.php#L194 
Steps to reproduce
```
\Cache::put('test', 12);
\Cache::get('test'); // returns Null
```