### PR TITLE
[5.5] Only set ID on NotificationFake if there is no ID set

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -174,7 +174,9 @@ class NotificationFake implements NotificationFactory, NotificationDispatcher
         }
 
         foreach ($notifiables as $notifiable) {
-            $notification->id = Uuid::uuid4()->toString();
+            if (! $notification->id) {
+                $notification->id = Uuid::uuid4()->toString();
+            }
 
             $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)][] = [
                 'notification' => $notification,

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -46,6 +46,26 @@ class NotificationFakeTest extends TestCase
             $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\NotificationStub] notification was sent.'));
         }
     }
+
+    public function testResettingNotificationId()
+    {
+        $notification = new NotificationStub();
+
+        $this->fake->send($this->user, $notification);
+
+        $id = $notification->id;
+
+        $this->fake->send($this->user, $notification);
+
+        $this->assertSame($id, $notification->id);
+
+        $notification->id = null;
+
+        $this->fake->send($this->user, $notification);
+
+        $this->assertNotNull($notification->id);
+        $this->assertNotSame($id, $notification->id);
+    }
 }
 
 class NotificationStub extends Notification


### PR DESCRIPTION
This PR makes the `NotificationFake@sendNow` method behave the same way as the sending functionality in the `NotificationSender`, in which the sender checks if the notification ID has already been set before setting it.