### PR TITLE
[5.7] Make MessageBag constructor behaviour consistent with `add`

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -34,8 +34,9 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     public function __construct(array $messages = [])
     {
         foreach ($messages as $key => $value) {
-            $this->messages[$key] = $value instanceof Arrayable
-                    ? $value->toArray() : (array) $value;
+            $value = $value instanceof Arrayable ? $value->toArray() : (array) $value;
+
+            $this->messages[$key] = array_unique($value);
         }
     }
 

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -298,4 +298,11 @@ class SupportMessageBagTest extends TestCase
         $container->setFormat(':message');
         $this->assertEquals(':message', $container->getFormat());
     }
+
+    public function testConstructorUniqueness()
+    {
+        $messageBag = new MessageBag(['messages' => ['first', 'second', 'third', 'third']]);
+        $messages = $messageBag->getMessages();
+        $this->assertEquals(['first', 'second', 'third'], $messages['messages']);
+    }
 }

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -299,9 +299,17 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals(':message', $container->getFormat());
     }
 
-    public function testConstructorUniqueness()
+    public function testConstructorUniquenessConsistency()
     {
         $messageBag = new MessageBag(['messages' => ['first', 'second', 'third', 'third']]);
+        $messages = $messageBag->getMessages();
+        $this->assertEquals(['first', 'second', 'third'], $messages['messages']);
+
+        $messageBag = new MessageBag;
+        $messageBag->add('messages', 'first');
+        $messageBag->add('messages', 'second');
+        $messageBag->add('messages', 'third');
+        $messageBag->add('messages', 'third');
         $messages = $messageBag->getMessages();
         $this->assertEquals(['first', 'second', 'third'], $messages['messages']);
     }


### PR DESCRIPTION
Addresses laravel/ideas#56 and the (long-closed) #13196.

This change in constructor behaviour aims to bring consistency with the public `add` method on the MessageBag class, which would prevent duplicate values in any given MessageBag's key.

Targeting next as this could affect user-land code.