### PR TITLE
[5.6] Move tightenco/collect to 'conflict'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,9 @@
         "illuminate/support": "self.version",
         "illuminate/translation": "self.version",
         "illuminate/validation": "self.version",
-        "illuminate/view": "self.version",
+        "illuminate/view": "self.version"
+    },
+    "conflict": {
         "tightenco/collect": "<5.5.33"
     },
     "require-dev": {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -20,7 +20,7 @@
         "illuminate/contracts": "5.6.*",
         "nesbot/carbon": "^1.20"
     },
-    "replace": {
+    "conflict": {
         "tightenco/collect": "<5.5.33"
     },
     "autoload": {


### PR DESCRIPTION
According to this issue: https://github.com/composer/composer/issues/7129, since `tighenco/collect` is not an illuminate's subtree, it must be set as a conflict and not a replacement. 

Tested this change in a [framework clone](https://github.com/antonioribeiro/illuminateframerocks), and this this is what happens now, when installing spatie/crawler:

![image](https://user-images.githubusercontent.com/3182864/36935444-a9574030-1ed6-11e8-92b8-a040a4412135.png)

Currently, if we try to install `spatie/crawler 4` along with `laravel/framework 5.6`, we get this:

![image](https://user-images.githubusercontent.com/3182864/36935480-0f236c5e-1ed7-11e8-8f1f-bd2ff3fcbb2d.png)
