### PR TITLE
[5.6] Remove unneeded parameter

### DIFF
--- a/src/Illuminate/Routing/Middleware/ValidateSignature.php
+++ b/src/Illuminate/Routing/Middleware/ValidateSignature.php
@@ -18,7 +18,7 @@ class ValidateSignature
      */
     public function handle($request, Closure $next)
     {
-        if ($request->hasValidSignature($request)) {
+        if ($request->hasValidSignature()) {
             return $next($request);
         }
 


### PR DESCRIPTION
The macro signature has no parameters, so passing `$request` is not needed.