### PR TITLE
[5.6] Improving asset loading

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -11,7 +11,7 @@
     <title>{{ config('app.name', 'Laravel') }}</title>
 
     <!-- Scripts -->
-    <script src="{{ asset('js/app.js') }}"></script>
+    <script src="{{ asset('js/app.js') }}" defer></script>
 
     <!-- Fonts -->
     <link rel="dns-prefetch" href="https://fonts.gstatic.com">

--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -10,6 +10,13 @@
 
     <title>{{ config('app.name', 'Laravel') }}</title>
 
+    <!-- Scripts -->
+    <script src="{{ asset('js/app.js') }}"></script>
+
+    <!-- Fonts -->
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css?family=Raleway:300,400,600" rel="stylesheet" type="text/css">
+
     <!-- Styles -->
     <link href="{{ asset('css/app.css') }}" rel="stylesheet">
 </head>
@@ -64,8 +71,5 @@
             @yield('content')
         </main>
     </div>
-
-    <!-- Scripts -->
-    <script src="{{ asset('js/app.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
The fonts requested via the Google stylesheet take time to load and a fair amount of time to lookup the DNS. So prefetch the DNS for the font files.
The Google Stylesheet doesn't start downloading until it's `@import` is discovered in app.css (see https://github.com/laravel/laravel/pull/4603). Moving it to the HTML will make it load sooner. (Another option would just be to preload the Google Stylesheet from the HTML and leave the CSS reference in app.css)
The Javascript should be placed higher so that it is discovered soon and can be downloaded as soon as the HTML parser finds it. If this Javascript is not critical to the page, we should add the `defer` attribute should be used instead of moving the tag to the bottom of the page.