### PR TITLE
[5.7] Database migrator print realtime

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -4,6 +4,7 @@ namespace Illuminate\Console\Scheduling;
 
 use Closure;
 use Cron\CronExpression;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Contracts\Mail\Mailer;
@@ -377,7 +378,7 @@ class Event
     {
         $this->ensureOutputIsBeingCapturedForEmail();
 
-        $addresses = is_array($addresses) ? $addresses : [$addresses];
+        $addresses = Arr::wrap($addresses);
 
         return $this->then(function (Mailer $mailer) use ($addresses, $onlyIfOutputExists) {
             $this->emailOutput($mailer, $addresses, $onlyIfOutputExists);

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -68,14 +68,7 @@ class MigrateCommand extends BaseCommand
         $this->migrator->run($this->getMigrationPaths(), [
             'pretend' => $this->option('pretend'),
             'step' => $this->option('step'),
-        ]);
-
-        // Once the migrator has run we will grab the note output and send it out to
-        // the console screen, since the migrator itself functions without having
-        // any instances of the OutputInterface contract passed into the class.
-        foreach ($this->migrator->getNotes() as $note) {
-            $this->output->writeln($note);
-        }
+        ], $this->getOutput());
 
         // Finally, if the "seed" option has been given, we will re-run the database
         // seed task to re-populate the database, which is convenient when adding

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -65,15 +65,8 @@ class ResetCommand extends BaseCommand
         }
 
         $this->migrator->reset(
-            $this->getMigrationPaths(), $this->option('pretend')
+            $this->getMigrationPaths(), $this->option('pretend'), $this->getOutput()
         );
-
-        // Once the migrator has run we will grab the note output and send it out to
-        // the console screen, since the migrator itself functions without having
-        // any instances of the OutputInterface contract passed into the class.
-        foreach ($this->migrator->getNotes() as $note) {
-            $this->output->writeln($note);
-        }
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -61,15 +61,8 @@ class RollbackCommand extends BaseCommand
             $this->getMigrationPaths(), [
                 'pretend' => $this->option('pretend'),
                 'step' => (int) $this->option('step'),
-            ]
+            ], $this->getOutput()
         );
-
-        // Once the migrator has run we will grab the note output and send it out to
-        // the console screen, since the migrator itself functions without having
-        // any instances of the OutputInterface contract passed into the class.
-        foreach ($this->migrator->getNotes() as $note) {
-            $this->output->writeln($note);
-        }
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -82,14 +82,12 @@ class Migrator
      *
      * @param  array|string  $paths
      * @param  array  $options
