### PR TITLE
[5.6] Add 'after' callback for model factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -23,6 +23,13 @@ class Factory implements ArrayAccess
     protected $states = [];
 
     /**
+     * The registered callbacks.
+     *
+     * @var array
+     */
+    protected $after = [];
+
+    /**
      * The Faker instance for the builder.
      *
      * @var \Faker\Generator
@@ -93,6 +100,26 @@ class Factory implements ArrayAccess
     public function state($class, $state, $attributes)
     {
         $this->states[$class][$state] = $attributes;
+
+        return $this;
+    }
+
+    /**
+     * Define a callback to run after an action.
+     *
+     * @param  string  $class
+     * @param  string  $action
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function after($class, $action, $callback = null)
+    {
+        if (is_callable($action) && $callback === null) {
+            $callback = $action;
+            $action = 'create';
+        }
+
+        $this->after[$class][$action] = $callback;
 
         return $this;
     }
@@ -184,7 +211,7 @@ class Factory implements ArrayAccess
      */
     public function of($class, $name = 'default')
     {
-        return new FactoryBuilder($class, $name, $this->definitions, $this->states, $this->faker);
+        return new FactoryBuilder($class, $name, $this->definitions, $this->states, $this->after, $this->faker);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -193,6 +193,7 @@ class FactoryBuilder
     {
         if ($this->amount === null) {
             $instance = $this->makeInstance($attributes);
+
             return $this->applyAfter(collect([$instance]), 'make');
         }
 
@@ -203,6 +204,7 @@ class FactoryBuilder
         $instances = (new $this->class)->newCollection(array_map(function () use ($attributes) {
             return $this->makeInstance($attributes);
         }, range(1, $this->amount)));
+
         return $this->applyAfter($instances, 'make');
     }
 
@@ -342,7 +344,7 @@ class FactoryBuilder
     }
 
     /**
-     * Run after callback on a collection of models
+     * Run after callback on a collection of models.
      *
      * @param  \Illuminate\Support\Collection  $results
      * @param  string  $action

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -193,8 +193,9 @@ class FactoryBuilder
     {
         if ($this->amount === null) {
             $instance = $this->makeInstance($attributes);
+            $this->applyAfter(collect([$instance]), 'make');
 
-            return $this->applyAfter(collect([$instance]), 'make');
+            return $instance;
         }
 
         if ($this->amount < 1) {
@@ -204,8 +205,9 @@ class FactoryBuilder
         $instances = (new $this->class)->newCollection(array_map(function () use ($attributes) {
             return $this->makeInstance($attributes);
         }, range(1, $this->amount)));
+        $this->applyAfter($instances, 'make');
 
-        return $this->applyAfter($instances, 'make');
+        return $instances;
     }
 
     /**
@@ -346,7 +348,7 @@ class FactoryBuilder
     /**
      * Run after callback on a collection of models.
      *
-     * @param  \Illuminate\Support\Collection  $results
+     * @param  \Illuminate\Support\Collection  $models
      * @param  string  $action
      * @return void
      */
@@ -359,7 +361,5 @@ class FactoryBuilder
 
             call_user_func_array($this->after[$this->class][$action], [$model, $this->faker]);
         });
-
-        return $models;
     }
 }

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -42,12 +42,12 @@ class EloquentFactoryBuilderTest extends TestCase
             return [
                 'user_id' => function () {
                     return factory(FactoryBuildableUser::class)->create()->id;
-                }
+                },
             ];
         });
 
         $factory->after(FactoryBuildableUser::class, 'make', function (FactoryBuildableUser $user, Generator $faker) {
-            $profile =factory(FactoryBuildableProfile::class)->make(['user_id' => $user->id]);
+            $profile = factory(FactoryBuildableProfile::class)->make(['user_id' => $user->id]);
             $user->setRelation('profile', $profile);
         });
 

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -38,6 +38,32 @@ class EloquentFactoryBuilderTest extends TestCase
             ];
         });
 
