### PR TITLE
[5.5] Set up loop variable correctly on all Traversable objects

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -3,6 +3,7 @@
 namespace Illuminate\View\Concerns;
 
 use Countable;
+use Traversable;
 use Illuminate\Support\Arr;
 
 trait ManagesLoops
@@ -17,12 +18,14 @@ trait ManagesLoops
     /**
      * Add new loop to the stack.
      *
-     * @param  \Countable|array  $data
+     * @param  \Countable|\Traversable|array  $data
      * @return void
      */
     public function addLoop($data)
     {
-        $length = is_array($data) || $data instanceof Countable ? count($data) : null;
+        $length = is_array($data) || $data instanceof Countable
+                    ? count($data)
+                    : ($data instanceof Traversable ? iterator_count($data) : null);
 
         $parent = Arr::last($this->loopsStack);
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -555,6 +555,28 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals([$expectedLoop], $factory->getLoopStack());
     }
 
+    public function testAddingTraversableLoop()
+    {
+        $factory = $this->getFactory();
+
+        $data = new \DatePeriod(\Carbon\Carbon::today(), \Carbon\CarbonInterval::day(), \Carbon\Carbon::tomorrow()->endOfDay());
+
+        $factory->addLoop($data);
+
+        $expectedLoop = [
+            'iteration' => 0,
+            'index' => 0,
+            'remaining' => 2,
+            'count' => 2,
+            'first' => true,
+            'last' => false,
+            'depth' => 1,
+            'parent' => null,
+        ];
+
+        $this->assertEquals([$expectedLoop], $factory->getLoopStack());
+    }
+
     public function testAddingUncountableLoop()
     {
         $factory = $this->getFactory();


### PR DESCRIPTION
The `$loop` variable within Blade's `@foreach` is not filled correctly if the object given implements `\Traversable` but not `\Countable`. The reason is that the stack size is not determined properly. This leads to unexpected behaviour using i.e. `$loop->last`.

This commit fixes the `$loop` variable so it works correctly with all `\Traversable` stacks (like `\DatePeriod`). It won't break any existing features as it just extends the functionality.