### PR TITLE
[5.6] Adds before, after and dateEquals to Illuminate\Validation\Rule

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -64,4 +64,37 @@ class Rule
     {
         return new Rules\Unique($table, $column);
     }
+
+    /**
+     * Get a date equals constraint builder instance.
+     *
+     * @param  \DateTime  $date
+     * @return Rules\DateComparison
+     */
+    public static function dateEquals(\DateTime $date)
+    {
+        return new Rules\DateComparison($date);
+    }
+
+    /**
+     * Get a before (date) constraint builder instance.
+     *
+     * @param  \DateTime  $date
+     * @return Rules\DateComparison
+     */
+    public static function before(\DateTime $date)
+    {
+        return (new Rules\DateComparison($date))->before();
+    }
+
+    /**
+     * Get a after (date) constraint builder instance.
+     *
+     * @param  \DateTime  $date
+     * @return Rules\DateComparison
+     */
+    public static function after(\DateTime $date)
+    {
+        return (new Rules\DateComparison($date))->after();
+    }
 }

--- a/src/Illuminate/Validation/Rules/DateComparison.php
+++ b/src/Illuminate/Validation/Rules/DateComparison.php
@@ -36,6 +36,7 @@ class DateComparison
     public function before()
     {
         $this->comparison = 'before';
+
         return $this;
     }
 
@@ -45,6 +46,7 @@ class DateComparison
     public function after()
     {
         $this->comparison = 'after';
+
         return $this;
     }
 
@@ -54,6 +56,7 @@ class DateComparison
     public function orEqual()
     {
         $this->orEqual = true;
+
         return $this;
     }
 

--- a/src/Illuminate/Validation/Rules/DateComparison.php
+++ b/src/Illuminate/Validation/Rules/DateComparison.php
@@ -69,7 +69,7 @@ class DateComparison
             '%s%s:%s',
             $this->comparison,
             $this->orEqual && $this->comparison !== 'date_equals' ? '_or_equal' : '',
-            $this->dateTime->format('Y-m-d H:i:s')
+            $this->dateTime->format('c')
         );
     }
 }

