### PR TITLE
[5.6] Add faker helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -489,6 +489,19 @@ if (! function_exists('factory')) {
     }
 }
 
+if (! function_exists('faker')) {
+    /**
+     * Create a Faker instance for the given locale.
+     *
+     * @param  string  $locale
+     * @return \Faker\Generator
+     */
+    function faker($locale = null)
+    {
+        return \Faker\Factory::create($locale ?? \Faker\Factory::DEFAULT_LOCALE);
+    }
+}
+
 if (! function_exists('info')) {
     /**
      * Write some information to the log.

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -78,4 +78,10 @@ class FoundationHelpersTest extends TestCase
 
         unlink(public_path('mix-manifest.json'));
     }
+
+    public function testFakerIsCreated()
+    {
+        $this->assertTrue(faker() instanceOf \Faker\Generator);
+        $this->assertTrue(faker('fr_FR') instanceOf \Faker\Generator);
+    }
 }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -81,7 +81,7 @@ class FoundationHelpersTest extends TestCase
 
     public function testFakerIsCreated()
     {
-        $this->assertTrue(faker() instanceOf \Faker\Generator);
-        $this->assertTrue(faker('fr_FR') instanceOf \Faker\Generator);
+        $this->assertTrue(faker() instanceof \Faker\Generator);
+        $this->assertTrue(faker('fr_FR') instanceof \Faker\Generator);
     }
 }


### PR DESCRIPTION
I'm currently adding a new section mockup to an existing app. This helper has been indispensable with creating fake data in my views as quickly as possible to get a visual to the client.

Directly in my mockup view I can...

```html
<span>{{ faker()->firstName }}</span>
```

This makes for some serious Rapid Mockup Development™️ but is also easy enough to add to an app's helpers if not wanted in the core.

This **only works in dev**, not in production as faker is a dev only requirement - but I think that makes sense for a mockup helper.