### PR TITLE
[5.6] FileSystem returns files and directories sorted by name

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -387,7 +387,7 @@ class Filesystem
     public function files($directory, $hidden = false)
     {
         return iterator_to_array(
-            Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->depth(0),
+            Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->depth(0)->sortByName(),
             false
         );
     }
@@ -402,7 +402,7 @@ class Filesystem
     public function allFiles($directory, $hidden = false)
     {
         return iterator_to_array(
-            Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory),
+            Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->sortByName(),
             false
         );
     }
@@ -417,7 +417,7 @@ class Filesystem
     {
         $directories = [];
 
-        foreach (Finder::create()->in($directory)->directories()->depth(0) as $dir) {
+        foreach (Finder::create()->in($directory)->directories()->depth(0)->sortByName() as $dir) {
             $directories[] = $dir->getPathname();
         }
 


### PR DESCRIPTION
A change made last year to version 5.5 changed the behavior of the `FileSystem files()` method:

https://github.com/laravel/framework/commit/0665f952fdee73f0fe41c0b311ea82ac6718bcb3#diff-3aea724aa0501a58dc0f933de2be07e7

Previously `files()` would return the list of files in alphabetical order. Since that change, the returned array is no longer sorted alphabetically by name. As the returned object is an array of `SplFileSystem` objects, sorting the result set in userland isn't as simple as just calling `sort()`. However, sorting the result set inside the `FileSystem` class is dead easy.

Many developers may prefer the `FileSystem` class to return arrays of things sorted by name, as per the original behavior. At the very least it seems like a nice convenience that shouldn't negatively impact anybody who doesn't need this behavior.