### PR TITLE
[5.6] Prevent missing key column when eager loading specific columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -9,10 +9,10 @@ use Illuminate\Support\Str;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 
 /**
  * @mixin \Illuminate\Database\Query\Builder
@@ -1124,7 +1124,7 @@ class Builder
             if ($query instanceof BelongsTo || $query instanceof HasOneOrMany) {
                 $key = $query instanceof BelongsTo ? $query->getOwnerKey() : $query->getForeignKeyName();
 
-                if (!in_array($key, $columns)) {
+                if (! in_array($key, $columns)) {
                     $columns[] = $key;
                 }
             }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Str;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
@@ -1114,7 +1116,20 @@ class Builder
     protected function createSelectWithConstraint($name)
     {
         return [explode(':', $name)[0], function ($query) use ($name) {
-            $query->select(explode(',', explode(':', $name)[1]));
+            $columns = explode(',', explode(':', $name)[1]);
+
+            // Belongs to, has one and has many relationships require the key column for matching the results.
+            // If it is missing, we add it to the selected columns.
+            // Belongs to many and has many through relationships get the key from the pivot table.
+            if ($query instanceof BelongsTo || $query instanceof HasOneOrMany) {
+                $key = $query instanceof BelongsTo ? $query->getOwnerKey() : $query->getForeignKeyName();
+
+                if (!in_array($key, $columns)) {
+                    $columns[] = $key;
+                }
+            }
+
+            $query->select($columns);
         }];
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -14,9 +14,9 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\InteractsWithTime;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class DatabaseEloquentModelTest extends TestCase
 {


### PR DESCRIPTION
When eager loading `BelongsTo`, `HasOne` and `HasMany` relationships with specific columns, it's easy to forget the key column that is required for matching the results.

This PR automatically adds the column if it is missing.

This is not necessary for `BelongsToMany` and `HasManyThrough` relationships. They get the key from the pivot table.