### PR TITLE
[5.6] Allow populating the collection by passing items as arguments

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -45,7 +45,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function __construct($items = [])
     {
-        $this->items = $this->getArrayableItems($items);
+        $this->items = $this->getArrayableItems(
+            func_num_args() === 1 ? $items : func_get_args()
+        );
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -413,14 +413,14 @@ if (! function_exists('class_uses_recursive')) {
 
 if (! function_exists('collect')) {
     /**
-     * Create a collection from the given value.
+     * Create a collection from the given values.
      *
      * @param  mixed  $value
      * @return \Illuminate\Support\Collection
      */
-    function collect($value = null)
+    function collect(...$value)
     {
-        return new Collection($value);
+        return new Collection(...$value);
     }
 }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1357,6 +1357,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $collection->all());
     }
 
+    public function testConstructMethodFromArguments()
+    {
+        $collection = new Collection('foo', 'bar', 'baz');
+        $this->assertEquals(['foo', 'bar', 'baz'], $collection->all());
+    }
+
     public function testSplice()
     {
         $data = new Collection(['foo', 'baz']);

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -873,6 +873,14 @@ class SupportHelpersTest extends TestCase
             return $five + 5;
         }));
     }
+
+    public function testCollect()
+    {
+        $this->assertEquals([], collect()->all());
+        $this->assertEquals(['foo'], collect('foo')->all());
+        $this->assertEquals(['foo', 'bar'], collect(['foo', 'bar'])->all());
+        $this->assertEquals(['foo', 'bar'], collect('foo', 'bar')->all());
+    }
 }
 
 trait SupportTestTraitOne


### PR DESCRIPTION
This was possible before:

```php
$items = new Collection('foo');
// instead of / in addition to
$items = new Collection(['foo']);
```

Now you can do

```php
$items = new Collection('foo', 'bar');
$items = Collection::make('foo', 'bar');

// instead of / in addition to
$items = new Collection(['foo', 'bar']);
$items = Collection::make(['foo', 'bar']);
```

and most importantly you can `collect` more naturally now

```php
$items = collect('foo', 'bar');
```

Comes with tests including previously absent test for `collect()` itself.

All credits and blame 😀😀😀 goes to @calebporzio 
https://twitter.com/calebporzio/status/973301864962850817
