### PR TITLE
Add equals method to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -396,6 +396,26 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Determine if all items in the collection are equal to the given items
+     *
+     * @param  mixed  $items
+     * @return bool
+     */
+    public function equals($items)
+    {
+        $givenItems = $this->getArrayableItems($items);
+
+        $firstDiff = count($this->diff($givenItems)) === 0;
+
+        $originalItems = $this->items;
+        $this->items = $givenItems;
+        $secondDiff = count($this->diff($originalItems)) === 0;
+        $this->items = $originalItems;
+
+        return  $firstDiff && $secondDiff;
+    }
+
+    /**
      * Determine if all items in the collection pass the given test.
      *
      * @param  string|callable  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -742,6 +742,24 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([[1, 'a', 0], [2, 'b', 1]], $result);
     }
 
+    public function testEquals(){
+        $a = new Collection(['id' => 1, 'first_word' => 'Hello']);
+        $b = new Collection(['id' => 1, 'first_word' => 'Hello']);
+        $c = new Collection(['id' => 1, 'first_word' => 'Goodbye']);
+        
+        $this->assertTrue($a->equals($b));
+        $this->assertTrue($b->equals($a));
+        $this->assertFalse($a->equals($c));
+
+        $a = new Collection([1,2,3]);
+        $b = new Collection([1,2,3]);
+        $c = new Collection([1,2,3,4]);
+        
+        $this->assertTrue($a->equals($b));
+        $this->assertTrue($b->equals($a));
+        $this->assertFalse($a->equals($c));
+    }
+
     public function testIntersectNull()
     {
         $c = new Collection(['id' => 1, 'first_word' => 'Hello']);


### PR DESCRIPTION
Hey, first time contributing to the framework, hope this is not too bad and sorry if it is

Similar to the is() method for model comparison I wanted to add an equals method to compare two collections based on their values.

My need to add this comes from testing that the collection a view received is the same as the one you created in a test, this method would allow a simple check like so:

```
$orders = factory(Order::class, 3)->create();

$this->get(route('orders.index'))
     ->assertViewHas('orders', function ($viewOrders) use ($orders) {
        return $viewOrders->equals($orders);
     });
```

If it is a single model you can easily do the comparison with the is() method, however I believe there is nothing similar for collections.

The way I do the check is by using the diff method in collections and verifying that the count equals 0 in both ways (that means that a is equal to b and that b is equal to a, because based on the way diff works it can lead to different results).

Thanks and again, sorry if I missed anything or if my implementation is too naive.