### PR TITLE
[5.6] Add @dump blade helper

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -35,4 +35,15 @@ trait CompilesHelpers
     {
         return "<?php echo method_field{$method}; ?>";
     }
+
+    /**
+     * Compile the "dump" statements into valid PHP.
+     *
+     * @param  string  $arguments
+     * @return string
+     */
+    protected function compileDump($arguments)
+    {
+        return "<?php dump{$arguments}; ?>";
+    }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -26,17 +26,6 @@ trait CompilesHelpers
     }
 
     /**
-     * Compile the method statements into valid PHP.
-     *
-     * @param  string  $method
-     * @return string
-     */
-    protected function compileMethod($method)
-    {
-        return "<?php echo method_field{$method}; ?>";
-    }
-
-    /**
      * Compile the "dump" statements into valid PHP.
      *
      * @param  string  $arguments
@@ -45,5 +34,16 @@ trait CompilesHelpers
     protected function compileDump($arguments)
     {
         return "<?php dump{$arguments}; ?>";
+    }
+
+    /**
+     * Compile the method statements into valid PHP.
+     *
+     * @param  string  $method
+     * @return string
+     */
+    protected function compileMethod($method)
+    {
+        return "<?php echo method_field{$method}; ?>";
     }
 }

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -10,5 +10,6 @@ class BladeHelpersTest extends AbstractBladeTestCase
         $this->assertEquals('<?php echo method_field(\'patch\'); ?>', $this->compiler->compileString("@method('patch')"));
         $this->assertEquals('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));
         $this->assertEquals('<?php dd($var1, $var2); ?>', $this->compiler->compileString('@dd($var1, $var2)'));
+        $this->assertEquals('<?php dump($var1, $var2); ?>', $this->compiler->compileString('@dump($var1, $var2)'));
     }
 }


### PR DESCRIPTION
Adds a `@dump($data)` help to Blade. Works similar to `@dd()` but doesn't "die".

![screen shot 2018-03-02 at 2 12 18 pm](https://user-images.githubusercontent.com/203882/36902859-d507be66-1e23-11e8-93d7-877823eaefb2.png)
