### PR TITLE
[5.6] Fix clearing the cache without a cache directory

### DIFF
--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -82,7 +82,14 @@ class ClearCommand extends Command
      */
     public function flushFacades()
     {
-        foreach ($this->files->files(storage_path('framework/cache')) as $file) {
+        // Applications that don't use the file cache may not have the directory
+        $storagePath = storage_path('framework/cache');
+
+        if (! $this->files->exists($storagePath)) {
+            return;
+        }
+
+        foreach ($this->files->files($storagePath) as $file) {
             if (preg_match('/facade-.*\.php$/', $file)) {
                 $this->files->delete($file);
             }

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -26,6 +26,7 @@ class ClearCommandTest extends TestCase
         $app = new Application;
         $app['path.storage'] = __DIR__;
         $command->setLaravel($app);
+        $files->shouldReceive('exists')->andReturn(true);
         $files->shouldReceive('files')->andReturn([]);
 
         $cacheManager->shouldReceive('store')->once()->with(null)->andReturn($cacheRepository);
@@ -46,6 +47,7 @@ class ClearCommandTest extends TestCase
         $app = new Application;
         $app['path.storage'] = __DIR__;
         $command->setLaravel($app);
+        $files->shouldReceive('exists')->andReturn(true);
         $files->shouldReceive('files')->andReturn([]);
 
         $cacheManager->shouldReceive('store')->once()->with('foo')->andReturn($cacheRepository);
@@ -89,6 +91,7 @@ class ClearCommandTest extends TestCase
         $app = new Application;
         $app['path.storage'] = __DIR__;
         $command->setLaravel($app);
+        $files->shouldReceive('exists')->andReturn(true);
         $files->shouldReceive('files')->andReturn([]);
 
         $cacheManager->shouldReceive('store')->once()->with(null)->andReturn($cacheRepository);
@@ -110,6 +113,7 @@ class ClearCommandTest extends TestCase
         $app = new Application;
         $app['path.storage'] = __DIR__;
         $command->setLaravel($app);
+        $files->shouldReceive('exists')->andReturn(true);
         $files->shouldReceive('files')->andReturn([]);
 
         $cacheManager->shouldReceive('store')->once()->with('redis')->andReturn($cacheRepository);
@@ -134,8 +138,32 @@ class ClearCommandTest extends TestCase
         $cacheManager->shouldReceive('store')->once()->with(null)->andReturn($cacheRepository);
         $cacheRepository->shouldReceive('flush')->once();
 
+        $files->shouldReceive('exists')->andReturn(true);
         $files->shouldReceive('files')->andReturn(['/facade-XXXX.php']);
         $files->shouldReceive('delete')->with('/facade-XXXX.php')->once();
+
+        $this->runCommand($command);
+    }
+
+    public function testClearWillNotClearRealTimeFacadesIfCacheDirectoryDoesntExist()
+    {
+        $command = new ClearCommandTestStub(
+            $cacheManager = m::mock('Illuminate\Cache\CacheManager'),
+            $files = m::mock('Illuminate\Filesystem\Filesystem')
+        );
+
+        $cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
+
+        $app = new Application;
+        $app['path.storage'] = __DIR__;
+        $command->setLaravel($app);
+        $cacheManager->shouldReceive('store')->once()->with(null)->andReturn($cacheRepository);
+        $cacheRepository->shouldReceive('flush')->once();
+
+        // No files should be looped over and nothing should be deleted if the cache directory doesn't exist
+        $files->shouldReceive('exists')->andReturn(false);
+        $files->shouldNotReceive('files');
+        $files->shouldNotReceive('delete');
 
         $this->runCommand($command);
     }

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -119,7 +119,7 @@ class ClearCommandTest extends TestCase
         $this->runCommand($command, ['store' => 'redis', '--tags' => 'foo']);
     }
 
-    public function testClearWillClearsRealTimeFacades()
+    public function testClearWillClearRealTimeFacades()
     {
         $command = new ClearCommandTestStub(
             $cacheManager = m::mock('Illuminate\Cache\CacheManager'),


### PR DESCRIPTION
## Problem

As mentioned in 
https://github.com/laravel/framework/commit/489c9f9a4fac72248bfff1db36386699995c500d, if `storage_path('framework/cache')` doesn't exist, `php artisan cache:clear` fails with the following error:

```
$ php artisan cache:clear -vvv

In Finder.php line 543:
                                                                        
  [InvalidArgumentException]                                            
  The "/vagrant/api/storage/framework/cache" directory does not exist.  
```

This happens regardless of the cache driver used, including `array`.

## Solution

Practically all cache drivers except `file` work just fine without the `framework/cache` directory, so it's common to have deployments where said directory doesn't exist. Clearing the cache should still work, especially since an `array` or `redis` cache should have nothing to do with the filesystem.

I've added appropriate tests and took the liberty to clean the whole test case up a bit.
