### PR TITLE
[5.6] Add queryString method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1674,6 +1674,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the collection of items as URL encoded query string.
+     *
+     * @param  string  $prefix
+     * @param  string  $separator
+     * @param  int  $encoding
+     * @return string
+     */
+    public function queryString($prefix = '', $separator = '&', $encoding = PHP_QUERY_RFC1738)
+    {
+        return http_build_query($this->toArray(), $prefix, $separator, $encoding);
+    }
+
+    /**
      * Get the collection of items as a plain array.
      *
      * @return array

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2019,6 +2019,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1, 2, 3, 4, 5], $c->all());
     }
 
+    public function testQueryString()
+    {
+        $c = new Collection(['a' => 'd', 'b' => 'e', 'c' => 'f']);
+        $this->assertEquals('a=d&b=e&c=f', $c->queryString());
+    }
+
     public function testGettingMaxItemsFromCollection()
     {
         $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);


### PR DESCRIPTION
I often find myself using collections to build up query strings. This simply adds a simple convenience method for building the query string straight off of the collection.

I realize it might be so trivial as to not warrant adding, but I have to admit… I really hate looking at `http_build_query` in my projects. 😅