### PR TITLE
[5.7] Fix event nextRunDate not respecting timezone

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -668,7 +668,7 @@ class Event
     {
         return Carbon::instance(CronExpression::factory(
             $this->getExpression()
-        )->getNextRunDate($currentTime, $nth, $allowCurrentDate));
+        )->getNextRunDate($currentTime, $nth, $allowCurrentDate, $this->timezone));
     }
 
     /**


### PR DESCRIPTION
CronExpression getNextRunDate supports a timezone argument to output the datetime in the specified timezone.

Resubmission of #23349, but now on the master branch so that the breaking change does not affect  users of 5.6