### PR TITLE
[5.6] Add support for ResetPassword

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -56,9 +56,10 @@ class ResetPassword extends Notification
         }
 
         return (new MailMessage)
-            ->line('You are receiving this email because we received a password reset request for your account.')
-            ->action('Reset Password', url(config('app.url').route('password.reset', $this->token, false)))
-            ->line('If you did not request a password reset, no further action is required.');
+            ->subject(trans('auth.reset_password'))
+            ->line(trans('auth.reset_password_message_line_1'))
+            ->action(trans('auth.reset_password'), url(config('app.url').route('password.reset', $this->token, false)))
+            ->line(trans('auth.reset_password_message_line_2'));
     }
 
     /**


### PR DESCRIPTION
Just suggestion, and it assumes we use the existing auth.php file in resources/lang/en to translate ResetPassword Notification Mail.

Thanks.