### PR TITLE
[5.6] Optimize query builder's pluck() method

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1315,7 +1315,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $results);
     }
 
-    public function testListMethodsGetsArrayOfColumnValues()
+    public function testPluckMethodGetsCollectionOfColumnValues()
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->andReturn([['foo' => 'bar'], ['foo' => 'baz']]);


### PR DESCRIPTION
Proposed by @vlakoff in https://github.com/laravel/ideas/issues/98 and yesterday acknowledged by Taylor...

This refactors the `pluck` method (and, to stay DRY, the `get` method) of `Illuminate\Database\Query\Builder` to no longer rely on `object_get` internally. As reported in the aforementioned issue, this can become a bottleneck when looping over a large number of results.

I've inlined `Collection::pluck` and then `Arr::pluck`, subsequently throwing away any overly generic code that is not necessary in this use case - because we know the data type of query results. Also, we don't need the other features of `object_get`, such as dot notation and default values.