### PR TITLE
[5.2] Allow depending on either v1 or v2 of random_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",
         "nesbot/carbon": "~1.20",
-        "paragonie/random_compat": "~1.4",
+        "paragonie/random_compat": "~1.4|~2.0",
         "psy/psysh": "0.7.*",
         "swiftmailer/swiftmailer": "~5.1",
         "symfony/console": "2.8.*|3.0.*",


### PR DESCRIPTION
`paragonie/random_compat <2` was recently [added](https://security.sensiolabs.org/database?package=paragonie/random_compat) to SensioLabs' Vulnerability Database. I'm aware that Laravel 5.2 is unsupported, but this would help us sad souls who are stuck on PHP 5.5 (and thus Laravel 5.2) a whole bunch when using packages such as `roave/security-advisories`.

Thanks!