### PR TITLE
[5.6] Correct param docblock in schedule run command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -86,7 +86,7 @@ class ScheduleRunCommand extends Command
     /**
      * Run the given single server event.
      *
-     * @param  \Illuminate\Support\Collection  $event
+     * @param  Event  $event
      * @return void
      */
     protected function runSingleServerEvent($event)
@@ -101,7 +101,7 @@ class ScheduleRunCommand extends Command
     /**
      * Run the given event.
      *
-     * @param  \Illuminate\Support\Collection  $event
+     * @param  Event  $event
      * @return void
      */
     protected function runEvent($event)


### PR DESCRIPTION
I noticed an incorrect param docblock in `ScheduleRunCommand`