### PR TITLE
[5.6] Increment and decrement tagged cache items

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -33,6 +33,34 @@ class RedisTaggedCache extends TaggedCache
     }
 
     /**
+     * Increment the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return void
+     */
+    public function increment($key, $value = 1)
+    {
+        $this->pushStandardKeys($this->tags->getNamespace(), $key);
+
+        parent::increment($key, $value);
+    }
+
+    /**
+     * Decrement the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return void
+     */
+    public function decrement($key, $value = 1)
+    {
+        $this->pushStandardKeys($s->tags->getNamespace(), $key);
+
+        parent::decrement($key, $value);
+    }
+
+    /**
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -42,7 +42,7 @@ class TaggedCache extends Repository
     }
 
     /**
-     * Increment the value of an item in the cache.
+     * Decrement the value of an item in the cache.
      *
      * @param  string  $key
      * @param  mixed   $value

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -52,6 +52,24 @@ class CacheTaggedCacheTest extends TestCase
         $this->assertEquals('bar', $store->tags('bop')->get('foo'));
     }
 
+    public function testTagsWithIncrementCanBeFlushed()
+    {
+        $store = new ArrayStore;
+        $store->tags('bop')->increment('foo', 5);
+        $this->assertEquals(5, $store->tags('bop')->get('foo'));
+        $store->tags('bop')->flush();
+        $this->assertNull($store->tags('bop')->get('foo'));
+    }
+
+    public function testTagsWithDecrementCanBeFlushed()
+    {
+        $store = new ArrayStore;
+        $store->tags('bop')->decrement('foo', 5);
+        $this->assertEquals(-5, $store->tags('bop')->get('foo'));
+        $store->tags('bop')->flush();
+        $this->assertNull($store->tags('bop')->get('foo'));
+    }
+
     public function testTagsCacheForever()
     {
         $store = new ArrayStore;


### PR DESCRIPTION
I noticed when using cache tags that keys created with increment and decrement are not removed during a tag flush.  

I added overrides for TaggedCache for increment and decrement to add the key to the set