### PR TITLE
[5.6] Add $useReadPdo to ConnectionInterface

### DIFF
--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -27,18 +27,20 @@ interface ConnectionInterface
      *
      * @param  string  $query
      * @param  array   $bindings
+     * @param  bool  $useReadPdo
      * @return mixed
      */
-    public function selectOne($query, $bindings = []);
+    public function selectOne($query, $bindings = [], $useReadPdo = true);
 
     /**
      * Run a select statement against the database.
      *
      * @param  string  $query
      * @param  array   $bindings
+     * @param  bool  $useReadPdo
      * @return array
      */
-    public function select($query, $bindings = []);
+    public function select($query, $bindings = [], $useReadPdo = true);
 
     /**
      * Run an insert statement against the database.


### PR DESCRIPTION
Before add `$useReadPdo` to `ConnectionInterface`, The third parameter of `select` is unknown.

![builder](https://user-images.githubusercontent.com/14247909/37350167-579663ba-26ed-11e8-878b-04e91015f4f0.png)
 I saw this in `\Illuminate\Database\Query\Builder.php` ==> `runSelect` & `exists` functions.
🤕 