### PR TITLE
[5.6] Add filledAny method to Request

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -131,7 +131,7 @@ trait InteractsWithInput
         return true;
     }
 
-        /**
+    /**
      * Determine if the request contains a non-empty value for any of the given inputs.
      *
      * @param  string|array  $keys

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -131,6 +131,25 @@ trait InteractsWithInput
         return true;
     }
 
+        /**
+     * Determine if the request contains a non-empty value for any of the given inputs.
+     *
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public function filledAny($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        foreach ($keys as $key) {
+            if ($this->filled($key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Determine if the given input key is an empty string for "has".
      *

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -304,6 +304,12 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->filledAny(['name']));
         $this->assertTrue($request->filledAny('name'));
 
+        $this->assertFalse($request->filledAny(['age']));
+        $this->assertFalse($request->filledAny('age'));
+
+        $this->assertFalse($request->filledAny(['foo']));
+        $this->assertFalse($request->filledAny('foo'));
+
         $this->assertTrue($request->filledAny(['age', 'name']));
         $this->assertTrue($request->filledAny('age', 'name'));
 
@@ -312,6 +318,9 @@ class HttpRequestTest extends TestCase
 
         $this->assertFalse($request->filledAny('age', 'city'));
         $this->assertFalse($request->filledAny('age', 'city'));
+
+        $this->assertFalse($request->filledAny('foo', 'bar'));
+        $this->assertFalse($request->filledAny('foo', 'bar'));
     }
 
     public function testInputMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -297,6 +297,23 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->filled('foo.bar'));
     }
 
+    public function testFilledAnyMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
+
+        $this->assertTrue($request->filledAny(['name']));
+        $this->assertTrue($request->filledAny('name'));
+
+        $this->assertTrue($request->filledAny(['age', 'name']));
+        $this->assertTrue($request->filledAny('age', 'name'));
+
+        $this->assertTrue($request->filledAny(['foo', 'name']));
+        $this->assertTrue($request->filledAny('foo', 'name'));
+
+        $this->assertFalse($request->filledAny('age', 'city'));
+        $this->assertFalse($request->filledAny('age', 'city'));
+    }
+
     public function testInputMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);


### PR DESCRIPTION
Currently to determine if the request has any *filled* values of a list of inputs, you do something like this:

```php
if ($request->filled('disk') || $request->filled('site')) {
    //
}
```

This allows you to check if the request has filled values for *any* of the keys - similar to the existing `hasAny`.

```php
if ($request->filledAny($filters)) {
    //
}
```

Although `$request->filled($keys)` accepts an array, it checks to determine if *all* the keys exist rather than *any*.