### PR TITLE
[5.6] Fix missing strtolower when getting an SQL alias

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -266,7 +266,7 @@ class MySqlGrammar extends Grammar
         $joins = ' '.$this->compileJoins($query, $query->joins);
 
         $alias = strpos(strtolower($table), ' as ') !== false
-                ? explode(' as ', $table)[1] : $table;
+            ? explode(' as ', strtolower($table))[1] : $table;
 
         return trim("delete {$alias} from {$table}{$joins} {$where}");
     }

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -270,7 +270,7 @@ class SqlServerGrammar extends Grammar
         $joins = ' '.$this->compileJoins($query, $query->joins);
 
         $alias = strpos(strtolower($table), ' as ') !== false
-                ? explode(' as ', $table)[1] : $table;
+            ? explode(' as ', strtolower($table))[1] : $table;
 
         return trim("delete {$alias} from {$table}{$joins} {$where}");
     }


### PR DESCRIPTION
This prevents AS in caps causing an undefined offset