### PR TITLE
[5.6] Fix dot notation in JSON translations

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -155,7 +155,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // only one level deep so we do not need to do any fancy searching through it.
         $this->load('*', '*', $locale);
 
-        $line = Arr::get($this->loaded['*']['*'][$locale], $key) ?? null;
+        $line = Arr::get($this->loaded['*']['*'][$locale], $key);
 
         // If we can't find a translation for the JSON key, we will attempt to translate it
         // using the typical translation file. This way developers can always just use a

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -155,7 +155,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // only one level deep so we do not need to do any fancy searching through it.
         $this->load('*', '*', $locale);
 
-        $line = $this->loaded['*']['*'][$locale][$key] ?? null;
+        $line = Arr::get($this->loaded['*']['*'][$locale], $key) ?? null;
 
         // If we can't find a translation for the JSON key, we will attempt to translate it
         // using the typical translation file. This way developers can always just use a

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -151,7 +151,7 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('David', $t->getFromJson('baz.user.name'));
     }
 
-    public function testGetJsonRetrievesItemWithDotNotationInOldFormat()
+    public function testGetJsonRetrievesItemWithDotNotationInOneLevelFormat()
     {
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => 'bar', 'baz.one' => 'two', 'baz.user.name' => 'David']);
@@ -163,6 +163,13 @@ class TranslationTranslatorTest extends TestCase
     {
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => ['to :name I give :greeting' => ':greeting :name']]);
+        $this->assertEquals('Greetings David', $t->getFromJson('foo.to :name I give :greeting', ['name' => 'David', 'greeting' => 'Greetings']));
+    }
+
+    public function testGetJsonPreservesOrderWithDotNotationInOneLevelFormat()
+    {
+        $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo.to :name I give :greeting' => ':greeting :name']);
         $this->assertEquals('Greetings David', $t->getFromJson('foo.to :name I give :greeting', ['name' => 'David', 'greeting' => 'Greetings']));
     }
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -83,6 +83,14 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('breeze bar', $t->get('foo.bar', ['foo' => 'bar']));
     }
 
+    public function testGetMethodProperlyLoadsAndRetrievesItemWithDotNotation()
+    {
+        $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => ['one' => 'breeze :foo']]);
+        $this->assertEquals('breeze bar', $t->get('foo::bar.baz.one', ['foo' => 'bar'], 'en'));
+        $this->assertEquals('foo', $t->get('foo::bar.foo'));
+    }
+
     public function testChoiceMethodProperlyLoadsAndRetrievesItem()
     {
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
@@ -133,6 +141,29 @@ class TranslationTranslatorTest extends TestCase
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['to :name I give :greeting' => ':greeting :name']);
         $this->assertEquals('Greetings David', $t->getFromJson('to :name I give :greeting', ['name' => 'David', 'greeting' => 'Greetings']));
+    }
+
+    public function testGetJsonRetrievesItemWithDotNotation()
+    {
+        $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => 'bar', 'baz' => ['one' => 'two', 'user' => ['name' => 'David']]]);
+        $this->assertEquals('two', $t->getFromJson('baz.one'));
+        $this->assertEquals('David', $t->getFromJson('baz.user.name'));
+    }
+
+    public function testGetJsonRetrievesItemWithDotNotationInOldFormat()
+    {
+        $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => 'bar', 'baz.one' => 'two', 'baz.user.name' => 'David']);
+        $this->assertEquals('two', $t->getFromJson('baz.one'));
+        $this->assertEquals('David', $t->getFromJson('baz.user.name'));
+    }
+
+    public function testGetJsonPreservesOrderWithDotNotation()
+    {
+        $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => ['to :name I give :greeting' => ':greeting :name']]);
+        $this->assertEquals('Greetings David', $t->getFromJson('foo.to :name I give :greeting', ['name' => 'David', 'greeting' => 'Greetings']));
     }
 
     public function testGetJsonForNonExistingJsonKeyLooksForRegularKeys()


### PR DESCRIPTION
@taylorotwell @sisve @tillkruss 
I previously used translations in the usual way, through php arrays. Dot notations works well, but at one stage of development I needed to build a js client, with prebuilded translations, and do not fetch them from the backend every time I booted client, and store it in `Local storage`.

At this point, I decided that it's better to export the php arrays to json file, but I ran into the problem that the current method of getting the value from the key `__('key')` ... `(new Translator)->getFromJson()` only works in the single root level of the json object, and if not found key in json, start to search in php translations.

My php source:
```php 
// resources/lang/en/emails.php

return [
    'hello'           => 'Hello',
    'account'         => [
        'password_changed' => [
            'text'  => 'You have succesfully changed your password.',
            'title' => 'Your password has been changed.',
        ],
    ],
];
```
Its conversion to json:
```json
// resources/lang/en.json
{
  "emails": {
    "hello": "Hello",
    "account": {
      "password_changed": {
        "text": "You have succesfully changed your password.",
        "title": "Your password has been changed."
      }
    }
  }
}
```
BUT:
If we call `__('emails.account.password_changed.text')`, we take the php version of the translations, because this key is not found in json
OK
For example. Create new:
```json
// resources/lang/en.json

{
  "emails": {
    "account": {
      "password_changed": {
        "text": "1",
      }
    },
    "account.password_changed.text": "2",
  },
  "emails.account.password_changed.text": "3",
}
```
and call `__('emails.account.password_changed.text')`, output will be `3`.
OK
removing key with value `3`:
```json
// resources/lang/en.json

{
  "emails": {
    "account": {
      "password_changed": {
        "text": "1",
      }
    },
    "account.password_changed.text": "2",
  },
}
```
and call `__('emails.account.password_changed.text')` again
output will be `Your password has been changed.`. neither 1 nor 2. Key not found in json, and fetching php value

by the way, i just used the same `Arr::get()` method from php implementation in `Translator` class from `get` method

I also wrote tests that show that getting a value from the root level works the same as before.

and I can already imagine what the .json files look like to those who now use this feature:
```json
{
 	"activity.columns.description": "Description",
 	"attachments.upload_files": "Upload files",
	"emails.account.password_changed.text": "You have succesfully changed your password.",
	"emails.account.password_changed.title": "Your password has been changed."
}
```
single level json, for me like a hell

**Conclusion:**
This feature was introduced in 5.4, but not covered enough with tests, and has not been completed
It's too late to fix the fix in 5.4, but we can still fix the situation, 5.5 LTS can still be edited.
I suggest not a feature, but a fix of previously introduced in the stable, but the finished feature

 #23405, #23392