### PR TITLE
[5.6] change error message for auth driver not defined

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -94,7 +94,7 @@ class AuthManager implements FactoryContract
             return $this->{$driverMethod}($name, $config);
         }
 
-        throw new InvalidArgumentException("Auth guard driver [{$name}] is not defined.");
+        throw new InvalidArgumentException("Auth driver for guard [{$name}] is not defined.");
     }
 
     /**

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -94,7 +94,7 @@ class AuthManager implements FactoryContract
             return $this->{$driverMethod}($name, $config);
         }
 
-        throw new InvalidArgumentException("Auth driver for guard [{$name}] is not defined.");
+        throw new InvalidArgumentException("Auth driver [{$config['driver']}] for guard [{$name}] is not defined.");
     }
 
     /**


### PR DESCRIPTION
Minor tweak to this error message - current wording suggests that the guard is not defined, when in fact it is the guard's driver which isn't defined.

Also lists the name of the missing driver now too.

Previously:

`Auth guard driver [api] is not defined.`

Now:

`Auth driver [jwt] for guard [api] is not defined.`