### PR TITLE
[5.6] Pass timezone to CronExpression getNextRunDate

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -668,7 +668,7 @@ class Event
     {
         return Carbon::instance(CronExpression::factory(
             $this->getExpression()
-        )->getNextRunDate($currentTime, $nth, $allowCurrentDate));
+        )->getNextRunDate($currentTime, $nth, $allowCurrentDate, $this->timezone));
     }
 
     /**


### PR DESCRIPTION
CronExpression getNextRunDate supports passing a timezone, this way the Datetime that is returned will respect the events timezone.