### PR TITLE
[5.7] Improve Application::environment function signature for IDEs

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -23,9 +23,15 @@ interface Application extends Container
     /**
      * Get or check the current application environment.
      *
-     * @return string
+     * If a string or array of strings is provided, it will be checked against the current
+     * environment. If a match is found, `true` is returned; `false` otherwise.
+     * If no arguments are provided, this method will return the name
+     * of the current environment as a string.
+     *
+     * @param  string|string[] $patterns,...
+     * @return string|bool
      */
-    public function environment();
+    public function environment(...$patterns);
 
     /**
      * Determine if the application is running in the console.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -474,13 +474,18 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get or check the current application environment.
      *
+     * If a string or array of strings is provided, it will be checked against the current
+     * environment. If a match is found, `true` is returned; `false` otherwise.
+     * If no arguments are provided, this method will return the name
+     * of the current environment as a string.
+     *
+     * @param  string|string[] $patterns,...
      * @return string|bool
      */
-    public function environment()
+    public function environment(...$patterns)
     {
-        if (func_num_args() > 0) {
-            $patterns = is_array(func_get_arg(0)) ? func_get_arg(0) : func_get_args();
-
+        if (count($patterns) > 0) {
+            $patterns = is_array($patterns[0]) ? $patterns[0] : $patterns;
             foreach ($patterns as $pattern) {
                 if (Str::is($pattern, $this['env'])) {
                     return true;

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -106,7 +106,7 @@ class ApplicationDatabaseMigrationStub extends Application
         }
     }
 
-    public function environment()
+    public function environment(...$patterns)
     {
         return 'development';
     }

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -95,7 +95,7 @@ class ApplicationDatabaseRefreshStub extends Application
         }
     }
 
-    public function environment()
+    public function environment(...$patterns)
     {
         return 'development';
     }

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -59,7 +59,7 @@ class ApplicationDatabaseResetStub extends Application
         }
     }
 
-    public function environment()
+    public function environment(...$patterns)
     {
         return 'development';
     }

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -85,7 +85,7 @@ class ApplicationDatabaseRollbackStub extends Application
         }
     }
 
-    public function environment()
+    public function environment(...$patterns)
     {
         return 'development';
     }


### PR DESCRIPTION
This is a follow up PR to my post here: https://github.com/laravel/ideas/issues/1060

To summarize the issues from the link above:
- The contract and main implementation of `Application::environment()` don't match
- `environment()` accepts variables in practice, but doesn't in the declaration. IDEs such as PHPStorm complain that it shouldn't be called with variables, causing warnings whenever it's used.
- The function is trying to do two very different things, which makes it confusing.
- The docblocks don't explain any of this.

----

I'm submitting this in hopes of opening a discussion regarding this function overall. It appears that this function is used in tests in such a way that it only returns a string and doesn't care about provided arguments; but the main implementation of this class does accept arguments and will return boolean if they are provided.

Tests aside, this function is frequently used throughout Laravel applications to check what environment the code is running in - but because of the method signature, IDEs like PHPStorm complain that the function does not accept arguments and therefore we're forced to live with warnings wherever this is used.

The real fix for this is probably to split this function into two:
- `public function environment(): string`, and
- `public function isEnvironment(string|array $patterns): bool`

Or, another solution is to keep it as is, but deprecate it in favour of:
- `public function getEnvironment(): string`, and
- `public function isEnvironment(string|array $patterns): bool`


Currently, the `environment()` function is trying to be both of those functions in different contexts and feels a bit convoluted.

That all said, I hope this PR stirs up a conversation regarding the future of this method - the main goal isn't to get merged; while that'd be nice, I'd actually prefer that this leads a more long-term solution, like the method being split as shown above, or in some other way if someone has a more eloquent solution.

Looking forward to comments and feedback.