### PR TITLE
[5.6] Add hashing configuration

### DIFF
--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -29,6 +29,18 @@ class ArgonHasher implements HasherContract
     protected $threads = 2;
 
     /**
+     * Constructor
+     *
+     * @param array $options
+     */
+    public function __construct($options=null)
+    {
+        $this->memory = $options['memory'] ?? $this->memory;
+        $this->time = $options['time'] ?? $this->time;
+        $this->threads = $options['threads'] ?? $this->threads;
+    }
+
+    /**
      * Get information about the given hashed value.
      *
      * @param  string  $hashedValue

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -29,11 +29,11 @@ class ArgonHasher implements HasherContract
     protected $threads = 2;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param array $options
      */
-    public function __construct($options=null)
+    public function __construct($options = null)
     {
         $this->memory = $options['memory'] ?? $this->memory;
         $this->time = $options['time'] ?? $this->time;

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -15,11 +15,11 @@ class BcryptHasher implements HasherContract
     protected $rounds = 10;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param array $options
      */
-    public function __construct($options=null)
+    public function __construct($options = null)
     {
         $this->rounds = $options['rounds'] ?? $this->rounds;
     }

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -15,6 +15,16 @@ class BcryptHasher implements HasherContract
     protected $rounds = 10;
 
     /**
+     * Constructor
+     *
+     * @param array $options
+     */
+    public function __construct($options=null)
+    {
+        $this->rounds = $options['rounds'] ?? $this->rounds;
+    }
+
+    /**
      * Get information about the given hashed value.
      *
      * @param  string  $hashedValue

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -14,7 +14,7 @@ class HashManager extends Manager implements Hasher
      */
     public function createBcryptDriver()
     {
-        return new BcryptHasher;
+        return new BcryptHasher($this->app['config']['hashing.bcrypt'] ?? []);
     }
 
     /**
@@ -24,7 +24,7 @@ class HashManager extends Manager implements Hasher
      */
     public function createArgonDriver()
     {
-        return new ArgonHasher;
+        return new ArgonHasher($this->app['config']['hashing.argon'] ?? []);
     }
 
     /**


### PR DESCRIPTION
When configuring hashing we should be able to manage the default settings.

The default configuration of argon is good for small systems but should be adjusted to target 0.5 sec to minimize the effect of make it harder to do a brute force attack.

The configuration file (hashing.php) should then have options to do that.

```
    /*
    |--------------------------------------------------------------------------
    | bcrypt options
    |--------------------------------------------------------------------------
    |
    | We could define the number of rounds the bcrypt algo will be using.
    |
    | The two digit cost parameter is the base-2 logarithm of the iteration
    | count for the underlying Blowfish-based hashing algorithmeter and must
    | be in range 04-31, values outside this range will cause crypt() to fail
    |
    | Default: 10
    */
    'bcrypt' => [
        'rounds' => 10
    ],

    /*
    |--------------------------------------------------------------------------
    | argon options
    |--------------------------------------------------------------------------
    |
    | These settings could be adjusted depending on your hardware.
    |
    | time: Maximum amount of time it may take to compute the Argon2 hash.
    |        (default: 2)
    |
    | memory: Maximum memory (in bytes) that may be used to compute the Argon2 hash
    |        (default : 1024)
    |
    | threads: Number of threads to use for computing the Argon2 hash
    |        (default : 2)
    |
    */
    'argon' => [
        'time' => 2,
        'memory' => 1024,
        'threads' => 2
    ]