### PR TITLE
[4.2] PHP 7.1 support for database migrations in test environment

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -102,7 +102,8 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 	 */
 	public function getLastBatchNumber()
 	{
-		return $this->table()->max('batch');
+		$max = $this->table()->max('batch');
+		return is_int($max) ? $max : 0;
 	}
 
 	/**


### PR DESCRIPTION
In PHP 7.1, getNextBatchNumber generates a 'non-numeric value encountered' warning if the migrations table is empty, because getLastBatchNumber returns a non-integer, since the max method takes the max of nothing. In the test-environment, this warning becomes an error, and so all tests that use the database (an in-memory sqlite database in my case) automatically fail.

I know 4.2 is hopelessly outdated but I'm stuck with it for now, and I'd love to see this small fix upstream :)