--- a/src/Illuminate/Validation/Rules/DateComparison.php
+++ b/src/Illuminate/Validation/Rules/DateComparison.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use DateTime;
+
+class DateComparison
+{
+    /**
+     * @var DateTime
+     */
+    protected $dateTime;
+
+    /**
+     * @var bool
+     */
+    protected $orEqual = false;
+
+    /**
+     * @var string
+     */
+    protected $comparison = 'date_equals';
+
+    /**
+     * DateComparison constructor.
+     * @param  DateTime  $dateTime
+     */
+    public function __construct(DateTime $dateTime)
+    {
+        $this->dateTime = $dateTime;
+    }
+
+    /**
+     * @return $this
+     */
+    public function before()
+    {
+        $this->comparison = 'before';
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function after()
+    {
+        $this->comparison = 'after';
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function orEqual()
+    {
+        $this->orEqual = true;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return sprintf(
+            '%s%s:%s',
+            $this->comparison,
+            $this->orEqual && $this->comparison !== 'date_equals' ? '_or_equal' : '',
+            $this->dateTime->format('Y-m-d H:i:s')
+        );
+    }
+}

--- a/tests/Validation/ValidationDateComparisonRuleTest.php
+++ b/tests/Validation/ValidationDateComparisonRuleTest.php
@@ -4,8 +4,8 @@ namespace Illuminate\Tests\Validation;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Validation\Rule;
-use Illuminate\Validation\Rules\DateComparison;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Rules\DateComparison;
 
 class ValidationDateComparisonRuleTest extends TestCase
 {

--- a/tests/Validation/ValidationDateComparisonRuleTest.php
+++ b/tests/Validation/ValidationDateComparisonRuleTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\DateComparison;
+use PHPUnit\Framework\TestCase;
+
+class ValidationDateComparisonRuleTest extends TestCase
+{
+    public function testItCorrectlyFormatsAStringVersionOfTheDateEqualsRule()
+    {
+        $rule = new DateComparison(
+            Carbon::create(1977, 05, 25, 06, 52, 59)
+        );
+
+        $this->assertEquals('date_equals:1977-05-25 06:52:59', (string) $rule);
+
+        $rule = (new DateComparison(
+            Carbon::create(1977, 05, 25, 06, 52, 59)
+        ))->orEqual();
+
+        $this->assertEquals('date_equals:1977-05-25 06:52:59', (string) $rule);
+
+        $rule = Rule::dateEquals(Carbon::create(1977, 05, 25, 06, 52, 59));
+
+        $this->assertEquals('date_equals:1977-05-25 06:52:59', (string) $rule);
+    }
+
+    public function testItCorrectlyFormatsAStringVersionOfTheBeforeRule()
+    {
+        $rule = (new DateComparison(
+            Carbon::create(1977, 05, 25, 06, 52, 59)
+        ))->before();
+
+        $this->assertEquals('before:1977-05-25 06:52:59', (string) $rule);
+
+        $rule = Rule::before(Carbon::create(1977, 05, 25, 06, 52, 59));
+
+        $this->assertEquals('before:1977-05-25 06:52:59', (string) $rule);
+    }
+
+    public function testItCorrectlyFormatsAStringVersionOfTheBeforeOrEqualRule()
+    {
+        $rule = (new DateComparison(
+            Carbon::create(1977, 05, 25, 06, 52, 59)
+        ))->before()->orEqual();
+
+        $this->assertEquals('before_or_equal:1977-05-25 06:52:59', (string) $rule);
+
+        $rule = Rule::before(Carbon::create(1977, 05, 25, 06, 52, 59))
+            ->orEqual();
+
+        $this->assertEquals('before_or_equal:1977-05-25 06:52:59', (string) $rule);
+    }
+
+    public function testItCorrectlyFormatsAStringVersionOfTheAfterRule()
+    {
+        $rule = (new DateComparison(
+            Carbon::create(1977, 05, 25, 06, 52, 59)
+        ))->after();
+
+        $this->assertEquals('after:1977-05-25 06:52:59', (string) $rule);
+
+        $rule = Rule::after(Carbon::create(1977, 05, 25, 06, 52, 59));
+
+        $this->assertEquals('after:1977-05-25 06:52:59', (string) $rule);
+    }
+
+    public function testItCorrectlyFormatsAStringVersionOfTheAfterOrEqualRule()
+    {
+        $rule = (new DateComparison(
+            Carbon::create(1977, 05, 25, 06, 52, 59)
+        ))->after()->orEqual();
+
+        $this->assertEquals('after_or_equal:1977-05-25 06:52:59', (string) $rule);
+
+        $rule = Rule::after(Carbon::create(1977, 05, 25, 06, 52, 59))
+            ->orEqual();
+
+        $this->assertEquals('after_or_equal:1977-05-25 06:52:59', (string) $rule);
+    }
+}

--- a/tests/Validation/ValidationDateComparisonRuleTest.php
+++ b/tests/Validation/ValidationDateComparisonRuleTest.php
@@ -15,17 +15,17 @@ class ValidationDateComparisonRuleTest extends TestCase
             Carbon::create(1977, 05, 25, 06, 52, 59)
         );
 
-        $this->assertEquals('date_equals:1977-05-25 06:52:59', (string) $rule);
+        $this->assertEquals('date_equals:1977-05-25T06:52:59+00:00', (string) $rule);
 
         $rule = (new DateComparison(
             Carbon::create(1977, 05, 25, 06, 52, 59)
         ))->orEqual();
 
-        $this->assertEquals('date_equals:1977-05-25 06:52:59', (string) $rule);
+        $this->assertEquals('date_equals:1977-05-25T06:52:59+00:00', (string) $rule);
 
         $rule = Rule::dateEquals(Carbon::create(1977, 05, 25, 06, 52, 59));
 
-        $this->assertEquals('date_equals:1977-05-25 06:52:59', (string) $rule);
+        $this->assertEquals('date_equals:1977-05-25T06:52:59+00:00', (string) $rule);
     }
 
     public function testItCorrectlyFormatsAStringVersionOfTheBeforeRule()
@@ -34,11 +34,11 @@ class ValidationDateComparisonRuleTest extends TestCase
             Carbon::create(1977, 05, 25, 06, 52, 59)
         ))->before();
 
