### PR TITLE
[5.6] Add ElseAuth and ElseGuest Blade directives

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -25,6 +25,19 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the else-auth statements into valid PHP.
+     *
+     * @param  string|null  $guard
+     * @return string
+     */
+    protected function compileElseAuth($guard = null)
+    {
+        $guard = is_null($guard) ? '()' : $guard;
+
+        return "<?php elseif(auth()->guard{$guard}->check()): ?>";
+    }
+
+    /**
      * Compile the end-auth statements into valid PHP.
      *
      * @return string
@@ -45,6 +58,19 @@ trait CompilesConditionals
         $guard = is_null($guard) ? '()' : $guard;
 
         return "<?php if(auth()->guard{$guard}->guest()): ?>";
+    }
+
+    /**
+     * Compile the else-guest statements into valid PHP.
+     *
+     * @param  string|null  $guard
+     * @return string
+     */
+    protected function compileElseGuest($guard = null)
+    {
+        $guard = is_null($guard) ? '()' : $guard;
+
+        return "<?php elseif(auth()->guard{$guard}->guest()): ?>";
     }
 
     /**

--- a/tests/View/Blade/BladeElseAuthStatementsTest.php
+++ b/tests/View/Blade/BladeElseAuthStatementsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Blade;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeElseAuthStatementsTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testElseAuthStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@auth("api")
+breeze
+@elseauth("standard")
+wheeze
+@endauth';
+        $expected = '<?php if(auth()->guard("api")->check()): ?>
+breeze
+<?php elseif(auth()->guard("standard")->check()): ?>
+wheeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testPlainElseAuthStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@auth("api")
+breeze
+@elseauth
+wheeze
+@endauth';
+        $expected = '<?php if(auth()->guard("api")->check()): ?>
+breeze
+<?php elseif(auth()->guard()->check()): ?>
+wheeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    protected function getFiles()
+    {
+        return m::mock('Illuminate\Filesystem\Filesystem');
+    }
+}

--- a/tests/View/Blade/BladeElseGuestStatementsTest.php
+++ b/tests/View/Blade/BladeElseGuestStatementsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Tests\Blade;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeElseGuestStatementsTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testIfStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@guest("api")
+breeze
+@elseguest("standard")
+wheeze
+@endguest';
+        $expected = '<?php if(auth()->guard("api")->guest()): ?>
+breeze
+<?php elseif(auth()->guard("standard")->guest()): ?>
+wheeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    protected function getFiles()
+    {
+        return m::mock('Illuminate\Filesystem\Filesystem');
+    }
+}


### PR DESCRIPTION
I currently have an app where I'm using multiple guards.  Being able to have else if statements for auth would be great. I.e.

```
@auth('administrator')
@elseauth('standard')
@endauth
```

I added the corresponding `elseguest` for completeness, as given `elseauth` I'd expect it to exist but in my usecase I'm not sure we'd actually use it.