### PR TITLE
[5.7] Add connection parameter to job scheduling

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -90,13 +90,13 @@ class Schedule
      * @param  string|null  $queue
      * @return \Illuminate\Console\Scheduling\CallbackEvent
      */
-    public function job($job, $queue = null)
+    public function job($job, $queue = null, $connection = null)
     {
-        return $this->call(function () use ($job, $queue) {
+        return $this->call(function () use ($job, $queue, $connection) {
             $job = is_string($job) ? resolve($job) : $job;
 
             if ($job instanceof ShouldQueue) {
-                dispatch($job)->onQueue($queue);
+                dispatch($job)->onConnection($connection)->onQueue($queue);
             } else {
                 dispatch_now($job);
             }


### PR DESCRIPTION
Currently, jobs scheduled via console scheduling can not specify a connection to dispatch that job onto. They can specify a queue.
This PR adds an optional connection parameter to the end of the job function.