### PR TITLE
[5.6] Provide access to validated dataset

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -726,6 +726,34 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Validate the rules and get the data under validation.
+     *
+     * @return array
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function getDataValidated()
+    {
+        $this->validate();
+
+        return $this->getDataForRules();
+    }
+
+    /**
+     * Get the data under validation only for the loaded rules.
+     *
+     * @return array
+     */
+    public function getDataForRules()
+    {
+        $ruleKeys = collect($this->getRules())->keys()->map(function ($rule) {
+            return explode('.', $rule, 2)[0];
+        })->unique()->toArray();
+
+        return collect($this->getData())->only($ruleKeys)->toArray();
+    }
+
+    /**
      * Set the data under validation.
      *
      * @param  array  $data

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3874,6 +3874,30 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($rule->called);
     }
 
+    public function testGetDataForRules()
+    {
+        $post = ['first'=>'john', 'last'=>'doe', 'type' => 'admin'];
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), $post, ['first' => 'required']);
+        $data = $v->getDataForRules();
+
+        $this->assertSame($data, ['first'=>'john']);
+
+        $v->sometimes('last', 'required', function () {
+            return true;
+        });
+        $data = $v->getDataForRules();
+
+        $this->assertSame($data, ['first'=>'john', 'last'=>'doe']);
+
+        $v->sometimes('type', 'required', function () {
+            return false;
+        });
+        $data = $v->getDataForRules();
+
+        $this->assertSame($data, ['first'=>'john', 'last'=>'doe']);
+    }
+
     protected function getTranslator()
     {
         return m::mock('Illuminate\Contracts\Translation\Translator');


### PR DESCRIPTION
Currently in your controller if you're using:
`$data = $request->validate([...]);`

If you need to switch to using advanced rules, there is no firect method available for accessing the validated data:

```
$validator = Validator::make($request->all(), [...]);
$validator->sometimes('phone', 'required', function(){ ... });
$validator->validate();
// Now how do you get your $data variable?

$data = $validator->getDataForRules(); // my new method
// OR
$data = $validator->getDataValidated(); // this takes care of calling validate()
```