### PR TITLE
[5.6] Change Mail fake methods visibility to public

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -49,7 +49,7 @@ class MailFake implements Mailer
      * @param  int  $times
      * @return void
      */
-    protected function assertSentTimes($mailable, $times = 1)
+    public function assertSentTimes($mailable, $times = 1)
     {
         PHPUnit::assertTrue(
             ($count = $this->sent($mailable)->count()) === $times,
@@ -108,7 +108,7 @@ class MailFake implements Mailer
      * @param  int  $times
      * @return void
      */
-    protected function assertQueuedTimes($mailable, $times = 1)
+    public function assertQueuedTimes($mailable, $times = 1)
     {
         PHPUnit::assertTrue(
             ($count = $this->queued($mailable)->count()) === $times,


### PR DESCRIPTION
Change the visibility of `Mail::assertSentTimes()` and `Mail::assertQueuedTimes()` to public.

A usage example:
I have a paper with mutliple authors.
I want to send an email only to the (main, primary, first) author.

```php
Mail::assertSent(CustomEmail::class, function($mail){
       return $mail->hasTo('paper_first_author@test.com');
});

Mail::assertSentTimes(CustomEmail::class, 1);
```