### PR TITLE
[5.6] Idea: Add byte() alias for unsignedTinyInteger

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -802,6 +802,19 @@ class Blueprint
     }
 
     /**
+     * Create a new unsigned tiny integer (1-byte) column on the table.
+     *
+     * Alias for self::unsignedTinyInteger().
+     * 
+     * @param string $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function byte($column)
+    {
+        return $this->unsignedTinyInteger($column);
+    }
+
+    /**
      * Create a new enum column on the table.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -805,7 +805,7 @@ class Blueprint
      * Create a new unsigned tiny integer (1-byte) column on the table.
      *
      * Alias for self::unsignedTinyInteger().
-     * 
+     *
      * @param string $column
      * @return \Illuminate\Support\Fluent
      */


### PR DESCRIPTION
Lately I've found myself using `unsignedTinyInteger()` a lot in my migrations, and it feels very verbose for what it actually is (literally just a byte). `byte()` is a lot easier to remember as a syntax and it better expresses what the maximum value is (I've Googled for the maximum sizes of the various int types more than once). 

Since it's just an alias, there should be no issues at all merging this, although the list of Blueprint methods is long as it is.

Thanks in advance!

Footnote: PostgreSQL doesn't support 1-byte integer columns, so the name might be a bit misleading for PostgreSQL users (although the comment/description for `unsignedTinyInteger()` is as well).