### PR TITLE
[5.7] Add Schedulable Feature

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedulable.php
+++ b/src/Illuminate/Console/Scheduling/Schedulable.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Cron\CronExpression;
+use Illuminate\Support\Carbon;
+use Illuminate\Console\Scheduling\ManagesFrequencies;
+
+trait Schedulable
+{
+
+    use ManagesFrequencies;
+
+    /**
+     * The cron expression representing the event's frequency.
+     *
+     * @var string
+     */
+    public $expression = '* * * * *';
+
+    /**
+     * The timezone the date should be evaluated on.
+     *
+     * @var \DateTimeZone|string
+     */
+    public $timezone;
+
+    /**
+     * Return a list of due items as a collection
+     *
+     * @return Illuminate\Support\Collection
+     */
+    public static function areDue()
+    {
+        return collect([])->filter->isDue();
+    }
+
+    /**
+     * Determine if the schedule is due to run
+     *
+     * @return boolean
+     */
+    public function isDue()
+    {
+        $date = Carbon::now();
+
+        if ($this->timezone) {
+            $date->setTimezone($this->timezone);
+        }
+
+        return CronExpression::factory($this->expression)->isDue($date->toDateTimeString());
+    }
+
+    /**
+     * When the schedule is next due to run
+     *
+     * @return Illuminate\Support\Carbon
+     */
+    public function nextDue()
+    {
+        return Carbon::instance(CronExpression::factory($this->expression)->getNextRunDate());
+    }
+
+    /**
+     * When the schedule was last due to run
+     *
+     * @return Illuminate\Support\Carbon
+     */
+    public function lastDue()
+    {
+        return Carbon::instance(CronExpression::factory($this->expression)->getPreviousRunDate());
+    }
+
+    /**
+     * Code to be run when the schedule is due
+     *
+     * @return void
+     */
+    public function runSchedule()
+    {
+        return true;
+    }
+}

--- a/src/Illuminate/Console/Scheduling/Schedulable.php
+++ b/src/Illuminate/Console/Scheduling/Schedulable.php
@@ -4,11 +4,9 @@ namespace Illuminate\Console\Scheduling;
 
 use Cron\CronExpression;
 use Illuminate\Support\Carbon;
-use Illuminate\Console\Scheduling\ManagesFrequencies;
 
 trait Schedulable
 {
-
     use ManagesFrequencies;
 
     /**
@@ -26,7 +24,8 @@ trait Schedulable
     public $timezone;
 
     /**
-     * Return a list of due items as a collection
+     * Return a list of due items as a collection.
+     * This is meant to be overidden.
      *
      * @return Illuminate\Support\Collection
      */
@@ -36,9 +35,9 @@ trait Schedulable
     }
 
     /**
-     * Determine if the schedule is due to run
+     * Determine if the schedule is due to run.
      *
-     * @return boolean
+     * @return bool
      */
     public function isDue()
     {
@@ -52,7 +51,7 @@ trait Schedulable
     }
 
     /**
-     * When the schedule is next due to run
+     * When the schedule is next due to run.
      *
      * @return Illuminate\Support\Carbon
      */
@@ -62,7 +61,7 @@ trait Schedulable
     }
 
     /**
-     * When the schedule was last due to run
+     * When the schedule was last due to run.
      *
      * @return Illuminate\Support\Carbon
      */
@@ -72,12 +71,11 @@ trait Schedulable
     }
 
     /**
-     * Code to be run when the schedule is due
-     *
-     * @return void
+     * Code to be run when the schedule is due.
+     * This is meant to be overidden.
      */
     public function runSchedule()
     {
-        return true;
+        // return true;
     }
 }

