### PR TITLE
[5.6] Add dropMorphs to Blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -408,6 +408,18 @@ class Blueprint
     }
 
     /**
+     * Indicate that the polymorphic columns should be dropped.
+     *
+     * @param string $name
+     *
+     * @return void
+     */
+    public function dropMorphs($name)
+    {
+        $this->dropColumn("{$name}_type", "{$name}_id");
+    }
+
+    /**
      * Rename the table to a given name.
      *
      * @param  string  $to

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -416,11 +416,11 @@ class Blueprint
      */
     public function dropMorphs($name, $indexName = null)
     {
-        $this->dropColumn("{$name}_type", "{$name}_id");
-
         $indexName = $indexName ?: $this->createIndexName('index', ["{$name}_type", "{$name}_id"]);
 
         $this->dropIndex($indexName);
+
+        $this->dropColumn("{$name}_type", "{$name}_id");
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -414,9 +414,13 @@ class Blueprint
      *
      * @return void
      */
-    public function dropMorphs($name)
+    public function dropMorphs($name, $indexName = null)
     {
         $this->dropColumn("{$name}_type", "{$name}_id");
+
+        $indexName = $indexName ?: $this->createIndexName('index', ["{$name}_type", "{$name}_id"]);
+
+        $this->dropIndex($indexName);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -410,7 +410,8 @@ class Blueprint
     /**
      * Indicate that the polymorphic columns should be dropped.
      *
-     * @param string $name
+     * @param string  $name
+     * @param  string|null  $indexName
      *
      * @return void
      */

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -410,7 +410,7 @@ class Blueprint
     /**
      * Indicate that the polymorphic columns should be dropped.
      *
-     * @param string  $name
+     * @param  string  $name
      * @param  string|null  $indexName
      *
      * @return void

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -412,7 +412,6 @@ class Blueprint
      *
      * @param  string  $name
      * @param  string|null  $indexName
-     *
      * @return void
      */
     public function dropMorphs($name, $indexName = null)

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -264,8 +264,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->dropMorphs('imageable');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
-        $this->assertCount(1, $statements);
+        $this->assertCount(2, $statements);
         $this->assertEquals('alter table `photos` drop `imageable_type`, drop `imageable_id`', $statements[0]);
+        $this->assertEquals('alter table `photos` drop index `photos_imageable_type_imageable_id_index`', $statements[1]);
     }
 
     public function testRenameTable()

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -258,6 +258,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
     }
 
+    public function testDropMorphs()
+    {
+        $blueprint = new Blueprint('photos');
+        $blueprint->dropMorphs('imageable');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `photos` drop `imageable_type`, drop `imageable_id`', $statements[0]);
+    }
+
     public function testRenameTable()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -265,8 +265,8 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('alter table `photos` drop `imageable_type`, drop `imageable_id`', $statements[0]);
-        $this->assertEquals('alter table `photos` drop index `photos_imageable_type_imageable_id_index`', $statements[1]);
+        $this->assertEquals('alter table `photos` drop index `photos_imageable_type_imageable_id_index`', $statements[0]);
+        $this->assertEquals('alter table `photos` drop `imageable_type`, drop `imageable_id`', $statements[1]);
     }
 
     public function testRenameTable()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -173,6 +173,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" drop column "created_at", drop column "updated_at"', $statements[0]);
     }
 
+    public function testDropMorphs()
+    {
+        $blueprint = new Blueprint('photos');
+        $blueprint->dropMorphs('imageable');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "photos" drop column "imageable_type", drop column "imageable_id"', $statements[0]);
+    }
+
     public function testRenameTable()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -180,8 +180,8 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('alter table "photos" drop column "imageable_type", drop column "imageable_id"', $statements[0]);
-        $this->assertEquals('drop index "photos_imageable_type_imageable_id_index"', $statements[1]);
+        $this->assertEquals('drop index "photos_imageable_type_imageable_id_index"', $statements[0]);
+        $this->assertEquals('alter table "photos" drop column "imageable_type", drop column "imageable_id"', $statements[1]);
     }
 
     public function testRenameTable()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -179,8 +179,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->dropMorphs('imageable');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
-        $this->assertCount(1, $statements);
+        $this->assertCount(2, $statements);
         $this->assertEquals('alter table "photos" drop column "imageable_type", drop column "imageable_id"', $statements[0]);
+        $this->assertEquals('drop index "photos_imageable_type_imageable_id_index"', $statements[1]);
     }
 
     public function testRenameTable()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -183,6 +183,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" drop column "created_at", "updated_at"', $statements[0]);
     }
 
+    public function testDropMorphs()
+    {
+        $blueprint = new Blueprint('photos');
+        $blueprint->dropMorphs('imageable');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "photos" drop column "imageable_type", "imageable_id"', $statements[0]);
+    }
+
     public function testRenameTable()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -190,8 +190,8 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('alter table "photos" drop column "imageable_type", "imageable_id"', $statements[0]);
-        $this->assertEquals('drop index "photos_imageable_type_imageable_id_index" on "photos"', $statements[1]);
+        $this->assertEquals('drop index "photos_imageable_type_imageable_id_index" on "photos"', $statements[0]);
+        $this->assertEquals('alter table "photos" drop column "imageable_type", "imageable_id"', $statements[1]);
     }
 
     public function testRenameTable()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -189,8 +189,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->dropMorphs('imageable');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
-        $this->assertCount(1, $statements);
+        $this->assertCount(2, $statements);
         $this->assertEquals('alter table "photos" drop column "imageable_type", "imageable_id"', $statements[0]);
+        $this->assertEquals('drop index "photos_imageable_type_imageable_id_index" on "photos"', $statements[1]);
     }
 
     public function testRenameTable()


### PR DESCRIPTION
Resubmitting as suggested in #23400 

> What about tests for SQLite?

@jmarcher This is similar to `dropTimestamps()` and is not tested for the same reason. Both are incompatible with SQLite's restriction on dropping more than one column per 'transaction'.

> Probably would need to drop the index as well. Feel free to re-submit if you want.

@taylorotwell Done.