### PR TITLE
[5.6] Don't bind parameters when DB::raw(...) is used with Builder::whereBetween

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -899,9 +899,15 @@ class Builder
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function whereBetween($column, array $values, $boolean = 'and', $not = false)
     {
+        if (count($values) !== 2) {
+            throw new InvalidArgumentException('Exactly 2 values required.');
+        }
+
         $type = 'between';
 
         $this->wheres[] = compact('column', 'type', 'boolean', 'not');

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -906,7 +906,11 @@ class Builder
 
         $this->wheres[] = compact('column', 'type', 'boolean', 'not');
 
-        $this->addBinding($values, 'where');
+        foreach ($values as $value) {
+            if (! $value instanceof Expression) {
+                $this->addBinding($value, 'where');
+            }
+        }
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -910,7 +910,7 @@ class Builder
 
         $type = 'between';
 
-        $this->wheres[] = compact('column', 'type', 'boolean', 'not');
+        $this->wheres[] = compact('column', 'values', 'type', 'boolean', 'not');
 
         foreach ($values as $value) {
             if (! $value instanceof Expression) {

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -330,7 +330,7 @@ class Grammar extends BaseGrammar
     {
         $between = $where['not'] ? 'not between' : 'between';
 
-        return $this->wrap($where['column']).' '.$between.' ? and ?';
+        return $this->wrap($where['column']).' '.$between.' '.$this->paramater($where['value'][0]).' and '.$this->paramater($where['value'][1]);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -330,7 +330,7 @@ class Grammar extends BaseGrammar
     {
         $between = $where['not'] ? 'not between' : 'between';
 
-        return $this->wrap($where['column']).' '.$between.' '.$this->paramater($where['value'][0]).' and '.$this->paramater($where['value'][1]);
+        return $this->wrap($where['column']).' '.$between.' '.$this->parameter($where['value'][0]).' and '.$this->parameter($where['value'][1]);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -330,7 +330,7 @@ class Grammar extends BaseGrammar
     {
         $between = $where['not'] ? 'not between' : 'between';
 
-        return $this->wrap($where['column']).' '.$between.' '.$this->parameter($where['value'][0]).' and '.$this->parameter($where['value'][1]);
+        return $this->wrap($where['column']).' '.$between.' '.$this->parameter($where['values'][0]).' and '.$this->parameter($where['values'][1]);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -473,6 +473,24 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testWhereBetweenThrowsExpectedExceptionWithTooFewValuesValueCount()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereBetween('id', [1]);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testWhereBetweenThrowsExpectedExceptionWithTooManyValuesValueCount()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereBetween('id', [1, DB::raw('2'), 3]);
+    }
+
     public function testBasicOrWheres()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -468,7 +468,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testWhereBetweenWithExpressions()
     {
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereBetween('id', [1, DB::raw('2')]);
+        $builder->select('*')->from('users')->whereBetween('id', [1, new Raw('2')]);
         $this->assertEquals('select * from "users" where "id" between ? and 2', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
@@ -488,7 +488,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testWhereBetweenThrowsExpectedExceptionWithTooManyValuesValueCount()
     {
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereBetween('id', [1, DB::raw('2'), 3]);
+        $builder->select('*')->from('users')->whereBetween('id', [1, 2, 3]);
     }
 
     public function testBasicOrWheres()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -465,6 +465,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
+    public function testWhereBetweenWithExpressions()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereBetween('id', [1, DB::raw('2')]);
+        $this->assertEquals('select * from "users" where "id" between ? and 2', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+    }
+
     public function testBasicOrWheres()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
The `whereBetween` method on `\Illuminate\Database\Query\Builder` will attempt to bind parameters even when using `DB::raw(...)`.

Using tinker to illustrate this;
```
>>> DB::table('test')->whereBetween('a', [1, 4])->toSql()
=> "select * from `test` where `a` between ? and ?"
>>> DB::table('test')->whereBetween('a', [DB::raw('b'), DB::raw('c')])->toSql()
=> "select * from `test` where `a` between ? and ?"
>>> DB::table('test')->whereBetween('a', [DB::raw('b'), DB::raw('c')])->getBindings()
=> [
     Illuminate\Database\Query\Expression {#1514},
     Illuminate\Database\Query\Expression {#1523},
   ]
```