### PR TITLE
[5.6] Validator should return validated data

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -296,7 +296,7 @@ class Validator implements ValidatorContract
     /**
      * Run the validator's rules against its data.
      *
-     * @return void
+     * @return array
      *
      * @throws \Illuminate\Validation\ValidationException
      */
@@ -305,6 +305,8 @@ class Validator implements ValidatorContract
         if ($this->fails()) {
             throw new ValidationException($this);
         }
+
+        return $this->getDataForRules();
     }
 
     /**
@@ -723,6 +725,20 @@ class Validator implements ValidatorContract
     public function getData()
     {
         return $this->data;
+    }
+
+    /**
+     * Get the data under validation only for the loaded rules.
+     *
+     * @return array
+     */
+    public function getDataForRules()
+    {
+        $ruleKeys = collect($this->getRules())->keys()->map(function ($rule) {
+            return explode('.', $rule, 2)[0];
+        })->unique()->toArray();
+
+        return collect($this->getData())->only($ruleKeys)->toArray();
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3874,6 +3874,30 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($rule->called);
     }
 
+    public function testGetDataForRules()
+    {
+        $post = ['first'=>'john', 'last'=>'doe', 'type' => 'admin'];
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), $post, ['first' => 'required']);
+        $data = $v->getDataForRules();
+
+        $this->assertSame($data, ['first'=>'john']);
+
+        $v->sometimes('last', 'required', function () {
+            return true;
+        });
+        $data = $v->getDataForRules();
+
+        $this->assertSame($data, ['first'=>'john', 'last'=>'doe']);
+
+        $v->sometimes('type', 'required', function () {
+            return false;
+        });
+        $data = $v->getDataForRules();
+
+        $this->assertSame($data, ['first'=>'john', 'last'=>'doe']);
+    }
+
     protected function getTranslator()
     {
         return m::mock('Illuminate\Contracts\Translation\Translator');


### PR DESCRIPTION
Currently in your controller if you're using:
`$data = $request->validate([...]);`

If you need to switch to using advanced rules, there is no direct method available for accessing the validated data:

```
$validator = Validator::make($request->all(), [...]);
$validator->sometimes('phone', 'required', function(){ ... });
$data = $validator->validate();  // This PR adds this return value
```