### PR TITLE
Show migration command output 

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -70,13 +70,6 @@ class MigrateCommand extends BaseCommand
             'step' => $this->option('step'),
         ], $this->getOutput());
 
-        // Once the migrator has run we will grab the note output and send it out to
-        // the console screen, since the migrator itself functions without having
-        // any instances of the OutputInterface contract passed into the class.
-        foreach ($this->migrator->getNotes() as $note) {
-            $this->output->writeln($note);
-        }
-
         // Finally, if the "seed" option has been given, we will re-run the database
         // seed task to re-populate the database, which is convenient when adding
         // a migration and a seed at the same time, as it is only this command.

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -68,7 +68,7 @@ class MigrateCommand extends BaseCommand
         $this->migrator->run($this->getMigrationPaths(), [
             'pretend' => $this->option('pretend'),
             'step' => $this->option('step'),
-        ]);
+        ], $this->getOutput());
 
         // Once the migrator has run we will grab the note output and send it out to
         // the console screen, since the migrator itself functions without having

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -51,6 +51,15 @@ class Migrator
      * @var array
      */
     protected $paths = [];
+    
+    
+    /**
+     * The paths to all of the migration files.
+     *
+     * @var Symfony\Component\Console\Output\OutputInterface
+     */
+    protected $output;
+    
 
     /**
      * Create a new migrator instance.
@@ -74,10 +83,13 @@ class Migrator
      *
      * @param  array|string  $paths
      * @param  array  $options
+     * @params Symfony\Component\Console\Output\OutputInterface $output
      * @return array
      */
-    public function run($paths = [], array $options = [])
+    public function run($paths = [], array $options = [], OutputInterface $output = null)
     {
+        $this->output = $output;
+        
         $this->notes = [];
 
         // Once we grab all of the migration files for the path, we will compare them
@@ -563,6 +575,10 @@ class Migrator
      */
     protected function note($message)
     {
+        if ($this->output) {
+            $this->output->writeln($message);
+        }
+        
         $this->notes[] = $message;
     }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -582,6 +582,7 @@ class Migrator
 
     /**
      * Raise a note event for the migrator.
+     * If Output Interface is set, writes a line to output
      *
      * @param  string  $message
      * @return void

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -6,8 +6,8 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Symfony\Component\Console\Output\OutputInterface;
+use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 class Migrator
 {
@@ -581,8 +581,7 @@ class Migrator
     }
 
     /**
-     * Raise a note event for the migrator.
-     * If Output Interface is set, writes a line to output
+     * Raise a note event for the migrator.If output is set, writes a line to output
      *
      * @param  string  $message
      * @return void

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -89,7 +89,9 @@ class Migrator
      */
     public function run($paths = [], array $options = [], OutputInterface $output = null)
     {
-        $this->output = $output;
+        if ($output) {
+            $this->setOutput($output);
+        }
         
         $this->notes = [];
 
@@ -566,6 +568,16 @@ class Migrator
     public function getFilesystem()
     {
         return $this->files;
+    }
+    
+    /**
+     * Set the default OutputInterface instance
+     *
+     * @params Symfony\Component\Console\Output\OutputInterface $output
+     */
+    public function setOutput($output)
+    {
+        $this->output = $output;
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -52,7 +52,7 @@ class Migrator
      * @var array
      */
     protected $paths = [];
-    
+
     /**
      * The paths to all of the migration files.
      *
@@ -90,7 +90,7 @@ class Migrator
         if ($output) {
             $this->setOutput($output);
         }
-        
+
         $this->notes = [];
 
         // Once we grab all of the migration files for the path, we will compare them
@@ -567,7 +567,7 @@ class Migrator
     {
         return $this->files;
     }
-    
+
     /**
      * Set the default OutputInterface instance
      *
@@ -589,7 +589,7 @@ class Migrator
         if ($this->output) {
             $this->output->writeln($message);
         }
-        
+
         $this->notes[] = $message;
     }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -569,7 +569,7 @@ class Migrator
     }
 
     /**
-     * Set the output instance
+     * Set the output instance.
      *
      * @params Symfony\Component\Console\Output\OutputInterface $output
      */
@@ -579,7 +579,7 @@ class Migrator
     }
 
     /**
-     * Raise a note event for the migrator, if an output is set, prints to the output
+     * Raise a note event for the migrator, if an output is set, prints to the output.
      *
      * @param  string  $message
      * @return void

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -569,7 +569,7 @@ class Migrator
     }
 
     /**
-     * Set the default OutputInterface instance
+     * Set the output instance
      *
      * @params Symfony\Component\Console\Output\OutputInterface $output
      */
@@ -579,7 +579,7 @@ class Migrator
     }
 
     /**
-     * Raise a note event for the migrator.If output is set, writes a line to output
+     * Raise a note event for the migrator, if an output is set, prints to the output
      *
      * @param  string  $message
      * @return void

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class Migrator
 {

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -53,14 +53,12 @@ class Migrator
      */
     protected $paths = [];
     
-    
     /**
      * The paths to all of the migration files.
      *
      * @var Symfony\Component\Console\Output\OutputInterface
      */
     protected $output;
-    
 
     /**
      * Create a new migrator instance.


### PR DESCRIPTION
Added optional OutputInterface to print migration command outputs to console as soon as action is performed, without waiting for it to finsih. This change will also allow outputs to be displayed when Migrator is ran through commands inside another, no matter how deep the call is made.