### PR TITLE
[5.6] Fixes Blade echo parsing matching PHP ternary operations

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -100,6 +100,6 @@ trait CompilesEchos
      */
     public function compileEchoDefaults($value)
     {
-        return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/si', 'isset($1) ? $1 : $2', $value);
+        return preg_replace('/^(?=\$)((?:[^\?]+?)|(?:.+\[(?:.+)\]))(?:\s+or\s+)(.+?)$/si', 'isset($1) ? $1 : $2', $value);
     }
 }

--- a/tests/View/Blade/BladeEchoTest.php
+++ b/tests/View/Blade/BladeEchoTest.php
@@ -43,6 +43,11 @@ class BladeEchoTest extends AbstractBladeTestCase
             $name or \'foo\'
         }}'));
 
+	    $this->assertEquals('<?php echo e($name ? "yes" : "no"); ?>', $this->compiler->compileString('{{$name ? "yes" : "no"}}'));
+	    $this->assertEquals('<?php echo e($name ? "lorem or ipsum" : "dolor or sit"); ?>', $this->compiler->compileString('{{$name ? "lorem or ipsum" : "dolor or sit"}}'));
+	    $this->assertEquals('<?php echo e(($name) ? "yes" : "no"); ?>', $this->compiler->compileString('{{($name) ? "yes" : "no"}}'));
+	    $this->assertEquals('<?php echo e(($name) ? "lorem or ipsum" : "dolor or sit"); ?>', $this->compiler->compileString('{{($name) ? "lorem or ipsum" : "dolor or sit"}}'));
+
         $this->assertEquals('<?php echo e(isset($age) ? $age : 90); ?>', $this->compiler->compileString('{{ $age or 90 }}'));
         $this->assertEquals('<?php echo e(isset($age) ? $age : 90); ?>', $this->compiler->compileString('{{$age or 90}}'));
         $this->assertEquals('<?php echo e(isset($age) ? $age : 90); ?>', $this->compiler->compileString('{{

--- a/tests/View/Blade/BladeEchoTest.php
+++ b/tests/View/Blade/BladeEchoTest.php
@@ -43,10 +43,10 @@ class BladeEchoTest extends AbstractBladeTestCase
             $name or \'foo\'
         }}'));
 
-	    $this->assertEquals('<?php echo e($name ? "yes" : "no"); ?>', $this->compiler->compileString('{{$name ? "yes" : "no"}}'));
-	    $this->assertEquals('<?php echo e($name ? "lorem or ipsum" : "dolor or sit"); ?>', $this->compiler->compileString('{{$name ? "lorem or ipsum" : "dolor or sit"}}'));
-	    $this->assertEquals('<?php echo e(($name) ? "yes" : "no"); ?>', $this->compiler->compileString('{{($name) ? "yes" : "no"}}'));
-	    $this->assertEquals('<?php echo e(($name) ? "lorem or ipsum" : "dolor or sit"); ?>', $this->compiler->compileString('{{($name) ? "lorem or ipsum" : "dolor or sit"}}'));
+        $this->assertEquals('<?php echo e($name ? "yes" : "no"); ?>', $this->compiler->compileString('{{$name ? "yes" : "no"}}'));
+        $this->assertEquals('<?php echo e($name ? "lorem or ipsum" : "dolor or sit"); ?>', $this->compiler->compileString('{{$name ? "lorem or ipsum" : "dolor or sit"}}'));
+        $this->assertEquals('<?php echo e(($name) ? "yes" : "no"); ?>', $this->compiler->compileString('{{($name) ? "yes" : "no"}}'));
+        $this->assertEquals('<?php echo e(($name) ? "lorem or ipsum" : "dolor or sit"); ?>', $this->compiler->compileString('{{($name) ? "lorem or ipsum" : "dolor or sit"}}'));
 
         $this->assertEquals('<?php echo e(isset($age) ? $age : 90); ?>', $this->compiler->compileString('{{ $age or 90 }}'));
         $this->assertEquals('<?php echo e(isset($age) ? $age : 90); ?>', $this->compiler->compileString('{{$age or 90}}'));


### PR DESCRIPTION
This fixes issues with Blade parsing echo defaults strings (issue #23528), by augmenting the RegExp in the defaults parser to exclude `?`, but only when not looking into array keys.

I've added some unit tests in RegEx101 (https://regex101.com/r/UmZmgH/1) to test the RegExp, as well as unit tests for the edge cases that caused the issue.

This is my first PR, so let me know if there's anything to be adjusted before the merge.