### PR TITLE
[5.6] Added states to model factory after callbacks

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -120,7 +120,22 @@ class Factory implements ArrayAccess
      */
     public function afterMaking($class, $callback)
     {
-        $this->afterMaking[$class][] = $callback;
+        $this->afterMaking[$class]['default'][] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Define a callback to run after making a model with given type.
+     *
+     * @param  string  $class
+     * @param  string  $state
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function afterMakingState($class, $state, callable $callback)
+    {
+        $this->afterMaking[$class][$state][] = $callback;
 
         return $this;
     }
@@ -134,7 +149,22 @@ class Factory implements ArrayAccess
      */
     public function afterCreating($class, $callback)
     {
-        $this->afterCreating[$class][] = $callback;
+        $this->afterCreating[$class]['default'][] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Define a callback to run after creating a model with given type.
+     *
+     * @param  string  $class
+     * @param  string  $state
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function afterCreatingState($class, $state, callable $callback)
+    {
+        $this->afterCreating[$class][$state][] = $callback;
 
         return $this;
     }

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -51,6 +51,14 @@ class EloquentFactoryBuilderTest extends TestCase
             $user->setRelation('profile', $profile);
         });
 
+        $factory->afterMakingState(FactoryBuildableUser::class, 'with_callable_server', function (FactoryBuildableUser $user, Generator $faker) {
+            $server = factory(FactoryBuildableServer::class)
+                ->states('callable')
+                ->make(['user_id' => $user->id]);
+
+            $user->servers->push($server);
+        });
+
         $factory->define(FactoryBuildableTeam::class, function (Generator $faker) {
             return [
                 'name' => $faker->name,
@@ -79,6 +87,12 @@ class EloquentFactoryBuilderTest extends TestCase
             return [
                 'status' => 'callable',
             ];
+        });
+
+        $factory->afterCreatingState(FactoryBuildableUser::class, 'with_callable_server', function(FactoryBuildableUser $user, Generator $faker){
+            $server = factory(FactoryBuildableServer::class)
+                ->states('callable')
+                ->create(['user_id' => $user->id]);
         });
 
         $factory->state(FactoryBuildableServer::class, 'inline', ['status' => 'inline']);
@@ -234,6 +248,15 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertTrue($team->users->contains($team->owner));
     }
 
+    /** @test **/
+    public function creating_models_with_after_callback_states()
+    {
+        $user = factory(FactoryBuildableUser::class)->states('with_callable_server')->create();
+
+        $this->assertNotNull($user->profile);
+        $this->assertNotNull($user->servers->where('status', 'callable')->first());
+    }
+
     /** @test */
     public function making_models_with_a_custom_connection()
     {
@@ -250,6 +273,15 @@ class EloquentFactoryBuilderTest extends TestCase
         $user = factory(FactoryBuildableUser::class)->make();
 
         $this->assertNotNull($user->profile);
+    }
+
+    /** @test **/
+    public function making_models_with_after_callback_states()
+    {
+        $user = factory(FactoryBuildableUser::class)->states('with_callable_server')->make();
+
+        $this->assertNotNull($user->profile);
+        $this->assertNotNull($user->servers->where('status', 'callable')->first());
     }
 }
 


### PR DESCRIPTION
This is an addition to this recently merged PR made by @Indemnity83. 
https://github.com/laravel/framework/pull/23495

It adds the ability to bind the after callbacks to specific model factory states using the existing api pattern of existing create/make methods. 

I this is not completely ready for PR. I wanted to submit it quickly after the above PR was merged to keep the discussion going. It still needs tests. Tagging the people that discussed the above PR to get their input: @deleugpn @browner12 @shadoWalker89
