### PR TITLE
[5.7] Add the validator as parameter to custom Rule classes

### DIFF
--- a/src/Illuminate/Contracts/Validation/Rule.php
+++ b/src/Illuminate/Contracts/Validation/Rule.php
@@ -7,11 +7,12 @@ interface Rule
     /**
      * Determine if the validation rule passes.
      *
-     * @param  string  $attribute
-     * @param  mixed  $value
+     * @param  string                                     $attribute
+     * @param  mixed                                      $value
+     * @param  \Illuminate\Contracts\Validation\Validator $validator
      * @return bool
      */
-    public function passes($attribute, $value);
+    public function passes($attribute, $value, $validator);
 
     /**
      * Get the validation error message.

--- a/src/Illuminate/Validation/ClosureValidationRule.php
+++ b/src/Illuminate/Validation/ClosureValidationRule.php
@@ -41,15 +41,16 @@ class ClosureValidationRule implements RuleContract
     /**
      * Determine if the validation rule passes.
      *
-     * @param  string  $attribute
-     * @param  mixed  $value
+     * @param  string                                     $attribute
+     * @param  mixed                                      $value
+     * @param  \Illuminate\Contracts\Validation\Validator $validator
      * @return bool
      */
-    public function passes($attribute, $value)
+    public function passes($attribute, $value, $validator)
     {
         $this->failed = false;
 
-        $this->callback->__invoke($attribute, $value, function ($message) {
+        $this->callback->__invoke($attribute, $value, $validator, function ($message) {
             $this->failed = true;
 
             $this->message = $message;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -530,7 +530,7 @@ class Validator implements ValidatorContract
      */
     protected function validateUsingCustomRule($attribute, $value, $rule)
     {
-        if (! $rule->passes($attribute, $value)) {
+        if (! $rule->passes($attribute, $value, $this)) {
             $this->failedRules[$attribute][get_class($rule)] = [];
 
             $this->messages->add($attribute, $this->makeReplacements(

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3798,7 +3798,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator(
             $this->getIlluminateArrayTranslator(),
             ['name' => 'adam'],
-            ['name' => function ($attribute, $value, $fail) {
+            ['name' => function ($attribute, $value, $validator, $fail) {
                 if ($value !== 'taylor') {
                     $fail(':attribute was '.$value.' instead of taylor');
                 }
@@ -3824,7 +3824,7 @@ class ValidationValidatorTest extends TestCase
                         return ':attribute must be AR or TX';
                     }
                 },
-                'name' => function ($attribute, $value, $fail) {
+                'name' => function ($attribute, $value, $validator, $fail) {
                     if ($value !== 'taylor') {
                         $fail(':attribute must be taylor');
                     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3785,7 +3785,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator(
             $this->getIlluminateArrayTranslator(),
             ['name' => 'taylor'],
-            ['name.*' => function ($attribute, $value, $fail) {
+            ['name.*' => function ($attribute, $value, $validator, $fail) {
                 if ($value !== 'taylor') {
                     $fail(':attribute was '.$value.' instead of taylor');
                 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3747,7 +3747,7 @@ class ValidationValidatorTest extends TestCase
             $this->getIlluminateArrayTranslator(),
             ['name' => 'taylor'],
             ['name' => new class implements Rule {
-                public function passes($attribute, $value)
+                public function passes($attribute, $value, $v)
                 {
                     return $value === 'taylor';
                 }
@@ -3766,7 +3766,7 @@ class ValidationValidatorTest extends TestCase
             $this->getIlluminateArrayTranslator(),
             ['name' => 'adam'],
             ['name' => [new class implements Rule {
-                public function passes($attribute, $value)
+                public function passes($attribute, $value, $v)
                 {
                     return $value === 'taylor';
                 }
@@ -3814,7 +3814,7 @@ class ValidationValidatorTest extends TestCase
             ['name' => 'taylor', 'states' => ['AR', 'TX'], 'number' => 9],
             [
                 'states.*' => new class implements Rule {
-                    public function passes($attribute, $value)
+                    public function passes($attribute, $value, $v)
                     {
                         return in_array($value, ['AK', 'HI']);
                     }
@@ -3856,7 +3856,7 @@ class ValidationValidatorTest extends TestCase
             ['name' => $rule = new class implements ImplicitRule {
                 public $called = false;
 
-                public function passes($attribute, $value)
+                public function passes($attribute, $value, $v)
                 {
                     $this->called = true;
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3747,7 +3747,7 @@ class ValidationValidatorTest extends TestCase
             $this->getIlluminateArrayTranslator(),
             ['name' => 'taylor'],
             ['name' => new class implements Rule {
-                public function passes($attribute, $value, $v)
+                public function passes($attribute, $value, $validator)
                 {
                     return $value === 'taylor';
                 }
@@ -3766,7 +3766,7 @@ class ValidationValidatorTest extends TestCase
             $this->getIlluminateArrayTranslator(),
             ['name' => 'adam'],
             ['name' => [new class implements Rule {
-                public function passes($attribute, $value, $v)
+                public function passes($attribute, $value, $validator)
                 {
                     return $value === 'taylor';
                 }
@@ -3814,7 +3814,7 @@ class ValidationValidatorTest extends TestCase
             ['name' => 'taylor', 'states' => ['AR', 'TX'], 'number' => 9],
             [
                 'states.*' => new class implements Rule {
-                    public function passes($attribute, $value, $v)
+                    public function passes($attribute, $value, $validator)
                     {
                         return in_array($value, ['AK', 'HI']);
                     }
@@ -3832,7 +3832,7 @@ class ValidationValidatorTest extends TestCase
                 'number' => [
                     'required',
                     'integer',
-                    function ($attribute, $value, $fail) {
+                    function ($attribute, $value, $validator, $fail) {
                         if ($value % 4 !== 0) {
                             $fail(':attribute must be divisible by 4');
                         }
@@ -3856,7 +3856,7 @@ class ValidationValidatorTest extends TestCase
             ['name' => $rule = new class implements ImplicitRule {
                 public $called = false;
 
-                public function passes($attribute, $value, $v)
+                public function passes($attribute, $value, $validator)
                 {
                     $this->called = true;
 


### PR DESCRIPTION
Currently it is only possible to get data from other fields by using `Validator::extend()` as it gets the $validator passed. For some reason this hasn't been done for rule classes.

This adds the $validator to the Rule interface and passes it to any class implementing it.

Please also let me know if I can backport this to 5.5.