### PR TITLE
[5.5] Remove attribute filling from pivot model #23401

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -80,7 +80,7 @@ class Pivot extends Model
      */
     public static function fromRawAttributes(Model $parent, $attributes, $table, $exists = false)
     {
-        $instance = static::fromAttributes($parent, $attributes, $table, $exists);
+        $instance = static::fromAttributes($parent, [], $table, $exists);
 
         $instance->setRawAttributes($attributes, true);
 

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -37,14 +37,14 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertTrue($pivot->getMutatorCalled());
     }
 
-    public function testFromRawAttributesDoesNotDoubleMutate()
+    public function testFromRawAttributesDoesNotMutate()
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
         $parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
 
-        $pivot = DatabaseEloquentPivotTestJsonCastStub::fromRawAttributes($parent, ['foo' => json_encode(['name' => 'Taylor'])], 'table', true);
+        $pivot = DatabaseEloquentPivotTestMutatorStub::fromRawAttributes($parent, ['foo' => 'bar'], 'table', true);
 
-        $this->assertEquals(['name' => 'Taylor'], $pivot->foo);
+        $this->assertFalse($pivot->getMutatorCalled());
     }
 
     public function testPropertiesUnchangedAreNotDirty()
@@ -134,11 +134,4 @@ class DatabaseEloquentPivotTestMutatorStub extends \Illuminate\Database\Eloquent
     {
         return $this->mutatorCalled;
     }
-}
-
-class DatabaseEloquentPivotTestJsonCastStub extends \Illuminate\Database\Eloquent\Relations\Pivot
-{
-    protected $casts = [
-        'foo' => 'json',
-    ];
 }

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -37,6 +37,16 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertTrue($pivot->getMutatorCalled());
     }
 
+    public function testFromRawAttributesDoesNotDoubleMutate()
+    {
+        $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
+        $parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $pivot = DatabaseEloquentPivotTestJsonCastStub::fromRawAttributes($parent, ['foo' => json_encode(['name' => 'Taylor'])], 'table', true);
+
+        $this->assertEquals(['name' => 'Taylor'], $pivot->foo);
+    }
+
     public function testFromRawAttributesDoesNotMutate()
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
@@ -134,4 +144,11 @@ class DatabaseEloquentPivotTestMutatorStub extends \Illuminate\Database\Eloquent
     {
         return $this->mutatorCalled;
     }
+}
+
+class DatabaseEloquentPivotTestJsonCastStub extends \Illuminate\Database\Eloquent\Relations\Pivot
+{
+    protected $casts = [
+        'foo' => 'json',
+    ];
 }


### PR DESCRIPTION
This PR is a copy of [this pr](https://github.com/laravel/framework/pull/23401)  that was merged for laravel 5.6. 
Laravel 5.6 needs a new version of php, and since is only a one line change I am hoping for this to get merged in 5.5 as well.

The original text from @staudenmeir . cheers.

When querying a pivot relationship with a specified model (using()) the attributes are set using forceFill(), causing custom mutators to be called.

This is inconsistent with non-pivot models and also unnecessary, since the values are immediately overwritten with the raw attributes.

Fixes #23234.