### PR TITLE
[5.6] Allow for custom token guard keys

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -36,14 +36,16 @@ class TokenGuard implements Guard
      *
      * @param  \Illuminate\Contracts\Auth\UserProvider  $provider
      * @param  \Illuminate\Http\Request  $request
+     * @param. string $inputKey
+     * @param  string $storageKey
      * @return void
      */
-    public function __construct(UserProvider $provider, Request $request)
+    public function __construct(UserProvider $provider, Request $request, $inputKey = 'api_token', $storageKey = 'api_token')
     {
         $this->request = $request;
         $this->provider = $provider;
-        $this->inputKey = 'api_token';
-        $this->storageKey = 'api_token';
+        $this->inputKey = $inputKey;
+        $this->storageKey = $storageKey;
     }
 
     /**

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -108,6 +108,84 @@ class AuthTokenGuardTest extends TestCase
 
         $this->assertEquals(1, $user->id);
     }
+
+    public function testUserCanBeRetrievedByBearerTokenWithCustomKey()
+    {
+        $provider = Mockery::mock(UserProvider::class);
+        $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn((object) ['id' => 1]);
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer foo']);
+
+        $guard = new TokenGuard($provider, $request, 'custom_token_field', 'custom_token_field');
+
+        $user = $guard->user();
+
+        $this->assertEquals(1, $user->id);
+    }
+
+    public function testUserCanBeRetrievedByQueryStringVariableWithCustomKey()
+    {
+        $provider = Mockery::mock(UserProvider::class);
+        $user = new AuthTokenGuardTestUser;
+        $user->id = 1;
+        $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn($user);
+        $request = Request::create('/', 'GET', ['custom_token_field' => 'foo']);
+
+        $guard = new TokenGuard($provider, $request, 'custom_token_field', 'custom_token_field');
+
+        $user = $guard->user();
+
+        $this->assertEquals(1, $user->id);
+        $this->assertTrue($guard->check());
+        $this->assertFalse($guard->guest());
+        $this->assertEquals(1, $guard->id());
+    }
+
+    public function testUserCanBeRetrievedByAuthHeadersWithCustomField()
+    {
+        $provider = Mockery::mock(UserProvider::class);
+        $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn((object) ['id' => 1]);
+        $request = Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo', 'PHP_AUTH_PW' => 'foo']);
+
+        $guard = new TokenGuard($provider, $request, 'custom_token_field', 'custom_token_field');
+
+        $user = $guard->user();
+
+        $this->assertEquals(1, $user->id);
+    }
+
+    public function testValidateCanDetermineIfCredentialsAreValidWithCustomKey()
+    {
+        $provider = Mockery::mock(UserProvider::class);
+        $user = new AuthTokenGuardTestUser;
+        $user->id = 1;
+        $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn($user);
+        $request = Request::create('/', 'GET', ['custom_token_field' => 'foo']);
+
+        $guard = new TokenGuard($provider, $request, 'custom_token_field', 'custom_token_field');
+
+        $this->assertTrue($guard->validate(['custom_token_field' => 'foo']));
+    }
+
+    public function testValidateCanDetermineIfCredentialsAreInvalidWithCustomKey()
+    {
+        $provider = Mockery::mock(UserProvider::class);
+        $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn(null);
+        $request = Request::create('/', 'GET', ['custom_token_field' => 'foo']);
+
+        $guard = new TokenGuard($provider, $request, 'custom_token_field', 'custom_token_field');
+
+        $this->assertFalse($guard->validate(['custom_token_field' => 'foo']));
+    }
+
+    public function testValidateIfApiTokenIsEmptyWithCustomKey()
+    {
+        $provider = Mockery::mock(UserProvider::class);
+        $request = Request::create('/', 'GET', ['custom_token_field' => '']);
+
+        $guard = new TokenGuard($provider, $request, 'custom_token_field', 'custom_token_field');
+
+        $this->assertFalse($guard->validate(['custom_token_field' => '']));
+    }
 }
 
 class AuthTokenGuardTestUser


### PR DESCRIPTION
Allows for easy customization of the `TokenGuard` key references for both the query param and the database field.

Leaves original values as defaults for backward compatibility.