### PR TITLE
[5.7] Added test helper to assert that a Job has been queued with a Chain

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -35,22 +35,51 @@ class QueueFake extends QueueManager implements Queue
     }
 
     /**
-     * Assert if a job was pushed with chain.
+     * Assert if a job was pushed with chained jobs based on a truth-test callback.
      *
      * @param  string  $job
      * @param  array $chain
+     * @param  callable|null  $callback
      * @return void
      */
-    public function assertPushedWithChain($job, $chain = [])
+    public function assertPushedWithChain($job, $chain = [], $callback = null)
     {
         PHPUnit::assertTrue(
-            $this->pushed($job)->count() > 0,
+            $this->pushed($job, $callback)->count() > 0,
             "The expected [{$job}] job was not pushed."
         );
 
+        PHPUnit::assertTrue(
+            collect($chain)->count() > 0,
+            "The expected chain can not be empty."
+        );
+
+        $isChainOfObjects = collect($chain)
+            ->filter(function ($job) {
+                return is_object($job);
+            })->count() == collect($chain)->count();
+
+        if ($isChainOfObjects)
+        {
+            PHPUnit::assertEquals(
+                collect($chain)->map(function ($job) { return serialize($job); })->all(),
+                $this->pushed($job, $callback)->first()->chained,
+                "The expected chain was not pushed."
+            );
+
+            return;
+        }
+
+        $chainedClasses = collect($this->pushed($job, $callback)->first()->chained)
+            ->map(function ($job) {
+                return unserialize($job);
+            })->map(function($job) {
+                return get_class($job);
+            })->all();
+
         PHPUnit::assertEquals(
-            collect($chain)->map(function ($job) { return serialize($job); })->all(),
-            $this->pushed($job)->first()->chained,
+            $chain,
+            $chainedClasses,
             "The expected chain was not pushed."
         );
     }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -181,28 +181,8 @@ class QueueFake extends QueueManager implements Queue
     {
         $this->jobs[is_object($job) ? get_class($job) : $job][] = [
             'job' => $job,
-            'queue' => $queue,
-            'chain' => $this->getJobChain($job)
+            'queue' => $queue
         ];
-    }
-
-    /**
-     * @param mixed $job
-     * @return array
-     */
-    private function getJobChain($job)
-    {
-        if (is_object($job))
-            return [];
-
-        dd($job->chained);
-
-        return collect($job->chained)
-            ->map(function ($shackle) {
-                return unserialize($shackle);
-            })->map(function ($shackle) {
-                return get_class($shackle);
-            })->toArray();
     }
 
     /**

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -3,13 +3,11 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
-use Illuminate\Queue\SerializesModels;
-use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Testing\Fakes\QueueFake;
-use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\Constraint\ExceptionMessage;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
 
 class QueueFakeTest extends TestCase
 {


### PR DESCRIPTION
The following PR adds a helper method for testing that allows to assert if a Job was pushed to the Queue with a specific Chain. The proposed method name is ```assertPushedWithChain``` and expects two parameters: the First Job in the Chain and an array of Jobs that will execute. 

I have attached an image on how this assertion can be used.

![image](https://user-images.githubusercontent.com/5126648/36941923-a5a590b4-1f34-11e8-90ac-b197167ba5a4.png)

I have used the ```Queueable``` trait ```chain``` method to simulate jobs serialization and have used the same method to check for the chain in the assertion method.

![image](https://user-images.githubusercontent.com/5126648/36941940-f9375e1a-1f34-11e8-9f1a-8221e73f4aa9.png)

This helper can be useful to assert that a chain has been triggered with a specific set of jobs and order.

Hope it is useful for others! Cheers!

