### PR TITLE
[5.6] Prevent considering an array attribute as callable in model factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -313,7 +313,7 @@ class FactoryBuilder
     protected function expandAttributes(array $attributes)
     {
         foreach ($attributes as &$attribute) {
-            if (is_callable($attribute) && ! is_string($attribute)) {
+            if (is_callable($attribute) && ! is_string($attribute) && ! is_array($attribute)) {
                 $attribute = $attribute($attributes);
             }
 

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -42,6 +42,7 @@ class EloquentFactoryBuilderTest extends TestCase
             return [
                 'name' => $faker->name,
                 'status' => 'active',
+                'tags' => ['Storage', 'Data'],
                 'user_id' => function () {
                     return factory(FactoryBuildableUser::class)->create()->id;
                 },
@@ -80,6 +81,7 @@ class EloquentFactoryBuilderTest extends TestCase
         Schema::create('servers', function ($table) {
             $table->increments('id');
             $table->string('name');
+            $table->string('tags');
             $table->integer('user_id');
             $table->string('status');
         });
@@ -134,6 +136,7 @@ class EloquentFactoryBuilderTest extends TestCase
         $callableServer = factory(FactoryBuildableServer::class)->states('callable')->create();
 
         $this->assertEquals('active', $server->status);
+        $this->assertEquals(['Storage', 'Data'], $server->tags);
         $this->assertEquals('callable', $callableServer->status);
     }
 
@@ -208,6 +211,7 @@ class FactoryBuildableServer extends Model
     public $table = 'servers';
     public $timestamps = false;
     protected $guarded = ['id'];
+    public $casts = ['tags' => 'array'];
 
     public function user()
     {


### PR DESCRIPTION
Having:

```
$factory->define(App\User::class, function (Faker $faker) {
    return [
        'name' => ['Storage', 'Bar'],
    ];
});
```

While building the factory, `is_callable(['Storage', 'Bar'])` will return true so the code will try to call the Bar method on the Storage class and that'll error.

In this PR we exclude array forms from being dealt with as callables.