### PR TITLE
[5.6] LogManager driver capable of producing logger with any Monolog handler

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -320,7 +320,7 @@ class LogManager implements LoggerInterface
     }
 
     /**
-     * Create an instance of any handler provided by Monolog provided via configuration.
+     * Create an instance of any handler available in Monolog from configuration.
      *
      * @param array $config
      * @return \Monolog\Logger
@@ -340,17 +340,10 @@ class LogManager implements LoggerInterface
             throw new InvalidArgumentException($handlerClass.' must be an instance of '.HandlerInterface::class);
         }
 
-        $container = $this->app;
-
-        if (isset($config['handler_params'])) {
-            // clone app so that contextual bindings are not persisted
-            $container = clone $this->app;
-            foreach ($config['handler_params'] as $name => $value) {
-                $container->addContextualBinding($handlerClass, '$'.$name, $value);
-            }
-        }
-
-        return new Monolog($this->parseChannel($config), [$this->prepareHandler($container->build($handlerClass))]);
+        return new Monolog(
+            $this->parseChannel($config),
+            [$this->prepareHandler($this->app->make($handlerClass, $config['handler_params'] ?? []))]
+        );
     }
 
     /**

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -320,7 +320,7 @@ class LogManager implements LoggerInterface
     }
 
     /**
-     * Create an instance of any handler provided by Monolog provided via configuration
+     * Create an instance of any handler provided by Monolog provided via configuration.
      *
      * @param array $config
      * @return \Monolog\Logger
@@ -346,7 +346,7 @@ class LogManager implements LoggerInterface
             // clone app so that contextual bindings are not persisted
             $container = clone $this->app;
             foreach ($config['handler_params'] as $name => $value) {
-                $container->addContextualBinding($handlerClass, '$' . $name, $value);
+                $container->addContextualBinding($handlerClass, '$'.$name, $value);
             }
         }
 

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -2,13 +2,13 @@
 
 namespace Illuminate\Tests\Log;
 
+use ReflectionProperty;
 use Illuminate\Log\Logger;
 use Illuminate\Log\LogManager;
-use Monolog\Handler\LogEntriesHandler;
-use Monolog\Handler\StreamHandler;
 use Monolog\Logger as Monolog;
 use Orchestra\Testbench\TestCase;
-use ReflectionProperty;
+use Monolog\Handler\StreamHandler;
+use Monolog\Handler\LogEntriesHandler;
 
 class LogManagerTest extends TestCase
 {
@@ -32,8 +32,8 @@ class LogManagerTest extends TestCase
             'handler_params' => [
                 'stream' => 'php://stderr',
                 'level' => Monolog::NOTICE,
-                'bubble' => false
-            ]
+                'bubble' => false,
+            ],
         ]);
 
         $manager = new LogManager($this->app);
@@ -55,8 +55,8 @@ class LogManagerTest extends TestCase
             'name' => 'le',
             'handler_type' => 'LogEntries',
             'handler_params' => [
-                'token' => '123456789'
-            ]
+                'token' => '123456789',
+            ],
         ]);
 
         $logger = $manager->channel('logentries');

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -2,8 +2,11 @@
 
 namespace Illuminate\Tests\Log;
 
+use Illuminate\Log\Logger;
 use Illuminate\Log\LogManager;
+use Monolog\Logger as Monolog;
 use Orchestra\Testbench\TestCase;
+
 
 class LogManagerTest extends TestCase
 {
@@ -15,5 +18,30 @@ class LogManagerTest extends TestCase
         $logger2 = $manager->channel('single')->getLogger();
 
         $this->assertSame($logger1, $logger2);
+    }
+
+    public function testLogManagerCreatesConfiguredMonologHandler()
+    {
+        $config = $this->app['config'];
+        $config->set('logging.channels.tester', [
+            'driver' => 'monolog',
+            'name' => 'foobar',
+            'handler_type' => 'stream',
+            'handler_params' => [
+                'stream' => 'php://stderr',
+                'level' => Monolog::NOTICE
+            ]
+        ]);
+
+        // create logger with handler specified from configuration
+        $manager = new LogManager($this->app);
+        $logger = $manager->channel('tester');
+        $handlers = $logger->getLogger()->getHandlers();
+
+        $this->assertInstanceOf(Logger::class, $logger);
+        $this->assertEquals('foobar', $logger->getName());
+        $this->assertCount(1, $handlers);
+        $this->assertEquals('php://stderr', $handlers[0]->getUrl());
+        $this->assertEquals(Monolog::NOTICE, $handlers[0]->getLevel());
     }
 }

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -4,9 +4,11 @@ namespace Illuminate\Tests\Log;
 
 use Illuminate\Log\Logger;
 use Illuminate\Log\LogManager;
+use Monolog\Handler\LogEntriesHandler;
+use Monolog\Handler\StreamHandler;
 use Monolog\Logger as Monolog;
 use Orchestra\Testbench\TestCase;
-
+use ReflectionProperty;
 
 class LogManagerTest extends TestCase
 {
@@ -23,25 +25,47 @@ class LogManagerTest extends TestCase
     public function testLogManagerCreatesConfiguredMonologHandler()
     {
         $config = $this->app['config'];
-        $config->set('logging.channels.tester', [
+        $config->set('logging.channels.nonbubblingstream', [
             'driver' => 'monolog',
             'name' => 'foobar',
             'handler_type' => 'stream',
             'handler_params' => [
                 'stream' => 'php://stderr',
-                'level' => Monolog::NOTICE
+                'level' => Monolog::NOTICE,
+                'bubble' => false
             ]
         ]);
 
-        // create logger with handler specified from configuration
         $manager = new LogManager($this->app);
-        $logger = $manager->channel('tester');
+
+        // create logger with handler specified from configuration
+        $logger = $manager->channel('nonbubblingstream');
         $handlers = $logger->getLogger()->getHandlers();
 
         $this->assertInstanceOf(Logger::class, $logger);
         $this->assertEquals('foobar', $logger->getName());
         $this->assertCount(1, $handlers);
+        $this->assertInstanceOf(StreamHandler::class, $handlers[0]);
         $this->assertEquals('php://stderr', $handlers[0]->getUrl());
         $this->assertEquals(Monolog::NOTICE, $handlers[0]->getLevel());
+        $this->assertFalse($handlers[0]->getBubble());
+
+        $config->set('logging.channels.logentries', [
+            'driver' => 'monolog',
+            'name' => 'le',
+            'handler_type' => 'LogEntries',
+            'handler_params' => [
+                'token' => '123456789'
+            ]
+        ]);
+
+        $logger = $manager->channel('logentries');
+        $handlers = $logger->getLogger()->getHandlers();
+
+        $logToken = new ReflectionProperty(get_class($handlers[0]), 'logToken');
+        $logToken->setAccessible(true);
+
+        $this->assertInstanceOf(LogEntriesHandler::class, $handlers[0]);
+        $this->assertEquals('123456789', $logToken->getValue($handlers[0]));
     }
 }

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -46,9 +46,12 @@ class LogManagerTest extends TestCase
         $this->assertEquals('foobar', $logger->getName());
         $this->assertCount(1, $handlers);
         $this->assertInstanceOf(StreamHandler::class, $handlers[0]);
-        $this->assertEquals('php://stderr', $handlers[0]->getUrl());
         $this->assertEquals(Monolog::NOTICE, $handlers[0]->getLevel());
         $this->assertFalse($handlers[0]->getBubble());
+
+        $url = new ReflectionProperty(get_class($handlers[0]), 'url');
+        $url->setAccessible(true);
+        $this->assertEquals('php://stderr', $url->getValue($handlers[0]));
 
         $config->set('logging.channels.logentries', [
             'driver' => 'monolog',


### PR DESCRIPTION
The provided driver allows a configuration centric approach to creating Logger instances (channels) where the handler can be any of the [built-in Monolog handlers](https://github.com/Seldaek/monolog/tree/master/src/Monolog/Handler) without needing to write custom factories (code).

By using `Container::build()` it is capable of matching any named constructor values from any Handler that are provided in the `handler_params` configuration option.  For non-monolog provided handlers, it is capable of accepting an option `handler_class` where it will use the full class name to instantiate/build.

Example of creating a `php://stderr` non-bubbling StreamHandler based logger:

```
    'channels' => [
        'nonbubblingstream' => [
            'driver' => 'monolog',
            'handler_type' => 'stream',
            'handler_params' => [
                'stream' => 'php://stderr',
                'bubble' => false
            ]
        ],
    //...
```

Example of a LogEntries based channel logger:

```
    'channels' => [
        'logentries' => [
            'driver' => 'monolog',
            'handler_type' => 'LogEntries',
            'handler_params' => [
                'token' => '123456789'
            ]
        ],
    //...
```

This feature is completely backwards compatible and opt-in.  If accepted, I will document it's usage in the manual.