### PR TITLE
[5.6] Add static getTableName helper

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1354,6 +1354,18 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         return $this->getKeyName();
     }
 
+
+    /**
+     * Get the table name for the model.
+     *
+     * @return string
+     */
+    public static function getTableName()
+    {
+        return (new static)->getTable();
+    }
+
+
     /**
      * Retrieve the model for a bound value.
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1354,7 +1354,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         return $this->getKeyName();
     }
 
-
     /**
      * Get the table name for the model.
      *
@@ -1364,7 +1363,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         return (new static)->getTable();
     }
-
 
     /**
      * Retrieve the model for a bound value.


### PR DESCRIPTION
Having a static method on the model is a cleaner and more dynamic way of getting the table name. It can be very helpful in many areas but especially in tests where you do not have a model instance.

Now you can have database assertions like below.


```
$this->assertDatabaseHas(
      Product::getTableName(), [
            'id'   => $id,
            'name' => 'Abc'
      ]
)
```

This is not something new (already documented here #1436) but since I am extending the model in every project I work with, I think the community would find this helpful too.