### PR TITLE
[5.7] Add cursor to ConnectionInterface

### DIFF
--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -27,18 +27,30 @@ interface ConnectionInterface
      *
      * @param  string  $query
      * @param  array   $bindings
+     * @param  bool  $useReadPdo
      * @return mixed
      */
-    public function selectOne($query, $bindings = []);
+    public function selectOne($query, $bindings = [], $useReadPdo = true);
 
     /**
      * Run a select statement against the database.
      *
      * @param  string  $query
      * @param  array   $bindings
+     * @param  bool  $useReadPdo
      * @return array
      */
-    public function select($query, $bindings = []);
+    public function select($query, $bindings = [], $useReadPdo = true);
+
+    /**
+     * Run a select statement against the database and returns a generator.
+     *
+     * @param  string  $query
+     * @param  array  $bindings
+     * @param  bool  $useReadPdo
+     * @return \Generator
+     */
+    public function cursor($query, $bindings = [], $useReadPdo = true);
 
     /**
      * Run an insert statement against the database.


### PR DESCRIPTION
Hi
I push #23522 to `master` 
+
 Add `cursor` to `ConnectionInterface`

![cursor](https://user-images.githubusercontent.com/14247909/37364678-6e7a8232-2710-11e8-83be-1cfb5a78edd1.png)
`framework\src\Illuminate\Database\Query\Builder.php`

```
/**
* The database connection instance.
*
* @var \Illuminate\Database\ConnectionInterface
*/
public $connection;
```

🤕 