--- a/src/Illuminate/Console/Scheduling/SchedulableClassEvent.php
+++ b/src/Illuminate/Console/Scheduling/SchedulableClassEvent.php
@@ -28,7 +28,7 @@ class SchedulableClassEvent extends Event
     {
         $schedulableClass = is_string($schedulableClass) ? resolve($schedulableClass) : $schedulableClass;
 
-        if (!in_array('Illuminate\Console\Scheduling\Schedulable', class_uses($schedulableClass))) {
+        if (! in_array('Illuminate\Console\Scheduling\Schedulable', class_uses($schedulableClass))) {
             throw new InvalidArgumentException(
                 'Schedulable trait was not found on this class'
             );
@@ -50,7 +50,7 @@ class SchedulableClassEvent extends Event
     public function run(Container $container)
     {
         if ($this->description && $this->withoutOverlapping &&
-            !$this->mutex->create($this)) {
+            ! $this->mutex->create($this)) {
             return;
         }
 
@@ -94,7 +94,7 @@ class SchedulableClassEvent extends Event
      */
     public function withoutOverlapping($expiresAt = 1440)
     {
-        if (!isset($this->description)) {
+        if (! isset($this->description)) {
             throw new LogicException(
                 "A scheduled event name is required to prevent overlapping. Use the 'name' method before 'withoutOverlapping'."
             );
@@ -118,7 +118,7 @@ class SchedulableClassEvent extends Event
      */
     public function onOneServer()
     {
-        if (!isset($this->description)) {
+        if (! isset($this->description)) {
             throw new LogicException(
                 "A scheduled event name is required to only run on one server. Use the 'name' method before 'onOneServer'."
             );

--- a/src/Illuminate/Console/Scheduling/SchedulableClassEvent.php
+++ b/src/Illuminate/Console/Scheduling/SchedulableClassEvent.php
@@ -63,7 +63,7 @@ class SchedulableClassEvent extends Event
         try {
             $due_items = resolve($this->schedulableClass)::areDue();
 
-            $due_items = collect(is_array($due_items) || $due_items instanceof Collection ? $due_items : array($due_items));
+            $due_items = collect(is_array($due_items) || $due_items instanceof Collection ? $due_items : [$due_items]);
 
             $due_items->each->runSchedule();
         } finally {
@@ -71,8 +71,6 @@ class SchedulableClassEvent extends Event
 
             parent::callAfterCallbacks($container);
         }
-
-        return;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/SchedulableClassEvent.php
+++ b/src/Illuminate/Console/Scheduling/SchedulableClassEvent.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use LogicException;
+use InvalidArgumentException;
+use Illuminate\Support\Collection;
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Contracts\Container\Container;
+
+class SchedulableClassEvent extends Event{
+
+
+    //TODO custom code here!
+
+    //use the props of the trait (and manage frequencies etc)
+
+    /**
+     * The schedulable class name to use.
+     *
+     * @var string
+     */
+    protected $schedulableClass;
+    
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
+     * @param  string  $schedulableClass
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(EventMutex $mutex, $schedulableClass)
+    {
+        $schedulableClass = is_string($schedulableClass) ? resolve($schedulableClass) : $schedulableClass;
+
+        if (!in_array('Illuminate\Console\Scheduling\Schedulable',class_uses($schedulableClass))) {
+            throw new InvalidArgumentException(
+                'Schedulable trait was not found on this class'
+            );
+        }
+
+        $this->mutex = $mutex;
+        $this->schedulableClass = $schedulableClass;
+    }
+
+    /**
+     * Run the given event.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    public function run(Container $container)
+    {
+        if ($this->description && $this->withoutOverlapping &&
+            ! $this->mutex->create($this)) {
+            return;
+        }
+
+        register_shutdown_function(function () {
+            $this->removeMutex();
+        });
+
+        parent::callBeforeCallbacks($container);
+
+        try {
+            $resolved = resolve($this->schedulableClass);
+
+            $due_items = $resolved::areDue();
+            
+            $due_items = collect(is_array($due_items) ||$due_items instanceof Collection  ? $due_items : array($due_items));
+
+            $due_items->each->runSchedule();
+        } finally {
+            $this->removeMutex();
+
+            parent::callAfterCallbacks($container);
+        }
+
+        return;
+    }
+
+    /**
+     * Clear the mutex for the event.
+     *
+     * @return void
+     */
+    protected function removeMutex()
+    {
+        if ($this->description) {
+            $this->mutex->forget($this);
+        }
+    }
+
+    /**
+     * Do not allow the event to overlap each other.
+     *
+     * @param  int  $expiresAt
+     * @return $this
+     *
+     * @throws \LogicException
+     */
+    public function withoutOverlapping($expiresAt = 1440)
+    {
+        if (! isset($this->description)) {
+            throw new LogicException(
+                "A scheduled event name is required to prevent overlapping. Use the 'name' method before 'withoutOverlapping'."
+            );
+        }
+
+        $this->withoutOverlapping = true;
+
+        $this->expiresAt = $expiresAt;
+
+        return $this->skip(function () {
+            return $this->mutex->exists($this);
+        });
+    }
+
+    /**
+     * Allow the event to only run on one server for each cron expression.
+     *
+     * @return $this
+     *
+     * @throws \LogicException
+     */
+    public function onOneServer()
+    {
+        if (! isset($this->description)) {
+            throw new LogicException(
+                "A scheduled event name is required to only run on one server. Use the 'name' method before 'onOneServer'."
+            );
+        }
+
+        $this->onOneServer = true;
+
+        return $this;
+    }
+
+    /**
+     * Get the mutex name for the scheduled command.
+     *
+     * @return string
+     */
+    public function mutexName()
+    {
+        return 'framework/schedule-'.sha1($this->description);
+    }
+
+    /**
+     * Get the summary of the event for display.
+     *
+     * @return string
+     */
+    public function getSummaryForDisplay()
+    {
+        if (is_string($this->description)) {
+            return $this->description;
+        }
+
+        return is_string($this->callback) ? $this->callback : 'Closure';
+    }
+
+
+}

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -156,7 +156,7 @@ class Schedule
                 $value = collect($value)->map(function ($value) {
                     return ProcessUtils::escapeArgument($value);
                 })->implode(' ');
-            } elseif (!is_numeric($value) && !preg_match('/^(-.$|--.*)/i', $value)) {
+            } elseif (! is_numeric($value) && !preg_match('/^(-.$|--.*)/i', $value)) {
                 $value = ProcessUtils::escapeArgument($value);
             }
 

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -156,7 +156,7 @@ class Schedule
                 $value = collect($value)->map(function ($value) {
                     return ProcessUtils::escapeArgument($value);
                 })->implode(' ');
-            } elseif (! is_numeric($value) && !preg_match('/^(-.$|--.*)/i', $value)) {
+            } elseif (! is_numeric($value) && ! preg_match('/^(-.$|--.*)/i', $value)) {
                 $value = ProcessUtils::escapeArgument($value);
             }
 

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -33,8 +33,6 @@ class Schedule
 
     /**
      * Create a new schedule instance.
-     *
-     * @return void
      */
     public function __construct()
     {
@@ -52,8 +50,9 @@ class Schedule
     /**
      * Add a new callback event to the schedule.
      *
-     * @param  string|callable  $callback
-     * @param  array   $parameters
+     * @param string|callable $callback
+     * @param array           $parameters
+     *
      * @return \Illuminate\Console\Scheduling\CallbackEvent
      */
     public function call($callback, array $parameters = [])
@@ -70,8 +69,9 @@ class Schedule
     /**
      * Add a new Artisan command event to the schedule.
      *
-     * @param  string  $command
-     * @param  array  $parameters
+     * @param string $command
+     * @param array  $parameters
+     *
      * @return \Illuminate\Console\Scheduling\Event
      */
     public function command($command, array $parameters = [])
@@ -80,14 +80,15 @@ class Schedule
             $command = Container::getInstance()->make($command)->getName();
         }
 
-        return $this->exec(Application::formatCommandString($command),$parameters);
+        return $this->exec(Application::formatCommandString($command), $parameters);
     }
 
     /**
      * Add a new job callback event to the schedule.
      *
-     * @param  object|string  $job
-     * @param  string|null  $queue
+     * @param object|string $job
+     * @param string|null   $queue
+     *
      * @return \Illuminate\Console\Scheduling\CallbackEvent
      */
     public function job($job, $queue = null)
@@ -106,7 +107,8 @@ class Schedule
     /**
      * Add a new SchedulableClass event to the schedule.
      *
-     * @param  object|string  $schedulableClass
+     * @param object|string $schedulableClass
+     *
      * @return \Illuminate\Console\Scheduling\SchedulableClassEvent
      */
     public function use($schedulableClass)
@@ -124,14 +126,15 @@ class Schedule
     /**
      * Add a new command event to the schedule.
      *
-     * @param  string  $command
-     * @param  array  $parameters
+     * @param string $command
+     * @param array  $parameters
+     *
      * @return \Illuminate\Console\Scheduling\Event
      */
     public function exec($command, array $parameters = [])
     {
         if (count($parameters)) {
-            $command .= ' ' . $this->compileParameters($parameters);
+            $command .= ' '.$this->compileParameters($parameters);
         }
 
         $this->events[] = $event = new Event($this->eventMutex, $command);
@@ -142,7 +145,8 @@ class Schedule
     /**
      * Compile parameters for a command.
      *
-     * @param  array  $parameters
+     * @param array $parameters
+     *
      * @return string
      */
     protected function compileParameters(array $parameters)
@@ -163,8 +167,9 @@ class Schedule
     /**
      * Determine if the server is allowed to run this event.
      *
-     * @param  \Illuminate\Console\Scheduling\Event  $event
-     * @param  \DateTimeInterface  $time
+     * @param \Illuminate\Console\Scheduling\Event $event
+     * @param \DateTimeInterface                   $time
+     *
      * @return bool
      */
     public function serverShouldRun(Event $event, DateTimeInterface $time)
@@ -175,7 +180,8 @@ class Schedule
     /**
      * Get all of the events on the schedule that are due.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     *
      * @return \Illuminate\Support\Collection
      */
     public function dueEvents($app)
@@ -196,7 +202,8 @@ class Schedule
     /**
      * Specify the cache store that should be used to store mutexes.
      *
-     * @param  string  $store
+     * @param string $store
+     *
      * @return $this
      */
     public function useCache($store)

--- a/tests/Console/Scheduling/SchedulableClassEventTest.php
+++ b/tests/Console/Scheduling/SchedulableClassEventTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Console\Scheduling;
 
 use Mockery as m;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Console\Scheduling\Event;
@@ -32,45 +33,45 @@ class SchedulableClassEventTest extends TestCase
     }
 
     //test can call a class with the Schedulable Trait
-    public function testCanAddSchedulableClass(){
-
+    public function testCanAddSchedulableClass()
+    {
         $this->schedule->use(FooSchedulableClassStub::class);
 
         $events = $this->schedule->events();
 
-        $this->assertCount(1,$events);
-        
+        $this->assertCount(1, $events);
+
         $this->assertEquals("Illuminate\Console\Scheduling\SchedulableClassEvent", get_class($events[0]));
-    } 
+    }
 
     //test exception thrown SchedulableTraitNotFoundException when no Scheduleable trait found
-    public function testCannotAddNonSchedulableClass(){
-
-        $this->expectException(InvalidArgumentException);
+    public function testCannotAddNonSchedulableClass()
+    {
+        $this->expectException(InvalidArgumentException::class);
 
         $this->schedule->use(BarClassStub::class);
 
         $events = $this->schedule->events();
 
-        $this->assertCount(0,$events);
-    } 
+        $this->assertCount(0, $events);
+    }
 
     //Test event is run every minute / has ***** expression
-    public function testSchedulableClassEventHasEeryMinuteSchedule(){
-
+    public function testSchedulableClassEventHasEeryMinuteSchedule()
+    {
         $this->schedule->use(FooSchedulableClassStub::class);
 
         $event = $this->schedule->events()[0];
-        
-        $this->assertEquals('* * * * *', $event->getExpression());
-    } 
 
+        $this->assertEquals('* * * * *', $event->getExpression());
+    }
 }
 
-class FooSchedulableClassStub{
+class FooSchedulableClassStub
+{
     use Schedulable;
 }
 
-class BarClassStub{
-
+class BarClassStub
+{
 }

--- a/tests/Console/Scheduling/SchedulableClassEventTest.php
+++ b/tests/Console/Scheduling/SchedulableClassEventTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Illuminate\Tests\Console\Scheduling;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Console\Scheduling\Schedulable;
+
+class SchedulableClassEventTest extends TestCase
+{
+    // /*
+    //  * @var \Illuminate\Console\Scheduling\Schedule
+    //  */
+    public $schedule;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $container = Container::getInstance();
+
+        $container->instance('Illuminate\Console\Scheduling\EventMutex', m::mock('Illuminate\Console\Scheduling\CacheEventMutex'));
+
+        $container->instance('Illuminate\Console\Scheduling\SchedulingMutex', m::mock('Illuminate\Console\Scheduling\CacheSchedulingMutex'));
+
+        $container->instance(
+            'Illuminate\Console\Scheduling\Schedule', $this->schedule = new Schedule(m::mock('Illuminate\Console\Scheduling\EventMutex'))
+        );
+    }
+
+    //test can call a class with the Schedulable Trait
+    public function testCanAddSchedulableClass(){
+
+        $this->schedule->use(FooSchedulableClassStub::class);
+
+        $events = $this->schedule->events();
+
+        $this->assertCount(1,$events);
+        
+        $this->assertEquals("Illuminate\Console\Scheduling\SchedulableClassEvent", get_class($events[0]));
+    } 
+
+    //test exception thrown SchedulableTraitNotFoundException when no Scheduleable trait found
+    public function testCannotAddNonSchedulableClass(){
+
+        $this->expectException(InvalidArgumentException);
+
+        $this->schedule->use(BarClassStub::class);
+
+        $events = $this->schedule->events();
+
+        $this->assertCount(0,$events);
+    } 
+
+    //Test event is run every minute / has ***** expression
+    public function testSchedulableClassEventHasEeryMinuteSchedule(){
+
+        $this->schedule->use(FooSchedulableClassStub::class);
+
+        $event = $this->schedule->events()[0];
+        
+        $this->assertEquals('* * * * *', $event->getExpression());
+    } 
+
+}
+
+class FooSchedulableClassStub{
+    use Schedulable;
+}
+
+class BarClassStub{
+
+}

--- a/tests/Console/Scheduling/SchedulableClassEventTest.php
+++ b/tests/Console/Scheduling/SchedulableClassEventTest.php
@@ -6,7 +6,6 @@ use Mockery as m;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
-use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\Schedulable;
 
@@ -32,10 +31,9 @@ class SchedulableClassEventTest extends TestCase
         );
     }
 
-    //test can call a class with the Schedulable Trait
     public function testCanAddSchedulableClass()
     {
-        $this->schedule->use(FooSchedulableClassStub::class);
+        $this->schedule->use(SchedulableClassStub::class);
 
         $events = $this->schedule->events();
 
@@ -44,22 +42,20 @@ class SchedulableClassEventTest extends TestCase
         $this->assertEquals("Illuminate\Console\Scheduling\SchedulableClassEvent", get_class($events[0]));
     }
 
-    //test exception thrown SchedulableTraitNotFoundException when no Scheduleable trait found
     public function testCannotAddNonSchedulableClass()
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $this->schedule->use(BarClassStub::class);
+        $this->schedule->use(NonSchedulableClassStub::class);
 
         $events = $this->schedule->events();
 
         $this->assertCount(0, $events);
     }
 
-    //Test event is run every minute / has ***** expression
     public function testSchedulableClassEventHasEeryMinuteSchedule()
     {
-        $this->schedule->use(FooSchedulableClassStub::class);
+        $this->schedule->use(SchedulableClassStub::class);
 
         $event = $this->schedule->events()[0];
 
@@ -67,11 +63,11 @@ class SchedulableClassEventTest extends TestCase
     }
 }
 
-class FooSchedulableClassStub
+class SchedulableClassStub
 {
     use Schedulable;
 }
 
-class BarClassStub
+class NonSchedulableClassStub
 {
 }

--- a/tests/Console/Scheduling/SchedulableTraitTest.php
+++ b/tests/Console/Scheduling/SchedulableTraitTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Tests\Console\Scheduling;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Console\Scheduling\Schedulable;
+use Illuminate\Support\Collection;
+
+class SchedulableTraitTest extends TestCase
+{
+    // // /*
+    // //  * @var \Illuminate\Console\Scheduling\Schedule
+    // //  */
+    // public $schedule;
+
+    public $schedulableClass;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // $container = Container::getInstance();
+
+        // $container->instance('Illuminate\Console\Scheduling\EventMutex', m::mock('Illuminate\Console\Scheduling\CacheEventMutex'));
+
+        // $container->instance('Illuminate\Console\Scheduling\SchedulingMutex', m::mock('Illuminate\Console\Scheduling\CacheSchedulingMutex'));
+
+        // $container->instance(
+        //     'Illuminate\Console\Scheduling\Schedule', $this->schedule = new Schedule(m::mock('Illuminate\Console\Scheduling\EventMutex'))
+        // );
+
+        $this->schedulableClass = new FooSchedulableClassStub();
+    }
+
+    //
+    //test when triat applied
+        //has isDue
+        //is Due is applied correctly
+        //areDue returns correct collection for coll /array / object
+
+        //runSchedule() - is applied
+
+
+    //test can call a class with the Schedulable Trait
+    public function testAddsRequiredMethods(){
+
+        $this->assertTrue(method_exists($this->schedulableClass,'isDue'));
+
+        $this->assertTrue(method_exists($this->schedulableClass,'areDue'));
+
+        $this->assertTrue(method_exists($this->schedulableClass,'runSchedule'));
+    }
+
+    //testScheduleCnaBEUpdayted
+    public function testScheduleCanBeSet(){
+        $this->schedulableClass->everyFiveMinutes();
+
+        $this->assertEquals('*/5 * * * *', $this->schedulableClass->expression);
+    }
+
+    public function testAreDueWithCollectionReturnsCollection(){
+        $schedulableCollectionClass = new FooSchedulableCollectionClassStub();
+
+        $this->assertTrue( $schedulableCollectionClass::areDue() instanceof Collection);
+
+        $this->assertCount(3,$schedulableCollectionClass::areDue());
+    }
+
+}
+
+class FooSchedulableClassStub{
+    use Schedulable;
+
+    public $name;
+}
+
+class FooSchedulableCollectionClassStub{
+    use Schedulable;
+
+    public $name;
+
+    public static function areDue(){
+        return collect([
+            new FooSchedulableCollectionClassStub(),
+            new FooSchedulableCollectionClassStub(),
+            new FooSchedulableCollectionClassStub()
+        ]);
+    }
+}

--- a/tests/Console/Scheduling/SchedulableTraitTest.php
+++ b/tests/Console/Scheduling/SchedulableTraitTest.php
@@ -2,92 +2,62 @@
 
 namespace Illuminate\Tests\Console\Scheduling;
 
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Container\Container;
-use Illuminate\Console\Scheduling\Event;
-use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\Schedulable;
 use Illuminate\Support\Collection;
 
 class SchedulableTraitTest extends TestCase
 {
-    // // /*
-    // //  * @var \Illuminate\Console\Scheduling\Schedule
-    // //  */
-    // public $schedule;
-
     public $schedulableClass;
 
     public function setUp()
     {
         parent::setUp();
 
-        // $container = Container::getInstance();
-
-        // $container->instance('Illuminate\Console\Scheduling\EventMutex', m::mock('Illuminate\Console\Scheduling\CacheEventMutex'));
-
-        // $container->instance('Illuminate\Console\Scheduling\SchedulingMutex', m::mock('Illuminate\Console\Scheduling\CacheSchedulingMutex'));
-
-        // $container->instance(
-        //     'Illuminate\Console\Scheduling\Schedule', $this->schedule = new Schedule(m::mock('Illuminate\Console\Scheduling\EventMutex'))
-        // );
-
-        $this->schedulableClass = new FooSchedulableClassStub();
+        $this->schedulableClass = new BaseSchedulableClassStub();
     }
 
-    //
-    //test when triat applied
-        //has isDue
-        //is Due is applied correctly
-        //areDue returns correct collection for coll /array / object
+    public function testAddsRequiredMethods()
+    {
+        $this->assertTrue(method_exists($this->schedulableClass, 'isDue'));
 
-        //runSchedule() - is applied
+        $this->assertTrue(method_exists($this->schedulableClass, 'areDue'));
 
-
-    //test can call a class with the Schedulable Trait
-    public function testAddsRequiredMethods(){
-
-        $this->assertTrue(method_exists($this->schedulableClass,'isDue'));
-
-        $this->assertTrue(method_exists($this->schedulableClass,'areDue'));
-
-        $this->assertTrue(method_exists($this->schedulableClass,'runSchedule'));
+        $this->assertTrue(method_exists($this->schedulableClass, 'runSchedule'));
     }
 
-    //testScheduleCnaBEUpdayted
-    public function testScheduleCanBeSet(){
+    public function testScheduleCanBeSet()
+    {
         $this->schedulableClass->everyFiveMinutes();
 
         $this->assertEquals('*/5 * * * *', $this->schedulableClass->expression);
     }
 
-    public function testAreDueWithCollectionReturnsCollection(){
-        $schedulableCollectionClass = new FooSchedulableCollectionClassStub();
+    public function testAreDueWithCollectionReturnsCollection()
+    {
+        $schedulableCollectionClass = new SchedulableCollectionClassStub();
 
-        $this->assertTrue( $schedulableCollectionClass::areDue() instanceof Collection);
+        $this->assertTrue($schedulableCollectionClass::areDue() instanceof Collection);
 
-        $this->assertCount(3,$schedulableCollectionClass::areDue());
+        $this->assertCount(3, $schedulableCollectionClass::areDue());
     }
-
 }
 
-class FooSchedulableClassStub{
+class BaseSchedulableClassStub
+{
     use Schedulable;
-
-    public $name;
 }
 
-class FooSchedulableCollectionClassStub{
+class SchedulableCollectionClassStub
+{
     use Schedulable;
 
-    public $name;
-
-    public static function areDue(){
+    public static function areDue()
+    {
         return collect([
-            new FooSchedulableCollectionClassStub(),
-            new FooSchedulableCollectionClassStub(),
-            new FooSchedulableCollectionClassStub()
+            new self(),
+            new self(),
+            new self(),
         ]);
     }
 }

--- a/tests/Console/Scheduling/SchedulableTraitTest.php
+++ b/tests/Console/Scheduling/SchedulableTraitTest.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Tests\Console\Scheduling;
 
 use PHPUnit\Framework\TestCase;
-use Illuminate\Console\Scheduling\Schedulable;
 use Illuminate\Support\Collection;
+use Illuminate\Console\Scheduling\Schedulable;
 
 class SchedulableTraitTest extends TestCase
 {


### PR DESCRIPTION
After requiring a model that needs to be individually scheduled (think Basecamp Check-in) I built a trait that uses existing Laravel logic.

This extends this into a core trait, a new Schedule Event class (similar to CallbackEvent) and one additional method on Schedule 'use'.

A Schedulable model/class can now be added to the schedule with
```php
$schedule->use(Checkin::class);
```
Behind the scenes it create a schedule event that runs every time and checks if anything needs to be run.

I have held off a significant refactoring of the Schedule Event system as it works great as is except for in this instance.


