### PR TITLE
[5.6] Add select to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1061,6 +1061,39 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get columns from array look like table.
+     *
+     * @param  mixed  $keys
+     * @return static
+     */
+    public function select($keys)
+    {
+        if (is_null($keys)) {
+            return new static($this->items);
+        }
+
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $result = [];
+
+        foreach ($this->items as $record) {
+            $row = [];
+
+            foreach ($record as $field => $value) {
+                if (in_array($field, $keys)) {
+                    $row[$field] = $value;
+                }
+            }
+
+            if ($row) {
+                $result[] = $row;
+            }
+        }
+
+        return new static($result);
+    }
+
+    /**
      * Get the items with the specified keys.
      *
      * @param  mixed  $keys

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1973,6 +1973,39 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($c->min());
     }
 
+    public function testSelect()
+    {
+        $data = new Collection([
+            [
+                'name' => 'Car',
+                'latitude' => 17.7187837,
+                'longitude' => 42.208035,
+            ],
+            [
+                'name' => 'Mobile',
+                'latitude' => null,
+                'longitude' => null,
+            ],
+            [
+                'name' => 'Watch',
+                'attend_date' => '2018-03-06 08:39:51',
+                'latitude' => 17.7187837,
+                'longitude' => 42.208035,
+            ],
+            [
+                'name' => 'TV',
+                'owner' => 'Abdelaziz Elrashed',
+                'attend_date' => '2018-03-06 08:39:43',
+            ],
+        ]);
+
+        $this->assertEquals(0, $data->select('company')->count());
+        $this->assertEquals(1, $data->select('owner')->count());
+        $this->assertEquals(2, $data->select('attend_date')->count());
+        $this->assertEquals(3, $data->select(['latitude', 'longitude'])->count());
+        $this->assertEquals(4, $data->select('name')->count());
+    }
+
     public function testOnly()
     {
         $data = new Collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
Hi,

I added a `select` function to Collection, which made the collection behave like SQL select,
here is what is the difference between `only` and new one `select`

##### Current `only` function in `Collection`
```php
$collection = collect(['product_id' => 1, 'name' => 'Desk', 'price' => 100, 'discount' => false]);

$filtered = $collection->only(['product_id', 'name']);

$filtered->all();

// ['product_id' => 1, 'name' => 'Desk']
```

##### New `select` function in `Collection`
```php
$collection = collect([
    ['product_id' => 1, 'name' => 'Desk', 'price' => 100, 'discount' => false],
    ['product_id' => 2, 'name' => 'Chair', 'price' => 100, 'discount' => false],
    ['product_id' => 3, 'name' => 'Pen', 'price' => 100, 'discount' => true],
    ['product_id' => 4, 'name' => 'Ruler', 'price' => 100, 'discount' => false],
]);

$filtered = $collection->select(['product_id', 'name']);

$filtered->all();

/*
[
    ['product_id' => 1, 'name' => 'Desk'],
    ['product_id' => 2, 'name' => 'Chair'],
    ['product_id' => 3, 'name' => 'Pen'],
    ['product_id' => 4, 'name' => 'Ruler']
]
*/
```

Thanks