### PR TITLE
[5.6] Fix #23592 (SeeInOrder)

### DIFF
--- a/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php
@@ -2,21 +2,20 @@
 
 namespace Illuminate\Foundation\Testing\Constraints;
 
-use Illuminate\Database\Connection;
 use PHPUnit\Framework\Constraint\Constraint;
 
 class SeeInOrder extends Constraint
 {
     /**
      * The value that failed. Used to display in the error message.
-     * 
+     *
      * @var string
      */
     protected $failedValue;
 
     /**
      * The string we want to check the content of.
-     * 
+     *
      * @var
      */
     protected $content;
@@ -47,11 +46,13 @@ class SeeInOrder extends Constraint
 
             if ($valuePosition === false || $valuePosition < $position) {
                 $this->failedValue = $value;
+
                 return false;
             }
 
             $position = $valuePosition + mb_strlen($value);
         }
+
         return true;
     }
 
@@ -78,6 +79,7 @@ class SeeInOrder extends Constraint
     public function toString() : string
     {
         $class = new ReflectionClass($this);
+
         return $class->name;
     }
 }

--- a/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Constraints;
+
+use Illuminate\Database\Connection;
+use PHPUnit\Framework\Constraint\Constraint;
+
+class SeeInOrder extends Constraint
+{
+    /**
+     * The value that failed. Used to display in the error message.
+     * 
+     * @var string
+     */
+    protected $failedValue;
+
+    /**
+     * The string we want to check the content of.
+     * 
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  string $content
+     * @return void
+     */
+    public function __construct(string $content)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * Check if the data is found in the given table.
+     *
+     * @param  array  $values
+     * @return bool
+     */
+    public function matches($values) : bool
+    {
+        $position = 0;
+
+        foreach ($values as $value) {
+            $valuePosition = mb_strpos($this->content, $value, $position);
+
+            if ($valuePosition === false || $valuePosition < $position) {
+                $this->failedValue = $value;
+                return false;
+            }
+
+            $position = $valuePosition + mb_strlen($value);
+        }
+        return true;
+    }
+
+    /**
+     * Get the description of the failure.
+     *
+     * @param  array  $values
+     * @return string
+     */
+    public function failureDescription($values) : string
+    {
+        return sprintf(
+            'Failed asserting that \'%s\' contains "%s" in specified order.',
+            $this->content,
+            $this->failedValue
+        );
+    }
+}

--- a/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php
@@ -16,7 +16,7 @@ class SeeInOrder extends Constraint
     /**
      * The string we want to check the content of.
      *
-     * @var
+     * @var string
      */
     protected $content;
 

--- a/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php
@@ -73,11 +73,11 @@ class SeeInOrder extends Constraint
     /**
      * Get a string representation of the object.
      *
-     * @param  int  $options
      * @return string
      */
-    public function toString($options = 0) : string
+    public function toString() : string
     {
-        return json_encode($this->data, $options);
+        $class = new ReflectionClass($this);
+        return $class->name;
     }
 }

--- a/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php
@@ -17,7 +17,7 @@ class SeeInOrder extends Constraint
     /**
      * The string we want to check the content of.
      * 
-     * @var string
+     * @var
      */
     protected $content;
 
@@ -68,5 +68,16 @@ class SeeInOrder extends Constraint
             $this->content,
             $this->failedValue
         );
+    }
+
+    /**
+     * Get a string representation of the object.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toString($options = 0) : string
+    {
+        return json_encode($this->data, $options);
     }
 }

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Foundation\Testing\Constraints\SeeInOrder;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 /**
@@ -293,20 +294,7 @@ class TestResponse
      */
     public function assertSeeInOrder(array $values)
     {
-        $position = 0;
-
-        foreach ($values as $value) {
-            $valuePosition = mb_strpos($this->getContent(), $value, $position);
-
-            if ($valuePosition === false || $valuePosition < $position) {
-                PHPUnit::fail(
-                    'Failed asserting that \''.$this->getContent().
-                    '\' contains "'.$value.'" in specified order.'
-                );
-            }
-
-            $position = $valuePosition + mb_strlen($value);
-        }
+        PHPUnit::assertThat($values, new SeeInOrder($this->getContent()));
 
         return $this;
     }
