### PR TITLE
[5.6] Support dot notation in Request object when using ArrayAccess

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -600,8 +600,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function offsetExists($offset)
     {
-        return array_key_exists(
-            $offset, $this->all() + $this->route()->parameters()
+        return Arr::has(
+            $this->all() + $this->route()->parameters(), $offset
         );
     }
 
@@ -658,10 +658,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function __get($key)
     {
-        if (array_key_exists($key, $this->all())) {
-            return data_get($this->all(), $key);
-        }
-
-        return $this->route($key);
+        return Arr::get($this->all(), $key, function () use ($key) {
+            return $this->route($key);
+        });
     }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -308,6 +308,32 @@ class HttpRequestTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\File\UploadedFile', $request['file']);
     }
 
+    public function testArrayAccess()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'foo' => ['bar' => null, 'baz' => '']]);
+        $request->setRouteResolver(function () use ($request) {
+            $route = new Route('GET', '/foo/bar/{id}', []);
+            $route->bind($request);
+            $route->setParameter('id', 'foo');
+
+            return $route;
+        });
+
+        $this->assertFalse(isset($request['non-existant']));
+        $this->assertNull($request['non-existant']);
+
+        $this->assertTrue(isset($request['name']));
+        $this->assertEquals('Taylor', $request['name']);
+
+        $this->assertTrue(isset($request['foo.bar']));
+        $this->assertEquals(null, $request['foo.bar']);
+        $this->assertTrue(isset($request['foo.baz']));
+        $this->assertEquals('', $request['foo.baz']);
+
+        $this->assertTrue(isset($request['id']));
+        $this->assertEquals('foo', $request['id']);
+    }
+
     public function testAllMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);


### PR DESCRIPTION
Currently you can access request's array input using dot notation like this:
```php
$request->input('foo.bar');
// It's also supported when using
$request->only('foo.bar');
$request->all('foo.bar');
```
Although when you try to do the same thing using ArrayAccess (`$request['foo.bar']`) it's not supported which makes it a bit inconsistent.

This adds support of the dot notation when used with ArrayAccess.
```php
$request['foo.bar'];
// and of course
isset($request['foo.bar']);
```
