### PR TITLE
Allow dynamic properties to be set on FormRequest

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -625,7 +625,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function offsetSet($offset, $value)
     {
-        $this->getInputSource()->set($offset, $value);
+        $this->__set($offset, $value);
     }
 
     /**
@@ -663,5 +663,17 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         }
 
         return $this->route($key);
+    }
+
+    /**
+     * Set an input value of a given key.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return void
+     */
+    public function __set($key, $value)
+    {
+        $this->getInputSource()->set($key, $value);
     }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -464,6 +464,19 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('Dayle', $request->input('buddy'));
     }
 
+    public function testDynamicPropertyFromInput()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor']);
+        $this->assertEquals('Taylor', $request->name);
+    }
+
+    public function testSetDynamicProperty()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor']);
+        $request->buddy = 'Dayle';
+        $this->assertEquals('Dayle', $request->input('buddy'));
+    }
+
     public function testReplaceMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);


### PR DESCRIPTION
One of my peers was confused why setting a dynamic property on a request object wouldn't carry over to a custom `FormRequest`, so I figured I would add in the behavior.

Note that these dynamic properties will now show up in `$request->all()` so this might not be desired behavior, however, `$request['foo'] = 'foo'` will also show up in this case. I figured I'd at least get the discussion going.