### PR TITLE
[5.6] Added when/unless methods to database rule.

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -48,6 +48,37 @@ trait DatabaseRule
     }
 
     /**
+     * Apply callback when given condition is true.
+     *
+     * @param bool|mixed $value
+     * @param callable $callback
+     * @return $this
+     */
+    public function when($value, callable $callback, callable $default = null)
+    {
+        if ($value) {
+            $this->using($callback);
+        } elseif ($default) {
+            $this->using($default);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Apply callback when given value is false.
+     *
+     * @param mixed|bool $value
+     * @param callable $callback
+     * @param callable $default
+     * @return $this
+     */
+    public function unless($value, callable $callback, callable $default = null)
+    {
+        return $this->when(!$value, $callback, $default);
+    }
+
+    /**
      * Set a "where" constraint on the query.
      *
      * @param  string|\Closure  $column

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -75,7 +75,7 @@ trait DatabaseRule
      */
     public function unless($value, callable $callback, callable $default = null)
     {
-        return $this->when(!$value, $callback, $default);
+        return $this->when(! $value, $callback, $default);
     }
 
     /**

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -4,11 +4,11 @@ namespace Illuminate\Tests\Validation;
 
 use PHPUnit\Framework\TestCase;
 use Illuminate\Validation\Validator;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Validation\DatabasePresenceVerifier;
-use Illuminate\Database\Query\Builder;
 
 class ValidationExistsRuleTest extends TestCase
 {


### PR DESCRIPTION
It can be very useful to have `when/unless` methods in `DatabaseRule`.

Quick example is: 
 - When user is admin - exists rule must check only row existence.
 - When user is not admin - add condition to check that he is owner of item. (Yep, I know it can be done in authorize() method, it's only example and validation can be used not only in 'form requests' ;) )

```php
public function rules(): array
{
   return [
     'item' => [
         Rule::exists('items')->unless($this->user()->isAdmin(), function (Builder $query) {
              $query->where('owner_id', $this->user()->getKey());
         })
     ]
  ]
}
```