### PR TITLE
[5.7] Redis events (simplified)

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Redis\RedisManager;
+use Illuminate\Foundation\Application;
 
 trait InteractsWithRedis
 {
@@ -27,6 +28,7 @@ trait InteractsWithRedis
      */
     public function setUpRedis()
     {
+        $app = $this->app ?? new Application;
         $host = getenv('REDIS_HOST') ?: '127.0.0.1';
         $port = getenv('REDIS_PORT') ?: 6379;
 
@@ -37,7 +39,7 @@ trait InteractsWithRedis
         }
 
         foreach ($this->redisDriverProvider() as $driver) {
-            $this->redis[$driver[0]] = new RedisManager($driver[0], [
+            $this->redis[$driver[0]] = new RedisManager($app, $driver[0], [
                 'cluster' => false,
                 'default' => [
                     'host' => $host,

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Redis\Connections;
 
 use Closure;
+use Illuminate\Redis\Events\QueryExecuted;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Redis\Limiters\DurationLimiterBuilder;
 use Illuminate\Redis\Limiters\ConcurrencyLimiterBuilder;
 
@@ -17,6 +19,13 @@ abstract class Connection
      * @var \Predis\Client
      */
     protected $client;
+
+    /**
+     * The event dispatcher instance.
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher
+     */
+    protected $events;
 
     /**
      * The Redis connection name.
@@ -100,7 +109,41 @@ abstract class Connection
      */
     public function command($method, array $parameters = [])
     {
-        return $this->client->{$method}(...$parameters);
+        $start = microtime(true);
+        $result = $this->client->{$method}(...$parameters);
+        $time = round((microtime(true) - $start) * 1000, 2);
+
+        if (isset($this->events)) {
+            $this->event(new QueryExecuted($method, $parameters, $time, $this));
+        }
+
+        return $result;
+    }
+
+    /**
+     * Fire the given event if possible.
+     *
+     * @param  mixed  $event
+     * @return void
+     */
+    protected function event($event)
+    {
+        if (isset($this->events)) {
+            $this->events->dispatch($event);
+        }
+    }
+
+    /**
+     * Register a Redis query listener with the connection.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function listen(Closure $callback)
+    {
+        if (isset($this->events)) {
+            $this->events->listen(QueryExecuted::class, $callback);
+        }
     }
 
     /**
@@ -124,6 +167,37 @@ abstract class Connection
         $this->name = $name;
 
         return $this;
+    }
+
+    /**
+     * Get the event dispatcher used by the connection.
+     *
+     * @return \Illuminate\Contracts\Events\Dispatcher
+     */
+    public function getEventDispatcher()
+    {
+        return $this->events;
+    }
+
+    /**
+     * Set the event dispatcher instance on the connection.
+     *
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $events
+     * @return void
+     */
+    public function setEventDispatcher(Dispatcher $events)
+    {
+        $this->events = $events;
+    }
+
+    /**
+     * Unset the event dispatcher instance on the connection.
+     *
+     * @return void
+     */
+    public function unsetEventDispatcher()
+    {
+        $this->events = null;
     }
 
     /**

--- a/src/Illuminate/Redis/Events/QueryExecuted.php
+++ b/src/Illuminate/Redis/Events/QueryExecuted.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Redis\Events;
+
+class QueryExecuted
+{
+    /**
+     * The Redis command that was executed.
+     *
+     * @var string
+     */
+    public $command;
+
+    /**
+     * The array of query parameters.
+     *
+     * @var array
+     */
+    public $parameters;
+
+    /**
+     * The number of milliseconds it took to execute the query.
+     *
+     * @var float
+     */
+    public $time;
+
+    /**
+     * The Redis connection instance.
+     *
+     * @var \Illuminate\Redis\Connections\Connection
+     */
+    public $connection;
+
+    /**
+     * The Redis connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $command
+     * @param  array  $parameters
+     * @param  float|null  $time
+     * @param  \Illuminate\Redis\Connections\Connection  $connection
+     * @return void
+     */
+    public function __construct($command, $parameters, $time, $connection)
+    {
+        $this->time = $time;
+        $this->command = $command;
+        $this->parameters = $parameters;
+        $this->connection = $connection;
+        $this->connectionName = $connection->getName();
+    }
+}

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -40,7 +40,7 @@ class RedisManager implements Factory
     protected $connections;
 
     /**
-     * Whether or not event dispatcher is set on connections.
+     * Indicates whether event dispatcher is set on connections.
      *
      * @var bool
      */
@@ -164,6 +164,16 @@ class RedisManager implements Factory
     }
 
     /**
+     * Enable setting event dispatcher on connections.
+     *
+     * @return array
+     */
+    public function enableEvents()
+    {
+        return $this->events = true;
+    }
+    
+        /**
      * Disable setting event dispatcher on connections.
      *
      * @return array

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -40,6 +40,13 @@ class RedisManager implements Factory
     protected $connections;
 
     /**
+     * Whether or not event dispatcher is set on connections.
+     *
+     * @var bool
+     */
+    protected $events = true;
+
+    /**
      * Create a new Redis manager instance.
      *
      * @param  \Illuminate\Foundation\Application  $app
@@ -124,7 +131,7 @@ class RedisManager implements Factory
     {
         $connection->setName($name);
 
-        if ($this->app->bound('events')) {
+        if ($this->events && $this->app->bound('events')) {
             $connection->setEventDispatcher($this->app['events']);
         }
 
@@ -154,6 +161,16 @@ class RedisManager implements Factory
     public function connections()
     {
         return $this->connections;
+    }
+
+    /**
+     * Disable setting event dispatcher on connections.
+     *
+     * @return array
+     */
+    public function disableEvents()
+    {
+        return $this->events = false;
     }
 
     /**

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -173,7 +173,7 @@ class RedisManager implements Factory
         return $this->events = true;
     }
     
-        /**
+    /**
      * Disable setting event dispatcher on connections.
      *
      * @return array

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -172,7 +172,7 @@ class RedisManager implements Factory
     {
         return $this->events = true;
     }
-    
+
     /**
      * Disable setting event dispatcher on connections.
      *

--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -24,7 +24,7 @@ class RedisServiceProvider extends ServiceProvider
         $this->app->singleton('redis', function ($app) {
             $config = $app->make('config')->get('database.redis');
 
-            return new RedisManager(Arr::pull($config, 'client', 'predis'), $config);
+            return new RedisManager($app, Arr::pull($config, 'client', 'predis'), $config);
         });
 
         $this->app->bind('redis.connection', function ($app) {


### PR DESCRIPTION
This is a reboot of #22961 without the clutter of #23225 and #23235.

It adds a `QueryExecuted` event to Redis connections. It's pretty much identical to what the database component is doing regarding events.

The only breaking change is that `RedisManager` constructor has changed and now requires a `Application` instance, just like `DatabaseManager` does.

My use case is: We're using the [Server Timing](https://www.w3.org/TR/server-timing/) API **in production** to continuously measure performance. Another interesting use case would be Debugbar support to get insights into Redis calls during development.

Just like in the database component, Redis events are enabled by default, but may be disabled in a service provider:

```php
class AppServiceProvider extends ServiceProvider
{
    public function boot()
    {
        Redis::disableEvents();
    }
}
```