### PR TITLE
[5.6] Add ability to extend DatabaseNotification model attributes on create

### DIFF
--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -45,7 +45,7 @@ class DatabaseChannel
     }
 
     /**
-     * Build up an array payload for the DatabaseNotification Model.
+     * Build an array payload for the DatabaseNotification Model.
      *
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Notification  $notification

--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -16,12 +16,9 @@ class DatabaseChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        return $notifiable->routeNotificationFor('database', $notification)->create([
-            'id' => $notification->id,
-            'type' => get_class($notification),
-            'data' => $this->getData($notifiable, $notification),
-            'read_at' => null,
-        ]);
+        return $notifiable->routeNotificationFor('database', $notification)->create(
+            $this->buildPayload($notifiable, $notification)
+        );
     }
 
     /**
@@ -45,5 +42,22 @@ class DatabaseChannel
         }
 
         throw new RuntimeException('Notification is missing toDatabase / toArray method.');
+    }
+
+    /**
+     * Build up an array payload for the DatabaseNotification Model.
+     *
+     * @param  mixed  $notifiable
+     * @param  \Illuminate\Notifications\Notification  $notification
+     * @return array
+     */
+    protected function buildPayload($notifiable, Notification $notification)
+    {
+        return [
+            'id' => $notification->id,
+            'type' => get_class($notification),
+            'data' => $this->getData($notifiable, $notification),
+            'read_at' => null,
+        ];
     }
 }


### PR DESCRIPTION
Building of attributes array for the `Illuminate\Notifications\DatabaseNotification` model inside `Illuminate\Notifications\Channels\DatabaseChannel` extracted to method, what allow us to extend or overwrite default attributes.

I found it useful because I were needed to add `seen_at` and some more attributes related to my application and were needed to extend default `DatabaseNotification` model. And instead just modifying attributes in `DatabaseChannel` class on notification creation, we need to copy-paste `send` method. That means that if there will be changes in `send` method in the future - we will require to update extended implementations.

With this change we can do:
```php
<?php

namespace App\Notification\Channels;

use Illuminate\Notifications\Channels\DatabaseChannel as BaseDatabaseChannel;
use Illuminate\Notifications\Notification;

class DatabaseChannel extends BaseDatabaseChannel
{
    protected function buildPayload($notifiable, Notification $notification)
    {
        return array_merge(parent::buildPayload($notifiable, $notification), [
            'seen_at' => null,
            'after_updrade' => 'Sleep well',
        ];
    }
}
```

Additionally it helps us to keep the code DRY.