-        $this->assertEquals('before:1977-05-25 06:52:59', (string) $rule);
+        $this->assertEquals('before:1977-05-25T06:52:59+00:00', (string) $rule);
 
         $rule = Rule::before(Carbon::create(1977, 05, 25, 06, 52, 59));
 
-        $this->assertEquals('before:1977-05-25 06:52:59', (string) $rule);
+        $this->assertEquals('before:1977-05-25T06:52:59+00:00', (string) $rule);
     }
 
     public function testItCorrectlyFormatsAStringVersionOfTheBeforeOrEqualRule()
@@ -47,12 +47,12 @@ class ValidationDateComparisonRuleTest extends TestCase
             Carbon::create(1977, 05, 25, 06, 52, 59)
         ))->before()->orEqual();
 
-        $this->assertEquals('before_or_equal:1977-05-25 06:52:59', (string) $rule);
+        $this->assertEquals('before_or_equal:1977-05-25T06:52:59+00:00', (string) $rule);
 
         $rule = Rule::before(Carbon::create(1977, 05, 25, 06, 52, 59))
             ->orEqual();
 
-        $this->assertEquals('before_or_equal:1977-05-25 06:52:59', (string) $rule);
+        $this->assertEquals('before_or_equal:1977-05-25T06:52:59+00:00', (string) $rule);
     }
 
     public function testItCorrectlyFormatsAStringVersionOfTheAfterRule()
@@ -61,11 +61,11 @@ class ValidationDateComparisonRuleTest extends TestCase
             Carbon::create(1977, 05, 25, 06, 52, 59)
         ))->after();
 
-        $this->assertEquals('after:1977-05-25 06:52:59', (string) $rule);
+        $this->assertEquals('after:1977-05-25T06:52:59+00:00', (string) $rule);
 
         $rule = Rule::after(Carbon::create(1977, 05, 25, 06, 52, 59));
 
-        $this->assertEquals('after:1977-05-25 06:52:59', (string) $rule);
+        $this->assertEquals('after:1977-05-25T06:52:59+00:00', (string) $rule);
     }
 
     public function testItCorrectlyFormatsAStringVersionOfTheAfterOrEqualRule()
@@ -74,11 +74,11 @@ class ValidationDateComparisonRuleTest extends TestCase
             Carbon::create(1977, 05, 25, 06, 52, 59)
         ))->after()->orEqual();
 
-        $this->assertEquals('after_or_equal:1977-05-25 06:52:59', (string) $rule);
+        $this->assertEquals('after_or_equal:1977-05-25T06:52:59+00:00', (string) $rule);
 
         $rule = Rule::after(Carbon::create(1977, 05, 25, 06, 52, 59))
             ->orEqual();
 
-        $this->assertEquals('after_or_equal:1977-05-25 06:52:59', (string) $rule);
+        $this->assertEquals('after_or_equal:1977-05-25T06:52:59+00:00', (string) $rule);
     }
 }


### PR DESCRIPTION
Allows for the easier creation of dynamic/relative date rules for date before, after and equals validation using DateTime instances through Illuminate\Validation\Rule.

I know strtotime() can handle relative dates quite well but I much prefer using Carbon to handle this myself, this also makes it easier if you already have a Carbon/DateTime instance and you want to produce a relative value from that instance.

```php
$this->validate($request, [
    'scheduled_for' => Rule::dateEquals(now()->addWeek()->startOfDay()),
]);

$this->validate($request, [
    'scheduled_for' => Rule::before(now()->addWeek()->startOfDay()),
]);

 $this->validate($request, [
    'scheduled_for' => Rule::before(now()->addWeek()->startOfDay())->orEqual(),
]);

$this->validate($request, [
    'scheduled_for' => Rule::after(now()->subWeek()->endOfDay()),
]);

$this->validate($request, [
    'scheduled_for' => Rule::after(now()->subWeek()->endOfDay())->orEqual(),
]);
```