### PR TITLE
Fix dot notation in JSON based translations

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -155,7 +155,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // only one level deep so we do not need to do any fancy searching through it.
         $this->load('*', '*', $locale);
 
-        $line = $this->loaded['*']['*'][$locale][$key] ?? null;
+        $line = Arr::get($this->loaded['*']['*'][$locale], $key) ?? null;
 
         // If we can't find a translation for the JSON key, we will attempt to translate it
         // using the typical translation file. This way developers can always just use a


### PR DESCRIPTION
Not sure in destination branch, because it was implemented in 5.4, and still was not fixed, even in 5.5 LTS
(I am using 5.5 for now)