### PR TITLE
[5.6] Factory names use basename when created with make:model

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -68,7 +68,7 @@ class ModelMakeCommand extends GeneratorCommand
     protected function createFactory()
     {
         $this->call('make:factory', [
-            'name' => $this->argument('name').'Factory',
+            'name' => class_basename($this->argument('name')).'Factory',
             '--model' => $this->argument('name'),
         ]);
     }


### PR DESCRIPTION
Previously when using the -f option with the artisan make:model command
the factory would be named with namespace. With this change factories
will be named with the class_basename instead.