### PR TITLE
[5.6] Separate the unauthenticated redirect URL out into an easily overridable method

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -218,7 +218,17 @@ class Handler implements ExceptionHandlerContract
     {
         return $request->expectsJson()
                     ? response()->json(['message' => $exception->getMessage()], 401)
-                    : redirect()->guest(route('login'));
+                    : redirect()->guest($this->unauthenticatedRedirectUrl());
+    }
+
+    /**
+     * Get the URL to redirect to when handling an authentication exception.
+     *
+     * @return string
+     */
+    protected function unauthenticatedRedirectUrl()
+    {
+        return route('login');
     }
 
     /**


### PR DESCRIPTION
See https://github.com/laravel/ideas/issues/800

I've elected to implement this as an easily overridable method. The alternative would be to do it with multiple properties like in [`FormRequest`](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Foundation/Http/FormRequest.php#L127), but that feels like a more complex and awkward way.