@@ -332,20 +320,7 @@ class TestResponse
      */
     public function assertSeeTextInOrder(array $values)
     {
-        $position = 0;
-
-        foreach ($values as $value) {
-            $valuePosition = mb_strpos(strip_tags($this->getContent()), $value, $position);
-
-            if ($valuePosition === false || $valuePosition < $position) {
-                PHPUnit::fail(
-                    'Failed asserting that \''.strip_tags($this->getContent()).
-                    '\' contains "'.$value.'" in specified order.'
-                );
-            }
-
-            $position = $valuePosition + mb_strlen($value);
-        }
+        PHPUnit::assertThat($values, new SeeInOrder(strip_tags($this->getContent())));
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -8,8 +8,8 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Foundation\Testing\Constraints\SeeInOrder;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Illuminate\Foundation\Testing\Constraints\SeeInOrder;
 
 /**
  * @mixin \Illuminate\Http\Response

--- a/tests/Foundation/Testing/Constraints/SeeInOrderTest.php
+++ b/tests/Foundation/Testing/Constraints/SeeInOrderTest.php
@@ -8,9 +8,20 @@ use Illuminate\Tests\Foundation\FoundationTestResponseTest;
 
 class SeeInOrderTest extends TestCase
 {
-    public function testAllAssertionsDetected()
+    public function testAllSeeInOrderAssertionsDetected()
     {
         $test = new FoundationTestResponseTest('testAssertSeeInOrder');
+        $test->run();
+        // If we get four assertions, that means all of the assertions
+        // were detected by PHPUnit, which is what we want to know.
+        // Doing it this way allows the test to work even though
+        // the global settings don't check for risky tests.
+        $this->assertEquals($test->getNumAssertions(), 4);
+    }
+
+    public function testAllSeeTextInOrderAssertionsDetected()
+    {
+        $test = new FoundationTestResponseTest('testAssertSeeTextInOrder');
         $test->run();
         // If we get four assertions, that means all of the assertions
         // were detected by PHPUnit, which is what we want to know.

--- a/tests/Foundation/Testing/Constraints/SeeInOrderTest.php
+++ b/tests/Foundation/Testing/Constraints/SeeInOrderTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Testing\Constraints\SeeInOrder;
+use Illuminate\Tests\Foundation\FoundationTestResponseTest;
+
+class SeeInOrderTest extends TestCase
+{
+    public function testAllAssertionsDetected()
+    {
+        $test = new FoundationTestResponseTest('testAssertSeeInOrder');
+        $test->run();
+        // If we get four assertions, that means all of the assertions
+        // were detected by PHPUnit, which is what we want to know.
+        // Doing it this way allows the test to work even though
+        // the global settings don't check for risky tests.
+        $this->assertEquals($test->getNumAssertions(), 4);
+    }
+}

--- a/tests/Foundation/Testing/Constraints/SeeInOrderTest.php
+++ b/tests/Foundation/Testing/Constraints/SeeInOrderTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Foundation\Constraints;
 
 use PHPUnit\Framework\TestCase;
-use Illuminate\Foundation\Testing\Constraints\SeeInOrder;
 use Illuminate\Tests\Foundation\FoundationTestResponseTest;
 
 class SeeInOrderTest extends TestCase


### PR DESCRIPTION
This adds a SeeInOrder PHPUnit Constraint to address Issue #23592. Calling `assertSeeInOrder()` or `assertSeeTextInOrder()` should now result in PHPUnit registering that assertions were made (and thus not marking tests with only those assertions as risky). Also added a test file to make sure PHPUnit is calling the assertions.