### PR TITLE
[5.6] Check whether method fetch exists instead of checking variable existence

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -188,7 +188,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     public function output()
     {
-        return $this->lastOutput ? $this->lastOutput->fetch() : '';
+        return (method_exists($this->lastOutput, 'fetch')) ? $this->lastOutput->fetch() : '';
     }
 
     /**


### PR DESCRIPTION
check whether method fetch exists instead of checking variable existence before calling fetch method as $this->lastOutput might be an object of ConsoleOutput which implements OutputInterface but doesn't have fetch method.

Now that its possible to pass OutputInterface which doesn't strict output method and also some will be passing instances of Symfony\Component\Console\Output\ConsoleOutput, in this case, it will through the following error. 
Call to undefined method Symfony\Component\Console\Output\ConsoleOutput::fetch()
To prevent it from throwing error we are checking