### PR TITLE
[5.6] Add mergeWhen method to Collection object

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1036,6 +1036,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Merge the collection with the given items based on a given condition.
+     *
+     * @param bool $condition
+     * @param  mixed  $items
+     * @return static
+     */
+    public function mergeWhen($condition, $items)
+    {
+        return $condition ? $this->merge($items) : $this;
+    }
+
+    /**
      * Create a collection by using this collection for keys and another for its values.
      *
      * @param  mixed  $values

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -605,6 +605,14 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['name' => 'World', 'id' => 1], $c->merge(new Collection(['name' => 'World', 'id' => 1]))->all());
     }
 
+    public function testMergeWhen()
+    {
+        $c = new Collection(['name' => 'Hello']);
+
+        $this->assertEquals(['name' => 'Hello'], $c->mergeWhen(false,new Collection(['name' => 'World', 'id' => 1]))->all());
+        $this->assertEquals(['name' => 'World', 'id' => 1], $c->mergeWhen(true,new Collection(['name' => 'World', 'id' => 1]))->all());
+    }
+
     public function testUnionNull()
     {
         $c = new Collection(['name' => 'Hello']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -609,8 +609,8 @@ class SupportCollectionTest extends TestCase
     {
         $c = new Collection(['name' => 'Hello']);
 
-        $this->assertEquals(['name' => 'Hello'], $c->mergeWhen(false,new Collection(['name' => 'World', 'id' => 1]))->all());
-        $this->assertEquals(['name' => 'World', 'id' => 1], $c->mergeWhen(true,new Collection(['name' => 'World', 'id' => 1]))->all());
+        $this->assertEquals(['name' => 'Hello'], $c->mergeWhen(false, new Collection(['name' => 'World', 'id' => 1]))->all());
+        $this->assertEquals(['name' => 'World', 'id' => 1], $c->mergeWhen(true, new Collection(['name' => 'World', 'id' => 1]))->all());
     }
 
     public function testUnionNull()


### PR DESCRIPTION
this **PR** adds **mergeWhen($condition,$items)** method to **Collection** object .

i thought if we had **$this->mergeWhen** in **Eloquent Resource** , we can make it also for **Collection** , and here's an example in request rules

Before : 
```php

public function rules()
{
    $rules = collect(['name' => 'required']);

    if(auth()->user()->hasRole('admin'))
    {
       $rules = $rules->merge(['secret' => 'required']);
    }

   return $rules->toArray();
}

```


After : 
```php

public function rules()
{
   return collect(['name' => 'required'])
        ->mergeWhen(auth()->user()->hasRole('admin') , 
                  [
                    'secret' => 'required'
                  ])
        ->toArray();
}

```