### PR TITLE
[5.7] Remove Blade defaults

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -46,7 +46,7 @@ trait CompilesEchos
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
-            return $matches[1] ? substr($matches[0], 1) : "<?php echo {$this->compileEchoDefaults($matches[2])}; ?>{$whitespace}";
+            return $matches[1] ? substr($matches[0], 1) : "<?php echo {$matches[2]}; ?>{$whitespace}";
         };
 
         return preg_replace_callback($pattern, $callback, $value);
@@ -65,7 +65,7 @@ trait CompilesEchos
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
-            $wrapped = sprintf($this->echoFormat, $this->compileEchoDefaults($matches[2]));
+            $wrapped = sprintf($this->echoFormat, $matches[2]);
 
             return $matches[1] ? substr($matches[0], 1) : "<?php echo {$wrapped}; ?>{$whitespace}";
         };
@@ -86,20 +86,9 @@ trait CompilesEchos
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
-            return $matches[1] ? $matches[0] : "<?php echo e({$this->compileEchoDefaults($matches[2])}); ?>{$whitespace}";
+            return $matches[1] ? $matches[0] : "<?php echo e({$matches[2]}); ?>{$whitespace}";
         };
 
         return preg_replace_callback($pattern, $callback, $value);
-    }
-
-    /**
-     * Compile the default values for the echo statement.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    public function compileEchoDefaults($value)
-    {
-        return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/si', 'isset($1) ? $1 : $2', $value);
     }
 }

--- a/tests/View/Blade/BladeEchoTest.php
+++ b/tests/View/Blade/BladeEchoTest.php
@@ -11,8 +11,6 @@ class BladeEchoTest extends AbstractBladeTestCase
         $this->assertEquals('<?php echo $name; ?>', $this->compiler->compileString('{!!
             $name
         !!}'));
-        $this->assertEquals('<?php echo isset($name) ? $name : \'foo\'; ?>',
-            $this->compiler->compileString('{!! $name or \'foo\' !!}'));
 
         $this->assertEquals('<?php echo e($name); ?>', $this->compiler->compileString('{{{$name}}}'));
         $this->assertEquals('<?php echo e($name); ?>', $this->compiler->compileString('{{$name}}'));
@@ -24,30 +22,6 @@ class BladeEchoTest extends AbstractBladeTestCase
         $this->assertEquals("<?php echo e(\$name); ?>\r\n\r\n", $this->compiler->compileString("{{ \$name }}\r\n"));
         $this->assertEquals("<?php echo e(\$name); ?>\n\n", $this->compiler->compileString("{{ \$name }}\n"));
         $this->assertEquals("<?php echo e(\$name); ?>\r\n\r\n", $this->compiler->compileString("{{ \$name }}\r\n"));
-
-        $this->assertEquals('<?php echo e(isset($name) ? $name : "foo"); ?>',
-            $this->compiler->compileString('{{ $name or "foo" }}'));
-        $this->assertEquals('<?php echo e(isset($user->name) ? $user->name : "foo"); ?>',
-            $this->compiler->compileString('{{ $user->name or "foo" }}'));
-        $this->assertEquals('<?php echo e(isset($name) ? $name : "foo"); ?>',
-            $this->compiler->compileString('{{$name or "foo"}}'));
-        $this->assertEquals('<?php echo e(isset($name) ? $name : "foo"); ?>', $this->compiler->compileString('{{
-            $name or "foo"
-        }}'));
-
-        $this->assertEquals('<?php echo e(isset($name) ? $name : \'foo\'); ?>',
-            $this->compiler->compileString('{{ $name or \'foo\' }}'));
-        $this->assertEquals('<?php echo e(isset($name) ? $name : \'foo\'); ?>',
-            $this->compiler->compileString('{{$name or \'foo\'}}'));
-        $this->assertEquals('<?php echo e(isset($name) ? $name : \'foo\'); ?>', $this->compiler->compileString('{{
-            $name or \'foo\'
-        }}'));
-
-        $this->assertEquals('<?php echo e(isset($age) ? $age : 90); ?>', $this->compiler->compileString('{{ $age or 90 }}'));
-        $this->assertEquals('<?php echo e(isset($age) ? $age : 90); ?>', $this->compiler->compileString('{{$age or 90}}'));
-        $this->assertEquals('<?php echo e(isset($age) ? $age : 90); ?>', $this->compiler->compileString('{{
-            $age or 90
-        }}'));
 
         $this->assertEquals('<?php echo e("Hello world or foo"); ?>',
             $this->compiler->compileString('{{ "Hello world or foo" }}'));


### PR DESCRIPTION
current Blade functionality allows the user to define a default value if the first value is not set.

`{{ $name or 'Andrew' }}`

This feature was added in an early version of Laravel to be a shorthand for

`isset($name) ? $name : 'Andrew'`

PHP7 has introduced the null coalesce operator (`??`) which performs this exact functionality.

`$name ?? 'Andrew'`

While the 'or' feature was good when it was needed, it could produce unexpected results when the characters 'or' appeared anywhere in the Blade expression.  This was solved with extensive regex, but was still somewhat error prone.

Now that Laravel requires PHP 7.1, we can utilize the null coalesce operator and remove the 'or' feature. User upgrade process will be a find and replace, and the number of characters will be identical.

```
{{ $name or 'Andrew' }}
{{ $name ?? 'Andrew' }}
```