### PR TITLE
[5.6] Add tests for updating existing pivot + add option for passing model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -188,7 +188,7 @@ trait InteractsWithPivotTable
             $attributes = $this->addTimestampsToAttachment($attributes, true);
         }
 
-        $updated = $this->newPivotStatementForId($id)->update(
+        $updated = $this->newPivotStatementForId($this->parseId($id))->update(
             $this->castAttributes($attributes)
         );
 
@@ -486,6 +486,21 @@ trait InteractsWithPivotTable
         }
 
         return (array) $value;
+    }
+
+    /**
+     * Get the ID from the given mixed value.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function parseId($value)
+    {
+        if ($value instanceof Model) {
+            return $value->getKey();
+        }
+
+        return $value;
     }
 
     /**


### PR DESCRIPTION
Added the `parseId` method to the `InteractsWithPivotTable` trait. This way we can now use models to update existing pivot values. For example
```
// Before (which still works as well)
$post->tags()->updateExistingPivot($tag->id, ['key' => 'value']);

// After
$post->tags()->updateExistingPivot($tag, ['key' => 'value']);
```
In addition to that I also added the missings tests for this method ;)

If for some reason you decide not to take the model part, you can at least add the tests 👍 