### PR TITLE
[5.6] Fix use of unique()

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -310,7 +310,7 @@ class Validator implements ValidatorContract
 
         return $data->only(collect($this->getRules())->keys()->map(function ($rule) {
             return Str::contains($rule, '.') ? explode('.', $rule)[0] : $rule;
-        }))->unique()->toArray();
+        })->unique())->toArray();
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3876,12 +3876,15 @@ class ValidationValidatorTest extends TestCase
 
     public function testValidateReturnsValidatedData()
     {
-        $post = ['first' => 'john', 'last' => 'doe', 'type' => 'admin'];
+        $post = ['first' => 'john',  'preferred'=>'john', 'last' => 'doe', 'type' => 'admin'];
 
-        $v = new Validator($this->getIlluminateArrayTranslator(), $post, ['first' => 'required']);
+        $v = new Validator($this->getIlluminateArrayTranslator(), $post, ['first' => 'required', 'preferred'=> 'required']);
+        $v->sometimes('type', 'required', function () {
+            return false;
+        });
         $data = $v->validate();
 
-        $this->assertEquals(['first' => 'john'], $data);
+        $this->assertEquals(['first' => 'john', 'preferred' => 'john'], $data);
     }
 
     protected function getTranslator()


### PR DESCRIPTION
*** **URGENT** ***

The unique() call must be on the keys collection, not on the data collection. Calling unique() on the data collection can result in missing data because unique() de-duplicates based on the VALUES.