### PR TITLE
[5.6] Add optional condition to tap()

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1023,19 +1023,22 @@ if (! function_exists('studly_case')) {
 
 if (! function_exists('tap')) {
     /**
-     * Call the given Closure with the given value then return the value.
+     * Call a Closure with a value if the condition is true, then return the value.
      *
      * @param  mixed  $value
      * @param  callable|null  $callback
+     * @param  mixed  $condition
      * @return mixed
      */
-    function tap($value, $callback = null)
+    function tap($value, $callback = null, $condition = true)
     {
         if (is_null($callback)) {
             return new HigherOrderTapProxy($value);
         }
 
-        $callback($value);
+        if ($condition) {
+            $callback($value);
+        }
 
         return $value;
     }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -745,6 +745,11 @@ class SupportHelpersTest extends TestCase
             $object->id = 2;
         })->id);
 
+        $object = (object) ['id' => 1];
+        $this->assertEquals(1, tap($object, function ($object) {
+            $object->id = 2;
+        }, false)->id);
+
         $mock = m::mock();
         $mock->shouldReceive('foo')->once()->andReturn('bar');
         $this->assertEquals($mock, tap($mock)->foo());


### PR DESCRIPTION
I am proposing that a condition be added to `tap()` such that if it is false, then the callback isn't run. For example, I have the following method in my application:

```php
protected function notifyAssignedAgent(Ticket $ticket, Notification $notification)
{
    return tap($ticket->agent, function (User $agent) use ($notification) {
        $agent->notify($notification);
    }, $ticket->agent);
}
```

I wouldn't have to check whether `$ticket->agent` is null, which in some situations may uglify things a bit. In this scenario, another use might include using `$notification->isEnabled()` to ensure the notification hasn't been disabled in its configuration before trying to send it.

## Alternative

An alternative would be to implement this as a new `tap_if()` function, with the signature `tap_if($condition, $value, $callback)`. This would mean:

- The `$condition` could be the first argument, which would make code clearer to anyone reading it (so it would logically read "tap if `$condition`".
- There wouldn't be any confusion if you were to use a false condition *and* provide a null callback, since there are no default arguments.