### PR TITLE
Feature: Adds attribute casting to specific object types

### DIFF
--- a/src/Illuminate/Database/Eloquent/ObjectCastable.php
+++ b/src/Illuminate/Database/Eloquent/ObjectCastable.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+interface ObjectCastable
+{
+    /**
+     * Returns an instance of the implementing class from the original object
+     *
+     * @param \stdClass  $object
+     * @return mixed
+     */
+    public static function castFromObject(\stdClass $object);
+}

--- a/src/Illuminate/Database/Eloquent/ObjectCastingException.php
+++ b/src/Illuminate/Database/Eloquent/ObjectCastingException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use RuntimeException;
+
+class ObjectCastingException extends RuntimeException
+{
+    /**
+     * Create a new JSON encoding exception for an attribute.
+     *
+     * @param  mixed  $model
+     * @param  mixed  $key
+     * @param  string  $castingClass
+     * @param  string  $message
+     * @return static
+     */
+    public static function forAttribute($model, $key, $castingClass, $message)
+    {
+        $class = get_class($model);
+
+        return new static("Unable to cast attribute [{$key}] for model [{$class}] to [$castingClass]: {$message}.");
+    }
+}


### PR DESCRIPTION
Models can now use ‘object:class’ as a way of casting to a specified class.

e.g. I could create a value class for an Address

```php
class Address implements ObjectCastable
{
    public $firstLine = '';
    public $secondLine = '';
    public $city = '';
    public $zipCode = '';
    public $country = '';

    /**
     * @param \stdClass $object
     * @return Address
     */
    public static function castFromObject(\stdClass $object)
    {
        $address = new self;
        $address->firstLine = $object->first_line;
        $address->secondLine = $object->second_line;
        $address->city = $object->city;
        $address->zipCode = $object->zip_code;
        $address->country = $object->country;

        return $address;
    }

    /**
     * @return string
     */
    public function __toString()
    {
        return json_encode($this);
    }
}
```
And then create a model like so

```php
public class Person extends Model
{
    protected $casts = [
        'address' => 'object:App\Address',
    ]; 
}
```

Which could automatically return the value object as a set instance type instead of having to make accessors for individual attributes etc.