### PR TITLE
[5.6] Prefixed Eloquent columns if necessary

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -225,6 +225,7 @@ class Builder
 
             $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
         } else {
+            $column = $this->model->qualifyColumn($column);
             $this->query->where(...func_get_args());
         }
 


### PR DESCRIPTION
I noticed if i join multiple tables together and put a where('id', '!=', $id) at the end the id column will not be prefixed with the table name.