### PR TITLE
[5.6] Fix Failing Build

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -340,14 +340,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
-    public function testWhereTimePostgres()
-    {
-        $builder = $this->getPostgresBuilder();
-        $builder->select('*')->from('users')->whereTime('created_at', '>=', '22:00');
-        $this->assertEquals('select * from "users" where "created_at"::time >= ?', $builder->toSql());
-        $this->assertEquals([0 => '22:00'], $builder->getBindings());
-    }
-
     public function testWhereTimeOperatorOptionalPostgres()
     {
         $builder = $this->getPostgresBuilder();


### PR DESCRIPTION
Travis CI is failing on "PHP Fatal error:  Cannot redeclare Illuminate\Tests\Database\DatabaseQueryBuilderTest::testWhereTimePostgres() in /home/travis/build/laravel/framework/tests/Database/DatabaseQueryBuilderTest.php on line 391"

Looks like a redundant function.