### PR TITLE
[5.6] Handling dot notation in getValue in Validator

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -748,6 +748,10 @@ class Validator implements ValidatorContract
      */
     protected function getValue($attribute)
     {
+        if (Str::contains($attribute, '->')) {
+            $attribute = str_replace('->', '.', $attribute);
+        }
+        
         return Arr::get($this->data, $attribute);
     }
 


### PR DESCRIPTION
Hello,

i propose this change to handle dot notation in validator data.
In parseData function, each '.' is replaced by a '->', and therefore validation does not work with dot notation data.

I understand that dot notation is removed to not interfere with the use of dot notation in the validation,
but i think we should handle it in getValue function, by replacing on the fly  '->'  to '.' in the attribute, to undo change make by parseData.

thanks.
