### PR TITLE
[5.6] Handle more JSON errors gracefully when JSON_PARTIAL_OUTPUT_ON_ERROR  is set

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -86,9 +86,24 @@ class JsonResponse extends BaseJsonResponse
      */
     protected function hasValidJson($jsonError)
     {
-        return $jsonError === JSON_ERROR_NONE ||
-                ($jsonError === JSON_ERROR_UNSUPPORTED_TYPE &&
-                $this->hasEncodingOption(JSON_PARTIAL_OUTPUT_ON_ERROR));
+        // No error is obviously fine
+        if ($jsonError === JSON_ERROR_NONE) {
+            return true;
+        }
+
+        // If the JSON_PARTIAL_OUTPUT_ON_ERROR option is set, some additional errors are fine
+        // (see https://secure.php.net/manual/en/json.constants.php)
+        if ($this->hasEncodingOption(JSON_PARTIAL_OUTPUT_ON_ERROR)) {
+            $acceptableErrors = [
+                JSON_ERROR_RECURSION,
+                JSON_ERROR_INF_OR_NAN,
+                JSON_ERROR_UNSUPPORTED_TYPE,
+            ];
+
+            return \in_array($jsonError, $acceptableErrors);
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -92,6 +92,29 @@ class HttpJsonResponseTest extends TestCase
         $this->assertInstanceOf('stdClass', $data);
         $this->assertNull($data->resource);
     }
+
+    public function testJsonErrorRecursionDetectedWithPartialOutputOnError()
+    {
+        $objectA = new \stdClass();
+        $objectB = new \stdClass();
+        $objectA->b = $objectB;
+        $objectB->a = $objectA;
+
+        $response = new \Illuminate\Http\JsonResponse($objectA, 200, [], JSON_PARTIAL_OUTPUT_ON_ERROR);
+        $data = $response->getData();
+
+        $this->assertNotNull($data);
+    }
+
+    public function testJsonErrorInfOrNanWithPartialOutputOnError()
+    {
+        $data = ['product' => NAN];
+
+        $response = new \Illuminate\Http\JsonResponse($data, 200, [], JSON_PARTIAL_OUTPUT_ON_ERROR);
+        $data = $response->getData();
+
+        $this->assertNotNull($data);
+    }
 }
 
 class JsonResponseTestJsonableObject implements Jsonable


### PR DESCRIPTION
It's fairly common for stack traces to be circular, i.e. they can't be encoded as JSON without limiting the recursion depth somehow. PHP automatically does this if JSON_PARTIAL_OUTPUT_ON_ERROR is true, but we still considered it an error.

By treating JSON_ERROR_RECURSION as okay if JSON_PARTIAL_OUTPUT_ON_ERROR is set we prevent things from blowing up if the user uses a JSON-based exception handler.

Since exceptions thrown in exception handlers are generally a recipe for disaster I added JSON_ERROR_INF_OR_NAN to the list of "acceptable" errors too.