### PR TITLE
[5.6] Signed routes with routable parameters

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -305,6 +305,8 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function signedRoute($name, $parameters = [], $expiration = null)
     {
+        $parameters = $this->formatParameters($parameters);
+
         if ($expiration) {
             $parameters = $parameters + ['expires' => $this->availableAt($expiration)];
         }


### PR DESCRIPTION
This adds the ability to pass in a parameter that implements the `UrlRoutable` interface when generating a signed route.

Given 
```php
class Invoice extends Model
{
    ...
}
```

and 

```php
Route::get('invoices/{invoice}', 'InvoiceController@show')->name('invoices.show');
```

then

```php
return url()->signedRoute('invoices.show', Invoice::first());
```

will generate a signed url for the invoice.