+        $factory->define(FactoryBuildableProfile::class, function (Generator $faker) {
+            return [
+                'user_id' => function () {
+                    return factory(FactoryBuildableUser::class)->create()->id;
+                }
+            ];
+        });
+
+        $factory->after(FactoryBuildableUser::class, 'make', function (FactoryBuildableUser $user, Generator $faker) {
+            $profile =factory(FactoryBuildableProfile::class)->make(['user_id' => $user->id]);
+            $user->setRelation('profile', $profile);
+        });
+
+        $factory->define(FactoryBuildableTeam::class, function (Generator $faker) {
+            return [
+                'name' => $faker->name,
+                'owner_id' => function () {
+                    return factory(FactoryBuildableUser::class)->create()->id;
+                },
+            ];
+        });
+
+        $factory->after(FactoryBuildableTeam::class, function (FactoryBuildableTeam $team, Generator $faker) {
+            $team->users()->attach($team->owner);
+        });
+
         $factory->define(FactoryBuildableServer::class, function (Generator $faker) {
             return [
                 'name' => $faker->name,
@@ -70,6 +96,23 @@ class EloquentFactoryBuilderTest extends TestCase
             $table->increments('id');
             $table->string('name');
             $table->string('email');
+        });
+
+        Schema::create('profiles', function ($table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id');
+        });
+
+        Schema::create('teams', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('owner_id');
+        });
+
+        Schema::create('team_users', function ($table) {
+            $table->increments('id');
+            $table->unsignedInteger('team_id');
+            $table->unsignedInteger('user_id');
         });
 
         Schema::connection('alternative-connection')->create('users', function ($table) {
@@ -183,6 +226,14 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertTrue($user->is($dbUser));
     }
 
+    /** @test **/
+    public function creating_models_with_after_callback()
+    {
+        $team = factory(FactoryBuildableTeam::class)->create();
+
+        $this->assertTrue($team->users->contains($team->owner));
+    }
+
     /** @test */
     public function making_models_with_a_custom_connection()
     {
@@ -191,6 +242,14 @@ class EloquentFactoryBuilderTest extends TestCase
             ->make();
 
         $this->assertEquals('alternative-connection', $user->getConnectionName());
+    }
+
+    /** @test **/
+    public function making_models_with_after_callback()
+    {
+        $user = factory(FactoryBuildableUser::class)->make();
+
+        $this->assertNotNull($user->profile);
     }
 }
 
@@ -203,6 +262,45 @@ class FactoryBuildableUser extends Model
     public function servers()
     {
         return $this->hasMany(FactoryBuildableServer::class, 'user_id');
+    }
+
+    public function profile()
+    {
+        return $this->hasOne(FactoryBuildableProfile::class, 'user_id');
+    }
+}
+
+class FactoryBuildableProfile extends Model
+{
+    public $table = 'profiles';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+
+    public function user()
+    {
+        return $this->belongsTo(FactoryBuildableUser::class, 'user_id');
+    }
+}
+
+class FactoryBuildableTeam extends Model
+{
+    public $table = 'teams';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+
+    public function owner()
+    {
+        return $this->belongsTo(FactoryBuildableUser::class, 'owner_id');
+    }
+
+    public function users()
+    {
+        return $this->belongsToMany(
+            FactoryBuildableUser::class,
+            'team_users',
+            'team_id',
+            'user_id'
+        );
     }
 }
 


### PR DESCRIPTION
This PR implements the ability to add an `after` callback for model factories. The callback allows the user to define an action to be run after the model is created or made. A common use case for this behavior is to associate a user who is the owner of a group or team with the group or team, or to create an associated profile record for a new user model.

```php
# TeamFactory.php

use Faker\Generator as Faker;

$factory->define(\App\Team::class, function (Faker $faker) {
    return [
        'name' => $faker->company,
        'slug' => $faker->slug(2),
        'owner_id' => function () {
            return factory(\App\User::class)->create()->id;
        },
    ];
});

$factory->after(\App\Team::class, 'create', function(\App\Team $team, Faker $faker) {
   $team->users()->attach($team->owner, ['role' => 'owner']);
});
```

If the action is omitted from the after function call, 'create' is assumed. Simplified ussage documentation snippet below:

# After Callbacks

After callbacks allow you to define additional required logic to run after a model is created by a model factory. For example, your User model might have a required profile model, or you have a group or team model that has an owner but also requires the user to be added to a pivot table. 

```php
$factory->after(\App\Team::class, function(\App\Team $team, Faker $faker) {
     $team->users()->attach($team->owner, ['role' => 'owner']);
});
```

By default after callbacks are run after a model is created; if you want to run a callback after a make() call you can define the action the callback is to be run after as a third argument. 


```php
$factory->after(\App\User::class, 'make', function(\App\User $user, Faker $faker) {
     $profile = factory(\App\Profile::class)->make(['user_id' => $user->id]);
     $user->setRelation('profile', $profile);
});
```