### PR TITLE
Set up loop variable correctly on all Traversable objects

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -4,6 +4,7 @@ namespace Illuminate\View\Concerns;
 
 use Countable;
 use Illuminate\Support\Arr;
+use Traversable;
 
 trait ManagesLoops
 {
@@ -22,7 +23,9 @@ trait ManagesLoops
      */
     public function addLoop($data)
     {
-        $length = is_array($data) || $data instanceof Countable ? count($data) : null;
+        $length = is_array($data) || $data instanceof Countable
+                    ? count($data)
+                    : ($data instanceof Traversable ? iterator_count($data) : null);
 
         $parent = Arr::last($this->loopsStack);
 


### PR DESCRIPTION
I experienced a bug while looping over a `\DatePeriod` object with Blade's `@foreach`. The `$loop` variable is not filled correctly.
With this change the length of all `\Traversable` objects will be determined properly.

Code to reproduce:
```
@foreach(new DatePeriod(\Carbon\Carbon::today(), \Carbon\CarbonInterval::day(), \Carbon\Carbon::tomorrow()->endOfDay()) as $day)
	<span>{{ $loop->first ? 'first' : 'not_first' }} / {{ $loop->last ? 'last' : 'not_last' }}</span><br>
@endforeach
```