### PR TITLE
[5.6] Register many observers for a model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -25,21 +25,38 @@ trait HasEvents
     protected $observables = [];
 
     /**
-     * Register an observer with the Model.
+     * Register observers with the Model.
      *
-     * @param  object|string  $class
+     * @param  object|string|array  $classes
      * @return void
      */
-    public static function observe($class)
+    public static function observe($classes)
     {
         $instance = new static;
 
+        if (! is_array($classes)) {
+            $classes = [$classes];
+        }
+
+        foreach ($classes as $class) {
+            $instance->registerObserver($class);
+        }
+    }
+
+    /**
+     * Registers a single observer with the Model.
+     *
+     * @param  object|string $class
+     * @return void
+     */
+    private function registerObserver($class)
+    {
         $className = is_string($class) ? $class : get_class($class);
 
         // When registering a model observer, we will spin through the possible events
         // and determine if this observer has that method. If it does, we will hook
         // it into the model's event system, making it convenient to watch these.
-        foreach ($instance->getObservableEvents() as $event) {
+        foreach ($this->getObservableEvents() as $event) {
             if (method_exists($class, $event)) {
                 static::registerModelEvent($event, $className.'@'.$event);
             }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1286,13 +1286,17 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
+
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestAnotherObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestAnotherObserverStub@saved');
+
         $events->shouldReceive('forget');
+
         EloquentModelStub::observe([
             'Illuminate\Tests\Database\EloquentTestObserverStub',
             'Illuminate\Tests\Database\EloquentTestAnotherObserverStub',
         ]);
+
         EloquentModelStub::flushEventListeners();
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1291,7 +1291,7 @@ class DatabaseEloquentModelTest extends TestCase
         $events->shouldReceive('forget');
         EloquentModelStub::observe([
             'Illuminate\Tests\Database\EloquentTestObserverStub',
-            'Illuminate\Tests\Database\EloquentTestAnotherObserverStub'
+            'Illuminate\Tests\Database\EloquentTestAnotherObserverStub',
         ]);
         EloquentModelStub::flushEventListeners();
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1271,6 +1271,31 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelStub::flushEventListeners();
     }
 
+    public function testModelObserversCanBeAttachedToModelsThroughAnArray()
+    {
+        EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
+        $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
+        $events->shouldReceive('forget');
+        EloquentModelStub::observe(['Illuminate\Tests\Database\EloquentTestObserverStub']);
+        EloquentModelStub::flushEventListeners();
+    }
+
+    public function testModelObserversCanBeAttachedToModelsThroughCallingObserveMethodOnlyOnce()
+    {
+        EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
+        $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
+        $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestAnotherObserverStub@creating');
+        $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestAnotherObserverStub@saved');
+        $events->shouldReceive('forget');
+        EloquentModelStub::observe([
+            'Illuminate\Tests\Database\EloquentTestObserverStub',
+            'Illuminate\Tests\Database\EloquentTestAnotherObserverStub'
+        ]);
+        EloquentModelStub::flushEventListeners();
+    }
+
     public function testSetObservableEvents()
     {
         $class = new EloquentModelStub;
@@ -1709,6 +1734,17 @@ class DatabaseEloquentModelTest extends TestCase
 }
 
 class EloquentTestObserverStub
+{
+    public function creating()
+    {
+    }
+
+    public function saved()
+    {
+    }
+}
+
+class EloquentTestAnotherObserverStub
 {
     public function creating()
     {


### PR DESCRIPTION
This PR adds the ability to pass an array of observers to the observe() method for a model instead of registering each of them one by one.
Consider we have a Thread model and we will register the following observers for it: DeleteThreadRepliesObserver, GenerateThreadSlugObserver, ReputationObserver, ThreadObserver

```
Currently:
\App\Thread::observe(\App\Observers\DeleteThreadRepliesObserver::class);
\App\Thread::observe(\App\Observers\GenerateThreadSlugObserver::class);
\App\Thread::observe(\App\Observers\ReputationObserver::class);
\App\Thread::observe(\App\Observers\ThreadObserver::class);
```
```
Proposed:
\App\Thread::observe([
\App\Observers\DeleteThreadRepliesObserver::class,
\App\Observers\GenerateThreadSlugObserver::class,
\App\Observers\ReputationObserver::class,
\App\Observers\ThreadObserver::class
]);
```
