### PR TITLE
[5.6] Throttle requests exception

### DIFF
--- a/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php
+++ b/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Http\Exceptions;
+
+use Exception;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class ThrottleRequestsException extends HttpException
+{
+    /**
+     * TooManyAttemptsException constructor.
+     *
+     * @param  string|null  $message
+     * @param  \Exception|null  $previous
+     * @param  array  $headers
+     * @param  int  $code
+     * @return void
+     */
+    public function __construct($message = null, Exception $previous = null, array $headers = [], $code = 0)
+    {
+        parent::__construct(429, $message, $previous, $headers, $code);
+    }
+}

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Str;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Support\InteractsWithTime;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\HttpException;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
 
 class ThrottleRequests
 {
@@ -40,7 +40,7 @@ class ThrottleRequests
      * @param  int|string  $maxAttempts
      * @param  float|int  $decayMinutes
      * @return mixed
-     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     * @throws \Illuminate\Http\Exceptions\ThrottleRequestsException
      */
     public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1)
     {
@@ -107,7 +107,7 @@ class ThrottleRequests
      *
      * @param  string  $key
      * @param  int  $maxAttempts
-     * @return \Symfony\Component\HttpKernel\Exception\HttpException
+     * @return \Illuminate\Http\Exceptions\ThrottleRequestsException
      */
     protected function buildException($key, $maxAttempts)
     {
@@ -119,8 +119,8 @@ class ThrottleRequests
             $retryAfter
         );
 
-        return new HttpException(
-            429, 'Too Many Attempts.', null, $headers
+        return new ThrottleRequestsException(
+            'Too Many Attempts.', null, $headers
         );
     }
 

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
 
 /**
  * @group integration
@@ -49,6 +50,7 @@ class ThrottleRequestsTest extends TestCase
         try {
             $this->withoutExceptionHandling()->get('/');
         } catch (Throwable $e) {
+            $this->assertTrue($e instanceof ThrottleRequestsException);
             $this->assertEquals(429, $e->getStatusCode());
             $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
             $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -50,7 +50,7 @@ class ThrottleRequestsTest extends TestCase
         try {
             $this->withoutExceptionHandling()->get('/');
         } catch (Throwable $e) {
-            $this->assertTrue($e instanceof ThrottleRequestsException);
+            $this->assertInstanceOf(ThrottleRequestsException::class, $e);
             $this->assertEquals(429, $e->getStatusCode());
             $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
             $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);


### PR DESCRIPTION
### Feature
I am proposing that the `ThrottleRequests` middleware throw a more specific exception as opposed to the current `\Symfony\Component\HttpKernel\Exception\HttpException`.

### Reasoning
The `$dontReport` property of the exception handler class contains the `\Symfony\Component\HttpKernel\Exception\HttpException::class` which means by default rate limiting will not be logged. If one wanted to log these events, they would need to update the `report` method of the exception handler class to something like:

    if ($exception instanceof HttpException && $exception->getStatusCode() === 429) {
        // Handle the logging as desired
    }
    
    return parent::report($exception);
    
Furthermore, I don't believe they would be able to use [Reportable Exceptions](https://laravel.com/docs/5.6/errors#renderable-exceptions) in this instance since the exception is thrown in the framework's middleware.

### Solution
Create a new exception which the `ThrottleRequests` middleware can utilize; one that simply extends the `\Symfony\Component\HttpKernel\Exception\HttpException` class. Add an additional test to the `ThrottleRequestsTest` to confirm the middleware is indeed throwing the desired exception.

### Final Thoughts
If approved, we may consider adding `\Illuminate\Http\Exceptions\ThrottleRequestsException::class` to the `$dontReport` property of the exception handler class. Otherwise, this update would remove the long-standing functionality of not logging rate limiting by default. I would submit a pull request to the `laravel` repository depending on the outcome of this pull request.