### PR TITLE
Illuminate\Pagination\AbstractPaginator must implement the according Contracts interface.

### DIFF
--- a/src/Illuminate/Contracts/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Contracts/Pagination/LengthAwarePaginator.php
@@ -14,6 +14,20 @@ interface LengthAwarePaginator extends Paginator
     public function getUrlRange($start, $end);
 
     /**
+     * Determine if there are enough items to split into multiple pages.
+     *
+     * @return bool
+     */
+    public function hasPages();
+
+    /**
+     * Determine if there is more items in the data store.
+     *
+     * @return bool
+     */
+    public function hasMorePages();
+
+    /**
      * Determine the total number of items in the data store.
      *
      * @return int

--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -79,20 +79,6 @@ interface Paginator
     public function currentPage();
 
     /**
-     * Determine if there are enough items to split into multiple pages.
-     *
-     * @return bool
-     */
-    public function hasPages();
-
-    /**
-     * Determine if there is more items in the data store.
-     *
-     * @return bool
-     */
-    public function hasMorePages();
-
-    /**
      * Determine if the list of items is empty or not.
      *
      * @return bool
@@ -111,7 +97,7 @@ interface Paginator
      *
      * @param  string|null  $view
      * @param  array  $data
-     * @return string
+     * @return \Illuminate\Support\HtmlString
      */
     public function render($view = null, $data = []);
 }

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -134,7 +134,7 @@ trait BuildsQueries
      * @param  int  $perPage
      * @param  int  $currentPage
      * @param  array  $options
-     * @return \Illuminate\Pagination\LengthAwarePaginator
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
     protected function paginator($items, $total, $perPage, $currentPage, $options)
     {

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -6,11 +6,12 @@ use Closure;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\Pagination\Paginator;
 
 /**
  * @mixin \Illuminate\Support\Collection
  */
-abstract class AbstractPaginator implements Htmlable
+abstract class AbstractPaginator implements Htmlable, Paginator
 {
     /**
      * All of the items being paginated.
@@ -108,6 +109,30 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Get the current page for the request.
+     *
+     * @param  int  $currentPage
+     * @param  string  $pageName
+     * @return int
+     */
+    protected function setCurrentPage($currentPage, $pageName)
+    {
+        $currentPage = $currentPage ?: static::resolveCurrentPage($pageName);
+
+        return $this->currentPage = $this->isValidPageNumber($currentPage) ? (int) $currentPage : 1;
+    }
+
+    /**
+     * Get the URL for the next page.
+     *
+     * @return string
+     */
+    public function nextPageUrl()
+    {
+        return $this->url($this->currentPage() + 1);
+    }
+
+    /**
      * Get the URL for the previous page.
      *
      * @return string|null
@@ -117,6 +142,8 @@ abstract class AbstractPaginator implements Htmlable
         if ($this->currentPage() > 1) {
             return $this->url($this->currentPage() - 1);
         }
+
+        return null;
     }
 
     /**
@@ -272,16 +299,6 @@ abstract class AbstractPaginator implements Htmlable
     public function perPage()
     {
         return $this->perPage;
-    }
-
-    /**
-     * Determine if there are enough items to split into multiple pages.
-     *
-     * @return bool
-     */
-    public function hasPages()
-    {
-        return $this->currentPage() != 1 || $this->hasMorePages();
     }
 
     /**

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -48,22 +48,8 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         $this->perPage = $perPage;
         $this->lastPage = max((int) ceil($total / $perPage), 1);
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
-        $this->currentPage = $this->setCurrentPage($currentPage, $this->pageName);
+        $this->setCurrentPage($currentPage, $this->pageName);
         $this->items = $items instanceof Collection ? $items : Collection::make($items);
-    }
-
-    /**
-     * Get the current page for the request.
-     *
-     * @param  int  $currentPage
-     * @param  string  $pageName
-     * @return int
-     */
-    protected function setCurrentPage($currentPage, $pageName)
-    {
-        $currentPage = $currentPage ?: static::resolveCurrentPage($pageName);
-
-        return $this->isValidPageNumber($currentPage) ? (int) $currentPage : 1;
     }
 
     /**
@@ -122,6 +108,16 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     }
 
     /**
+     * Determine if there are enough items to split into multiple pages.
+     *
+     * @return bool
+     */
+    public function hasPages()
+    {
+        return $this->currentPage() != 1 || $this->hasMorePages();
+    }
+
+    /**
      * Determine if there are more items in the data source.
      *
      * @return bool
@@ -141,6 +137,8 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         if ($this->lastPage() > $this->currentPage()) {
             return $this->url($this->currentPage() + 1);
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Also there must be one pagination interface in Database library
Abstractions fixes - pagination length aware context, interfaces completeness and logic.

Problems related to the proposed pull request:
1. Illuminate\Pagination\AbstractPaginator was actually length aware because it was using $this->hasMorePages(), which is a length aware method. If Illuminate\Pagination\AbstractPaginator does not implement Illuminate\Contracts\Pagination\Paginator, this method is undefined at all in abstract class. Maybe the methods hasPages(), hasMorePages() must be moved from Illuminate\Contracts\Pagination\Paginator and Illuminate\Pagination\AbstractPaginator to the according LengthAwarePaginatorS as length aware method.
2. Adding "implements Illuminate\Contracts\Pagination\Paginator" construction adds to Illuminate\Pagination\AbstractPaginator another one indirectly length aware method - nextPageUrl() - it's implementation in Illuminate\Pagination\LengthAwarePaginator suppose the idea of lastPage() method. This method has to be rewritten in Illuminate\Pagination\AbstractPaginator to ignore length aware context.
3. Illuminate\Pagination\AbstractPaginator has no setCurrentPage() method, but it has everything for it, and AbstractPaginator nature, whether length aware or not, suppose this method to exist, so setCurrentPage() should be moved to Illuminate\Pagination\AbstractPaginator from Illuminate\Pagination\LengthAwarePaginator. Moreover, this method has object context and it's name suppose protected property currentPage to be set, but instead it does not do this and works as a static method. It is not the expected setter behaviour. This method suppose to return void, but I have left the signature unchanged for backward compatibility.