### PR TITLE
[5.7] Dot notation support in Request object's ArrayAccess

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -600,8 +600,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function offsetExists($offset)
     {
-        return array_key_exists(
-            $offset, $this->all() + $this->route()->parameters()
+        return Arr::has(
+            $this->all() + $this->route()->parameters(), $offset
         );
     }
 
@@ -658,10 +658,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function __get($key)
     {
-        if (array_key_exists($key, $this->all())) {
-            return data_get($this->all(), $key);
-        }
-
-        return $this->route($key);
+        return Arr::get($this->all(), $key, function () use ($key) {
+            return $this->route($key);
+        });
     }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -325,6 +325,34 @@ class HttpRequestTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\File\UploadedFile', $request['file']);
     }
 
+    public function testArrayAccess()
+    {
+        $request = Request::create('/', 'GET', ['name' => null, 'foo' => ['bar' => null, 'baz' => '']]);
+        $request->setRouteResolver(function () use ($request) {
+            $route = new Route('GET', '/foo/bar/{id}/{name}', []);
+            $route->bind($request);
+            $route->setParameter('id', 'foo');
+            $route->setParameter('name', 'Taylor');
+
+            return $route;
+        });
+
+        $this->assertFalse(isset($request['non-existant']));
+        $this->assertNull($request['non-existant']);
+
+        $this->assertTrue(isset($request['name']));
+        $this->assertEquals(null, $request['name']);
+        $this->assertNotEquals('Taylor', $request['name']);
+
+        $this->assertTrue(isset($request['foo.bar']));
+        $this->assertEquals(null, $request['foo.bar']);
+        $this->assertTrue(isset($request['foo.baz']));
+        $this->assertEquals('', $request['foo.baz']);
+
+        $this->assertTrue(isset($request['id']));
+        $this->assertEquals('foo', $request['id']);
+    }
+
     public function testAllMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);


### PR DESCRIPTION
Hello,

I decided to reopen previously rejected PR with some proof that the breaking change does not really exist. https://github.com/laravel/framework/pull/23456

# Feature reference
Currently you can access request's array input using dot notation like this:
```php
$request->input('foo.bar');
// It's also supported when using
$request->only('foo.bar');
$request->all('foo.bar');
```
Although when you try to do the same thing using ArrayAccess (`$request['foo.bar']`) it's not supported which makes it a bit inconsistent.

This adds support of the dot notation when used with ArrayAccess.
```php
$request['foo.bar'];
// and of course
isset($request['foo.bar']);
```

# Rejection reference
Initial PR got rejected due to this:
> You have a big breaking change in the __get method by using Arr::get... all null inputs will now use the "default" closure and fallback to the route variables. That was not the prior behaviour.

Although `Arr::get` method **does not** check if a given key is `null` before using the "default" value. It only checks if a given key **exists** in an array.

To prove that this change still has the old behaviour I modified an ArrayAccess test to reflect it.
```
Given we have a route `/foo/bar/{id}/{name}` where `id=foo` and `name=Taylor`
AND an input data of `['name' => null]`
When we ask for the `name` param it prioritizes request data over route parameters.
The result is `null`
```

Thanks