-     * @params Symfony\Component\Console\Output\OutputInterface $output
+     * @param Symfony\Component\Console\Output\OutputInterface $output
      * @return array
      */
     public function run($paths = [], array $options = [], OutputInterface $output = null)
     {
-        if ($output) {
-            $this->setOutput($output);
-        }
+        $this->setOutput($output);
 
         $this->notes = [];
 
@@ -202,10 +200,13 @@ class Migrator
      *
      * @param  array|string $paths
      * @param  array  $options
+     * @param Symfony\Component\Console\Output\OutputInterface $output
      * @return array
      */
-    public function rollback($paths = [], array $options = [])
+    public function rollback($paths = [], array $options = [], OutputInterface $output = null)
     {
+        $this->setOutput($output);
+
         $this->notes = [];
 
         // We want to pull in the last batch of migrations that ran on the previous
@@ -279,10 +280,13 @@ class Migrator
      *
      * @param  array|string $paths
      * @param  bool  $pretend
+     * @param Symfony\Component\Console\Output\OutputInterface $output
      * @return array
      */
-    public function reset($paths = [], $pretend = false)
+    public function reset($paths = [], $pretend = false, OutputInterface $output = null)
     {
+        $this->setOutput($output);
+
         $this->notes = [];
 
         // Next, we will reverse the migration list so we can run them back in the
@@ -571,7 +575,8 @@ class Migrator
     /**
      * Set the output instance.
      *
-     * @params Symfony\Component\Console\Output\OutputInterface $output
+     * @param Symfony\Component\Console\Output\OutputInterface $output
+     * @return  void
      */
     public function setOutput($output)
     {

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Output\OutputInterface;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 class Migrator
@@ -53,6 +54,13 @@ class Migrator
     protected $paths = [];
 
     /**
+     * The paths to all of the migration files.
+     *
+     * @var Symfony\Component\Console\Output\OutputInterface
+     */
+    protected $output;
+
+    /**
      * Create a new migrator instance.
      *
      * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
@@ -74,10 +82,15 @@ class Migrator
      *
      * @param  array|string  $paths
      * @param  array  $options
+     * @params Symfony\Component\Console\Output\OutputInterface $output
      * @return array
      */
-    public function run($paths = [], array $options = [])
+    public function run($paths = [], array $options = [], OutputInterface $output = null)
     {
+        if ($output) {
+            $this->setOutput($output);
+        }
+
         $this->notes = [];
 
         // Once we grab all of the migration files for the path, we will compare them
@@ -556,13 +569,27 @@ class Migrator
     }
 
     /**
-     * Raise a note event for the migrator.
+     * Set the output instance.
+     *
+     * @params Symfony\Component\Console\Output\OutputInterface $output
+     */
+    public function setOutput($output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * Raise a note event for the migrator, if an output is set, prints to the output.
      *
      * @param  string  $message
      * @return void
      */
     protected function note($message)
     {
+        if ($this->output) {
+            $this->output->writeln($message);
+        }
+
         $this->notes[] = $message;
     }
 

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use Throwable;
 use ReflectionClass;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Symfony\Component\Finder\Finder;
@@ -195,7 +196,7 @@ class Kernel implements KernelContract
      */
     protected function load($paths)
     {
-        $paths = array_unique(is_array($paths) ? $paths : (array) $paths);
+        $paths = array_unique(Arr::wrap($paths));
 
         $paths = array_filter($paths, function ($path) {
             return is_dir($path);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -153,7 +153,7 @@ class Str
      */
     public static function is($pattern, $value)
     {
-        $patterns = is_array($pattern) ? $pattern : (array) $pattern;
+        $patterns = Arr::wrap($pattern);
 
         if (empty($patterns)) {
             return false;

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
+use Symfony\Component\Console\Output\OutputInterface;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 
 class DatabaseMigrationMigrateCommandTest extends TestCase
@@ -22,8 +23,8 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false], m::type('Symfony\Component\Console\Output\OutputInterface'));
+        $migrator->shouldNotReceive('getNotes');
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command);
@@ -38,8 +39,8 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false], m::type('Symfony\Component\Console\Output\OutputInterface'));
+        $migrator->shouldNotReceive('getNotes');
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(false);
         $command->expects($this->once())->method('call')->with($this->equalTo('migrate:install'), $this->equalTo(['--database' => null]));
 
@@ -54,8 +55,8 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => false]);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => false], m::type('Symfony\Component\Console\Output\OutputInterface'));
+        $migrator->shouldNotReceive('getNotes');
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--pretend' => true]);
@@ -69,8 +70,8 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with('foo');
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false], m::type('Symfony\Component\Console\Output\OutputInterface'));
+        $migrator->shouldNotReceive('getNotes');
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--database' => 'foo']);
@@ -84,8 +85,8 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => true]);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => true], m::type('Symfony\Component\Console\Output\OutputInterface'));
+        $migrator->shouldNotReceive('getNotes');
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--step' => true]);

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Database;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
-use Symfony\Component\Console\Output\OutputInterface;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 
 class DatabaseMigrationMigrateCommandTest extends TestCase

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -23,8 +23,8 @@ class DatabaseMigrationResetCommandTest extends TestCase
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
-        $migrator->shouldReceive('reset')->once()->with([__DIR__.'/migrations'], false);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('reset')->once()->with([__DIR__.'/migrations'], false, m::type('Symfony\Component\Console\Output\OutputInterface'));
+        $migrator->shouldNotReceive('getNotes');
 
         $this->runCommand($command);
     }
@@ -38,8 +38,8 @@ class DatabaseMigrationResetCommandTest extends TestCase
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with('foo');
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
-        $migrator->shouldReceive('reset')->once()->with([__DIR__.'/migrations'], true);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('reset')->once()->with([__DIR__.'/migrations'], true, m::type('Symfony\Component\Console\Output\OutputInterface'));
+        $migrator->shouldNotReceive('getNotes');
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
     }

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -22,8 +22,8 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], ['pretend' => false, 'step' => 0]);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], ['pretend' => false, 'step' => 0], m::type('Symfony\Component\Console\Output\OutputInterface'));
+        $migrator->shouldNotReceive('getNotes');
 
         $this->runCommand($command);
     }
@@ -36,8 +36,8 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], ['pretend' => false, 'step' => 2]);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], ['pretend' => false, 'step' => 2], m::type('Symfony\Component\Console\Output\OutputInterface'));
+        $migrator->shouldNotReceive('getNotes');
 
         $this->runCommand($command, ['--step' => 2]);
     }
@@ -50,8 +50,8 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with('foo');
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], true);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], true, m::type('Symfony\Component\Console\Output\OutputInterface'));
+        $migrator->shouldNotReceive('getNotes');
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
     }
@@ -64,8 +64,8 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with('foo');
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], ['pretend' => true, 'step' => 2]);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], ['pretend' => true, 'step' => 2], m::type('Symfony\Component\Console\Output\OutputInterface'));
+        $migrator->shouldNotReceive('getNotes');
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2]);
     }


### PR DESCRIPTION
Database Migrator modified to print action outputs to the terminal as soon as each process is finished.
Additionally, now that we are passing the OutputInterface of the callee to the migrator we will be able to use the Migrator independently or in other words, we can call from within other commands and expect the output to be printed to the terminal.