### PR TITLE
[5.6] Storage fake test and requiring flysystem 1.0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/inflector": "~1.1",
         "dragonmantank/cron-expression": "~2.0",
         "erusev/parsedown": "~1.7",
-        "league/flysystem": "~1.0",
+        "league/flysystem": "^1.0.8",
         "monolog/monolog": "~1.12",
         "nesbot/carbon": "^1.24.1",
         "psr/container": "~1.0",

--- a/tests/Support/SupportTestingStorageFakeTest.php
+++ b/tests/Support/SupportTestingStorageFakeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Filesystem\FilesystemManager;
+use PHPUnit\Framework\ExpectationFailedException;
+
+class StorageFakeTest extends TestCase
+{
+    protected $fake;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $app = new Application;
+        $app['path.storage'] = __DIR__;
+        $app['filesystem'] = new FilesystemManager($app);
+        Storage::setFacadeApplication($app);
+        Storage::fake('testing');
+        $this->fake = Storage::disk('testing');
+    }
+
+    public function testAssertExists()
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        $this->fake->assertExists('letter.txt');
+    }
+
+    public function testAssertMissing()
+    {
+        $this->fake->put('letter.txt', 'hi');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $this->fake->assertMissing('letter.txt');
+    }
+}


### PR DESCRIPTION
Flysystem version constraint update according to https://github.com/laravel/framework/pull/23516 plus a test that actually triggers the error (when using flysystem <1.0.8)