### PR TITLE
[5.6] Fix whereTime method for SQLiteGrammar with correct formatting.

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -117,6 +117,18 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile a "where time" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereTime(Builder $query, $where)
+    {
+        return $this->dateBasedWhere('%H:%M:%S', $query, $where);
+    }
+
+    /**
      * Compile a date based where clause.
      *
      * @param  string  $type

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -404,6 +404,22 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2014], $builder->getBindings());
     }
 
+    public function testWhereTimeSqlite()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereTime('created_at', '>=', '22:00');
+        $this->assertEquals('select * from "users" where strftime(\'%H:%M:%S\', "created_at") >= ?', $builder->toSql());
+        $this->assertEquals([0 => '22:00'], $builder->getBindings());
+    }
+
+    public function testWhereTimeOperatorOptionalSqlite()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereTime('created_at', '22:00');
+        $this->assertEquals('select * from "users" where strftime(\'%H:%M:%S\', "created_at") = ?', $builder->toSql());
+        $this->assertEquals([0 => '22:00'], $builder->getBindings());
+    }
+
     public function testWhereDaySqlServer()
     {
         $builder = $this->getSqlServerBuilder();


### PR DESCRIPTION
```strftime('time', created_at)``` is not working for sqlite and we need to apply correct formatting ```%H:%M:%S```.

Currently, ```->whereTime()``` method does nothing and no filtering is performed.
SQLite's strftime function accepts formatting string. Passing 'time' to it returns 'time' string instead of expected ```%H:%M:%S``` formatted time string.
In example, comparing 'time' string and provided time like '12:00' does nothing.

It's a bug. ```->whereTime()``` function doesn't works as expected when using sqlite. So, it should be merged to 5.5 LTS too, I think.

You can read more about sqlite date functions here: https://www.sqlite.org/lang_datefunc.html