### PR TITLE
[5.7] Add return void type to tests, as well setUp and tearDown

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -15,12 +15,12 @@ class GateTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Callback must be a callable or a 'Class@method'
      */
-    public function test_gate_throws_exception_on_invalid_callback_type()
+    public function test_gate_throws_exception_on_invalid_callback_type(): void
     {
         $this->getBasicGate()->define('foo', 'foo');
     }
 
-    public function test_basic_closures_can_be_defined()
+    public function test_basic_closures_can_be_defined(): void
     {
         $gate = $this->getBasicGate();
 
@@ -35,7 +35,7 @@ class GateTest extends TestCase
         $this->assertFalse($gate->check('bar'));
     }
 
-    public function test_resource_gates_can_be_defined()
+    public function test_resource_gates_can_be_defined(): void
     {
         $gate = $this->getBasicGate();
 
@@ -49,7 +49,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('test.delete', $dummy));
     }
 
-    public function test_custom_resource_gates_can_be_defined()
+    public function test_custom_resource_gates_can_be_defined(): void
     {
         $gate = $this->getBasicGate();
 
@@ -64,7 +64,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('test.ability2'));
     }
 
-    public function test_before_callbacks_can_override_result_if_necessary()
+    public function test_before_callbacks_can_override_result_if_necessary(): void
     {
         $gate = $this->getBasicGate();
 
@@ -80,7 +80,7 @@ class GateTest extends TestCase
         $this->assertFalse($gate->check('foo'));
     }
 
-    public function test_before_callbacks_dont_interrupt_gate_check_if_no_value_is_returned()
+    public function test_before_callbacks_dont_interrupt_gate_check_if_no_value_is_returned(): void
     {
         $gate = $this->getBasicGate();
 
@@ -93,7 +93,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('foo'));
     }
 
-    public function test_after_callbacks_are_called_with_result()
+    public function test_after_callbacks_are_called_with_result(): void
     {
         $gate = $this->getBasicGate();
 
@@ -117,7 +117,7 @@ class GateTest extends TestCase
         $this->assertFalse($gate->check('missing'));
     }
 
-    public function test_current_user_that_is_on_gate_always_injected_into_closure_callbacks()
+    public function test_current_user_that_is_on_gate_always_injected_into_closure_callbacks(): void
     {
         $gate = $this->getBasicGate();
 
@@ -130,7 +130,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('foo'));
     }
 
-    public function test_a_single_argument_can_be_passed_when_checking_abilities()
+    public function test_a_single_argument_can_be_passed_when_checking_abilities(): void
     {
         $gate = $this->getBasicGate();
 
@@ -145,7 +145,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('foo', $dummy));
     }
 
-    public function test_multiple_arguments_can_be_passed_when_checking_abilities()
+    public function test_multiple_arguments_can_be_passed_when_checking_abilities(): void
     {
         $gate = $this->getBasicGate();
 
@@ -162,7 +162,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('foo', [$dummy1, $dummy2]));
     }
 
-    public function test_classes_can_be_defined_as_callbacks_using_at_notation()
+    public function test_classes_can_be_defined_as_callbacks_using_at_notation(): void
     {
         $gate = $this->getBasicGate();
 
@@ -171,7 +171,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('foo'));
     }
 
-    public function test_policy_classes_can_be_defined_to_handle_checks_for_given_type()
+    public function test_policy_classes_can_be_defined_to_handle_checks_for_given_type(): void
     {
         $gate = $this->getBasicGate();
 
@@ -180,7 +180,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestDummy));
     }
 
-    public function test_policy_classes_handle_checks_for_all_subtypes()
+    public function test_policy_classes_handle_checks_for_all_subtypes(): void
     {
         $gate = $this->getBasicGate();
 
@@ -189,7 +189,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestSubDummy));
     }
 
-    public function test_policy_classes_handle_checks_for_interfaces()
+    public function test_policy_classes_handle_checks_for_interfaces(): void
     {
         $gate = $this->getBasicGate();
 
@@ -198,7 +198,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestSubDummy));
     }
 
-    public function test_policy_converts_dash_to_camel()
+    public function test_policy_converts_dash_to_camel(): void
     {
         $gate = $this->getBasicGate();
 
@@ -207,7 +207,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('update-dash', new AccessGateTestDummy));
     }
 
-    public function test_policy_default_to_false_if_method_does_not_exist_and_gate_does_not_exist()
+    public function test_policy_default_to_false_if_method_does_not_exist_and_gate_does_not_exist(): void
     {
         $gate = $this->getBasicGate();
 
@@ -216,7 +216,7 @@ class GateTest extends TestCase
         $this->assertFalse($gate->check('nonexistent_method', new AccessGateTestDummy));
     }
 
-    public function test_policy_classes_can_be_defined_to_handle_checks_for_given_class_name()
+    public function test_policy_classes_can_be_defined_to_handle_checks_for_given_class_name(): void
     {
         $gate = $this->getBasicGate(true);
 
@@ -225,7 +225,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('create', [AccessGateTestDummy::class, true]));
     }
 
-    public function test_policies_may_have_before_methods_to_override_checks()
+    public function test_policies_may_have_before_methods_to_override_checks(): void
     {
         $gate = $this->getBasicGate();
 
@@ -234,7 +234,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestDummy));
     }
 
-    public function test_policies_always_override_closures_with_same_name()
+    public function test_policies_always_override_closures_with_same_name(): void
     {
         $gate = $this->getBasicGate();
 
@@ -247,7 +247,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestDummy));
     }
 
-    public function test_policies_defer_to_gates_if_method_does_not_exist()
+    public function test_policies_defer_to_gates_if_method_does_not_exist(): void
     {
         $gate = $this->getBasicGate();
 
@@ -260,7 +260,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('nonexistent_method', new AccessGateTestDummy));
     }
 
-    public function test_for_user_method_attaches_a_new_user_to_a_new_gate_instance()
+    public function test_for_user_method_attaches_a_new_user_to_a_new_gate_instance(): void
     {
         $gate = $this->getBasicGate();
 
@@ -278,7 +278,7 @@ class GateTest extends TestCase
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
      * @expectedExceptionMessage You are not an admin.
      */
-    public function test_authorize_throws_unauthorized_exception()
+    public function test_authorize_throws_unauthorized_exception(): void
     {
         $gate = $this->getBasicGate();
 
@@ -287,7 +287,7 @@ class GateTest extends TestCase
         $gate->authorize('create', new AccessGateTestDummy);
     }
 
-    public function test_authorize_returns_allowed_response()
+    public function test_authorize_returns_allowed_response(): void
     {
         $gate = $this->getBasicGate(true);
 
@@ -301,7 +301,7 @@ class GateTest extends TestCase
         $this->assertTrue($check);
     }
 
-    public function test_authorize_returns_an_allowed_response_for_a_truthy_return()
+    public function test_authorize_returns_an_allowed_response_for_a_truthy_return(): void
     {
         $gate = $this->getBasicGate();
 
@@ -320,7 +320,7 @@ class GateTest extends TestCase
         });
     }
 
-    public function test_any_ability_check_passes_if_all_pass()
+    public function test_any_ability_check_passes_if_all_pass(): void
     {
         $gate = $this->getBasicGate();
 
@@ -329,7 +329,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->any(['edit', 'update'], new AccessGateTestDummy));
     }
 
-    public function test_any_ability_check_passes_if_at_least_one_passes()
+    public function test_any_ability_check_passes_if_at_least_one_passes(): void
     {
         $gate = $this->getBasicGate();
 
@@ -338,7 +338,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->any(['edit', 'update'], new AccessGateTestDummy));
     }
 
-    public function test_any_ability_check_fails_if_none_pass()
+    public function test_any_ability_check_fails_if_none_pass(): void
     {
         $gate = $this->getBasicGate();
 
@@ -347,7 +347,7 @@ class GateTest extends TestCase
         $this->assertFalse($gate->any(['edit', 'update'], new AccessGateTestDummy));
     }
 
-    public function test_every_ability_check_passes_if_all_pass()
+    public function test_every_ability_check_passes_if_all_pass(): void
     {
         $gate = $this->getBasicGate();
 
@@ -356,7 +356,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check(['edit', 'update'], new AccessGateTestDummy));
     }
 
-    public function test_every_ability_check_fails_if_at_least_one_fails()
+    public function test_every_ability_check_fails_if_at_least_one_fails(): void
     {
         $gate = $this->getBasicGate();
 
@@ -365,7 +365,7 @@ class GateTest extends TestCase
         $this->assertFalse($gate->check(['edit', 'update'], new AccessGateTestDummy));
     }
 
-    public function test_every_ability_check_fails_if_none_pass()
+    public function test_every_ability_check_fails_if_none_pass(): void
     {
         $gate = $this->getBasicGate();
 

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -9,14 +9,14 @@ use Illuminate\Auth\Passwords\DatabaseTokenRepository;
 
 class AuthDatabaseTokenRepositoryTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         Carbon::setTestNow(Carbon::now());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -24,7 +24,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         Carbon::setTestNow(null);
     }
 
-    public function testCreateInsertsNewRecordIntoTable()
+    public function testCreateInsertsNewRecordIntoTable(): void
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('make')->once()->andReturn('hashed-token');
@@ -41,7 +41,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $this->assertGreaterThan(1, strlen($results));
     }
 
-    public function testExistReturnsFalseIfNoRowFoundForUser()
+    public function testExistReturnsFalseIfNoRowFoundForUser(): void
     {
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
@@ -53,7 +53,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $this->assertFalse($repo->exists($user, 'token'));
     }
 
-    public function testExistReturnsFalseIfRecordIsExpired()
+    public function testExistReturnsFalseIfRecordIsExpired(): void
     {
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
@@ -66,7 +66,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $this->assertFalse($repo->exists($user, 'token'));
     }
 
-    public function testExistReturnsTrueIfValidRecordExists()
+    public function testExistReturnsTrueIfValidRecordExists(): void
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->once()->with('token', 'hashed-token')->andReturn(true);
@@ -80,7 +80,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $this->assertTrue($repo->exists($user, 'token'));
     }
 
-    public function testExistReturnsFalseIfInvalidToken()
+    public function testExistReturnsFalseIfInvalidToken(): void
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->once()->with('wrong-token', 'hashed-token')->andReturn(false);
@@ -94,7 +94,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $this->assertFalse($repo->exists($user, 'wrong-token'));
     }
 
-    public function testDeleteMethodDeletesByToken()
+    public function testDeleteMethodDeletesByToken(): void
     {
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
@@ -106,7 +106,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $repo->delete($user);
     }
 
-    public function testDeleteExpiredMethodDeletesExpiredTokens()
+    public function testDeleteExpiredMethodDeletesExpiredTokens(): void
     {
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -9,12 +9,12 @@ use Illuminate\Auth\DatabaseUserProvider;
 
 class AuthDatabaseUserProviderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testRetrieveByIDReturnsUserWhenUserIsFound()
+    public function testRetrieveByIDReturnsUserWhenUserIsFound(): void
     {
         $conn = m::mock('Illuminate\Database\Connection');
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
@@ -28,7 +28,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertEquals('Dayle', $user->name);
     }
 
-    public function testRetrieveByIDReturnsNullWhenUserIsNotFound()
+    public function testRetrieveByIDReturnsNullWhenUserIsNotFound(): void
     {
         $conn = m::mock('Illuminate\Database\Connection');
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
@@ -40,7 +40,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testRetrieveByTokenReturnsUser()
+    public function testRetrieveByTokenReturnsUser(): void
     {
         $mockUser = new \stdClass();
         $mockUser->remember_token = 'a';
@@ -55,7 +55,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertEquals(new GenericUser((array) $mockUser), $user);
     }
 
-    public function testRetrieveTokenWithBadIdentifierReturnsNull()
+    public function testRetrieveTokenWithBadIdentifierReturnsNull(): void
     {
         $conn = m::mock('Illuminate\Database\Connection');
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
@@ -67,7 +67,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testRetrieveByBadTokenReturnsNull()
+    public function testRetrieveByBadTokenReturnsNull(): void
     {
         $mockUser = new \stdClass();
         $mockUser->remember_token = null;
@@ -82,7 +82,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testRetrieveByCredentialsReturnsUserWhenUserIsFound()
+    public function testRetrieveByCredentialsReturnsUserWhenUserIsFound(): void
     {
         $conn = m::mock('Illuminate\Database\Connection');
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
@@ -97,7 +97,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertEquals('taylor', $user->name);
     }
 
-    public function testRetrieveByCredentialsReturnsNullWhenUserIsFound()
+    public function testRetrieveByCredentialsReturnsNullWhenUserIsFound(): void
     {
         $conn = m::mock('Illuminate\Database\Connection');
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
@@ -110,7 +110,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testCredentialValidation()
+    public function testCredentialValidation(): void
     {
         $conn = m::mock('Illuminate\Database\Connection');
         $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -8,12 +8,12 @@ use Illuminate\Auth\EloquentUserProvider;
 
 class AuthEloquentUserProviderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testRetrieveByIDReturnsUser()
+    public function testRetrieveByIDReturnsUser(): void
     {
         $provider = $this->getProviderMock();
         $mock = m::mock('stdClass');
@@ -27,7 +27,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertEquals('bar', $user);
     }
 
-    public function testRetrieveByTokenReturnsUser()
+    public function testRetrieveByTokenReturnsUser(): void
     {
         $mockUser = m::mock('stdClass');
         $mockUser->shouldReceive('getRememberToken')->once()->andReturn('a');
@@ -43,7 +43,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertEquals($mockUser, $user);
     }
 
-    public function testRetrieveTokenWithBadIdentifierReturnsNull()
+    public function testRetrieveTokenWithBadIdentifierReturnsNull(): void
     {
         $provider = $this->getProviderMock();
         $mock = m::mock('stdClass');
@@ -56,7 +56,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testRetrieveByBadTokenReturnsNull()
+    public function testRetrieveByBadTokenReturnsNull(): void
     {
         $mockUser = m::mock('stdClass');
         $mockUser->shouldReceive('getRememberToken')->once()->andReturn(null);
@@ -72,7 +72,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testRetrieveByCredentialsReturnsUser()
+    public function testRetrieveByCredentialsReturnsUser(): void
     {
         $provider = $this->getProviderMock();
         $mock = m::mock('stdClass');
@@ -85,7 +85,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertEquals('bar', $user);
     }
 
-    public function testCredentialValidation()
+    public function testCredentialValidation(): void
     {
         $conn = m::mock('Illuminate\Database\Connection');
         $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
@@ -98,7 +98,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testModelsCanBeCreated()
+    public function testModelsCanBeCreated(): void
     {
         $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
         $provider = new EloquentUserProvider($hasher, 'Illuminate\Tests\Auth\EloquentProviderUserStub');

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -11,12 +11,12 @@ use Symfony\Component\HttpFoundation\Request;
 
 class AuthGuardTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBasicReturnsNullOnValidAttempt()
+    public function testBasicReturnsNullOnValidAttempt(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = m::mock('Illuminate\Auth\SessionGuard[check,attempt]', ['default', $provider, $session]);
@@ -28,7 +28,7 @@ class AuthGuardTest extends TestCase
         $guard->basic('email');
     }
 
-    public function testBasicReturnsNullWhenAlreadyLoggedIn()
+    public function testBasicReturnsNullWhenAlreadyLoggedIn(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = m::mock('Illuminate\Auth\SessionGuard[check]', ['default', $provider, $session]);
@@ -43,7 +43,7 @@ class AuthGuardTest extends TestCase
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
      */
-    public function testBasicReturnsResponseOnFailure()
+    public function testBasicReturnsResponseOnFailure(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = m::mock('Illuminate\Auth\SessionGuard[check,attempt]', ['default', $provider, $session]);
@@ -54,7 +54,7 @@ class AuthGuardTest extends TestCase
         $guard->basic('email');
     }
 
-    public function testBasicWithExtraConditions()
+    public function testBasicWithExtraConditions(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = m::mock('Illuminate\Auth\SessionGuard[check,attempt]', ['default', $provider, $session]);
@@ -66,7 +66,7 @@ class AuthGuardTest extends TestCase
         $guard->basic('email', ['active' => 1]);
     }
 
-    public function testAttemptCallsRetrieveByCredentials()
+    public function testAttemptCallsRetrieveByCredentials(): void
     {
         $guard = $this->getGuard();
         $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
@@ -76,7 +76,7 @@ class AuthGuardTest extends TestCase
         $guard->attempt(['foo']);
     }
 
-    public function testAttemptReturnsUserInterface()
+    public function testAttemptReturnsUserInterface(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -89,7 +89,7 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($guard->attempt(['foo']));
     }
 
-    public function testAttemptReturnsFalseIfUserNotGiven()
+    public function testAttemptReturnsFalseIfUserNotGiven(): void
     {
         $mock = $this->getGuard();
         $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
@@ -99,7 +99,7 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($mock->attempt(['foo']));
     }
 
-    public function testLoginStoresIdentifierInSession()
+    public function testLoginStoresIdentifierInSession(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -111,7 +111,7 @@ class AuthGuardTest extends TestCase
         $mock->login($user);
     }
 
-    public function testSessionGuardIsMacroable()
+    public function testSessionGuardIsMacroable(): void
     {
         $guard = $this->getGuard();
 
@@ -124,7 +124,7 @@ class AuthGuardTest extends TestCase
         );
     }
 
-    public function testLoginFiresLoginAndAuthenticatedEvents()
+    public function testLoginFiresLoginAndAuthenticatedEvents(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -139,7 +139,7 @@ class AuthGuardTest extends TestCase
         $mock->login($user);
     }
 
-    public function testFailedAttemptFiresFailedEvent()
+    public function testFailedAttemptFiresFailedEvent(): void
     {
         $guard = $this->getGuard();
         $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
@@ -149,7 +149,7 @@ class AuthGuardTest extends TestCase
         $guard->attempt(['foo']);
     }
 
-    public function testAuthenticateReturnsUserWhenUserIsNotNull()
+    public function testAuthenticateReturnsUserWhenUserIsNotNull(): void
     {
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $guard = $this->getGuard()->setUser($user);
@@ -157,7 +157,7 @@ class AuthGuardTest extends TestCase
         $this->assertEquals($user, $guard->authenticate());
     }
 
-    public function testSetUserFiresAuthenticatedEvent()
+    public function testSetUserFiresAuthenticatedEvent(): void
     {
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $guard = $this->getGuard();
@@ -170,7 +170,7 @@ class AuthGuardTest extends TestCase
      * @expectedException \Illuminate\Auth\AuthenticationException
      * @expectedExceptionMessage Unauthenticated.
      */
-    public function testAuthenticateThrowsWhenUserIsNull()
+    public function testAuthenticateThrowsWhenUserIsNull(): void
     {
         $guard = $this->getGuard();
         $guard->getSession()->shouldReceive('get')->once()->andReturn(null);
@@ -178,7 +178,7 @@ class AuthGuardTest extends TestCase
         $guard->authenticate();
     }
 
-    public function testIsAuthedReturnsTrueWhenUserIsNotNull()
+    public function testIsAuthedReturnsTrueWhenUserIsNotNull(): void
     {
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $mock = $this->getGuard();
@@ -187,7 +187,7 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($mock->guest());
     }
 
-    public function testIsAuthedReturnsFalseWhenUserIsNull()
+    public function testIsAuthedReturnsFalseWhenUserIsNull(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['user'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -196,7 +196,7 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($mock->guest());
     }
 
-    public function testUserMethodReturnsCachedUser()
+    public function testUserMethodReturnsCachedUser(): void
     {
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $mock = $this->getGuard();
@@ -204,14 +204,14 @@ class AuthGuardTest extends TestCase
         $this->assertSame($user, $mock->user());
     }
 
-    public function testNullIsReturnedForUserIfNoUserFound()
+    public function testNullIsReturnedForUserIfNoUserFound(): void
     {
         $mock = $this->getGuard();
         $mock->getSession()->shouldReceive('get')->once()->andReturn(null);
         $this->assertNull($mock->user());
     }
 
-    public function testUserIsSetToRetrievedUser()
+    public function testUserIsSetToRetrievedUser(): void
     {
         $mock = $this->getGuard();
         $mock->getSession()->shouldReceive('get')->once()->andReturn(1);
@@ -221,7 +221,7 @@ class AuthGuardTest extends TestCase
         $this->assertSame($user, $mock->getUser());
     }
 
-    public function testLogoutRemovesSessionTokenAndRememberMeCookie()
+    public function testLogoutRemovesSessionTokenAndRememberMeCookie(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -242,7 +242,7 @@ class AuthGuardTest extends TestCase
         $this->assertNull($mock->getUser());
     }
 
-    public function testLogoutDoesNotEnqueueRememberMeCookieForDeletionIfCookieDoesntExist()
+    public function testLogoutDoesNotEnqueueRememberMeCookieForDeletionIfCookieDoesntExist(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -259,7 +259,7 @@ class AuthGuardTest extends TestCase
         $this->assertNull($mock->getUser());
     }
 
-    public function testLogoutFiresLogoutEvent()
+    public function testLogoutFiresLogoutEvent(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -274,7 +274,7 @@ class AuthGuardTest extends TestCase
         $mock->logout();
     }
 
-    public function testLoginMethodQueuesCookieWhenRemembering()
+    public function testLoginMethodQueuesCookieWhenRemembering(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = new \Illuminate\Auth\SessionGuard('default', $provider, $session, $request);
@@ -293,7 +293,7 @@ class AuthGuardTest extends TestCase
         $guard->login($user, true);
     }
 
-    public function testLoginMethodCreatesRememberTokenIfOneDoesntExist()
+    public function testLoginMethodCreatesRememberTokenIfOneDoesntExist(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = new \Illuminate\Auth\SessionGuard('default', $provider, $session, $request);
@@ -312,7 +312,7 @@ class AuthGuardTest extends TestCase
         $guard->login($user, true);
     }
 
-    public function testLoginUsingIdLogsInWithUser()
+    public function testLoginUsingIdLogsInWithUser(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
 
@@ -325,7 +325,7 @@ class AuthGuardTest extends TestCase
         $this->assertSame($user, $guard->loginUsingId(10));
     }
 
-    public function testLoginUsingIdFailure()
+    public function testLoginUsingIdFailure(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
@@ -336,7 +336,7 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($guard->loginUsingId(11));
     }
 
-    public function testOnceUsingIdSetsUser()
+    public function testOnceUsingIdSetsUser(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
@@ -348,7 +348,7 @@ class AuthGuardTest extends TestCase
         $this->assertSame($user, $guard->onceUsingId(10));
     }
 
-    public function testOnceUsingIdFailure()
+    public function testOnceUsingIdFailure(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
@@ -359,7 +359,7 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($guard->onceUsingId(11));
     }
 
-    public function testUserUsesRememberCookieIfItExists()
+    public function testUserUsesRememberCookieIfItExists(): void
     {
         $guard = $this->getGuard();
         list($session, $provider, $request, $cookie) = $this->getMocks();
@@ -375,7 +375,7 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($guard->viaRemember());
     }
 
-    public function testLoginOnceSetsUser()
+    public function testLoginOnceSetsUser(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
@@ -386,7 +386,7 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($guard->once(['foo']));
     }
 
-    public function testLoginOnceFailure()
+    public function testLoginOnceFailure(): void
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -9,12 +9,12 @@ use Illuminate\Contracts\Auth\PasswordBroker;
 
 class AuthPasswordBrokerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testIfUserIsNotFoundErrorRedirectIsReturned()
+    public function testIfUserIsNotFoundErrorRedirectIsReturned(): void
     {
         $mocks = $this->getMocks();
         $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['getUser', 'makeErrorRedirect'])->setConstructorArgs(array_values($mocks))->getMock();
@@ -27,7 +27,7 @@ class AuthPasswordBrokerTest extends TestCase
      * @expectedException \UnexpectedValueException
      * @expectedExceptionMessage User must implement CanResetPassword interface.
      */
-    public function testGetUserThrowsExceptionIfUserDoesntImplementCanResetPassword()
+    public function testGetUserThrowsExceptionIfUserDoesntImplementCanResetPassword(): void
     {
         $broker = $this->getBroker($mocks = $this->getMocks());
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn('bar');
@@ -35,7 +35,7 @@ class AuthPasswordBrokerTest extends TestCase
         $broker->getUser(['foo']);
     }
 
-    public function testUserIsRetrievedByCredentials()
+    public function testUserIsRetrievedByCredentials(): void
     {
         $broker = $this->getBroker($mocks = $this->getMocks());
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
@@ -43,7 +43,7 @@ class AuthPasswordBrokerTest extends TestCase
         $this->assertEquals($user, $broker->getUser(['foo']));
     }
 
-    public function testBrokerCreatesTokenAndRedirectsWithoutError()
+    public function testBrokerCreatesTokenAndRedirectsWithoutError(): void
     {
         $mocks = $this->getMocks();
         $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
@@ -56,7 +56,7 @@ class AuthPasswordBrokerTest extends TestCase
         $this->assertEquals(PasswordBroker::RESET_LINK_SENT, $broker->sendResetLink(['foo'], $callback));
     }
 
-    public function testRedirectIsReturnedByResetWhenUserCredentialsInvalid()
+    public function testRedirectIsReturnedByResetWhenUserCredentialsInvalid(): void
     {
         $broker = $this->getBroker($mocks = $this->getMocks());
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['creds'])->andReturn(null);
@@ -65,7 +65,7 @@ class AuthPasswordBrokerTest extends TestCase
         }));
     }
 
-    public function testRedirectReturnedByRemindWhenPasswordsDontMatch()
+    public function testRedirectReturnedByRemindWhenPasswordsDontMatch(): void
     {
         $creds = ['password' => 'foo', 'password_confirmation' => 'bar'];
         $broker = $this->getBroker($mocks = $this->getMocks());
@@ -75,7 +75,7 @@ class AuthPasswordBrokerTest extends TestCase
         }));
     }
 
-    public function testRedirectReturnedByRemindWhenPasswordNotSet()
+    public function testRedirectReturnedByRemindWhenPasswordNotSet(): void
     {
         $creds = ['password' => null, 'password_confirmation' => null];
         $broker = $this->getBroker($mocks = $this->getMocks());
@@ -85,7 +85,7 @@ class AuthPasswordBrokerTest extends TestCase
         }));
     }
 
-    public function testRedirectReturnedByRemindWhenPasswordsLessThanSixCharacters()
+    public function testRedirectReturnedByRemindWhenPasswordsLessThanSixCharacters(): void
     {
         $creds = ['password' => 'abc', 'password_confirmation' => 'abc'];
         $broker = $this->getBroker($mocks = $this->getMocks());
@@ -95,7 +95,7 @@ class AuthPasswordBrokerTest extends TestCase
         }));
     }
 
-    public function testRedirectReturnedByRemindWhenPasswordDoesntPassValidator()
+    public function testRedirectReturnedByRemindWhenPasswordDoesntPassValidator(): void
     {
         $creds = ['password' => 'abcdef', 'password_confirmation' => 'abcdef'];
         $broker = $this->getBroker($mocks = $this->getMocks());
@@ -108,7 +108,7 @@ class AuthPasswordBrokerTest extends TestCase
         }));
     }
 
-    public function testRedirectReturnedByRemindWhenRecordDoesntExistInTable()
+    public function testRedirectReturnedByRemindWhenRecordDoesntExistInTable(): void
     {
         $creds = ['token' => 'token'];
         $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['validateNewPassword'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
@@ -120,7 +120,7 @@ class AuthPasswordBrokerTest extends TestCase
         }));
     }
 
-    public function testResetRemovesRecordOnReminderTableAndCallsCallback()
+    public function testResetRemovesRecordOnReminderTableAndCallsCallback(): void
     {
         unset($_SERVER['__password.reset.test']);
         $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['validateReset', 'getPassword', 'getToken'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -10,12 +10,12 @@ use Illuminate\Contracts\Auth\UserProvider;
 
 class AuthTokenGuardTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Mockery::close();
     }
 
-    public function testUserCanBeRetrievedByQueryStringVariable()
+    public function testUserCanBeRetrievedByQueryStringVariable(): void
     {
         $provider = Mockery::mock(UserProvider::class);
         $user = new AuthTokenGuardTestUser;
@@ -33,7 +33,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertEquals(1, $guard->id());
     }
 
-    public function testUserCanBeRetrievedByAuthHeaders()
+    public function testUserCanBeRetrievedByAuthHeaders(): void
     {
         $provider = Mockery::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn((object) ['id' => 1]);
@@ -46,7 +46,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertEquals(1, $user->id);
     }
 
-    public function testUserCanBeRetrievedByBearerToken()
+    public function testUserCanBeRetrievedByBearerToken(): void
     {
         $provider = Mockery::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn((object) ['id' => 1]);
@@ -59,7 +59,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertEquals(1, $user->id);
     }
 
-    public function testValidateCanDetermineIfCredentialsAreValid()
+    public function testValidateCanDetermineIfCredentialsAreValid(): void
     {
         $provider = Mockery::mock(UserProvider::class);
         $user = new AuthTokenGuardTestUser;
@@ -72,7 +72,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertTrue($guard->validate(['api_token' => 'foo']));
     }
 
-    public function testValidateCanDetermineIfCredentialsAreInvalid()
+    public function testValidateCanDetermineIfCredentialsAreInvalid(): void
     {
         $provider = Mockery::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn(null);
@@ -83,7 +83,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertFalse($guard->validate(['api_token' => 'foo']));
     }
 
-    public function testValidateIfApiTokenIsEmpty()
+    public function testValidateIfApiTokenIsEmpty(): void
     {
         $provider = Mockery::mock(UserProvider::class);
         $request = Request::create('/', 'GET', ['api_token' => '']);
@@ -93,7 +93,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertFalse($guard->validate(['api_token' => '']));
     }
 
-    public function testItAllowsToPassCustomRequestInSetterAndUseItForValidation()
+    public function testItAllowsToPassCustomRequestInSetterAndUseItForValidation(): void
     {
         $provider = Mockery::mock(UserProvider::class);
         $user = new AuthTokenGuardTestUser;

--- a/tests/Auth/AuthenticatableTest.php
+++ b/tests/Auth/AuthenticatableTest.php
@@ -7,21 +7,21 @@ use Illuminate\Foundation\Auth\User;
 
 class AuthenticatableTest extends TestCase
 {
-    public function testItReturnsSameRememberTokenForString()
+    public function testItReturnsSameRememberTokenForString(): void
     {
         $user = new User();
         $user->setRememberToken('sample_token');
         $this->assertSame('sample_token', $user->getRememberToken());
     }
 
-    public function testItReturnsStringAsRememberTokenWhenItWasSetToTrue()
+    public function testItReturnsStringAsRememberTokenWhenItWasSetToTrue(): void
     {
         $user = new User();
         $user->setRememberToken(true);
         $this->assertSame('1', $user->getRememberToken());
     }
 
-    public function testItReturnsNullWhenRememberTokenNameWasSetToEmpty()
+    public function testItReturnsNullWhenRememberTokenNameWasSetToEmpty(): void
     {
         $user = new class extends User {
             public function getRememberTokenName()

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -18,12 +18,12 @@ class AuthenticateMiddlewareTest extends TestCase
 {
     protected $auth;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $container = Container::setInstance(new Container);
 
@@ -38,14 +38,14 @@ class AuthenticateMiddlewareTest extends TestCase
      * @expectedException \Illuminate\Auth\AuthenticationException
      * @expectedExceptionMessage Unauthenticated.
      */
-    public function testDefaultUnauthenticatedThrows()
+    public function testDefaultUnauthenticatedThrows(): void
     {
         $this->registerAuthDriver('default', false);
 
         $this->authenticate();
     }
 
-    public function testDefaultUnauthenticatedThrowsWithGuards()
+    public function testDefaultUnauthenticatedThrowsWithGuards(): void
     {
         try {
             $this->registerAuthDriver('default', false);
@@ -57,10 +57,10 @@ class AuthenticateMiddlewareTest extends TestCase
             return;
         }
 
-        return $this->fail();
+        $this->fail();
     }
 
-    public function testDefaultAuthenticatedKeepsDefaultDriver()
+    public function testDefaultAuthenticatedKeepsDefaultDriver(): void
     {
         $driver = $this->registerAuthDriver('default', true);
 
@@ -69,7 +69,7 @@ class AuthenticateMiddlewareTest extends TestCase
         $this->assertSame($driver, $this->auth->guard());
     }
 
-    public function testSecondaryAuthenticatedUpdatesDefaultDriver()
+    public function testSecondaryAuthenticatedUpdatesDefaultDriver(): void
     {
         $this->registerAuthDriver('default', false);
 
@@ -84,7 +84,7 @@ class AuthenticateMiddlewareTest extends TestCase
      * @expectedException \Illuminate\Auth\AuthenticationException
      * @expectedExceptionMessage Unauthenticated.
      */
-    public function testMultipleDriversUnauthenticatedThrows()
+    public function testMultipleDriversUnauthenticatedThrows(): void
     {
         $this->registerAuthDriver('default', false);
 
@@ -93,7 +93,7 @@ class AuthenticateMiddlewareTest extends TestCase
         $this->authenticate('default', 'secondary');
     }
 
-    public function testMultipleDriversUnauthenticatedThrowsWithGuards()
+    public function testMultipleDriversUnauthenticatedThrowsWithGuards(): void
     {
         $expectedGuards = ['default', 'secondary'];
 
@@ -109,10 +109,10 @@ class AuthenticateMiddlewareTest extends TestCase
             return;
         }
 
-        return $this->fail();
+        $this->fail();
     }
 
-    public function testMultipleDriversAuthenticatedUpdatesDefault()
+    public function testMultipleDriversAuthenticatedUpdatesDefault(): void
     {
         $this->registerAuthDriver('default', false);
 

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -21,12 +21,12 @@ class AuthorizeMiddlewareTest extends TestCase
     protected $container;
     protected $user;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -58,7 +58,7 @@ class AuthorizeMiddlewareTest extends TestCase
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
      * @expectedExceptionMessage This action is unauthorized.
      */
-    public function testSimpleAbilityUnauthorized()
+    public function testSimpleAbilityUnauthorized(): void
     {
         $this->gate()->define('view-dashboard', function ($user, $additional = null) {
             $this->assertNull($additional);
@@ -76,7 +76,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->router->dispatch(Request::create('dashboard', 'GET'));
     }
 
-    public function testSimpleAbilityAuthorized()
+    public function testSimpleAbilityAuthorized(): void
     {
         $this->gate()->define('view-dashboard', function ($user) {
             return true;
@@ -98,7 +98,7 @@ class AuthorizeMiddlewareTest extends TestCase
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
      * @expectedExceptionMessage This action is unauthorized.
      */
-    public function testModelTypeUnauthorized()
+    public function testModelTypeUnauthorized(): void
     {
         $this->gate()->define('create', function ($user, $model) {
             $this->assertEquals($model, 'App\User');
@@ -116,7 +116,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->router->dispatch(Request::create('users/create', 'GET'));
     }
 
-    public function testModelTypeAuthorized()
+    public function testModelTypeAuthorized(): void
     {
         $this->gate()->define('create', function ($user, $model) {
             $this->assertEquals($model, 'App\User');
@@ -140,7 +140,7 @@ class AuthorizeMiddlewareTest extends TestCase
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
      * @expectedExceptionMessage This action is unauthorized.
      */
-    public function testModelUnauthorized()
+    public function testModelUnauthorized(): void
     {
         $post = new stdClass;
 
@@ -164,7 +164,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->router->dispatch(Request::create('posts/1/edit', 'GET'));
     }
 
-    public function testModelAuthorized()
+    public function testModelAuthorized(): void
     {
         $post = new stdClass;
 
@@ -190,7 +190,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertEquals($response->content(), 'success');
     }
 
-    public function testModelInstanceAsParameter()
+    public function testModelInstanceAsParameter(): void
     {
         $instance = m::mock(\Illuminate\Database\Eloquent\Model::class);
 

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -11,42 +11,42 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class AuthorizesResourcesTest extends TestCase
 {
-    public function testCreateMethod()
+    public function testCreateMethod(): void
     {
         $controller = new AuthorizesResourcesController;
 
         $this->assertHasMiddleware($controller, 'create', 'can:create,App\User');
     }
 
-    public function testStoreMethod()
+    public function testStoreMethod(): void
     {
         $controller = new AuthorizesResourcesController;
 
         $this->assertHasMiddleware($controller, 'store', 'can:create,App\User');
     }
 
-    public function testShowMethod()
+    public function testShowMethod(): void
     {
         $controller = new AuthorizesResourcesController;
 
         $this->assertHasMiddleware($controller, 'show', 'can:view,user');
     }
 
-    public function testEditMethod()
+    public function testEditMethod(): void
     {
         $controller = new AuthorizesResourcesController;
 
         $this->assertHasMiddleware($controller, 'edit', 'can:update,user');
     }
 
-    public function testUpdateMethod()
+    public function testUpdateMethod(): void
     {
         $controller = new AuthorizesResourcesController;
 
         $this->assertHasMiddleware($controller, 'update', 'can:update,user');
     }
 
-    public function testDestroyMethod()
+    public function testDestroyMethod(): void
     {
         $controller = new AuthorizesResourcesController;
 

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -9,12 +9,12 @@ use Illuminate\Contracts\Broadcasting\Broadcaster;
 
 class BroadcastEventTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBasicEventBroadcastParameterFormatting()
+    public function testBasicEventBroadcastParameterFormatting(): void
     {
         $broadcaster = m::mock(Broadcaster::class);
 
@@ -27,7 +27,7 @@ class BroadcastEventTest extends TestCase
         (new \Illuminate\Broadcasting\BroadcastEvent($event))->handle($broadcaster);
     }
 
-    public function testManualParameterSpecification()
+    public function testManualParameterSpecification(): void
     {
         $broadcaster = m::mock(Broadcaster::class);
 

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -11,12 +11,12 @@ use Illuminate\Broadcasting\Broadcasters\Broadcaster;
 
 class BroadcasterTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testExtractingParametersWhileCheckingForUserAccess()
+    public function testExtractingParametersWhileCheckingForUserAccess(): void
     {
         $broadcaster = new FakeBroadcaster;
 
@@ -57,7 +57,7 @@ class BroadcasterTest extends TestCase
         Container::setInstance(new Container);
     }
 
-    public function testCanUseChannelClasses()
+    public function testCanUseChannelClasses(): void
     {
         $broadcaster = new FakeBroadcaster;
 
@@ -68,14 +68,14 @@ class BroadcasterTest extends TestCase
     /**
      * @expectedException \Exception
      */
-    public function testUnknownChannelAuthHandlerTypeThrowsException()
+    public function testUnknownChannelAuthHandlerTypeThrowsException(): void
     {
         $broadcaster = new FakeBroadcaster;
 
         $broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', 123);
     }
 
-    public function testCanRegisterChannelsAsClasses()
+    public function testCanRegisterChannelsAsClasses(): void
     {
         $broadcaster = new FakeBroadcaster;
 
@@ -87,7 +87,7 @@ class BroadcasterTest extends TestCase
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
      */
-    public function testNotFoundThrowsHttpException()
+    public function testNotFoundThrowsHttpException(): void
     {
         $broadcaster = new FakeBroadcaster;
         $callback = function ($user, BroadcasterTestEloquentModelNotFoundStub $model) {

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -10,12 +10,12 @@ use Illuminate\Config\Repository as Config;
 
 class BusDispatcherTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testCommandsThatShouldQueueIsQueued()
+    public function testCommandsThatShouldQueueIsQueued(): void
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
@@ -28,7 +28,7 @@ class BusDispatcherTest extends TestCase
         $dispatcher->dispatch(m::mock('Illuminate\Contracts\Queue\ShouldQueue'));
     }
 
-    public function testCommandsThatShouldQueueIsQueuedUsingCustomHandler()
+    public function testCommandsThatShouldQueueIsQueuedUsingCustomHandler(): void
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
@@ -41,7 +41,7 @@ class BusDispatcherTest extends TestCase
         $dispatcher->dispatch(new BusDispatcherTestCustomQueueCommand);
     }
 
-    public function testCommandsThatShouldQueueIsQueuedUsingCustomQueueAndDelay()
+    public function testCommandsThatShouldQueueIsQueuedUsingCustomQueueAndDelay(): void
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
@@ -54,7 +54,7 @@ class BusDispatcherTest extends TestCase
         $dispatcher->dispatch(new BusDispatcherTestSpecificQueueAndDelayCommand);
     }
 
-    public function testDispatchNowShouldNeverQueue()
+    public function testDispatchNowShouldNeverQueue(): void
     {
         $container = new Container;
         $mock = m::mock('Illuminate\Contracts\Queue\Queue');
@@ -66,7 +66,7 @@ class BusDispatcherTest extends TestCase
         $dispatcher->dispatch(new BusDispatcherBasicCommand);
     }
 
-    public function testDispatcherCanDispatchStandAloneHandler()
+    public function testDispatcherCanDispatchStandAloneHandler(): void
     {
         $container = new Container;
         $mock = m::mock('Illuminate\Contracts\Queue\Queue');
@@ -81,7 +81,7 @@ class BusDispatcherTest extends TestCase
         $this->assertInstanceOf(StandAloneCommand::class, $response);
     }
 
-    public function testOnConnectionOnJobWhenDispatching()
+    public function testOnConnectionOnJobWhenDispatching(): void
     {
         $container = new Container;
         $container->singleton('config', function () {

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class CacheApcStoreTest extends TestCase
 {
-    public function testGetReturnsNullWhenNotFound()
+    public function testGetReturnsNullWhenNotFound(): void
     {
         $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['get'])->getMock();
         $apc->expects($this->once())->method('get')->with($this->equalTo('foobar'))->will($this->returnValue(null));
@@ -14,7 +14,7 @@ class CacheApcStoreTest extends TestCase
         $this->assertNull($store->get('bar'));
     }
 
-    public function testAPCValueIsReturned()
+    public function testAPCValueIsReturned(): void
     {
         $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['get'])->getMock();
         $apc->expects($this->once())->method('get')->will($this->returnValue('bar'));
@@ -22,7 +22,7 @@ class CacheApcStoreTest extends TestCase
         $this->assertEquals('bar', $store->get('foo'));
     }
 
-    public function testGetMultipleReturnsNullWhenNotFoundAndValueWhenFound()
+    public function testGetMultipleReturnsNullWhenNotFoundAndValueWhenFound(): void
     {
         $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['get'])->getMock();
         $apc->expects($this->exactly(3))->method('get')->willReturnMap([
@@ -38,7 +38,7 @@ class CacheApcStoreTest extends TestCase
         ], $store->many(['foo', 'bar', 'baz']));
     }
 
-    public function testSetMethodProperlyCallsAPC()
+    public function testSetMethodProperlyCallsAPC(): void
     {
         $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['put'])->getMock();
         $apc->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60));
@@ -46,7 +46,7 @@ class CacheApcStoreTest extends TestCase
         $store->put('foo', 'bar', 1);
     }
 
-    public function testSetMultipleMethodProperlyCallsAPC()
+    public function testSetMultipleMethodProperlyCallsAPC(): void
     {
         $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['put'])->getMock();
         $apc->expects($this->exactly(3))->method('put')->withConsecutive([
@@ -64,7 +64,7 @@ class CacheApcStoreTest extends TestCase
         ], 1);
     }
 
-    public function testIncrementMethodProperlyCallsAPC()
+    public function testIncrementMethodProperlyCallsAPC(): void
     {
         $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['increment'])->getMock();
         $apc->expects($this->once())->method('increment')->with($this->equalTo('foo'), $this->equalTo(5));
@@ -72,7 +72,7 @@ class CacheApcStoreTest extends TestCase
         $store->increment('foo', 5);
     }
 
-    public function testDecrementMethodProperlyCallsAPC()
+    public function testDecrementMethodProperlyCallsAPC(): void
     {
         $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['decrement'])->getMock();
         $apc->expects($this->once())->method('decrement')->with($this->equalTo('foo'), $this->equalTo(5));
@@ -80,7 +80,7 @@ class CacheApcStoreTest extends TestCase
         $store->decrement('foo', 5);
     }
 
-    public function testStoreItemForeverProperlyCallsAPC()
+    public function testStoreItemForeverProperlyCallsAPC(): void
     {
         $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['put'])->getMock();
         $apc->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0));
@@ -88,7 +88,7 @@ class CacheApcStoreTest extends TestCase
         $store->forever('foo', 'bar');
     }
 
-    public function testForgetMethodProperlyCallsAPC()
+    public function testForgetMethodProperlyCallsAPC(): void
     {
         $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['delete'])->getMock();
         $apc->expects($this->once())->method('delete')->with($this->equalTo('foo'));
@@ -96,7 +96,7 @@ class CacheApcStoreTest extends TestCase
         $store->forget('foo');
     }
 
-    public function testFlushesCached()
+    public function testFlushesCached(): void
     {
         $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['flush'])->getMock();
         $apc->expects($this->once())->method('flush')->willReturn(true);

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -7,14 +7,14 @@ use Illuminate\Cache\ArrayStore;
 
 class CacheArrayStoreTest extends TestCase
 {
-    public function testItemsCanBeSetAndRetrieved()
+    public function testItemsCanBeSetAndRetrieved(): void
     {
         $store = new ArrayStore;
         $store->put('foo', 'bar', 10);
         $this->assertEquals('bar', $store->get('foo'));
     }
 
-    public function testMultipleItemsCanBeSetAndRetrieved()
+    public function testMultipleItemsCanBeSetAndRetrieved(): void
     {
         $store = new ArrayStore;
         $store->put('foo', 'bar', 10);
@@ -30,14 +30,14 @@ class CacheArrayStoreTest extends TestCase
         ], $store->many(['foo', 'fizz', 'quz', 'norf']));
     }
 
-    public function testStoreItemForeverProperlyStoresInArray()
+    public function testStoreItemForeverProperlyStoresInArray(): void
     {
         $mock = $this->getMockBuilder('Illuminate\Cache\ArrayStore')->setMethods(['put'])->getMock();
         $mock->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0));
         $mock->forever('foo', 'bar');
     }
 
-    public function testValuesCanBeIncremented()
+    public function testValuesCanBeIncremented(): void
     {
         $store = new ArrayStore;
         $store->put('foo', 1, 10);
@@ -45,14 +45,14 @@ class CacheArrayStoreTest extends TestCase
         $this->assertEquals(2, $store->get('foo'));
     }
 
-    public function testNonExistingKeysCanBeIncremented()
+    public function testNonExistingKeysCanBeIncremented(): void
     {
         $store = new ArrayStore;
         $store->increment('foo');
         $this->assertEquals(1, $store->get('foo'));
     }
 
-    public function testValuesCanBeDecremented()
+    public function testValuesCanBeDecremented(): void
     {
         $store = new ArrayStore;
         $store->put('foo', 1, 10);
@@ -60,7 +60,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertEquals(0, $store->get('foo'));
     }
 
-    public function testItemsCanBeRemoved()
+    public function testItemsCanBeRemoved(): void
     {
         $store = new ArrayStore;
         $store->put('foo', 'bar', 10);
@@ -68,7 +68,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertNull($store->get('foo'));
     }
 
-    public function testItemsCanBeFlushed()
+    public function testItemsCanBeFlushed(): void
     {
         $store = new ArrayStore;
         $store->put('foo', 'bar', 10);
@@ -79,7 +79,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertNull($store->get('baz'));
     }
 
-    public function testCacheKey()
+    public function testCacheKey(): void
     {
         $store = new ArrayStore;
         $this->assertEmpty($store->getPrefix());

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -9,12 +9,12 @@ use Illuminate\Cache\DatabaseStore;
 
 class CacheDatabaseStoreTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testNullIsReturnedWhenItemNotFound()
+    public function testNullIsReturnedWhenItemNotFound(): void
     {
         $store = $this->getStore();
         $table = m::mock('stdClass');
@@ -25,7 +25,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertNull($store->get('foo'));
     }
 
-    public function testNullIsReturnedAndItemDeletedWhenItemIsExpired()
+    public function testNullIsReturnedAndItemDeletedWhenItemIsExpired(): void
     {
         $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['forget'])->setConstructorArgs($this->getMocks())->getMock();
         $table = m::mock('stdClass');
@@ -37,7 +37,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertNull($store->get('foo'));
     }
 
-    public function testDecryptedValueIsReturnedWhenItemIsValid()
+    public function testDecryptedValueIsReturnedWhenItemIsValid(): void
     {
         $store = $this->getStore();
         $table = m::mock('stdClass');
@@ -48,7 +48,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertEquals('bar', $store->get('foo'));
     }
 
-    public function testValueIsInsertedWhenNoExceptionsAreThrown()
+    public function testValueIsInsertedWhenNoExceptionsAreThrown(): void
     {
         $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
         $table = m::mock('stdClass');
@@ -59,7 +59,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store->put('foo', 'bar', 1);
     }
 
-    public function testValueIsUpdatedWhenInsertThrowsException()
+    public function testValueIsUpdatedWhenInsertThrowsException(): void
     {
         $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
         $table = m::mock('stdClass');
@@ -74,14 +74,14 @@ class CacheDatabaseStoreTest extends TestCase
         $store->put('foo', 'bar', 1);
     }
 
-    public function testForeverCallsStoreItemWithReallyLongTime()
+    public function testForeverCallsStoreItemWithReallyLongTime(): void
     {
         $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['put'])->setConstructorArgs($this->getMocks())->getMock();
         $store->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(5256000));
         $store->forever('foo', 'bar');
     }
 
-    public function testItemsMayBeRemovedFromCache()
+    public function testItemsMayBeRemovedFromCache(): void
     {
         $store = $this->getStore();
         $table = m::mock('stdClass');
@@ -92,7 +92,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store->forget('foo');
     }
 
-    public function testItemsMayBeFlushedFromCache()
+    public function testItemsMayBeFlushedFromCache(): void
     {
         $store = $this->getStore();
         $table = m::mock('stdClass');
@@ -103,7 +103,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testIncrementReturnsCorrectValues()
+    public function testIncrementReturnsCorrectValues(): void
     {
         $store = $this->getStore();
         $table = m::mock('stdClass');
@@ -142,7 +142,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertEquals(3, $store->increment('foo'));
     }
 
-    public function testDecrementReturnsCorrectValues()
+    public function testDecrementReturnsCorrectValues(): void
     {
         $store = $this->getStore();
         $table = m::mock('stdClass');

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -11,12 +11,12 @@ use Illuminate\Cache\Events\KeyForgotten;
 
 class CacheEventsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testHasTriggersEvents()
+    public function testHasTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -34,7 +34,7 @@ class CacheEventsTest extends TestCase
         $this->assertTrue($repository->tags('taylor')->has('baz'));
     }
 
-    public function testGetTriggersEvents()
+    public function testGetTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -52,7 +52,7 @@ class CacheEventsTest extends TestCase
         $this->assertEquals('qux', $repository->tags('taylor')->get('baz'));
     }
 
-    public function testPullTriggersEvents()
+    public function testPullTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -62,7 +62,7 @@ class CacheEventsTest extends TestCase
         $this->assertEquals('qux', $repository->pull('baz'));
     }
 
-    public function testPullTriggersEventsUsingTags()
+    public function testPullTriggersEventsUsingTags(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -72,7 +72,7 @@ class CacheEventsTest extends TestCase
         $this->assertEquals('qux', $repository->tags('taylor')->pull('baz'));
     }
 
-    public function testPutTriggersEvents()
+    public function testPutTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -84,7 +84,7 @@ class CacheEventsTest extends TestCase
         $repository->tags('taylor')->put('foo', 'bar', 99);
     }
 
-    public function testAddTriggersEvents()
+    public function testAddTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -98,7 +98,7 @@ class CacheEventsTest extends TestCase
         $this->assertTrue($repository->tags('taylor')->add('foo', 'bar', 99));
     }
 
-    public function testForeverTriggersEvents()
+    public function testForeverTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -110,7 +110,7 @@ class CacheEventsTest extends TestCase
         $repository->tags('taylor')->forever('foo', 'bar');
     }
 
-    public function testRememberTriggersEvents()
+    public function testRememberTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -128,7 +128,7 @@ class CacheEventsTest extends TestCase
         }));
     }
 
-    public function testRememberForeverTriggersEvents()
+    public function testRememberForeverTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -146,7 +146,7 @@ class CacheEventsTest extends TestCase
         }));
     }
 
-    public function testForgetTriggersEvents()
+    public function testForgetTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -9,21 +9,21 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class CacheFileStoreTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         Carbon::setTestNow(Carbon::now());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
         Carbon::setTestNow(null);
     }
 
-    public function testNullIsReturnedIfFileDoesntExist()
+    public function testNullIsReturnedIfFileDoesntExist(): void
     {
         $files = $this->mockFilesystem();
         $files->expects($this->once())->method('get')->will($this->throwException(new FileNotFoundException));
@@ -32,7 +32,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertNull($value);
     }
 
-    public function testPutCreatesMissingDirectories()
+    public function testPutCreatesMissingDirectories(): void
     {
         $files = $this->mockFilesystem();
         $hash = sha1('foo');
@@ -43,7 +43,7 @@ class CacheFileStoreTest extends TestCase
         $store->put('foo', '0000000000', 0);
     }
 
-    public function testExpiredItemsReturnNull()
+    public function testExpiredItemsReturnNull(): void
     {
         $files = $this->mockFilesystem();
         $contents = '0000000000';
@@ -54,7 +54,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertNull($value);
     }
 
-    public function testValidItemReturnsContents()
+    public function testValidItemReturnsContents(): void
     {
         $files = $this->mockFilesystem();
         $contents = '9999999999'.serialize('Hello World');
@@ -63,7 +63,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertEquals('Hello World', $store->get('foo'));
     }
 
-    public function testStoreItemProperlyStoresValues()
+    public function testStoreItemProperlyStoresValues(): void
     {
         $files = $this->mockFilesystem();
         $store = $this->getMockBuilder('Illuminate\Cache\FileStore')->setMethods(['expiration'])->setConstructorArgs([$files, __DIR__])->getMock();
@@ -75,7 +75,7 @@ class CacheFileStoreTest extends TestCase
         $store->put('foo', 'Hello World', 10);
     }
 
-    public function testForeversAreStoredWithHighTimestamp()
+    public function testForeversAreStoredWithHighTimestamp(): void
     {
         $files = $this->mockFilesystem();
         $contents = '9999999999'.serialize('Hello World');
@@ -86,7 +86,7 @@ class CacheFileStoreTest extends TestCase
         $store->forever('foo', 'Hello World', 10);
     }
 
-    public function testForeversAreNotRemovedOnIncrement()
+    public function testForeversAreNotRemovedOnIncrement(): void
     {
         $files = $this->mockFilesystem();
         $contents = '9999999999'.serialize('Hello World');
@@ -97,7 +97,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertEquals('Hello World', $store->get('foo'));
     }
 
-    public function testIncrementDoesNotExtendCacheLife()
+    public function testIncrementDoesNotExtendCacheLife(): void
     {
         $files = $this->mockFilesystem();
         $expiration = Carbon::now()->addSeconds(50)->getTimestamp();
@@ -111,7 +111,7 @@ class CacheFileStoreTest extends TestCase
         $store->increment('foo');
     }
 
-    public function testRemoveDeletesFileDoesntExist()
+    public function testRemoveDeletesFileDoesntExist(): void
     {
         $files = $this->mockFilesystem();
         $hash = sha1('foobull');
@@ -121,7 +121,7 @@ class CacheFileStoreTest extends TestCase
         $store->forget('foobull');
     }
 
-    public function testRemoveDeletesFile()
+    public function testRemoveDeletesFile(): void
     {
         $files = $this->mockFilesystem();
         $hash = sha1('foobar');
@@ -133,7 +133,7 @@ class CacheFileStoreTest extends TestCase
         $store->forget('foobar');
     }
 
-    public function testFlushCleansDirectory()
+    public function testFlushCleansDirectory(): void
     {
         $files = $this->mockFilesystem();
         $files->expects($this->once())->method('isDirectory')->with($this->equalTo(__DIR__))->will($this->returnValue(true));
@@ -145,7 +145,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertTrue($result, 'Flush failed');
     }
 
-    public function testFlushFailsDirectoryClean()
+    public function testFlushFailsDirectoryClean(): void
     {
         $files = $this->mockFilesystem();
         $files->expects($this->once())->method('isDirectory')->with($this->equalTo(__DIR__))->will($this->returnValue(true));
@@ -157,7 +157,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertFalse($result, 'Flush should not have cleared directories');
     }
 
-    public function testFlushIgnoreNonExistingDirectory()
+    public function testFlushIgnoreNonExistingDirectory(): void
     {
         $files = $this->mockFilesystem();
         $files->expects($this->once())->method('isDirectory')->with($this->equalTo(__DIR__.'--wrong'))->will($this->returnValue(false));

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -8,12 +8,12 @@ use Illuminate\Cache\CacheManager;
 
 class CacheManagerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testCustomDriverClosureBoundObjectIsCacheManager()
+    public function testCustomDriverClosureBoundObjectIsCacheManager(): void
     {
         $cacheManager = new CacheManager([
             'config' => [

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -8,12 +8,12 @@ use PHPUnit\Framework\TestCase;
 
 class CacheMemcachedConnectorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testServersAreAddedCorrectly()
+    public function testServersAreAddedCorrectly(): void
     {
         $memcached = $this->memcachedMockWithAddServer();
 
@@ -27,7 +27,7 @@ class CacheMemcachedConnectorTest extends TestCase
         $this->assertSame($result, $memcached);
     }
 
-    public function testServersAreAddedCorrectlyWithPersistentConnection()
+    public function testServersAreAddedCorrectlyWithPersistentConnection(): void
     {
         $persistentConnectionId = 'persistent_connection_id';
 
@@ -44,7 +44,7 @@ class CacheMemcachedConnectorTest extends TestCase
         $this->assertSame($result, $memcached);
     }
 
-    public function testServersAreAddedCorrectlyWithValidOptions()
+    public function testServersAreAddedCorrectlyWithValidOptions(): void
     {
         if (! class_exists('Memcached')) {
             $this->markTestSkipped('Memcached module not installed');
@@ -68,7 +68,7 @@ class CacheMemcachedConnectorTest extends TestCase
         $this->assertSame($result, $memcached);
     }
 
-    public function testServersAreAddedCorrectlyWithSaslCredentials()
+    public function testServersAreAddedCorrectlyWithSaslCredentials(): void
     {
         if (! class_exists('Memcached')) {
             $this->markTestSkipped('Memcached module not installed');

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -8,7 +8,7 @@ use Illuminate\Cache\MemcachedStore;
 
 class CacheMemcachedStoreTest extends TestCase
 {
-    public function testGetReturnsNullWhenNotFound()
+    public function testGetReturnsNullWhenNotFound(): void
     {
         if (! class_exists(Memcached::class)) {
             $this->markTestSkipped('Memcached module not installed');
@@ -21,7 +21,7 @@ class CacheMemcachedStoreTest extends TestCase
         $this->assertNull($store->get('bar'));
     }
 
-    public function testMemcacheValueIsReturned()
+    public function testMemcacheValueIsReturned(): void
     {
         if (! class_exists(Memcached::class)) {
             $this->markTestSkipped('Memcached module not installed');
@@ -34,7 +34,7 @@ class CacheMemcachedStoreTest extends TestCase
         $this->assertEquals('bar', $store->get('foo'));
     }
 
-    public function testMemcacheGetMultiValuesAreReturnedWithCorrectKeys()
+    public function testMemcacheGetMultiValuesAreReturnedWithCorrectKeys(): void
     {
         if (! class_exists(Memcached::class)) {
             $this->markTestSkipped('Memcached module not installed');
@@ -57,7 +57,7 @@ class CacheMemcachedStoreTest extends TestCase
         ]));
     }
 
-    public function testSetMethodProperlyCallsMemcache()
+    public function testSetMethodProperlyCallsMemcache(): void
     {
         if (! class_exists(Memcached::class)) {
             $this->markTestSkipped('Memcached module not installed');
@@ -71,7 +71,7 @@ class CacheMemcachedStoreTest extends TestCase
         \Illuminate\Support\Carbon::setTestNow();
     }
 
-    public function testIncrementMethodProperlyCallsMemcache()
+    public function testIncrementMethodProperlyCallsMemcache(): void
     {
         if (! class_exists(Memcached::class)) {
             $this->markTestSkipped('Memcached module not installed');
@@ -83,7 +83,7 @@ class CacheMemcachedStoreTest extends TestCase
         $store->increment('foo', 5);
     }
 
-    public function testDecrementMethodProperlyCallsMemcache()
+    public function testDecrementMethodProperlyCallsMemcache(): void
     {
         if (! class_exists(Memcached::class)) {
             $this->markTestSkipped('Memcached module not installed');
@@ -95,7 +95,7 @@ class CacheMemcachedStoreTest extends TestCase
         $store->decrement('foo', 5);
     }
 
-    public function testStoreItemForeverProperlyCallsMemcached()
+    public function testStoreItemForeverProperlyCallsMemcached(): void
     {
         if (! class_exists(Memcached::class)) {
             $this->markTestSkipped('Memcached module not installed');
@@ -107,7 +107,7 @@ class CacheMemcachedStoreTest extends TestCase
         $store->forever('foo', 'bar');
     }
 
-    public function testForgetMethodProperlyCallsMemcache()
+    public function testForgetMethodProperlyCallsMemcache(): void
     {
         if (! class_exists(Memcached::class)) {
             $this->markTestSkipped('Memcached module not installed');
@@ -119,7 +119,7 @@ class CacheMemcachedStoreTest extends TestCase
         $store->forget('foo');
     }
 
-    public function testFlushesCached()
+    public function testFlushesCached(): void
     {
         if (! class_exists('Memcached')) {
             $this->markTestSkipped('Memcached module not installed');
@@ -132,7 +132,7 @@ class CacheMemcachedStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testGetAndSetPrefix()
+    public function testGetAndSetPrefix(): void
     {
         if (! class_exists(Memcached::class)) {
             $this->markTestSkipped('Memcached module not installed');

--- a/tests/Cache/CacheNullStoreTest.php
+++ b/tests/Cache/CacheNullStoreTest.php
@@ -7,14 +7,14 @@ use PHPUnit\Framework\TestCase;
 
 class CacheNullStoreTest extends TestCase
 {
-    public function testItemsCanNotBeCached()
+    public function testItemsCanNotBeCached(): void
     {
         $store = new NullStore;
         $store->put('foo', 'bar', 10);
         $this->assertNull($store->get('foo'));
     }
 
-    public function testGetMultipleReturnsMultipleNulls()
+    public function testGetMultipleReturnsMultipleNulls(): void
     {
         $store = new NullStore;
 

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -9,12 +9,12 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 
 class CacheRateLimiterTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testTooManyAttemptsReturnTrueIfAlreadyLockedOut()
+    public function testTooManyAttemptsReturnTrueIfAlreadyLockedOut(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(1);
@@ -25,7 +25,7 @@ class CacheRateLimiterTest extends TestCase
         $this->assertTrue($rateLimiter->tooManyAttempts('key', 1));
     }
 
-    public function testHitProperlyIncrementsAttemptCount()
+    public function testHitProperlyIncrementsAttemptCount(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1)->andReturn(true);
@@ -36,7 +36,7 @@ class CacheRateLimiterTest extends TestCase
         $rateLimiter->hit('key', 1);
     }
 
-    public function testHitHasNoMemoryLeak()
+    public function testHitHasNoMemoryLeak(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1)->andReturn(true);
@@ -48,7 +48,7 @@ class CacheRateLimiterTest extends TestCase
         $rateLimiter->hit('key', 1);
     }
 
-    public function testRetriesLeftReturnsCorrectCount()
+    public function testRetriesLeftReturnsCorrectCount(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(3);
@@ -57,7 +57,7 @@ class CacheRateLimiterTest extends TestCase
         $this->assertEquals(2, $rateLimiter->retriesLeft('key', 5));
     }
 
-    public function testClearClearsTheCacheKeys()
+    public function testClearClearsTheCacheKeys(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('forget')->once()->with('key');

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class CacheRedisStoreTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testGetReturnsNullWhenNotFound()
+    public function testGetReturnsNullWhenNotFound(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -20,7 +20,7 @@ class CacheRedisStoreTest extends TestCase
         $this->assertNull($redis->get('foo'));
     }
 
-    public function testRedisValueIsReturned()
+    public function testRedisValueIsReturned(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -28,7 +28,7 @@ class CacheRedisStoreTest extends TestCase
         $this->assertEquals('foo', $redis->get('foo'));
     }
 
-    public function testRedisMultipleValuesAreReturned()
+    public function testRedisMultipleValuesAreReturned(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -48,7 +48,7 @@ class CacheRedisStoreTest extends TestCase
         $this->assertNull($results['null']);
     }
 
-    public function testRedisValueIsReturnedForNumerics()
+    public function testRedisValueIsReturnedForNumerics(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -56,7 +56,7 @@ class CacheRedisStoreTest extends TestCase
         $this->assertEquals(1, $redis->get('foo'));
     }
 
-    public function testSetMethodProperlyCallsRedis()
+    public function testSetMethodProperlyCallsRedis(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -64,7 +64,7 @@ class CacheRedisStoreTest extends TestCase
         $redis->put('foo', 'foo', 60);
     }
 
-    public function testSetMultipleMethodProperlyCallsRedis()
+    public function testSetMultipleMethodProperlyCallsRedis(): void
     {
         $redis = $this->getRedis();
         /** @var m\MockInterface $connection */
@@ -83,7 +83,7 @@ class CacheRedisStoreTest extends TestCase
         ], 60);
     }
 
-    public function testSetMethodProperlyCallsRedisForNumerics()
+    public function testSetMethodProperlyCallsRedisForNumerics(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -91,7 +91,7 @@ class CacheRedisStoreTest extends TestCase
         $redis->put('foo', 1, 60);
     }
 
-    public function testIncrementMethodProperlyCallsRedis()
+    public function testIncrementMethodProperlyCallsRedis(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -99,7 +99,7 @@ class CacheRedisStoreTest extends TestCase
         $redis->increment('foo', 5);
     }
 
-    public function testDecrementMethodProperlyCallsRedis()
+    public function testDecrementMethodProperlyCallsRedis(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -107,7 +107,7 @@ class CacheRedisStoreTest extends TestCase
         $redis->decrement('foo', 5);
     }
 
-    public function testStoreItemForeverProperlyCallsRedis()
+    public function testStoreItemForeverProperlyCallsRedis(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -115,7 +115,7 @@ class CacheRedisStoreTest extends TestCase
         $redis->forever('foo', 'foo', 60);
     }
 
-    public function testForgetMethodProperlyCallsRedis()
+    public function testForgetMethodProperlyCallsRedis(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -123,7 +123,7 @@ class CacheRedisStoreTest extends TestCase
         $redis->forget('foo');
     }
 
-    public function testFlushesCached()
+    public function testFlushesCached(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -132,7 +132,7 @@ class CacheRedisStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testGetAndSetPrefix()
+    public function testGetAndSetPrefix(): void
     {
         $redis = $this->getRedis();
         $this->assertEquals('prefix:', $redis->getPrefix());

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -11,34 +11,34 @@ use PHPUnit\Framework\TestCase;
 
 class CacheRepositoryTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         m::close();
         Carbon::setTestNow();
     }
 
-    public function testGetReturnsValueFromCache()
+    public function testGetReturnsValueFromCache(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
         $this->assertEquals('bar', $repo->get('foo'));
     }
 
-    public function testGetReturnsMultipleValuesFromCacheWhenGivenAnArray()
+    public function testGetReturnsMultipleValuesFromCacheWhenGivenAnArray(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('many')->once()->with(['foo', 'bar'])->andReturn(['foo' => 'bar', 'bar' => 'baz']);
         $this->assertEquals(['foo' => 'bar', 'bar' => 'baz'], $repo->get(['foo', 'bar']));
     }
 
-    public function testGetReturnsMultipleValuesFromCacheWhenGivenAnArrayWithDefaultValues()
+    public function testGetReturnsMultipleValuesFromCacheWhenGivenAnArrayWithDefaultValues(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('many')->once()->with(['foo', 'bar'])->andReturn(['foo' => null, 'bar' => 'baz']);
         $this->assertEquals(['foo' => 'default', 'bar' => 'baz'], $repo->get(['foo' => 'default', 'bar']));
     }
 
-    public function testDefaultValueIsReturned()
+    public function testDefaultValueIsReturned(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->times(2)->andReturn(null);
@@ -48,14 +48,14 @@ class CacheRepositoryTest extends TestCase
         }));
     }
 
-    public function testSettingDefaultCacheTime()
+    public function testSettingDefaultCacheTime(): void
     {
         $repo = $this->getRepository();
         $repo->setDefaultCacheTime(10);
         $this->assertEquals(10, $repo->getDefaultCacheTime());
     }
 
-    public function testHasMethod()
+    public function testHasMethod(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
@@ -65,7 +65,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($repo->has('foo'));
     }
 
-    public function testRememberMethodCallsPutAndReturnsDefault()
+    public function testRememberMethodCallsPutAndReturnsDefault(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
@@ -94,7 +94,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertEquals('qux', $result);
     }
 
-    public function testRememberForeverMethodCallsForeverAndReturnsDefault()
+    public function testRememberForeverMethodCallsForeverAndReturnsDefault(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
@@ -105,14 +105,14 @@ class CacheRepositoryTest extends TestCase
         $this->assertEquals('bar', $result);
     }
 
-    public function testPuttingMultipleItemsInCache()
+    public function testPuttingMultipleItemsInCache(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('putMany')->once()->with(['foo' => 'bar', 'bar' => 'baz'], 1);
         $repo->put(['foo' => 'bar', 'bar' => 'baz'], 1);
     }
 
-    public function testSettingMultipleItemsInCache()
+    public function testSettingMultipleItemsInCache(): void
     {
         // Alias of PuttingMultiple
         $repo = $this->getRepository();
@@ -120,7 +120,7 @@ class CacheRepositoryTest extends TestCase
         $repo->setMultiple(['foo' => 'bar', 'bar' => 'baz'], 1);
     }
 
-    public function testPutWithDatetimeInPastOrZeroSecondsDoesntSaveItem()
+    public function testPutWithDatetimeInPastOrZeroSecondsDoesntSaveItem(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('put')->never();
@@ -128,7 +128,7 @@ class CacheRepositoryTest extends TestCase
         $repo->put('foo', 'bar', Carbon::now());
     }
 
-    public function testAddWithDatetimeInPastOrZeroSecondsReturnsImmediately()
+    public function testAddWithDatetimeInPastOrZeroSecondsReturnsImmediately(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('add', 'get', 'put')->never();
@@ -138,7 +138,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function testCacheAddCallsRedisStoreAdd()
+    public function testCacheAddCallsRedisStoreAdd(): void
     {
         $store = m::mock(\Illuminate\Cache\RedisStore::class);
         $store->shouldReceive('add')->once()->with('k', 'v', 60)->andReturn(true);
@@ -163,7 +163,7 @@ class CacheRepositoryTest extends TestCase
      * @dataProvider dataProviderTestGetMinutes
      * @param mixed $duration
      */
-    public function testGetMinutes($duration)
+    public function testGetMinutes($duration): void
     {
         Carbon::setTestNow(Carbon::parse($this->getTestDate()));
 
@@ -172,7 +172,7 @@ class CacheRepositoryTest extends TestCase
         $repo->put($key, $value, $duration);
     }
 
-    public function testRegisterMacroWithNonStaticCall()
+    public function testRegisterMacroWithNonStaticCall(): void
     {
         $repo = $this->getRepository();
         $repo::macro(__CLASS__, function () {
@@ -181,14 +181,14 @@ class CacheRepositoryTest extends TestCase
         $this->assertEquals($repo->{__CLASS__}(), 'Taylor');
     }
 
-    public function testForgettingCacheKey()
+    public function testForgettingCacheKey(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('forget')->once()->with('a-key')->andReturn(true);
         $repo->forget('a-key');
     }
 
-    public function testRemovingCacheKey()
+    public function testRemovingCacheKey(): void
     {
         // Alias of Forget
         $repo = $this->getRepository();
@@ -196,21 +196,21 @@ class CacheRepositoryTest extends TestCase
         $repo->delete('a-key');
     }
 
-    public function testSettingCache()
+    public function testSettingCache(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('put')->with($key = 'foo', $value = 'bar', 1);
         $repo->set($key, $value, 1);
     }
 
-    public function testClearingWholeCache()
+    public function testClearingWholeCache(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('flush')->andReturn(true);
         $repo->clear();
     }
 
-    public function testGettingMultipleValuesFromCache()
+    public function testGettingMultipleValuesFromCache(): void
     {
         $keys = ['key1', 'key2', 'key3'];
         $default = ['key2' => 5];
@@ -220,7 +220,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertEquals(['key1' => 1, 'key2' => 5, 'key3' => null], $repo->getMultiple($keys, $default));
     }
 
-    public function testRemovingMultipleKeys()
+    public function testRemovingMultipleKeys(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('forget')->once()->with('a-key')->andReturn(true);

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -9,12 +9,12 @@ use Illuminate\Cache\Console\CacheTableCommand;
 
 class CacheTableCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testCreateMakesMigration()
+    public function testCreateMakesMigration(): void
     {
         $command = new CacheTableCommandTestStub(
             $files = m::mock('Illuminate\Filesystem\Filesystem'),

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -10,12 +10,12 @@ use Illuminate\Cache\ArrayStore;
 
 class CacheTaggedCacheTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testCacheCanBeSavedWithMultipleTags()
+    public function testCacheCanBeSavedWithMultipleTags(): void
     {
         $store = new ArrayStore;
         $tags = ['bop', 'zap'];
@@ -23,7 +23,7 @@ class CacheTaggedCacheTest extends TestCase
         $this->assertEquals('bar', $store->tags($tags)->get('foo'));
     }
 
-    public function testCacheCanBeSetWithDatetimeArgument()
+    public function testCacheCanBeSetWithDatetimeArgument(): void
     {
         $store = new ArrayStore;
         $tags = ['bop', 'zap'];
@@ -33,7 +33,7 @@ class CacheTaggedCacheTest extends TestCase
         $this->assertEquals('bar', $store->tags($tags)->get('foo'));
     }
 
-    public function testCacheSavedWithMultipleTagsCanBeFlushed()
+    public function testCacheSavedWithMultipleTagsCanBeFlushed(): void
     {
         $store = new ArrayStore;
         $tags1 = ['bop', 'zap'];
@@ -45,14 +45,14 @@ class CacheTaggedCacheTest extends TestCase
         $this->assertEquals('bar', $store->tags($tags2)->get('foo'));
     }
 
-    public function testTagsWithStringArgument()
+    public function testTagsWithStringArgument(): void
     {
         $store = new ArrayStore;
         $store->tags('bop')->put('foo', 'bar', 10);
         $this->assertEquals('bar', $store->tags('bop')->get('foo'));
     }
 
-    public function testTagsCacheForever()
+    public function testTagsCacheForever(): void
     {
         $store = new ArrayStore;
         $tags = ['bop', 'zap'];
@@ -60,7 +60,7 @@ class CacheTaggedCacheTest extends TestCase
         $this->assertEquals('bar', $store->tags($tags)->get('foo'));
     }
 
-    public function testRedisCacheTagsPushForeverKeysCorrectly()
+    public function testRedisCacheTagsPushForeverKeysCorrectly(): void
     {
         $store = m::mock('Illuminate\Contracts\Cache\Store');
         $tagSet = m::mock('Illuminate\Cache\TagSet', [$store, ['foo', 'bar']]);
@@ -77,7 +77,7 @@ class CacheTaggedCacheTest extends TestCase
         $redis->forever('key1', 'key1:value');
     }
 
-    public function testRedisCacheTagsPushStandardKeysCorrectly()
+    public function testRedisCacheTagsPushStandardKeysCorrectly(): void
     {
         $store = m::mock('Illuminate\Contracts\Cache\Store');
         $tagSet = m::mock('Illuminate\Cache\TagSet', [$store, ['foo', 'bar']]);
@@ -93,7 +93,7 @@ class CacheTaggedCacheTest extends TestCase
         $redis->put('key1', 'key1:value');
     }
 
-    public function testRedisCacheTagsCanBeFlushed()
+    public function testRedisCacheTagsCanBeFlushed(): void
     {
         $store = m::mock('Illuminate\Contracts\Cache\Store');
         $tagSet = m::mock('Illuminate\Cache\TagSet', [$store, ['foo', 'bar']]);

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -9,12 +9,12 @@ use Illuminate\Cache\Console\ClearCommand;
 
 class ClearCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testClearWithNoStoreArgument()
+    public function testClearWithNoStoreArgument(): void
     {
         $command = new ClearCommandTestStub(
             $cacheManager = m::mock('Illuminate\Cache\CacheManager'),
@@ -34,7 +34,7 @@ class ClearCommandTest extends TestCase
         $this->runCommand($command);
     }
 
-    public function testClearWithStoreArgument()
+    public function testClearWithStoreArgument(): void
     {
         $command = new ClearCommandTestStub(
             $cacheManager = m::mock('Illuminate\Cache\CacheManager'),
@@ -57,7 +57,7 @@ class ClearCommandTest extends TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testClearWithInvalidStoreArgument()
+    public function testClearWithInvalidStoreArgument(): void
     {
         $command = new ClearCommandTestStub(
             $cacheManager = m::mock('Illuminate\Cache\CacheManager'),
@@ -77,7 +77,7 @@ class ClearCommandTest extends TestCase
         $this->runCommand($command, ['store' => 'bar']);
     }
 
-    public function testClearWithTagsOption()
+    public function testClearWithTagsOption(): void
     {
         $command = new ClearCommandTestStub(
             $cacheManager = m::mock('Illuminate\Cache\CacheManager'),
@@ -98,7 +98,7 @@ class ClearCommandTest extends TestCase
         $this->runCommand($command, ['--tags' => 'foo,bar']);
     }
 
-    public function testClearWithStoreArgumentAndTagsOption()
+    public function testClearWithStoreArgumentAndTagsOption(): void
     {
         $command = new ClearCommandTestStub(
             $cacheManager = m::mock('Illuminate\Cache\CacheManager'),
@@ -119,7 +119,7 @@ class ClearCommandTest extends TestCase
         $this->runCommand($command, ['store' => 'redis', '--tags' => 'foo']);
     }
 
-    public function testClearWillClearsRealTimeFacades()
+    public function testClearWillClearsRealTimeFacades(): void
     {
         $command = new ClearCommandTestStub(
             $cacheManager = m::mock('Illuminate\Cache\CacheManager'),

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -12,13 +12,13 @@ class RedisCacheIntegrationTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->setUpRedis();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         m::close();
@@ -30,7 +30,7 @@ class RedisCacheIntegrationTest extends TestCase
      *
      * @param string $driver
      */
-    public function testRedisCacheAddTwice($driver)
+    public function testRedisCacheAddTwice($driver): void
     {
         $store = new RedisStore($this->redis[$driver]);
         $repository = new Repository($store);
@@ -46,7 +46,7 @@ class RedisCacheIntegrationTest extends TestCase
      *
      * @param string $driver
      */
-    public function testRedisCacheAddFalse($driver)
+    public function testRedisCacheAddFalse($driver): void
     {
         $store = new RedisStore($this->redis[$driver]);
         $repository = new Repository($store);
@@ -62,7 +62,7 @@ class RedisCacheIntegrationTest extends TestCase
      *
      * @param string $driver
      */
-    public function testRedisCacheAddNull($driver)
+    public function testRedisCacheAddNull($driver): void
     {
         $store = new RedisStore($this->redis[$driver]);
         $repository = new Repository($store);

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -17,7 +17,7 @@ class RepositoryTest extends TestCase
      */
     protected $config;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->repository = new Repository($this->config = [
             'foo' => 'bar',
@@ -40,27 +40,27 @@ class RepositoryTest extends TestCase
         parent::setUp();
     }
 
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $this->assertInstanceOf(Repository::class, $this->repository);
     }
 
-    public function testHasIsTrue()
+    public function testHasIsTrue(): void
     {
         $this->assertTrue($this->repository->has('foo'));
     }
 
-    public function testHasIsFalse()
+    public function testHasIsFalse(): void
     {
         $this->assertFalse($this->repository->has('not-exist'));
     }
 
-    public function testGet()
+    public function testGet(): void
     {
         $this->assertSame('bar', $this->repository->get('foo'));
     }
 
-    public function testGetWithArrayOfKeys()
+    public function testGetWithArrayOfKeys(): void
     {
         $this->assertSame([
             'foo' => 'bar',
@@ -85,7 +85,7 @@ class RepositoryTest extends TestCase
         ]));
     }
 
-    public function testGetMany()
+    public function testGetMany(): void
     {
         $this->assertSame([
             'foo' => 'bar',
@@ -110,18 +110,18 @@ class RepositoryTest extends TestCase
         ]));
     }
 
-    public function testGetWithDefault()
+    public function testGetWithDefault(): void
     {
         $this->assertSame('default', $this->repository->get('not-exist', 'default'));
     }
 
-    public function testSet()
+    public function testSet(): void
     {
         $this->repository->set('key', 'value');
         $this->assertSame('value', $this->repository->get('key'));
     }
 
-    public function testSetArray()
+    public function testSetArray(): void
     {
         $this->repository->set([
             'key1' => 'value1',
@@ -131,24 +131,24 @@ class RepositoryTest extends TestCase
         $this->assertSame('value2', $this->repository->get('key2'));
     }
 
-    public function testPrepend()
+    public function testPrepend(): void
     {
         $this->repository->prepend('array', 'xxx');
         $this->assertSame('xxx', $this->repository->get('array.0'));
     }
 
-    public function testPush()
+    public function testPush(): void
     {
         $this->repository->push('array', 'xxx');
         $this->assertSame('xxx', $this->repository->get('array.2'));
     }
 
-    public function testAll()
+    public function testAll(): void
     {
         $this->assertSame($this->config, $this->repository->all());
     }
 
-    public function testOffsetUnset()
+    public function testOffsetUnset(): void
     {
         $this->assertArrayHasKey('associate', $this->repository->all());
         $this->assertSame($this->config['associate'], $this->repository->get('associate'));

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class ConsoleApplicationTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testAddSetsLaravelInstance()
+    public function testAddSetsLaravelInstance(): void
     {
         $app = $this->getMockConsole(['addToParent']);
         $command = m::mock('Illuminate\Console\Command');
@@ -23,7 +23,7 @@ class ConsoleApplicationTest extends TestCase
         $this->assertEquals($command, $result);
     }
 
-    public function testLaravelNotSetOnSymfonyCommands()
+    public function testLaravelNotSetOnSymfonyCommands(): void
     {
         $app = $this->getMockConsole(['addToParent']);
         $command = m::mock('Symfony\Component\Console\Command\Command');
@@ -34,7 +34,7 @@ class ConsoleApplicationTest extends TestCase
         $this->assertEquals($command, $result);
     }
 
-    public function testResolveAddsCommandViaApplicationResolution()
+    public function testResolveAddsCommandViaApplicationResolution(): void
     {
         $app = $this->getMockConsole(['addToParent']);
         $command = m::mock('Symfony\Component\Console\Command\Command');

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -11,7 +11,7 @@ use Illuminate\Console\Scheduling\SchedulingMutex;
 
 class ConsoleEventSchedulerTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -26,12 +26,12 @@ class ConsoleEventSchedulerTest extends TestCase
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testMutexCanReceiveCustomStore()
+    public function testMutexCanReceiveCustomStore(): void
     {
         Container::getInstance()->make(EventMutex::class)->shouldReceive('useStore')->once()->with('test');
         Container::getInstance()->make(SchedulingMutex::class)->shouldReceive('useStore')->once()->with('test');
@@ -39,7 +39,7 @@ class ConsoleEventSchedulerTest extends TestCase
         $this->schedule->useCache('test');
     }
 
-    public function testExecCreatesNewCommand()
+    public function testExecCreatesNewCommand(): void
     {
         $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
         $escapeReal = '\\' === DIRECTORY_SEPARATOR ? '\\"' : '"';
@@ -65,7 +65,7 @@ class ConsoleEventSchedulerTest extends TestCase
         $this->assertEquals("path/to/command {$escape}-1 minute{$escape}", $events[7]->command);
     }
 
-    public function testCommandCreatesNewArtisanCommand()
+    public function testCommandCreatesNewArtisanCommand(): void
     {
         $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
 
@@ -81,7 +81,7 @@ class ConsoleEventSchedulerTest extends TestCase
         $this->assertEquals($binary.' artisan queue:listen --tries=3', $events[2]->command);
     }
 
-    public function testCreateNewArtisanCommandUsingCommandClass()
+    public function testCreateNewArtisanCommandUsingCommandClass(): void
     {
         $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
 

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class ConsoleParserTest extends TestCase
 {
-    public function testBasicParameterParsing()
+    public function testBasicParameterParsing(): void
     {
         $results = Parser::parse('command:name');
 
@@ -66,7 +66,7 @@ class ConsoleParserTest extends TestCase
         $this->assertTrue($results[2][0]->isArray());
     }
 
-    public function testShortcutNameParsing()
+    public function testShortcutNameParsing(): void
     {
         $results = Parser::parse('command:name {--o|option}');
 
@@ -108,7 +108,7 @@ class ConsoleParserTest extends TestCase
         $this->assertTrue($results[2][0]->isArray());
     }
 
-    public function testDefaultValueParsing()
+    public function testDefaultValueParsing(): void
     {
         $results = Parser::parse('command:name {argument=defaultArgumentValue} {--option=defaultOptionValue}');
 
@@ -127,7 +127,7 @@ class ConsoleParserTest extends TestCase
         $this->assertEquals(['defaultOptionValue1', 'defaultOptionValue2'], $results[2][0]->getDefault());
     }
 
-    public function testArgumentDefaultValue()
+    public function testArgumentDefaultValue(): void
     {
         $results = Parser::parse('command:name {argument= : The argument description.}');
         $this->assertNull($results[1][0]->getDefault());
@@ -136,7 +136,7 @@ class ConsoleParserTest extends TestCase
         $this->assertSame('default', $results[1][0]->getDefault());
     }
 
-    public function testOptionDefaultValue()
+    public function testOptionDefaultValue(): void
     {
         $results = Parser::parse('command:name {--option= : The option description.}');
         $this->assertNull($results[2][0]->getDefault());

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -16,20 +16,20 @@ class ConsoleScheduledEventTest extends TestCase
      */
     protected $defaultTimezone;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->defaultTimezone = date_default_timezone_get();
         date_default_timezone_set('UTC');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         date_default_timezone_set($this->defaultTimezone);
         Carbon::setTestNow(null);
         m::close();
     }
 
-    public function testBasicCronCompilation()
+    public function testBasicCronCompilation(): void
     {
         $app = m::mock('Illuminate\Foundation\Application[isDownForMaintenance,environment]');
         $app->shouldReceive('isDownForMaintenance')->andReturn(false);
@@ -73,7 +73,7 @@ class ConsoleScheduledEventTest extends TestCase
             $eventB->hourly()->weekdays()->getExpression());
     }
 
-    public function testEventIsDueCheck()
+    public function testEventIsDueCheck(): void
     {
         $app = m::mock('Illuminate\Foundation\Application[isDownForMaintenance,environment]');
         $app->shouldReceive('isDownForMaintenance')->andReturn(false);
@@ -89,7 +89,7 @@ class ConsoleScheduledEventTest extends TestCase
         $this->assertTrue($event->isDue($app));
     }
 
-    public function testTimeBetweenChecks()
+    public function testTimeBetweenChecks(): void
     {
         $app = m::mock('Illuminate\Foundation\Application[isDownForMaintenance,environment]');
         $app->shouldReceive('isDownForMaintenance')->andReturn(false);

--- a/tests/Console/Scheduling/CacheEventMutexTest.php
+++ b/tests/Console/Scheduling/CacheEventMutexTest.php
@@ -29,7 +29,7 @@ class CacheEventMutexTest extends TestCase
      */
     protected $cacheRepository;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -40,14 +40,14 @@ class CacheEventMutexTest extends TestCase
         $this->event = new Event($this->cacheMutex, 'command');
     }
 
-    public function testPreventOverlap()
+    public function testPreventOverlap(): void
     {
         $this->cacheRepository->shouldReceive('add')->once();
 
         $this->cacheMutex->create($this->event);
     }
 
-    public function testCustomConnection()
+    public function testCustomConnection(): void
     {
         $this->cacheFactory->shouldReceive('store')->with('test')->andReturn($this->cacheRepository);
         $this->cacheRepository->shouldReceive('add')->once();
@@ -56,28 +56,28 @@ class CacheEventMutexTest extends TestCase
         $this->cacheMutex->create($this->event);
     }
 
-    public function testPreventOverlapFails()
+    public function testPreventOverlapFails(): void
     {
         $this->cacheRepository->shouldReceive('add')->once()->andReturn(false);
 
         $this->assertFalse($this->cacheMutex->create($this->event));
     }
 
-    public function testOverlapsForNonRunningTask()
+    public function testOverlapsForNonRunningTask(): void
     {
         $this->cacheRepository->shouldReceive('has')->once()->andReturn(false);
 
         $this->assertFalse($this->cacheMutex->exists($this->event));
     }
 
-    public function testOverlapsForRunningTask()
+    public function testOverlapsForRunningTask(): void
     {
         $this->cacheRepository->shouldReceive('has')->once()->andReturn(true);
 
         $this->assertTrue($this->cacheMutex->exists($this->event));
     }
 
-    public function testResetOverlap()
+    public function testResetOverlap(): void
     {
         $this->cacheRepository->shouldReceive('forget')->once();
 

--- a/tests/Console/Scheduling/CacheSchedulingMutexTest.php
+++ b/tests/Console/Scheduling/CacheSchedulingMutexTest.php
@@ -36,7 +36,7 @@ class CacheSchedulingMutexTest extends TestCase
      */
     protected $cacheRepository;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -48,14 +48,14 @@ class CacheSchedulingMutexTest extends TestCase
         $this->time = Carbon::now();
     }
 
-    public function testMutexReceviesCorrectCreate()
+    public function testMutexReceviesCorrectCreate(): void
     {
         $this->cacheRepository->shouldReceive('add')->once()->with($this->event->mutexName().$this->time->format('Hi'), true, 60)->andReturn(true);
 
         $this->assertTrue($this->cacheMutex->create($this->event, $this->time));
     }
 
-    public function testCanUseCustomConnection()
+    public function testCanUseCustomConnection(): void
     {
         $this->cacheFactory->shouldReceive('store')->with('test')->andReturn($this->cacheRepository);
         $this->cacheRepository->shouldReceive('add')->once()->with($this->event->mutexName().$this->time->format('Hi'), true, 60)->andReturn(true);
@@ -64,21 +64,21 @@ class CacheSchedulingMutexTest extends TestCase
         $this->assertTrue($this->cacheMutex->create($this->event, $this->time));
     }
 
-    public function testPreventsMultipleRuns()
+    public function testPreventsMultipleRuns(): void
     {
         $this->cacheRepository->shouldReceive('add')->once()->with($this->event->mutexName().$this->time->format('Hi'), true, 60)->andReturn(false);
 
         $this->assertFalse($this->cacheMutex->create($this->event, $this->time));
     }
 
-    public function testChecksForNonRunSchedule()
+    public function testChecksForNonRunSchedule(): void
     {
         $this->cacheRepository->shouldReceive('has')->once()->with($this->event->mutexName().$this->time->format('Hi'))->andReturn(false);
 
         $this->assertFalse($this->cacheMutex->exists($this->event, $this->time));
     }
 
-    public function testChecksForAlreadyRunSchedule()
+    public function testChecksForAlreadyRunSchedule(): void
     {
         $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName().$this->time->format('Hi'))->andReturn(true);
 

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -8,12 +8,12 @@ use Illuminate\Console\Scheduling\Event;
 
 class EventTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBuildCommand()
+    public function testBuildCommand(): void
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
@@ -31,7 +31,7 @@ class EventTest extends TestCase
         $this->assertSame("(php -i > {$quote}{$defaultOutput}{$quote} 2>&1 ; '".PHP_BINARY."' artisan schedule:finish \"framework/schedule-eeb46c93d45e928d62aaf684d727e213b7094822\") > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
     }
 
-    public function testBuildCommandSendOutputTo()
+    public function testBuildCommandSendOutputTo(): void
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
@@ -46,7 +46,7 @@ class EventTest extends TestCase
         $this->assertSame("php -i > {$quote}/my folder/foo.log{$quote} 2>&1", $event->buildCommand());
     }
 
-    public function testBuildCommandAppendOutput()
+    public function testBuildCommandAppendOutput(): void
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
@@ -56,7 +56,7 @@ class EventTest extends TestCase
         $this->assertSame("php -i >> {$quote}/dev/null{$quote} 2>&1", $event->buildCommand());
     }
 
-    public function testNextRunDate()
+    public function testNextRunDate(): void
     {
         $event = new Event(m::mock('Illuminate\Console\Scheduling\EventMutex'), 'php -i');
         $event->dailyAt('10:15');

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -13,7 +13,7 @@ class FrequencyTest extends TestCase
      */
     protected $event;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->event = new Event(
             m::mock('Illuminate\Console\Scheduling\EventMutex'),
@@ -21,104 +21,104 @@ class FrequencyTest extends TestCase
         );
     }
 
-    public function testEveryMinute()
+    public function testEveryMinute(): void
     {
         $this->assertEquals('* * * * *', $this->event->getExpression());
         $this->assertEquals('* * * * *', $this->event->everyMinute()->getExpression());
     }
 
-    public function testEveryFiveMinutes()
+    public function testEveryFiveMinutes(): void
     {
         $this->assertEquals('*/5 * * * *', $this->event->everyFiveMinutes()->getExpression());
     }
 
-    public function testDaily()
+    public function testDaily(): void
     {
         $this->assertEquals('0 0 * * *', $this->event->daily()->getExpression());
     }
 
-    public function testTwiceDaily()
+    public function testTwiceDaily(): void
     {
         $this->assertEquals('0 3,15 * * *', $this->event->twiceDaily(3, 15)->getExpression());
     }
 
-    public function testOverrideWithHourly()
+    public function testOverrideWithHourly(): void
     {
         $this->assertEquals('0 * * * *', $this->event->everyFiveMinutes()->hourly()->getExpression());
         $this->assertEquals('37 * * * *', $this->event->hourlyAt(37)->getExpression());
     }
 
-    public function testMonthlyOn()
+    public function testMonthlyOn(): void
     {
         $this->assertEquals('0 15 4 * *', $this->event->monthlyOn(4, '15:00')->getExpression());
     }
 
-    public function testTwiceMonthly()
+    public function testTwiceMonthly(): void
     {
         $this->assertEquals('0 0 1,16 * *', $this->event->twiceMonthly(1, 16)->getExpression());
     }
 
-    public function testMonthlyOnWithMinutes()
+    public function testMonthlyOnWithMinutes(): void
     {
         $this->assertEquals('15 15 4 * *', $this->event->monthlyOn(4, '15:15')->getExpression());
     }
 
-    public function testWeekdaysDaily()
+    public function testWeekdaysDaily(): void
     {
         $this->assertEquals('0 0 * * 1-5', $this->event->weekdays()->daily()->getExpression());
     }
 
-    public function testWeekdaysHourly()
+    public function testWeekdaysHourly(): void
     {
         $this->assertEquals('0 * * * 1-5', $this->event->weekdays()->hourly()->getExpression());
     }
 
-    public function testWeekdays()
+    public function testWeekdays(): void
     {
         $this->assertEquals('* * * * 1-5', $this->event->weekdays()->getExpression());
     }
 
-    public function testSundays()
+    public function testSundays(): void
     {
         $this->assertEquals('* * * * 0', $this->event->sundays()->getExpression());
     }
 
-    public function testMondays()
+    public function testMondays(): void
     {
         $this->assertEquals('* * * * 1', $this->event->mondays()->getExpression());
     }
 
-    public function testTuesdays()
+    public function testTuesdays(): void
     {
         $this->assertEquals('* * * * 2', $this->event->tuesdays()->getExpression());
     }
 
-    public function testWednesdays()
+    public function testWednesdays(): void
     {
         $this->assertEquals('* * * * 3', $this->event->wednesdays()->getExpression());
     }
 
-    public function testThursdays()
+    public function testThursdays(): void
     {
         $this->assertEquals('* * * * 4', $this->event->thursdays()->getExpression());
     }
 
-    public function testFridays()
+    public function testFridays(): void
     {
         $this->assertEquals('* * * * 5', $this->event->fridays()->getExpression());
     }
 
-    public function testSaturdays()
+    public function testSaturdays(): void
     {
         $this->assertEquals('* * * * 6', $this->event->saturdays()->getExpression());
     }
 
-    public function testQuarterly()
+    public function testQuarterly(): void
     {
         $this->assertEquals('0 0 1 1-12/3 *', $this->event->quarterly()->getExpression());
     }
 
-    public function testFrequencyMacro()
+    public function testFrequencyMacro(): void
     {
         Event::macro('everyXMinutes', function ($x) {
             return $this->spliceIntoPosition(1, "*/{$x}");

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -8,7 +8,7 @@ use Illuminate\Container\Container;
 
 class ContainerTest extends TestCase
 {
-    public function testContainerSingleton()
+    public function testContainerSingleton(): void
     {
         $container = Container::setInstance(new Container);
 
@@ -22,7 +22,7 @@ class ContainerTest extends TestCase
         $this->assertNotSame($container, $container2);
     }
 
-    public function testClosureResolution()
+    public function testClosureResolution(): void
     {
         $container = new Container;
         $container->bind('name', function () {
@@ -31,7 +31,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('Taylor', $container->make('name'));
     }
 
-    public function testBindIfDoesntRegisterIfServiceAlreadyRegistered()
+    public function testBindIfDoesntRegisterIfServiceAlreadyRegistered(): void
     {
         $container = new Container;
         $container->bind('name', function () {
@@ -44,7 +44,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('Taylor', $container->make('name'));
     }
 
-    public function testBindIfDoesRegisterIfServiceNotRegisteredYet()
+    public function testBindIfDoesRegisterIfServiceNotRegisteredYet(): void
     {
         $container = new Container;
         $container->bind('surname', function () {
@@ -57,7 +57,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('Dayle', $container->make('name'));
     }
 
-    public function testSharedClosureResolution()
+    public function testSharedClosureResolution(): void
     {
         $container = new Container;
         $class = new stdClass;
@@ -67,13 +67,13 @@ class ContainerTest extends TestCase
         $this->assertSame($class, $container->make('class'));
     }
 
-    public function testAutoConcreteResolution()
+    public function testAutoConcreteResolution(): void
     {
         $container = new Container;
         $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $container->make('Illuminate\Tests\Container\ContainerConcreteStub'));
     }
 
-    public function testSharedConcreteResolution()
+    public function testSharedConcreteResolution(): void
     {
         $container = new Container;
         $container->singleton('Illuminate\Tests\Container\ContainerConcreteStub');
@@ -83,7 +83,7 @@ class ContainerTest extends TestCase
         $this->assertSame($var1, $var2);
     }
 
-    public function testAbstractToConcreteResolution()
+    public function testAbstractToConcreteResolution(): void
     {
         $container = new Container;
         $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
@@ -91,7 +91,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $class->impl);
     }
 
-    public function testNestedDependencyResolution()
+    public function testNestedDependencyResolution(): void
     {
         $container = new Container;
         $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
@@ -100,7 +100,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $class->inner->impl);
     }
 
-    public function testContainerIsPassedToResolvers()
+    public function testContainerIsPassedToResolvers(): void
     {
         $container = new Container;
         $container->bind('something', function ($c) {
@@ -110,7 +110,7 @@ class ContainerTest extends TestCase
         $this->assertSame($c, $container);
     }
 
-    public function testArrayAccess()
+    public function testArrayAccess(): void
     {
         $container = new Container;
         $container['something'] = function () {
@@ -122,7 +122,7 @@ class ContainerTest extends TestCase
         $this->assertFalse(isset($container['something']));
     }
 
-    public function testAliases()
+    public function testAliases(): void
     {
         $container = new Container;
         $container['foo'] = 'bar';
@@ -133,7 +133,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('bar', $container->make('bat'));
     }
 
-    public function testAliasesWithArrayOfParameters()
+    public function testAliasesWithArrayOfParameters(): void
     {
         $container = new Container;
         $container->bind('foo', function ($app, $config) {
@@ -143,7 +143,7 @@ class ContainerTest extends TestCase
         $this->assertEquals([1, 2, 3], $container->make('baz', [1, 2, 3]));
     }
 
-    public function testBindingsCanBeOverridden()
+    public function testBindingsCanBeOverridden(): void
     {
         $container = new Container;
         $container['foo'] = 'bar';
@@ -151,7 +151,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('baz', $container['foo']);
     }
 
-    public function testExtendedBindings()
+    public function testExtendedBindings(): void
     {
         $container = new Container;
         $container['foo'] = 'foo';
@@ -179,7 +179,7 @@ class ContainerTest extends TestCase
         $this->assertSame($result, $container->make('foo'));
     }
 
-    public function testMultipleExtends()
+    public function testMultipleExtends(): void
     {
         $container = new Container;
         $container['foo'] = 'foo';
@@ -193,7 +193,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('foobarbaz', $container->make('foo'));
     }
 
-    public function testBindingAnInstanceReturnsTheInstance()
+    public function testBindingAnInstanceReturnsTheInstance(): void
     {
         $container = new Container;
 
@@ -203,7 +203,7 @@ class ContainerTest extends TestCase
         $this->assertSame($bound, $resolved);
     }
 
-    public function testExtendInstancesArePreserved()
+    public function testExtendInstancesArePreserved(): void
     {
         $container = new Container;
         $container->bind('foo', function () {
@@ -231,7 +231,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('foo', $container->make('foo')->baz);
     }
 
-    public function testExtendIsLazyInitialized()
+    public function testExtendIsLazyInitialized(): void
     {
         ContainerLazyExtendStub::$initialized = false;
 
@@ -247,7 +247,7 @@ class ContainerTest extends TestCase
         $this->assertTrue(ContainerLazyExtendStub::$initialized);
     }
 
-    public function testExtendCanBeCalledBeforeBind()
+    public function testExtendCanBeCalledBeforeBind(): void
     {
         $container = new Container;
         $container->extend('foo', function ($old, $container) {
@@ -258,7 +258,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('foobar', $container->make('foo'));
     }
 
-    public function testExtendInstanceRebindingCallback()
+    public function testExtendInstanceRebindingCallback(): void
     {
         $_SERVER['_test_rebind'] = false;
 
@@ -277,7 +277,7 @@ class ContainerTest extends TestCase
         $this->assertTrue($_SERVER['_test_rebind']);
     }
 
-    public function testExtendBindRebindingCallback()
+    public function testExtendBindRebindingCallback(): void
     {
         $_SERVER['_test_rebind'] = false;
 
@@ -302,7 +302,7 @@ class ContainerTest extends TestCase
         $this->assertTrue($_SERVER['_test_rebind']);
     }
 
-    public function testUnsetExtend()
+    public function testUnsetExtend(): void
     {
         $container = new Container;
         $container->bind('foo', function () {
@@ -328,7 +328,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('foo', $container->make('foo'));
     }
 
-    public function testResolutionOfDefaultParameters()
+    public function testResolutionOfDefaultParameters(): void
     {
         $container = new Container;
         $instance = $container->make('Illuminate\Tests\Container\ContainerDefaultValueStub');
@@ -336,7 +336,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $instance->default);
     }
 
-    public function testResolvingCallbacksAreCalledForSpecificAbstracts()
+    public function testResolvingCallbacksAreCalledForSpecificAbstracts(): void
     {
         $container = new Container;
         $container->resolving('foo', function ($object) {
@@ -350,7 +350,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $instance->name);
     }
 
-    public function testResolvingCallbacksAreCalled()
+    public function testResolvingCallbacksAreCalled(): void
     {
         $container = new Container;
         $container->resolving(function ($object) {
@@ -364,7 +364,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $instance->name);
     }
 
-    public function testResolvingCallbacksAreCalledForType()
+    public function testResolvingCallbacksAreCalledForType(): void
     {
         $container = new Container;
         $container->resolving('stdClass', function ($object) {
@@ -378,7 +378,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $instance->name);
     }
 
-    public function testUnsetRemoveBoundInstances()
+    public function testUnsetRemoveBoundInstances(): void
     {
         $container = new Container;
         $container->instance('object', new stdClass);
@@ -387,7 +387,7 @@ class ContainerTest extends TestCase
         $this->assertFalse($container->bound('object'));
     }
 
-    public function testBoundInstanceAndAliasCheckViaArrayAccess()
+    public function testBoundInstanceAndAliasCheckViaArrayAccess(): void
     {
         $container = new Container;
         $container->instance('object', new stdClass);
@@ -397,7 +397,7 @@ class ContainerTest extends TestCase
         $this->assertTrue(isset($container['alias']));
     }
 
-    public function testReboundListeners()
+    public function testReboundListeners(): void
     {
         unset($_SERVER['__test.rebind']);
 
@@ -413,7 +413,7 @@ class ContainerTest extends TestCase
         $this->assertTrue($_SERVER['__test.rebind']);
     }
 
-    public function testReboundListenersOnInstances()
+    public function testReboundListenersOnInstances(): void
     {
         unset($_SERVER['__test.rebind']);
 
@@ -429,7 +429,7 @@ class ContainerTest extends TestCase
         $this->assertTrue($_SERVER['__test.rebind']);
     }
 
-    public function testReboundListenersOnInstancesOnlyFiresIfWasAlreadyBound()
+    public function testReboundListenersOnInstancesOnlyFiresIfWasAlreadyBound(): void
     {
         $_SERVER['__test.rebind'] = false;
 
@@ -447,7 +447,7 @@ class ContainerTest extends TestCase
      * @expectedException \Illuminate\Contracts\Container\BindingResolutionException
      * @expectedExceptionMessage Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class Illuminate\Tests\Container\ContainerMixedPrimitiveStub
      */
-    public function testInternalClassWithDefaultParameters()
+    public function testInternalClassWithDefaultParameters(): void
     {
         $container = new Container;
         $container->make('Illuminate\Tests\Container\ContainerMixedPrimitiveStub', []);
@@ -457,7 +457,7 @@ class ContainerTest extends TestCase
      * @expectedException \Illuminate\Contracts\Container\BindingResolutionException
      * @expectedExceptionMessage Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable.
      */
-    public function testBindingResolutionExceptionMessage()
+    public function testBindingResolutionExceptionMessage(): void
     {
         $container = new Container;
         $container->make('Illuminate\Tests\Container\IContainerContractStub', []);
@@ -467,13 +467,13 @@ class ContainerTest extends TestCase
      * @expectedException \Illuminate\Contracts\Container\BindingResolutionException
      * @expectedExceptionMessage Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable while building [Illuminate\Tests\Container\ContainerTestContextInjectOne].
      */
-    public function testBindingResolutionExceptionMessageIncludesBuildStack()
+    public function testBindingResolutionExceptionMessageIncludesBuildStack(): void
     {
         $container = new Container;
         $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne', []);
     }
 
-    public function testCallWithDependencies()
+    public function testCallWithDependencies(): void
     {
         $container = new Container;
         $result = $container->call(function (stdClass $foo, $bar = []) {
@@ -508,13 +508,13 @@ class ContainerTest extends TestCase
      * @expectedException \ReflectionException
      * @expectedExceptionMessage Function ContainerTestCallStub() does not exist
      */
-    public function testCallWithAtSignBasedClassReferencesWithoutMethodThrowsException()
+    public function testCallWithAtSignBasedClassReferencesWithoutMethodThrowsException(): void
     {
         $container = new Container;
         $result = $container->call('ContainerTestCallStub');
     }
 
-    public function testCallWithAtSignBasedClassReferences()
+    public function testCallWithAtSignBasedClassReferences(): void
     {
         $container = new Container;
         $result = $container->call('Illuminate\Tests\Container\ContainerTestCallStub@work', ['foo', 'bar']);
@@ -535,7 +535,7 @@ class ContainerTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
-    public function testCallWithCallableArray()
+    public function testCallWithCallableArray(): void
     {
         $container = new Container;
         $stub = new ContainerTestCallStub;
@@ -543,7 +543,7 @@ class ContainerTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
-    public function testCallWithStaticMethodNameString()
+    public function testCallWithStaticMethodNameString(): void
     {
         $container = new Container;
         $result = $container->call('Illuminate\Tests\Container\ContainerStaticMethodStub::inject');
@@ -551,7 +551,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $result[1]);
     }
 
-    public function testCallWithGlobalMethodName()
+    public function testCallWithGlobalMethodName(): void
     {
         $container = new Container;
         $result = $container->call('Illuminate\Tests\Container\containerTestInject');
@@ -559,7 +559,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $result[1]);
     }
 
-    public function testCallWithBoundMethod()
+    public function testCallWithBoundMethod(): void
     {
         $container = new Container;
         $container->bindMethod('Illuminate\Tests\Container\ContainerTestCallStub@unresolvable', function ($stub) {
@@ -576,7 +576,7 @@ class ContainerTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
-    public function testBindMethodAcceptsAnArray()
+    public function testBindMethodAcceptsAnArray(): void
     {
         $container = new Container;
         $container->bindMethod([\Illuminate\Tests\Container\ContainerTestCallStub::class, 'unresolvable'], function ($stub) {
@@ -593,7 +593,7 @@ class ContainerTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
-    public function testContainerCanInjectDifferentImplementationsDependingOnContext()
+    public function testContainerCanInjectDifferentImplementationsDependingOnContext(): void
     {
         $container = new Container;
 
@@ -627,7 +627,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStubTwo', $two->impl);
     }
 
-    public function testContextualBindingWorksForExistingInstancedBindings()
+    public function testContextualBindingWorksForExistingInstancedBindings(): void
     {
         $container = new Container;
 
@@ -641,7 +641,7 @@ class ContainerTest extends TestCase
         );
     }
 
-    public function testContextualBindingWorksForNewlyInstancedBindings()
+    public function testContextualBindingWorksForNewlyInstancedBindings(): void
     {
         $container = new Container;
 
@@ -655,7 +655,7 @@ class ContainerTest extends TestCase
         );
     }
 
-    public function testContextualBindingWorksOnExistingAliasedInstances()
+    public function testContextualBindingWorksOnExistingAliasedInstances(): void
     {
         $container = new Container;
 
@@ -670,7 +670,7 @@ class ContainerTest extends TestCase
         );
     }
 
-    public function testContextualBindingWorksOnNewAliasedInstances()
+    public function testContextualBindingWorksOnNewAliasedInstances(): void
     {
         $container = new Container;
 
@@ -685,7 +685,7 @@ class ContainerTest extends TestCase
         );
     }
 
-    public function testContextualBindingWorksOnNewAliasedBindings()
+    public function testContextualBindingWorksOnNewAliasedBindings(): void
     {
         $container = new Container;
 
@@ -700,7 +700,7 @@ class ContainerTest extends TestCase
         );
     }
 
-    public function testContextualBindingDoesntOverrideNonContextualResolution()
+    public function testContextualBindingDoesntOverrideNonContextualResolution(): void
     {
         $container = new Container;
 
@@ -720,7 +720,7 @@ class ContainerTest extends TestCase
         );
     }
 
-    public function testContextuallyBoundInstancesAreNotUnnecessarilyRecreated()
+    public function testContextuallyBoundInstancesAreNotUnnecessarilyRecreated(): void
     {
         ContainerTestContextInjectInstantiations::$instantiations = 0;
 
@@ -741,7 +741,7 @@ class ContainerTest extends TestCase
         $this->assertEquals(1, ContainerTestContextInjectInstantiations::$instantiations);
     }
 
-    public function testContainerTags()
+    public function testContainerTags(): void
     {
         $container = new Container;
         $container->tag('Illuminate\Tests\Container\ContainerImplementationStub', 'foo', 'bar');
@@ -762,7 +762,7 @@ class ContainerTest extends TestCase
         $this->assertEmpty($container->tagged('this_tag_does_not_exist'));
     }
 
-    public function testForgetInstanceForgetsInstance()
+    public function testForgetInstanceForgetsInstance(): void
     {
         $container = new Container;
         $containerConcreteStub = new ContainerConcreteStub;
@@ -772,7 +772,7 @@ class ContainerTest extends TestCase
         $this->assertFalse($container->isShared('Illuminate\Tests\Container\ContainerConcreteStub'));
     }
 
-    public function testForgetInstancesForgetsAllInstances()
+    public function testForgetInstancesForgetsAllInstances(): void
     {
         $container = new Container;
         $containerConcreteStub1 = new ContainerConcreteStub;
@@ -790,7 +790,7 @@ class ContainerTest extends TestCase
         $this->assertFalse($container->isShared('Instance3'));
     }
 
-    public function testContainerFlushFlushesAllBindingsAliasesAndResolvedInstances()
+    public function testContainerFlushFlushesAllBindingsAliasesAndResolvedInstances(): void
     {
         $container = new Container;
         $container->bind('ConcreteStub', function () {
@@ -809,7 +809,7 @@ class ContainerTest extends TestCase
         $this->assertFalse($container->isShared('ConcreteStub'));
     }
 
-    public function testResolvedResolvesAliasToBindingNameBeforeChecking()
+    public function testResolvedResolvesAliasToBindingNameBeforeChecking(): void
     {
         $container = new Container;
         $container->bind('ConcreteStub', function () {
@@ -826,14 +826,14 @@ class ContainerTest extends TestCase
         $this->assertTrue($container->resolved('foo'));
     }
 
-    public function testGetAlias()
+    public function testGetAlias(): void
     {
         $container = new Container;
         $container->alias('ConcreteStub', 'foo');
         $this->assertEquals($container->getAlias('foo'), 'ConcreteStub');
     }
 
-    public function testItThrowsExceptionWhenAbstractIsSameAsAlias()
+    public function testItThrowsExceptionWhenAbstractIsSameAsAlias(): void
     {
         $container = new Container;
         $container->alias('name', 'name');
@@ -844,7 +844,7 @@ class ContainerTest extends TestCase
         $container->getAlias('name');
     }
 
-    public function testContainerCanInjectSimpleVariable()
+    public function testContainerCanInjectSimpleVariable(): void
     {
         $container = new Container;
         $container->when('Illuminate\Tests\Container\ContainerInjectVariableStub')->needs('$something')->give(100);
@@ -859,7 +859,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $instance->something);
     }
 
-    public function testContainerGetFactory()
+    public function testContainerGetFactory(): void
     {
         $container = new Container;
         $container->bind('name', function () {
@@ -870,7 +870,7 @@ class ContainerTest extends TestCase
         $this->assertEquals($container->make('name'), $factory());
     }
 
-    public function testExtensionWorksOnAliasedBindings()
+    public function testExtensionWorksOnAliasedBindings(): void
     {
         $container = new Container;
         $container->singleton('something', function () {
@@ -884,7 +884,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('some value extended', $container->make('something'));
     }
 
-    public function testContextualBindingWorksWithAliasedTargets()
+    public function testContextualBindingWorksWithAliasedTargets(): void
     {
         $container = new Container;
 
@@ -903,7 +903,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStubTwo', $two->impl);
     }
 
-    public function testResolvingCallbacksShouldBeFiredWhenCalledWithAliases()
+    public function testResolvingCallbacksShouldBeFiredWhenCalledWithAliases(): void
     {
         $container = new Container;
         $container->alias('stdClass', 'std');
@@ -918,7 +918,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $instance->name);
     }
 
-    public function testMakeWithMethodIsAnAliasForMakeMethod()
+    public function testMakeWithMethodIsAnAliasForMakeMethod(): void
     {
         $mock = $this->getMockBuilder(Container::class)
                      ->setMethods(['make'])
@@ -934,7 +934,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $result);
     }
 
-    public function testResolvingWithArrayOfParameters()
+    public function testResolvingWithArrayOfParameters(): void
     {
         $container = new Container;
         $instance = $container->make(ContainerDefaultValueStub::class, ['default' => 'adam']);
@@ -950,7 +950,7 @@ class ContainerTest extends TestCase
         $this->assertEquals([1, 2, 3], $container->make('foo', [1, 2, 3]));
     }
 
-    public function testResolvingWithUsingAnInterface()
+    public function testResolvingWithUsingAnInterface(): void
     {
         $container = new Container;
         $container->bind(IContainerContractStub::class, ContainerInjectVariableStubWithInterfaceImplementation::class);
@@ -958,7 +958,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('laurence', $instance->something);
     }
 
-    public function testNestedParameterOverride()
+    public function testNestedParameterOverride(): void
     {
         $container = new Container;
         $container->bind('foo', function ($app, $config) {
@@ -971,7 +971,7 @@ class ContainerTest extends TestCase
         $this->assertEquals(['name' => 'Taylor'], $container->make('foo', ['something']));
     }
 
-    public function testNestedParametersAreResetForFreshMake()
+    public function testNestedParametersAreResetForFreshMake(): void
     {
         $container = new Container;
 
@@ -986,7 +986,7 @@ class ContainerTest extends TestCase
         $this->assertEquals([], $container->make('foo', ['something']));
     }
 
-    public function testSingletonBindingsNotRespectedWithMakeParameters()
+    public function testSingletonBindingsNotRespectedWithMakeParameters(): void
     {
         $container = new Container;
 
@@ -998,34 +998,34 @@ class ContainerTest extends TestCase
         $this->assertEquals(['name' => 'abigail'], $container->make('foo', ['name' => 'abigail']));
     }
 
-    public function testCanBuildWithoutParameterStackWithNoConstructors()
+    public function testCanBuildWithoutParameterStackWithNoConstructors(): void
     {
         $container = new Container;
         $this->assertInstanceOf(ContainerConcreteStub::class, $container->build(ContainerConcreteStub::class));
     }
 
-    public function testCanBuildWithoutParameterStackWithConstructors()
+    public function testCanBuildWithoutParameterStackWithConstructors(): void
     {
         $container = new Container;
         $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
         $this->assertInstanceOf(ContainerDependentStub::class, $container->build(ContainerDependentStub::class));
     }
 
-    public function testContainerKnowsEntry()
+    public function testContainerKnowsEntry(): void
     {
         $container = new Container;
         $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
         $this->assertTrue($container->has('Illuminate\Tests\Container\IContainerContractStub'));
     }
 
-    public function testContainerCanBindAnyWord()
+    public function testContainerCanBindAnyWord(): void
     {
         $container = new Container;
         $container->bind('Taylor', stdClass::class);
         $this->assertInstanceOf(stdClass::class, $container->get('Taylor'));
     }
 
-    public function testContainerCanDynamicallySetService()
+    public function testContainerCanDynamicallySetService(): void
     {
         $container = new Container;
         $this->assertFalse(isset($container['name']));
@@ -1037,7 +1037,7 @@ class ContainerTest extends TestCase
     /**
      * @expectedException \Illuminate\Container\EntryNotFoundException
      */
-    public function testUnknownEntryThrowsException()
+    public function testUnknownEntryThrowsException(): void
     {
         $container = new Container;
         $container->get('Taylor');

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -9,12 +9,12 @@ use Symfony\Component\HttpFoundation\Request;
 
 class CookieTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testCookiesAreCreatedWithProperOptions()
+    public function testCookiesAreCreatedWithProperOptions(): void
     {
         $cookie = $this->getCreator();
         $cookie->setDefaultPathAndDomain('foo', 'bar');
@@ -39,7 +39,7 @@ class CookieTest extends TestCase
         $this->assertTrue($c3->getExpiresTime() < time());
     }
 
-    public function testCookiesAreCreatedWithProperOptionsUsingDefaultPathAndDomain()
+    public function testCookiesAreCreatedWithProperOptionsUsingDefaultPathAndDomain(): void
     {
         $cookie = $this->getCreator();
         $cookie->setDefaultPathAndDomain('/path', '/domain', true, 'lax');
@@ -51,7 +51,7 @@ class CookieTest extends TestCase
         $this->assertEquals('lax', $c->getSameSite());
     }
 
-    public function testCookiesCanSetSecureOptionUsingDefaultPathAndDomain()
+    public function testCookiesCanSetSecureOptionUsingDefaultPathAndDomain(): void
     {
         $cookie = $this->getCreator();
         $cookie->setDefaultPathAndDomain('/path', '/domain', true, 'lax');
@@ -63,7 +63,7 @@ class CookieTest extends TestCase
         $this->assertEquals('lax', $c->getSameSite());
     }
 
-    public function testQueuedCookies()
+    public function testQueuedCookies(): void
     {
         $cookie = $this->getCreator();
         $this->assertEmpty($cookie->getQueuedCookies());
@@ -78,7 +78,7 @@ class CookieTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Cookie', $cookie->queued('qu'));
     }
 
-    public function testUnqueue()
+    public function testUnqueue(): void
     {
         $cookie = $this->getCreator();
         $cookie->queue($cookie->make('foo', 'bar'));

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -26,7 +26,7 @@ class EncryptCookiesTest extends TestCase
     protected $setCookiePath = 'cookie/set';
     protected $queueCookiePath = 'cookie/queue';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -38,7 +38,7 @@ class EncryptCookiesTest extends TestCase
         $this->router = new Router(new Dispatcher, $container);
     }
 
-    public function testSetCookieEncryption()
+    public function testSetCookieEncryption(): void
     {
         $this->router->get($this->setCookiePath, [
             'middleware' => 'Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestMiddleware',
@@ -55,7 +55,7 @@ class EncryptCookiesTest extends TestCase
         $this->assertEquals('value', $cookies[1]->getValue());
     }
 
-    public function testQueuedCookieEncryption()
+    public function testQueuedCookieEncryption(): void
     {
         $this->router->get($this->queueCookiePath, [
             'middleware' => ['Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestMiddleware', 'Illuminate\Tests\Cookie\Middleware\AddQueuedCookiesToResponseTestMiddleware'],

--- a/tests/Database/DatabaseConcernsBuildsQueriesTraitTest.php
+++ b/tests/Database/DatabaseConcernsBuildsQueriesTraitTest.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Concerns\BuildsQueries;
 
 class DatabaseConcernsBuildsQueriesTraitTest extends TestCase
 {
-    public function testTapCallbackInstance()
+    public function testTapCallbackInstance(): void
     {
         $mock = $this->getMockForTrait(BuildsQueries::class);
         $mock->tap(function ($builder) use ($mock) {

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -12,7 +12,7 @@ class DatabaseConnectionFactoryTest extends TestCase
 {
     protected $db;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->db = new DB;
 
@@ -34,12 +34,12 @@ class DatabaseConnectionFactoryTest extends TestCase
         $this->db->setAsGlobal();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testConnectionCanBeCreated()
+    public function testConnectionCanBeCreated(): void
     {
         $this->assertInstanceOf('PDO', $this->db->connection()->getPdo());
         $this->assertInstanceOf('PDO', $this->db->connection()->getReadPdo());
@@ -47,7 +47,7 @@ class DatabaseConnectionFactoryTest extends TestCase
         $this->assertInstanceOf('PDO', $this->db->connection('read_write')->getReadPdo());
     }
 
-    public function testSingleConnectionNotCreatedUntilNeeded()
+    public function testSingleConnectionNotCreatedUntilNeeded(): void
     {
         $connection = $this->db->connection();
         $pdo = new ReflectionProperty(get_class($connection), 'pdo');
@@ -59,7 +59,7 @@ class DatabaseConnectionFactoryTest extends TestCase
         $this->assertNotInstanceOf('PDO', $readPdo->getValue($connection));
     }
 
-    public function testReadWriteConnectionsNotCreatedUntilNeeded()
+    public function testReadWriteConnectionsNotCreatedUntilNeeded(): void
     {
         $connection = $this->db->connection('read_write');
         $pdo = new ReflectionProperty(get_class($connection), 'pdo');
@@ -75,7 +75,7 @@ class DatabaseConnectionFactoryTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage A driver must be specified.
      */
-    public function testIfDriverIsntSetExceptionIsThrown()
+    public function testIfDriverIsntSetExceptionIsThrown(): void
     {
         $factory = new ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
         $factory->createConnector(['foo']);
@@ -85,14 +85,14 @@ class DatabaseConnectionFactoryTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Unsupported driver [foo]
      */
-    public function testExceptionIsThrownOnUnsupportedDriver()
+    public function testExceptionIsThrownOnUnsupportedDriver(): void
     {
         $factory = new ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
         $container->shouldReceive('bound')->once()->andReturn(false);
         $factory->createConnector(['driver' => 'foo']);
     }
 
-    public function testCustomConnectorsCanBeResolvedViaContainer()
+    public function testCustomConnectorsCanBeResolvedViaContainer(): void
     {
         $factory = new ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
         $container->shouldReceive('bound')->once()->with('db.connector.foo')->andReturn(true);

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -8,12 +8,12 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseConnectionTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testSettingDefaultCallsGetDefaultGrammar()
+    public function testSettingDefaultCallsGetDefaultGrammar(): void
     {
         $connection = $this->getMockConnection();
         $mock = m::mock('stdClass');
@@ -22,7 +22,7 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals($mock, $connection->getQueryGrammar());
     }
 
-    public function testSettingDefaultCallsGetDefaultPostProcessor()
+    public function testSettingDefaultCallsGetDefaultPostProcessor(): void
     {
         $connection = $this->getMockConnection();
         $mock = m::mock('stdClass');
@@ -31,14 +31,14 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals($mock, $connection->getPostProcessor());
     }
 
-    public function testSelectOneCallsSelectAndReturnsSingleResult()
+    public function testSelectOneCallsSelectAndReturnsSingleResult(): void
     {
         $connection = $this->getMockConnection(['select']);
         $connection->expects($this->once())->method('select')->with('foo', ['bar' => 'baz'])->will($this->returnValue(['foo']));
         $this->assertEquals('foo', $connection->selectOne('foo', ['bar' => 'baz']));
     }
 
-    public function testSelectProperlyCallsPDO()
+    public function testSelectProperlyCallsPDO(): void
     {
         $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
         $writePdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
@@ -59,7 +59,7 @@ class DatabaseConnectionTest extends TestCase
         $this->assertInternalType('numeric', $log[0]['time']);
     }
 
-    public function testInsertCallsTheStatementMethod()
+    public function testInsertCallsTheStatementMethod(): void
     {
         $connection = $this->getMockConnection(['statement']);
         $connection->expects($this->once())->method('statement')->with($this->equalTo('foo'), $this->equalTo(['bar']))->will($this->returnValue('baz'));
@@ -67,7 +67,7 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals('baz', $results);
     }
 
-    public function testUpdateCallsTheAffectingStatementMethod()
+    public function testUpdateCallsTheAffectingStatementMethod(): void
     {
         $connection = $this->getMockConnection(['affectingStatement']);
         $connection->expects($this->once())->method('affectingStatement')->with($this->equalTo('foo'), $this->equalTo(['bar']))->will($this->returnValue('baz'));
@@ -75,7 +75,7 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals('baz', $results);
     }
 
-    public function testDeleteCallsTheAffectingStatementMethod()
+    public function testDeleteCallsTheAffectingStatementMethod(): void
     {
         $connection = $this->getMockConnection(['affectingStatement']);
         $connection->expects($this->once())->method('affectingStatement')->with($this->equalTo('foo'), $this->equalTo(['bar']))->will($this->returnValue('baz'));
@@ -83,7 +83,7 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals('baz', $results);
     }
 
-    public function testStatementProperlyCallsPDO()
+    public function testStatementProperlyCallsPDO(): void
     {
         $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
         $statement = $this->getMockBuilder('PDOStatement')->setMethods(['execute', 'bindValue'])->getMock();
@@ -100,7 +100,7 @@ class DatabaseConnectionTest extends TestCase
         $this->assertInternalType('numeric', $log[0]['time']);
     }
 
-    public function testAffectingStatementProperlyCallsPDO()
+    public function testAffectingStatementProperlyCallsPDO(): void
     {
         $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
         $statement = $this->getMockBuilder('PDOStatement')->setMethods(['execute', 'rowCount', 'bindValue'])->getMock();
@@ -118,7 +118,7 @@ class DatabaseConnectionTest extends TestCase
         $this->assertInternalType('numeric', $log[0]['time']);
     }
 
-    public function testTransactionLevelNotIncrementedOnTransactionException()
+    public function testTransactionLevelNotIncrementedOnTransactionException(): void
     {
         $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
         $pdo->expects($this->once())->method('beginTransaction')->will($this->throwException(new \Exception));
@@ -130,7 +130,7 @@ class DatabaseConnectionTest extends TestCase
         }
     }
 
-    public function testBeginTransactionMethodRetriesOnFailure()
+    public function testBeginTransactionMethodRetriesOnFailure(): void
     {
         $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
         $pdo->expects($this->exactly(2))->method('beginTransaction');
@@ -141,7 +141,7 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals(1, $connection->transactionLevel());
     }
 
-    public function testBeginTransactionMethodNeverRetriesIfWithinTransaction()
+    public function testBeginTransactionMethodNeverRetriesIfWithinTransaction(): void
     {
         $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
         $pdo->expects($this->once())->method('beginTransaction');
@@ -160,7 +160,7 @@ class DatabaseConnectionTest extends TestCase
         }
     }
 
-    public function testSwapPDOWithOpenTransactionResetsTransactionLevel()
+    public function testSwapPDOWithOpenTransactionResetsTransactionLevel(): void
     {
         $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
         $pdo->expects($this->once())->method('beginTransaction')->will($this->returnValue(true));
@@ -170,7 +170,7 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals(0, $connection->transactionLevel());
     }
 
-    public function testBeganTransactionFiresEventsIfSet()
+    public function testBeganTransactionFiresEventsIfSet(): void
     {
         $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
         $connection = $this->getMockConnection(['getName'], $pdo);
@@ -180,7 +180,7 @@ class DatabaseConnectionTest extends TestCase
         $connection->beginTransaction();
     }
 
-    public function testCommittedFiresEventsIfSet()
+    public function testCommittedFiresEventsIfSet(): void
     {
         $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
         $connection = $this->getMockConnection(['getName'], $pdo);
@@ -190,7 +190,7 @@ class DatabaseConnectionTest extends TestCase
         $connection->commit();
     }
 
-    public function testRollBackedFiresEventsIfSet()
+    public function testRollBackedFiresEventsIfSet(): void
     {
         $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
         $connection = $this->getMockConnection(['getName'], $pdo);
@@ -201,7 +201,7 @@ class DatabaseConnectionTest extends TestCase
         $connection->rollBack();
     }
 
-    public function testRedundantRollBackFiresNoEvent()
+    public function testRedundantRollBackFiresNoEvent(): void
     {
         $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
         $connection = $this->getMockConnection(['getName'], $pdo);
@@ -211,7 +211,7 @@ class DatabaseConnectionTest extends TestCase
         $connection->rollBack();
     }
 
-    public function testTransactionMethodRunsSuccessfully()
+    public function testTransactionMethodRunsSuccessfully(): void
     {
         $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['beginTransaction', 'commit'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
@@ -227,7 +227,7 @@ class DatabaseConnectionTest extends TestCase
      * @expectedException \Illuminate\Database\QueryException
      * @expectedExceptionMessage Deadlock found when trying to get lock (SQL: )
      */
-    public function testTransactionMethodRetriesOnDeadlock()
+    public function testTransactionMethodRetriesOnDeadlock(): void
     {
         $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['beginTransaction', 'commit', 'rollBack'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
@@ -239,7 +239,7 @@ class DatabaseConnectionTest extends TestCase
         }, 3);
     }
 
-    public function testTransactionMethodRollsbackAndThrows()
+    public function testTransactionMethodRollsbackAndThrows(): void
     {
         $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['beginTransaction', 'commit', 'rollBack'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
@@ -259,7 +259,7 @@ class DatabaseConnectionTest extends TestCase
      * @expectedException \Illuminate\Database\QueryException
      * @expectedExceptionMessage server has gone away (SQL: foo)
      */
-    public function testOnLostConnectionPDOIsNotSwappedWithinATransaction()
+    public function testOnLostConnectionPDOIsNotSwappedWithinATransaction(): void
     {
         $pdo = m::mock(\PDO::class);
         $pdo->shouldReceive('beginTransaction')->once();
@@ -272,7 +272,7 @@ class DatabaseConnectionTest extends TestCase
         $connection->statement('foo');
     }
 
-    public function testOnLostConnectionPDOIsSwappedOutsideTransaction()
+    public function testOnLostConnectionPDOIsSwappedOutsideTransaction(): void
     {
         $pdo = m::mock(\PDO::class);
 
@@ -295,7 +295,7 @@ class DatabaseConnectionTest extends TestCase
         $this->assertTrue($called);
     }
 
-    public function testRunMethodRetriesOnFailure()
+    public function testRunMethodRetriesOnFailure(): void
     {
         $method = (new \ReflectionClass('Illuminate\Database\Connection'))->getMethod('run');
         $method->setAccessible(true);
@@ -313,7 +313,7 @@ class DatabaseConnectionTest extends TestCase
      * @expectedException \Illuminate\Database\QueryException
      * @expectedExceptionMessage  (SQL: ) (SQL: )
      */
-    public function testRunMethodNeverRetriesIfWithinTransaction()
+    public function testRunMethodNeverRetriesIfWithinTransaction(): void
     {
         $method = (new \ReflectionClass('Illuminate\Database\Connection'))->getMethod('run');
         $method->setAccessible(true);
@@ -329,7 +329,7 @@ class DatabaseConnectionTest extends TestCase
         }]);
     }
 
-    public function testFromCreatesNewQueryBuilder()
+    public function testFromCreatesNewQueryBuilder(): void
     {
         $conn = $this->getMockConnection();
         $conn->setQueryGrammar(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
@@ -339,7 +339,7 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals('users', $builder->from);
     }
 
-    public function testPrepareBindings()
+    public function testPrepareBindings(): void
     {
         $date = m::mock('DateTime');
         $date->shouldReceive('format')->once()->with('foo')->andReturn('bar');
@@ -352,7 +352,7 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals(['test' => 'bar'], $result);
     }
 
-    public function testLogQueryFiresEventsIfSet()
+    public function testLogQueryFiresEventsIfSet(): void
     {
         $connection = $this->getMockConnection();
         $connection->logQuery('foo', [], time());
@@ -361,7 +361,7 @@ class DatabaseConnectionTest extends TestCase
         $connection->logQuery('foo', [], null);
     }
 
-    public function testPretendOnlyLogsQueries()
+    public function testPretendOnlyLogsQueries(): void
     {
         $connection = $this->getMockConnection();
         $queries = $connection->pretend(function ($connection) {
@@ -371,7 +371,7 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals(['baz'], $queries[0]['bindings']);
     }
 
-    public function testSchemaBuilderCanBeCreated()
+    public function testSchemaBuilderCanBeCreated(): void
     {
         $connection = $this->getMockConnection();
         $schema = $connection->getSchemaBuilder();

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -8,12 +8,12 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseConnectorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testOptionResolution()
+    public function testOptionResolution(): void
     {
         $connector = new \Illuminate\Database\Connectors\Connector;
         $connector->setDefaultOptions([0 => 'foo', 1 => 'bar']);
@@ -23,7 +23,7 @@ class DatabaseConnectorTest extends TestCase
     /**
      * @dataProvider mySqlConnectProvider
      */
-    public function testMySqlConnectCallsCreateConnectionWithProperArguments($dsn, $config)
+    public function testMySqlConnectCallsCreateConnectionWithProperArguments($dsn, $config): void
     {
         $connector = $this->getMockBuilder('Illuminate\Database\Connectors\MySqlConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock('PDO');
@@ -46,7 +46,7 @@ class DatabaseConnectorTest extends TestCase
         ];
     }
 
-    public function testPostgresConnectCallsCreateConnectionWithProperArguments()
+    public function testPostgresConnectCallsCreateConnectionWithProperArguments(): void
     {
         $dsn = 'pgsql:host=foo;dbname=bar;port=111';
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'charset' => 'utf8'];
@@ -61,7 +61,7 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
-    public function testPostgresSearchPathIsSet()
+    public function testPostgresSearchPathIsSet(): void
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => 'public', 'charset' => 'utf8'];
@@ -77,7 +77,7 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
-    public function testPostgresSearchPathArraySupported()
+    public function testPostgresSearchPathArraySupported(): void
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => ['public', 'user'], 'charset' => 'utf8'];
@@ -93,7 +93,7 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
-    public function testPostgresApplicationNameIsSet()
+    public function testPostgresApplicationNameIsSet(): void
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'charset' => 'utf8', 'application_name' => 'Laravel App'];
@@ -109,7 +109,7 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
-    public function testSQLiteMemoryDatabasesMayBeConnectedTo()
+    public function testSQLiteMemoryDatabasesMayBeConnectedTo(): void
     {
         $dsn = 'sqlite::memory:';
         $config = ['database' => ':memory:'];
@@ -122,7 +122,7 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
-    public function testSQLiteFileDatabasesMayBeConnectedTo()
+    public function testSQLiteFileDatabasesMayBeConnectedTo(): void
     {
         $dsn = 'sqlite:'.__DIR__;
         $config = ['database' => __DIR__];
@@ -135,7 +135,7 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
-    public function testSqlServerConnectCallsCreateConnectionWithProperArguments()
+    public function testSqlServerConnectCallsCreateConnectionWithProperArguments(): void
     {
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111];
         $dsn = $this->getDsn($config);
@@ -148,7 +148,7 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
-    public function testSqlServerConnectCallsCreateConnectionWithOptionalArguments()
+    public function testSqlServerConnectCallsCreateConnectionWithOptionalArguments(): void
     {
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'readonly' => true, 'charset' => 'utf-8', 'pooling' => false, 'appname' => 'baz'];
         $dsn = $this->getDsn($config);

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -7,18 +7,18 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testwithPivotValueMethodSetsWhereConditionsForFetching()
+    public function testwithPivotValueMethodSetsWhereConditionsForFetching(): void
     {
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withPivotValue(['is_admin' => 1]);
     }
 
-    public function testwithPivotValueMethodSetsDefaultArgumentsForInsertion()
+    public function testwithPivotValueMethodSetsDefaultArgumentsForInsertion(): void
     {
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withPivotValue(['is_admin' => 1]);

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -13,12 +13,12 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     protected $related;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBelongsToWithDefault()
+    public function testBelongsToWithDefault(): void
     {
         $relation = $this->getRelation()->withDefault(); //belongsTo relationships
 
@@ -31,7 +31,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $this->assertSame($newModel, $relation->getResults());
     }
 
-    public function testBelongsToWithDynamicDefault()
+    public function testBelongsToWithDynamicDefault(): void
     {
         $relation = $this->getRelation()->withDefault(function ($newModel) {
             $newModel->username = 'taylor';
@@ -48,7 +48,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $this->assertSame('taylor', $newModel->username);
     }
 
-    public function testBelongsToWithArrayDefault()
+    public function testBelongsToWithArrayDefault(): void
     {
         $relation = $this->getRelation()->withDefault(['username' => 'taylor']);
 
@@ -63,7 +63,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $this->assertSame('taylor', $newModel->username);
     }
 
-    public function testUpdateMethodRetrievesModelAndUpdates()
+    public function testUpdateMethodRetrievesModelAndUpdates(): void
     {
         $relation = $this->getRelation();
         $mock = m::mock('Illuminate\Database\Eloquent\Model');
@@ -74,7 +74,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $this->assertTrue($relation->update(['attributes']));
     }
 
-    public function testEagerConstraintsAreProperlyAdded()
+    public function testEagerConstraintsAreProperlyAdded(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', ['foreign.value', 'foreign.value.two']);
@@ -82,7 +82,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation->addEagerConstraints($models);
     }
 
-    public function testIdsInEagerConstraintsCanBeZero()
+    public function testIdsInEagerConstraintsCanBeZero(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', ['foreign.value', 0]);
@@ -90,7 +90,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation->addEagerConstraints($models);
     }
 
-    public function testRelationIsProperlyInitialized()
+    public function testRelationIsProperlyInitialized(): void
     {
         $relation = $this->getRelation();
         $model = m::mock('Illuminate\Database\Eloquent\Model');
@@ -100,7 +100,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $this->assertEquals([$model], $models);
     }
 
-    public function testModelsAreProperlyMatchedToParents()
+    public function testModelsAreProperlyMatchedToParents(): void
     {
         $relation = $this->getRelation();
         $result1 = m::mock('stdClass');
@@ -117,7 +117,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $this->assertEquals(2, $models[1]->foo->getAttribute('id'));
     }
 
-    public function testAssociateMethodSetsForeignKeyOnModel()
+    public function testAssociateMethodSetsForeignKeyOnModel(): void
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model');
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
@@ -130,7 +130,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation->associate($associate);
     }
 
-    public function testDissociateMethodUnsetsForeignKeyOnModel()
+    public function testDissociateMethodUnsetsForeignKeyOnModel(): void
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model');
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
@@ -140,7 +140,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation->dissociate();
     }
 
-    public function testAssociateMethodSetsForeignKeyOnModelById()
+    public function testAssociateMethodSetsForeignKeyOnModelById(): void
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model');
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
@@ -149,7 +149,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation->associate(1);
     }
 
-    public function testDefaultEagerConstraintsWhenIncrementing()
+    public function testDefaultEagerConstraintsWhenIncrementing(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', m::mustBe([null]));
@@ -157,7 +157,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation->addEagerConstraints($models);
     }
 
-    public function testDefaultEagerConstraintsWhenIncrementingAndNonIntKeyType()
+    public function testDefaultEagerConstraintsWhenIncrementingAndNonIntKeyType(): void
     {
         $relation = $this->getRelation(null, false, 'string');
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', m::mustBe([null]));
@@ -165,7 +165,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation->addEagerConstraints($models);
     }
 
-    public function testDefaultEagerConstraintsWhenNotIncrementing()
+    public function testDefaultEagerConstraintsWhenNotIncrementing(): void
     {
         $relation = $this->getRelation(null, false);
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', m::mustBe([null]));

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -12,12 +12,12 @@ use Illuminate\Database\Query\Builder as BaseBuilder;
 
 class DatabaseEloquentBuilderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testFindMethod()
+    public function testFindMethod(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($this->getMockModel());
@@ -28,7 +28,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('baz', $result);
     }
 
-    public function testFindOrNewMethodModelFound()
+    public function testFindOrNewMethodModelFound(): void
     {
         $model = $this->getMockModel();
         $model->shouldReceive('findOrNew')->once()->andReturn('baz');
@@ -43,7 +43,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testFindOrNewMethodModelNotFound()
+    public function testFindOrNewMethodModelNotFound(): void
     {
         $model = $this->getMockModel();
         $model->shouldReceive('findOrNew')->once()->andReturn(m::mock('Illuminate\Database\Eloquent\Model'));
@@ -62,7 +62,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     /**
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function testFindOrFailMethodThrowsModelNotFoundException()
+    public function testFindOrFailMethodThrowsModelNotFoundException(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($this->getMockModel());
@@ -74,7 +74,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     /**
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function testFindOrFailMethodWithManyThrowsModelNotFoundException()
+    public function testFindOrFailMethodWithManyThrowsModelNotFoundException(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[get]', [$this->getMockQueryBuilder()]);
         $builder->setModel($this->getMockModel());
@@ -86,7 +86,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     /**
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function testFirstOrFailMethodThrowsModelNotFoundException()
+    public function testFirstOrFailMethodThrowsModelNotFoundException(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($this->getMockModel());
@@ -94,7 +94,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $result = $builder->firstOrFail(['column']);
     }
 
-    public function testFindWithMany()
+    public function testFindWithMany(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', [1, 2]);
@@ -105,7 +105,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('baz', $result);
     }
 
-    public function testFindWithManyUsingCollection()
+    public function testFindWithManyUsingCollection(): void
     {
         $ids = collect([1, 2]);
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[get]', [$this->getMockQueryBuilder()]);
@@ -117,7 +117,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('baz', $result);
     }
 
-    public function testFirstMethod()
+    public function testFirstMethod(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[get,take]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('take')->with(1)->andReturnSelf();
@@ -127,7 +127,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('bar', $result);
     }
 
-    public function testQualifyColumn()
+    public function testQualifyColumn(): void
     {
         $builder = new Builder(m::mock(BaseBuilder::class));
         $builder->shouldReceive('from')->with('stub');
@@ -137,7 +137,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('stub.column', $builder->qualifyColumn('column'));
     }
 
-    public function testGetMethodLoadsModelsAndHydratesEagerRelations()
+    public function testGetMethodLoadsModelsAndHydratesEagerRelations(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[getModels,eagerLoadRelations]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('applyScopes')->andReturnSelf();
@@ -150,7 +150,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['bar', 'baz'], $results->all());
     }
 
-    public function testGetMethodDoesntHydrateEagerRelationsWhenNoResultsAreReturned()
+    public function testGetMethodDoesntHydrateEagerRelationsWhenNoResultsAreReturned(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[getModels,eagerLoadRelations]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('applyScopes')->andReturnSelf();
@@ -163,7 +163,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals([], $results->all());
     }
 
-    public function testValueMethodWithModelFound()
+    public function testValueMethodWithModelFound(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', [$this->getMockQueryBuilder()]);
         $mockModel = new stdClass;
@@ -173,7 +173,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('foo', $builder->value('name'));
     }
 
-    public function testValueMethodWithModelNotFound()
+    public function testValueMethodWithModelNotFound(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('first')->with(['name'])->andReturn(null);
@@ -181,7 +181,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertNull($builder->value('name'));
     }
 
-    public function testChunkWithLastChunkComplete()
+    public function testChunkWithLastChunkComplete(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -204,7 +204,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         });
     }
 
-    public function testChunkWithLastChunkPartial()
+    public function testChunkWithLastChunkPartial(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -224,7 +224,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         });
     }
 
-    public function testChunkCanBeStoppedByReturningFalse()
+    public function testChunkCanBeStoppedByReturningFalse(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -246,7 +246,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         });
     }
 
-    public function testChunkWithCountZero()
+    public function testChunkWithCountZero(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -263,7 +263,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         });
     }
 
-    public function testChunkPaginatesUsingIdWithLastChunkComplete()
+    public function testChunkPaginatesUsingIdWithLastChunkComplete(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -286,7 +286,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         }, 'someIdField');
     }
 
-    public function testChunkPaginatesUsingIdWithLastChunkPartial()
+    public function testChunkPaginatesUsingIdWithLastChunkPartial(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -306,7 +306,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         }, 'someIdField');
     }
 
-    public function testChunkPaginatesUsingIdWithCountZero()
+    public function testChunkPaginatesUsingIdWithCountZero(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -323,7 +323,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         }, 'someIdField');
     }
 
-    public function testPluckReturnsTheMutatedAttributesOfAModel()
+    public function testPluckReturnsTheMutatedAttributesOfAModel(): void
     {
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('pluck')->with('name', '')->andReturn(new BaseCollection(['bar', 'baz']));
@@ -335,7 +335,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['foo_bar', 'foo_baz'], $builder->pluck('name')->all());
     }
 
-    public function testPluckReturnsTheCastedAttributesOfAModel()
+    public function testPluckReturnsTheCastedAttributesOfAModel(): void
     {
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('pluck')->with('name', '')->andReturn(new BaseCollection(['bar', 'baz']));
@@ -348,7 +348,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['foo_bar', 'foo_baz'], $builder->pluck('name')->all());
     }
 
-    public function testPluckReturnsTheDateAttributesOfAModel()
+    public function testPluckReturnsTheDateAttributesOfAModel(): void
     {
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('pluck')->with('created_at', '')->andReturn(new BaseCollection(['2010-01-01 00:00:00', '2011-01-01 00:00:00']));
@@ -362,7 +362,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['date_2010-01-01 00:00:00', 'date_2011-01-01 00:00:00'], $builder->pluck('created_at')->all());
     }
 
-    public function testPluckWithoutModelGetterJustReturnTheAttributesFoundInDatabase()
+    public function testPluckWithoutModelGetterJustReturnTheAttributesFoundInDatabase(): void
     {
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('pluck')->with('name', '')->andReturn(new BaseCollection(['bar', 'baz']));
@@ -374,7 +374,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['bar', 'baz'], $builder->pluck('name')->all());
     }
 
-    public function testLocalMacrosAreCalledOnBuilder()
+    public function testLocalMacrosAreCalledOnBuilder(): void
     {
         unset($_SERVER['__test.builder']);
         $builder = new Builder(new BaseBuilder(
@@ -394,7 +394,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         unset($_SERVER['__test.builder']);
     }
 
-    public function testGlobalMacrosAreCalledOnBuilder()
+    public function testGlobalMacrosAreCalledOnBuilder(): void
     {
         Builder::macro('foo', function ($bar) {
             return $bar;
@@ -408,7 +408,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder->bam(), $builder->getQuery());
     }
 
-    public function testGetModelsProperlyHydratesModels()
+    public function testGetModelsProperlyHydratesModels(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[get]', [$this->getMockQueryBuilder()]);
         $records[] = ['name' => 'taylor', 'age' => 26];
@@ -423,7 +423,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($models, ['hydrated']);
     }
 
-    public function testEagerLoadRelationsLoadTopLevelRelationships()
+    public function testEagerLoadRelationsLoadTopLevelRelationships(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[eagerLoadRelation]', [$this->getMockQueryBuilder()]);
         $nop1 = function () {
@@ -437,7 +437,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['foo'], $results);
     }
 
-    public function testRelationshipEagerLoadProcess()
+    public function testRelationshipEagerLoadProcess(): void
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[getRelation]', [$this->getMockQueryBuilder()]);
         $builder->setEagerLoads(['orders' => function ($query) {
@@ -456,7 +456,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         unset($_SERVER['__eloquent.constrain']);
     }
 
-    public function testGetRelationProperlySetsNestedRelationships()
+    public function testGetRelationProperlySetsNestedRelationships(): void
     {
         $builder = $this->getBuilder();
         $builder->setModel($this->getMockModel());
@@ -469,7 +469,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $relation = $builder->getRelation('orders');
     }
 
-    public function testGetRelationProperlySetsNestedRelationshipsWithSimilarNames()
+    public function testGetRelationProperlySetsNestedRelationshipsWithSimilarNames(): void
     {
         $builder = $this->getBuilder();
         $builder->setModel($this->getMockModel());
@@ -492,7 +492,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     /**
      * @expectedException \Illuminate\Database\Eloquent\RelationNotFoundException
      */
-    public function testGetRelationThrowsException()
+    public function testGetRelationThrowsException(): void
     {
         $builder = $this->getBuilder();
         $builder->setModel($this->getMockModel());
@@ -500,7 +500,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getRelation('invalid');
     }
 
-    public function testEagerLoadParsingSetsProperRelationships()
+    public function testEagerLoadParsingSetsProperRelationships(): void
     {
         $builder = $this->getBuilder();
         $builder->with(['orders', 'orders.lines']);
@@ -545,7 +545,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('foo', $eagers['orders.lines']());
     }
 
-    public function testQueryPassThru()
+    public function testQueryPassThru(): void
     {
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('foobar')->once()->andReturn('foo');
@@ -558,7 +558,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('foo', $builder->insert(['bar']));
     }
 
-    public function testQueryScopes()
+    public function testQueryScopes(): void
     {
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('from');
@@ -569,7 +569,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder, $result);
     }
 
-    public function testNestedWhere()
+    public function testNestedWhere(): void
     {
         $nestedQuery = m::mock('Illuminate\Database\Eloquent\Builder');
         $nestedRawQuery = $this->getMockQueryBuilder();
@@ -588,7 +588,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder, $result);
     }
 
-    public function testRealNestedWhereWithScopes()
+    public function testRealNestedWhereWithScopes(): void
     {
         $model = new EloquentBuilderTestNestedStub;
         $this->mockConnectionForModel($model, 'SQLite');
@@ -599,7 +599,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['bar', 9000], $query->getBindings());
     }
 
-    public function testRealNestedWhereWithMultipleScopesAndOneDeadScope()
+    public function testRealNestedWhereWithMultipleScopesAndOneDeadScope(): void
     {
         $model = new EloquentBuilderTestNestedStub;
         $this->mockConnectionForModel($model, 'SQLite');
@@ -610,7 +610,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['bar', 9000], $query->getBindings());
     }
 
-    public function testSimpleWhere()
+    public function testSimpleWhere(): void
     {
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('where')->once()->with('foo', '=', 'bar');
@@ -618,7 +618,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($result, $builder);
     }
 
-    public function testPostgresOperatorsWhere()
+    public function testPostgresOperatorsWhere(): void
     {
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('where')->once()->with('foo', '@>', 'bar');
@@ -626,7 +626,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($result, $builder);
     }
 
-    public function testDeleteOverride()
+    public function testDeleteOverride(): void
     {
         $builder = $this->getBuilder();
         $builder->onDelete(function ($builder) {
@@ -635,7 +635,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['foo' => $builder], $builder->delete());
     }
 
-    public function testWithCount()
+    public function testWithCount(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -644,7 +644,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
-    public function testWithCountAndSelect()
+    public function testWithCountAndSelect(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -653,7 +653,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
-    public function testWithCountAndMergedWheres()
+    public function testWithCountAndMergedWheres(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -665,7 +665,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['qux', true], $builder->getBindings());
     }
 
-    public function testWithCountAndGlobalScope()
+    public function testWithCountAndGlobalScope(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
         EloquentBuilderTestModelCloseRelatedStub::addGlobalScope('withCount', function ($query) {
@@ -681,7 +681,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
-    public function testWithCountAndConstraintsAndHaving()
+    public function testWithCountAndConstraintsAndHaving(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -694,7 +694,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['qux', 'baz', 1], $builder->getBindings());
     }
 
-    public function testWithCountAndRename()
+    public function testWithCountAndRename(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -703,7 +703,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
-    public function testWithCountMultipleAndPartialRename()
+    public function testWithCountMultipleAndPartialRename(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -712,7 +712,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
-    public function testHasWithConstraintsAndHavingInSubquery()
+    public function testHasWithConstraintsAndHavingInSubquery(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -725,7 +725,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['baz', 'qux', 'quuux'], $builder->getBindings());
     }
 
-    public function testHasWithConstraintsWithOrWhereAndHavingInSubquery()
+    public function testHasWithConstraintsWithOrWhereAndHavingInSubquery(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -740,7 +740,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['larry', '90210', '90220', 'fooside dr', 29], $builder->getBindings());
     }
 
-    public function testHasWithContraintsAndJoinAndHavingInSubquery()
+    public function testHasWithContraintsAndJoinAndHavingInSubquery(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
         $builder = $model->where('bar', 'baz');
@@ -755,7 +755,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['baz', 'quuuuuux', 'qux', 'quuux'], $builder->getBindings());
     }
 
-    public function testHasWithConstraintsAndHavingInSubqueryWithCount()
+    public function testHasWithConstraintsAndHavingInSubqueryWithCount(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -768,7 +768,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['baz', 'qux', 'quuux'], $builder->getBindings());
     }
 
-    public function testHasNestedWithConstraints()
+    public function testHasNestedWithConstraints(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -785,7 +785,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder, $result);
     }
 
-    public function testHasNested()
+    public function testHasNested(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -798,7 +798,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder->toSql(), $result);
     }
 
-    public function testOrHasNested()
+    public function testOrHasNested(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -813,7 +813,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder->toSql(), $result);
     }
 
-    public function testSelfHasNested()
+    public function testSelfHasNested(): void
     {
         $model = new EloquentBuilderTestModelSelfRelatedStub;
 
@@ -833,7 +833,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($nestedSql, $dotSql);
     }
 
-    public function testSelfHasNestedUsesAlias()
+    public function testSelfHasNestedUsesAlias(): void
     {
         $model = new EloquentBuilderTestModelSelfRelatedStub;
 
@@ -848,7 +848,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertContains('"self_alias_hash"."id" = "self_related_stubs"."parent_id"', $sql);
     }
 
-    public function testDoesntHave()
+    public function testDoesntHave(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -857,7 +857,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where not exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id")', $builder->toSql());
     }
 
-    public function testOrDoesntHave()
+    public function testOrDoesntHave(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -867,7 +867,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['baz'], $builder->getBindings());
     }
 
-    public function testWhereDoesntHave()
+    public function testWhereDoesntHave(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -879,7 +879,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['baz'], $builder->getBindings());
     }
 
-    public function testOrWhereDoesntHave()
+    public function testOrWhereDoesntHave(): void
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -891,7 +891,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['baz', 'quux'], $builder->getBindings());
     }
 
-    public function testWhereKeyMethodWithInt()
+    public function testWhereKeyMethodWithInt(): void
     {
         $model = $this->getMockModel();
         $builder = $this->getBuilder()->setModel($model);
@@ -904,7 +904,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->whereKey($int);
     }
 
-    public function testWhereKeyMethodWithArray()
+    public function testWhereKeyMethodWithArray(): void
     {
         $model = $this->getMockModel();
         $builder = $this->getBuilder()->setModel($model);
@@ -917,7 +917,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->whereKey($array);
     }
 
-    public function testWhereKeyMethodWithCollection()
+    public function testWhereKeyMethodWithCollection(): void
     {
         $model = $this->getMockModel();
         $builder = $this->getBuilder()->setModel($model);
@@ -930,7 +930,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->whereKey($collection);
     }
 
-    public function testWhereKeyNotMethodWithInt()
+    public function testWhereKeyNotMethodWithInt(): void
     {
         $model = $this->getMockModel();
         $builder = $this->getBuilder()->setModel($model);
@@ -943,7 +943,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->whereKeyNot($int);
     }
 
-    public function testWhereKeyNotMethodWithArray()
+    public function testWhereKeyNotMethodWithArray(): void
     {
         $model = $this->getMockModel();
         $builder = $this->getBuilder()->setModel($model);
@@ -956,7 +956,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->whereKeyNot($array);
     }
 
-    public function testWhereKeyNotMethodWithCollection()
+    public function testWhereKeyNotMethodWithCollection(): void
     {
         $model = $this->getMockModel();
         $builder = $this->getBuilder()->setModel($model);

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -9,31 +9,31 @@ use Illuminate\Support\Collection as BaseCollection;
 
 class DatabaseEloquentCollectionTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testAddingItemsToCollection()
+    public function testAddingItemsToCollection(): void
     {
         $c = new Collection(['foo']);
         $c->add('bar')->add('baz');
         $this->assertEquals(['foo', 'bar', 'baz'], $c->all());
     }
 
-    public function testGettingMaxItemsFromCollection()
+    public function testGettingMaxItemsFromCollection(): void
     {
         $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
         $this->assertEquals(20, $c->max('foo'));
     }
 
-    public function testGettingMinItemsFromCollection()
+    public function testGettingMinItemsFromCollection(): void
     {
         $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
         $this->assertEquals(10, $c->min('foo'));
     }
 
-    public function testContainsWithMultipleArguments()
+    public function testContainsWithMultipleArguments(): void
     {
         $c = new Collection([['id' => 1], ['id' => 2]]);
 
@@ -42,7 +42,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertFalse($c->contains('id', '>', 2));
     }
 
-    public function testContainsIndicatesIfModelInArray()
+    public function testContainsIndicatesIfModelInArray(): void
     {
         $mockModel = m::mock('Illuminate\Database\Eloquent\Model');
         $mockModel->shouldReceive('is')->with($mockModel)->andReturn(true);
@@ -60,7 +60,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertFalse($c->contains($mockModel3));
     }
 
-    public function testContainsIndicatesIfDifferentModelInArray()
+    public function testContainsIndicatesIfDifferentModelInArray(): void
     {
         $mockModelFoo = m::namedMock('Foo', 'Illuminate\Database\Eloquent\Model');
         $mockModelFoo->shouldReceive('is')->with($mockModelFoo)->andReturn(true);
@@ -74,7 +74,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertFalse($c->contains($mockModelBar));
     }
 
-    public function testContainsIndicatesIfKeyedModelInArray()
+    public function testContainsIndicatesIfKeyedModelInArray(): void
     {
         $mockModel = m::mock('Illuminate\Database\Eloquent\Model');
         $mockModel->shouldReceive('getKey')->andReturn('1');
@@ -88,7 +88,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertFalse($c->contains(3));
     }
 
-    public function testContainsKeyAndValueIndicatesIfModelInArray()
+    public function testContainsKeyAndValueIndicatesIfModelInArray(): void
     {
         $mockModel1 = m::mock('Illuminate\Database\Eloquent\Model');
         $mockModel1->shouldReceive('offsetExists')->with('name')->andReturn(true);
@@ -103,7 +103,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertFalse($c->contains('name', 'Dayle'));
     }
 
-    public function testContainsClosureIndicatesIfModelInArray()
+    public function testContainsClosureIndicatesIfModelInArray(): void
     {
         $mockModel1 = m::mock('Illuminate\Database\Eloquent\Model');
         $mockModel1->shouldReceive('getKey')->andReturn(1);
@@ -119,7 +119,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         }));
     }
 
-    public function testFindMethodFindsModelById()
+    public function testFindMethodFindsModelById(): void
     {
         $mockModel = m::mock('Illuminate\Database\Eloquent\Model');
         $mockModel->shouldReceive('getKey')->andReturn(1);
@@ -129,7 +129,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertSame('taylor', $c->find(2, 'taylor'));
     }
 
-    public function testFindMethodFindsManyModelsById()
+    public function testFindMethodFindsManyModelsById(): void
     {
         $model1 = (new TestEloquentCollectionModel)->forceFill(['id' => 1]);
         $model2 = (new TestEloquentCollectionModel)->forceFill(['id' => 2]);
@@ -153,7 +153,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals([2, 3], $c->find([2, 3, 4])->pluck('id')->all());
     }
 
-    public function testLoadMethodEagerLoadsGivenRelationships()
+    public function testLoadMethodEagerLoadsGivenRelationships(): void
     {
         $c = $this->getMockBuilder('Illuminate\Database\Eloquent\Collection')->setMethods(['first'])->setConstructorArgs([['foo']])->getMock();
         $mockItem = m::mock('stdClass');
@@ -166,7 +166,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(['results'], $c->all());
     }
 
-    public function testCollectionDictionaryReturnsModelKeys()
+    public function testCollectionDictionaryReturnsModelKeys(): void
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');
         $one->shouldReceive('getKey')->andReturn(1);
@@ -182,7 +182,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals([1, 2, 3], $c->modelKeys());
     }
 
-    public function testCollectionMergesWithGivenCollection()
+    public function testCollectionMergesWithGivenCollection(): void
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');
         $one->shouldReceive('getKey')->andReturn(1);
@@ -199,7 +199,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(new Collection([$one, $two, $three]), $c1->merge($c2));
     }
 
-    public function testMap()
+    public function testMap(): void
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');
         $two = m::mock('Illuminate\Database\Eloquent\Model');
@@ -214,7 +214,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertInstanceOf(Collection::class, $cAfterMap);
     }
 
-    public function testMappingToNonModelsReturnsABaseCollection()
+    public function testMappingToNonModelsReturnsABaseCollection(): void
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');
         $two = m::mock('Illuminate\Database\Eloquent\Model');
@@ -226,7 +226,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(BaseCollection::class, get_class($c));
     }
 
-    public function testCollectionDiffsWithGivenCollection()
+    public function testCollectionDiffsWithGivenCollection(): void
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');
         $one->shouldReceive('getKey')->andReturn(1);
@@ -243,7 +243,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(new Collection([$one]), $c1->diff($c2));
     }
 
-    public function testCollectionIntersectsWithGivenCollection()
+    public function testCollectionIntersectsWithGivenCollection(): void
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');
         $one->shouldReceive('getKey')->andReturn(1);
@@ -260,7 +260,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(new Collection([$two]), $c1->intersect($c2));
     }
 
-    public function testCollectionReturnsUniqueItems()
+    public function testCollectionReturnsUniqueItems(): void
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');
         $one->shouldReceive('getKey')->andReturn(1);
@@ -273,7 +273,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(new Collection([$one, $two]), $c->unique());
     }
 
-    public function testOnlyReturnsCollectionWithGivenModelKeys()
+    public function testOnlyReturnsCollectionWithGivenModelKeys(): void
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');
         $one->shouldReceive('getKey')->andReturn(1);
@@ -291,7 +291,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(new Collection([$two, $three]), $c->only([2, 3]));
     }
 
-    public function testExceptReturnsCollectionWithoutGivenModelKeys()
+    public function testExceptReturnsCollectionWithoutGivenModelKeys(): void
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');
         $one->shouldReceive('getKey')->andReturn(1);
@@ -308,7 +308,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(new Collection([$one]), $c->except([2, 3]));
     }
 
-    public function testMakeHiddenAddsHiddenOnEntireCollection()
+    public function testMakeHiddenAddsHiddenOnEntireCollection(): void
     {
         $c = new Collection([new TestEloquentCollectionModel]);
         $c = $c->makeHidden(['visible']);
@@ -316,7 +316,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(['hidden', 'visible'], $c[0]->getHidden());
     }
 
-    public function testMakeVisibleRemovesHiddenFromEntireCollection()
+    public function testMakeVisibleRemovesHiddenFromEntireCollection(): void
     {
         $c = new Collection([new TestEloquentCollectionModel]);
         $c = $c->makeVisible(['hidden']);
@@ -324,7 +324,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals([], $c[0]->getHidden());
     }
 
-    public function testNonModelRelatedMethods()
+    public function testNonModelRelatedMethods(): void
     {
         $a = new Collection([['foo' => 'bar'], ['foo' => 'baz']]);
         $b = new Collection(['a', 'b', 'c']);
@@ -336,7 +336,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(BaseCollection::class, get_class($b->flip()));
     }
 
-    public function testMakeVisibleRemovesHiddenAndIncludesVisible()
+    public function testMakeVisibleRemovesHiddenAndIncludesVisible(): void
     {
         $c = new Collection([new TestEloquentCollectionModel]);
         $c = $c->makeVisible('hidden');
@@ -345,7 +345,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(['visible', 'hidden'], $c[0]->getVisible());
     }
 
-    public function testQueueableCollectionImplementation()
+    public function testQueueableCollectionImplementation(): void
     {
         $c = new Collection([new TestEloquentCollectionModel, new TestEloquentCollectionModel]);
         $this->assertEquals(TestEloquentCollectionModel::class, $c->getQueueableClass());
@@ -355,13 +355,13 @@ class DatabaseEloquentCollectionTest extends TestCase
      * @expectedException \LogicException
      * @expectedExceptionMessage Queueing collections with multiple model types is not supported.
      */
-    public function testQueueableCollectionImplementationThrowsExceptionOnMultipleModelTypes()
+    public function testQueueableCollectionImplementationThrowsExceptionOnMultipleModelTypes(): void
     {
         $c = new Collection([new TestEloquentCollectionModel, (object) ['id' => 'something']]);
         $c->getQueueableClass();
     }
 
-    public function testEmptyCollectionStayEmptyOnFresh()
+    public function testEmptyCollectionStayEmptyOnFresh(): void
     {
         $c = new Collection();
         $this->assertEquals($c, $c->fresh());

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentGlobalScopesTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -19,14 +19,14 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         ])->bootEloquent();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
 
         Eloquent::unsetConnectionResolver();
     }
 
-    public function testGlobalScopeIsApplied()
+    public function testGlobalScopeIsApplied(): void
     {
         $model = new EloquentGlobalScopesTestModel;
         $query = $model->newQuery();
@@ -34,7 +34,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([1], $query->getBindings());
     }
 
-    public function testGlobalScopeCanBeRemoved()
+    public function testGlobalScopeCanBeRemoved(): void
     {
         $model = new EloquentGlobalScopesTestModel;
         $query = $model->newQuery()->withoutGlobalScope(ActiveScope::class);
@@ -42,7 +42,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([], $query->getBindings());
     }
 
-    public function testClosureGlobalScopeIsApplied()
+    public function testClosureGlobalScopeIsApplied(): void
     {
         $model = new EloquentClosureGlobalScopesTestModel;
         $query = $model->newQuery();
@@ -50,7 +50,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([1], $query->getBindings());
     }
 
-    public function testClosureGlobalScopeCanBeRemoved()
+    public function testClosureGlobalScopeCanBeRemoved(): void
     {
         $model = new EloquentClosureGlobalScopesTestModel;
         $query = $model->newQuery()->withoutGlobalScope('active_scope');
@@ -58,7 +58,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([], $query->getBindings());
     }
 
-    public function testGlobalScopeCanBeRemovedAfterTheQueryIsExecuted()
+    public function testGlobalScopeCanBeRemovedAfterTheQueryIsExecuted(): void
     {
         $model = new EloquentClosureGlobalScopesTestModel;
         $query = $model->newQuery();
@@ -70,7 +70,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([], $query->getBindings());
     }
 
-    public function testAllGlobalScopesCanBeRemoved()
+    public function testAllGlobalScopesCanBeRemoved(): void
     {
         $model = new EloquentClosureGlobalScopesTestModel;
         $query = $model->newQuery()->withoutGlobalScopes();
@@ -82,7 +82,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([], $query->getBindings());
     }
 
-    public function testGlobalScopesWithOrWhereConditionsAreNested()
+    public function testGlobalScopesWithOrWhereConditionsAreNested(): void
     {
         $model = new EloquentClosureGlobalScopesWithOrTestModel;
 
@@ -95,7 +95,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals(['val1', 'val2', 'taylor@gmail.com', 'someone@else.com', 1], $query->getBindings());
     }
 
-    public function testRegularScopesWithOrWhereConditionsAreNested()
+    public function testRegularScopesWithOrWhereConditionsAreNested(): void
     {
         $query = EloquentClosureGlobalScopesTestModel::withoutGlobalScopes()->where('foo', 'foo')->orWhere('bar', 'bar')->approved();
 
@@ -103,7 +103,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals(['foo', 'bar', 1, 0], $query->getBindings());
     }
 
-    public function testScopesStartingWithOrBooleanArePreserved()
+    public function testScopesStartingWithOrBooleanArePreserved(): void
     {
         $query = EloquentClosureGlobalScopesTestModel::withoutGlobalScopes()->where('foo', 'foo')->orWhere('bar', 'bar')->orApproved();
 
@@ -111,7 +111,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals(['foo', 'bar', 1, 0], $query->getBindings());
     }
 
-    public function testHasQueryWhereBothModelsHaveGlobalScopes()
+    public function testHasQueryWhereBothModelsHaveGlobalScopes(): void
     {
         $query = EloquentGlobalScopesWithRelationModel::has('related')->where('bar', 'baz');
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -11,12 +11,12 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class DatabaseEloquentHasManyTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testMakeMethodDoesNotSaveNewModel()
+    public function testMakeMethodDoesNotSaveNewModel(): void
     {
         $relation = $this->getRelation();
         $instance = $this->expectNewModel($relation, ['name' => 'taylor']);
@@ -25,7 +25,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals($instance, $relation->make(['name' => 'taylor']));
     }
 
-    public function testCreateMethodProperlyCreatesNewModel()
+    public function testCreateMethodProperlyCreatesNewModel(): void
     {
         $relation = $this->getRelation();
         $created = $this->expectCreatedModel($relation, ['name' => 'taylor']);
@@ -33,7 +33,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals($created, $relation->create(['name' => 'taylor']));
     }
 
-    public function testFindOrNewMethodFindsModel()
+    public function testFindOrNewMethodFindsModel(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn($model = m::mock('stdClass'));
@@ -42,7 +42,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $relation->findOrNew('foo'));
     }
 
-    public function testFindOrNewMethodReturnsNewModelWithForeignKeySet()
+    public function testFindOrNewMethodReturnsNewModelWithForeignKeySet(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn(null);
@@ -52,7 +52,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->findOrNew('foo'));
     }
 
-    public function testFirstOrNewMethodFindsFirstModel()
+    public function testFirstOrNewMethodFindsFirstModel(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
@@ -62,7 +62,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $relation->firstOrNew(['foo']));
     }
 
-    public function testFirstOrNewMethodWithValuesFindsFirstModel()
+    public function testFirstOrNewMethodWithValuesFindsFirstModel(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
@@ -73,7 +73,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $relation->firstOrNew(['foo' => 'bar'], ['baz' => 'qux']));
     }
 
-    public function testFirstOrNewMethodReturnsNewModelWithForeignKeySet()
+    public function testFirstOrNewMethodReturnsNewModelWithForeignKeySet(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
@@ -83,7 +83,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals($model, $relation->firstOrNew(['foo']));
     }
 
-    public function testFirstOrNewMethodWithValuesCreatesNewModelWithForeignKeySet()
+    public function testFirstOrNewMethodWithValuesCreatesNewModelWithForeignKeySet(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
@@ -93,7 +93,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals($model, $relation->firstOrNew(['foo' => 'bar'], ['baz' => 'qux']));
     }
 
-    public function testFirstOrCreateMethodFindsFirstModel()
+    public function testFirstOrCreateMethodFindsFirstModel(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
@@ -105,7 +105,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $relation->firstOrCreate(['foo']));
     }
 
-    public function testFirstOrCreateMethodWithValuesFindsFirstModel()
+    public function testFirstOrCreateMethodWithValuesFindsFirstModel(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
@@ -117,7 +117,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $relation->firstOrCreate(['foo' => 'bar'], ['baz' => 'qux']));
     }
 
-    public function testFirstOrCreateMethodCreatesNewModelWithForeignKeySet()
+    public function testFirstOrCreateMethodCreatesNewModelWithForeignKeySet(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
@@ -127,7 +127,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals($model, $relation->firstOrCreate(['foo']));
     }
 
-    public function testFirstOrCreateMethodWithValuesCreatesNewModelWithForeignKeySet()
+    public function testFirstOrCreateMethodWithValuesCreatesNewModelWithForeignKeySet(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
@@ -137,7 +137,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals($model, $relation->firstOrCreate(['foo' => 'bar'], ['baz' => 'qux']));
     }
 
-    public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()
+    public function testUpdateOrCreateMethodFindsFirstModelAndUpdates(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
@@ -149,7 +149,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $relation->updateOrCreate(['foo'], ['bar']));
     }
 
-    public function testUpdateOrCreateMethodCreatesNewModelWithForeignKeySet()
+    public function testUpdateOrCreateMethodCreatesNewModelWithForeignKeySet(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
@@ -162,7 +162,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->updateOrCreate(['foo'], ['bar']));
     }
 
-    public function testUpdateMethodUpdatesModelsWithTimestamps()
+    public function testUpdateMethodUpdatesModelsWithTimestamps(): void
     {
         $relation = $this->getRelation();
         $relation->getRelated()->shouldReceive('usesTimestamps')->once()->andReturn(true);
@@ -173,7 +173,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals('results', $relation->update(['foo' => 'bar']));
     }
 
-    public function testRelationIsProperlyInitialized()
+    public function testRelationIsProperlyInitialized(): void
     {
         $relation = $this->getRelation();
         $model = m::mock('Illuminate\Database\Eloquent\Model');
@@ -186,7 +186,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals([$model], $models);
     }
 
-    public function testEagerConstraintsAreProperlyAdded()
+    public function testEagerConstraintsAreProperlyAdded(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.foreign_key', [1, 2]);
@@ -197,7 +197,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation->addEagerConstraints([$model1, $model2]);
     }
 
-    public function testModelsAreProperlyMatchedToParents()
+    public function testModelsAreProperlyMatchedToParents(): void
     {
         $relation = $this->getRelation();
 
@@ -228,7 +228,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertNull($models[2]->foo);
     }
 
-    public function testCreateManyCreatesARelatedModelForEachRecord()
+    public function testCreateManyCreatesARelatedModelForEachRecord(): void
     {
         $records = [
             'taylor' => ['name' => 'taylor'],

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -63,14 +63,14 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('posts');
         $this->schema()->drop('countries');
     }
 
-    public function testItLoadsAHasManyThroughRelationWithCustomKeys()
+    public function testItLoadsAHasManyThroughRelationWithCustomKeys(): void
     {
         $this->seedData();
         $posts = HasManyThroughTestCountry::first()->posts;
@@ -79,7 +79,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertCount(2, $posts);
     }
 
-    public function testItLoadsADefaultHasManyThroughRelation()
+    public function testItLoadsADefaultHasManyThroughRelation(): void
     {
         $this->migrateDefault();
         $this->seedDefaultData();
@@ -91,7 +91,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->resetDefault();
     }
 
-    public function testItLoadsARelationWithCustomIntermediateAndLocalKey()
+    public function testItLoadsARelationWithCustomIntermediateAndLocalKey(): void
     {
         $this->seedData();
         $posts = HasManyThroughIntermediateTestCountry::first()->posts;
@@ -100,7 +100,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertCount(2, $posts);
     }
 
-    public function testEagerLoadingARelationWithCustomIntermediateAndLocalKey()
+    public function testEagerLoadingARelationWithCustomIntermediateAndLocalKey(): void
     {
         $this->seedData();
         $posts = HasManyThroughIntermediateTestCountry::with('posts')->first()->posts;
@@ -109,7 +109,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertCount(2, $posts);
     }
 
-    public function testWhereHasOnARelationWithCustomIntermediateAndLocalKey()
+    public function testWhereHasOnARelationWithCustomIntermediateAndLocalKey(): void
     {
         $this->seedData();
         $country = HasManyThroughIntermediateTestCountry::whereHas('posts', function ($query) {
@@ -123,7 +123,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].
      */
-    public function testFirstOrFailThrowsAnException()
+    public function testFirstOrFailThrowsAnException(): void
     {
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
@@ -135,7 +135,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].
      */
-    public function testFindOrFailThrowsAnException()
+    public function testFindOrFailThrowsAnException(): void
     {
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
                                  ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
@@ -143,7 +143,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         HasManyThroughTestCountry::first()->posts()->findOrFail(1);
     }
 
-    public function testFirstRetrievesFirstRecord()
+    public function testFirstRetrievesFirstRecord(): void
     {
         $this->seedData();
         $post = HasManyThroughTestCountry::first()->posts()->first();
@@ -152,7 +152,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertEquals('A title', $post->title);
     }
 
-    public function testAllColumnsAreRetrievedByDefault()
+    public function testAllColumnsAreRetrievedByDefault(): void
     {
         $this->seedData();
         $post = HasManyThroughTestCountry::first()->posts()->first();
@@ -169,7 +169,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         ], array_keys($post->getAttributes()));
     }
 
-    public function testOnlyProperColumnsAreSelectedIfProvided()
+    public function testOnlyProperColumnsAreSelectedIfProvided(): void
     {
         $this->seedData();
         $post = HasManyThroughTestCountry::first()->posts()->first(['title', 'body']);
@@ -181,7 +181,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         ], array_keys($post->getAttributes()));
     }
 
-    public function testIntermediateSoftDeletesAreIgnored()
+    public function testIntermediateSoftDeletesAreIgnored(): void
     {
         $this->seedData();
         HasManyThroughSoftDeletesTestUser::first()->delete();
@@ -192,7 +192,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertCount(2, $posts);
     }
 
-    public function testEagerLoadingLoadsRelatedModelsCorrectly()
+    public function testEagerLoadingLoadsRelatedModelsCorrectly(): void
     {
         $this->seedData();
         $country = HasManyThroughSoftDeletesTestCountry::with('posts')->first();

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -15,12 +15,12 @@ class DatabaseEloquentHasOneTest extends TestCase
 
     protected $parent;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testHasOneWithDefault()
+    public function testHasOneWithDefault(): void
     {
         $relation = $this->getRelation()->withDefault();
 
@@ -35,7 +35,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertSame(1, $newModel->getAttribute('foreign_key'));
     }
 
-    public function testHasOneWithDynamicDefault()
+    public function testHasOneWithDynamicDefault(): void
     {
         $relation = $this->getRelation()->withDefault(function ($newModel) {
             $newModel->username = 'taylor';
@@ -54,7 +54,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertSame(1, $newModel->getAttribute('foreign_key'));
     }
 
-    public function testHasOneWithDynamicDefaultUseParentModel()
+    public function testHasOneWithDynamicDefaultUseParentModel(): void
     {
         $relation = $this->getRelation()->withDefault(function ($newModel, $parentModel) {
             $newModel->username = $parentModel->username;
@@ -73,7 +73,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertSame(1, $newModel->getAttribute('foreign_key'));
     }
 
-    public function testHasOneWithArrayDefault()
+    public function testHasOneWithArrayDefault(): void
     {
         $attributes = ['username' => 'taylor'];
 
@@ -92,7 +92,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertSame(1, $newModel->getAttribute('foreign_key'));
     }
 
-    public function testMakeMethodDoesNotSaveNewModel()
+    public function testMakeMethodDoesNotSaveNewModel(): void
     {
         $relation = $this->getRelation();
         $instance = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['save', 'newInstance', 'setAttribute'])->getMock();
@@ -103,7 +103,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertEquals($instance, $relation->make(['name' => 'taylor']));
     }
 
-    public function testSaveMethodSetsForeignKeyOnModel()
+    public function testSaveMethodSetsForeignKeyOnModel(): void
     {
         $relation = $this->getRelation();
         $mockModel = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['save'])->getMock();
@@ -114,7 +114,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertEquals(1, $attributes['foreign_key']);
     }
 
-    public function testCreateMethodProperlyCreatesNewModel()
+    public function testCreateMethodProperlyCreatesNewModel(): void
     {
         $relation = $this->getRelation();
         $created = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['save', 'getKey', 'setAttribute'])->getMock();
@@ -125,7 +125,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertEquals($created, $relation->create(['name' => 'taylor']));
     }
 
-    public function testUpdateMethodUpdatesModelsWithTimestamps()
+    public function testUpdateMethodUpdatesModelsWithTimestamps(): void
     {
         $relation = $this->getRelation();
         $relation->getRelated()->shouldReceive('usesTimestamps')->once()->andReturn(true);
@@ -136,7 +136,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertEquals('results', $relation->update(['foo' => 'bar']));
     }
 
-    public function testRelationIsProperlyInitialized()
+    public function testRelationIsProperlyInitialized(): void
     {
         $relation = $this->getRelation();
         $model = m::mock('Illuminate\Database\Eloquent\Model');
@@ -146,7 +146,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertEquals([$model], $models);
     }
 
-    public function testEagerConstraintsAreProperlyAdded()
+    public function testEagerConstraintsAreProperlyAdded(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.foreign_key', [1, 2]);
@@ -157,7 +157,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $relation->addEagerConstraints([$model1, $model2]);
     }
 
-    public function testModelsAreProperlyMatchedToParents()
+    public function testModelsAreProperlyMatchedToParents(): void
     {
         $relation = $this->getRelation();
 
@@ -180,7 +180,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertNull($models[2]->foo);
     }
 
-    public function testRelationCountQueryCanBeBuilt()
+    public function testRelationCountQueryCanBeBuilt(): void
     {
         $relation = $this->getRelation();
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -21,7 +21,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -114,7 +114,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach (['default', 'second_connection'] as $connection) {
             $this->schema($connection)->drop('users');
@@ -131,7 +131,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     /**
      * Tests...
      */
-    public function testBasicModelRetrieval()
+    public function testBasicModelRetrieval(): void
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
@@ -181,7 +181,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         }
     }
 
-    public function testBasicModelCollectionRetrieval()
+    public function testBasicModelCollectionRetrieval(): void
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
@@ -196,7 +196,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('abigailotwell@gmail.com', $models[1]->email);
     }
 
-    public function testPaginatedModelCollectionRetrieval()
+    public function testPaginatedModelCollectionRetrieval(): void
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
@@ -225,7 +225,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('foo@gmail.com', $models[0]->email);
     }
 
-    public function testPaginatedModelCollectionRetrievalWhenNoElements()
+    public function testPaginatedModelCollectionRetrievalWhenNoElements(): void
     {
         Paginator::currentPageResolver(function () {
             return 1;
@@ -243,7 +243,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(0, $models->count());
     }
 
-    public function testPaginatedModelCollectionRetrievalWhenNoElementsAndDefaultPerPage()
+    public function testPaginatedModelCollectionRetrievalWhenNoElementsAndDefaultPerPage(): void
     {
         $models = EloquentTestUser::oldest('id')->paginate();
 
@@ -251,7 +251,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf('Illuminate\Pagination\LengthAwarePaginator', $models);
     }
 
-    public function testCountForPaginationWithGrouping()
+    public function testCountForPaginationWithGrouping(): void
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
@@ -263,7 +263,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(3, $query->getCountForPagination());
     }
 
-    public function testFirstOrCreate()
+    public function testFirstOrCreate(): void
     {
         $user1 = EloquentTestUser::firstOrCreate(['email' => 'taylorotwell@gmail.com']);
 
@@ -289,7 +289,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('Abigail Otwell', $user3->name);
     }
 
-    public function testUpdateOrCreate()
+    public function testUpdateOrCreate(): void
     {
         $user1 = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
 
@@ -311,7 +311,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(EloquentTestUser::count(), 2);
     }
 
-    public function testUpdateOrCreateOnDifferentConnection()
+    public function testUpdateOrCreateOnDifferentConnection(): void
     {
         EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
 
@@ -329,7 +329,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(EloquentTestUser::on('second_connection')->count(), 2);
     }
 
-    public function testCheckAndCreateMethodsOnMultiConnections()
+    public function testCheckAndCreateMethodsOnMultiConnections(): void
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::on('second_connection')->find(
@@ -358,7 +358,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(2, EloquentTestUser::on('second_connection')->count());
     }
 
-    public function testCreatingModelWithEmptyAttributes()
+    public function testCreatingModelWithEmptyAttributes(): void
     {
         $model = EloquentTestNonIncrementing::create([]);
 
@@ -366,7 +366,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertFalse($model->wasRecentlyCreated);
     }
 
-    public function testPluck()
+    public function testPluck(): void
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
@@ -378,7 +378,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals([1 => 'taylorotwell@gmail.com', 2 => 'abigailotwell@gmail.com'], $keyed);
     }
 
-    public function testPluckWithJoin()
+    public function testPluckWithJoin(): void
     {
         $user1 = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         $user2 = EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
@@ -393,7 +393,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(['abigailotwell@gmail.com' => 'First post', 'taylorotwell@gmail.com' => 'Second post'], $query->pluck('posts.name', 'users.email as user_email')->all());
     }
 
-    public function testFindOrFail()
+    public function testFindOrFail(): void
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
@@ -412,7 +412,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1
      */
-    public function testFindOrFailWithSingleIdThrowsModelNotFoundException()
+    public function testFindOrFailWithSingleIdThrowsModelNotFoundException(): void
     {
         EloquentTestUser::findOrFail(1);
     }
@@ -421,13 +421,13 @@ class DatabaseEloquentIntegrationTest extends TestCase
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1, 2
      */
-    public function testFindOrFailWithMultipleIdsThrowsModelNotFoundException()
+    public function testFindOrFailWithMultipleIdsThrowsModelNotFoundException(): void
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::findOrFail([1, 2]);
     }
 
-    public function testOneToOneRelationship()
+    public function testOneToOneRelationship(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $user->post()->create(['name' => 'First Post']);
@@ -442,7 +442,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('First Post', $post->name);
     }
 
-    public function testIssetLoadsInRelationshipIfItIsntLoadedAlready()
+    public function testIssetLoadsInRelationshipIfItIsntLoadedAlready(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $user->post()->create(['name' => 'First Post']);
@@ -450,7 +450,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue(isset($user->post->name));
     }
 
-    public function testOneToManyRelationship()
+    public function testOneToManyRelationship(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $user->posts()->create(['name' => 'First Post']);
@@ -469,7 +469,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('taylorotwell@gmail.com', $post2->user->email);
     }
 
-    public function testBasicModelHydration()
+    public function testBasicModelHydration(): void
     {
         $user = new EloquentTestUser(['email' => 'taylorotwell@gmail.com']);
         $user->setConnection('second_connection');
@@ -488,7 +488,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(1, $models->count());
     }
 
-    public function testHasOnSelfReferencingBelongsToManyRelationship()
+    public function testHasOnSelfReferencingBelongsToManyRelationship(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $friend = $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
@@ -501,7 +501,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('taylorotwell@gmail.com', $results->first()->email);
     }
 
-    public function testWhereHasOnSelfReferencingBelongsToManyRelationship()
+    public function testWhereHasOnSelfReferencingBelongsToManyRelationship(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $friend = $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
@@ -514,7 +514,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('taylorotwell@gmail.com', $results->first()->email);
     }
 
-    public function testHasOnNestedSelfReferencingBelongsToManyRelationship()
+    public function testHasOnNestedSelfReferencingBelongsToManyRelationship(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $friend = $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
@@ -526,7 +526,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('taylorotwell@gmail.com', $results->first()->email);
     }
 
-    public function testWhereHasOnNestedSelfReferencingBelongsToManyRelationship()
+    public function testWhereHasOnNestedSelfReferencingBelongsToManyRelationship(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $friend = $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
@@ -540,7 +540,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('taylorotwell@gmail.com', $results->first()->email);
     }
 
-    public function testHasOnSelfReferencingBelongsToManyRelationshipWithWherePivot()
+    public function testHasOnSelfReferencingBelongsToManyRelationshipWithWherePivot(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $friend = $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
@@ -551,7 +551,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('taylorotwell@gmail.com', $results->first()->email);
     }
 
-    public function testHasOnNestedSelfReferencingBelongsToManyRelationshipWithWherePivot()
+    public function testHasOnNestedSelfReferencingBelongsToManyRelationshipWithWherePivot(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $friend = $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
@@ -563,7 +563,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('taylorotwell@gmail.com', $results->first()->email);
     }
 
-    public function testHasOnSelfReferencingBelongsToRelationship()
+    public function testHasOnSelfReferencingBelongsToRelationship(): void
     {
         $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'user_id' => 1]);
         $childPost = EloquentTestPost::create(['name' => 'Child Post', 'parent_id' => $parentPost->id, 'user_id' => 2]);
@@ -574,7 +574,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('Child Post', $results->first()->name);
     }
 
-    public function testAggregatedValuesOfDatetimeField()
+    public function testAggregatedValuesOfDatetimeField(): void
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'test1@test.test', 'created_at' => '2016-08-10 09:21:00', 'updated_at' => \Illuminate\Support\Carbon::now()]);
         EloquentTestUser::create(['id' => 2, 'email' => 'test2@test.test', 'created_at' => '2016-08-01 12:00:00', 'updated_at' => \Illuminate\Support\Carbon::now()]);
@@ -583,7 +583,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('2016-08-01 12:00:00', EloquentTestUser::min('created_at'));
     }
 
-    public function testWhereHasOnSelfReferencingBelongsToRelationship()
+    public function testWhereHasOnSelfReferencingBelongsToRelationship(): void
     {
         $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'user_id' => 1]);
         $childPost = EloquentTestPost::create(['name' => 'Child Post', 'parent_id' => $parentPost->id, 'user_id' => 2]);
@@ -596,7 +596,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('Child Post', $results->first()->name);
     }
 
-    public function testHasOnNestedSelfReferencingBelongsToRelationship()
+    public function testHasOnNestedSelfReferencingBelongsToRelationship(): void
     {
         $grandParentPost = EloquentTestPost::create(['name' => 'Grandparent Post', 'user_id' => 1]);
         $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'parent_id' => $grandParentPost->id, 'user_id' => 2]);
@@ -608,7 +608,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('Child Post', $results->first()->name);
     }
 
-    public function testWhereHasOnNestedSelfReferencingBelongsToRelationship()
+    public function testWhereHasOnNestedSelfReferencingBelongsToRelationship(): void
     {
         $grandParentPost = EloquentTestPost::create(['name' => 'Grandparent Post', 'user_id' => 1]);
         $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'parent_id' => $grandParentPost->id, 'user_id' => 2]);
@@ -622,7 +622,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('Child Post', $results->first()->name);
     }
 
-    public function testHasOnSelfReferencingHasManyRelationship()
+    public function testHasOnSelfReferencingHasManyRelationship(): void
     {
         $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'user_id' => 1]);
         $childPost = EloquentTestPost::create(['name' => 'Child Post', 'parent_id' => $parentPost->id, 'user_id' => 2]);
@@ -633,7 +633,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('Parent Post', $results->first()->name);
     }
 
-    public function testWhereHasOnSelfReferencingHasManyRelationship()
+    public function testWhereHasOnSelfReferencingHasManyRelationship(): void
     {
         $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'user_id' => 1]);
         $childPost = EloquentTestPost::create(['name' => 'Child Post', 'parent_id' => $parentPost->id, 'user_id' => 2]);
@@ -646,7 +646,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('Parent Post', $results->first()->name);
     }
 
-    public function testHasOnNestedSelfReferencingHasManyRelationship()
+    public function testHasOnNestedSelfReferencingHasManyRelationship(): void
     {
         $grandParentPost = EloquentTestPost::create(['name' => 'Grandparent Post', 'user_id' => 1]);
         $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'parent_id' => $grandParentPost->id, 'user_id' => 2]);
@@ -658,7 +658,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('Grandparent Post', $results->first()->name);
     }
 
-    public function testWhereHasOnNestedSelfReferencingHasManyRelationship()
+    public function testWhereHasOnNestedSelfReferencingHasManyRelationship(): void
     {
         $grandParentPost = EloquentTestPost::create(['name' => 'Grandparent Post', 'user_id' => 1]);
         $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'parent_id' => $grandParentPost->id, 'user_id' => 2]);
@@ -672,7 +672,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('Grandparent Post', $results->first()->name);
     }
 
-    public function testHasWithNonWhereBindings()
+    public function testHasWithNonWhereBindings(): void
     {
         $user = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
 
@@ -687,7 +687,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals($questionMarksCount, $bindingsCount);
     }
 
-    public function testBelongsToManyRelationshipModelsAreProperlyHydratedOverChunkedRequest()
+    public function testBelongsToManyRelationshipModelsAreProperlyHydratedOverChunkedRequest(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $friend = $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
@@ -700,7 +700,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         });
     }
 
-    public function testBasicHasManyEagerLoading()
+    public function testBasicHasManyEagerLoading(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $user->posts()->create(['name' => 'First Post']);
@@ -712,7 +712,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('taylorotwell@gmail.com', $post->first()->user->email);
     }
 
-    public function testBasicNestedSelfReferencingHasManyEagerLoading()
+    public function testBasicNestedSelfReferencingHasManyEagerLoading(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $post = $user->posts()->create(['name' => 'First Post']);
@@ -732,7 +732,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('taylorotwell@gmail.com', $post->first()->parentPost->user->email);
     }
 
-    public function testBasicMorphManyRelationship()
+    public function testBasicMorphManyRelationship(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $user->photos()->create(['name' => 'Avatar 1']);
@@ -762,7 +762,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('First Post', $photos[3]->imageable->name);
     }
 
-    public function testMorphMapIsUsedForCreatingAndFetchingThroughRelation()
+    public function testMorphMapIsUsedForCreatingAndFetchingThroughRelation(): void
     {
         Relation::morphMap([
             'user' => 'Illuminate\Tests\Database\EloquentTestUser',
@@ -793,7 +793,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('post', $post->photos[1]->imageable_type);
     }
 
-    public function testMorphMapIsUsedWhenFetchingParent()
+    public function testMorphMapIsUsedWhenFetchingParent(): void
     {
         Relation::morphMap([
             'user' => 'Illuminate\Tests\Database\EloquentTestUser',
@@ -808,7 +808,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $photo->imageable);
     }
 
-    public function testMorphMapIsMergedByDefault()
+    public function testMorphMapIsMergedByDefault(): void
     {
         $map1 = [
             'user' => 'Illuminate\Tests\Database\EloquentTestUser',
@@ -823,7 +823,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(array_merge($map1, $map2), Relation::morphMap());
     }
 
-    public function testMorphMapOverwritesCurrentMap()
+    public function testMorphMapOverwritesCurrentMap(): void
     {
         $map1 = [
             'user' => 'Illuminate\Tests\Database\EloquentTestUser',
@@ -838,14 +838,14 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals($map2, Relation::morphMap());
     }
 
-    public function testEmptyMorphToRelationship()
+    public function testEmptyMorphToRelationship(): void
     {
         $photo = new EloquentTestPhoto;
 
         $this->assertNull($photo->imageable);
     }
 
-    public function testSaveOrFail()
+    public function testSaveOrFail(): void
     {
         $date = '1970-01-01';
         $post = new EloquentTestPost([
@@ -856,7 +856,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(1, EloquentTestPost::count());
     }
 
-    public function testSavingJSONFields()
+    public function testSavingJSONFields(): void
     {
         $model = EloquentTestWithJSON::create(['json' => ['x' => 0]]);
         $this->assertEquals(['x' => 0], $model->json);
@@ -876,7 +876,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
      * @expectedException \Illuminate\Database\QueryException
      * @expectedExceptionMessage SQLSTATE[23000]:
      */
-    public function testSaveOrFailWithDuplicatedEntry()
+    public function testSaveOrFailWithDuplicatedEntry(): void
     {
         $date = '1970-01-01';
         EloquentTestPost::create([
@@ -890,7 +890,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $post->saveOrFail();
     }
 
-    public function testMultiInsertsWithDifferentValues()
+    public function testMultiInsertsWithDifferentValues(): void
     {
         $date = '1970-01-01';
         $result = EloquentTestPost::insert([
@@ -902,7 +902,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(2, EloquentTestPost::count());
     }
 
-    public function testMultiInsertsWithSameValues()
+    public function testMultiInsertsWithSameValues(): void
     {
         $date = '1970-01-01';
         $result = EloquentTestPost::insert([
@@ -914,7 +914,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(2, EloquentTestPost::count());
     }
 
-    public function testNestedTransactions()
+    public function testNestedTransactions(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylor@laravel.com']);
         $this->connection()->transaction(function () use ($user) {
@@ -932,7 +932,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         });
     }
 
-    public function testNestedTransactionsUsingSaveOrFailWillSucceed()
+    public function testNestedTransactionsUsingSaveOrFailWillSucceed(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylor@laravel.com']);
         $this->connection()->transaction(function () use ($user) {
@@ -949,7 +949,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         });
     }
 
-    public function testNestedTransactionsUsingSaveOrFailWillFails()
+    public function testNestedTransactionsUsingSaveOrFailWillFails(): void
     {
         $user = EloquentTestUser::create(['email' => 'taylor@laravel.com']);
         $this->connection()->transaction(function () use ($user) {
@@ -967,7 +967,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         });
     }
 
-    public function testToArrayIncludesDefaultFormattedTimestamps()
+    public function testToArrayIncludesDefaultFormattedTimestamps(): void
     {
         $model = new EloquentTestUser;
 
@@ -982,7 +982,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('2012-12-05 00:00:00', $array['updated_at']);
     }
 
-    public function testToArrayIncludesCustomFormattedTimestamps()
+    public function testToArrayIncludesCustomFormattedTimestamps(): void
     {
         $model = new EloquentTestUser;
         $model->setDateFormat('d-m-y');
@@ -998,7 +998,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('05-12-12', $array['updated_at']);
     }
 
-    public function testIncrementingPrimaryKeysAreCastToIntegersByDefault()
+    public function testIncrementingPrimaryKeysAreCastToIntegersByDefault(): void
     {
         EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
 
@@ -1006,7 +1006,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInternalType('int', $user->id);
     }
 
-    public function testDefaultIncrementingPrimaryKeyIntegerCastCanBeOverwritten()
+    public function testDefaultIncrementingPrimaryKeyIntegerCastCanBeOverwritten(): void
     {
         EloquentTestUserWithStringCastId::create(['email' => 'taylorotwell@gmail.com']);
 
@@ -1014,7 +1014,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInternalType('string', $user->id);
     }
 
-    public function testRelationsArePreloadedInGlobalScope()
+    public function testRelationsArePreloadedInGlobalScope(): void
     {
         $user = EloquentTestUserWithGlobalScope::create(['email' => 'taylorotwell@gmail.com']);
         $user->posts()->create(['name' => 'My Post']);
@@ -1024,14 +1024,14 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertCount(1, $result->getRelations());
     }
 
-    public function testModelIgnoredByGlobalScopeCanBeRefreshed()
+    public function testModelIgnoredByGlobalScopeCanBeRefreshed(): void
     {
         $user = EloquentTestUserWithOmittingGlobalScope::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
 
         $this->assertNotNull($user->fresh());
     }
 
-    public function testGlobalScopeCanBeRemovedByOtherGlobalScope()
+    public function testGlobalScopeCanBeRemovedByOtherGlobalScope(): void
     {
         $user = EloquentTestUserWithGlobalScopeRemovingOtherScope::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         $user->delete();
@@ -1039,7 +1039,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertNotNull(EloquentTestUserWithGlobalScopeRemovingOtherScope::find($user->id));
     }
 
-    public function testForPageAfterIdCorrectlyPaginates()
+    public function testForPageAfterIdCorrectlyPaginates(): void
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
@@ -1053,7 +1053,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(2, $results->first()->id);
     }
 
-    public function testMorphToRelationsAcrossDatabaseConnections()
+    public function testMorphToRelationsAcrossDatabaseConnections(): void
     {
         $item = null;
 
@@ -1068,7 +1068,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestItem', $item);
     }
 
-    public function testBelongsToManyCustomPivot()
+    public function testBelongsToManyCustomPivot(): void
     {
         $john = EloquentTestUserWithCustomFriendPivot::create(['id' => 1, 'name' => 'John Doe', 'email' => 'johndoe@example.com']);
         $jane = EloquentTestUserWithCustomFriendPivot::create(['id' => 2, 'name' => 'Jane Doe', 'email' => 'janedoe@example.com']);
@@ -1090,7 +1090,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('Jule Doe', $johnWithFriends->friends->find(4)->pivot->friend->name);
     }
 
-    public function testIsAfterRetrievingTheSameModel()
+    public function testIsAfterRetrievingTheSameModel(): void
     {
         $saved = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         $retrieved = EloquentTestUser::find(1);
@@ -1098,7 +1098,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($saved->is($retrieved));
     }
 
-    public function testFreshMethodOnModel()
+    public function testFreshMethodOnModel(): void
     {
         $now = \Illuminate\Support\Carbon::now();
         \Illuminate\Support\Carbon::setTestNow($now);
@@ -1126,7 +1126,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertNull($freshNotStoredUser);
     }
 
-    public function testFreshMethodOnCollection()
+    public function testFreshMethodOnCollection(): void
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::create(['id' => 2, 'email' => 'taylorotwell@gmail.com']);
@@ -1143,7 +1143,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals($users->map->fresh(), $users->fresh());
     }
 
-    public function testTimestampsUsingDefaultDateFormat()
+    public function testTimestampsUsingDefaultDateFormat(): void
     {
         $model = new EloquentTestUser;
         $model->setDateFormat('Y-m-d H:i:s'); // Default MySQL/PostgreSQL/SQLite date format
@@ -1155,7 +1155,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('2017-11-14 08:23:19', $model->fromDateTime($model->getAttribute('created_at')));
     }
 
-    public function testTimestampsUsingDefaultSqlServerDateFormat()
+    public function testTimestampsUsingDefaultSqlServerDateFormat(): void
     {
         $model = new EloquentTestUser;
         $model->setDateFormat('Y-m-d H:i:s.v'); // Default SQL Server date format
@@ -1170,7 +1170,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('2017-11-14 08:23:19.734', $model->fromDateTime($model->getAttribute('updated_at')));
     }
 
-    public function testTimestampsUsingCustomDateFormat()
+    public function testTimestampsUsingCustomDateFormat(): void
     {
         // Simulating using custom precisions with timestamps(4)
         $model = new EloquentTestUser;
@@ -1187,7 +1187,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('2017-11-14 08:23:19.734800', $model->fromDateTime($model->getAttribute('updated_at')));
     }
 
-    public function testTimestampsUsingOldSqlServerDateFormat()
+    public function testTimestampsUsingOldSqlServerDateFormat(): void
     {
         $model = new EloquentTestUser;
         $model->setDateFormat('Y-m-d H:i:s.000'); // Old SQL Server date format
@@ -1202,7 +1202,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testTimestampsUsingOldSqlServerDateFormatFailInEdgeCases()
+    public function testTimestampsUsingOldSqlServerDateFormatFailInEdgeCases(): void
     {
         $model = new EloquentTestUser;
         $model->setDateFormat('Y-m-d H:i:s.000'); // Old SQL Server date format

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -14,7 +14,7 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -65,7 +65,7 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach (['default'] as $connection) {
             $this->schema($connection)->drop('users');
@@ -77,7 +77,7 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
         Relation::morphMap([], false);
     }
 
-    public function testBasicModelHydration()
+    public function testBasicModelHydration(): void
     {
         EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::create(['email' => 'abigailotwell@gmail.com']);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -20,14 +20,14 @@ class DatabaseEloquentModelTest extends TestCase
 {
     use InteractsWithTime;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         Carbon::setTestNow(Carbon::now());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -38,7 +38,7 @@ class DatabaseEloquentModelTest extends TestCase
         \Illuminate\Support\Carbon::resetToStringFormat();
     }
 
-    public function testAttributeManipulation()
+    public function testAttributeManipulation(): void
     {
         $model = new EloquentModelStub;
         $model->name = 'foo';
@@ -54,7 +54,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(json_encode(['name' => 'taylor']), $attributes['list_items']);
     }
 
-    public function testDirtyAttributes()
+    public function testDirtyAttributes(): void
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);
         $model->syncOriginal();
@@ -69,7 +69,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty(['foo', 'bar']));
     }
 
-    public function testDirtyOnCastOrDateAttributes()
+    public function testDirtyOnCastOrDateAttributes(): void
     {
         $model = new EloquentModelCastingStub;
         $model->setDateFormat('Y-m-d H:i:s');
@@ -94,7 +94,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty('datetimeAttribute'));
     }
 
-    public function testCleanAttributes()
+    public function testCleanAttributes(): void
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);
         $model->syncOriginal();
@@ -109,7 +109,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->isClean(['foo', 'bar']));
     }
 
-    public function testCalculatedAttributes()
+    public function testCalculatedAttributes(): void
     {
         $model = new EloquentModelStub;
         $model->password = 'secret';
@@ -125,7 +125,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals($hash, $model->password_hash);
     }
 
-    public function testArrayAccessToAttributes()
+    public function testArrayAccessToAttributes(): void
     {
         $model = new EloquentModelStub(['attributes' => 1, 'connection' => 2, 'table' => 3]);
         unset($model['table']);
@@ -139,7 +139,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse(isset($model['with']));
     }
 
-    public function testOnly()
+    public function testOnly(): void
     {
         $model = new EloquentModelStub;
         $model->first_name = 'taylor';
@@ -151,7 +151,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->only(['first_name', 'last_name']));
     }
 
-    public function testNewInstanceReturnsNewInstanceWithAttributesSet()
+    public function testNewInstanceReturnsNewInstanceWithAttributesSet(): void
     {
         $model = new EloquentModelStub;
         $instance = $model->newInstance(['name' => 'taylor']);
@@ -159,7 +159,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('taylor', $instance->name);
     }
 
-    public function testCreateMethodSavesNewModel()
+    public function testCreateMethodSavesNewModel(): void
     {
         $_SERVER['__eloquent.saved'] = false;
         $model = EloquentModelSaveStub::create(['name' => 'taylor']);
@@ -167,7 +167,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('taylor', $model->name);
     }
 
-    public function testMakeMethodDoesNotSaveNewModel()
+    public function testMakeMethodDoesNotSaveNewModel(): void
     {
         $_SERVER['__eloquent.saved'] = false;
         $model = EloquentModelSaveStub::make(['name' => 'taylor']);
@@ -175,7 +175,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('taylor', $model->name);
     }
 
-    public function testForceCreateMethodSavesNewModelWithGuardedAttributes()
+    public function testForceCreateMethodSavesNewModelWithGuardedAttributes(): void
     {
         $_SERVER['__eloquent.saved'] = false;
         $model = EloquentModelSaveStub::forceCreate(['id' => 21]);
@@ -183,23 +183,23 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(21, $model->id);
     }
 
-    public function testFindMethodUseWritePdo()
+    public function testFindMethodUseWritePdo(): void
     {
         $result = EloquentModelFindWithWritePdoStub::onWriteConnection()->find(1);
     }
 
-    public function testDestroyMethodCallsQueryBuilderCorrectly()
+    public function testDestroyMethodCallsQueryBuilderCorrectly(): void
     {
         $result = EloquentModelDestroyStub::destroy(1, 2, 3);
     }
 
-    public function testWithMethodCallsQueryBuilderCorrectly()
+    public function testWithMethodCallsQueryBuilderCorrectly(): void
     {
         $result = EloquentModelWithStub::with('foo', 'bar');
         $this->assertEquals('foo', $result);
     }
 
-    public function testWithoutMethodRemovesEagerLoadedRelationshipCorrectly()
+    public function testWithoutMethodRemovesEagerLoadedRelationshipCorrectly(): void
     {
         $model = new EloquentModelWithoutRelationStub;
         $this->addMockConnection($model);
@@ -207,7 +207,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEmpty($instance->getEagerLoads());
     }
 
-    public function testEagerLoadingWithColumns()
+    public function testEagerLoadingWithColumns(): void
     {
         $model = new EloquentModelWithoutRelationStub;
         $instance = $model->newInstance()->newQuery()->with('foo:bar,baz', 'hadi');
@@ -219,13 +219,13 @@ class DatabaseEloquentModelTest extends TestCase
         $closure($builder);
     }
 
-    public function testWithMethodCallsQueryBuilderCorrectlyWithArray()
+    public function testWithMethodCallsQueryBuilderCorrectlyWithArray(): void
     {
         $result = EloquentModelWithStub::with(['foo', 'bar']);
         $this->assertEquals('foo', $result);
     }
 
-    public function testUpdateProcess()
+    public function testUpdateProcess(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -248,7 +248,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->save());
     }
 
-    public function testUpdateProcessDoesntOverrideTimestamps()
+    public function testUpdateProcessDoesntOverrideTimestamps(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -267,7 +267,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->save());
     }
 
-    public function testSaveIsCancelledIfSavingEventReturnsFalse()
+    public function testSaveIsCancelledIfSavingEventReturnsFalse(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -279,7 +279,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->save());
     }
 
-    public function testUpdateIsCancelledIfUpdatingEventReturnsFalse()
+    public function testUpdateIsCancelledIfUpdatingEventReturnsFalse(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -293,7 +293,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->save());
     }
 
-    public function testEventsCanBeFiredWithCustomEventObjects()
+    public function testEventsCanBeFiredWithCustomEventObjects(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelEventObjectStub')->setMethods(['newQueryWithoutScopes'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -305,7 +305,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->save());
     }
 
-    public function testUpdateProcessWithoutTimestamps()
+    public function testUpdateProcessWithoutTimestamps(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelEventObjectStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'fireModelEvent'])->getMock();
         $model->timestamps = false;
@@ -323,7 +323,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->save());
     }
 
-    public function testUpdateUsesOldPrimaryKey()
+    public function testUpdateUsesOldPrimaryKey(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -346,7 +346,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->save());
     }
 
-    public function testTimestampsAreReturnedAsObjects()
+    public function testTimestampsAreReturnedAsObjects(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentDateModelStub')->setMethods(['getDateFormat'])->getMock();
         $model->expects($this->any())->method('getDateFormat')->will($this->returnValue('Y-m-d'));
@@ -359,7 +359,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->updated_at);
     }
 
-    public function testTimestampsAreReturnedAsObjectsFromPlainDatesAndTimestamps()
+    public function testTimestampsAreReturnedAsObjectsFromPlainDatesAndTimestamps(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentDateModelStub')->setMethods(['getDateFormat'])->getMock();
         $model->expects($this->any())->method('getDateFormat')->will($this->returnValue('Y-m-d H:i:s'));
@@ -372,7 +372,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->updated_at);
     }
 
-    public function testTimestampsAreReturnedAsObjectsOnCreate()
+    public function testTimestampsAreReturnedAsObjectsOnCreate(): void
     {
         $timestamps = [
             'created_at' => \Illuminate\Support\Carbon::now(),
@@ -388,7 +388,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $instance->created_at);
     }
 
-    public function testDateTimeAttributesReturnNullIfSetToNull()
+    public function testDateTimeAttributesReturnNullIfSetToNull(): void
     {
         $timestamps = [
             'created_at' => \Illuminate\Support\Carbon::now(),
@@ -405,7 +405,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($instance->created_at);
     }
 
-    public function testTimestampsAreCreatedFromStringsAndIntegers()
+    public function testTimestampsAreCreatedFromStringsAndIntegers(): void
     {
         $model = new EloquentDateModelStub;
         $model->created_at = '2013-05-22 00:00:00';
@@ -424,7 +424,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->created_at);
     }
 
-    public function testFromDateTime()
+    public function testFromDateTime(): void
     {
         $model = new EloquentModelStub;
 
@@ -454,7 +454,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
     }
 
-    public function testInsertProcess()
+    public function testInsertProcess(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -496,7 +496,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->exists);
     }
 
-    public function testInsertIsCancelledIfCreatingEventReturnsFalse()
+    public function testInsertIsCancelledIfCreatingEventReturnsFalse(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -510,7 +510,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->exists);
     }
 
-    public function testDeleteProperlyDeletesModel()
+    public function testDeleteProperlyDeletesModel(): void
     {
         $model = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'touchOwners'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -523,7 +523,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->delete();
     }
 
-    public function testPushNoRelations()
+    public function testPushNoRelations(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -540,7 +540,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->exists);
     }
 
-    public function testPushEmptyOneRelation()
+    public function testPushEmptyOneRelation(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -559,7 +559,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($model->relationOne);
     }
 
-    public function testPushOneRelation()
+    public function testPushOneRelation(): void
     {
         $related1 = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -590,7 +590,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($related1->exists);
     }
 
-    public function testPushEmptyManyRelation()
+    public function testPushEmptyManyRelation(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -609,7 +609,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertCount(0, $model->relationMany);
     }
 
-    public function testPushManyRelation()
+    public function testPushManyRelation(): void
     {
         $related1 = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -647,7 +647,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals([2, 3], $model->relationMany->pluck('id')->all());
     }
 
-    public function testNewQueryReturnsEloquentQueryBuilder()
+    public function testNewQueryReturnsEloquentQueryBuilder(): void
     {
         $conn = m::mock('Illuminate\Database\Connection');
         $grammar = m::mock('Illuminate\Database\Query\Grammars\Grammar');
@@ -661,7 +661,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf('Illuminate\Database\Eloquent\Builder', $builder);
     }
 
-    public function testGetAndSetTableOperations()
+    public function testGetAndSetTableOperations(): void
     {
         $model = new EloquentModelStub;
         $this->assertEquals('stub', $model->getTable());
@@ -669,7 +669,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('foo', $model->getTable());
     }
 
-    public function testGetKeyReturnsValueOfPrimaryKey()
+    public function testGetKeyReturnsValueOfPrimaryKey(): void
     {
         $model = new EloquentModelStub;
         $model->id = 1;
@@ -677,7 +677,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('id', $model->getKeyName());
     }
 
-    public function testConnectionManagement()
+    public function testConnectionManagement(): void
     {
         EloquentModelStub::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
         $model = m::mock('Illuminate\Tests\Database\EloquentModelStub[getConnectionName,connection]');
@@ -692,7 +692,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('bar', $model->getConnection());
     }
 
-    public function testToArray()
+    public function testToArray(): void
     {
         $model = new EloquentModelStub;
         $model->name = 'foo';
@@ -721,7 +721,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('appended', $array['appendable']);
     }
 
-    public function testVisibleCreatesArrayWhitelist()
+    public function testVisibleCreatesArrayWhitelist(): void
     {
         $model = new EloquentModelStub;
         $model->setVisible(['name']);
@@ -732,7 +732,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['name' => 'Taylor'], $array);
     }
 
-    public function testHiddenCanAlsoExcludeRelationships()
+    public function testHiddenCanAlsoExcludeRelationships(): void
     {
         $model = new EloquentModelStub;
         $model->name = 'Taylor';
@@ -743,7 +743,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['name' => 'Taylor'], $array);
     }
 
-    public function testGetArrayableRelationsFunctionExcludeHiddenRelationships()
+    public function testGetArrayableRelationsFunctionExcludeHiddenRelationships(): void
     {
         $model = new EloquentModelStub;
 
@@ -760,7 +760,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame(['bam' => ['boom']], $array);
     }
 
-    public function testToArraySnakeAttributes()
+    public function testToArraySnakeAttributes(): void
     {
         $model = new EloquentModelStub;
         $model->setRelation('namesList', new \Illuminate\Database\Eloquent\Collection([
@@ -781,7 +781,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('boom', $array['namesList'][1]['bam']);
     }
 
-    public function testToArrayUsesMutators()
+    public function testToArrayUsesMutators(): void
     {
         $model = new EloquentModelStub;
         $model->list_items = [1, 2, 3];
@@ -790,7 +790,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals([1, 2, 3], $array['list_items']);
     }
 
-    public function testHidden()
+    public function testHidden(): void
     {
         $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
         $model->setHidden(['age', 'id']);
@@ -799,7 +799,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayNotHasKey('age', $array);
     }
 
-    public function testVisible()
+    public function testVisible(): void
     {
         $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
         $model->setVisible(['name', 'id']);
@@ -808,7 +808,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayNotHasKey('age', $array);
     }
 
-    public function testDynamicHidden()
+    public function testDynamicHidden(): void
     {
         $model = new EloquentModelDynamicHiddenStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
         $array = $model->toArray();
@@ -816,7 +816,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayNotHasKey('age', $array);
     }
 
-    public function testWithHidden()
+    public function testWithHidden(): void
     {
         $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
         $model->setHidden(['age', 'id']);
@@ -827,7 +827,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayNotHasKey('id', $array);
     }
 
-    public function testMakeHidden()
+    public function testMakeHidden(): void
     {
         $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'address' => 'foobar', 'id' => 'baz']);
         $array = $model->toArray();
@@ -849,7 +849,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayHasKey('id', $array);
     }
 
-    public function testDynamicVisible()
+    public function testDynamicVisible(): void
     {
         $model = new EloquentModelDynamicVisibleStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
         $array = $model->toArray();
@@ -857,7 +857,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayNotHasKey('age', $array);
     }
 
-    public function testFillable()
+    public function testFillable(): void
     {
         $model = new EloquentModelStub;
         $model->fillable(['name', 'age']);
@@ -866,20 +866,20 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('bar', $model->age);
     }
 
-    public function testQualifyColumn()
+    public function testQualifyColumn(): void
     {
         $model = new EloquentModelStub;
 
         $this->assertEquals('stub.column', $model->qualifyColumn('column'));
     }
 
-    public function testForceFillMethodFillsGuardedAttributes()
+    public function testForceFillMethodFillsGuardedAttributes(): void
     {
         $model = (new EloquentModelSaveStub)->forceFill(['id' => 21]);
         $this->assertEquals(21, $model->id);
     }
 
-    public function testFillingJSONAttributes()
+    public function testFillingJSONAttributes(): void
     {
         $model = new EloquentModelStub;
         $model->fillable(['meta->name', 'meta->price', 'meta->size->width']);
@@ -898,7 +898,7 @@ class DatabaseEloquentModelTest extends TestCase
         );
     }
 
-    public function testUnguardAllowsAnythingToBeSet()
+    public function testUnguardAllowsAnythingToBeSet(): void
     {
         $model = new EloquentModelStub;
         EloquentModelStub::unguard();
@@ -909,14 +909,14 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelStub::unguard(false);
     }
 
-    public function testUnderscorePropertiesAreNotFilled()
+    public function testUnderscorePropertiesAreNotFilled(): void
     {
         $model = new EloquentModelStub;
         $model->fill(['_method' => 'PUT']);
         $this->assertEquals([], $model->getAttributes());
     }
 
-    public function testGuarded()
+    public function testGuarded(): void
     {
         $model = new EloquentModelStub;
         $model->guard(['name', 'age']);
@@ -926,7 +926,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('bar', $model->foo);
     }
 
-    public function testFillableOverridesGuarded()
+    public function testFillableOverridesGuarded(): void
     {
         $model = new EloquentModelStub;
         $model->guard(['name', 'age']);
@@ -941,14 +941,14 @@ class DatabaseEloquentModelTest extends TestCase
      * @expectedException \Illuminate\Database\Eloquent\MassAssignmentException
      * @expectedExceptionMessage name
      */
-    public function testGlobalGuarded()
+    public function testGlobalGuarded(): void
     {
         $model = new EloquentModelStub;
         $model->guard(['*']);
         $model->fill(['name' => 'foo', 'age' => 'bar', 'votes' => 'baz']);
     }
 
-    public function testUnguardedRunsCallbackWhileBeingUnguarded()
+    public function testUnguardedRunsCallbackWhileBeingUnguarded(): void
     {
         $model = Model::unguarded(function () {
             return (new EloquentModelStub)->guard(['*'])->fill(['name' => 'Taylor']);
@@ -957,7 +957,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse(Model::isUnguarded());
     }
 
-    public function testUnguardedCallDoesNotChangeUnguardedState()
+    public function testUnguardedCallDoesNotChangeUnguardedState(): void
     {
         Model::unguard();
         $model = Model::unguarded(function () {
@@ -968,7 +968,7 @@ class DatabaseEloquentModelTest extends TestCase
         Model::reguard();
     }
 
-    public function testUnguardedCallDoesNotChangeUnguardedStateOnException()
+    public function testUnguardedCallDoesNotChangeUnguardedStateOnException(): void
     {
         try {
             Model::unguarded(function () {
@@ -980,7 +980,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse(Model::isUnguarded());
     }
 
-    public function testHasOneCreatesProperRelation()
+    public function testHasOneCreatesProperRelation(): void
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
@@ -995,7 +995,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
     }
 
-    public function testMorphOneCreatesProperRelation()
+    public function testMorphOneCreatesProperRelation(): void
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
@@ -1005,7 +1005,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('Illuminate\Tests\Database\EloquentModelStub', $relation->getMorphClass());
     }
 
-    public function testCorrectMorphClassIsReturned()
+    public function testCorrectMorphClassIsReturned(): void
     {
         Relation::morphMap(['alias' => 'AnotherModel']);
         $model = new EloquentModelStub;
@@ -1017,7 +1017,7 @@ class DatabaseEloquentModelTest extends TestCase
         }
     }
 
-    public function testHasManyCreatesProperRelation()
+    public function testHasManyCreatesProperRelation(): void
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
@@ -1033,7 +1033,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
     }
 
-    public function testMorphManyCreatesProperRelation()
+    public function testMorphManyCreatesProperRelation(): void
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
@@ -1043,7 +1043,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('Illuminate\Tests\Database\EloquentModelStub', $relation->getMorphClass());
     }
 
-    public function testBelongsToCreatesProperRelation()
+    public function testBelongsToCreatesProperRelation(): void
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
@@ -1058,7 +1058,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('foo', $relation->getForeignKey());
     }
 
-    public function testMorphToCreatesProperRelation()
+    public function testMorphToCreatesProperRelation(): void
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
@@ -1090,7 +1090,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('someName', $relation4->getRelation());
     }
 
-    public function testBelongsToManyCreatesProperRelation()
+    public function testBelongsToManyCreatesProperRelation(): void
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
@@ -1111,7 +1111,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
     }
 
-    public function testRelationsWithVariedConnections()
+    public function testRelationsWithVariedConnections(): void
     {
         // Has one
         $model = new EloquentModelStub;
@@ -1192,7 +1192,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
     }
 
-    public function testModelsAssumeTheirName()
+    public function testModelsAssumeTheirName(): void
     {
         require_once __DIR__.'/stubs/EloquentModelNamespacedStub.php';
 
@@ -1203,7 +1203,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('eloquent_model_namespaced_stubs', $namespacedModel->getTable());
     }
 
-    public function testTheMutatorCacheIsPopulated()
+    public function testTheMutatorCacheIsPopulated(): void
     {
         $class = new EloquentModelStub;
 
@@ -1216,20 +1216,20 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals($expectedAttributes, $class->getMutatedAttributes());
     }
 
-    public function testRouteKeyIsPrimaryKey()
+    public function testRouteKeyIsPrimaryKey(): void
     {
         $model = new EloquentModelNonIncrementingStub;
         $model->id = 'foo';
         $this->assertEquals('foo', $model->getRouteKey());
     }
 
-    public function testRouteNameIsPrimaryKeyName()
+    public function testRouteNameIsPrimaryKeyName(): void
     {
         $model = new EloquentModelStub;
         $this->assertEquals('id', $model->getRouteKeyName());
     }
 
-    public function testCloneModelMakesAFreshCopyOfTheModel()
+    public function testCloneModelMakesAFreshCopyOfTheModel(): void
     {
         $class = new EloquentModelStub;
         $class->id = 1;
@@ -1251,7 +1251,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['bar'], $clone->foo);
     }
 
-    public function testModelObserversCanBeAttachedToModels()
+    public function testModelObserversCanBeAttachedToModels(): void
     {
         EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
@@ -1261,7 +1261,7 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelStub::flushEventListeners();
     }
 
-    public function testModelObserversCanBeAttachedToModelsWithString()
+    public function testModelObserversCanBeAttachedToModelsWithString(): void
     {
         EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
@@ -1271,7 +1271,7 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelStub::flushEventListeners();
     }
 
-    public function testSetObservableEvents()
+    public function testSetObservableEvents(): void
     {
         $class = new EloquentModelStub;
         $class->setObservableEvents(['foo']);
@@ -1279,7 +1279,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertContains('foo', $class->getObservableEvents());
     }
 
-    public function testAddObservableEvent()
+    public function testAddObservableEvent(): void
     {
         $class = new EloquentModelStub;
         $class->addObservableEvents('foo');
@@ -1287,7 +1287,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertContains('foo', $class->getObservableEvents());
     }
 
-    public function testAddMultipleObserveableEvents()
+    public function testAddMultipleObserveableEvents(): void
     {
         $class = new EloquentModelStub;
         $class->addObservableEvents('foo', 'bar');
@@ -1296,7 +1296,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertContains('bar', $class->getObservableEvents());
     }
 
-    public function testRemoveObservableEvent()
+    public function testRemoveObservableEvent(): void
     {
         $class = new EloquentModelStub;
         $class->setObservableEvents(['foo', 'bar']);
@@ -1305,7 +1305,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNotContains('bar', $class->getObservableEvents());
     }
 
-    public function testRemoveMultipleObservableEvents()
+    public function testRemoveMultipleObservableEvents(): void
     {
         $class = new EloquentModelStub;
         $class->setObservableEvents(['foo', 'bar']);
@@ -1319,13 +1319,13 @@ class DatabaseEloquentModelTest extends TestCase
      * @expectedException \LogicException
      * @expectedExceptionMessage Illuminate\Tests\Database\EloquentModelStub::incorrectRelationStub must return a relationship instance.
      */
-    public function testGetModelAttributeMethodThrowsExceptionIfNotRelation()
+    public function testGetModelAttributeMethodThrowsExceptionIfNotRelation(): void
     {
         $model = new EloquentModelStub;
         $relation = $model->incorrectRelationStub;
     }
 
-    public function testModelIsBootedOnUnserialize()
+    public function testModelIsBootedOnUnserialize(): void
     {
         $model = new EloquentModelBootingTestStub;
         $this->assertTrue(EloquentModelBootingTestStub::isBooted());
@@ -1338,7 +1338,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue(EloquentModelBootingTestStub::isBooted());
     }
 
-    public function testAppendingOfAttributes()
+    public function testAppendingOfAttributes(): void
     {
         $model = new EloquentModelAppendsStub;
 
@@ -1357,7 +1357,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals([], $model->toArray());
     }
 
-    public function testGetMutatedAttributes()
+    public function testGetMutatedAttributes(): void
     {
         $model = new EloquentModelGetMutatorsStub;
 
@@ -1369,7 +1369,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['firstName', 'middleName', 'lastName'], $model->getMutatedAttributes());
     }
 
-    public function testReplicateCreatesANewModelInstanceWithSameAttributeValues()
+    public function testReplicateCreatesANewModelInstanceWithSameAttributeValues(): void
     {
         $model = new EloquentModelStub;
         $model->id = 'id';
@@ -1384,7 +1384,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($replicated->updated_at);
     }
 
-    public function testIncrementOnExistingModelCallsQueryAndSetsAttribute()
+    public function testIncrementOnExistingModelCallsQueryAndSetsAttribute(): void
     {
         $model = m::mock('Illuminate\Tests\Database\EloquentModelStub[newQuery]');
         $model->exists = true;
@@ -1405,7 +1405,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty('category'));
     }
 
-    public function testRelationshipTouchOwnersIsPropagated()
+    public function testRelationshipTouchOwnersIsPropagated(): void
     {
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsTo')->setMethods(['touch'])->disableOriginalConstructor()->getMock();
         $relation->expects($this->once())->method('touch');
@@ -1422,7 +1422,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->touchOwners();
     }
 
-    public function testRelationshipTouchOwnersIsNotPropagatedIfNoRelationshipResult()
+    public function testRelationshipTouchOwnersIsNotPropagatedIfNoRelationshipResult(): void
     {
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsTo')->setMethods(['touch'])->disableOriginalConstructor()->getMock();
         $relation->expects($this->once())->method('touch');
@@ -1437,7 +1437,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->touchOwners();
     }
 
-    public function testModelAttributesAreCastedWhenPresentInCastsArray()
+    public function testModelAttributesAreCastedWhenPresentInCastsArray(): void
     {
         $model = new EloquentModelCastingStub;
         $model->setDateFormat('Y-m-d H:i:s');
@@ -1494,7 +1494,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(-14173440, $arr['timestampAttribute']);
     }
 
-    public function testModelDateAttributeCastingResetsTime()
+    public function testModelDateAttributeCastingResetsTime(): void
     {
         $model = new EloquentModelCastingStub;
         $model->setDateFormat('Y-m-d H:i:s');
@@ -1506,7 +1506,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('1969-07-20 00:00:00', $arr['dateAttribute']);
     }
 
-    public function testModelAttributeCastingPreservesNull()
+    public function testModelAttributeCastingPreservesNull(): void
     {
         $model = new EloquentModelCastingStub;
         $model->intAttribute = null;
@@ -1566,7 +1566,7 @@ class DatabaseEloquentModelTest extends TestCase
      * @expectedException \Illuminate\Database\Eloquent\JsonEncodingException
      * @expectedExceptionMessage Unable to encode attribute [objectAttribute] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.
      */
-    public function testModelAttributeCastingFailsOnUnencodableData()
+    public function testModelAttributeCastingFailsOnUnencodableData(): void
     {
         $model = new EloquentModelCastingStub;
         $model->objectAttribute = ['foo' => "b\xF8r"];
@@ -1578,13 +1578,13 @@ class DatabaseEloquentModelTest extends TestCase
         $model->getAttributes();
     }
 
-    public function testUpdatingNonExistentModelFails()
+    public function testUpdatingNonExistentModelFails(): void
     {
         $model = new EloquentModelStub;
         $this->assertFalse($model->update());
     }
 
-    public function testIssetBehavesCorrectlyWithAttributesAndRelationships()
+    public function testIssetBehavesCorrectlyWithAttributesAndRelationships(): void
     {
         $model = new EloquentModelStub;
         $this->assertFalse(isset($model->nonexistent));
@@ -1596,7 +1596,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue(isset($model->some_relation));
     }
 
-    public function testNonExistingAttributeWithInternalMethodNameDoesntCallMethod()
+    public function testNonExistingAttributeWithInternalMethodNameDoesntCallMethod(): void
     {
         $model = m::mock('Illuminate\Tests\Database\EloquentModelStub[delete,getRelationValue]');
         $model->name = 'Spark';
@@ -1617,7 +1617,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(123, $model->delete);
     }
 
-    public function testIntKeyTypePreserved()
+    public function testIntKeyTypePreserved(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -1629,7 +1629,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(1, $model->id);
     }
 
-    public function testStringKeyTypePreserved()
+    public function testStringKeyTypePreserved(): void
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentKeyTypeModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -1641,7 +1641,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('string id', $model->id);
     }
 
-    public function testScopesMethod()
+    public function testScopesMethod(): void
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
@@ -1657,7 +1657,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame($scopes, $model->scopesCalled);
     }
 
-    public function testIsWithNull()
+    public function testIsWithNull(): void
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
         $secondInstance = null;
@@ -1665,7 +1665,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($firstInstance->is($secondInstance));
     }
 
-    public function testIsWithTheSameModelInstance()
+    public function testIsWithTheSameModelInstance(): void
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
         $secondInstance = new EloquentModelStub(['id' => 1]);
@@ -1673,7 +1673,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testIsWithAnotherModelInstance()
+    public function testIsWithAnotherModelInstance(): void
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
         $secondInstance = new EloquentModelStub(['id' => 2]);
@@ -1681,7 +1681,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function testIsWithAnotherTable()
+    public function testIsWithAnotherTable(): void
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
         $secondInstance = new EloquentModelStub(['id' => 1]);
@@ -1690,7 +1690,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function testIsWithAnotherConnection()
+    public function testIsWithAnotherConnection(): void
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
         $secondInstance = new EloquentModelStub(['id' => 1]);

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -11,19 +11,19 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 class DatabaseEloquentMorphTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Relation::morphMap([], false);
 
         m::close();
     }
 
-    public function testMorphOneSetsProperConstraints()
+    public function testMorphOneSetsProperConstraints(): void
     {
         $relation = $this->getOneRelation();
     }
 
-    public function testMorphOneEagerConstraintsAreProperlyAdded()
+    public function testMorphOneEagerConstraintsAreProperlyAdded(): void
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', [1, 2]);
@@ -40,12 +40,12 @@ class DatabaseEloquentMorphTest extends TestCase
      * Note that the tests are the exact same for morph many because the classes share this code...
      * Will still test to be safe.
      */
-    public function testMorphManySetsProperConstraints()
+    public function testMorphManySetsProperConstraints(): void
     {
         $relation = $this->getManyRelation();
     }
 
-    public function testMorphManyEagerConstraintsAreProperlyAdded()
+    public function testMorphManyEagerConstraintsAreProperlyAdded(): void
     {
         $relation = $this->getManyRelation();
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', [1, 2]);
@@ -58,7 +58,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->addEagerConstraints([$model1, $model2]);
     }
 
-    public function testMakeFunctionOnMorph()
+    public function testMakeFunctionOnMorph(): void
     {
         $_SERVER['__eloquent.saved'] = false;
         // Doesn't matter which relation type we use since they share the code...
@@ -72,7 +72,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertEquals($instance, $relation->make(['name' => 'taylor']));
     }
 
-    public function testCreateFunctionOnMorph()
+    public function testCreateFunctionOnMorph(): void
     {
         // Doesn't matter which relation type we use since they share the code...
         $relation = $this->getOneRelation();
@@ -85,7 +85,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertEquals($created, $relation->create(['name' => 'taylor']));
     }
 
-    public function testFindOrNewMethodFindsModel()
+    public function testFindOrNewMethodFindsModel(): void
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
@@ -96,7 +96,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->findOrNew('foo'));
     }
 
-    public function testFindOrNewMethodReturnsNewModelWithMorphKeysSet()
+    public function testFindOrNewMethodReturnsNewModelWithMorphKeysSet(): void
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn(null);
@@ -108,7 +108,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->findOrNew('foo'));
     }
 
-    public function testFirstOrNewMethodFindsFirstModel()
+    public function testFirstOrNewMethodFindsFirstModel(): void
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
@@ -120,7 +120,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->firstOrNew(['foo']));
     }
 
-    public function testFirstOrNewMethodWithValueFindsFirstModel()
+    public function testFirstOrNewMethodWithValueFindsFirstModel(): void
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
@@ -132,7 +132,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->firstOrNew(['foo' => 'bar'], ['baz' => 'qux']));
     }
 
-    public function testFirstOrNewMethodReturnsNewModelWithMorphKeysSet()
+    public function testFirstOrNewMethodReturnsNewModelWithMorphKeysSet(): void
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
@@ -145,7 +145,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->firstOrNew(['foo']));
     }
 
-    public function testFirstOrNewMethodWithValuesReturnsNewModelWithMorphKeysSet()
+    public function testFirstOrNewMethodWithValuesReturnsNewModelWithMorphKeysSet(): void
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
@@ -158,7 +158,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->firstOrNew(['foo' => 'bar'], ['baz' => 'qux']));
     }
 
-    public function testFirstOrCreateMethodFindsFirstModel()
+    public function testFirstOrCreateMethodFindsFirstModel(): void
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
@@ -170,7 +170,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->firstOrCreate(['foo']));
     }
 
-    public function testFirstOrCreateMethodWithValuesFindsFirstModel()
+    public function testFirstOrCreateMethodWithValuesFindsFirstModel(): void
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
@@ -182,7 +182,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->firstOrCreate(['foo' => 'bar'], ['baz' => 'qux']));
     }
 
-    public function testFirstOrCreateMethodCreatesNewMorphModel()
+    public function testFirstOrCreateMethodCreatesNewMorphModel(): void
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
@@ -195,7 +195,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->firstOrCreate(['foo']));
     }
 
-    public function testFirstOrCreateMethodWithValuesCreatesNewMorphModel()
+    public function testFirstOrCreateMethodWithValuesCreatesNewMorphModel(): void
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
@@ -208,7 +208,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->firstOrCreate(['foo' => 'bar'], ['baz' => 'qux']));
     }
 
-    public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()
+    public function testUpdateOrCreateMethodFindsFirstModelAndUpdates(): void
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
@@ -221,7 +221,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->updateOrCreate(['foo'], ['bar']));
     }
 
-    public function testUpdateOrCreateMethodCreatesNewMorphModel()
+    public function testUpdateOrCreateMethodCreatesNewMorphModel(): void
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
@@ -235,7 +235,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->updateOrCreate(['foo'], ['bar']));
     }
 
-    public function testCreateFunctionOnNamespacedMorph()
+    public function testCreateFunctionOnNamespacedMorph(): void
     {
         $relation = $this->getNamespacedRelation('namespace');
         $created = m::mock('Illuminate\Database\Eloquent\Model');

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -8,12 +8,12 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 class DatabaseEloquentMorphToManyTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testEagerConstraintsAreProperlyAdded()
+    public function testEagerConstraintsAreProperlyAdded(): void
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('taggables.taggable_id', [1, 2]);
@@ -25,7 +25,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation->addEagerConstraints([$model1, $model2]);
     }
 
-    public function testAttachInsertsPivotTableRecord()
+    public function testAttachInsertsPivotTableRecord(): void
     {
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\MorphToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
@@ -38,7 +38,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation->attach(2, ['foo' => 'bar']);
     }
 
-    public function testDetachRemovesPivotTableRecord()
+    public function testDetachRemovesPivotTableRecord(): void
     {
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\MorphToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
@@ -54,7 +54,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $this->assertTrue($relation->detach([1, 2, 3]));
     }
 
-    public function testDetachMethodClearsAllPivotRecordsWhenNoIDsAreGiven()
+    public function testDetachMethodClearsAllPivotRecordsWhenNoIDsAreGiven(): void
     {
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\MorphToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -8,12 +8,12 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class DatabaseEloquentMorphToTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testLookupDictionaryIsProperlyConstructed()
+    public function testLookupDictionaryIsProperlyConstructed(): void
     {
         $relation = $this->getRelation();
         $relation->addEagerConstraints([
@@ -39,7 +39,7 @@ class DatabaseEloquentMorphToTest extends TestCase
         ], $dictionary);
     }
 
-    public function testAssociateMethodSetsForeignKeyAndTypeOnModel()
+    public function testAssociateMethodSetsForeignKeyAndTypeOnModel(): void
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model');
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
@@ -57,7 +57,7 @@ class DatabaseEloquentMorphToTest extends TestCase
         $relation->associate($associate);
     }
 
-    public function testAssociateMethodIgnoresNullValue()
+    public function testAssociateMethodIgnoresNullValue(): void
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model');
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
@@ -71,7 +71,7 @@ class DatabaseEloquentMorphToTest extends TestCase
         $relation->associate(null);
     }
 
-    public function testDissociateMethodDeletesUnsetsKeyAndTypeOnModel()
+    public function testDissociateMethodDeletesUnsetsKeyAndTypeOnModel(): void
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model');
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -8,12 +8,12 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class DatabaseEloquentPivotTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testPropertiesAreSetCorrectly()
+    public function testPropertiesAreSetCorrectly(): void
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
         $parent->shouldReceive('getConnectionName')->twice()->andReturn('connection');
@@ -27,7 +27,7 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertTrue($pivot->exists);
     }
 
-    public function testMutatorsAreCalledFromConstructor()
+    public function testMutatorsAreCalledFromConstructor(): void
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
         $parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
@@ -37,7 +37,7 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertTrue($pivot->getMutatorCalled());
     }
 
-    public function testFromRawAttributesDoesNotDoubleMutate()
+    public function testFromRawAttributesDoesNotDoubleMutate(): void
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
         $parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
@@ -47,7 +47,7 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertEquals(['name' => 'Taylor'], $pivot->foo);
     }
 
-    public function testFromRawAttributesDoesNotMutate()
+    public function testFromRawAttributesDoesNotMutate(): void
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
         $parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
@@ -57,7 +57,7 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertFalse($pivot->getMutatorCalled());
     }
 
-    public function testPropertiesUnchangedAreNotDirty()
+    public function testPropertiesUnchangedAreNotDirty(): void
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
         $parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
@@ -66,7 +66,7 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertEquals([], $pivot->getDirty());
     }
 
-    public function testPropertiesChangedAreDirty()
+    public function testPropertiesChangedAreDirty(): void
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
         $parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
@@ -76,7 +76,7 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertEquals(['shimy' => 'changed'], $pivot->getDirty());
     }
 
-    public function testTimestampPropertyIsSetIfCreatedAtInAttributes()
+    public function testTimestampPropertyIsSetIfCreatedAtInAttributes(): void
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName,getDates]');
         $parent->shouldReceive('getConnectionName')->andReturn('connection');
@@ -88,7 +88,7 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertFalse($pivot->timestamps);
     }
 
-    public function testKeysCanBeSetProperly()
+    public function testKeysCanBeSetProperly(): void
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
         $parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
@@ -99,7 +99,7 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertEquals('other', $pivot->getOtherKey());
     }
 
-    public function testDeleteMethodDeletesModelByKeys()
+    public function testDeleteMethodDeletesModelByKeys(): void
     {
         $pivot = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\Pivot')->setMethods(['newQuery'])->getMock();
         $pivot->setPivotKeys('foreign', 'other');
@@ -113,7 +113,7 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertTrue($pivot->delete());
     }
 
-    public function testPivotModelTableNameIsSingular()
+    public function testPivotModelTableNameIsSingular(): void
     {
         $pivot = new Pivot();
 

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -68,14 +68,14 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('posts');
         $this->schema()->drop('comments');
     }
 
-    public function testItLoadsRelationshipsAutomatically()
+    public function testItLoadsRelationshipsAutomatically(): void
     {
         $this->seedData();
 
@@ -85,7 +85,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $this->assertEquals(TestComment::first(), $like->likeable);
     }
 
-    public function testItLoadsChainedRelationshipsAutomatically()
+    public function testItLoadsChainedRelationshipsAutomatically(): void
     {
         $this->seedData();
 
@@ -95,7 +95,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $this->assertEquals(TestPost::first(), $like->likeable->commentable);
     }
 
-    public function testItLoadsNestedRelationshipsAutomatically()
+    public function testItLoadsNestedRelationshipsAutomatically(): void
     {
         $this->seedData();
 
@@ -107,7 +107,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $this->assertEquals(TestUser::first(), $like->likeable->owner);
     }
 
-    public function testItLoadsNestedRelationshipsOnDemand()
+    public function testItLoadsNestedRelationshipsOnDemand(): void
     {
         $this->seedData();
 

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -14,7 +14,7 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -58,7 +58,7 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach (['default'] as $connection) {
             $this->schema($connection)->drop('posts');
@@ -70,7 +70,7 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
         Relation::morphMap([], false);
     }
 
-    public function testCreation()
+    public function testCreation(): void
     {
         $post = EloquentManyToManyPolymorphicTestPost::create();
         $image = EloquentManyToManyPolymorphicTestImage::create();
@@ -89,7 +89,7 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
         $this->assertEquals(0, $tag2->images->count());
     }
 
-    public function testEagerLoading()
+    public function testEagerLoading(): void
     {
         $post = EloquentManyToManyPolymorphicTestPost::create();
         $tag = EloquentManyToManyPolymorphicTestTag::create();

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -11,12 +11,12 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 
 class DatabaseEloquentRelationTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testSetRelationFail()
+    public function testSetRelationFail(): void
     {
         $parent = new EloquentRelationResetModelStub;
         $relation = new EloquentRelationResetModelStub;
@@ -25,7 +25,7 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertArrayNotHasKey('foo', $parent->toArray());
     }
 
-    public function testTouchMethodUpdatesRelatedTimestamps()
+    public function testTouchMethodUpdatesRelatedTimestamps(): void
     {
         $builder = m::mock(Builder::class);
         $parent = m::mock(Model::class);
@@ -44,7 +44,7 @@ class DatabaseEloquentRelationTest extends TestCase
         $relation->touch();
     }
 
-    public function testSettingMorphMapWithNumericArrayUsesTheTableNames()
+    public function testSettingMorphMapWithNumericArrayUsesTheTableNames(): void
     {
         Relation::morphMap([EloquentRelationResetModelStub::class]);
 
@@ -55,7 +55,7 @@ class DatabaseEloquentRelationTest extends TestCase
         Relation::morphMap([], false);
     }
 
-    public function testSettingMorphMapWithNumericKeys()
+    public function testSettingMorphMapWithNumericKeys(): void
     {
         Relation::morphMap([1 => 'App\User']);
 
@@ -66,7 +66,7 @@ class DatabaseEloquentRelationTest extends TestCase
         Relation::morphMap([], false);
     }
 
-    public function testMacroable()
+    public function testMacroable(): void
     {
         Relation::macro('foo', function () {
             return 'foo';

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -83,7 +83,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('posts');
@@ -93,7 +93,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
     /**
      * Tests...
      */
-    public function testSoftDeletesAreNotRetrieved()
+    public function testSoftDeletesAreNotRetrieved(): void
     {
         $this->createUsers();
 
@@ -104,7 +104,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertNull(SoftDeletesTestUser::find(1));
     }
 
-    public function testSoftDeletesAreNotRetrievedFromBaseQuery()
+    public function testSoftDeletesAreNotRetrievedFromBaseQuery(): void
     {
         $this->createUsers();
 
@@ -114,7 +114,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertCount(1, $query->get());
     }
 
-    public function testSoftDeletesAreNotRetrievedFromBuilderHelpers()
+    public function testSoftDeletesAreNotRetrievedFromBuilderHelpers(): void
     {
         $this->createUsers();
 
@@ -142,7 +142,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals(0, SoftDeletesTestUser::where('email', 'taylorotwell@gmail.com')->decrement('id'));
     }
 
-    public function testWithTrashedReturnsAllRecords()
+    public function testWithTrashedReturnsAllRecords(): void
     {
         $this->createUsers();
 
@@ -150,7 +150,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertInstanceOf(Eloquent::class, SoftDeletesTestUser::withTrashed()->find(1));
     }
 
-    public function testWithTrashedAcceptsAnArgument()
+    public function testWithTrashedAcceptsAnArgument(): void
     {
         $this->createUsers();
 
@@ -158,7 +158,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertCount(2, SoftDeletesTestUser::withTrashed(true)->get());
     }
 
-    public function testDeleteSetsDeletedColumn()
+    public function testDeleteSetsDeletedColumn(): void
     {
         $this->createUsers();
 
@@ -166,7 +166,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertNull(SoftDeletesTestUser::find(2)->deleted_at);
     }
 
-    public function testForceDeleteActuallyDeletesRecords()
+    public function testForceDeleteActuallyDeletesRecords(): void
     {
         $this->createUsers();
         SoftDeletesTestUser::find(2)->forceDelete();
@@ -177,7 +177,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals(1, $users->first()->id);
     }
 
-    public function testRestoreRestoresRecords()
+    public function testRestoreRestoresRecords(): void
     {
         $this->createUsers();
         $taylor = SoftDeletesTestUser::withTrashed()->find(1);
@@ -193,7 +193,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertNull($users->find(2)->deleted_at);
     }
 
-    public function testOnlyTrashedOnlyReturnsTrashedRecords()
+    public function testOnlyTrashedOnlyReturnsTrashedRecords(): void
     {
         $this->createUsers();
 
@@ -203,7 +203,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals(1, $users->first()->id);
     }
 
-    public function testOnlyWithoutTrashedOnlyReturnsTrashedRecords()
+    public function testOnlyWithoutTrashedOnlyReturnsTrashedRecords(): void
     {
         $this->createUsers();
 
@@ -218,7 +218,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals(2, $users->first()->id);
     }
 
-    public function testFirstOrNew()
+    public function testFirstOrNew(): void
     {
         $this->createUsers();
 
@@ -229,7 +229,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals(1, $result->id);
     }
 
-    public function testFindOrNew()
+    public function testFindOrNew(): void
     {
         $this->createUsers();
 
@@ -240,7 +240,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals(1, $result->id);
     }
 
-    public function testFirstOrCreate()
+    public function testFirstOrCreate(): void
     {
         $this->createUsers();
 
@@ -254,7 +254,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertCount(3, SoftDeletesTestUser::withTrashed()->get());
     }
 
-    public function testUpdateOrCreate()
+    public function testUpdateOrCreate(): void
     {
         $this->createUsers();
 
@@ -268,7 +268,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertCount(3, SoftDeletesTestUser::withTrashed()->get());
     }
 
-    public function testHasOneRelationshipCanBeSoftDeleted()
+    public function testHasOneRelationshipCanBeSoftDeleted(): void
     {
         $this->createUsers();
 
@@ -306,7 +306,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertNull($abigail->address);
     }
 
-    public function testBelongsToRelationshipCanBeSoftDeleted()
+    public function testBelongsToRelationshipCanBeSoftDeleted(): void
     {
         $this->createUsers();
 
@@ -346,7 +346,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertNull($abigail->group()->withTrashed()->first());
     }
 
-    public function testHasManyRelationshipCanBeSoftDeleted()
+    public function testHasManyRelationshipCanBeSoftDeleted(): void
     {
         $this->createUsers();
 
@@ -379,7 +379,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertCount(1, $abigail->posts()->withTrashed()->get());
     }
 
-    public function testSecondLevelRelationshipCanBeSoftDeleted()
+    public function testSecondLevelRelationshipCanBeSoftDeleted(): void
     {
         $this->createUsers();
 
@@ -395,7 +395,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertCount(1, $abigail->posts()->first()->comments()->withTrashed()->get());
     }
 
-    public function testWhereHasWithDeletedRelationship()
+    public function testWhereHasWithDeletedRelationship(): void
     {
         $this->createUsers();
 
@@ -433,7 +433,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertCount(0, $users);
     }
 
-    public function testWhereHasWithNestedDeletedRelationshipAndOnlyTrashedCondition()
+    public function testWhereHasWithNestedDeletedRelationshipAndOnlyTrashedCondition(): void
     {
         $this->createUsers();
 
@@ -455,7 +455,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertCount(1, $users);
     }
 
-    public function testWhereHasWithNestedDeletedRelationship()
+    public function testWhereHasWithNestedDeletedRelationship(): void
     {
         $this->createUsers();
 
@@ -471,7 +471,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertCount(1, $users);
     }
 
-    public function testWhereHasWithNestedDeletedRelationshipAndWithTrashedCondition()
+    public function testWhereHasWithNestedDeletedRelationshipAndWithTrashedCondition(): void
     {
         $this->createUsers();
 
@@ -483,7 +483,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertCount(1, $users);
     }
 
-    public function testWithCountWithNestedDeletedRelationshipAndOnlyTrashedCondition()
+    public function testWithCountWithNestedDeletedRelationshipAndOnlyTrashedCondition(): void
     {
         $this->createUsers();
 
@@ -517,7 +517,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals(0, $user->posts_count);
     }
 
-    public function testOrWhereWithSoftDeleteConstraint()
+    public function testOrWhereWithSoftDeleteConstraint(): void
     {
         $this->createUsers();
 
@@ -525,7 +525,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals(['abigailotwell@gmail.com'], $users->pluck('email')->all());
     }
 
-    public function testMorphToWithTrashed()
+    public function testMorphToWithTrashed(): void
     {
         $this->createUsers();
 
@@ -561,7 +561,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
     /**
      * @expectedException \BadMethodCallException
      */
-    public function testMorphToWithBadMethodCall()
+    public function testMorphToWithBadMethodCall(): void
     {
         $this->createUsers();
 
@@ -579,7 +579,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         }])->first();
     }
 
-    public function testMorphToWithConstraints()
+    public function testMorphToWithConstraints(): void
     {
         $this->createUsers();
 
@@ -598,7 +598,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertNull($comment->owner);
     }
 
-    public function testMorphToWithoutConstraints()
+    public function testMorphToWithoutConstraints(): void
     {
         $this->createUsers();
 
@@ -620,7 +620,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertNull($comment->owner);
     }
 
-    public function testMorphToNonSoftDeletingModel()
+    public function testMorphToNonSoftDeletingModel(): void
     {
         $taylor = TestUserWithoutSoftDelete::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         $post1 = $taylor->posts()->create(['title' => 'First Title']);

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseMigrationCreatorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBasicCreateMethodStoresMigrationFile()
+    public function testBasicCreateMethodStoresMigrationFile(): void
     {
         $creator = $this->getCreator();
         unset($_SERVER['__migration.creator']);
@@ -30,7 +30,7 @@ class DatabaseMigrationCreatorTest extends TestCase
         unset($_SERVER['__migration.creator']);
     }
 
-    public function testTableUpdateMigrationStoresMigrationFile()
+    public function testTableUpdateMigrationStoresMigrationFile(): void
     {
         $creator = $this->getCreator();
         $creator->expects($this->any())->method('getDatePrefix')->will($this->returnValue('foo'));
@@ -40,7 +40,7 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->create('create_bar', 'foo', 'baz');
     }
 
-    public function testTableCreationMigrationStoresMigrationFile()
+    public function testTableCreationMigrationStoresMigrationFile(): void
     {
         $creator = $this->getCreator();
         $creator->expects($this->any())->method('getDatePrefix')->will($this->returnValue('foo'));
@@ -54,7 +54,7 @@ class DatabaseMigrationCreatorTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage A MigrationCreatorFakeMigration class already exists.
      */
-    public function testTableUpdateMigrationWontCreateDuplicateClass()
+    public function testTableUpdateMigrationWontCreateDuplicateClass(): void
     {
         $creator = $this->getCreator();
 

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseMigrationInstallCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testFireCallsRepositoryToInstall()
+    public function testFireCallsRepositoryToInstall(): void
     {
         $command = new \Illuminate\Database\Console\Migrations\InstallCommand($repo = m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'));
         $command->setLaravel(new \Illuminate\Foundation\Application);

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -8,12 +8,12 @@ use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
 
 class DatabaseMigrationMakeCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBasicCreateDumpsAutoload()
+    public function testBasicCreateDumpsAutoload(): void
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
@@ -28,7 +28,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $this->runCommand($command, ['name' => 'create_foo']);
     }
 
-    public function testBasicCreateGivesCreatorProperArguments()
+    public function testBasicCreateGivesCreatorProperArguments(): void
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
@@ -42,7 +42,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $this->runCommand($command, ['name' => 'create_foo']);
     }
 
-    public function testBasicCreateGivesCreatorProperArgumentsWhenNameIsStudlyCase()
+    public function testBasicCreateGivesCreatorProperArgumentsWhenNameIsStudlyCase(): void
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
@@ -56,7 +56,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $this->runCommand($command, ['name' => 'CreateFoo']);
     }
 
-    public function testBasicCreateGivesCreatorProperArgumentsWhenTableIsSet()
+    public function testBasicCreateGivesCreatorProperArgumentsWhenTableIsSet(): void
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
@@ -70,7 +70,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $this->runCommand($command, ['name' => 'create_foo', '--create' => 'users']);
     }
 
-    public function testBasicCreateGivesCreatorProperArgumentsWhenCreateTablePatternIsFound()
+    public function testBasicCreateGivesCreatorProperArgumentsWhenCreateTablePatternIsFound(): void
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
@@ -84,7 +84,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $this->runCommand($command, ['name' => 'create_users_table']);
     }
 
-    public function testCanSpecifyPathToCreateMigrationsIn()
+    public function testCanSpecifyPathToCreateMigrationsIn(): void
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -9,12 +9,12 @@ use Illuminate\Database\Console\Migrations\MigrateCommand;
 
 class DatabaseMigrationMigrateCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBasicMigrationsCallMigratorWithProperArguments()
+    public function testBasicMigrationsCallMigratorWithProperArguments(): void
     {
         $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
@@ -29,7 +29,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $this->runCommand($command);
     }
 
-    public function testMigrationRepositoryCreatedWhenNecessary()
+    public function testMigrationRepositoryCreatedWhenNecessary(): void
     {
         $params = [$migrator = m::mock('Illuminate\Database\Migrations\Migrator')];
         $command = $this->getMockBuilder('Illuminate\Database\Console\Migrations\MigrateCommand')->setMethods(['call'])->setConstructorArgs($params)->getMock();
@@ -46,7 +46,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $this->runCommand($command);
     }
 
-    public function testTheCommandMayBePretended()
+    public function testTheCommandMayBePretended(): void
     {
         $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
@@ -61,7 +61,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $this->runCommand($command, ['--pretend' => true]);
     }
 
-    public function testTheDatabaseMayBeSet()
+    public function testTheDatabaseMayBeSet(): void
     {
         $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
@@ -76,7 +76,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $this->runCommand($command, ['--database' => 'foo']);
     }
 
-    public function testStepMayBeSet()
+    public function testStepMayBeSet(): void
     {
         $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -14,12 +14,12 @@ use Symfony\Component\Console\Application as ConsoleApplication;
 
 class DatabaseMigrationRefreshCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testRefreshCommandCallsCommandsWithProperArguments()
+    public function testRefreshCommandCallsCommandsWithProperArguments(): void
     {
         $command = new RefreshCommand($migrator = m::mock(Migrator::class));
 
@@ -41,7 +41,7 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
         $this->runCommand($command);
     }
 
-    public function testRefreshCommandCallsCommandsWithStep()
+    public function testRefreshCommandCallsCommandsWithStep(): void
     {
         $command = new RefreshCommand($migrator = m::mock(Migrator::class));
 

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -9,12 +9,12 @@ use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 
 class DatabaseMigrationRepositoryTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testGetRanMigrationsListMigrationsByPackage()
+    public function testGetRanMigrationsListMigrationsByPackage(): void
     {
         $repo = $this->getRepository();
         $query = m::mock('stdClass');
@@ -29,7 +29,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $this->assertEquals(['bar'], $repo->getRan());
     }
 
-    public function testGetLastMigrationsGetsAllMigrationsWithTheLatestBatchNumber()
+    public function testGetLastMigrationsGetsAllMigrationsWithTheLatestBatchNumber(): void
     {
         $repo = $this->getMockBuilder('Illuminate\Database\Migrations\DatabaseMigrationRepository')->setMethods(['getLastBatchNumber'])->setConstructorArgs([
             $resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'), 'migrations',
@@ -47,7 +47,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $this->assertEquals(['foo'], $repo->getLast());
     }
 
-    public function testLogMethodInsertsRecordIntoMigrationTable()
+    public function testLogMethodInsertsRecordIntoMigrationTable(): void
     {
         $repo = $this->getRepository();
         $query = m::mock('stdClass');
@@ -60,7 +60,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $repo->log('bar', 1);
     }
 
-    public function testDeleteMethodRemovesAMigrationFromTheTable()
+    public function testDeleteMethodRemovesAMigrationFromTheTable(): void
     {
         $repo = $this->getRepository();
         $query = m::mock('stdClass');
@@ -75,7 +75,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $repo->delete($migration);
     }
 
-    public function testGetNextBatchNumberReturnsLastBatchNumberPlusOne()
+    public function testGetNextBatchNumberReturnsLastBatchNumberPlusOne(): void
     {
         $repo = $this->getMockBuilder('Illuminate\Database\Migrations\DatabaseMigrationRepository')->setMethods(['getLastBatchNumber'])->setConstructorArgs([
             m::mock('Illuminate\Database\ConnectionResolverInterface'), 'migrations',
@@ -85,7 +85,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $this->assertEquals(2, $repo->getNextBatchNumber());
     }
 
-    public function testGetLastBatchNumberReturnsMaxBatch()
+    public function testGetLastBatchNumberReturnsMaxBatch(): void
     {
         $repo = $this->getRepository();
         $query = m::mock('stdClass');
@@ -98,7 +98,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $this->assertEquals(1, $repo->getLastBatchNumber());
     }
 
-    public function testCreateRepositoryCreatesProperDatabaseTable()
+    public function testCreateRepositoryCreatesProperDatabaseTable(): void
     {
         $repo = $this->getRepository();
         $schema = m::mock('stdClass');

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -9,12 +9,12 @@ use Illuminate\Database\Console\Migrations\ResetCommand;
 
 class DatabaseMigrationResetCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testResetCommandCallsMigratorWithProperArguments()
+    public function testResetCommandCallsMigratorWithProperArguments(): void
     {
         $command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $app = new ApplicationDatabaseResetStub(['path.database' => __DIR__]);
@@ -29,7 +29,7 @@ class DatabaseMigrationResetCommandTest extends TestCase
         $this->runCommand($command);
     }
 
-    public function testResetCommandCanBePretended()
+    public function testResetCommandCanBePretended(): void
     {
         $command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $app = new ApplicationDatabaseResetStub(['path.database' => __DIR__]);

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -9,12 +9,12 @@ use Illuminate\Database\Console\Migrations\RollbackCommand;
 
 class DatabaseMigrationRollbackCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testRollbackCommandCallsMigratorWithProperArguments()
+    public function testRollbackCommandCallsMigratorWithProperArguments(): void
     {
         $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
@@ -28,7 +28,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $this->runCommand($command);
     }
 
-    public function testRollbackCommandCallsMigratorWithStepOption()
+    public function testRollbackCommandCallsMigratorWithStepOption(): void
     {
         $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
@@ -42,7 +42,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $this->runCommand($command, ['--step' => 2]);
     }
 
-    public function testRollbackCommandCanBePretended()
+    public function testRollbackCommandCanBePretended(): void
     {
         $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
@@ -56,7 +56,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
     }
 
-    public function testRollbackCommandCanBePretendedWithStepOption()
+    public function testRollbackCommandCanBePretendedWithStepOption(): void
     {
         $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -18,7 +18,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->db = $db = new DB;
 
@@ -44,13 +44,13 @@ class DatabaseMigratorIntegrationTest extends TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         \Illuminate\Support\Facades\Facade::clearResolvedInstances();
         \Illuminate\Support\Facades\Facade::setFacadeApplication(null);
     }
 
-    public function testBasicMigrationOfSingleFolder()
+    public function testBasicMigrationOfSingleFolder(): void
     {
         $ran = $this->migrator->run([__DIR__.'/migrations/one']);
 
@@ -61,7 +61,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->assertTrue(Str::contains($ran[1], 'password_resets'));
     }
 
-    public function testMigrationsCanBeRolledBack()
+    public function testMigrationsCanBeRolledBack(): void
     {
         $this->migrator->run([__DIR__.'/migrations/one']);
         $this->assertTrue($this->db->schema()->hasTable('users'));
@@ -74,7 +74,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->assertTrue(Str::contains($rolledBack[1], 'users'));
     }
 
-    public function testMigrationsCanBeReset()
+    public function testMigrationsCanBeReset(): void
     {
         $this->migrator->run([__DIR__.'/migrations/one']);
         $this->assertTrue($this->db->schema()->hasTable('users'));
@@ -87,7 +87,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->assertTrue(Str::contains($rolledBack[1], 'users'));
     }
 
-    public function testNoErrorIsThrownWhenNoOutstandingMigrationsExist()
+    public function testNoErrorIsThrownWhenNoOutstandingMigrationsExist(): void
     {
         $this->migrator->run([__DIR__.'/migrations/one']);
         $this->assertTrue($this->db->schema()->hasTable('users'));
@@ -95,7 +95,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->migrator->run([__DIR__.'/migrations/one']);
     }
 
-    public function testNoErrorIsThrownWhenNothingToRollback()
+    public function testNoErrorIsThrownWhenNothingToRollback(): void
     {
         $this->migrator->run([__DIR__.'/migrations/one']);
         $this->assertTrue($this->db->schema()->hasTable('users'));
@@ -106,7 +106,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->migrator->rollback([__DIR__.'/migrations/one']);
     }
 
-    public function testMigrationsCanRunAcrossMultiplePaths()
+    public function testMigrationsCanRunAcrossMultiplePaths(): void
     {
         $this->migrator->run([__DIR__.'/migrations/one', __DIR__.'/migrations/two']);
         $this->assertTrue($this->db->schema()->hasTable('users'));
@@ -114,7 +114,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->assertTrue($this->db->schema()->hasTable('flights'));
     }
 
-    public function testMigrationsCanBeRolledBackAcrossMultiplePaths()
+    public function testMigrationsCanBeRolledBackAcrossMultiplePaths(): void
     {
         $this->migrator->run([__DIR__.'/migrations/one', __DIR__.'/migrations/two']);
         $this->assertTrue($this->db->schema()->hasTable('users'));
@@ -126,7 +126,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->assertFalse($this->db->schema()->hasTable('flights'));
     }
 
-    public function testMigrationsCanBeResetAcrossMultiplePaths()
+    public function testMigrationsCanBeResetAcrossMultiplePaths(): void
     {
         $this->migrator->run([__DIR__.'/migrations/one', __DIR__.'/migrations/two']);
         $this->assertTrue($this->db->schema()->hasTable('users'));

--- a/tests/Database/DatabaseMySqlProcessorTest.php
+++ b/tests/Database/DatabaseMySqlProcessorTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseMySqlProcessorTest extends TestCase
 {
-    public function testProcessColumnListing()
+    public function testProcessColumnListing(): void
     {
         $processor = new \Illuminate\Database\Query\Processors\MySqlProcessor;
         $listing = [['column_name' => 'id'], ['column_name' => 'name'], ['column_name' => 'email']];

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -8,12 +8,12 @@ use Illuminate\Database\Schema\Blueprint;
 
 class DatabaseMySqlSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBasicCreateTable()
+    public function testBasicCreateTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -43,7 +43,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `id` int unsigned not null auto_increment primary key, add `email` varchar(255) not null', $statements[0]);
     }
 
-    public function testEngineCreateTable()
+    public function testEngineCreateTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -76,7 +76,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate utf8_unicode_ci engine = InnoDB', $statements[0]);
     }
 
-    public function testCharsetCollationCreateTable()
+    public function testCharsetCollationCreateTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -109,7 +109,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) character set utf8mb4 collate utf8mb4_unicode_ci not null) default character set utf8 collate utf8_unicode_ci', $statements[0]);
     }
 
-    public function testBasicCreateTableWithPrefix()
+    public function testBasicCreateTableWithPrefix(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -127,7 +127,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('create table `prefix_users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
     }
 
-    public function testCreateTemporaryTable()
+    public function testCreateTemporaryTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -144,7 +144,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('create temporary table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
     }
 
-    public function testDropTable()
+    public function testDropTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->drop();
@@ -154,7 +154,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('drop table `users`', $statements[0]);
     }
 
-    public function testDropTableIfExists()
+    public function testDropTableIfExists(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropIfExists();
@@ -164,7 +164,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('drop table if exists `users`', $statements[0]);
     }
 
-    public function testDropColumn()
+    public function testDropColumn(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropColumn('foo');
@@ -188,7 +188,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` drop `foo`, drop `bar`', $statements[0]);
     }
 
-    public function testDropPrimary()
+    public function testDropPrimary(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropPrimary();
@@ -198,7 +198,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` drop primary key', $statements[0]);
     }
 
-    public function testDropUnique()
+    public function testDropUnique(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropUnique('foo');
@@ -208,7 +208,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` drop index `foo`', $statements[0]);
     }
 
-    public function testDropIndex()
+    public function testDropIndex(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropIndex('foo');
@@ -218,7 +218,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` drop index `foo`', $statements[0]);
     }
 
-    public function testDropSpatialIndex()
+    public function testDropSpatialIndex(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->dropSpatialIndex(['coordinates']);
@@ -228,7 +228,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `geo` drop index `geo_coordinates_spatialindex`', $statements[0]);
     }
 
-    public function testDropForeign()
+    public function testDropForeign(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropForeign('foo');
@@ -238,7 +238,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` drop foreign key `foo`', $statements[0]);
     }
 
-    public function testDropTimestamps()
+    public function testDropTimestamps(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropTimestamps();
@@ -248,7 +248,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
     }
 
-    public function testDropTimestampsTz()
+    public function testDropTimestampsTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropTimestampsTz();
@@ -258,7 +258,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
     }
 
-    public function testDropMorphs()
+    public function testDropMorphs(): void
     {
         $blueprint = new Blueprint('photos');
         $blueprint->dropMorphs('imageable');
@@ -269,7 +269,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `photos` drop `imageable_type`, drop `imageable_id`', $statements[1]);
     }
 
-    public function testRenameTable()
+    public function testRenameTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->rename('foo');
@@ -279,7 +279,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('rename table `users` to `foo`', $statements[0]);
     }
 
-    public function testAddingPrimaryKey()
+    public function testAddingPrimaryKey(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->primary('foo', 'bar');
@@ -289,7 +289,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add primary key `bar`(`foo`)', $statements[0]);
     }
 
-    public function testAddingPrimaryKeyWithAlgorithm()
+    public function testAddingPrimaryKeyWithAlgorithm(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->primary('foo', 'bar', 'hash');
@@ -299,7 +299,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add primary key `bar` using hash(`foo`)', $statements[0]);
     }
 
-    public function testAddingUniqueKey()
+    public function testAddingUniqueKey(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->unique('foo', 'bar');
@@ -309,7 +309,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add unique `bar`(`foo`)', $statements[0]);
     }
 
-    public function testAddingIndex()
+    public function testAddingIndex(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->index(['foo', 'bar'], 'baz');
@@ -319,7 +319,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add index `baz`(`foo`, `bar`)', $statements[0]);
     }
 
-    public function testAddingIndexWithAlgorithm()
+    public function testAddingIndexWithAlgorithm(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->index(['foo', 'bar'], 'baz', 'hash');
@@ -329,7 +329,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add index `baz` using hash(`foo`, `bar`)', $statements[0]);
     }
 
-    public function testAddingSpatialIndex()
+    public function testAddingSpatialIndex(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->spatialIndex('coordinates');
@@ -339,7 +339,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[0]);
     }
 
-    public function testAddingFluentSpatialIndex()
+    public function testAddingFluentSpatialIndex(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->point('coordinates')->spatialIndex();
@@ -349,7 +349,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[1]);
     }
 
-    public function testAddingForeignKey()
+    public function testAddingForeignKey(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->foreign('foo_id')->references('id')->on('orders');
@@ -359,7 +359,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`)', $statements[0]);
     }
 
-    public function testAddingIncrementingID()
+    public function testAddingIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');
@@ -369,7 +369,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `id` int unsigned not null auto_increment primary key', $statements[0]);
     }
 
-    public function testAddingSmallIncrementingID()
+    public function testAddingSmallIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->smallIncrements('id');
@@ -379,7 +379,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `id` smallint unsigned not null auto_increment primary key', $statements[0]);
     }
 
-    public function testAddingBigIncrementingID()
+    public function testAddingBigIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->bigIncrements('id');
@@ -389,7 +389,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
     }
 
-    public function testAddingColumnInTableFirst()
+    public function testAddingColumnInTableFirst(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->string('name')->first();
@@ -399,7 +399,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `name` varchar(255) not null first', $statements[0]);
     }
 
-    public function testAddingColumnAfterAnotherColumn()
+    public function testAddingColumnAfterAnotherColumn(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->string('name')->after('foo');
@@ -409,7 +409,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `name` varchar(255) not null after `foo`', $statements[0]);
     }
 
-    public function testAddingGeneratedColumn()
+    public function testAddingGeneratedColumn(): void
     {
         $blueprint = new Blueprint('products');
         $blueprint->integer('price');
@@ -421,7 +421,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `products` add `price` int not null, add `discounted_virtual` int as (price - 5), add `discounted_stored` int as (price - 5) stored', $statements[0]);
     }
 
-    public function testAddingString()
+    public function testAddingString(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->string('foo');
@@ -452,7 +452,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` varchar(100) null default CURRENT TIMESTAMP', $statements[0]);
     }
 
-    public function testAddingText()
+    public function testAddingText(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->text('foo');
@@ -462,7 +462,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` text not null', $statements[0]);
     }
 
-    public function testAddingBigInteger()
+    public function testAddingBigInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->bigInteger('foo');
@@ -479,7 +479,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` bigint not null auto_increment primary key', $statements[0]);
     }
 
-    public function testAddingInteger()
+    public function testAddingInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->integer('foo');
@@ -496,7 +496,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` int not null auto_increment primary key', $statements[0]);
     }
 
-    public function testAddingMediumInteger()
+    public function testAddingMediumInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->mediumInteger('foo');
@@ -513,7 +513,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` mediumint not null auto_increment primary key', $statements[0]);
     }
 
-    public function testAddingSmallInteger()
+    public function testAddingSmallInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->smallInteger('foo');
@@ -530,7 +530,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` smallint not null auto_increment primary key', $statements[0]);
     }
 
-    public function testAddingTinyInteger()
+    public function testAddingTinyInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->tinyInteger('foo');
@@ -547,7 +547,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` tinyint not null auto_increment primary key', $statements[0]);
     }
 
-    public function testAddingFloat()
+    public function testAddingFloat(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->float('foo', 5, 2);
@@ -557,7 +557,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` double(5, 2) not null', $statements[0]);
     }
 
-    public function testAddingDouble()
+    public function testAddingDouble(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->double('foo');
@@ -567,7 +567,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` double not null', $statements[0]);
     }
 
-    public function testAddingDoubleSpecifyingPrecision()
+    public function testAddingDoubleSpecifyingPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->double('foo', 15, 8);
@@ -577,7 +577,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` double(15, 8) not null', $statements[0]);
     }
 
-    public function testAddingDecimal()
+    public function testAddingDecimal(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->decimal('foo', 5, 2);
@@ -587,7 +587,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` decimal(5, 2) not null', $statements[0]);
     }
 
-    public function testAddingBoolean()
+    public function testAddingBoolean(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->boolean('foo');
@@ -597,7 +597,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` tinyint(1) not null', $statements[0]);
     }
 
-    public function testAddingEnum()
+    public function testAddingEnum(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->enum('role', ['member', 'admin']);
@@ -607,7 +607,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `role` enum(\'member\', \'admin\') not null', $statements[0]);
     }
 
-    public function testAddingJson()
+    public function testAddingJson(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->json('foo');
@@ -617,7 +617,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` json not null', $statements[0]);
     }
 
-    public function testAddingJsonb()
+    public function testAddingJsonb(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->jsonb('foo');
@@ -627,7 +627,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` json not null', $statements[0]);
     }
 
-    public function testAddingDate()
+    public function testAddingDate(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->date('foo');
@@ -637,7 +637,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` date not null', $statements[0]);
     }
 
-    public function testAddingYear()
+    public function testAddingYear(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->year('birth_year');
@@ -646,7 +646,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `birth_year` year not null', $statements[0]);
     }
 
-    public function testAddingDateTime()
+    public function testAddingDateTime(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dateTime('foo');
@@ -661,7 +661,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` datetime(1) not null', $statements[0]);
     }
 
-    public function testAddingDateTimeTz()
+    public function testAddingDateTimeTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dateTimeTz('foo', 1);
@@ -676,7 +676,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` datetime not null', $statements[0]);
     }
 
-    public function testAddingTime()
+    public function testAddingTime(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->time('created_at');
@@ -685,7 +685,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` time not null', $statements[0]);
     }
 
-    public function testAddingTimeWithPrecision()
+    public function testAddingTimeWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->time('created_at', 1);
@@ -694,7 +694,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` time(1) not null', $statements[0]);
     }
 
-    public function testAddingTimeTz()
+    public function testAddingTimeTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timeTz('created_at');
@@ -703,7 +703,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` time not null', $statements[0]);
     }
 
-    public function testAddingTimeTzWithPrecision()
+    public function testAddingTimeTzWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timeTz('created_at', 1);
@@ -712,7 +712,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` time(1) not null', $statements[0]);
     }
 
-    public function testAddingTimestamp()
+    public function testAddingTimestamp(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamp('created_at');
@@ -721,7 +721,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` timestamp not null', $statements[0]);
     }
 
-    public function testAddingTimestampWithPrecision()
+    public function testAddingTimestampWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamp('created_at', 1);
@@ -730,7 +730,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
     }
 
-    public function testAddingTimestampWithDefault()
+    public function testAddingTimestampWithDefault(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamp('created_at')->default('2015-07-22 11:43:17');
@@ -739,7 +739,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
     }
 
-    public function testAddingTimestampTz()
+    public function testAddingTimestampTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampTz('created_at');
@@ -748,7 +748,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` timestamp not null', $statements[0]);
     }
 
-    public function testAddingTimestampTzWithPrecision()
+    public function testAddingTimestampTzWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampTz('created_at', 1);
@@ -757,7 +757,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
     }
 
-    public function testAddingTimeStampTzWithDefault()
+    public function testAddingTimeStampTzWithDefault(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampTz('created_at')->default('2015-07-22 11:43:17');
@@ -766,7 +766,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
     }
 
-    public function testAddingTimestamps()
+    public function testAddingTimestamps(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamps();
@@ -775,7 +775,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
     }
 
-    public function testAddingTimestampsTz()
+    public function testAddingTimestampsTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampsTz();
@@ -784,7 +784,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
     }
 
-    public function testAddingRememberToken()
+    public function testAddingRememberToken(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->rememberToken();
@@ -794,7 +794,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `remember_token` varchar(100) null', $statements[0]);
     }
 
-    public function testAddingBinary()
+    public function testAddingBinary(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->binary('foo');
@@ -804,7 +804,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` blob not null', $statements[0]);
     }
 
-    public function testAddingUuid()
+    public function testAddingUuid(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->uuid('foo');
@@ -814,7 +814,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` char(36) not null', $statements[0]);
     }
 
-    public function testAddingIpAddress()
+    public function testAddingIpAddress(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->ipAddress('foo');
@@ -824,7 +824,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` varchar(45) not null', $statements[0]);
     }
 
-    public function testAddingMacAddress()
+    public function testAddingMacAddress(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->macAddress('foo');
@@ -834,7 +834,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` varchar(17) not null', $statements[0]);
     }
 
-    public function testAddingGeometry()
+    public function testAddingGeometry(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->geometry('coordinates');
@@ -844,7 +844,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `geo` add `coordinates` geometry not null', $statements[0]);
     }
 
-    public function testAddingPoint()
+    public function testAddingPoint(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->point('coordinates');
@@ -854,7 +854,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `geo` add `coordinates` point not null', $statements[0]);
     }
 
-    public function testAddingLineString()
+    public function testAddingLineString(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->linestring('coordinates');
@@ -864,7 +864,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `geo` add `coordinates` linestring not null', $statements[0]);
     }
 
-    public function testAddingPolygon()
+    public function testAddingPolygon(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->polygon('coordinates');
@@ -874,7 +874,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `geo` add `coordinates` polygon not null', $statements[0]);
     }
 
-    public function testAddingGeometryCollection()
+    public function testAddingGeometryCollection(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->geometrycollection('coordinates');
@@ -884,7 +884,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `geo` add `coordinates` geometrycollection not null', $statements[0]);
     }
 
-    public function testAddingMultiPoint()
+    public function testAddingMultiPoint(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->multipoint('coordinates');
@@ -894,7 +894,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `geo` add `coordinates` multipoint not null', $statements[0]);
     }
 
-    public function testAddingMultiLineString()
+    public function testAddingMultiLineString(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->multilinestring('coordinates');
@@ -904,7 +904,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `geo` add `coordinates` multilinestring not null', $statements[0]);
     }
 
-    public function testAddingMultiPolygon()
+    public function testAddingMultiPolygon(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->multipolygon('coordinates');
@@ -914,7 +914,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `geo` add `coordinates` multipolygon not null', $statements[0]);
     }
 
-    public function testAddingComment()
+    public function testAddingComment(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->string('foo')->comment("Escape ' when using words like it's");
@@ -924,7 +924,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
     }
 
-    public function testDropAllTables()
+    public function testDropAllTables(): void
     {
         $statement = $this->getGrammar()->compileDropAllTables(['alpha', 'beta', 'gamma']);
 

--- a/tests/Database/DatabasePostgresProcessorTest.php
+++ b/tests/Database/DatabasePostgresProcessorTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class DatabasePostgresProcessorTest extends TestCase
 {
-    public function testProcessColumnListing()
+    public function testProcessColumnListing(): void
     {
         $processor = new \Illuminate\Database\Query\Processors\PostgresProcessor;
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -8,12 +8,12 @@ use Illuminate\Database\Schema\Blueprint;
 
 class DatabasePostgresSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBasicCreateTable()
+    public function testBasicCreateTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -33,7 +33,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "id" serial primary key not null, add column "email" varchar(255) not null', $statements[0]);
     }
 
-    public function testCreateTableAndCommentColumn()
+    public function testCreateTableAndCommentColumn(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -46,7 +46,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('comment on column "users"."email" is \'my first comment\'', $statements[1]);
     }
 
-    public function testCreateTemporaryTable()
+    public function testCreateTemporaryTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -59,7 +59,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('create temporary table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
     }
 
-    public function testDropTable()
+    public function testDropTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->drop();
@@ -69,7 +69,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('drop table "users"', $statements[0]);
     }
 
-    public function testDropTableIfExists()
+    public function testDropTableIfExists(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropIfExists();
@@ -79,7 +79,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('drop table if exists "users"', $statements[0]);
     }
 
-    public function testDropColumn()
+    public function testDropColumn(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropColumn('foo');
@@ -103,7 +103,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" drop column "foo", drop column "bar"', $statements[0]);
     }
 
-    public function testDropPrimary()
+    public function testDropPrimary(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropPrimary();
@@ -113,7 +113,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" drop constraint "users_pkey"', $statements[0]);
     }
 
-    public function testDropUnique()
+    public function testDropUnique(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropUnique('foo');
@@ -123,7 +123,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
     }
 
-    public function testDropIndex()
+    public function testDropIndex(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropIndex('foo');
@@ -133,7 +133,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('drop index "foo"', $statements[0]);
     }
 
-    public function testDropSpatialIndex()
+    public function testDropSpatialIndex(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->dropSpatialIndex(['coordinates']);
@@ -143,7 +143,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('drop index "geo_coordinates_spatialindex"', $statements[0]);
     }
 
-    public function testDropForeign()
+    public function testDropForeign(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropForeign('foo');
@@ -153,7 +153,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
     }
 
-    public function testDropTimestamps()
+    public function testDropTimestamps(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropTimestamps();
@@ -163,7 +163,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" drop column "created_at", drop column "updated_at"', $statements[0]);
     }
 
-    public function testDropTimestampsTz()
+    public function testDropTimestampsTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropTimestampsTz();
@@ -173,7 +173,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" drop column "created_at", drop column "updated_at"', $statements[0]);
     }
 
-    public function testDropMorphs()
+    public function testDropMorphs(): void
     {
         $blueprint = new Blueprint('photos');
         $blueprint->dropMorphs('imageable');
@@ -184,7 +184,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "photos" drop column "imageable_type", drop column "imageable_id"', $statements[1]);
     }
 
-    public function testRenameTable()
+    public function testRenameTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->rename('foo');
@@ -194,7 +194,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" rename to "foo"', $statements[0]);
     }
 
-    public function testAddingPrimaryKey()
+    public function testAddingPrimaryKey(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->primary('foo');
@@ -204,7 +204,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add primary key ("foo")', $statements[0]);
     }
 
-    public function testAddingUniqueKey()
+    public function testAddingUniqueKey(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->unique('foo', 'bar');
@@ -214,7 +214,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add constraint "bar" unique ("foo")', $statements[0]);
     }
 
-    public function testAddingIndex()
+    public function testAddingIndex(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->index(['foo', 'bar'], 'baz');
@@ -224,7 +224,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
-    public function testAddingIndexWithAlgorithm()
+    public function testAddingIndexWithAlgorithm(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->index(['foo', 'bar'], 'baz', 'hash');
@@ -234,7 +234,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('create index "baz" on "users" using hash ("foo", "bar")', $statements[0]);
     }
 
-    public function testAddingSpatialIndex()
+    public function testAddingSpatialIndex(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->spatialIndex('coordinates');
@@ -244,7 +244,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('create index "geo_coordinates_spatialindex" on "geo" using gist ("coordinates")', $statements[0]);
     }
 
-    public function testAddingFluentSpatialIndex()
+    public function testAddingFluentSpatialIndex(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->point('coordinates')->spatialIndex();
@@ -254,7 +254,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('create index "geo_coordinates_spatialindex" on "geo" using gist ("coordinates")', $statements[1]);
     }
 
-    public function testAddingIncrementingID()
+    public function testAddingIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');
@@ -264,7 +264,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "id" serial primary key not null', $statements[0]);
     }
 
-    public function testAddingSmallIncrementingID()
+    public function testAddingSmallIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->smallIncrements('id');
@@ -274,7 +274,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "id" smallserial primary key not null', $statements[0]);
     }
 
-    public function testAddingMediumIncrementingID()
+    public function testAddingMediumIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->mediumIncrements('id');
@@ -284,7 +284,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "id" serial primary key not null', $statements[0]);
     }
 
-    public function testAddingBigIncrementingID()
+    public function testAddingBigIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->bigIncrements('id');
@@ -294,7 +294,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "id" bigserial primary key not null', $statements[0]);
     }
 
-    public function testAddingString()
+    public function testAddingString(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->string('foo');
@@ -318,7 +318,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" varchar(100) null default \'bar\'', $statements[0]);
     }
 
-    public function testAddingText()
+    public function testAddingText(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->text('foo');
@@ -328,7 +328,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" text not null', $statements[0]);
     }
 
-    public function testAddingBigInteger()
+    public function testAddingBigInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->bigInteger('foo');
@@ -345,7 +345,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" bigserial primary key not null', $statements[0]);
     }
 
-    public function testAddingInteger()
+    public function testAddingInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->integer('foo');
@@ -362,7 +362,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" serial primary key not null', $statements[0]);
     }
 
-    public function testAddingMediumInteger()
+    public function testAddingMediumInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->mediumInteger('foo');
@@ -379,7 +379,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" serial primary key not null', $statements[0]);
     }
 
-    public function testAddingTinyInteger()
+    public function testAddingTinyInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->tinyInteger('foo');
@@ -396,7 +396,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" smallserial primary key not null', $statements[0]);
     }
 
-    public function testAddingSmallInteger()
+    public function testAddingSmallInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->smallInteger('foo');
@@ -413,7 +413,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" smallserial primary key not null', $statements[0]);
     }
 
-    public function testAddingFloat()
+    public function testAddingFloat(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->float('foo', 5, 2);
@@ -423,7 +423,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" double precision not null', $statements[0]);
     }
 
-    public function testAddingDouble()
+    public function testAddingDouble(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->double('foo', 15, 8);
@@ -433,7 +433,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" double precision not null', $statements[0]);
     }
 
-    public function testAddingDecimal()
+    public function testAddingDecimal(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->decimal('foo', 5, 2);
@@ -443,7 +443,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" decimal(5, 2) not null', $statements[0]);
     }
 
-    public function testAddingBoolean()
+    public function testAddingBoolean(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->boolean('foo');
@@ -453,7 +453,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" boolean not null', $statements[0]);
     }
 
-    public function testAddingEnum()
+    public function testAddingEnum(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->enum('role', ['member', 'admin']);
@@ -463,7 +463,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "role" varchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
     }
 
-    public function testAddingDate()
+    public function testAddingDate(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->date('foo');
@@ -473,7 +473,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" date not null', $statements[0]);
     }
 
-    public function testAddingYear()
+    public function testAddingYear(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->year('birth_year');
@@ -482,7 +482,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "birth_year" integer not null', $statements[0]);
     }
 
-    public function testAddingJson()
+    public function testAddingJson(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->json('foo');
@@ -492,7 +492,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" json not null', $statements[0]);
     }
 
-    public function testAddingJsonb()
+    public function testAddingJsonb(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->jsonb('foo');
@@ -502,7 +502,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" jsonb not null', $statements[0]);
     }
 
-    public function testAddingDateTime()
+    public function testAddingDateTime(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dateTime('created_at');
@@ -511,7 +511,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone not null', $statements[0]);
     }
 
-    public function testAddingDateTimeWithPrecision()
+    public function testAddingDateTimeWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dateTime('created_at', 1);
@@ -520,7 +520,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" timestamp(1) without time zone not null', $statements[0]);
     }
 
-    public function testAddingDateTimeTz()
+    public function testAddingDateTimeTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dateTimeTz('created_at');
@@ -529,7 +529,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone not null', $statements[0]);
     }
 
-    public function testAddingDateTimeTzWithPrecision()
+    public function testAddingDateTimeTzWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dateTimeTz('created_at', 1);
@@ -538,7 +538,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" timestamp(1) with time zone not null', $statements[0]);
     }
 
-    public function testAddingTime()
+    public function testAddingTime(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->time('created_at');
@@ -547,7 +547,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" time(0) without time zone not null', $statements[0]);
     }
 
-    public function testAddingTimeWithPrecision()
+    public function testAddingTimeWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->time('created_at', 1);
@@ -556,7 +556,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" time(1) without time zone not null', $statements[0]);
     }
 
-    public function testAddingTimeTz()
+    public function testAddingTimeTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timeTz('created_at');
@@ -565,7 +565,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" time(0) with time zone not null', $statements[0]);
     }
 
-    public function testAddingTimeTzWithPrecision()
+    public function testAddingTimeTzWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timeTz('created_at', 1);
@@ -574,7 +574,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" time(1) with time zone not null', $statements[0]);
     }
 
-    public function testAddingTimestamp()
+    public function testAddingTimestamp(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamp('created_at');
@@ -583,7 +583,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone not null', $statements[0]);
     }
 
-    public function testAddingTimestampWithPrecision()
+    public function testAddingTimestampWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamp('created_at', 1);
@@ -592,7 +592,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" timestamp(1) without time zone not null', $statements[0]);
     }
 
-    public function testAddingTimestampTz()
+    public function testAddingTimestampTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampTz('created_at');
@@ -601,7 +601,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone not null', $statements[0]);
     }
 
-    public function testAddingTimestampTzWithPrecision()
+    public function testAddingTimestampTzWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampTz('created_at', 1);
@@ -610,7 +610,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" timestamp(1) with time zone not null', $statements[0]);
     }
 
-    public function testAddingTimestamps()
+    public function testAddingTimestamps(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamps();
@@ -619,7 +619,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone null, add column "updated_at" timestamp(0) without time zone null', $statements[0]);
     }
 
-    public function testAddingTimestampsTz()
+    public function testAddingTimestampsTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampsTz();
@@ -628,7 +628,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone null, add column "updated_at" timestamp(0) with time zone null', $statements[0]);
     }
 
-    public function testAddingBinary()
+    public function testAddingBinary(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->binary('foo');
@@ -638,7 +638,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" bytea not null', $statements[0]);
     }
 
-    public function testAddingUuid()
+    public function testAddingUuid(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->uuid('foo');
@@ -648,7 +648,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" uuid not null', $statements[0]);
     }
 
-    public function testAddingIpAddress()
+    public function testAddingIpAddress(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->ipAddress('foo');
@@ -658,7 +658,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" inet not null', $statements[0]);
     }
 
-    public function testAddingMacAddress()
+    public function testAddingMacAddress(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->macAddress('foo');
@@ -668,7 +668,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" macaddr not null', $statements[0]);
     }
 
-    public function testCompileForeign()
+    public function testCompileForeign(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->foreign('parent_id')->references('id')->on('parents')->onDelete('cascade')->deferrable();
@@ -696,14 +696,14 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage The database driver in use does not support the Geometry spatial column type.
      */
-    public function testAddingGeometry()
+    public function testAddingGeometry(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->geometry('coordinates');
         $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
-    public function testAddingPoint()
+    public function testAddingPoint(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->point('coordinates');
@@ -713,7 +713,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" geography(point, 4326) not null', $statements[0]);
     }
 
-    public function testAddingLineString()
+    public function testAddingLineString(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->linestring('coordinates');
@@ -723,7 +723,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" geography(linestring, 4326) not null', $statements[0]);
     }
 
-    public function testAddingPolygon()
+    public function testAddingPolygon(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->polygon('coordinates');
@@ -733,7 +733,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" geography(polygon, 4326) not null', $statements[0]);
     }
 
-    public function testAddingGeometryCollection()
+    public function testAddingGeometryCollection(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->geometrycollection('coordinates');
@@ -743,7 +743,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" geography(geometrycollection, 4326) not null', $statements[0]);
     }
 
-    public function testAddingMultiPoint()
+    public function testAddingMultiPoint(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->multipoint('coordinates');
@@ -753,7 +753,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" geography(multipoint, 4326) not null', $statements[0]);
     }
 
-    public function testAddingMultiLineString()
+    public function testAddingMultiLineString(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->multilinestring('coordinates');
@@ -763,7 +763,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" geography(multilinestring, 4326) not null', $statements[0]);
     }
 
-    public function testAddingMultiPolygon()
+    public function testAddingMultiPolygon(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->multipolygon('coordinates');
@@ -773,7 +773,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" geography(multipolygon, 4326) not null', $statements[0]);
     }
 
-    public function testDropAllTablesEscapesTableNames()
+    public function testDropAllTablesEscapesTableNames(): void
     {
         $statement = $this->getGrammar()->compileDropAllTables(['alpha', 'beta', 'gamma']);
 

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseProcessorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testInsertGetIdProcessing()
+    public function testInsertGetIdProcessing(): void
     {
         $pdo = $this->createMock('Illuminate\Tests\Database\ProcessorTestPDOStub');
         $pdo->expects($this->once())->method('lastInsertId')->with($this->equalTo('id'))->will($this->returnValue('1'));

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -11,19 +11,19 @@ use Illuminate\Pagination\AbstractPaginator as Paginator;
 
 class DatabaseQueryBuilderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBasicSelect()
+    public function testBasicSelect(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users');
         $this->assertEquals('select * from "users"', $builder->toSql());
     }
 
-    public function testBasicSelectWithGetColumns()
+    public function testBasicSelectWithGetColumns(): void
     {
         $builder = $this->getBuilder();
         $builder->getProcessor()->shouldReceive('processSelect');
@@ -44,7 +44,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertNull($builder->columns);
     }
 
-    public function testBasicSelectUseWritePdo()
+    public function testBasicSelectUseWritePdo(): void
     {
         $builder = $this->getMySqlBuilderWithProcessor();
         $builder->getConnection()->shouldReceive('select')->once()
@@ -57,35 +57,35 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->get();
     }
 
-    public function testBasicTableWrappingProtectsQuotationMarks()
+    public function testBasicTableWrappingProtectsQuotationMarks(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('some"table');
         $this->assertEquals('select * from "some""table"', $builder->toSql());
     }
 
-    public function testAliasWrappingAsWholeConstant()
+    public function testAliasWrappingAsWholeConstant(): void
     {
         $builder = $this->getBuilder();
         $builder->select('x.y as foo.bar')->from('baz');
         $this->assertEquals('select "x"."y" as "foo.bar" from "baz"', $builder->toSql());
     }
 
-    public function testAliasWrappingWithSpacesInDatabaseName()
+    public function testAliasWrappingWithSpacesInDatabaseName(): void
     {
         $builder = $this->getBuilder();
         $builder->select('w x.y.z as foo.bar')->from('baz');
         $this->assertEquals('select "w x"."y"."z" as "foo.bar" from "baz"', $builder->toSql());
     }
 
-    public function testAddingSelects()
+    public function testAddingSelects(): void
     {
         $builder = $this->getBuilder();
         $builder->select('foo')->addSelect('bar')->addSelect(['baz', 'boom'])->from('users');
         $this->assertEquals('select "foo", "bar", "baz", "boom" from "users"', $builder->toSql());
     }
 
-    public function testBasicSelectWithPrefix()
+    public function testBasicSelectWithPrefix(): void
     {
         $builder = $this->getBuilder();
         $builder->getGrammar()->setTablePrefix('prefix_');
@@ -93,21 +93,21 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "prefix_users"', $builder->toSql());
     }
 
-    public function testBasicSelectDistinct()
+    public function testBasicSelectDistinct(): void
     {
         $builder = $this->getBuilder();
         $builder->distinct()->select('foo', 'bar')->from('users');
         $this->assertEquals('select distinct "foo", "bar" from "users"', $builder->toSql());
     }
 
-    public function testBasicAlias()
+    public function testBasicAlias(): void
     {
         $builder = $this->getBuilder();
         $builder->select('foo as bar')->from('users');
         $this->assertEquals('select "foo" as "bar" from "users"', $builder->toSql());
     }
 
-    public function testAliasWithPrefix()
+    public function testAliasWithPrefix(): void
     {
         $builder = $this->getBuilder();
         $builder->getGrammar()->setTablePrefix('prefix_');
@@ -115,7 +115,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "prefix_users" as "prefix_people"', $builder->toSql());
     }
 
-    public function testJoinAliasesWithPrefix()
+    public function testJoinAliasesWithPrefix(): void
     {
         $builder = $this->getBuilder();
         $builder->getGrammar()->setTablePrefix('prefix_');
@@ -123,14 +123,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "prefix_services" inner join "prefix_translations" as "prefix_t" on "prefix_t"."item_id" = "prefix_services"."id"', $builder->toSql());
     }
 
-    public function testBasicTableWrapping()
+    public function testBasicTableWrapping(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('public.users');
         $this->assertEquals('select * from "public"."users"', $builder->toSql());
     }
 
-    public function testWhenCallback()
+    public function testWhenCallback(): void
     {
         $callback = function ($query, $condition) {
             $this->assertTrue($condition);
@@ -147,7 +147,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
     }
 
-    public function testWhenCallbackWithReturn()
+    public function testWhenCallbackWithReturn(): void
     {
         $callback = function ($query, $condition) {
             $this->assertTrue($condition);
@@ -164,7 +164,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
     }
 
-    public function testWhenCallbackWithDefault()
+    public function testWhenCallbackWithDefault(): void
     {
         $callback = function ($query, $condition) {
             $this->assertEquals($condition, 'truthy');
@@ -189,7 +189,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2, 1 => 'foo'], $builder->getBindings());
     }
 
-    public function testUnlessCallback()
+    public function testUnlessCallback(): void
     {
         $callback = function ($query, $condition) {
             $this->assertFalse($condition);
@@ -206,7 +206,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
     }
 
-    public function testUnlessCallbackWithReturn()
+    public function testUnlessCallbackWithReturn(): void
     {
         $callback = function ($query, $condition) {
             $this->assertFalse($condition);
@@ -223,7 +223,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
     }
 
-    public function testUnlessCallbackWithDefault()
+    public function testUnlessCallbackWithDefault(): void
     {
         $callback = function ($query, $condition) {
             $this->assertEquals($condition, 0);
@@ -248,7 +248,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2, 1 => 'foo'], $builder->getBindings());
     }
 
-    public function testTapCallback()
+    public function testTapCallback(): void
     {
         $callback = function ($query) {
             return $query->where('id', '=', 1);
@@ -259,7 +259,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
     }
 
-    public function testBasicWheres()
+    public function testBasicWheres(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
@@ -267,14 +267,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testMySqlWrappingProtectsQuotationMarks()
+    public function testMySqlWrappingProtectsQuotationMarks(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->From('some`table');
         $this->assertEquals('select * from `some``table`', $builder->toSql());
     }
 
-    public function testDateBasedWheresAcceptsTwoArguments()
+    public function testDateBasedWheresAcceptsTwoArguments(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', 1);
@@ -293,14 +293,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from `users` where year(`created_at`) = ?', $builder->toSql());
     }
 
-    public function testDateBasedWheresExpressionIsNotBound()
+    public function testDateBasedWheresExpressionIsNotBound(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', new Raw('NOW()'))->where('admin', true);
         $this->assertEquals([true], $builder->getBindings());
     }
 
-    public function testWhereDayMySql()
+    public function testWhereDayMySql(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereDay('created_at', '=', 1);
@@ -308,7 +308,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testOrWhereDayMySql()
+    public function testOrWhereDayMySql(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereDay('created_at', '=', 1)->orWhereDay('created_at', '=', 2);
@@ -316,7 +316,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
-    public function testWhereMonthMySql()
+    public function testWhereMonthMySql(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
@@ -324,7 +324,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 5], $builder->getBindings());
     }
 
-    public function testOrWhereMonthMySql()
+    public function testOrWhereMonthMySql(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereMonth('created_at', '=', 5)->orWhereMonth('created_at', '=', 6);
@@ -332,7 +332,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 5, 1 => 6], $builder->getBindings());
     }
 
-    public function testWhereYearMySql()
+    public function testWhereYearMySql(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
@@ -340,7 +340,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2014], $builder->getBindings());
     }
 
-    public function testOrWhereYearMySql()
+    public function testOrWhereYearMySql(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereYear('created_at', '=', 2014)->orWhereYear('created_at', '=', 2015);
@@ -348,7 +348,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2014, 1 => 2015], $builder->getBindings());
     }
 
-    public function testWhereTimeMySql()
+    public function testWhereTimeMySql(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', '>=', '22:00');
@@ -356,7 +356,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
-    public function testWhereTimeOperatorOptionalMySql()
+    public function testWhereTimeOperatorOptionalMySql(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', '22:00');
@@ -364,7 +364,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
-    public function testWhereTimeOperatorOptionalPostgres()
+    public function testWhereTimeOperatorOptionalPostgres(): void
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', '22:00');
@@ -372,7 +372,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
-    public function testWhereDatePostgres()
+    public function testWhereDatePostgres(): void
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', '=', '2015-12-21');
@@ -380,7 +380,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '2015-12-21'], $builder->getBindings());
     }
 
-    public function testWhereDayPostgres()
+    public function testWhereDayPostgres(): void
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereDay('created_at', '=', 1);
@@ -388,7 +388,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testWhereMonthPostgres()
+    public function testWhereMonthPostgres(): void
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
@@ -396,7 +396,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 5], $builder->getBindings());
     }
 
-    public function testWhereYearPostgres()
+    public function testWhereYearPostgres(): void
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
@@ -404,7 +404,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2014], $builder->getBindings());
     }
 
-    public function testWhereTimePostgres()
+    public function testWhereTimePostgres(): void
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', '>=', '22:00');
@@ -412,7 +412,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
-    public function testWhereDaySqlite()
+    public function testWhereDaySqlite(): void
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereDay('created_at', '=', 1);
@@ -420,7 +420,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testWhereMonthSqlite()
+    public function testWhereMonthSqlite(): void
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
@@ -428,7 +428,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 5], $builder->getBindings());
     }
 
-    public function testWhereYearSqlite()
+    public function testWhereYearSqlite(): void
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
@@ -436,7 +436,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2014], $builder->getBindings());
     }
 
-    public function testWhereTimeSqlite()
+    public function testWhereTimeSqlite(): void
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', '>=', '22:00');
@@ -444,7 +444,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
-    public function testWhereTimeOperatorOptionalSqlite()
+    public function testWhereTimeOperatorOptionalSqlite(): void
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', '22:00');
@@ -452,7 +452,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
-    public function testWhereDaySqlServer()
+    public function testWhereDaySqlServer(): void
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereDay('created_at', '=', 1);
@@ -460,7 +460,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testWhereMonthSqlServer()
+    public function testWhereMonthSqlServer(): void
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
@@ -468,7 +468,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 5], $builder->getBindings());
     }
 
-    public function testWhereYearSqlServer()
+    public function testWhereYearSqlServer(): void
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
@@ -476,7 +476,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2014], $builder->getBindings());
     }
 
-    public function testWhereBetweens()
+    public function testWhereBetweens(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetween('id', [1, 2]);
@@ -489,7 +489,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
-    public function testBasicOrWheres()
+    public function testBasicOrWheres(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhere('email', '=', 'foo');
@@ -497,7 +497,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
-    public function testRawWheres()
+    public function testRawWheres(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereRaw('id = ? or email = ?', [1, 'foo']);
@@ -505,7 +505,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
-    public function testRawOrWheres()
+    public function testRawOrWheres(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereRaw('email = ?', ['foo']);
@@ -513,7 +513,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
-    public function testBasicWhereIns()
+    public function testBasicWhereIns(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIn('id', [1, 2, 3]);
@@ -526,7 +526,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
     }
 
-    public function testBasicWhereNotIns()
+    public function testBasicWhereNotIns(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotIn('id', [1, 2, 3]);
@@ -539,7 +539,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
     }
 
-    public function testRawWhereIns()
+    public function testRawWhereIns(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIn('id', [new Raw(1)]);
@@ -551,7 +551,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testEmptyWhereIns()
+    public function testEmptyWhereIns(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIn('id', []);
@@ -564,7 +564,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testEmptyWhereNotIns()
+    public function testEmptyWhereNotIns(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotIn('id', []);
@@ -577,7 +577,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testBasicWhereColumn()
+    public function testBasicWhereColumn(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn('first_name', 'last_name')->orWhereColumn('first_name', 'middle_name');
@@ -590,7 +590,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([], $builder->getBindings());
     }
 
-    public function testArrayWhereColumn()
+    public function testArrayWhereColumn(): void
     {
         $conditions = [
             ['first_name', 'last_name'],
@@ -603,7 +603,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([], $builder->getBindings());
     }
 
-    public function testUnions()
+    public function testUnions(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
@@ -632,7 +632,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
-    public function testUnionAlls()
+    public function testUnionAlls(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
@@ -641,7 +641,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
-    public function testMultipleUnions()
+    public function testMultipleUnions(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
@@ -651,7 +651,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
     }
 
-    public function testMultipleUnionAlls()
+    public function testMultipleUnionAlls(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
@@ -661,7 +661,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
     }
 
-    public function testUnionOrderBys()
+    public function testUnionOrderBys(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
@@ -671,7 +671,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
-    public function testUnionLimitsAndOffsets()
+    public function testUnionLimitsAndOffsets(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users');
@@ -680,7 +680,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" union select * from "dogs" limit 10 offset 5', $builder->toSql());
     }
 
-    public function testUnionWithJoin()
+    public function testUnionWithJoin(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users');
@@ -692,7 +692,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testMySqlUnionOrderBys()
+    public function testMySqlUnionOrderBys(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
@@ -702,7 +702,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
-    public function testMySqlUnionLimitsAndOffsets()
+    public function testMySqlUnionLimitsAndOffsets(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users');
@@ -711,7 +711,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('(select * from `users`) union (select * from `dogs`) limit 10 offset 5', $builder->toSql());
     }
 
-    public function testSubSelectWhereIns()
+    public function testSubSelectWhereIns(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIn('id', function ($q) {
@@ -728,7 +728,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([25], $builder->getBindings());
     }
 
-    public function testBasicWhereNulls()
+    public function testBasicWhereNulls(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNull('id');
@@ -741,7 +741,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testBasicWhereNotNulls()
+    public function testBasicWhereNotNulls(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotNull('id');
@@ -754,7 +754,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testGroupBys()
+    public function testGroupBys(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->groupBy('email');
@@ -773,7 +773,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" group by DATE(created_at)', $builder->toSql());
     }
 
-    public function testOrderBys()
+    public function testOrderBys(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->orderBy('email')->orderBy('age', 'desc');
@@ -795,7 +795,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" order by "name" desc', $builder->toSql());
     }
 
-    public function testHavings()
+    public function testHavings(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->having('email', '>', 1);
@@ -824,14 +824,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select "category", count(*) as "total" from "item" where "department" = ? group by "category" having "total" > ?', $builder->toSql());
     }
 
-    public function testHavingShortcut()
+    public function testHavingShortcut(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->having('email', 1)->orHaving('email', 2);
         $this->assertEquals('select * from "users" having "email" = ? or "email" = ?', $builder->toSql());
     }
 
-    public function testHavingFollowedBySelectGet()
+    public function testHavingFollowedBySelectGet(): void
     {
         $builder = $this->getBuilder();
         $query = 'select "category", count(*) as "total" from "item" where "department" = ? group by "category" having "total" > ?';
@@ -855,7 +855,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([['category' => 'rock', 'total' => 5]], $result->all());
     }
 
-    public function testRawHavings()
+    public function testRawHavings(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->havingRaw('user_foo < user_bar');
@@ -866,7 +866,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" having "baz" = ? or user_foo < user_bar', $builder->toSql());
     }
 
-    public function testLimitsAndOffsets()
+    public function testLimitsAndOffsets(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->offset(5)->limit(10);
@@ -885,7 +885,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" offset 0', $builder->toSql());
     }
 
-    public function testForPage()
+    public function testForPage(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->forPage(2, 15);
@@ -912,7 +912,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" limit 0 offset 0', $builder->toSql());
     }
 
-    public function testGetCountForPaginationWithBindings()
+    public function testGetCountForPaginationWithBindings(): void
     {
         $builder = $this->getBuilder();
         $builder->from('users')->selectSub(function ($q) {
@@ -929,7 +929,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([4], $builder->getBindings());
     }
 
-    public function testGetCountForPaginationWithColumnAliases()
+    public function testGetCountForPaginationWithColumnAliases(): void
     {
         $builder = $this->getBuilder();
         $columns = ['body as post_body', 'teaser', 'posts.created as published'];
@@ -944,7 +944,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $count);
     }
 
-    public function testWhereShortcut()
+    public function testWhereShortcut(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', 1)->orWhere('name', 'foo');
@@ -952,7 +952,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
-    public function testWhereWithArrayConditions()
+    public function testWhereWithArrayConditions(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where([['foo', 1], ['bar', 2]]);
@@ -970,7 +970,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
-    public function testNestedWheres()
+    public function testNestedWheres(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('email', '=', 'foo')->orWhere(function ($q) {
@@ -980,7 +980,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 'foo', 1 => 'bar', 2 => 25], $builder->getBindings());
     }
 
-    public function testFullSubSelects()
+    public function testFullSubSelects(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('email', '=', 'foo')->orWhere('id', '=', function ($q) {
@@ -991,7 +991,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 'foo', 1 => 'bar'], $builder->getBindings());
     }
 
-    public function testWhereExists()
+    public function testWhereExists(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->whereExists(function ($q) {
@@ -1018,7 +1018,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
     }
 
-    public function testBasicJoins()
+    public function testBasicJoins(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', 'users.id', 'contacts.id');
@@ -1034,7 +1034,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['bar', 'foo'], $builder->getBindings());
     }
 
-    public function testCrossJoins()
+    public function testCrossJoins(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('sizes')->crossJoin('colors');
@@ -1049,7 +1049,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "tableB" cross join "tableA" on "tableA"."column1" = "tableB"."column2"', $builder->toSql());
     }
 
-    public function testComplexJoin()
+    public function testComplexJoin(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', function ($j) {
@@ -1069,7 +1069,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $builder->getBindings());
     }
 
-    public function testJoinWhereNull()
+    public function testJoinWhereNull(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', function ($j) {
@@ -1084,7 +1084,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."deleted_at" is null', $builder->toSql());
     }
 
-    public function testJoinWhereNotNull()
+    public function testJoinWhereNotNull(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', function ($j) {
@@ -1099,7 +1099,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."deleted_at" is not null', $builder->toSql());
     }
 
-    public function testJoinWhereIn()
+    public function testJoinWhereIn(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', function ($j) {
@@ -1116,7 +1116,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([48, 'baz', null], $builder->getBindings());
     }
 
-    public function testJoinWhereInSubquery()
+    public function testJoinWhereInSubquery(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', function ($j) {
@@ -1137,7 +1137,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['baz'], $builder->getBindings());
     }
 
-    public function testJoinWhereNotIn()
+    public function testJoinWhereNotIn(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', function ($j) {
@@ -1154,7 +1154,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([48, 'baz', null], $builder->getBindings());
     }
 
-    public function testJoinsWithNestedConditions()
+    public function testJoinsWithNestedConditions(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->leftJoin('contacts', function ($j) {
@@ -1179,7 +1179,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([1, 'UK', 'US'], $builder->getBindings());
     }
 
-    public function testJoinsWithAdvancedConditions()
+    public function testJoinsWithAdvancedConditions(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->leftJoin('contacts', function ($j) {
@@ -1193,7 +1193,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['admin'], $builder->getBindings());
     }
 
-    public function testJoinsWithSubqueryCondition()
+    public function testJoinsWithSubqueryCondition(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->leftJoin('contacts', function ($j) {
@@ -1219,7 +1219,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['1'], $builder->getBindings());
     }
 
-    public function testJoinsWithAdvancedSubqueryCondition()
+    public function testJoinsWithAdvancedSubqueryCondition(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->leftJoin('contacts', function ($j) {
@@ -1238,7 +1238,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['1', true], $builder->getBindings());
     }
 
-    public function testJoinsWithNestedJoins()
+    public function testJoinsWithNestedJoins(): void
     {
         $builder = $this->getBuilder();
         $builder->select('users.id', 'contacts.id', 'contact_types.id')->from('users')->leftJoin('contacts', function ($j) {
@@ -1247,7 +1247,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select "users"."id", "contacts"."id", "contact_types"."id" from "users" left join "contacts" inner join "contact_types" on "contacts"."contact_type_id" = "contact_types"."id" on "users"."id" = "contacts"."id"', $builder->toSql());
     }
 
-    public function testJoinsWithMultipleNestedJoins()
+    public function testJoinsWithMultipleNestedJoins(): void
     {
         $builder = $this->getBuilder();
         $builder->select('users.id', 'contacts.id', 'contact_types.id', 'countrys.id', 'planets.id')->from('users')->leftJoin('contacts', function ($j) {
@@ -1266,7 +1266,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['1', 10000], $builder->getBindings());
     }
 
-    public function testJoinsWithNestedJoinWithAdvancedSubqueryCondition()
+    public function testJoinsWithNestedJoinWithAdvancedSubqueryCondition(): void
     {
         $builder = $this->getBuilder();
         $builder->select('users.id', 'contacts.id', 'contact_types.id')->from('users')->leftJoin('contacts', function ($j) {
@@ -1286,14 +1286,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['1', 10000], $builder->getBindings());
     }
 
-    public function testRawExpressionsInSelect()
+    public function testRawExpressionsInSelect(): void
     {
         $builder = $this->getBuilder();
         $builder->select(new Raw('substr(foo, 6)'))->from('users');
         $this->assertEquals('select substr(foo, 6) from "users"', $builder->toSql());
     }
 
-    public function testFindReturnsFirstResultByID()
+    public function testFindReturnsFirstResultByID(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select * from "users" where "id" = ? limit 1', [1], true)->andReturn([['foo' => 'bar']]);
@@ -1304,7 +1304,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $results);
     }
 
-    public function testFirstMethodReturnsFirstResult()
+    public function testFirstMethodReturnsFirstResult(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select * from "users" where "id" = ? limit 1', [1], true)->andReturn([['foo' => 'bar']]);
@@ -1315,7 +1315,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $results);
     }
 
-    public function testListMethodsGetsArrayOfColumnValues()
+    public function testListMethodsGetsArrayOfColumnValues(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->andReturn([['foo' => 'bar'], ['foo' => 'baz']]);
@@ -1334,7 +1334,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([1 => 'bar', 10 => 'baz'], $results->all());
     }
 
-    public function testImplode()
+    public function testImplode(): void
     {
         // Test without glue.
         $builder = $this->getBuilder();
@@ -1355,7 +1355,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('bar,baz', $results);
     }
 
-    public function testValueMethodReturnsSingleColumn()
+    public function testValueMethodReturnsSingleColumn(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select "foo" from "users" where "id" = ? limit 1', [1], true)->andReturn([['foo' => 'bar']]);
@@ -1364,7 +1364,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('bar', $results);
     }
 
-    public function testAggregateFunctions()
+    public function testAggregateFunctions(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select count(*) as aggregate from "users"', [], true)->andReturn([['aggregate' => 1]]);
@@ -1409,7 +1409,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $results);
     }
 
-    public function testSqlServerExists()
+    public function testSqlServerExists(): void
     {
         $builder = $this->getSqlServerBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select top 1 1 [exists] from [users]', [], true)->andReturn([['exists' => 1]]);
@@ -1417,7 +1417,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($results);
     }
 
-    public function testAggregateResetFollowedByGet()
+    public function testAggregateResetFollowedByGet(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select count(*) as aggregate from "users"', [], true)->andReturn([['aggregate' => 1]]);
@@ -1435,7 +1435,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([['column1' => 'foo', 'column2' => 'bar']], $result->all());
     }
 
-    public function testAggregateResetFollowedBySelectGet()
+    public function testAggregateResetFollowedBySelectGet(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select count("column1") as aggregate from "users"', [], true)->andReturn([['aggregate' => 1]]);
@@ -1450,7 +1450,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([['column2' => 'foo', 'column3' => 'bar']], $result->all());
     }
 
-    public function testAggregateResetFollowedByGetWithColumns()
+    public function testAggregateResetFollowedByGetWithColumns(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select count("column1") as aggregate from "users"', [], true)->andReturn([['aggregate' => 1]]);
@@ -1465,7 +1465,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([['column2' => 'foo', 'column3' => 'bar']], $result->all());
     }
 
-    public function testAggregateWithSubSelect()
+    public function testAggregateWithSubSelect(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select count(*) as aggregate from "users"', [], true)->andReturn([['aggregate' => 1]]);
@@ -1481,7 +1481,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo'], $builder->getBindings());
     }
 
-    public function testSubqueriesBindings()
+    public function testSubqueriesBindings(): void
     {
         $builder = $this->getBuilder();
         $second = $this->getBuilder()->select('*')->from('users')->orderByRaw('id = ?', 2);
@@ -1498,7 +1498,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 'bar', 1 => 4, 2 => '%.com', 3 => 'foo', 4 => 5], $builder->getBindings());
     }
 
-    public function testInsertMethod()
+    public function testInsertMethod(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email") values (?)', ['foo'])->andReturn(true);
@@ -1506,7 +1506,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testSQLiteMultipleInserts()
+    public function testSQLiteMultipleInserts(): void
     {
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email", "name") select ? as "email", ? as "name" union all select ? as "email", ? as "name"', ['foo', 'taylor', 'bar', 'dayle'])->andReturn(true);
@@ -1514,7 +1514,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testInsertGetIdMethod()
+    public function testInsertGetIdMethod(): void
     {
         $builder = $this->getBuilder();
         $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email") values (?)', ['foo'], 'id')->andReturn(1);
@@ -1522,7 +1522,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testInsertGetIdMethodRemovesExpressions()
+    public function testInsertGetIdMethodRemovesExpressions(): void
     {
         $builder = $this->getBuilder();
         $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email", "bar") values (?, bar)', ['foo'], 'id')->andReturn(1);
@@ -1530,7 +1530,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testInsertMethodRespectsRawBindings()
+    public function testInsertMethodRespectsRawBindings(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email") values (CURRENT TIMESTAMP)', [])->andReturn(true);
@@ -1538,7 +1538,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testMultipleInsertsWithExpressionValues()
+    public function testMultipleInsertsWithExpressionValues(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email") values (UPPER(\'Foo\')), (LOWER(\'Foo\'))', [])->andReturn(true);
@@ -1546,7 +1546,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testUpdateMethod()
+    public function testUpdateMethod(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "id" = ?', ['foo', 'bar', 1])->andReturn(1);
@@ -1559,7 +1559,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testUpdateMethodWithJoins()
+    public function testUpdateMethodWithJoins(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" inner join "orders" on "users"."id" = "orders"."user_id" set "email" = ?, "name" = ? where "users"."id" = ?', ['foo', 'bar', 1])->andReturn(1);
@@ -1575,7 +1575,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testUpdateMethodWithJoinsOnSqlServer()
+    public function testUpdateMethodWithJoinsOnSqlServer(): void
     {
         $builder = $this->getSqlServerBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update [users] set [email] = ?, [name] = ? from [users] inner join [orders] on [users].[id] = [orders].[user_id] where [users].[id] = ?', ['foo', 'bar', 1])->andReturn(1);
@@ -1591,7 +1591,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testUpdateMethodWithJoinsOnMySql()
+    public function testUpdateMethodWithJoinsOnMySql(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update `users` inner join `orders` on `users`.`id` = `orders`.`user_id` set `email` = ?, `name` = ? where `users`.`id` = ?', ['foo', 'bar', 1])->andReturn(1);
@@ -1607,7 +1607,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testUpdateMethodWithJoinsOnSQLite()
+    public function testUpdateMethodWithJoinsOnSQLite(): void
     {
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "rowid" in (select "users"."rowid" from "users" where "users"."id" > ? order by "id" asc limit 3)', ['foo', 'bar', 1])->andReturn(1);
@@ -1628,7 +1628,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testUpdateMethodWithJoinsAndAliasesOnSqlServer()
+    public function testUpdateMethodWithJoinsAndAliasesOnSqlServer(): void
     {
         $builder = $this->getSqlServerBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update [u] set [email] = ?, [name] = ? from [users] as [u] inner join [orders] on [u].[id] = [orders].[user_id] where [u].[id] = ?', ['foo', 'bar', 1])->andReturn(1);
@@ -1636,7 +1636,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testUpdateMethodWithoutJoinsOnPostgres()
+    public function testUpdateMethodWithoutJoinsOnPostgres(): void
     {
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "id" = ?', ['foo', 'bar', 1])->andReturn(1);
@@ -1644,7 +1644,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testUpdateMethodWithJoinsOnPostgres()
+    public function testUpdateMethodWithJoinsOnPostgres(): void
     {
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" where "users"."id" = ? and "users"."id" = "orders"."user_id"', ['foo', 'bar', 1])->andReturn(1);
@@ -1660,7 +1660,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testUpdateMethodRespectsRaw()
+    public function testUpdateMethodRespectsRaw(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = foo, "name" = ? where "id" = ?', ['bar', 1])->andReturn(1);
@@ -1668,7 +1668,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testUpdateOrInsertMethod()
+    public function testUpdateOrInsertMethod(): void
     {
         $builder = m::mock('Illuminate\Database\Query\Builder[where,exists,insert]', [
             m::mock('Illuminate\Database\ConnectionInterface'),
@@ -1696,7 +1696,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($builder->updateOrInsert(['email' => 'foo'], ['name' => 'bar']));
     }
 
-    public function testDeleteMethod()
+    public function testDeleteMethod(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "email" = ?', ['foo'])->andReturn(1);
@@ -1724,7 +1724,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testDeleteWithJoinMethod()
+    public function testDeleteWithJoinMethod(): void
     {
         $builder = $this->getSqliteBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "rowid" in (select "users"."rowid" from "users" inner join "contacts" on "users"."id" = "contacts"."id" where "users"."email" = ? order by "users"."id" asc limit 1)', ['foo'])->andReturn(1);
@@ -1777,7 +1777,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testTruncateMethod()
+    public function testTruncateMethod(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('statement')->once()->with('truncate "users"', []);
@@ -1792,7 +1792,7 @@ class DatabaseQueryBuilderTest extends TestCase
         ], $sqlite->compileTruncate($builder));
     }
 
-    public function testPostgresInsertGetId()
+    public function testPostgresInsertGetId(): void
     {
         $builder = $this->getPostgresBuilder();
         $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email") values (?) returning "id"', ['foo'], 'id')->andReturn(1);
@@ -1800,14 +1800,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testMySqlWrapping()
+    public function testMySqlWrapping(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users');
         $this->assertEquals('select * from `users`', $builder->toSql());
     }
 
-    public function testMySqlUpdateWrappingJson()
+    public function testMySqlUpdateWrappingJson(): void
     {
         $grammar = new \Illuminate\Database\Query\Grammars\MySqlGrammar;
         $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
@@ -1825,7 +1825,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $result = $builder->from('users')->where('active', '=', 1)->update(['name->first_name' => 'John', 'name->last_name' => 'Doe']);
     }
 
-    public function testMySqlUpdateWrappingNestedJson()
+    public function testMySqlUpdateWrappingNestedJson(): void
     {
         $grammar = new \Illuminate\Database\Query\Grammars\MySqlGrammar;
         $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
@@ -1843,7 +1843,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $result = $builder->from('users')->where('active', '=', 1)->update(['meta->name->first_name' => 'John', 'meta->name->last_name' => 'Doe']);
     }
 
-    public function testMySqlUpdateWithJsonRemovesBindingsCorrectly()
+    public function testMySqlUpdateWithJsonRemovesBindingsCorrectly(): void
     {
         $grammar = new \Illuminate\Database\Query\Grammars\MySqlGrammar;
         $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
@@ -1868,7 +1868,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->where('id', '=', 0)->update(['options->size' => 45, 'updated_at' => '2015-05-26 22:02:06']);
     }
 
-    public function testMySqlWrappingJsonWithString()
+    public function testMySqlWrappingJsonWithString(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->sku', '=', 'foo-bar');
@@ -1877,35 +1877,35 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('foo-bar', $builder->getRawBindings()['where'][0]);
     }
 
-    public function testMySqlWrappingJsonWithInteger()
+    public function testMySqlWrappingJsonWithInteger(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price', '=', 1);
         $this->assertEquals('select * from `users` where `items`->\'$."price"\' = ?', $builder->toSql());
     }
 
-    public function testMySqlWrappingJsonWithDouble()
+    public function testMySqlWrappingJsonWithDouble(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price', '=', 1.5);
         $this->assertEquals('select * from `users` where `items`->\'$."price"\' = ?', $builder->toSql());
     }
 
-    public function testMySqlWrappingJsonWithBoolean()
+    public function testMySqlWrappingJsonWithBoolean(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true);
         $this->assertEquals('select * from `users` where `items`->\'$."available"\' = true', $builder->toSql());
     }
 
-    public function testMySqlWrappingJsonWithBooleanAndIntegerThatLooksLikeOne()
+    public function testMySqlWrappingJsonWithBooleanAndIntegerThatLooksLikeOne(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true)->where('items->active', '=', false)->where('items->number_available', '=', 0);
         $this->assertEquals('select * from `users` where `items`->\'$."available"\' = true and `items`->\'$."active"\' = false and `items`->\'$."number_available"\' = ?', $builder->toSql());
     }
 
-    public function testMySqlWrappingJson()
+    public function testMySqlWrappingJson(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereRaw('items->\'$."price"\' = 1');
@@ -1924,7 +1924,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from `users` where `items`->\'$."price"."in_usd"\' = ? and `items`->\'$."age"\' = ?', $builder->toSql());
     }
 
-    public function testPostgresWrappingJson()
+    public function testPostgresWrappingJson(): void
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('items->price')->from('users')->where('items->price', '=', 1)->orderBy('items->price');
@@ -1939,14 +1939,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" where "items"->\'price\'->>\'in_usd\' = ? and "items"->>\'age\' = ?', $builder->toSql());
     }
 
-    public function testSQLiteOrderBy()
+    public function testSQLiteOrderBy(): void
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->orderBy('email', 'desc');
         $this->assertEquals('select * from "users" order by "email" desc', $builder->toSql());
     }
 
-    public function testSqlServerLimitsAndOffsets()
+    public function testSqlServerLimitsAndOffsets(): void
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->take(10);
@@ -1965,7 +1965,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from (select *, row_number() over (order by [email] desc) as row_num from [users]) as temp_table where row_num between 11 and 20', $builder->toSql());
     }
 
-    public function testMySqlSoundsLikeOperator()
+    public function testMySqlSoundsLikeOperator(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('name', 'sounds like', 'John Doe');
@@ -1973,7 +1973,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['John Doe'], $builder->getBindings());
     }
 
-    public function testMergeWheresCanMergeWheresAndBindings()
+    public function testMergeWheresCanMergeWheresAndBindings(): void
     {
         $builder = $this->getBuilder();
         $builder->wheres = ['foo'];
@@ -1982,7 +1982,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $builder->getBindings());
     }
 
-    public function testProvidingNullWithOperatorsBuildsCorrectly()
+    public function testProvidingNullWithOperatorsBuildsCorrectly(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('foo', null);
@@ -2001,7 +2001,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" where "foo" is not null', $builder->toSql());
     }
 
-    public function testDynamicWhere()
+    public function testDynamicWhere(): void
     {
         $method = 'whereFooBarAndBazOrQux';
         $parameters = ['corge', 'waldo', 'fred'];
@@ -2014,7 +2014,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals($builder, $builder->dynamicWhere($method, $parameters));
     }
 
-    public function testDynamicWhereIsNotGreedy()
+    public function testDynamicWhereIsNotGreedy(): void
     {
         $method = 'whereIosVersionAndAndroidVersionOrOrientation';
         $parameters = ['6.1', '4.2', 'Vertical'];
@@ -2027,7 +2027,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->dynamicWhere($method, $parameters);
     }
 
-    public function testCallTriggersDynamicWhere()
+    public function testCallTriggersDynamicWhere(): void
     {
         $builder = $this->getBuilder();
 
@@ -2038,7 +2038,7 @@ class DatabaseQueryBuilderTest extends TestCase
     /**
      * @expectedException \BadMethodCallException
      */
-    public function testBuilderThrowsExpectedExceptionWithUndefinedMethod()
+    public function testBuilderThrowsExpectedExceptionWithUndefinedMethod(): void
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select');
@@ -2047,7 +2047,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->noValidMethodHere();
     }
 
-    public function testMySqlLock()
+    public function testMySqlLock(): void
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock();
@@ -2065,7 +2065,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['baz'], $builder->getBindings());
     }
 
-    public function testPostgresLock()
+    public function testPostgresLock(): void
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock();
@@ -2083,7 +2083,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['baz'], $builder->getBindings());
     }
 
-    public function testSqlServerLock()
+    public function testSqlServerLock(): void
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock();
@@ -2101,7 +2101,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['baz'], $builder->getBindings());
     }
 
-    public function testSelectWithLockUsesWritePdo()
+    public function testSelectWithLockUsesWritePdo(): void
     {
         $builder = $this->getMySqlBuilderWithProcessor();
         $builder->getConnection()->shouldReceive('select')->once()
@@ -2114,7 +2114,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock(false)->get();
     }
 
-    public function testBindingOrder()
+    public function testBindingOrder(): void
     {
         $expectedSql = 'select * from "users" inner join "othertable" on "bar" = ? where "registered" = ? group by "city" having "population" > ? order by match ("foo") against(?)';
         $expectedBindings = ['foo', 1, 3, 'bar'];
@@ -2135,7 +2135,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals($expectedBindings, $builder->getBindings());
     }
 
-    public function testAddBindingWithArrayMergesBindings()
+    public function testAddBindingWithArrayMergesBindings(): void
     {
         $builder = $this->getBuilder();
         $builder->addBinding(['foo', 'bar']);
@@ -2143,7 +2143,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'baz'], $builder->getBindings());
     }
 
-    public function testAddBindingWithArrayMergesBindingsInCorrectOrder()
+    public function testAddBindingWithArrayMergesBindingsInCorrectOrder(): void
     {
         $builder = $this->getBuilder();
         $builder->addBinding(['bar', 'baz'], 'having');
@@ -2151,7 +2151,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'baz'], $builder->getBindings());
     }
 
-    public function testMergeBuilders()
+    public function testMergeBuilders(): void
     {
         $builder = $this->getBuilder();
         $builder->addBinding(['foo', 'bar']);
@@ -2161,7 +2161,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'baz'], $builder->getBindings());
     }
 
-    public function testMergeBuildersBindingOrder()
+    public function testMergeBuildersBindingOrder(): void
     {
         $builder = $this->getBuilder();
         $builder->addBinding('foo', 'where');
@@ -2172,7 +2172,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'baz'], $builder->getBindings());
     }
 
-    public function testSubSelect()
+    public function testSubSelect(): void
     {
         $expectedSql = 'select "foo", "bar", (select "baz" from "two" where "subkey" = ?) as "sub" from "one" where "key" = ?';
         $expectedBindings = ['subval', 'val'];
@@ -2194,7 +2194,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals($expectedBindings, $builder->getBindings());
     }
 
-    public function testSqlServerWhereDate()
+    public function testSqlServerWhereDate(): void
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', '=', '2015-09-23');
@@ -2202,28 +2202,28 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '2015-09-23'], $builder->getBindings());
     }
 
-    public function testUppercaseLeadingBooleansAreRemoved()
+    public function testUppercaseLeadingBooleansAreRemoved(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('name', '=', 'Taylor', 'AND');
         $this->assertEquals('select * from "users" where "name" = ?', $builder->toSql());
     }
 
-    public function testLowercaseLeadingBooleansAreRemoved()
+    public function testLowercaseLeadingBooleansAreRemoved(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('name', '=', 'Taylor', 'and');
         $this->assertEquals('select * from "users" where "name" = ?', $builder->toSql());
     }
 
-    public function testCaseInsensitiveLeadingBooleansAreRemoved()
+    public function testCaseInsensitiveLeadingBooleansAreRemoved(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('name', '=', 'Taylor', 'And');
         $this->assertEquals('select * from "users" where "name" = ?', $builder->toSql());
     }
 
-    public function testTableValuedFunctionAsTableInSqlServer()
+    public function testTableValuedFunctionAsTableInSqlServer(): void
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users()');
@@ -2234,7 +2234,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from [users](1,2)', $builder->toSql());
     }
 
-    public function testChunkWithLastChunkComplete()
+    public function testChunkWithLastChunkComplete(): void
     {
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -2257,7 +2257,7 @@ class DatabaseQueryBuilderTest extends TestCase
         });
     }
 
-    public function testChunkWithLastChunkPartial()
+    public function testChunkWithLastChunkPartial(): void
     {
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -2277,7 +2277,7 @@ class DatabaseQueryBuilderTest extends TestCase
         });
     }
 
-    public function testChunkCanBeStoppedByReturningFalse()
+    public function testChunkCanBeStoppedByReturningFalse(): void
     {
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -2299,7 +2299,7 @@ class DatabaseQueryBuilderTest extends TestCase
         });
     }
 
-    public function testChunkWithCountZero()
+    public function testChunkWithCountZero(): void
     {
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -2316,7 +2316,7 @@ class DatabaseQueryBuilderTest extends TestCase
         });
     }
 
-    public function testChunkPaginatesUsingIdWithLastChunkComplete()
+    public function testChunkPaginatesUsingIdWithLastChunkComplete(): void
     {
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -2339,7 +2339,7 @@ class DatabaseQueryBuilderTest extends TestCase
         }, 'someIdField');
     }
 
-    public function testChunkPaginatesUsingIdWithLastChunkPartial()
+    public function testChunkPaginatesUsingIdWithLastChunkPartial(): void
     {
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -2359,7 +2359,7 @@ class DatabaseQueryBuilderTest extends TestCase
         }, 'someIdField');
     }
 
-    public function testChunkPaginatesUsingIdWithCountZero()
+    public function testChunkPaginatesUsingIdWithCountZero(): void
     {
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -2376,7 +2376,7 @@ class DatabaseQueryBuilderTest extends TestCase
         }, 'someIdField');
     }
 
-    public function testChunkPaginatesUsingIdWithAlias()
+    public function testChunkPaginatesUsingIdWithAlias(): void
     {
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
@@ -2396,7 +2396,7 @@ class DatabaseQueryBuilderTest extends TestCase
         }, 'table.id', 'table_id');
     }
 
-    public function testPaginate()
+    public function testPaginate(): void
     {
         $perPage = 16;
         $columns = ['test'];
@@ -2423,7 +2423,7 @@ class DatabaseQueryBuilderTest extends TestCase
         ]), $result);
     }
 
-    public function testPaginateWithDefaultArguments()
+    public function testPaginateWithDefaultArguments(): void
     {
         $perPage = 15;
         $columns = ['*'];
@@ -2454,7 +2454,7 @@ class DatabaseQueryBuilderTest extends TestCase
         ]), $result);
     }
 
-    public function testPaginateWhenNoResults()
+    public function testPaginateWhenNoResults(): void
     {
         $perPage = 15;
         $columns = ['*'];
@@ -2485,7 +2485,7 @@ class DatabaseQueryBuilderTest extends TestCase
         ]), $result);
     }
 
-    public function testWhereRowValues()
+    public function testWhereRowValues(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->whereRowValues(['last_update', 'order_number'], '<', [1, 2]);
@@ -2496,7 +2496,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "orders" where "company_id" = ? or (last_update, order_number) < (?, ?)', $builder->toSql());
     }
 
-    public function testWhereRowValuesArityMismatch()
+    public function testWhereRowValuesArityMismatch(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('The number of columns must match the number of values');

--- a/tests/Database/DatabaseSQLiteProcessorTest.php
+++ b/tests/Database/DatabaseSQLiteProcessorTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseSQLiteProcessorTest extends TestCase
 {
-    public function testProcessColumnListing()
+    public function testProcessColumnListing(): void
     {
         $processor = new \Illuminate\Database\Query\Processors\SQLiteProcessor;
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -8,12 +8,12 @@ use Illuminate\Database\Schema\Blueprint;
 
 class DatabaseSQLiteSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBasicCreateTable()
+    public function testBasicCreateTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -37,7 +37,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals($expected, $statements);
     }
 
-    public function testCreateTemporaryTable()
+    public function testCreateTemporaryTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -50,7 +50,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('create temporary table "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
     }
 
-    public function testDropTable()
+    public function testDropTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->drop();
@@ -60,7 +60,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('drop table "users"', $statements[0]);
     }
 
-    public function testDropTableIfExists()
+    public function testDropTableIfExists(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropIfExists();
@@ -70,7 +70,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('drop table if exists "users"', $statements[0]);
     }
 
-    public function testDropUnique()
+    public function testDropUnique(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropUnique('foo');
@@ -80,7 +80,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('drop index "foo"', $statements[0]);
     }
 
-    public function testDropIndex()
+    public function testDropIndex(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropIndex('foo');
@@ -90,7 +90,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('drop index "foo"', $statements[0]);
     }
 
-    public function testDropColumn()
+    public function testDropColumn(): void
     {
         if (! class_exists('Doctrine\DBAL\Schema\SqliteSchemaManager')) {
             $this->markTestSkipped('Doctrine should be installed to run dropColumn tests');
@@ -125,14 +125,14 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage The database driver in use does not support spatial indexes.
      */
-    public function testDropSpatialIndex()
+    public function testDropSpatialIndex(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->dropSpatialIndex(['coordinates']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
-    public function testRenameTable()
+    public function testRenameTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->rename('foo');
@@ -142,7 +142,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" rename to "foo"', $statements[0]);
     }
 
-    public function testAddingPrimaryKey()
+    public function testAddingPrimaryKey(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -153,7 +153,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('create table "users" ("foo" varchar not null, primary key ("foo"))', $statements[0]);
     }
 
-    public function testAddingForeignKey()
+    public function testAddingForeignKey(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -166,7 +166,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('create table "users" ("foo" varchar not null, "order_id" varchar not null, foreign key("order_id") references "orders"("id"), primary key ("foo"))', $statements[0]);
     }
 
-    public function testAddingUniqueKey()
+    public function testAddingUniqueKey(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->unique('foo', 'bar');
@@ -176,7 +176,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('create unique index "bar" on "users" ("foo")', $statements[0]);
     }
 
-    public function testAddingIndex()
+    public function testAddingIndex(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->index(['foo', 'bar'], 'baz');
@@ -190,7 +190,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage The database driver in use does not support spatial indexes.
      */
-    public function testAddingSpatialIndex()
+    public function testAddingSpatialIndex(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->spatialIndex('coordinates');
@@ -201,14 +201,14 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage The database driver in use does not support spatial indexes.
      */
-    public function testAddingFluentSpatialIndex()
+    public function testAddingFluentSpatialIndex(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->point('coordinates')->spatialIndex();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
-    public function testAddingIncrementingID()
+    public function testAddingIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');
@@ -218,7 +218,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
     }
 
-    public function testAddingSmallIncrementingID()
+    public function testAddingSmallIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->smallIncrements('id');
@@ -228,7 +228,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
     }
 
-    public function testAddingMediumIncrementingID()
+    public function testAddingMediumIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->mediumIncrements('id');
@@ -238,7 +238,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
     }
 
-    public function testAddingBigIncrementingID()
+    public function testAddingBigIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->bigIncrements('id');
@@ -248,7 +248,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
     }
 
-    public function testAddingString()
+    public function testAddingString(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->string('foo');
@@ -272,7 +272,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" varchar null default \'bar\'', $statements[0]);
     }
 
-    public function testAddingText()
+    public function testAddingText(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->text('foo');
@@ -282,7 +282,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" text not null', $statements[0]);
     }
 
-    public function testAddingBigInteger()
+    public function testAddingBigInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->bigInteger('foo');
@@ -299,7 +299,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
     }
 
-    public function testAddingInteger()
+    public function testAddingInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->integer('foo');
@@ -316,7 +316,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
     }
 
-    public function testAddingMediumInteger()
+    public function testAddingMediumInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->mediumInteger('foo');
@@ -333,7 +333,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
     }
 
-    public function testAddingTinyInteger()
+    public function testAddingTinyInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->tinyInteger('foo');
@@ -350,7 +350,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
     }
 
-    public function testAddingSmallInteger()
+    public function testAddingSmallInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->smallInteger('foo');
@@ -367,7 +367,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
     }
 
-    public function testAddingFloat()
+    public function testAddingFloat(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->float('foo', 5, 2);
@@ -377,7 +377,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" float not null', $statements[0]);
     }
 
-    public function testAddingDouble()
+    public function testAddingDouble(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->double('foo', 15, 8);
@@ -387,7 +387,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" float not null', $statements[0]);
     }
 
-    public function testAddingDecimal()
+    public function testAddingDecimal(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->decimal('foo', 5, 2);
@@ -397,7 +397,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" numeric not null', $statements[0]);
     }
 
-    public function testAddingBoolean()
+    public function testAddingBoolean(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->boolean('foo');
@@ -407,7 +407,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" tinyint(1) not null', $statements[0]);
     }
 
-    public function testAddingEnum()
+    public function testAddingEnum(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->enum('role', ['member', 'admin']);
@@ -417,7 +417,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "role" varchar check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
     }
 
-    public function testAddingJson()
+    public function testAddingJson(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->json('foo');
@@ -427,7 +427,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" text not null', $statements[0]);
     }
 
-    public function testAddingJsonb()
+    public function testAddingJsonb(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->jsonb('foo');
@@ -437,7 +437,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" text not null', $statements[0]);
     }
 
-    public function testAddingDate()
+    public function testAddingDate(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->date('foo');
@@ -447,7 +447,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" date not null', $statements[0]);
     }
 
-    public function testAddingYear()
+    public function testAddingYear(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->year('birth_year');
@@ -456,7 +456,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "birth_year" integer not null', $statements[0]);
     }
 
-    public function testAddingDateTime()
+    public function testAddingDateTime(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dateTime('created_at');
@@ -465,7 +465,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
-    public function testAddingDateTimeWithPrecision()
+    public function testAddingDateTimeWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dateTime('created_at', 1);
@@ -474,7 +474,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
-    public function testAddingDateTimeTz()
+    public function testAddingDateTimeTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dateTimeTz('created_at');
@@ -483,7 +483,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
-    public function testAddingDateTimeTzWithPrecision()
+    public function testAddingDateTimeTzWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dateTimeTz('created_at', 1);
@@ -492,7 +492,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
-    public function testAddingTime()
+    public function testAddingTime(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->time('created_at');
@@ -501,7 +501,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
-    public function testAddingTimeWithPrecision()
+    public function testAddingTimeWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->time('created_at', 1);
@@ -510,7 +510,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
-    public function testAddingTimeTz()
+    public function testAddingTimeTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timeTz('created_at');
@@ -519,7 +519,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
-    public function testAddingTimeTzWithPrecision()
+    public function testAddingTimeTzWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timeTz('created_at', 1);
@@ -528,7 +528,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
-    public function testAddingTimestamp()
+    public function testAddingTimestamp(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamp('created_at');
@@ -537,7 +537,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
-    public function testAddingTimestampWithPrecision()
+    public function testAddingTimestampWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamp('created_at', 1);
@@ -546,7 +546,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
-    public function testAddingTimestampTz()
+    public function testAddingTimestampTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampTz('created_at');
@@ -555,7 +555,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
-    public function testAddingTimestampTzWithPrecision()
+    public function testAddingTimestampTzWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampTz('created_at', 1);
@@ -564,7 +564,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
-    public function testAddingTimestamps()
+    public function testAddingTimestamps(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamps();
@@ -576,7 +576,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
-    public function testAddingTimestampsTz()
+    public function testAddingTimestampsTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampsTz();
@@ -588,7 +588,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
-    public function testAddingRememberToken()
+    public function testAddingRememberToken(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->rememberToken();
@@ -598,7 +598,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "remember_token" varchar null', $statements[0]);
     }
 
-    public function testAddingBinary()
+    public function testAddingBinary(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->binary('foo');
@@ -608,7 +608,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" blob not null', $statements[0]);
     }
 
-    public function testAddingUuid()
+    public function testAddingUuid(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->uuid('foo');
@@ -618,7 +618,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" varchar not null', $statements[0]);
     }
 
-    public function testAddingIpAddress()
+    public function testAddingIpAddress(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->ipAddress('foo');
@@ -628,7 +628,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" varchar not null', $statements[0]);
     }
 
-    public function testAddingMacAddress()
+    public function testAddingMacAddress(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->macAddress('foo');
@@ -638,7 +638,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" varchar not null', $statements[0]);
     }
 
-    public function testAddingGeometry()
+    public function testAddingGeometry(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->geometry('coordinates');
@@ -648,7 +648,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" geometry not null', $statements[0]);
     }
 
-    public function testAddingPoint()
+    public function testAddingPoint(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->point('coordinates');
@@ -658,7 +658,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" point not null', $statements[0]);
     }
 
-    public function testAddingLineString()
+    public function testAddingLineString(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->linestring('coordinates');
@@ -668,7 +668,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" linestring not null', $statements[0]);
     }
 
-    public function testAddingPolygon()
+    public function testAddingPolygon(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->polygon('coordinates');
@@ -678,7 +678,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" polygon not null', $statements[0]);
     }
 
-    public function testAddingGeometryCollection()
+    public function testAddingGeometryCollection(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->geometrycollection('coordinates');
@@ -688,7 +688,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" geometrycollection not null', $statements[0]);
     }
 
-    public function testAddingMultiPoint()
+    public function testAddingMultiPoint(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->multipoint('coordinates');
@@ -698,7 +698,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" multipoint not null', $statements[0]);
     }
 
-    public function testAddingMultiLineString()
+    public function testAddingMultiLineString(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->multilinestring('coordinates');
@@ -708,7 +708,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" multilinestring not null', $statements[0]);
     }
 
-    public function testAddingMultiPolygon()
+    public function testAddingMultiPolygon(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->multipolygon('coordinates');

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -17,7 +17,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->db = $db = new DB;
 
@@ -33,13 +33,13 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         Facade::setFacadeApplication($container);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
     }
 
-    public function testRenamingAndChangingColumnsWork()
+    public function testRenamingAndChangingColumnsWork(): void
     {
         $this->db->connection()->getSchemaBuilder()->create('users', function ($table) {
             $table->string('name');

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -12,12 +12,12 @@ use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 
 class DatabaseSchemaBlueprintTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testToSqlRunsCommandsFromBlueprint()
+    public function testToSqlRunsCommandsFromBlueprint(): void
     {
         $conn = m::mock('Illuminate\Database\Connection');
         $conn->shouldReceive('statement')->once()->with('foo');
@@ -29,7 +29,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint->build($conn, $grammar);
     }
 
-    public function testIndexDefaultNames()
+    public function testIndexDefaultNames(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->unique(['foo', 'bar']);
@@ -47,7 +47,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals('geo_coordinates_spatialindex', $commands[0]->index);
     }
 
-    public function testDropIndexDefaultNames()
+    public function testDropIndexDefaultNames(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropUnique(['foo', 'bar']);
@@ -65,7 +65,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals('geo_coordinates_spatialindex', $commands[0]->index);
     }
 
-    public function testDefaultCurrentTimestamp()
+    public function testDefaultCurrentTimestamp(): void
     {
         $base = new Blueprint('users', function ($table) {
             $table->timestamp('created')->useCurrent();
@@ -86,7 +86,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table "users" add "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar));
     }
 
-    public function testUnsignedDecimalTable()
+    public function testUnsignedDecimalTable(): void
     {
         $base = new Blueprint('users', function ($table) {
             $table->unsignedDecimal('money', 10, 2)->useCurrent();

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -16,7 +16,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->db = $db = new DB;
 
@@ -32,13 +32,13 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         Facade::setFacadeApplication($container);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
     }
 
-    public function testDropAllTablesWorksWithForeignKeys()
+    public function testDropAllTablesWorksWithForeignKeys(): void
     {
         $this->db->connection()->getSchemaBuilder()->create('table1', function ($table) {
             $table->integer('id');
@@ -60,7 +60,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         $this->assertFalse($this->db->connection()->getSchemaBuilder()->hasTable('table2'));
     }
 
-    public function testHasColumnWithTablePrefix()
+    public function testHasColumnWithTablePrefix(): void
     {
         $this->db->connection()->setTablePrefix('test_');
 

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -8,12 +8,12 @@ use Illuminate\Database\Schema\Builder;
 
 class DatabaseSchemaBuilderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testHasTableCorrectlyCallsGrammar()
+    public function testHasTableCorrectlyCallsGrammar(): void
     {
         $connection = m::mock('Illuminate\Database\Connection');
         $grammar = m::mock('stdClass');
@@ -26,7 +26,7 @@ class DatabaseSchemaBuilderTest extends TestCase
         $this->assertTrue($builder->hasTable('table'));
     }
 
-    public function testTableHasColumns()
+    public function testTableHasColumns(): void
     {
         $connection = m::mock('Illuminate\Database\Connection');
         $grammar = m::mock('stdClass');
@@ -38,7 +38,7 @@ class DatabaseSchemaBuilderTest extends TestCase
         $this->assertFalse($builder->hasColumns('users', ['id', 'address']));
     }
 
-    public function testGetColumnTypeAddsPrefix()
+    public function testGetColumnTypeAddsPrefix(): void
     {
         $connection = m::mock('Illuminate\Database\Connection');
         $column = m::mock('stdClass');

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -25,12 +25,12 @@ class TestDepsSeeder extends Seeder
 
 class DatabaseSeederTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testCallResolveTheClassAndCallsRun()
+    public function testCallResolveTheClassAndCallsRun(): void
     {
         $seeder = new TestSeeder;
         $seeder->setContainer($container = m::mock('Illuminate\Container\Container'));
@@ -47,21 +47,21 @@ class DatabaseSeederTest extends TestCase
         $seeder->call('ClassName');
     }
 
-    public function testSetContainer()
+    public function testSetContainer(): void
     {
         $seeder = new TestSeeder;
         $container = m::mock('Illuminate\Container\Container');
         $this->assertEquals($seeder->setContainer($container), $seeder);
     }
 
-    public function testSetCommand()
+    public function testSetCommand(): void
     {
         $seeder = new TestSeeder;
         $command = m::mock('Illuminate\Console\Command');
         $this->assertEquals($seeder->setCommand($command), $seeder);
     }
 
-    public function testInjectDependenciesOnRunMethod()
+    public function testInjectDependenciesOnRunMethod(): void
     {
         $container = m::mock('Illuminate\Container\Container');
         $container->shouldReceive('call');

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseSoftDeletingScopeTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testApplyingScopeToABuilder()
+    public function testApplyingScopeToABuilder(): void
     {
         $scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[extend]');
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -23,7 +23,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $scope->apply($builder, $model);
     }
 
-    public function testRestoreExtension()
+    public function testRestoreExtension(): void
     {
         $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
             m::mock('Illuminate\Database\ConnectionInterface'),
@@ -42,7 +42,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $callback($givenBuilder);
     }
 
-    public function testWithTrashedExtension()
+    public function testWithTrashedExtension(): void
     {
         $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
             m::mock('Illuminate\Database\ConnectionInterface'),
@@ -60,7 +60,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $this->assertEquals($givenBuilder, $result);
     }
 
-    public function testOnlyTrashedExtension()
+    public function testOnlyTrashedExtension(): void
     {
         $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
             m::mock('Illuminate\Database\ConnectionInterface'),
@@ -83,7 +83,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $this->assertEquals($givenBuilder, $result);
     }
 
-    public function testWithoutTrashedExtension()
+    public function testWithoutTrashedExtension(): void
     {
         $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
             m::mock('Illuminate\Database\ConnectionInterface'),

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseSoftDeletingTraitTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testDeleteSetsSoftDeletedColumn()
+    public function testDeleteSetsSoftDeletedColumn(): void
     {
         $model = m::mock('Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub');
         $model->shouldDeferMissing();
@@ -28,7 +28,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->deleted_at);
     }
 
-    public function testRestore()
+    public function testRestore(): void
     {
         $model = m::mock('Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub');
         $model->shouldDeferMissing();
@@ -41,7 +41,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         $this->assertNull($model->deleted_at);
     }
 
-    public function testRestoreCancel()
+    public function testRestoreCancel(): void
     {
         $model = m::mock('Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub');
         $model->shouldDeferMissing();

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -8,12 +8,12 @@ use Illuminate\Database\Schema\Blueprint;
 
 class DatabaseSqlServerSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBasicCreateTable()
+    public function testBasicCreateTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -42,7 +42,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('create table "prefix_users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
     }
 
-    public function testCreateTemporaryTable()
+    public function testCreateTemporaryTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -55,7 +55,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('create table "#users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
     }
 
-    public function testDropTable()
+    public function testDropTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->drop();
@@ -72,7 +72,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('drop table "prefix_users"', $statements[0]);
     }
 
-    public function testDropTableIfExists()
+    public function testDropTableIfExists(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropIfExists();
@@ -89,7 +89,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('if exists (select * from INFORMATION_SCHEMA.TABLES where TABLE_NAME = \'prefix_users\') drop table "prefix_users"', $statements[0]);
     }
 
-    public function testDropColumn()
+    public function testDropColumn(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropColumn('foo');
@@ -113,7 +113,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" drop column "foo", "bar"', $statements[0]);
     }
 
-    public function testDropPrimary()
+    public function testDropPrimary(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropPrimary('foo');
@@ -123,7 +123,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
     }
 
-    public function testDropUnique()
+    public function testDropUnique(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropUnique('foo');
@@ -133,7 +133,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('drop index "foo" on "users"', $statements[0]);
     }
 
-    public function testDropIndex()
+    public function testDropIndex(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropIndex('foo');
@@ -143,7 +143,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('drop index "foo" on "users"', $statements[0]);
     }
 
-    public function testDropSpatialIndex()
+    public function testDropSpatialIndex(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->dropSpatialIndex(['coordinates']);
@@ -153,7 +153,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('drop index "geo_coordinates_spatialindex" on "geo"', $statements[0]);
     }
 
-    public function testDropForeign()
+    public function testDropForeign(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropForeign('foo');
@@ -163,7 +163,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
     }
 
-    public function testDropTimestamps()
+    public function testDropTimestamps(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropTimestamps();
@@ -173,7 +173,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" drop column "created_at", "updated_at"', $statements[0]);
     }
 
-    public function testDropTimestampsTz()
+    public function testDropTimestampsTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropTimestampsTz();
@@ -183,7 +183,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" drop column "created_at", "updated_at"', $statements[0]);
     }
 
-    public function testDropMorphs()
+    public function testDropMorphs(): void
     {
         $blueprint = new Blueprint('photos');
         $blueprint->dropMorphs('imageable');
@@ -194,7 +194,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "photos" drop column "imageable_type", "imageable_id"', $statements[1]);
     }
 
-    public function testRenameTable()
+    public function testRenameTable(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->rename('foo');
@@ -204,7 +204,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('sp_rename "users", "foo"', $statements[0]);
     }
 
-    public function testAddingPrimaryKey()
+    public function testAddingPrimaryKey(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->primary('foo', 'bar');
@@ -214,7 +214,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add constraint "bar" primary key ("foo")', $statements[0]);
     }
 
-    public function testAddingUniqueKey()
+    public function testAddingUniqueKey(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->unique('foo', 'bar');
@@ -224,7 +224,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('create unique index "bar" on "users" ("foo")', $statements[0]);
     }
 
-    public function testAddingIndex()
+    public function testAddingIndex(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->index(['foo', 'bar'], 'baz');
@@ -234,7 +234,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
-    public function testAddingSpatialIndex()
+    public function testAddingSpatialIndex(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->spatialIndex('coordinates');
@@ -244,7 +244,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('create spatial index "geo_coordinates_spatialindex" on "geo" ("coordinates")', $statements[0]);
     }
 
-    public function testAddingFluentSpatialIndex()
+    public function testAddingFluentSpatialIndex(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->point('coordinates')->spatialIndex();
@@ -254,7 +254,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('create spatial index "geo_coordinates_spatialindex" on "geo" ("coordinates")', $statements[1]);
     }
 
-    public function testAddingIncrementingID()
+    public function testAddingIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');
@@ -264,7 +264,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "id" int identity primary key not null', $statements[0]);
     }
 
-    public function testAddingSmallIncrementingID()
+    public function testAddingSmallIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->smallIncrements('id');
@@ -274,7 +274,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "id" smallint identity primary key not null', $statements[0]);
     }
 
-    public function testAddingMediumIncrementingID()
+    public function testAddingMediumIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->mediumIncrements('id');
@@ -284,7 +284,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "id" int identity primary key not null', $statements[0]);
     }
 
-    public function testAddingBigIncrementingID()
+    public function testAddingBigIncrementingID(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->bigIncrements('id');
@@ -294,7 +294,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "id" bigint identity primary key not null', $statements[0]);
     }
 
-    public function testAddingString()
+    public function testAddingString(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->string('foo');
@@ -318,7 +318,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" nvarchar(100) null default \'bar\'', $statements[0]);
     }
 
-    public function testAddingText()
+    public function testAddingText(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->text('foo');
@@ -328,7 +328,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
     }
 
-    public function testAddingBigInteger()
+    public function testAddingBigInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->bigInteger('foo');
@@ -345,7 +345,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" bigint identity primary key not null', $statements[0]);
     }
 
-    public function testAddingInteger()
+    public function testAddingInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->integer('foo');
@@ -362,7 +362,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" int identity primary key not null', $statements[0]);
     }
 
-    public function testAddingMediumInteger()
+    public function testAddingMediumInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->mediumInteger('foo');
@@ -379,7 +379,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" int identity primary key not null', $statements[0]);
     }
 
-    public function testAddingTinyInteger()
+    public function testAddingTinyInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->tinyInteger('foo');
@@ -396,7 +396,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" tinyint identity primary key not null', $statements[0]);
     }
 
-    public function testAddingSmallInteger()
+    public function testAddingSmallInteger(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->smallInteger('foo');
@@ -413,7 +413,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" smallint identity primary key not null', $statements[0]);
     }
 
-    public function testAddingFloat()
+    public function testAddingFloat(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->float('foo', 5, 2);
@@ -423,7 +423,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" float not null', $statements[0]);
     }
 
-    public function testAddingDouble()
+    public function testAddingDouble(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->double('foo', 15, 2);
@@ -433,7 +433,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" float not null', $statements[0]);
     }
 
-    public function testAddingDecimal()
+    public function testAddingDecimal(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->decimal('foo', 5, 2);
@@ -443,7 +443,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" decimal(5, 2) not null', $statements[0]);
     }
 
-    public function testAddingBoolean()
+    public function testAddingBoolean(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->boolean('foo');
@@ -453,7 +453,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" bit not null', $statements[0]);
     }
 
-    public function testAddingEnum()
+    public function testAddingEnum(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->enum('role', ['member', 'admin']);
@@ -463,7 +463,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "role" nvarchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
     }
 
-    public function testAddingJson()
+    public function testAddingJson(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->json('foo');
@@ -473,7 +473,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
     }
 
-    public function testAddingJsonb()
+    public function testAddingJsonb(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->jsonb('foo');
@@ -483,7 +483,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
     }
 
-    public function testAddingDate()
+    public function testAddingDate(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->date('foo');
@@ -493,7 +493,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" date not null', $statements[0]);
     }
 
-    public function testAddingYear()
+    public function testAddingYear(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->year('birth_year');
@@ -502,7 +502,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "birth_year" int not null', $statements[0]);
     }
 
-    public function testAddingDateTime()
+    public function testAddingDateTime(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dateTime('created_at');
@@ -511,7 +511,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" datetime not null', $statements[0]);
     }
 
-    public function testAddingDateTimeWithPrecision()
+    public function testAddingDateTimeWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dateTime('created_at', 1);
@@ -520,7 +520,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" datetime2(1) not null', $statements[0]);
     }
 
-    public function testAddingDateTimeTz()
+    public function testAddingDateTimeTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dateTimeTz('foo');
@@ -529,7 +529,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" datetimeoffset not null', $statements[0]);
     }
 
-    public function testAddingDateTimeTzWithPrecision()
+    public function testAddingDateTimeTzWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dateTimeTz('foo', 1);
@@ -538,7 +538,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" datetimeoffset(1) not null', $statements[0]);
     }
 
-    public function testAddingTime()
+    public function testAddingTime(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->time('created_at');
@@ -547,7 +547,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" time not null', $statements[0]);
     }
 
-    public function testAddingTimeWithPrecision()
+    public function testAddingTimeWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->time('created_at', 1);
@@ -556,7 +556,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" time(1) not null', $statements[0]);
     }
 
-    public function testAddingTimeTz()
+    public function testAddingTimeTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timeTz('created_at');
@@ -565,7 +565,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" time not null', $statements[0]);
     }
 
-    public function testAddingTimeTzWithPrecision()
+    public function testAddingTimeTzWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timeTz('created_at', 1);
@@ -574,7 +574,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" time(1) not null', $statements[0]);
     }
 
-    public function testAddingTimestamp()
+    public function testAddingTimestamp(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamp('created_at');
@@ -583,7 +583,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" datetime not null', $statements[0]);
     }
 
-    public function testAddingTimestampWithPrecision()
+    public function testAddingTimestampWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamp('created_at', 1);
@@ -592,7 +592,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" datetime2(1) not null', $statements[0]);
     }
 
-    public function testAddingTimestampTz()
+    public function testAddingTimestampTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampTz('created_at');
@@ -601,7 +601,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" datetimeoffset(0) not null', $statements[0]);
     }
 
-    public function testAddingTimestampTzWithPrecision()
+    public function testAddingTimestampTzWithPrecision(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampTz('created_at', 1);
@@ -610,7 +610,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" datetimeoffset(1) not null', $statements[0]);
     }
 
-    public function testAddingTimestamps()
+    public function testAddingTimestamps(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamps();
@@ -619,7 +619,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" datetime null, "updated_at" datetime null', $statements[0]);
     }
 
-    public function testAddingTimestampsTz()
+    public function testAddingTimestampsTz(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampsTz();
@@ -628,7 +628,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" datetimeoffset(0) null, "updated_at" datetimeoffset(0) null', $statements[0]);
     }
 
-    public function testAddingRememberToken()
+    public function testAddingRememberToken(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->rememberToken();
@@ -638,7 +638,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "remember_token" nvarchar(100) null', $statements[0]);
     }
 
-    public function testAddingBinary()
+    public function testAddingBinary(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->binary('foo');
@@ -648,7 +648,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" varbinary(max) not null', $statements[0]);
     }
 
-    public function testAddingUuid()
+    public function testAddingUuid(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->uuid('foo');
@@ -658,7 +658,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" uniqueidentifier not null', $statements[0]);
     }
 
-    public function testAddingIpAddress()
+    public function testAddingIpAddress(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->ipAddress('foo');
@@ -668,7 +668,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" nvarchar(45) not null', $statements[0]);
     }
 
-    public function testAddingMacAddress()
+    public function testAddingMacAddress(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->macAddress('foo');
@@ -678,7 +678,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" nvarchar(17) not null', $statements[0]);
     }
 
-    public function testAddingGeometry()
+    public function testAddingGeometry(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->geometry('coordinates');
@@ -688,7 +688,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
-    public function testAddingPoint()
+    public function testAddingPoint(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->point('coordinates');
@@ -698,7 +698,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
-    public function testAddingLineString()
+    public function testAddingLineString(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->linestring('coordinates');
@@ -708,7 +708,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
-    public function testAddingPolygon()
+    public function testAddingPolygon(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->polygon('coordinates');
@@ -718,7 +718,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
-    public function testAddingGeometryCollection()
+    public function testAddingGeometryCollection(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->geometrycollection('coordinates');
@@ -728,7 +728,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
-    public function testAddingMultiPoint()
+    public function testAddingMultiPoint(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->multipoint('coordinates');
@@ -738,7 +738,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
-    public function testAddingMultiLineString()
+    public function testAddingMultiLineString(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->multilinestring('coordinates');
@@ -748,7 +748,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
-    public function testAddingMultiPolygon()
+    public function testAddingMultiPolygon(): void
     {
         $blueprint = new Blueprint('geo');
         $blueprint->multipolygon('coordinates');

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\ConnectionResolverInterface;
 
 class SeedCommandTest extends TestCase
 {
-    public function testHandle()
+    public function testHandle(): void
     {
         $seeder = Mockery::mock(Seeder::class);
         $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
@@ -36,7 +36,7 @@ class SeedCommandTest extends TestCase
         $container->shouldHaveReceived('call')->with([$command, 'handle']);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -7,7 +7,7 @@ use Illuminate\Encryption\Encrypter;
 
 class EncrypterTest extends TestCase
 {
-    public function testEncryption()
+    public function testEncryption(): void
     {
         $e = new Encrypter(str_repeat('a', 16));
         $encrypted = $e->encrypt('foo');
@@ -15,7 +15,7 @@ class EncrypterTest extends TestCase
         $this->assertEquals('foo', $e->decrypt($encrypted));
     }
 
-    public function testRawStringEncryption()
+    public function testRawStringEncryption(): void
     {
         $e = new Encrypter(str_repeat('a', 16));
         $encrypted = $e->encryptString('foo');
@@ -23,7 +23,7 @@ class EncrypterTest extends TestCase
         $this->assertEquals('foo', $e->decryptString($encrypted));
     }
 
-    public function testEncryptionUsingBase64EncodedKey()
+    public function testEncryptionUsingBase64EncodedKey(): void
     {
         $e = new Encrypter(random_bytes(16));
         $encrypted = $e->encrypt('foo');
@@ -31,7 +31,7 @@ class EncrypterTest extends TestCase
         $this->assertEquals('foo', $e->decrypt($encrypted));
     }
 
-    public function testWithCustomCipher()
+    public function testWithCustomCipher(): void
     {
         $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
         $encrypted = $e->encrypt('bar');
@@ -48,7 +48,7 @@ class EncrypterTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
      */
-    public function testDoNoAllowLongerKey()
+    public function testDoNoAllowLongerKey(): void
     {
         new Encrypter(str_repeat('z', 32));
     }
@@ -57,7 +57,7 @@ class EncrypterTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
      */
-    public function testWithBadKeyLength()
+    public function testWithBadKeyLength(): void
     {
         new Encrypter(str_repeat('a', 5));
     }
@@ -66,7 +66,7 @@ class EncrypterTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
      */
-    public function testWithBadKeyLengthAlternativeCipher()
+    public function testWithBadKeyLengthAlternativeCipher(): void
     {
         new Encrypter(str_repeat('a', 16), 'AES-256-CFB8');
     }
@@ -75,7 +75,7 @@ class EncrypterTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
      */
-    public function testWithUnsupportedCipher()
+    public function testWithUnsupportedCipher(): void
     {
         new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
     }
@@ -84,7 +84,7 @@ class EncrypterTest extends TestCase
      * @expectedException \Illuminate\Contracts\Encryption\DecryptException
      * @expectedExceptionMessage The payload is invalid.
      */
-    public function testExceptionThrownWhenPayloadIsInvalid()
+    public function testExceptionThrownWhenPayloadIsInvalid(): void
     {
         $e = new Encrypter(str_repeat('a', 16));
         $payload = $e->encrypt('foo');
@@ -96,7 +96,7 @@ class EncrypterTest extends TestCase
      * @expectedException \Illuminate\Contracts\Encryption\DecryptException
      * @expectedExceptionMessage The MAC is invalid.
      */
-    public function testExceptionThrownWithDifferentKey()
+    public function testExceptionThrownWithDifferentKey(): void
     {
         $a = new Encrypter(str_repeat('a', 16));
         $b = new Encrypter(str_repeat('b', 16));

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -9,12 +9,12 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 class EventsDispatcherTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBasicEventExecution()
+    public function testBasicEventExecution(): void
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
@@ -25,7 +25,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertEquals('bar', $_SERVER['__event.test']);
     }
 
-    public function testHaltingEventExecution()
+    public function testHaltingEventExecution(): void
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
@@ -40,7 +40,7 @@ class EventsDispatcherTest extends TestCase
         $d->until('foo', ['bar']);
     }
 
-    public function testContainerResolutionOfEventHandlers()
+    public function testContainerResolutionOfEventHandlers(): void
     {
         $d = new Dispatcher($container = m::mock('Illuminate\Container\Container'));
         $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock('stdClass'));
@@ -49,7 +49,7 @@ class EventsDispatcherTest extends TestCase
         $d->fire('foo', ['foo', 'bar']);
     }
 
-    public function testContainerResolutionOfEventHandlersWithDefaultMethods()
+    public function testContainerResolutionOfEventHandlersWithDefaultMethods(): void
     {
         $d = new Dispatcher($container = m::mock('Illuminate\Container\Container'));
         $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock('stdClass'));
@@ -58,7 +58,7 @@ class EventsDispatcherTest extends TestCase
         $d->fire('foo', ['foo', 'bar']);
     }
 
-    public function testQueuedEventsAreFired()
+    public function testQueuedEventsAreFired(): void
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
@@ -72,7 +72,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertEquals('taylor', $_SERVER['__event.test']);
     }
 
-    public function testQueuedEventsCanBeForgotten()
+    public function testQueuedEventsCanBeForgotten(): void
     {
         $_SERVER['__event.test'] = 'unset';
         $d = new Dispatcher;
@@ -86,7 +86,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertEquals('unset', $_SERVER['__event.test']);
     }
 
-    public function testWildcardListeners()
+    public function testWildcardListeners(): void
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
@@ -104,7 +104,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertEquals('wildcard', $_SERVER['__event.test']);
     }
 
-    public function testWildcardListenersCacheFlushing()
+    public function testWildcardListenersCacheFlushing(): void
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
@@ -121,7 +121,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertEquals('new_wildcard', $_SERVER['__event.test']);
     }
 
-    public function testListenersCanBeRemoved()
+    public function testListenersCanBeRemoved(): void
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
@@ -134,7 +134,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertFalse(isset($_SERVER['__event.test']));
     }
 
-    public function testWildcardListenersCanBeRemoved()
+    public function testWildcardListenersCanBeRemoved(): void
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
@@ -147,7 +147,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertFalse(isset($_SERVER['__event.test']));
     }
 
-    public function testListenersCanBeFound()
+    public function testListenersCanBeFound(): void
     {
         $d = new Dispatcher;
         $this->assertFalse($d->hasListeners('foo'));
@@ -157,7 +157,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertTrue($d->hasListeners('foo'));
     }
 
-    public function testWildcardListenersCanBeFound()
+    public function testWildcardListenersCanBeFound(): void
     {
         $d = new Dispatcher;
         $this->assertFalse($d->hasListeners('foo.*'));
@@ -167,7 +167,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertTrue($d->hasListeners('foo.*'));
     }
 
-    public function testEventPassedFirstToWildcards()
+    public function testEventPassedFirstToWildcards(): void
     {
         $d = new Dispatcher;
         $d->listen('foo.*', function ($event, $data) {
@@ -184,7 +184,7 @@ class EventsDispatcherTest extends TestCase
         $d->fire('foo.bar', ['first', 'second']);
     }
 
-    public function testQueuedEventHandlersAreQueued()
+    public function testQueuedEventHandlersAreQueued(): void
     {
         $d = new Dispatcher;
         $queue = m::mock('Illuminate\Contracts\Queue\Queue');
@@ -201,7 +201,7 @@ class EventsDispatcherTest extends TestCase
         $d->fire('some.event', ['foo', 'bar']);
     }
 
-    public function testClassesWork()
+    public function testClassesWork(): void
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
@@ -213,7 +213,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame('baz', $_SERVER['__event.test']);
     }
 
-    public function testInterfacesWork()
+    public function testInterfacesWork(): void
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
@@ -225,7 +225,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame('bar', $_SERVER['__event.test']);
     }
 
-    public function testBothClassesAndInterfacesWork()
+    public function testBothClassesAndInterfacesWork(): void
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
@@ -241,7 +241,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame('baar', $_SERVER['__event.test2']);
     }
 
-    public function testShouldBroadcastSuccess()
+    public function testShouldBroadcastSuccess(): void
     {
         $d = m::mock(Dispatcher::class);
 
@@ -252,7 +252,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertTrue($d->shouldBroadcast([$event]));
     }
 
-    public function testShouldBroadcastFail()
+    public function testShouldBroadcastFail(): void
     {
         $d = m::mock(Dispatcher::class);
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -14,19 +14,19 @@ class FilesystemAdapterTest extends TestCase
     private $tempDir;
     private $filesystem;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->tempDir = __DIR__.'/tmp';
         $this->filesystem = new Filesystem(new Local($this->tempDir));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $filesystem = new Filesystem(new Local(dirname($this->tempDir)));
         $filesystem->deleteDir(basename($this->tempDir));
     }
 
-    public function testResponse()
+    public function testResponse(): void
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $files = new FilesystemAdapter($this->filesystem);
@@ -41,7 +41,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals('inline; filename="file.txt"', $response->headers->get('content-disposition'));
     }
 
-    public function testDownload()
+    public function testDownload(): void
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $files = new FilesystemAdapter($this->filesystem);
@@ -50,42 +50,42 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals('attachment; filename="hello.txt"', $response->headers->get('content-disposition'));
     }
 
-    public function testExists()
+    public function testExists(): void
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $this->assertTrue($filesystemAdapter->exists('file.txt'));
     }
 
-    public function testPath()
+    public function testPath(): void
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $this->assertEquals($this->tempDir.'/file.txt', $filesystemAdapter->path('file.txt'));
     }
 
-    public function testGet()
+    public function testGet(): void
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $this->assertEquals('Hello World', $filesystemAdapter->get('file.txt'));
     }
 
-    public function testGetFileNotFound()
+    public function testGetFileNotFound(): void
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $this->expectException(FileNotFoundException::class);
         $filesystemAdapter->get('file.txt');
     }
 
-    public function testPut()
+    public function testPut(): void
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $filesystemAdapter->put('file.txt', 'Something inside');
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Something inside');
     }
 
-    public function testPrepend()
+    public function testPrepend(): void
     {
         file_put_contents($this->tempDir.'/file.txt', 'World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
@@ -93,7 +93,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', "Hello \nWorld");
     }
 
-    public function testAppend()
+    public function testAppend(): void
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello ');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
@@ -101,7 +101,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', "Hello \nMoon");
     }
 
-    public function testDelete()
+    public function testDelete(): void
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
@@ -109,13 +109,13 @@ class FilesystemAdapterTest extends TestCase
         $this->assertFalse(file_exists($this->tempDir.'/file.txt'));
     }
 
-    public function testDeleteReturnsFalseWhenFileNotFound()
+    public function testDeleteReturnsFalseWhenFileNotFound(): void
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $this->assertFalse($filesystemAdapter->delete('file.txt'));
     }
 
-    public function testCopy()
+    public function testCopy(): void
     {
         $data = '33232';
         mkdir($this->tempDir.'/foo');
@@ -131,7 +131,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($data, file_get_contents($this->tempDir.'/foo/foo2.txt'));
     }
 
-    public function testMove()
+    public function testMove(): void
     {
         $data = '33232';
         mkdir($this->tempDir.'/foo');

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -13,13 +13,13 @@ class FilesystemTest extends TestCase
 {
     private $tempDir;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->tempDir = __DIR__.'/tmp';
         mkdir($this->tempDir);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
 
@@ -27,21 +27,21 @@ class FilesystemTest extends TestCase
         $files->deleteDirectory($this->tempDir);
     }
 
-    public function testGetRetrievesFiles()
+    public function testGetRetrievesFiles(): void
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');
         $files = new Filesystem;
         $this->assertEquals('Hello World', $files->get($this->tempDir.'/file.txt'));
     }
 
-    public function testPutStoresFiles()
+    public function testPutStoresFiles(): void
     {
         $files = new Filesystem;
         $files->put($this->tempDir.'/file.txt', 'Hello World');
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello World');
     }
 
-    public function testSetChmod()
+    public function testSetChmod(): void
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');
         $files = new Filesystem;
@@ -50,7 +50,7 @@ class FilesystemTest extends TestCase
         $this->assertEquals('0755', $filePermission);
     }
 
-    public function testGetChmod()
+    public function testGetChmod(): void
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');
         chmod($this->tempDir.'/file.txt', 0755);
@@ -60,7 +60,7 @@ class FilesystemTest extends TestCase
         $this->assertEquals('0755', $filePermisson);
     }
 
-    public function testDeleteRemovesFiles()
+    public function testDeleteRemovesFiles(): void
     {
         file_put_contents($this->tempDir.'/file1.txt', 'Hello World');
         file_put_contents($this->tempDir.'/file2.txt', 'Hello World');
@@ -75,7 +75,7 @@ class FilesystemTest extends TestCase
         $this->assertFileNotExists($this->tempDir.'/file3.txt');
     }
 
-    public function testPrependExistingFiles()
+    public function testPrependExistingFiles(): void
     {
         $files = new Filesystem;
         $files->put($this->tempDir.'/file.txt', 'World');
@@ -83,14 +83,14 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello World');
     }
 
-    public function testPrependNewFiles()
+    public function testPrependNewFiles(): void
     {
         $files = new Filesystem;
         $files->prepend($this->tempDir.'/file.txt', 'Hello World');
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello World');
     }
 
-    public function testDeleteDirectory()
+    public function testDeleteDirectory(): void
     {
         mkdir($this->tempDir.'/foo');
         file_put_contents($this->tempDir.'/foo/file.txt', 'Hello World');
@@ -100,7 +100,7 @@ class FilesystemTest extends TestCase
         $this->assertFileNotExists($this->tempDir.'/foo/file.txt');
     }
 
-    public function testDeleteDirectoryReturnFalseWhenNotADirectory()
+    public function testDeleteDirectoryReturnFalseWhenNotADirectory(): void
     {
         mkdir($this->tempDir.'/foo');
         file_put_contents($this->tempDir.'/foo/file.txt', 'Hello World');
@@ -108,7 +108,7 @@ class FilesystemTest extends TestCase
         $this->assertFalse($files->deleteDirectory($this->tempDir.'/foo/file.txt'));
     }
 
-    public function testCleanDirectory()
+    public function testCleanDirectory(): void
     {
         mkdir($this->tempDir.'/foo');
         file_put_contents($this->tempDir.'/foo/file.txt', 'Hello World');
@@ -118,7 +118,7 @@ class FilesystemTest extends TestCase
         $this->assertFileNotExists($this->tempDir.'/foo/file.txt');
     }
 
-    public function testMacro()
+    public function testMacro(): void
     {
         file_put_contents($this->tempDir.'/foo.txt', 'Hello World');
         $files = new Filesystem;
@@ -129,7 +129,7 @@ class FilesystemTest extends TestCase
         $this->assertEquals('Hello World', $files->getFoo());
     }
 
-    public function testFilesMethod()
+    public function testFilesMethod(): void
     {
         mkdir($this->tempDir.'/foo');
         file_put_contents($this->tempDir.'/foo/1.txt', '1');
@@ -142,13 +142,13 @@ class FilesystemTest extends TestCase
         unset($files);
     }
 
-    public function testCopyDirectoryReturnsFalseIfSourceIsntDirectory()
+    public function testCopyDirectoryReturnsFalseIfSourceIsntDirectory(): void
     {
         $files = new Filesystem;
         $this->assertFalse($files->copyDirectory($this->tempDir.'/foo/bar/baz/breeze/boom', $this->tempDir));
     }
 
-    public function testCopyDirectoryMovesEntireDirectory()
+    public function testCopyDirectoryMovesEntireDirectory(): void
     {
         mkdir($this->tempDir.'/tmp', 0777, true);
         file_put_contents($this->tempDir.'/tmp/foo.txt', '');
@@ -165,7 +165,7 @@ class FilesystemTest extends TestCase
         $this->assertFileExists($this->tempDir.'/tmp2/nested/baz.txt');
     }
 
-    public function testMoveDirectoryMovesEntireDirectory()
+    public function testMoveDirectoryMovesEntireDirectory(): void
     {
         mkdir($this->tempDir.'/tmp', 0777, true);
         file_put_contents($this->tempDir.'/tmp/foo.txt', '');
@@ -183,7 +183,7 @@ class FilesystemTest extends TestCase
         $this->assertDirectoryNotExists($this->tempDir.'/tmp');
     }
 
-    public function testMoveDirectoryMovesEntireDirectoryAndOverwrites()
+    public function testMoveDirectoryMovesEntireDirectoryAndOverwrites(): void
     {
         mkdir($this->tempDir.'/tmp', 0777, true);
         file_put_contents($this->tempDir.'/tmp/foo.txt', '');
@@ -206,7 +206,7 @@ class FilesystemTest extends TestCase
         $this->assertDirectoryNotExists($this->tempDir.'/tmp');
     }
 
-    public function testMoveDirectoryReturnsFalseWhileOverwritingAndUnableToDeleteDestinationDirectory()
+    public function testMoveDirectoryReturnsFalseWhileOverwritingAndUnableToDeleteDestinationDirectory(): void
     {
         mkdir($this->tempDir.'/tmp', 0777, true);
         file_put_contents($this->tempDir.'/tmp/foo.txt', '');
@@ -220,13 +220,13 @@ class FilesystemTest extends TestCase
     /**
      * @expectedException \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    public function testGetThrowsExceptionNonexisitingFile()
+    public function testGetThrowsExceptionNonexisitingFile(): void
     {
         $files = new Filesystem;
         $files->get($this->tempDir.'/unknown-file.txt');
     }
 
-    public function testGetRequireReturnsProperly()
+    public function testGetRequireReturnsProperly(): void
     {
         file_put_contents($this->tempDir.'/file.php', '<?php return "Howdy?"; ?>');
         $files = new Filesystem;
@@ -236,13 +236,13 @@ class FilesystemTest extends TestCase
     /**
      * @expectedException \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    public function testGetRequireThrowsExceptionNonexisitingFile()
+    public function testGetRequireThrowsExceptionNonexisitingFile(): void
     {
         $files = new Filesystem;
         $files->getRequire($this->tempDir.'/file.php');
     }
 
-    public function testAppendAddsDataToFile()
+    public function testAppendAddsDataToFile(): void
     {
         file_put_contents($this->tempDir.'/file.txt', 'foo');
         $files = new Filesystem;
@@ -252,7 +252,7 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'foobar');
     }
 
-    public function testMoveMovesFiles()
+    public function testMoveMovesFiles(): void
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem;
@@ -261,49 +261,49 @@ class FilesystemTest extends TestCase
         $this->assertFileNotExists($this->tempDir.'/foo.txt');
     }
 
-    public function testNameReturnsName()
+    public function testNameReturnsName(): void
     {
         file_put_contents($this->tempDir.'/foobar.txt', 'foo');
         $filesystem = new Filesystem;
         $this->assertEquals('foobar', $filesystem->name($this->tempDir.'/foobar.txt'));
     }
 
-    public function testExtensionReturnsExtension()
+    public function testExtensionReturnsExtension(): void
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem;
         $this->assertEquals('txt', $files->extension($this->tempDir.'/foo.txt'));
     }
 
-    public function testBasenameReturnsBasename()
+    public function testBasenameReturnsBasename(): void
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem;
         $this->assertEquals('foo.txt', $files->basename($this->tempDir.'/foo.txt'));
     }
 
-    public function testDirnameReturnsDirectory()
+    public function testDirnameReturnsDirectory(): void
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem;
         $this->assertEquals($this->tempDir, $files->dirname($this->tempDir.'/foo.txt'));
     }
 
-    public function testTypeIdentifiesFile()
+    public function testTypeIdentifiesFile(): void
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem;
         $this->assertEquals('file', $files->type($this->tempDir.'/foo.txt'));
     }
 
-    public function testTypeIdentifiesDirectory()
+    public function testTypeIdentifiesDirectory(): void
     {
         mkdir($this->tempDir.'/foo');
         $files = new Filesystem;
         $this->assertEquals('dir', $files->type($this->tempDir.'/foo'));
     }
 
-    public function testSizeOutputsSize()
+    public function testSizeOutputsSize(): void
     {
         $size = file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem;
@@ -313,14 +313,14 @@ class FilesystemTest extends TestCase
     /**
      * @requires extension fileinfo
      */
-    public function testMimeTypeOutputsMimeType()
+    public function testMimeTypeOutputsMimeType(): void
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem;
         $this->assertEquals('text/plain', $files->mimeType($this->tempDir.'/foo.txt'));
     }
 
-    public function testIsWritable()
+    public function testIsWritable(): void
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem;
@@ -330,7 +330,7 @@ class FilesystemTest extends TestCase
         $this->assertTrue($files->isWritable($this->tempDir.'/foo.txt'));
     }
 
-    public function testIsReadable()
+    public function testIsReadable(): void
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem;
@@ -346,7 +346,7 @@ class FilesystemTest extends TestCase
         $this->assertFalse($files->isReadable($this->tempDir.'/doesnotexist.txt'));
     }
 
-    public function testGlobFindsFiles()
+    public function testGlobFindsFiles(): void
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         file_put_contents($this->tempDir.'/bar.txt', 'bar');
@@ -356,7 +356,7 @@ class FilesystemTest extends TestCase
         $this->assertContains($this->tempDir.'/bar.txt', $glob);
     }
 
-    public function testAllFilesFindsFiles()
+    public function testAllFilesFindsFiles(): void
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         file_put_contents($this->tempDir.'/bar.txt', 'bar');
@@ -369,7 +369,7 @@ class FilesystemTest extends TestCase
         $this->assertContains('bar.txt', $allFiles);
     }
 
-    public function testDirectoriesFindsDirectories()
+    public function testDirectoriesFindsDirectories(): void
     {
         mkdir($this->tempDir.'/foo');
         mkdir($this->tempDir.'/bar');
@@ -379,7 +379,7 @@ class FilesystemTest extends TestCase
         $this->assertContains($this->tempDir.DIRECTORY_SEPARATOR.'bar', $directories);
     }
 
-    public function testMakeDirectory()
+    public function testMakeDirectory(): void
     {
         $files = new Filesystem;
         $this->assertTrue($files->makeDirectory($this->tempDir.'/foo'));
@@ -389,7 +389,7 @@ class FilesystemTest extends TestCase
     /**
      * @requires extension pcntl
      */
-    public function testSharedGet()
+    public function testSharedGet(): void
     {
         if (! function_exists('pcntl_fork')) {
             $this->markTestSkipped('Skipping since the pcntl extension is not available');
@@ -418,7 +418,7 @@ class FilesystemTest extends TestCase
         $this->assertTrue($result === 1);
     }
 
-    public function testRequireOnceRequiresFileProperly()
+    public function testRequireOnceRequiresFileProperly(): void
     {
         $filesystem = new Filesystem;
         mkdir($this->tempDir.'/foo');
@@ -430,7 +430,7 @@ class FilesystemTest extends TestCase
         $this->assertFalse(function_exists('random_function_xyz_changed'));
     }
 
-    public function testCopyCopiesFileProperly()
+    public function testCopyCopiesFileProperly(): void
     {
         $filesystem = new Filesystem;
         $data = 'contents';
@@ -441,7 +441,7 @@ class FilesystemTest extends TestCase
         $this->assertEquals($data, file_get_contents($this->tempDir.'/foo/foo2.txt'));
     }
 
-    public function testIsFileChecksFilesProperly()
+    public function testIsFileChecksFilesProperly(): void
     {
         $filesystem = new Filesystem;
         mkdir($this->tempDir.'/foo');
@@ -450,7 +450,7 @@ class FilesystemTest extends TestCase
         $this->assertFalse($filesystem->isFile($this->tempDir.'./foo'));
     }
 
-    public function testFilesMethodReturnsFileInfoObjects()
+    public function testFilesMethodReturnsFileInfoObjects(): void
     {
         mkdir($this->tempDir.'/foo');
         file_put_contents($this->tempDir.'/foo/1.txt', '1');
@@ -463,7 +463,7 @@ class FilesystemTest extends TestCase
         unset($files);
     }
 
-    public function testAllFilesReturnsFileInfoObjects()
+    public function testAllFilesReturnsFileInfoObjects(): void
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         file_put_contents($this->tempDir.'/bar.txt', 'bar');
@@ -474,7 +474,7 @@ class FilesystemTest extends TestCase
         }
     }
 
-    public function testCreateFtpDriver()
+    public function testCreateFtpDriver(): void
     {
         $filesystem = new FilesystemManager(new Application());
 
@@ -492,7 +492,7 @@ class FilesystemTest extends TestCase
         $this->assertEquals('admin', $adapter->getUsername());
     }
 
-    public function testHash()
+    public function testHash(): void
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $filesystem = new Filesystem;

--- a/tests/Foundation/FoundationAliasLoaderTest.php
+++ b/tests/Foundation/FoundationAliasLoaderTest.php
@@ -7,7 +7,7 @@ use Illuminate\Foundation\AliasLoader;
 
 class FoundationAliasLoaderTest extends TestCase
 {
-    public function testLoaderCanBeCreatedAndRegisteredOnce()
+    public function testLoaderCanBeCreatedAndRegisteredOnce(): void
     {
         $loader = AliasLoader::getInstance(['foo' => 'bar']);
 
@@ -18,7 +18,7 @@ class FoundationAliasLoaderTest extends TestCase
         $this->assertTrue($loader->isRegistered());
     }
 
-    public function testGetInstanceCreatesOneInstance()
+    public function testGetInstanceCreatesOneInstance(): void
     {
         $loader = AliasLoader::getInstance(['foo' => 'bar']);
         $this->assertSame($loader, AliasLoader::getInstance());

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -9,12 +9,12 @@ use Illuminate\Support\ServiceProvider;
 
 class FoundationApplicationTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testSetLocaleSetsLocaleAndFiresLocaleChangedEvent()
+    public function testSetLocaleSetsLocaleAndFiresLocaleChangedEvent(): void
     {
         $app = new Application;
         $app['config'] = $config = m::mock('stdClass');
@@ -27,7 +27,7 @@ class FoundationApplicationTest extends TestCase
         $app->setLocale('foo');
     }
 
-    public function testServiceProvidersAreCorrectlyRegistered()
+    public function testServiceProvidersAreCorrectlyRegistered(): void
     {
         $provider = m::mock('Illuminate\Tests\Foundation\ApplicationBasicServiceProviderStub');
         $class = get_class($provider);
@@ -38,7 +38,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertTrue(in_array($class, $app->getLoadedProviders()));
     }
 
-    public function testClassesAreBoundWhenServiceProviderIsRegistered()
+    public function testClassesAreBoundWhenServiceProviderIsRegistered(): void
     {
         $app = new Application;
         $provider = new ServiceProviderForTestingThree($app);
@@ -49,7 +49,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertInstanceOf(ConcreteClass::class, $app->make(AbstractClass::class));
     }
 
-    public function testSingletonsAreCreatedWhenServiceProviderIsRegistered()
+    public function testSingletonsAreCreatedWhenServiceProviderIsRegistered(): void
     {
         $app = new Application;
         $provider = new ServiceProviderForTestingThree($app);
@@ -62,7 +62,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertSame($instance, $app->make(AbstractClass::class));
     }
 
-    public function testServiceProvidersAreCorrectlyRegisteredWhenRegisterMethodIsNotPresent()
+    public function testServiceProvidersAreCorrectlyRegisteredWhenRegisterMethodIsNotPresent(): void
     {
         $provider = m::mock('Illuminate\Support\ServiceProvider');
         $class = get_class($provider);
@@ -73,7 +73,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertTrue(in_array($class, $app->getLoadedProviders()));
     }
 
-    public function testDeferredServicesMarkedAsBound()
+    public function testDeferredServicesMarkedAsBound(): void
     {
         $app = new Application;
         $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub']);
@@ -81,7 +81,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertEquals('foo', $app->make('foo'));
     }
 
-    public function testDeferredServicesAreSharedProperly()
+    public function testDeferredServicesAreSharedProperly(): void
     {
         $app = new Application;
         $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredSharedServiceProviderStub']);
@@ -93,7 +93,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertSame($one, $two);
     }
 
-    public function testDeferredServicesCanBeExtended()
+    public function testDeferredServicesCanBeExtended(): void
     {
         $app = new Application;
         $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub']);
@@ -103,7 +103,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertEquals('foobar', $app->make('foo'));
     }
 
-    public function testDeferredServiceProviderIsRegisteredOnlyOnce()
+    public function testDeferredServiceProviderIsRegisteredOnlyOnce(): void
     {
         $app = new Application;
         $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderCountStub']);
@@ -113,7 +113,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertEquals(1, ApplicationDeferredServiceProviderCountStub::$count);
     }
 
-    public function testDeferredServiceDontRunWhenInstanceSet()
+    public function testDeferredServiceDontRunWhenInstanceSet(): void
     {
         $app = new Application;
         $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub']);
@@ -122,7 +122,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertEquals($instance, 'bar');
     }
 
-    public function testDeferredServicesAreLazilyInitialized()
+    public function testDeferredServicesAreLazilyInitialized(): void
     {
         ApplicationDeferredServiceProviderStub::$initialized = false;
         $app = new Application;
@@ -137,7 +137,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertTrue(ApplicationDeferredServiceProviderStub::$initialized);
     }
 
-    public function testDeferredServicesCanRegisterFactories()
+    public function testDeferredServicesCanRegisterFactories(): void
     {
         $app = new Application;
         $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationFactoryProviderStub']);
@@ -147,7 +147,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertEquals(3, $app->make('foo'));
     }
 
-    public function testSingleProviderCanProvideMultipleDeferredServices()
+    public function testSingleProviderCanProvideMultipleDeferredServices(): void
     {
         $app = new Application;
         $app->setDeferredServices([
@@ -158,7 +158,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertEquals('foobar', $app->make('bar'));
     }
 
-    public function testEnvironment()
+    public function testEnvironment(): void
     {
         $app = new Application;
         $app['env'] = 'foo';
@@ -176,7 +176,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertFalse($app->environment(['qux', 'bar']));
     }
 
-    public function testMethodAfterLoadingEnvironmentAddsClosure()
+    public function testMethodAfterLoadingEnvironmentAddsClosure(): void
     {
         $app = new Application;
         $closure = function () {
@@ -186,7 +186,7 @@ class FoundationApplicationTest extends TestCase
         // $this->assertSame($closure, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables')[0]);
     }
 
-    public function testBeforeBootstrappingAddsClosure()
+    public function testBeforeBootstrappingAddsClosure(): void
     {
         $app = new Application;
         $closure = function () {
@@ -196,7 +196,7 @@ class FoundationApplicationTest extends TestCase
         // $this->assertSame($closure, $app['events']->getListeners('bootstrapping: Illuminate\Foundation\Bootstrap\RegisterFacades')[0]);
     }
 
-    public function testAfterBootstrappingAddsClosure()
+    public function testAfterBootstrappingAddsClosure(): void
     {
         $app = new Application;
         $closure = function () {

--- a/tests/Foundation/FoundationAuthenticationTest.php
+++ b/tests/Foundation/FoundationAuthenticationTest.php
@@ -49,12 +49,12 @@ class FoundationAuthenticationTest extends TestCase
         return $guard;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testAssertAuthenticated()
+    public function testAssertAuthenticated(): void
     {
         $this->mockGuard()
             ->shouldReceive('check')
@@ -64,7 +64,7 @@ class FoundationAuthenticationTest extends TestCase
         $this->assertAuthenticated();
     }
 
-    public function testAssertGuest()
+    public function testAssertGuest(): void
     {
         $this->mockGuard()
             ->shouldReceive('check')
@@ -74,7 +74,7 @@ class FoundationAuthenticationTest extends TestCase
         $this->assertGuest();
     }
 
-    public function testAssertAuthenticatedAs()
+    public function testAssertAuthenticatedAs(): void
     {
         $expected = m::mock(Authenticatable::class);
         $expected->shouldReceive('getAuthIdentifier')
@@ -112,14 +112,14 @@ class FoundationAuthenticationTest extends TestCase
             ->andReturn($provider);
     }
 
-    public function testAssertCredentials()
+    public function testAssertCredentials(): void
     {
         $this->setupProvider($this->credentials);
 
         $this->assertCredentials($this->credentials);
     }
 
-    public function testAssertCredentialsMissing()
+    public function testAssertCredentialsMissing(): void
     {
         $credentials = [
             'email' => 'invalid',

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 
 class FoundationAuthorizesRequestsTraitTest extends TestCase
 {
-    public function test_basic_gate_check()
+    public function test_basic_gate_check(): void
     {
         unset($_SERVER['_test.authorizes.trait']);
 
@@ -33,7 +33,7 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
      * @expectedExceptionMessage This action is unauthorized.
      */
-    public function test_exception_is_thrown_if_gate_check_fails()
+    public function test_exception_is_thrown_if_gate_check_fails(): void
     {
         $gate = $this->getBasicGate();
 
@@ -44,7 +44,7 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
         (new FoundationTestAuthorizeTraitClass)->authorize('baz');
     }
 
-    public function test_policies_may_be_called()
+    public function test_policies_may_be_called(): void
     {
         unset($_SERVER['_test.authorizes.trait.policy']);
 
@@ -58,7 +58,7 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
         $this->assertTrue($_SERVER['_test.authorizes.trait.policy']);
     }
 
-    public function test_policy_method_may_be_guessed_passing_model_instance()
+    public function test_policy_method_may_be_guessed_passing_model_instance(): void
     {
         unset($_SERVER['_test.authorizes.trait.policy']);
 
@@ -72,7 +72,7 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
         $this->assertTrue($_SERVER['_test.authorizes.trait.policy']);
     }
 
-    public function test_policy_method_may_be_guessed_passing_class_name()
+    public function test_policy_method_may_be_guessed_passing_class_name(): void
     {
         unset($_SERVER['_test.authorizes.trait.policy']);
 
@@ -86,7 +86,7 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
         $this->assertTrue($_SERVER['_test.authorizes.trait.policy']);
     }
 
-    public function test_policy_method_may_be_guessed_and_normalized()
+    public function test_policy_method_may_be_guessed_and_normalized(): void
     {
         unset($_SERVER['_test.authorizes.trait.policy']);
 

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class FoundationComposerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testDumpAutoloadRunsTheCorrectCommand()
+    public function testDumpAutoloadRunsTheCorrectCommand(): void
     {
         $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
 
@@ -26,7 +26,7 @@ class FoundationComposerTest extends TestCase
         $composer->dumpAutoloads();
     }
 
-    public function testDumpAutoloadRunsTheCorrectCommandWhenComposerIsntPresent()
+    public function testDumpAutoloadRunsTheCorrectCommandWhenComposerIsntPresent(): void
     {
         $composer = $this->getMockBuilder('Illuminate\Support\Composer')->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__])->getMock();
         $files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(false);

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class FoundationEnvironmentDetectorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testClosureCanBeUsedForCustomEnvironmentDetection()
+    public function testClosureCanBeUsedForCustomEnvironmentDetection(): void
     {
         $env = new \Illuminate\Foundation\EnvironmentDetector;
 
@@ -22,7 +22,7 @@ class FoundationEnvironmentDetectorTest extends TestCase
         $this->assertEquals('foobar', $result);
     }
 
-    public function testConsoleEnvironmentDetection()
+    public function testConsoleEnvironmentDetection(): void
     {
         $env = new \Illuminate\Foundation\EnvironmentDetector;
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -23,7 +23,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     protected $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->config = m::mock(Config::class);
 
@@ -45,12 +45,12 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->handler = new Handler($this->container);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testHandlerReportsExceptionAsContext()
+    public function testHandlerReportsExceptionAsContext(): void
     {
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);
@@ -59,7 +59,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->handler->report(new \RuntimeException('Exception message'));
     }
 
-    public function testReturnsJsonWithStackTraceWhenAjaxRequestAndDebugTrue()
+    public function testReturnsJsonWithStackTraceWhenAjaxRequestAndDebugTrue(): void
     {
         $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(true);
         $this->request->shouldReceive('expectsJson')->once()->andReturn(true);
@@ -73,14 +73,14 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertContains('"trace":', $response);
     }
 
-    public function testReturnsCustomResponseWhenExceptionImplementsResponsable()
+    public function testReturnsCustomResponseWhenExceptionImplementsResponsable(): void
     {
         $response = $this->handler->render($this->request, new CustomException)->getContent();
 
         $this->assertSame('{"response":"My custom exception response"}', $response);
     }
 
-    public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalseAndExceptionMessageIsMasked()
+    public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalseAndExceptionMessageIsMasked(): void
     {
         $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(false);
         $this->request->shouldReceive('expectsJson')->once()->andReturn(true);
@@ -95,7 +95,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertNotContains('"trace":', $response);
     }
 
-    public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalseAndHttpExceptionErrorIsShown()
+    public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalseAndHttpExceptionErrorIsShown(): void
     {
         $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(false);
         $this->request->shouldReceive('expectsJson')->once()->andReturn(true);
@@ -110,7 +110,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertNotContains('"trace":', $response);
     }
 
-    public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalseAndAccessDeniedHttpExceptionErrorIsShown()
+    public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalseAndAccessDeniedHttpExceptionErrorIsShown(): void
     {
         $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(false);
         $this->request->shouldReceive('expectsJson')->once()->andReturn(true);

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -18,14 +18,14 @@ class FoundationFormRequestTest extends TestCase
 {
     protected $mocks = [];
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
 
         $this->mocks = [];
     }
 
-    public function test_validated_method_returns_the_validated_data()
+    public function test_validated_method_returns_the_validated_data(): void
     {
         $request = $this->createRequest(['name' => 'specified', 'with' => 'extras']);
 
@@ -37,7 +37,7 @@ class FoundationFormRequestTest extends TestCase
     /**
      * @expectedException \Illuminate\Validation\ValidationException
      */
-    public function test_validate_throws_when_validation_fails()
+    public function test_validate_throws_when_validation_fails(): void
     {
         $request = $this->createRequest(['no' => 'name']);
 
@@ -50,12 +50,12 @@ class FoundationFormRequestTest extends TestCase
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
      * @expectedExceptionMessage This action is unauthorized.
      */
-    public function test_validate_method_throws_when_authorization_fails()
+    public function test_validate_method_throws_when_authorization_fails(): void
     {
         $this->createRequest([], FoundationTestFormRequestForbiddenStub::class)->validateResolved();
     }
 
-    public function test_prepare_for_validation_runs_before_validation()
+    public function test_prepare_for_validation_runs_before_validation(): void
     {
         $this->createRequest([], FoundationTestFormRequestHooks::class)->validateResolved();
     }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -8,12 +8,12 @@ use Illuminate\Foundation\Application;
 
 class FoundationHelpersTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testCache()
+    public function testCache(): void
     {
         $app = new Application;
         $app['cache'] = $cache = m::mock('stdClass');
@@ -38,12 +38,12 @@ class FoundationHelpersTest extends TestCase
      * @expectedException \Exception
      * @expectedExceptionMessage You must specify an expiration time when setting a value in the cache.
      */
-    public function testCacheThrowsAnExceptionIfAnExpirationIsNotProvided()
+    public function testCacheThrowsAnExceptionIfAnExpirationIsNotProvided(): void
     {
         cache(['foo' => 'bar']);
     }
 
-    public function testUnversionedElixir()
+    public function testUnversionedElixir(): void
     {
         $file = 'unversioned.css';
 
@@ -58,7 +58,7 @@ class FoundationHelpersTest extends TestCase
         unlink(public_path($file));
     }
 
-    public function testMixDoesNotIncludeHost()
+    public function testMixDoesNotIncludeHost(): void
     {
         $file = 'unversioned.css';
 

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -18,17 +18,17 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     protected $connection;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->connection = m::mock(Connection::class);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testSeeInDatabaseFindsResults()
+    public function testSeeInDatabaseFindsResults(): void
     {
         $this->mockCountBuilder(1);
 
@@ -39,7 +39,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
      * @expectedException \PHPUnit\Framework\ExpectationFailedException
      * @expectedExceptionMessage The table is empty.
      */
-    public function testSeeInDatabaseDoesNotFindResults()
+    public function testSeeInDatabaseDoesNotFindResults(): void
     {
         $builder = $this->mockCountBuilder(0);
 
@@ -51,7 +51,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     /**
      * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
-    public function testSeeInDatabaseFindsNotMatchingResults()
+    public function testSeeInDatabaseFindsNotMatchingResults(): void
     {
         $this->expectExceptionMessage('Found: '.json_encode([['title' => 'Forge']], JSON_PRETTY_PRINT));
 
@@ -66,7 +66,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     /**
      * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
-    public function testSeeInDatabaseFindsManyNotMatchingResults()
+    public function testSeeInDatabaseFindsManyNotMatchingResults(): void
     {
         $this->expectExceptionMessage('Found: '.json_encode(['data', 'data', 'data'], JSON_PRETTY_PRINT).' and 2 others.');
 
@@ -80,7 +80,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
-    public function testDontSeeInDatabaseDoesNotFindResults()
+    public function testDontSeeInDatabaseDoesNotFindResults(): void
     {
         $this->mockCountBuilder(0);
 
@@ -90,7 +90,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     /**
      * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
-    public function testDontSeeInDatabaseFindsResults()
+    public function testDontSeeInDatabaseFindsResults(): void
     {
         $builder = $this->mockCountBuilder(1);
 
@@ -100,7 +100,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseMissing($this->table, $this->data);
     }
 
-    public function testSeeSoftDeletedInDatabaseFindsResults()
+    public function testSeeSoftDeletedInDatabaseFindsResults(): void
     {
         $this->mockCountBuilder(1);
 
@@ -111,7 +111,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
      * @expectedException \PHPUnit\Framework\ExpectationFailedException
      * @expectedExceptionMessage The table is empty.
      */
-    public function testSeeSoftDeletedInDatabaseDoesNotFindResults()
+    public function testSeeSoftDeletedInDatabaseDoesNotFindResults(): void
     {
         $builder = $this->mockCountBuilder(0);
 

--- a/tests/Foundation/FoundationPackageManifestTest.php
+++ b/tests/Foundation/FoundationPackageManifestTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\PackageManifest;
 
 class FoundationPackageManifestTest extends TestCase
 {
-    public function testAssetLoading()
+    public function testAssetLoading(): void
     {
         @unlink(__DIR__.'/fixtures/packages.php');
         $manifest = new PackageManifest(new Filesystem, __DIR__.'/fixtures', __DIR__.'/fixtures/packages.php');

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class FoundationProviderRepositoryTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testServicesAreRegisteredWhenManifestIsNotRecompiled()
+    public function testServicesAreRegisteredWhenManifestIsNotRecompiled(): void
     {
         $app = m::mock('Illuminate\Foundation\Application');
 
@@ -28,7 +28,7 @@ class FoundationProviderRepositoryTest extends TestCase
         $repo->load([]);
     }
 
-    public function testManifestIsProperlyRecompiled()
+    public function testManifestIsProperlyRecompiled(): void
     {
         $app = m::mock('Illuminate\Foundation\Application');
 
@@ -57,7 +57,7 @@ class FoundationProviderRepositoryTest extends TestCase
         $manifest = $repo->load(['foo', 'bar']);
     }
 
-    public function testShouldRecompileReturnsCorrectValue()
+    public function testShouldRecompileReturnsCorrectValue(): void
     {
         $repo = new \Illuminate\Foundation\ProviderRepository(m::mock('Illuminate\Contracts\Foundation\Application'), new \Illuminate\Filesystem\Filesystem, __DIR__.'/services.php');
         $this->assertTrue($repo->shouldRecompile(null, []));
@@ -65,7 +65,7 @@ class FoundationProviderRepositoryTest extends TestCase
         $this->assertFalse($repo->shouldRecompile(['providers' => ['foo']], ['foo']));
     }
 
-    public function testLoadManifestReturnsParsedJSON()
+    public function testLoadManifestReturnsParsedJSON(): void
     {
         $repo = new \Illuminate\Foundation\ProviderRepository(m::mock('Illuminate\Contracts\Foundation\Application'), $files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__.'/services.php');
         $files->shouldReceive('exists')->once()->with(__DIR__.'/services.php')->andReturn(true);
@@ -74,7 +74,7 @@ class FoundationProviderRepositoryTest extends TestCase
         $this->assertEquals($array, $repo->loadManifest());
     }
 
-    public function testWriteManifestStoresToProperLocation()
+    public function testWriteManifestStoresToProperLocation(): void
     {
         $repo = new \Illuminate\Foundation\ProviderRepository(m::mock('Illuminate\Contracts\Foundation\Application'), $files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__.'/services.php');
         $files->shouldReceive('put')->once()->with(__DIR__.'/services.php', '<?php return '.var_export(['foo'], true).';');

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class FoundationTestResponseTest extends TestCase
 {
-    public function testAssertViewIs()
+    public function testAssertViewIs(): void
     {
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(\Mockery::mock(View::class, [
@@ -27,7 +27,7 @@ class FoundationTestResponseTest extends TestCase
         $response->assertViewIs('dir.my-view');
     }
 
-    public function testAssertViewHas()
+    public function testAssertViewHas(): void
     {
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(\Mockery::mock(View::class, [
@@ -41,7 +41,7 @@ class FoundationTestResponseTest extends TestCase
         $response->assertViewHas('foo');
     }
 
-    public function testAssertSeeInOrder()
+    public function testAssertSeeInOrder(): void
     {
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(\Mockery::mock(View::class, [
@@ -67,7 +67,7 @@ class FoundationTestResponseTest extends TestCase
         }
     }
 
-    public function testAssertSeeText()
+    public function testAssertSeeText(): void
     {
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(\Mockery::mock(View::class, [
@@ -80,7 +80,7 @@ class FoundationTestResponseTest extends TestCase
         $response->assertSeeText('foobar');
     }
 
-    public function testAssertSeeTextInOrder()
+    public function testAssertSeeTextInOrder(): void
     {
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(\Mockery::mock(View::class, [
@@ -106,7 +106,7 @@ class FoundationTestResponseTest extends TestCase
         }
     }
 
-    public function testAssertHeader()
+    public function testAssertHeader(): void
     {
         $baseResponse = tap(new Response, function ($response) {
             $response->header('Location', '/foo');
@@ -127,7 +127,7 @@ class FoundationTestResponseTest extends TestCase
      * @expectedException \PHPUnit\Framework\ExpectationFailedException
      * @expectedExceptionMessage Unexpected header [Location] is present on response.
      */
-    public function testAssertHeaderMissing()
+    public function testAssertHeaderMissing(): void
     {
         $baseResponse = tap(new Response, function ($response) {
             $response->header('Location', '/foo');
@@ -138,7 +138,7 @@ class FoundationTestResponseTest extends TestCase
         $response->assertHeaderMissing('Location');
     }
 
-    public function testAssertJsonWithArray()
+    public function testAssertJsonWithArray(): void
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
@@ -147,7 +147,7 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJson($resource->jsonSerialize());
     }
 
-    public function testAssertJsonWithMixed()
+    public function testAssertJsonWithMixed(): void
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
@@ -156,7 +156,7 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJson($resource->jsonSerialize());
     }
 
-    public function testAssertJsonFragment()
+    public function testAssertJsonFragment(): void
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
@@ -175,7 +175,7 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonFragment(['foo' => 'bar 0', 'bar' => ['foo' => 'bar 0', 'bar' => 'foo 0']]);
     }
 
-    public function testAssertJsonStructure()
+    public function testAssertJsonStructure(): void
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
@@ -200,7 +200,7 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonStructure(['*' => ['foo', 'bar', 'foobar']]);
     }
 
-    public function testAssertJsonCount()
+    public function testAssertJsonCount(): void
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
@@ -216,7 +216,7 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonCount(4);
     }
 
-    public function testMacroable()
+    public function testMacroable(): void
     {
         TestResponse::macro('foo', function () {
             return 'bar';
@@ -229,7 +229,7 @@ class FoundationTestResponseTest extends TestCase
         );
     }
 
-    public function testCanBeCreatedFromBinaryFileResponses()
+    public function testCanBeCreatedFromBinaryFileResponses(): void
     {
         $files = new Filesystem;
         $tempDir = __DIR__.'/tmp';
@@ -243,7 +243,7 @@ class FoundationTestResponseTest extends TestCase
         $files->deleteDirectory($tempDir);
     }
 
-    public function testJsonHelper()
+    public function testJsonHelper(): void
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 

--- a/tests/Foundation/Http/Middleware/TransformsRequestTest.php
+++ b/tests/Foundation/Http/Middleware/TransformsRequestTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Http\Middleware\TransformsRequest;
 
 class TransformsRequestTest extends TestCase
 {
-    public function testLowerAgeAndAddBeer()
+    public function testLowerAgeAndAddBeer(): void
     {
         $middleware = new ManipulateInput;
         $request = new Request(
@@ -26,7 +26,7 @@ class TransformsRequestTest extends TestCase
         });
     }
 
-    public function testAjaxLowerAgeAndAddBeer()
+    public function testAjaxLowerAgeAndAddBeer(): void
     {
         $middleware = new ManipulateInput;
         $request = new Request(

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -6,7 +6,7 @@ use Orchestra\Testbench\TestCase;
 
 class MakesHttpRequestsTest extends TestCase
 {
-    public function testWithoutAndWithMiddleware()
+    public function testWithoutAndWithMiddleware(): void
     {
         $this->assertFalse($this->app->has('middleware.disable'));
 
@@ -18,7 +18,7 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertFalse($this->app->has('middleware.disable'));
     }
 
-    public function testWithoutAndWithMiddlewareWithParameter()
+    public function testWithoutAndWithMiddlewareWithParameter(): void
     {
         $next = function ($request) {
             return $request;

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class HasherTest extends TestCase
 {
-    public function testBasicBcryptHashing()
+    public function testBasicBcryptHashing(): void
     {
         $hasher = new \Illuminate\Hashing\BcryptHasher;
         $value = $hasher->make('password');
@@ -16,7 +16,7 @@ class HasherTest extends TestCase
         $this->assertTrue($hasher->needsRehash($value, ['rounds' => 1]));
     }
 
-    public function testBasicArgonHashing()
+    public function testBasicArgonHashing(): void
     {
         if (! defined('PASSWORD_ARGON2I')) {
             $this->markTestSkipped('PHP not compiled with argon2 hashing support.');

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Support\Arrayable;
 
 class HttpJsonResponseTest extends TestCase
 {
-    public function testSetAndRetrieveJsonableData()
+    public function testSetAndRetrieveJsonableData(): void
     {
         $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestJsonableObject);
         $data = $response->getData();
@@ -17,7 +17,7 @@ class HttpJsonResponseTest extends TestCase
         $this->assertEquals('bar', $data->foo);
     }
 
-    public function testSetAndRetrieveJsonSerializeData()
+    public function testSetAndRetrieveJsonSerializeData(): void
     {
         $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestJsonSerializeObject);
         $data = $response->getData();
@@ -25,7 +25,7 @@ class HttpJsonResponseTest extends TestCase
         $this->assertEquals('bar', $data->foo);
     }
 
-    public function testSetAndRetrieveArrayableData()
+    public function testSetAndRetrieveArrayableData(): void
     {
         $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestArrayableObject);
         $data = $response->getData();
@@ -33,7 +33,7 @@ class HttpJsonResponseTest extends TestCase
         $this->assertEquals('bar', $data->foo);
     }
 
-    public function testSetAndRetrieveData()
+    public function testSetAndRetrieveData(): void
     {
         $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar']);
         $data = $response->getData();
@@ -41,7 +41,7 @@ class HttpJsonResponseTest extends TestCase
         $this->assertEquals('bar', $data->foo);
     }
 
-    public function testGetOriginalContent()
+    public function testGetOriginalContent(): void
     {
         $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestArrayableObject);
         $this->assertInstanceOf(JsonResponseTestArrayableObject::class, $response->getOriginalContent());
@@ -51,20 +51,20 @@ class HttpJsonResponseTest extends TestCase
         $this->assertInstanceOf(JsonResponseTestArrayableObject::class, $response->getOriginalContent());
     }
 
-    public function testSetAndRetrieveOptions()
+    public function testSetAndRetrieveOptions(): void
     {
         $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar']);
         $response->setEncodingOptions(JSON_PRETTY_PRINT);
         $this->assertSame(JSON_PRETTY_PRINT, $response->getEncodingOptions());
     }
 
-    public function testSetAndRetrieveDefaultOptions()
+    public function testSetAndRetrieveDefaultOptions(): void
     {
         $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar']);
         $this->assertSame(0, $response->getEncodingOptions());
     }
 
-    public function testSetAndRetrieveStatusCode()
+    public function testSetAndRetrieveStatusCode(): void
     {
         $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar'], 404);
         $this->assertSame(404, $response->getStatusCode());
@@ -81,7 +81,7 @@ class HttpJsonResponseTest extends TestCase
      *
      * @dataProvider jsonErrorDataProvider
      */
-    public function testInvalidArgumentExceptionOnJsonError($data)
+    public function testInvalidArgumentExceptionOnJsonError($data): void
     {
         new \Illuminate\Http\JsonResponse(['data' => $data]);
     }
@@ -91,7 +91,7 @@ class HttpJsonResponseTest extends TestCase
      *
      * @dataProvider jsonErrorDataProvider
      */
-    public function testGracefullyHandledSomeJsonErrorsWithPartialOutputOnError($data)
+    public function testGracefullyHandledSomeJsonErrorsWithPartialOutputOnError($data): void
     {
         new \Illuminate\Http\JsonResponse(['data' => $data], 200, [], JSON_PARTIAL_OUTPUT_ON_ERROR);
     }

--- a/tests/Http/HttpMimeTypeTest.php
+++ b/tests/Http/HttpMimeTypeTest.php
@@ -7,33 +7,33 @@ use Illuminate\Http\Testing\MimeType;
 
 class HttpMimeTypeTest extends TestCase
 {
-    public function testMimeTypeFromFileNameExistsTrue()
+    public function testMimeTypeFromFileNameExistsTrue(): void
     {
         $this->assertSame('image/jpeg', MimeType::from('foo.jpg'));
     }
 
-    public function testMimeTypeFromFileNameExistsFalse()
+    public function testMimeTypeFromFileNameExistsFalse(): void
     {
         $this->assertSame('application/octet-stream', MimeType::from('foo.bar'));
     }
 
-    public function testMimeTypeFromExtensionExistsTrue()
+    public function testMimeTypeFromExtensionExistsTrue(): void
     {
         $this->assertSame('image/jpeg', MimeType::get('jpg'));
     }
 
-    public function testMimeTypeFromExtensionExistsFalse()
+    public function testMimeTypeFromExtensionExistsFalse(): void
     {
         $this->assertSame('application/octet-stream', MimeType::get('bar'));
     }
 
-    public function testGetAllMimeTypes()
+    public function testGetAllMimeTypes(): void
     {
         $this->assertInternalType('array', MimeType::get());
         $this->assertArraySubset(['jpg' => 'image/jpeg'], MimeType::get());
     }
 
-    public function testSearchExtensionFromMimeType()
+    public function testSearchExtensionFromMimeType(): void
     {
         $this->assertSame('mov', MimeType::search('video/quicktime'));
         $this->assertNull(MimeType::search('foo/bar'));

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -9,12 +9,12 @@ use Illuminate\Http\RedirectResponse;
 
 class HttpRedirectResponseTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testHeaderOnRedirect()
+    public function testHeaderOnRedirect(): void
     {
         $response = new RedirectResponse('foo.bar');
         $this->assertNull($response->headers->get('foo'));
@@ -26,7 +26,7 @@ class HttpRedirectResponseTest extends TestCase
         $this->assertEquals('baz', $response->headers->get('foo'));
     }
 
-    public function testWithOnRedirect()
+    public function testWithOnRedirect(): void
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
@@ -35,7 +35,7 @@ class HttpRedirectResponseTest extends TestCase
         $response->with(['name', 'age']);
     }
 
-    public function testWithCookieOnRedirect()
+    public function testWithCookieOnRedirect(): void
     {
         $response = new RedirectResponse('foo.bar');
         $this->assertCount(0, $response->headers->getCookies());
@@ -46,7 +46,7 @@ class HttpRedirectResponseTest extends TestCase
         $this->assertEquals('bar', $cookies[0]->getValue());
     }
 
-    public function testInputOnRedirect()
+    public function testInputOnRedirect(): void
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
@@ -55,7 +55,7 @@ class HttpRedirectResponseTest extends TestCase
         $response->withInput();
     }
 
-    public function testOnlyInputOnRedirect()
+    public function testOnlyInputOnRedirect(): void
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
@@ -64,7 +64,7 @@ class HttpRedirectResponseTest extends TestCase
         $response->onlyInput('name');
     }
 
-    public function testExceptInputOnRedirect()
+    public function testExceptInputOnRedirect(): void
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
@@ -73,7 +73,7 @@ class HttpRedirectResponseTest extends TestCase
         $response->exceptInput('age');
     }
 
-    public function testFlashingErrorsOnRedirect()
+    public function testFlashingErrorsOnRedirect(): void
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
@@ -85,7 +85,7 @@ class HttpRedirectResponseTest extends TestCase
         $response->withErrors($provider);
     }
 
-    public function testSettersGettersOnRequest()
+    public function testSettersGettersOnRequest(): void
     {
         $response = new RedirectResponse('foo.bar');
         $this->assertNull($response->getRequest());
@@ -99,7 +99,7 @@ class HttpRedirectResponseTest extends TestCase
         $this->assertSame($session, $response->getSession());
     }
 
-    public function testRedirectWithErrorsArrayConvertsToMessageBag()
+    public function testRedirectWithErrorsArrayConvertsToMessageBag(): void
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
@@ -110,7 +110,7 @@ class HttpRedirectResponseTest extends TestCase
         $response->withErrors($provider);
     }
 
-    public function testMagicCall()
+    public function testMagicCall(): void
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
@@ -123,7 +123,7 @@ class HttpRedirectResponseTest extends TestCase
      * @expectedException \BadMethodCallException
      * @expectedExceptionMessage Method Illuminate\Http\RedirectResponse::doesNotExist does not exist.
      */
-    public function testMagicCallException()
+    public function testMagicCallException(): void
     {
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -10,18 +10,18 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class HttpRequestTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testInstanceMethod()
+    public function testInstanceMethod(): void
     {
         $request = Request::create('', 'GET');
         $this->assertSame($request, $request->instance());
     }
 
-    public function testMethodMethod()
+    public function testMethodMethod(): void
     {
         $request = Request::create('', 'GET');
         $this->assertSame('GET', $request->method());
@@ -45,13 +45,13 @@ class HttpRequestTest extends TestCase
         $this->assertSame('OPTIONS', $request->method());
     }
 
-    public function testRootMethod()
+    public function testRootMethod(): void
     {
         $request = Request::create('http://example.com/foo/bar/script.php?test');
         $this->assertEquals('http://example.com', $request->root());
     }
 
-    public function testPathMethod()
+    public function testPathMethod(): void
     {
         $request = Request::create('', 'GET');
         $this->assertEquals('/', $request->path());
@@ -60,7 +60,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('foo/bar', $request->path());
     }
 
-    public function testDecodedPathMethod()
+    public function testDecodedPathMethod(): void
     {
         $request = Request::create('/foo%20bar');
         $this->assertEquals('foo bar', $request->decodedPath());
@@ -69,7 +69,7 @@ class HttpRequestTest extends TestCase
     /**
      * @dataProvider segmentProvider
      */
-    public function testSegmentMethod($path, $segment, $expected)
+    public function testSegmentMethod($path, $segment, $expected): void
     {
         $request = Request::create($path, 'GET');
         $this->assertEquals($expected, $request->segment($segment, 'default'));
@@ -88,7 +88,7 @@ class HttpRequestTest extends TestCase
     /**
      * @dataProvider segmentsProvider
      */
-    public function testSegmentsMethod($path, $expected)
+    public function testSegmentsMethod($path, $expected): void
     {
         $request = Request::create($path, 'GET');
         $this->assertEquals($expected, $request->segments());
@@ -107,7 +107,7 @@ class HttpRequestTest extends TestCase
         ];
     }
 
-    public function testUrlMethod()
+    public function testUrlMethod(): void
     {
         $request = Request::create('http://foo.com/foo/bar?name=taylor', 'GET');
         $this->assertEquals('http://foo.com/foo/bar', $request->url());
@@ -116,7 +116,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('http://foo.com/foo/bar', $request->url());
     }
 
-    public function testFullUrlMethod()
+    public function testFullUrlMethod(): void
     {
         $request = Request::create('http://foo.com/foo/bar?name=taylor', 'GET');
         $this->assertEquals('http://foo.com/foo/bar?name=taylor', $request->fullUrl());
@@ -143,7 +143,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('http://foo.com/foo/bar?name=graham', $request->fullUrlWithQuery(['name' => 'graham']));
     }
 
-    public function testIsMethod()
+    public function testIsMethod(): void
     {
         $request = Request::create('/foo/bar', 'GET');
 
@@ -157,7 +157,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->is('/'));
     }
 
-    public function testFullUrlIsMethod()
+    public function testFullUrlIsMethod(): void
     {
         $request = Request::create('http://example.com/foo/bar', 'GET');
 
@@ -169,7 +169,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->fullUrlIs('*'));
     }
 
-    public function testRouteIsMethod()
+    public function testRouteIsMethod(): void
     {
         $request = Request::create('/foo/bar', 'GET');
 
@@ -187,7 +187,7 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->routeIs('foo.foo'));
     }
 
-    public function testRouteMethod()
+    public function testRouteMethod(): void
     {
         $request = Request::create('/foo/bar', 'GET');
 
@@ -204,7 +204,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('default', $request->route('optional', 'default'));
     }
 
-    public function testAjaxMethod()
+    public function testAjaxMethod(): void
     {
         $request = Request::create('/', 'GET');
         $this->assertFalse($request->ajax());
@@ -217,7 +217,7 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->ajax());
     }
 
-    public function testPjaxMethod()
+    public function testPjaxMethod(): void
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_X_PJAX' => 'true'], '{}');
         $this->assertTrue($request->pjax());
@@ -229,7 +229,7 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->pjax());
     }
 
-    public function testSecureMethod()
+    public function testSecureMethod(): void
     {
         $request = Request::create('http://example.com', 'GET');
         $this->assertFalse($request->secure());
@@ -237,7 +237,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->secure());
     }
 
-    public function testUserAgentMethod()
+    public function testUserAgentMethod(): void
     {
         $request = Request::create('/', 'GET', [], [], [], [
             'HTTP_USER_AGENT' => 'Laravel',
@@ -246,7 +246,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('Laravel', $request->userAgent());
     }
 
-    public function testHasMethod()
+    public function testHasMethod(): void
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
         $this->assertTrue($request->has('name'));
@@ -271,7 +271,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->has('foo.baz'));
     }
 
-    public function testHasAnyMethod()
+    public function testHasAnyMethod(): void
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
         $this->assertTrue($request->hasAny('name'));
@@ -293,7 +293,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->hasAny(['foo.bax', 'foo.baz']));
     }
 
-    public function testFilledMethod()
+    public function testFilledMethod(): void
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
         $this->assertTrue($request->filled('name'));
@@ -314,7 +314,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->filled('foo.bar'));
     }
 
-    public function testInputMethod()
+    public function testInputMethod(): void
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);
         $this->assertEquals('Taylor', $request->input('name'));
@@ -325,7 +325,7 @@ class HttpRequestTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\File\UploadedFile', $request['file']);
     }
 
-    public function testArrayAccess()
+    public function testArrayAccess(): void
     {
         $request = Request::create('/', 'GET', ['name' => null, 'foo' => ['bar' => null, 'baz' => '']]);
 
@@ -355,7 +355,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('foo', $request['id']);
     }
 
-    public function testAllMethod()
+    public function testAllMethod(): void
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
         $this->assertEquals(['name' => 'Taylor', 'age' => null, 'email' => null], $request->all('name', 'age', 'email'));
@@ -370,7 +370,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(['developer' => ['name' => 'Taylor', 'age' => null]], $request->all());
     }
 
-    public function testKeysMethod()
+    public function testKeysMethod(): void
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
         $this->assertEquals(['name', 'age'], $request->keys());
@@ -391,7 +391,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(['name', 'foo'], $request->keys());
     }
 
-    public function testOnlyMethod()
+    public function testOnlyMethod(): void
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
         $this->assertEquals(['name' => 'Taylor', 'age' => null], $request->only('name', 'age', 'email'));
@@ -402,14 +402,14 @@ class HttpRequestTest extends TestCase
         $this->assertEquals([], $request->only('developer.skills'));
     }
 
-    public function testExceptMethod()
+    public function testExceptMethod(): void
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 25]);
         $this->assertEquals(['name' => 'Taylor'], $request->except('age'));
         $this->assertEquals([], $request->except('age', 'name'));
     }
 
-    public function testQueryMethod()
+    public function testQueryMethod(): void
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);
         $this->assertEquals('Taylor', $request->query('name'));
@@ -418,7 +418,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('Taylor', $all['name']);
     }
 
-    public function testPostMethod()
+    public function testPostMethod(): void
     {
         $request = Request::create('/', 'POST', ['name' => 'Taylor']);
         $this->assertEquals('Taylor', $request->post('name'));
@@ -427,7 +427,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('Taylor', $all['name']);
     }
 
-    public function testCookieMethod()
+    public function testCookieMethod(): void
     {
         $request = Request::create('/', 'GET', [], ['name' => 'Taylor']);
         $this->assertEquals('Taylor', $request->cookie('name'));
@@ -436,14 +436,14 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('Taylor', $all['name']);
     }
 
-    public function testHasCookieMethod()
+    public function testHasCookieMethod(): void
     {
         $request = Request::create('/', 'GET', [], ['foo' => 'bar']);
         $this->assertTrue($request->hasCookie('foo'));
         $this->assertFalse($request->hasCookie('qu'));
     }
 
-    public function testFileMethod()
+    public function testFileMethod(): void
     {
         $files = [
             'foo' => [
@@ -458,7 +458,7 @@ class HttpRequestTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\File\UploadedFile', $request->file('foo'));
     }
 
-    public function testHasFileMethod()
+    public function testHasFileMethod(): void
     {
         $request = Request::create('/', 'GET', [], [], []);
         $this->assertFalse($request->hasFile('foo'));
@@ -476,7 +476,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->hasFile('foo'));
     }
 
-    public function testServerMethod()
+    public function testServerMethod(): void
     {
         $request = Request::create('/', 'GET', [], [], [], ['foo' => 'bar']);
         $this->assertEquals('bar', $request->server('foo'));
@@ -485,7 +485,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('bar', $all['foo']);
     }
 
-    public function testMergeMethod()
+    public function testMergeMethod(): void
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);
         $merge = ['buddy' => 'Dayle'];
@@ -494,7 +494,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('Dayle', $request->input('buddy'));
     }
 
-    public function testReplaceMethod()
+    public function testReplaceMethod(): void
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);
         $replace = ['buddy' => 'Dayle'];
@@ -503,7 +503,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('Dayle', $request->input('buddy'));
     }
 
-    public function testHeaderMethod()
+    public function testHeaderMethod(): void
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_DO_THIS' => 'foo']);
         $this->assertEquals('foo', $request->header('do-this'));
@@ -511,7 +511,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('foo', $all['do-this'][0]);
     }
 
-    public function testJSONMethod()
+    public function testJSONMethod(): void
     {
         $payload = ['name' => 'taylor'];
         $request = Request::create('/', 'GET', [], [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($payload));
@@ -521,7 +521,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals($payload, $data);
     }
 
-    public function testJSONEmulatingPHPBuiltInServer()
+    public function testJSONEmulatingPHPBuiltInServer(): void
     {
         $payload = ['name' => 'taylor'];
         $content = json_encode($payload);
@@ -534,7 +534,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals($payload, $data);
     }
 
-    public function testPrefers()
+    public function testPrefers(): void
     {
         $this->assertEquals('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json'])->prefers(['json']));
         $this->assertEquals('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json'])->prefers(['html', 'json']));
@@ -559,28 +559,28 @@ class HttpRequestTest extends TestCase
         $this->assertNull(Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*'])->prefers('text/html'));
     }
 
-    public function testAllInputReturnsInputAndFiles()
+    public function testAllInputReturnsInputAndFiles(): void
     {
         $file = $this->getMockBuilder('Illuminate\Http\UploadedFile')->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
         $request = Request::create('/?boom=breeze', 'GET', ['foo' => 'bar'], [], ['baz' => $file]);
         $this->assertEquals(['foo' => 'bar', 'baz' => $file, 'boom' => 'breeze'], $request->all());
     }
 
-    public function testAllInputReturnsNestedInputAndFiles()
+    public function testAllInputReturnsNestedInputAndFiles(): void
     {
         $file = $this->getMockBuilder('Illuminate\Http\UploadedFile')->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
         $request = Request::create('/?boom=breeze', 'GET', ['foo' => ['bar' => 'baz']], [], ['foo' => ['photo' => $file]]);
         $this->assertEquals(['foo' => ['bar' => 'baz', 'photo' => $file], 'boom' => 'breeze'], $request->all());
     }
 
-    public function testAllInputReturnsInputAfterReplace()
+    public function testAllInputReturnsInputAfterReplace(): void
     {
         $request = Request::create('/?boom=breeze', 'GET', ['foo' => ['bar' => 'baz']]);
         $request->replace(['foo' => ['bar' => 'baz'], 'boom' => 'breeze']);
         $this->assertEquals(['foo' => ['bar' => 'baz'], 'boom' => 'breeze'], $request->all());
     }
 
-    public function testAllInputWithNumericKeysReturnsInputAfterReplace()
+    public function testAllInputWithNumericKeysReturnsInputAfterReplace(): void
     {
         $request1 = Request::create('/', 'POST', [0 => 'A', 1 => 'B', 2 => 'C']);
         $request1->replace([0 => 'A', 1 => 'B', 2 => 'C']);
@@ -591,7 +591,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals([1 => 'A', 2 => 'B', 3 => 'C'], $request2->all());
     }
 
-    public function testInputWithEmptyFilename()
+    public function testInputWithEmptyFilename(): void
     {
         $invalidFiles = [
             'file' => [
@@ -608,7 +608,7 @@ class HttpRequestTest extends TestCase
         $request = Request::createFromBase($baseRequest);
     }
 
-    public function testMultipleFileUploadWithEmptyValue()
+    public function testMultipleFileUploadWithEmptyValue(): void
     {
         $invalidFiles = [
             'file' => [
@@ -627,7 +627,7 @@ class HttpRequestTest extends TestCase
         $this->assertEmpty($request->files->all());
     }
 
-    public function testOldMethodCallsSession()
+    public function testOldMethodCallsSession(): void
     {
         $request = Request::create('/', 'GET');
         $session = m::mock('Illuminate\Session\Store');
@@ -636,7 +636,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('boom', $request->old('foo', 'bar'));
     }
 
-    public function testFlushMethodCallsSession()
+    public function testFlushMethodCallsSession(): void
     {
         $request = Request::create('/', 'GET');
         $session = m::mock('Illuminate\Session\Store');
@@ -645,7 +645,7 @@ class HttpRequestTest extends TestCase
         $request->flush();
     }
 
-    public function testExpectsJson()
+    public function testExpectsJson(): void
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
         $this->assertTrue($request->expectsJson());
@@ -672,7 +672,7 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->expectsJson());
     }
 
-    public function testFormatReturnsAcceptableFormat()
+    public function testFormatReturnsAcceptableFormat(): void
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
         $this->assertEquals('json', $request->format());
@@ -691,7 +691,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('foo', $request->format('foo'));
     }
 
-    public function testFormatReturnsAcceptsJson()
+    public function testFormatReturnsAcceptsJson(): void
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
         $this->assertEquals('json', $request->format());
@@ -710,7 +710,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->accepts('application/json'));
     }
 
-    public function testFormatReturnsAcceptsHtml()
+    public function testFormatReturnsAcceptsHtml(): void
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'text/html']);
         $this->assertEquals('html', $request->format());
@@ -723,7 +723,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->accepts('text/plain'));
     }
 
-    public function testFormatReturnsAcceptsAll()
+    public function testFormatReturnsAcceptsAll(): void
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => '*/*']);
         $this->assertEquals('html', $request->format());
@@ -742,7 +742,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->acceptsJson());
     }
 
-    public function testFormatReturnsAcceptsMultiple()
+    public function testFormatReturnsAcceptsMultiple(): void
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json,text/*']);
         $this->assertTrue($request->accepts(['text/html', 'application/json']));
@@ -752,7 +752,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->accepts('application/baz+json'));
     }
 
-    public function testFormatReturnsAcceptsCharset()
+    public function testFormatReturnsAcceptsCharset(): void
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json; charset=utf-8']);
         $this->assertTrue($request->accepts(['text/html', 'application/json']));
@@ -762,7 +762,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->accepts('application/baz+json'));
     }
 
-    public function testBadAcceptHeader()
+    public function testBadAcceptHeader(): void
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'Mozilla/5.0 (Windows; U; Windows NT 5.1; pt-PT; rv:1.9.1.2) Gecko/20090729 Firefox/3.5.2 (.NET CLR 3.5.30729)']);
         $this->assertFalse($request->accepts(['text/html', 'application/json']));
@@ -787,13 +787,13 @@ class HttpRequestTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Session store not set on request.
      */
-    public function testSessionMethod()
+    public function testSessionMethod(): void
     {
         $request = Request::create('/', 'GET');
         $request->session();
     }
 
-    public function testUserResolverMakesUserAvailableAsMagicProperty()
+    public function testUserResolverMakesUserAvailableAsMagicProperty(): void
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
         $request->setUserResolver(function () {
@@ -802,7 +802,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('user', $request->user());
     }
 
-    public function testFingerprintMethod()
+    public function testFingerprintMethod(): void
     {
         $request = Request::create('/', 'GET', [], [], [], []);
         $request->setRouteResolver(function () use ($request) {
@@ -819,13 +819,13 @@ class HttpRequestTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Unable to generate fingerprint. Route unavailable.
      */
-    public function testFingerprintWithoutRoute()
+    public function testFingerprintWithoutRoute(): void
     {
         $request = Request::create('/', 'GET', [], [], [], []);
         $request->fingerprint();
     }
 
-    public function testCreateFromBase()
+    public function testCreateFromBase(): void
     {
         $body = [
             'foo' => 'bar',
@@ -848,7 +848,7 @@ class HttpRequestTest extends TestCase
      *
      * @link https://github.com/laravel/framework/issues/10403 Form request object attribute returns empty when have some string.
      */
-    public function testMagicMethods()
+    public function testMagicMethods(): void
     {
         // Simulates QueryStrings.
         $request = Request::create('/', 'GET', ['foo' => 'bar', 'empty' => '']);
@@ -918,7 +918,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(empty($request->undefined), true);
     }
 
-    public function testHttpRequestFlashCallsSessionFlashInputWithInputData()
+    public function testHttpRequestFlashCallsSessionFlashInputWithInputData(): void
     {
         $session = m::mock('Illuminate\Session\Store');
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor', 'email' => 'foo']);
@@ -927,7 +927,7 @@ class HttpRequestTest extends TestCase
         $request->flash();
     }
 
-    public function testHttpRequestFlashOnlyCallsFlashWithProperParameters()
+    public function testHttpRequestFlashOnlyCallsFlashWithProperParameters(): void
     {
         $session = m::mock('Illuminate\Session\Store');
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
@@ -936,7 +936,7 @@ class HttpRequestTest extends TestCase
         $request->flashOnly(['name']);
     }
 
-    public function testHttpRequestFlashExceptCallsFlashWithProperParameters()
+    public function testHttpRequestFlashExceptCallsFlashWithProperParameters(): void
     {
         $session = m::mock('Illuminate\Session\Store');
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -12,12 +12,12 @@ use Illuminate\Contracts\Support\Arrayable;
 
 class HttpResponseTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testJsonResponsesAreConvertedAndHeadersAreSet()
+    public function testJsonResponsesAreConvertedAndHeadersAreSet(): void
     {
         $response = new \Illuminate\Http\Response(new ArrayableStub);
         $this->assertEquals('{"foo":"bar"}', $response->getContent());
@@ -49,7 +49,7 @@ class HttpResponseTest extends TestCase
         $this->assertEquals('application/json', $response->headers->get('Content-Type'));
     }
 
-    public function testRenderablesAreRendered()
+    public function testRenderablesAreRendered(): void
     {
         $mock = m::mock('Illuminate\Contracts\Support\Renderable');
         $mock->shouldReceive('render')->once()->andReturn('foo');
@@ -57,7 +57,7 @@ class HttpResponseTest extends TestCase
         $this->assertEquals('foo', $response->getContent());
     }
 
-    public function testHeader()
+    public function testHeader(): void
     {
         $response = new \Illuminate\Http\Response;
         $this->assertNull($response->headers->get('foo'));
@@ -69,7 +69,7 @@ class HttpResponseTest extends TestCase
         $this->assertEquals('baz', $response->headers->get('foo'));
     }
 
-    public function testWithCookie()
+    public function testWithCookie(): void
     {
         $response = new \Illuminate\Http\Response;
         $this->assertCount(0, $response->headers->getCookies());
@@ -80,7 +80,7 @@ class HttpResponseTest extends TestCase
         $this->assertEquals('bar', $cookies[0]->getValue());
     }
 
-    public function testGetOriginalContent()
+    public function testGetOriginalContent(): void
     {
         $arr = ['foo' => 'bar'];
         $response = new \Illuminate\Http\Response;
@@ -88,7 +88,7 @@ class HttpResponseTest extends TestCase
         $this->assertSame($arr, $response->getOriginalContent());
     }
 
-    public function testGetOriginalContentRetrievesTheFirstOriginalContent()
+    public function testGetOriginalContentRetrievesTheFirstOriginalContent(): void
     {
         $previousResponse = new \Illuminate\Http\Response(['foo' => 'bar']);
         $response = new \Illuminate\Http\Response($previousResponse);
@@ -96,14 +96,14 @@ class HttpResponseTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $response->getOriginalContent());
     }
 
-    public function testSetAndRetrieveStatusCode()
+    public function testSetAndRetrieveStatusCode(): void
     {
         $response = new \Illuminate\Http\Response('foo');
         $response->setStatusCode(404);
         $this->assertSame(404, $response->getStatusCode());
     }
 
-    public function testOnlyInputOnRedirect()
+    public function testOnlyInputOnRedirect(): void
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
@@ -112,7 +112,7 @@ class HttpResponseTest extends TestCase
         $response->onlyInput('name');
     }
 
-    public function testExceptInputOnRedirect()
+    public function testExceptInputOnRedirect(): void
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
@@ -121,7 +121,7 @@ class HttpResponseTest extends TestCase
         $response->exceptInput('age');
     }
 
-    public function testFlashingErrorsOnRedirect()
+    public function testFlashingErrorsOnRedirect(): void
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
@@ -133,7 +133,7 @@ class HttpResponseTest extends TestCase
         $response->withErrors($provider);
     }
 
-    public function testSettersGettersOnRequest()
+    public function testSettersGettersOnRequest(): void
     {
         $response = new RedirectResponse('foo.bar');
         $this->assertNull($response->getRequest());
@@ -147,7 +147,7 @@ class HttpResponseTest extends TestCase
         $this->assertSame($session, $response->getSession());
     }
 
-    public function testRedirectWithErrorsArrayConvertsToMessageBag()
+    public function testRedirectWithErrorsArrayConvertsToMessageBag(): void
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
@@ -158,7 +158,7 @@ class HttpResponseTest extends TestCase
         $response->withErrors($provider);
     }
 
-    public function testWithHeaders()
+    public function testWithHeaders(): void
     {
         $response = new \Illuminate\Http\Response(null, 200, ['foo' => 'bar']);
         $this->assertSame('bar', $response->headers->get('foo'));
@@ -178,7 +178,7 @@ class HttpResponseTest extends TestCase
         $this->assertSame('TATA', $response->headers->get('titi'));
     }
 
-    public function testMagicCall()
+    public function testMagicCall(): void
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
@@ -191,7 +191,7 @@ class HttpResponseTest extends TestCase
      * @expectedException \BadMethodCallException
      * @expectedExceptionMessage Method Illuminate\Http\RedirectResponse::doesNotExist does not exist.
      */
-    public function testMagicCallException()
+    public function testMagicCallException(): void
     {
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -9,7 +9,7 @@ use Illuminate\Http\Middleware\SetCacheHeaders as Cache;
 
 class CacheTest extends TestCase
 {
-    public function testDoNotSetHeaderWhenMethodNotCacheable()
+    public function testDoNotSetHeaderWhenMethodNotCacheable(): void
     {
         $request = new Request();
         $request->setMethod('PUT');
@@ -21,7 +21,7 @@ class CacheTest extends TestCase
         $this->assertNull($response->getMaxAge());
     }
 
-    public function testDoNotSetHeaderWhenNoContent()
+    public function testDoNotSetHeaderWhenNoContent(): void
     {
         $response = (new Cache())->handle(new Request(), function () {
             return new Response();
@@ -31,7 +31,7 @@ class CacheTest extends TestCase
         $this->assertNull($response->getEtag());
     }
 
-    public function testAddHeaders()
+    public function testAddHeaders(): void
     {
         $response = (new Cache())->handle(new Request(), function () {
             return new Response('some content');
@@ -41,7 +41,7 @@ class CacheTest extends TestCase
         $this->assertSame('max-age=100, public, s-maxage=200', $response->headers->get('Cache-Control'));
     }
 
-    public function testAddHeadersUsingArray()
+    public function testAddHeadersUsingArray(): void
     {
         $response = (new Cache())->handle(new Request(), function () {
             return new Response('some content');
@@ -51,7 +51,7 @@ class CacheTest extends TestCase
         $this->assertSame('max-age=100, public, s-maxage=200', $response->headers->get('Cache-Control'));
     }
 
-    public function testGenerateEtag()
+    public function testGenerateEtag(): void
     {
         $response = (new Cache())->handle(new Request(), function () {
             return new Response('some content');
@@ -61,7 +61,7 @@ class CacheTest extends TestCase
         $this->assertSame('max-age=100, public, s-maxage=200', $response->headers->get('Cache-Control'));
     }
 
-    public function testIsNotModified()
+    public function testIsNotModified(): void
     {
         $request = new Request();
         $request->headers->set('If-None-Match', '"9893532233caff98cd083a116b013c0b"');
@@ -76,7 +76,7 @@ class CacheTest extends TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testInvalidOption()
+    public function testInvalidOption(): void
     {
         (new Cache())->handle(new Request(), function () {
             return new Response('some content');

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -28,7 +28,7 @@ class AuthenticationTest extends TestCase
         $app['config']->set('hashing', ['driver' => 'bcrypt']);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -138,7 +138,7 @@ class AuthenticationTest extends TestCase
     /**
      * @test
      */
-    public function test_logging_in_using_id()
+    public function test_logging_in_using_id(): void
     {
         $this->app['auth']->loginUsingId(1);
         $this->assertEquals(1, $this->app['auth']->user()->id);
@@ -149,7 +149,7 @@ class AuthenticationTest extends TestCase
     /**
      * @test
      */
-    public function test_logging_out()
+    public function test_logging_out(): void
     {
         Event::fake();
 

--- a/tests/Integration/Cache/CacheLockTest.php
+++ b/tests/Integration/Cache/CacheLockTest.php
@@ -15,7 +15,7 @@ class CacheLockTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -24,7 +24,7 @@ class CacheLockTest extends TestCase
         }
     }
 
-    public function test_memcached_locks_can_be_acquired_and_released()
+    public function test_memcached_locks_can_be_acquired_and_released(): void
     {
         Cache::store('memcached')->lock('foo')->release();
         $this->assertTrue(Cache::store('memcached')->lock('foo', 10)->get());
@@ -35,7 +35,7 @@ class CacheLockTest extends TestCase
         Cache::store('memcached')->lock('foo')->release();
     }
 
-    public function test_redis_locks_can_be_acquired_and_released()
+    public function test_redis_locks_can_be_acquired_and_released(): void
     {
         $this->ifRedisAvailable(function () {
             Cache::store('redis')->lock('foo')->release();
@@ -48,7 +48,7 @@ class CacheLockTest extends TestCase
         });
     }
 
-    public function test_memcached_locks_can_block_for_seconds()
+    public function test_memcached_locks_can_block_for_seconds(): void
     {
         Carbon::setTestNow();
 
@@ -61,7 +61,7 @@ class CacheLockTest extends TestCase
         $this->assertTrue(Cache::store('memcached')->lock('foo', 10)->block(1));
     }
 
-    public function test_redis_locks_can_block_for_seconds()
+    public function test_redis_locks_can_block_for_seconds(): void
     {
         $this->ifRedisAvailable(function () {
             Carbon::setTestNow();
@@ -76,7 +76,7 @@ class CacheLockTest extends TestCase
         });
     }
 
-    public function test_locks_can_run_callbacks()
+    public function test_locks_can_run_callbacks(): void
     {
         Cache::store('memcached')->lock('foo')->release();
         $this->assertEquals('taylor', Cache::store('memcached')->lock('foo', 10)->get(function () {
@@ -87,7 +87,7 @@ class CacheLockTest extends TestCase
     /**
      * @expectedException \Illuminate\Contracts\Cache\LockTimeoutException
      */
-    public function test_locks_throw_timeout_if_block_expires()
+    public function test_locks_throw_timeout_if_block_expires(): void
     {
         Carbon::setTestNow();
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -15,7 +15,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentBelongsToManyTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/EloquentCollectionFreshTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class EloquentCollectionFreshTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -20,7 +20,7 @@ class EloquentCollectionFreshTest extends DatabaseTestCase
         });
     }
 
-    public function test_eloquent_collection_fresh()
+    public function test_eloquent_collection_fresh(): void
     {
         User::insert([
             ['email' => 'laravel@framework.com'],

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class EloquentCustomPivotCastTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -31,7 +31,7 @@ class EloquentCustomPivotCastTest extends DatabaseTestCase
         });
     }
 
-    public function test_casts_are_respected_on_attach()
+    public function test_casts_are_respected_on_attach(): void
     {
         $user = CustomPivotCastTestUser::forceCreate([
             'email' => 'taylor@laravel.com',
@@ -47,7 +47,7 @@ class EloquentCustomPivotCastTest extends DatabaseTestCase
         $this->assertEquals(['foo' => 'bar'], $project->collaborators[0]->pivot->permissions);
     }
 
-    public function test_casts_are_respected_on_attach_array()
+    public function test_casts_are_respected_on_attach_array(): void
     {
         $user = CustomPivotCastTestUser::forceCreate([
             'email' => 'taylor@laravel.com',
@@ -71,7 +71,7 @@ class EloquentCustomPivotCastTest extends DatabaseTestCase
         $this->assertEquals(['baz' => 'bar'], $project->collaborators[1]->pivot->permissions);
     }
 
-    public function test_casts_are_respected_on_sync()
+    public function test_casts_are_respected_on_sync(): void
     {
         $user = CustomPivotCastTestUser::forceCreate([
             'email' => 'taylor@laravel.com',
@@ -87,7 +87,7 @@ class EloquentCustomPivotCastTest extends DatabaseTestCase
         $this->assertEquals(['foo' => 'bar'], $project->collaborators[0]->pivot->permissions);
     }
 
-    public function test_casts_are_respected_on_sync_array()
+    public function test_casts_are_respected_on_sync_array(): void
     {
         $user = CustomPivotCastTestUser::forceCreate([
             'email' => 'taylor@laravel.com',
@@ -111,7 +111,7 @@ class EloquentCustomPivotCastTest extends DatabaseTestCase
         $this->assertEquals(['baz' => 'bar'], $project->collaborators[1]->pivot->permissions);
     }
 
-    public function test_casts_are_respected_on_sync_array_while_updating_existing()
+    public function test_casts_are_respected_on_sync_array_while_updating_existing(): void
     {
         $user = CustomPivotCastTestUser::forceCreate([
             'email' => 'taylor@laravel.com',

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -25,7 +25,7 @@ class EloquentDeleteTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -49,7 +49,7 @@ class EloquentDeleteTest extends TestCase
         });
     }
 
-    public function testOnlyDeleteWhatGiven()
+    public function testOnlyDeleteWhatGiven(): void
     {
         for ($i = 1; $i <= 10; $i++) {
             Comment::create([
@@ -64,7 +64,7 @@ class EloquentDeleteTest extends TestCase
         $this->assertEquals(8, Post::all()->count());
     }
 
-    public function testForceDeletedEventIsFired()
+    public function testForceDeletedEventIsFired(): void
     {
         $role = Role::create([]);
         $this->assertInstanceOf(Role::class, $role);

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -62,7 +62,7 @@ class EloquentFactoryBuilderTest extends TestCase
         });
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -11,7 +11,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentHasManyThroughTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
@@ -11,7 +11,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentLazyEagerLoadingTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelConnectionsTest.php
+++ b/tests/Integration/Database/EloquentModelConnectionsTest.php
@@ -30,7 +30,7 @@ class EloquentModelConnectionsTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -57,7 +57,7 @@ class EloquentModelConnectionsTest extends TestCase
         });
     }
 
-    public function test_child_obeys_parent_connection()
+    public function test_child_obeys_parent_connection(): void
     {
         $parent1 = ParentModel::create(['name' => str_random()]);
         $parent1->children()->create(['name' => 'childOnConn1']);
@@ -74,7 +74,7 @@ class EloquentModelConnectionsTest extends TestCase
         $this->assertEquals('childOnConn2', $parents2[0]->children[0]->name);
     }
 
-    public function test_child_uses_its_own_connection_if_set()
+    public function test_child_uses_its_own_connection_if_set(): void
     {
         $parent1 = ParentModel::create(['name' => str_random()]);
         $parent1->childrenDefaultConn2()->create(['name' => 'childAlwaysOnConn2']);
@@ -85,7 +85,7 @@ class EloquentModelConnectionsTest extends TestCase
         $this->assertEquals('childAlwaysOnConn2', $parents1[0]->childrenDefaultConn2[0]->name);
     }
 
-    public function test_child_uses_its_own_connection_if_set_even_if_parent_explicit_connection()
+    public function test_child_uses_its_own_connection_if_set_even_if_parent_explicit_connection(): void
     {
         $parent1 = ParentModel::on('conn1')->create(['name' => str_random()]);
         $parent1->childrenDefaultConn2()->create(['name' => 'childAlwaysOnConn2']);

--- a/tests/Integration/Database/EloquentModelCustomEventsTest.php
+++ b/tests/Integration/Database/EloquentModelCustomEventsTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelCustomEventsTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -25,7 +25,7 @@ class EloquentModelCustomEventsTest extends DatabaseTestCase
         });
     }
 
-    public function testFlushListenersClearsCustomEvents()
+    public function testFlushListenersClearsCustomEvents(): void
     {
         $_SERVER['fired_event'] = false;
 
@@ -36,7 +36,7 @@ class EloquentModelCustomEventsTest extends DatabaseTestCase
         $this->assertFalse($_SERVER['fired_event']);
     }
 
-    public function testCustomEventListenersAreFired()
+    public function testCustomEventListenersAreFired(): void
     {
         $_SERVER['fired_event'] = false;
 

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelDateCastingTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -23,7 +23,7 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         });
     }
 
-    public function test_dates_are_custom_castable()
+    public function test_dates_are_custom_castable(): void
     {
         $user = TestModel1::create([
             'date_field' => '2019-10-01',

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelRefreshTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class EloquentModelTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -26,7 +26,7 @@ class EloquentModelTest extends DatabaseTestCase
         });
     }
 
-    public function test_user_can_update_nullable_date()
+    public function test_user_can_update_nullable_date(): void
     {
         $user = TestModel1::create([
             'nullable_date' => null,
@@ -41,7 +41,7 @@ class EloquentModelTest extends DatabaseTestCase
         $this->assertEquals($now->toDateString(), $user->nullable_date->toDateString());
     }
 
-    public function test_attribute_changes()
+    public function test_attribute_changes(): void
     {
         $user = TestModel2::create([
             'name' => str_random(), 'title' => str_random(),

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentMorphManyTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -11,7 +11,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentPaginateTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -22,7 +22,7 @@ class EloquentPaginateTest extends DatabaseTestCase
         });
     }
 
-    public function test_pagination_on_top_of_columns()
+    public function test_pagination_on_top_of_columns(): void
     {
         for ($i = 1; $i <= 50; $i++) {
             Post::create([

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Eloquent\Collection as DatabaseCollection;
  */
 class EloquentPivotSerializationTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -48,7 +48,7 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
         });
     }
 
-    public function test_pivot_can_be_serialized_and_restored()
+    public function test_pivot_can_be_serialized_and_restored(): void
     {
         $user = PivotSerializationTestUser::forceCreate(['email' => 'taylor@laravel.com']);
         $project = PivotSerializationTestProject::forceCreate(['name' => 'Test Project']);
@@ -65,7 +65,7 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
         $class->pivot->save();
     }
 
-    public function test_morph_pivot_can_be_serialized_and_restored()
+    public function test_morph_pivot_can_be_serialized_and_restored(): void
     {
         $project = PivotSerializationTestProject::forceCreate(['name' => 'Test Project']);
         $tag = PivotSerializationTestTag::forceCreate(['name' => 'Test Tag']);
@@ -83,7 +83,7 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
         $class->pivot->save();
     }
 
-    public function test_collection_of_pivots_can_be_serialized_and_restored()
+    public function test_collection_of_pivots_can_be_serialized_and_restored(): void
     {
         $user = PivotSerializationTestUser::forceCreate(['email' => 'taylor@laravel.com']);
         $user2 = PivotSerializationTestUser::forceCreate(['email' => 'mohamed@laravel.com']);
@@ -101,7 +101,7 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
         $this->assertEquals($project->collaborators[1]->pivot->project_id, $class->pivots[1]->project_id);
     }
 
-    public function test_collection_of_morph_pivots_can_be_serialized_and_restored()
+    public function test_collection_of_morph_pivots_can_be_serialized_and_restored(): void
     {
         $tag = PivotSerializationTestTag::forceCreate(['name' => 'Test Tag 1']);
         $tag2 = PivotSerializationTestTag::forceCreate(['name' => 'Test Tag 2']);

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentTouchParentWithGlobalScopeTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -25,7 +25,7 @@ class EloquentUpdateTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -44,7 +44,7 @@ class EloquentUpdateTest extends TestCase
         });
     }
 
-    public function testBasicUpdate()
+    public function testBasicUpdate(): void
     {
         TestUpdateModel1::create([
             'name' => str_random(),
@@ -56,7 +56,7 @@ class EloquentUpdateTest extends TestCase
         $this->assertEquals(0, TestUpdateModel1::all()->count());
     }
 
-    public function testUpdateWithLimitsAndOrders()
+    public function testUpdateWithLimitsAndOrders(): void
     {
         for ($i = 1; $i <= 10; $i++) {
             TestUpdateModel1::create();
@@ -68,7 +68,7 @@ class EloquentUpdateTest extends TestCase
         $this->assertNotEquals('Dr.', TestUpdateModel1::find(7)->title);
     }
 
-    public function testUpdatedAtWithJoins()
+    public function testUpdatedAtWithJoins(): void
     {
         TestUpdateModel1::create([
             'name' => 'Abdul',
@@ -89,7 +89,7 @@ class EloquentUpdateTest extends TestCase
         $this->assertEquals('Engineer: Abdul', $record->job.': '.$record->name);
     }
 
-    public function testSoftDeleteWithJoins()
+    public function testSoftDeleteWithJoins(): void
     {
         TestUpdateModel1::create([
             'name' => str_random(),

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -11,7 +11,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentWithCountTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/MigrateWithRealpathTest.php
+++ b/tests/Integration/Database/MigrateWithRealpathTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 
 class MigrateWithRealpathTest extends DatabaseTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -22,12 +22,12 @@ class MigrateWithRealpathTest extends DatabaseTestCase
         });
     }
 
-    public function test_realpath_migration_has_properly_executed()
+    public function test_realpath_migration_has_properly_executed(): void
     {
         $this->assertTrue(Schema::hasTable('members'));
     }
 
-    public function test_migrations_has_the_migrated_table()
+    public function test_migrations_has_the_migrated_table(): void
     {
         $this->assertDatabaseHas('migrations', [
             'id' => 1,

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -10,7 +10,7 @@ use Orchestra\Testbench\TestCase;
  */
 class HelpersTest extends TestCase
 {
-    public function test_rescue()
+    public function test_rescue(): void
     {
         $this->assertEquals(rescue(function () {
             throw new Exception;

--- a/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
+++ b/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
@@ -23,7 +23,7 @@ class InteractsWithAuthenticationTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -44,7 +44,7 @@ class InteractsWithAuthenticationTest extends TestCase
         ]);
     }
 
-    public function test_acting_as_is_properly_handled_for_session_auth()
+    public function test_acting_as_is_properly_handled_for_session_auth(): void
     {
         Route::get('me', function (Request $request) {
             return 'Hello '.$request->user()->username;
@@ -58,7 +58,7 @@ class InteractsWithAuthenticationTest extends TestCase
             ->assertSeeText('Hello taylorotwell');
     }
 
-    public function test_acting_as_is_properly_handled_for_auth_via_request()
+    public function test_acting_as_is_properly_handled_for_auth_via_request(): void
     {
         Route::get('me', function (Request $request) {
             return 'Hello '.$request->user()->username;

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -11,7 +11,7 @@ class VerifyCsrfTokenExceptTest extends TestCase
     private $stub;
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -19,20 +19,20 @@ class VerifyCsrfTokenExceptTest extends TestCase
         $this->request = Request::create('http://example.com/foo/bar', 'POST');
     }
 
-    public function testItCanExceptPaths()
+    public function testItCanExceptPaths(): void
     {
         $this->assertMatchingExcept(['/foo/bar']);
         $this->assertMatchingExcept(['foo/bar']);
         $this->assertNonMatchingExcept(['/bar/foo']);
     }
 
-    public function testItCanExceptWildcardPaths()
+    public function testItCanExceptWildcardPaths(): void
     {
         $this->assertMatchingExcept(['/foo/*']);
         $this->assertNonMatchingExcept(['/bar*']);
     }
 
-    public function testItCanExceptFullUrlPaths()
+    public function testItCanExceptFullUrlPaths(): void
     {
         $this->assertMatchingExcept(['http://example.com/foo/bar']);
         $this->assertMatchingExcept(['http://example.com/foo/bar/']);
@@ -41,7 +41,7 @@ class VerifyCsrfTokenExceptTest extends TestCase
         $this->assertNonMatchingExcept(['http://foobar.com/']);
     }
 
-    public function testItCanExceptFullUrlWildcardPaths()
+    public function testItCanExceptFullUrlWildcardPaths(): void
     {
         $this->assertMatchingExcept(['http://example.com/*']);
         $this->assertMatchingExcept(['*example.com*']);

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -27,7 +27,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalPivotRela
  */
 class ResourceTest extends TestCase
 {
-    public function test_resources_may_be_converted_to_json()
+    public function test_resources_may_be_converted_to_json(): void
     {
         Route::get('/', function () {
             return new PostResource(new Post([
@@ -50,7 +50,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_resources_may_have_no_wrap()
+    public function test_resources_may_have_no_wrap(): void
     {
         Route::get('/', function () {
             return new PostResourceWithoutWrap(new Post([
@@ -69,7 +69,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_resources_may_have_optional_values()
+    public function test_resources_may_have_optional_values(): void
     {
         Route::get('/', function () {
             return new PostResourceWithOptionalData(new Post([
@@ -92,7 +92,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_resources_may_have_optional_Merges()
+    public function test_resources_may_have_optional_Merges(): void
     {
         Route::get('/', function () {
             return new PostResourceWithOptionalMerging(new Post([
@@ -114,7 +114,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_resources_may_have_optional_relationships()
+    public function test_resources_may_have_optional_relationships(): void
     {
         Route::get('/', function () {
             return new PostResourceWithOptionalRelationship(new Post([
@@ -136,7 +136,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_resources_may_load_optional_relationships()
+    public function test_resources_may_load_optional_relationships(): void
     {
         Route::get('/', function () {
             $post = new Post([
@@ -164,7 +164,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_resources_may_shows_null_for_loaded_relationship_with_value_null()
+    public function test_resources_may_shows_null_for_loaded_relationship_with_value_null(): void
     {
         Route::get('/', function () {
             $post = new Post([
@@ -192,7 +192,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_resources_may_have_optional_pivot_relationships()
+    public function test_resources_may_have_optional_pivot_relationships(): void
     {
         Route::get('/', function () {
             $post = new Post(['id' => 5]);
@@ -217,7 +217,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_resource_is_url_routable()
+    public function test_resource_is_url_routable(): void
     {
         $post = new PostResource(new Post([
             'id' => 5,
@@ -227,7 +227,7 @@ class ResourceTest extends TestCase
         $this->assertEquals('http://localhost/post/5', url('/post', $post));
     }
 
-    public function test_named_routes_are_url_routable()
+    public function test_named_routes_are_url_routable(): void
     {
         $post = new PostResource(new Post([
             'id' => 5,
@@ -243,7 +243,7 @@ class ResourceTest extends TestCase
         $this->assertEquals('http://localhost/post/5', $response->original);
     }
 
-    public function test_resources_may_be_serializable()
+    public function test_resources_may_be_serializable(): void
     {
         Route::get('/', function () {
             return new SerializablePostResource(new Post([
@@ -265,7 +265,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_resources_may_customize_responses()
+    public function test_resources_may_customize_responses(): void
     {
         Route::get('/', function () {
             return new PostResource(new Post([
@@ -282,7 +282,7 @@ class ResourceTest extends TestCase
         $response->assertHeader('X-Resource', 'True');
     }
 
-    public function test_resources_may_customize_extra_data()
+    public function test_resources_may_customize_extra_data(): void
     {
         Route::get('/', function () {
             return new PostResourceWithExtraData(new Post([
@@ -304,7 +304,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_resources_may_customize_extra_data_when_building_response()
+    public function test_resources_may_customize_extra_data_when_building_response(): void
     {
         Route::get('/', function () {
             return (new PostResourceWithExtraData(new Post([
@@ -327,7 +327,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_custom_headers_may_be_set_on_responses()
+    public function test_custom_headers_may_be_set_on_responses(): void
     {
         Route::get('/', function () {
             return (new PostResource(new Post([
@@ -344,7 +344,7 @@ class ResourceTest extends TestCase
         $response->assertHeader('X-Custom', 'True');
     }
 
-    public function test_resources_may_receive_proper_status_code_for_fresh_models()
+    public function test_resources_may_receive_proper_status_code_for_fresh_models(): void
     {
         Route::get('/', function () {
             $post = new Post([
@@ -364,7 +364,7 @@ class ResourceTest extends TestCase
         $response->assertStatus(201);
     }
 
-    public function test_collections_are_not_doubled_wrapped()
+    public function test_collections_are_not_doubled_wrapped(): void
     {
         Route::get('/', function () {
             return new PostCollectionResource(collect([new Post([
@@ -389,7 +389,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_paginators_receive_links()
+    public function test_paginators_receive_links(): void
     {
         Route::get('/', function () {
             $paginator = new LengthAwarePaginator(
@@ -431,7 +431,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_to_json_may_be_left_off_of_collection()
+    public function test_to_json_may_be_left_off_of_collection(): void
     {
         Route::get('/', function () {
             return new EmptyPostCollectionResource(new LengthAwarePaginator(
@@ -472,7 +472,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_to_json_may_be_left_off_of_single_resource()
+    public function test_to_json_may_be_left_off_of_single_resource(): void
     {
         Route::get('/', function () {
             return new ReallyEmptyPostResource(new Post([
@@ -495,7 +495,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function test_original_on_response_is_model_when_single_resource()
+    public function test_original_on_response_is_model_when_single_resource(): void
     {
         $createdPost = new Post(['id' => 5, 'title' => 'Test Title']);
         Route::get('/', function () use ($createdPost) {
@@ -507,7 +507,7 @@ class ResourceTest extends TestCase
         $this->assertTrue($createdPost->is($response->getOriginalContent()));
     }
 
-    public function test_original_on_response_is_collection_of_model_when_collection_resource()
+    public function test_original_on_response_is_collection_of_model_when_collection_resource(): void
     {
         $createdPosts = collect([
             new Post(['id' => 5, 'title' => 'Test Title']),
@@ -524,7 +524,7 @@ class ResourceTest extends TestCase
         });
     }
 
-    public function test_leading_merge__keyed_value_is_merged_correctly()
+    public function test_leading_merge__keyed_value_is_merged_correctly(): void
     {
         $filter = new class {
             use ConditionallyLoadsAttributes;
@@ -544,7 +544,7 @@ class ResourceTest extends TestCase
         ], $results);
     }
 
-    public function test_leading_merge_value_is_merged_correctly()
+    public function test_leading_merge_value_is_merged_correctly(): void
     {
         $filter = new class {
             use ConditionallyLoadsAttributes;
@@ -569,7 +569,7 @@ class ResourceTest extends TestCase
         ], $results);
     }
 
-    public function test_merge_values_may_be_missing()
+    public function test_merge_values_may_be_missing(): void
     {
         $filter = new class {
             use ConditionallyLoadsAttributes;
@@ -594,7 +594,7 @@ class ResourceTest extends TestCase
         ], $results);
     }
 
-    public function test_initial_merge_values_may_be_missing()
+    public function test_initial_merge_values_may_be_missing(): void
     {
         $filter = new class {
             use ConditionallyLoadsAttributes;
@@ -619,7 +619,7 @@ class ResourceTest extends TestCase
         ], $results);
     }
 
-    public function test_all_merge_values_may_be_missing()
+    public function test_all_merge_values_may_be_missing(): void
     {
         $filter = new class {
             use ConditionallyLoadsAttributes;
@@ -644,7 +644,7 @@ class ResourceTest extends TestCase
         ], $results);
     }
 
-    public function test_nested_merges()
+    public function test_nested_merges(): void
     {
         $filter = new class {
             use ConditionallyLoadsAttributes;

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -14,7 +14,7 @@ use Illuminate\Http\Exceptions\ThrottleRequestsException;
  */
 class ThrottleRequestsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         Carbon::setTestNow(null);
@@ -25,7 +25,7 @@ class ThrottleRequestsTest extends TestCase
         $app['config']->set('hashing', ['driver' => 'bcrypt']);
     }
 
-    public function test_lock_opens_immediately_after_decay()
+    public function test_lock_opens_immediately_after_decay(): void
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 0, 0, 0));
 

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -16,7 +16,7 @@ class ThrottleRequestsWithRedisTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         Carbon::setTestNow(null);
@@ -27,7 +27,7 @@ class ThrottleRequestsWithRedisTest extends TestCase
         $app['config']->set('hashing', ['driver' => 'bcrypt']);
     }
 
-    public function test_lock_opens_immediately_after_decay()
+    public function test_lock_opens_immediately_after_decay(): void
     {
         $this->ifRedisAvailable(function () {
             Carbon::setTestNow(null);

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Route;
  */
 class IntegrationTest extends TestCase
 {
-    public function test_simple_route_through_the_framework()
+    public function test_simple_route_through_the_framework(): void
     {
         Route::get('/', function () {
             return 'Hello World';

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\View;
  */
 class SendingMailWithLocaleTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -40,12 +40,12 @@ class SendingMailWithLocaleTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }
 
-    public function test_mail_is_sent_with_default_locale()
+    public function test_mail_is_sent_with_default_locale(): void
     {
         Mail::to('test@mail.com')->send(new TestMail());
 
@@ -54,7 +54,7 @@ class SendingMailWithLocaleTest extends TestCase
         );
     }
 
-    public function test_mail_is_sent_with_selected_locale()
+    public function test_mail_is_sent_with_selected_locale(): void
     {
         Mail::to('test@mail.com')->locale('ar')->send(new TestMail());
 
@@ -63,7 +63,7 @@ class SendingMailWithLocaleTest extends TestCase
         );
     }
 
-    public function test_locale_is_set_back_to_default_after_mail_sent()
+    public function test_locale_is_set_back_to_default_after_mail_sent(): void
     {
         Mail::to('test@mail.com')->locale('ar')->send(new TestMail());
         Mail::to('test@mail.com')->send(new TestMail());

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -21,7 +21,7 @@ class SendingMailNotificationsTest extends TestCase
 {
     public $mailer;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -52,7 +52,7 @@ class SendingMailNotificationsTest extends TestCase
         });
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -62,7 +62,7 @@ class SendingMailNotificationsTest extends TestCase
         });
     }
 
-    public function test_mail_is_sent()
+    public function test_mail_is_sent(): void
     {
         $notification = new TestMailNotification;
 
@@ -102,7 +102,7 @@ class SendingMailNotificationsTest extends TestCase
         $user->notify($notification);
     }
 
-    public function test_mail_is_sent_with_subject()
+    public function test_mail_is_sent_with_subject(): void
     {
         $notification = new TestMailNotificationWithSubject;
 
@@ -132,7 +132,7 @@ class SendingMailNotificationsTest extends TestCase
         $user->notify($notification);
     }
 
-    public function test_mail_is_sent_using_mailable()
+    public function test_mail_is_sent_using_mailable(): void
     {
         $notification = new TestMailNotificationWithMailable;
 

--- a/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
@@ -20,7 +20,7 @@ class SendingNotificationsViaAnonymousNotifiableTest extends TestCase
         $app['config']->set('app.debug', 'true');
     }
 
-    public function test_mail_is_sent()
+    public function test_mail_is_sent(): void
     {
         $notifiable = (new AnonymousNotifiable())
             ->route('testchannel', 'enzo')
@@ -36,7 +36,7 @@ class SendingNotificationsViaAnonymousNotifiableTest extends TestCase
         ], $_SERVER['__notifiable.route']);
     }
 
-    public function test_faking()
+    public function test_faking(): void
     {
         $fake = NotificationFacade::fake();
 

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -12,14 +12,14 @@ use Illuminate\Queue\Events\JobFailed;
  */
 class CallQueuedHandlerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
         Mockery::close();
     }
 
-    public function test_job_can_be_dispatched()
+    public function test_job_can_be_dispatched(): void
     {
         CallQueuedHandlerTestJob::$handled = false;
 
@@ -39,7 +39,7 @@ class CallQueuedHandlerTest extends TestCase
         $this->assertTrue(CallQueuedHandlerTestJob::$handled);
     }
 
-    public function test_job_is_marked_as_failed_if_model_not_found_exception_is_thrown()
+    public function test_job_is_marked_as_failed_if_model_not_found_exception_is_thrown(): void
     {
         Event::fake();
 
@@ -60,7 +60,7 @@ class CallQueuedHandlerTest extends TestCase
         Event::assertDispatched(JobFailed::class);
     }
 
-    public function test_job_is_deleted_if_has_delete_property()
+    public function test_job_is_deleted_if_has_delete_property(): void
     {
         Event::fake();
 

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -29,14 +29,14 @@ class JobChainingTest extends TestCase
         ]);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         JobChainingTestFirstJob::$ran = false;
         JobChainingTestSecondJob::$ran = false;
         JobChainingTestThirdJob::$ran = false;
     }
 
-    public function test_jobs_can_be_chained_on_success()
+    public function test_jobs_can_be_chained_on_success(): void
     {
         JobChainingTestFirstJob::dispatch()->chain([
             new JobChainingTestSecondJob,
@@ -46,7 +46,7 @@ class JobChainingTest extends TestCase
         $this->assertTrue(JobChainingTestSecondJob::$ran);
     }
 
-    public function test_jobs_can_be_chained_on_success_using_pending_chain()
+    public function test_jobs_can_be_chained_on_success_using_pending_chain(): void
     {
         JobChainingTestFirstJob::withChain([
             new JobChainingTestSecondJob,
@@ -56,7 +56,7 @@ class JobChainingTest extends TestCase
         $this->assertTrue(JobChainingTestSecondJob::$ran);
     }
 
-    public function test_jobs_chained_on_explicit_delete()
+    public function test_jobs_chained_on_explicit_delete(): void
     {
         JobChainingTestDeletingJob::dispatch()->chain([
             new JobChainingTestSecondJob,
@@ -66,7 +66,7 @@ class JobChainingTest extends TestCase
         $this->assertTrue(JobChainingTestSecondJob::$ran);
     }
 
-    public function test_jobs_can_be_chained_on_success_with_several_jobs()
+    public function test_jobs_can_be_chained_on_success_with_several_jobs(): void
     {
         JobChainingTestFirstJob::dispatch()->chain([
             new JobChainingTestSecondJob,
@@ -78,7 +78,7 @@ class JobChainingTest extends TestCase
         $this->assertTrue(JobChainingTestThirdJob::$ran);
     }
 
-    public function test_jobs_can_be_chained_on_success_using_helper()
+    public function test_jobs_can_be_chained_on_success_using_helper(): void
     {
         dispatch(new JobChainingTestFirstJob)->chain([
             new JobChainingTestSecondJob,
@@ -88,7 +88,7 @@ class JobChainingTest extends TestCase
         $this->assertTrue(JobChainingTestSecondJob::$ran);
     }
 
-    public function test_jobs_can_be_chained_via_queue()
+    public function test_jobs_can_be_chained_via_queue(): void
     {
         Queue::connection('sync')->push((new JobChainingTestFirstJob)->chain([
             new JobChainingTestSecondJob,
@@ -98,7 +98,7 @@ class JobChainingTest extends TestCase
         $this->assertTrue(JobChainingTestSecondJob::$ran);
     }
 
-    public function test_second_job_is_not_fired_if_first_failed()
+    public function test_second_job_is_not_fired_if_first_failed(): void
     {
         Queue::connection('sync')->push((new JobChainingTestFailingJob)->chain([
             new JobChainingTestSecondJob,
@@ -107,7 +107,7 @@ class JobChainingTest extends TestCase
         $this->assertFalse(JobChainingTestSecondJob::$ran);
     }
 
-    public function test_second_job_is_not_fired_if_first_released()
+    public function test_second_job_is_not_fired_if_first_released(): void
     {
         Queue::connection('sync')->push((new JobChainingTestReleasingJob)->chain([
             new JobChainingTestSecondJob,
@@ -116,7 +116,7 @@ class JobChainingTest extends TestCase
         $this->assertFalse(JobChainingTestSecondJob::$ran);
     }
 
-    public function test_third_job_is_not_fired_if_second_fails()
+    public function test_third_job_is_not_fired_if_second_fails(): void
     {
         Queue::connection('sync')->push((new JobChainingTestFirstJob)->chain([
             new JobChainingTestFailingJob,
@@ -127,7 +127,7 @@ class JobChainingTest extends TestCase
         $this->assertFalse(JobChainingTestThirdJob::$ran);
     }
 
-    public function test_chain_jobs_use_same_config()
+    public function test_chain_jobs_use_same_config(): void
     {
         JobChainingTestFirstJob::dispatch()->allOnQueue('some_queue')->allOnConnection('sync1')->chain([
             new JobChainingTestSecondJob,
@@ -144,7 +144,7 @@ class JobChainingTest extends TestCase
         $this->assertEquals('sync1', JobChainingTestThirdJob::$usedConnection);
     }
 
-    public function test_chain_jobs_use_own_config()
+    public function test_chain_jobs_use_own_config(): void
     {
         JobChainingTestFirstJob::dispatch()->allOnQueue('some_queue')->allOnConnection('sync1')->chain([
             (new JobChainingTestSecondJob)->onQueue('another_queue')->onConnection('sync2'),
@@ -161,7 +161,7 @@ class JobChainingTest extends TestCase
         $this->assertEquals('sync1', JobChainingTestThirdJob::$usedConnection);
     }
 
-    public function test_chain_jobs_use_default_config()
+    public function test_chain_jobs_use_default_config(): void
     {
         JobChainingTestFirstJob::dispatch()->onQueue('some_queue')->onConnection('sync1')->chain([
             (new JobChainingTestSecondJob)->onQueue('another_queue')->onConnection('sync2'),

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -30,7 +30,7 @@ class ModelSerializationTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Queue/QueuedListenersTest.php
+++ b/tests/Integration/Queue/QueuedListenersTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
  */
 class QueuedListenersTest extends TestCase
 {
-    public function test_listeners_can_be_queued_optionally()
+    public function test_listeners_can_be_queued_optionally(): void
     {
         \Queue::fake();
 

--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Route;
  */
 class FallbackRouteTest extends TestCase
 {
-    public function test_basic_fallback()
+    public function test_basic_fallback(): void
     {
         Route::fallback(function () {
             return response('fallback', 404);
@@ -25,7 +25,7 @@ class FallbackRouteTest extends TestCase
         $this->assertEquals(404, $this->get('/non-existing')->getStatusCode());
     }
 
-    public function test_fallback_with_prefix()
+    public function test_fallback_with_prefix(): void
     {
         Route::group(['prefix' => 'prefix'], function () {
             Route::fallback(function () {
@@ -43,7 +43,7 @@ class FallbackRouteTest extends TestCase
         $this->assertContains('Page Not Found', $this->get('/non-existing')->getContent());
     }
 
-    public function test_fallback_with_wildcards()
+    public function test_fallback_with_wildcards(): void
     {
         Route::fallback(function () {
             return response('fallback', 404);
@@ -62,7 +62,7 @@ class FallbackRouteTest extends TestCase
         $this->assertEquals(200, $this->get('/non-existing')->getStatusCode());
     }
 
-    public function test_no_routes()
+    public function test_no_routes(): void
     {
         Route::fallback(function () {
             return response('fallback', 404);
@@ -72,7 +72,7 @@ class FallbackRouteTest extends TestCase
         $this->assertEquals(404, $this->get('/non-existing')->getStatusCode());
     }
 
-    public function test_respond_with_named_fallback_route()
+    public function test_respond_with_named_fallback_route(): void
     {
         Route::fallback(function () {
             return response('fallback', 404);
@@ -86,7 +86,7 @@ class FallbackRouteTest extends TestCase
         $this->assertContains('fallback', $this->get('/one')->getContent());
     }
 
-    public function test_no_fallbacks()
+    public function test_no_fallbacks(): void
     {
         Route::get('one', function () {
             return 'one';

--- a/tests/Integration/Routing/FluentRoutingTest.php
+++ b/tests/Integration/Routing/FluentRoutingTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Route;
  */
 class FluentRoutingTest extends TestCase
 {
-    public function test_middleware_run_when_registered_as_array_or_params()
+    public function test_middleware_run_when_registered_as_array_or_params(): void
     {
         Route::middleware(Middleware::class, Middleware2::class)
             ->get('one', function () {

--- a/tests/Integration/Routing/ResponsableTest.php
+++ b/tests/Integration/Routing/ResponsableTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Support\Responsable;
  */
 class ResponsableTest extends TestCase
 {
-    public function test_responsable_objects_are_rendered()
+    public function test_responsable_objects_are_rendered(): void
     {
         Route::get('/responsable', function () {
             return new TestResponsableResponse;

--- a/tests/Integration/Routing/RouteRedirectTest.php
+++ b/tests/Integration/Routing/RouteRedirectTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Route;
  */
 class RouteRedirectTest extends TestCase
 {
-    public function test_route_redirect()
+    public function test_route_redirect(): void
     {
         Route::redirect('from', 'to', 301);
 
@@ -19,7 +19,7 @@ class RouteRedirectTest extends TestCase
         $this->assertEquals('to', $response->headers->get('Location'));
     }
 
-    public function test_route_redirect_with_params()
+    public function test_route_redirect_with_params(): void
     {
         Route::redirect('from/{param}/{param2?}', 'to', 301);
 

--- a/tests/Integration/Routing/RouteViewTest.php
+++ b/tests/Integration/Routing/RouteViewTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Route;
  */
 class RouteViewTest extends TestCase
 {
-    public function test_route_view()
+    public function test_route_view(): void
     {
         Route::view('route', 'view', ['foo' => 'bar']);
 
@@ -20,7 +20,7 @@ class RouteViewTest extends TestCase
         $this->assertContains('Test bar', $this->get('/route')->getContent());
     }
 
-    public function test_route_view_with_params()
+    public function test_route_view_with_params(): void
     {
         Route::view('route/{param}/{param2?}', 'view', ['foo' => 'bar']);
 

--- a/tests/Integration/Support/ManagerTest.php
+++ b/tests/Integration/Support/ManagerTest.php
@@ -9,7 +9,7 @@ class ManagerTest extends TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testDefaultDriverCannotBeNull()
+    public function testDefaultDriverCannotBeNull(): void
     {
         (new Fixtures\NullableManager($this->app))->driver();
     }

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -8,12 +8,12 @@ use PHPUnit\Framework\TestCase;
 
 class LogLoggerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testMethodsPassErrorAdditionsToMonolog()
+    public function testMethodsPassErrorAdditionsToMonolog(): void
     {
         $writer = new Logger($monolog = m::mock('Monolog\Logger'));
         $monolog->shouldReceive('error')->once()->with('foo', []);
@@ -21,7 +21,7 @@ class LogLoggerTest extends TestCase
         $writer->error('foo');
     }
 
-    public function testLoggerFiresEventsDispatcher()
+    public function testLoggerFiresEventsDispatcher(): void
     {
         $writer = new Logger($monolog = m::mock('Monolog\Logger'), $events = new \Illuminate\Events\Dispatcher);
         $monolog->shouldReceive('error')->once()->with('foo', []);
@@ -48,14 +48,14 @@ class LogLoggerTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Events dispatcher has not been set.
      */
-    public function testListenShortcutFailsWithNoDispatcher()
+    public function testListenShortcutFailsWithNoDispatcher(): void
     {
         $writer = new Logger($monolog = m::mock('Monolog\Logger'));
         $writer->listen(function () {
         });
     }
 
-    public function testListenShortcut()
+    public function testListenShortcut(): void
     {
         $writer = new Logger($monolog = m::mock('Monolog\Logger'), $events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
 

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -7,7 +7,7 @@ use Orchestra\Testbench\TestCase;
 
 class LogManagerTest extends TestCase
 {
-    public function testLogManagerCachesLoggerInstances()
+    public function testLogManagerCachesLoggerInstances(): void
     {
         $manager = new LogManager($this->app);
 

--- a/tests/Mail/MailMailableDataTest.php
+++ b/tests/Mail/MailMailableDataTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class MailMailableDataTest extends TestCase
 {
-    public function testMailableDataIsNotLost()
+    public function testMailableDataIsNotLost(): void
     {
         $testData = ['first_name' => 'James'];
 

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class MailMailableTest extends TestCase
 {
-    public function testMailableSetsRecipientsCorrectly()
+    public function testMailableSetsRecipientsCorrectly(): void
     {
         $mailable = new WelcomeMailableStub;
         $mailable->to('taylor@laravel.com');
@@ -54,7 +54,7 @@ class MailMailableTest extends TestCase
         $this->assertTrue($mailable->hasTo('taylor@laravel.com'));
     }
 
-    public function testMailableSetsReplyToCorrectly()
+    public function testMailableSetsReplyToCorrectly(): void
     {
         $mailable = new WelcomeMailableStub;
         $mailable->replyTo('taylor@laravel.com');
@@ -101,7 +101,7 @@ class MailMailableTest extends TestCase
         $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com'));
     }
 
-    public function testMailableBuildsViewData()
+    public function testMailableBuildsViewData(): void
     {
         $mailable = new WelcomeMailableStub;
 

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -9,12 +9,12 @@ use Illuminate\Support\HtmlString;
 
 class MailMailerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testMailerSendSendsMessageWithProperViewContent()
+    public function testMailerSendSendsMessageWithProperViewContent(): void
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
@@ -34,7 +34,7 @@ class MailMailerTest extends TestCase
         unset($_SERVER['__mailer.test']);
     }
 
-    public function testMailerSendSendsMessageWithProperViewContentUsingHtmlStrings()
+    public function testMailerSendSendsMessageWithProperViewContentUsingHtmlStrings(): void
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
@@ -55,7 +55,7 @@ class MailMailerTest extends TestCase
         unset($_SERVER['__mailer.test']);
     }
 
-    public function testMailerSendSendsMessageWithProperViewContentUsingHtmlMethod()
+    public function testMailerSendSendsMessageWithProperViewContentUsingHtmlMethod(): void
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
@@ -75,7 +75,7 @@ class MailMailerTest extends TestCase
         unset($_SERVER['__mailer.test']);
     }
 
-    public function testMailerSendSendsMessageWithProperPlainViewContent()
+    public function testMailerSendSendsMessageWithProperPlainViewContent(): void
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
@@ -97,7 +97,7 @@ class MailMailerTest extends TestCase
         unset($_SERVER['__mailer.test']);
     }
 
-    public function testMailerSendSendsMessageWithProperPlainViewContentWhenExplicit()
+    public function testMailerSendSendsMessageWithProperPlainViewContentWhenExplicit(): void
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
@@ -119,7 +119,7 @@ class MailMailerTest extends TestCase
         unset($_SERVER['__mailer.test']);
     }
 
-    public function testGlobalFromIsRespectedOnAllMessages()
+    public function testGlobalFromIsRespectedOnAllMessages(): void
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMailer();
@@ -135,7 +135,7 @@ class MailMailerTest extends TestCase
         });
     }
 
-    public function testFailedRecipientsAreAppendedAndCanBeRetrieved()
+    public function testFailedRecipientsAreAppendedAndCanBeRetrieved(): void
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMailer();
@@ -153,7 +153,7 @@ class MailMailerTest extends TestCase
         $this->assertEquals(['taylorotwell@gmail.com'], $mailer->failures());
     }
 
-    public function testEventsAreDispatched()
+    public function testEventsAreDispatched(): void
     {
         unset($_SERVER['__mailer.test']);
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
@@ -169,7 +169,7 @@ class MailMailerTest extends TestCase
         });
     }
 
-    public function testMacroable()
+    public function testMacroable(): void
     {
         Mailer::macro('foo', function () {
             return 'bar';

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -6,12 +6,12 @@ use PHPUnit\Framework\TestCase;
 
 class MailMarkdownTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         \Mockery::close();
     }
 
-    public function testRenderFunctionReturnsHtml()
+    public function testRenderFunctionReturnsHtml(): void
     {
         $viewFactory = \Mockery::mock('Illuminate\View\Factory');
         $markdown = new \Illuminate\Mail\Markdown($viewFactory);
@@ -26,7 +26,7 @@ class MailMarkdownTest extends TestCase
         $this->assertTrue(strpos($result, '<html></html>') !== false);
     }
 
-    public function testRenderFunctionReturnsHtmlWithCustomTheme()
+    public function testRenderFunctionReturnsHtmlWithCustomTheme(): void
     {
         $viewFactory = \Mockery::mock('Illuminate\View\Factory');
         $markdown = new \Illuminate\Mail\Markdown($viewFactory);
@@ -42,7 +42,7 @@ class MailMarkdownTest extends TestCase
         $this->assertTrue(strpos($result, '<html></html>') !== false);
     }
 
-    public function testRenderTextReturnsText()
+    public function testRenderTextReturnsText(): void
     {
         $viewFactory = \Mockery::mock('Illuminate\View\Factory');
         $markdown = new \Illuminate\Mail\Markdown($viewFactory);
@@ -56,7 +56,7 @@ class MailMarkdownTest extends TestCase
         $this->assertEquals('text', $result);
     }
 
-    public function testParseReturnsParsedMarkdown()
+    public function testParseReturnsParsedMarkdown(): void
     {
         $viewFactory = \Mockery::mock('Illuminate\View\Factory');
         $markdown = new \Illuminate\Mail\Markdown($viewFactory);

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -18,7 +18,7 @@ class MailMessageTest extends TestCase
      */
     protected $message;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -26,77 +26,77 @@ class MailMessageTest extends TestCase
         $this->message = new Message($this->swift);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testFromMethod()
+    public function testFromMethod(): void
     {
         $this->swift->shouldReceive('setFrom')->once()->with('foo@bar.baz', 'Foo');
         $this->assertInstanceOf(Message::class, $this->message->from('foo@bar.baz', 'Foo'));
     }
 
-    public function testSenderMethod()
+    public function testSenderMethod(): void
     {
         $this->swift->shouldReceive('setSender')->once()->with('foo@bar.baz', 'Foo');
         $this->assertInstanceOf(Message::class, $this->message->sender('foo@bar.baz', 'Foo'));
     }
 
-    public function testReturnPathMethod()
+    public function testReturnPathMethod(): void
     {
         $this->swift->shouldReceive('setReturnPath')->once()->with('foo@bar.baz');
         $this->assertInstanceOf(Message::class, $this->message->returnPath('foo@bar.baz'));
     }
 
-    public function testToMethod()
+    public function testToMethod(): void
     {
         $this->swift->shouldReceive('addTo')->once()->with('foo@bar.baz', 'Foo');
         $this->assertInstanceOf(Message::class, $this->message->to('foo@bar.baz', 'Foo', false));
     }
 
-    public function testToMethodWithOverride()
+    public function testToMethodWithOverride(): void
     {
         $this->swift->shouldReceive('setTo')->once()->with('foo@bar.baz', 'Foo');
         $this->assertInstanceOf(Message::class, $this->message->to('foo@bar.baz', 'Foo', true));
     }
 
-    public function testCcMethod()
+    public function testCcMethod(): void
     {
         $this->swift->shouldReceive('addCc')->once()->with('foo@bar.baz', 'Foo');
         $this->assertInstanceOf(Message::class, $this->message->cc('foo@bar.baz', 'Foo'));
     }
 
-    public function testBccMethod()
+    public function testBccMethod(): void
     {
         $this->swift->shouldReceive('addBcc')->once()->with('foo@bar.baz', 'Foo');
         $this->assertInstanceOf(Message::class, $this->message->bcc('foo@bar.baz', 'Foo'));
     }
 
-    public function testReplyToMethod()
+    public function testReplyToMethod(): void
     {
         $this->swift->shouldReceive('addReplyTo')->once()->with('foo@bar.baz', 'Foo');
         $this->assertInstanceOf(Message::class, $this->message->replyTo('foo@bar.baz', 'Foo'));
     }
 
-    public function testSubjectMethod()
+    public function testSubjectMethod(): void
     {
         $this->swift->shouldReceive('setSubject')->once()->with('foo');
         $this->assertInstanceOf(Message::class, $this->message->subject('foo'));
     }
 
-    public function testPriorityMethod()
+    public function testPriorityMethod(): void
     {
         $this->swift->shouldReceive('setPriority')->once()->with(1);
         $this->assertInstanceOf(Message::class, $this->message->priority(1));
     }
 
-    public function testGetSwiftMessageMethod()
+    public function testGetSwiftMessageMethod(): void
     {
         $this->assertInstanceOf(\Swift_Mime_Message::class, $this->message->getSwiftMessage());
     }
 
-    public function testBasicAttachment()
+    public function testBasicAttachment(): void
     {
         $swift = m::mock('stdClass');
         $message = $this->getMockBuilder('Illuminate\Mail\Message')->setMethods(['createAttachmentFromPath'])->setConstructorArgs([$swift])->getMock();
@@ -108,7 +108,7 @@ class MailMessageTest extends TestCase
         $message->attach('foo.jpg', ['mime' => 'image/jpeg', 'as' => 'bar.jpg']);
     }
 
-    public function testDataAttachment()
+    public function testDataAttachment(): void
     {
         $swift = m::mock('stdClass');
         $message = $this->getMockBuilder('Illuminate\Mail\Message')->setMethods(['createAttachmentFromData'])->setConstructorArgs([$swift])->getMock();

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -12,7 +12,7 @@ use Illuminate\Mail\Transport\SesTransport;
 
 class MailSesTransportTest extends TestCase
 {
-    public function testGetTransport()
+    public function testGetTransport(): void
     {
         /** @var Application $app */
         $app = [
@@ -36,7 +36,7 @@ class MailSesTransportTest extends TestCase
         $this->assertEquals('us-east-1', $ses->getRegion());
     }
 
-    public function testSend()
+    public function testSend(): void
     {
         $message = new \Swift_Message('Foo subject', 'Bar body');
         $message->setSender('myself@example.com');

--- a/tests/Notifications/NotificationActionTest.php
+++ b/tests/Notifications/NotificationActionTest.php
@@ -7,7 +7,7 @@ use Illuminate\Notifications\Action;
 
 class NotificationActionTest extends TestCase
 {
-    public function testActionIsCreatedProperly()
+    public function testActionIsCreatedProperly(): void
     {
         $action = new Action('Text', 'url');
 

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -10,12 +10,12 @@ use Illuminate\Notifications\Channels\BroadcastChannel;
 
 class NotificationBroadcastChannelTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }
 
-    public function testDatabaseChannelCreatesDatabaseRecordWithProperData()
+    public function testDatabaseChannelCreatesDatabaseRecordWithProperData(): void
     {
         $notification = new NotificationBroadcastChannelTestNotification;
         $notification->id = 1;
@@ -27,7 +27,7 @@ class NotificationBroadcastChannelTest extends TestCase
         $channel->send($notifiable, $notification);
     }
 
-    public function testNotificationIsBroadcastedOnCustomChannels()
+    public function testNotificationIsBroadcastedOnCustomChannels(): void
     {
         $notification = new CustomChannelsTestNotification;
         $notification->id = 1;
@@ -42,7 +42,7 @@ class NotificationBroadcastChannelTest extends TestCase
         $this->assertEquals(new PrivateChannel('custom-channel'), $channels[0]);
     }
 
-    public function testNotificationIsBroadcastedWithCustomEventName()
+    public function testNotificationIsBroadcastedWithCustomEventName(): void
     {
         $notification = new CustomEventNameTestNotification;
         $notification->id = 1;
@@ -57,7 +57,7 @@ class NotificationBroadcastChannelTest extends TestCase
         $this->assertSame('custom.type', $eventName);
     }
 
-    public function testNotificationIsBroadcastedWithCustomDataType()
+    public function testNotificationIsBroadcastedWithCustomDataType(): void
     {
         $notification = new CustomEventNameTestNotification;
         $notification->id = 1;
@@ -72,7 +72,7 @@ class NotificationBroadcastChannelTest extends TestCase
         $this->assertSame('custom.type', $data['type']);
     }
 
-    public function testNotificationIsBroadcastedNow()
+    public function testNotificationIsBroadcastedNow(): void
     {
         $notification = new TestNotificationBroadCastedNow;
         $notification->id = 1;

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -12,12 +12,12 @@ use Illuminate\Contracts\Bus\Dispatcher as Bus;
 
 class NotificationChannelManagerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }
 
-    public function testNotificationCanBeDispatchedToDriver()
+    public function testNotificationCanBeDispatchedToDriver(): void
     {
         $container = new Container;
         $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
@@ -33,7 +33,7 @@ class NotificationChannelManagerTest extends TestCase
         $manager->send(new NotificationChannelManagerTestNotifiable, new NotificationChannelManagerTestNotification);
     }
 
-    public function testNotificationNotSentOnHalt()
+    public function testNotificationNotSentOnHalt(): void
     {
         $container = new Container;
         $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
@@ -50,7 +50,7 @@ class NotificationChannelManagerTest extends TestCase
         $manager->send([new NotificationChannelManagerTestNotifiable], new NotificationChannelManagerTestNotificationWithTwoChannels);
     }
 
-    public function testNotificationCanBeQueued()
+    public function testNotificationCanBeQueued(): void
     {
         $container = new Container;
         $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -10,12 +10,12 @@ use Illuminate\Notifications\Messages\DatabaseMessage;
 
 class NotificationDatabaseChannelTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }
 
-    public function testDatabaseChannelCreatesDatabaseRecordWithProperData()
+    public function testDatabaseChannelCreatesDatabaseRecordWithProperData(): void
     {
         $notification = new NotificationDatabaseChannelTestNotification;
         $notification->id = 1;
@@ -32,7 +32,7 @@ class NotificationDatabaseChannelTest extends TestCase
         $channel->send($notifiable, $notification);
     }
 
-    public function testCorrectPayloadIsSentToDatabase()
+    public function testCorrectPayloadIsSentToDatabase(): void
     {
         $notification = new NotificationDatabaseChannelTestNotification;
         $notification->id = 1;

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -7,12 +7,12 @@ use Illuminate\Notifications\Messages\MailMessage;
 
 class NotificationMailMessageTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->message = new MailMessage;
     }
 
-    public function testTemplate()
+    public function testTemplate(): void
     {
         $this->assertEquals('notifications::email', $this->message->markdown);
 

--- a/tests/Notifications/NotificationMessageTest.php
+++ b/tests/Notifications/NotificationMessageTest.php
@@ -7,7 +7,7 @@ use Illuminate\Notifications\Messages\SimpleMessage as Message;
 
 class NotificationMessageTest extends TestCase
 {
-    public function testLevelCanBeRetrieved()
+    public function testLevelCanBeRetrieved(): void
     {
         $message = new Message;
         $this->assertEquals('info', $message->level);
@@ -17,7 +17,7 @@ class NotificationMessageTest extends TestCase
         $this->assertEquals('error', $message->level);
     }
 
-    public function testMessageFormatsMultiLineText()
+    public function testMessageFormatsMultiLineText(): void
     {
         $message = new Message;
         $message->with('

--- a/tests/Notifications/NotificationNexmoChannelTest.php
+++ b/tests/Notifications/NotificationNexmoChannelTest.php
@@ -9,12 +9,12 @@ use Illuminate\Notifications\Messages\NexmoMessage;
 
 class NotificationNexmoChannelTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }
 
-    public function testSmsIsSentViaNexmo()
+    public function testSmsIsSentViaNexmo(): void
     {
         $notification = new NotificationNexmoChannelTestNotification;
         $notifiable = new NotificationNexmoChannelTestNotifiable;
@@ -33,7 +33,7 @@ class NotificationNexmoChannelTest extends TestCase
         $channel->send($notifiable, $notification);
     }
 
-    public function testSmsIsSentViaNexmoWithCustomFrom()
+    public function testSmsIsSentViaNexmoWithCustomFrom(): void
     {
         $notification = new NotificationNexmoChannelTestCustomFromNotification;
         $notifiable = new NotificationNexmoChannelTestNotifiable;

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -10,12 +10,12 @@ use Illuminate\Contracts\Notifications\Dispatcher;
 
 class NotificationRoutesNotificationsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }
 
-    public function testNotificationCanBeDispatched()
+    public function testNotificationCanBeDispatched(): void
     {
         $container = new Container;
         $factory = Mockery::mock(Dispatcher::class);
@@ -28,7 +28,7 @@ class NotificationRoutesNotificationsTest extends TestCase
         $notifiable->notify($instance);
     }
 
-    public function testNotificationCanBeSentNow()
+    public function testNotificationCanBeSentNow(): void
     {
         $container = new Container;
         $factory = Mockery::mock(Dispatcher::class);
@@ -41,7 +41,7 @@ class NotificationRoutesNotificationsTest extends TestCase
         $notifiable->notifyNow($instance);
     }
 
-    public function testNotificationOptionRouting()
+    public function testNotificationOptionRouting(): void
     {
         $instance = new RoutesNotificationsTestInstance;
         $this->assertEquals('bar', $instance->routeNotificationFor('foo'));

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -8,12 +8,12 @@ use Illuminate\Notifications\SendQueuedNotifications;
 
 class NotificationSendQueuedNotificationTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }
 
-    public function testNotificationsCanBeSent()
+    public function testNotificationsCanBeSent(): void
     {
         $job = new SendQueuedNotifications('notifiables', 'notification');
         $manager = Mockery::mock('Illuminate\Notifications\ChannelManager');

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -9,7 +9,7 @@ use Illuminate\Notifications\Messages\SlackMessage;
 
 class NotificationSlackChannelTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }
@@ -31,7 +31,7 @@ class NotificationSlackChannelTest extends TestCase
         $channel->send($notifiable, $notification);
     }
 
-    public function testCorrectPayloadIsSentToSlack()
+    public function testCorrectPayloadIsSentToSlack(): void
     {
         $this->validatePayload(
             new NotificationSlackChannelTestNotification,
@@ -68,7 +68,7 @@ class NotificationSlackChannelTest extends TestCase
         );
     }
 
-    public function testCorrectPayloadIsSentToSlackWithImageIcon()
+    public function testCorrectPayloadIsSentToSlackWithImageIcon(): void
     {
         $this->validatePayload(
             new NotificationSlackChannelTestNotificationWithImageIcon,
@@ -102,7 +102,7 @@ class NotificationSlackChannelTest extends TestCase
         );
     }
 
-    public function testCorrectPayloadWithoutOptionalFieldsIsSentToSlack()
+    public function testCorrectPayloadWithoutOptionalFieldsIsSentToSlack(): void
     {
         $this->validatePayload(
             new NotificationSlackChannelWithoutOptionalFieldsTestNotification,
@@ -128,7 +128,7 @@ class NotificationSlackChannelTest extends TestCase
         );
     }
 
-    public function testCorrectPayloadWithAttachmentFieldBuilderIsSentToSlack()
+    public function testCorrectPayloadWithAttachmentFieldBuilderIsSentToSlack(): void
     {
         $this->validatePayload(
             new NotificationSlackChannelWithAttachmentFieldBuilderTestNotification,

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -7,17 +7,17 @@ use Illuminate\Pagination\LengthAwarePaginator;
 
 class LengthAwarePaginatorTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->p);
     }
 
-    public function testLengthAwarePaginatorGetAndSetPageName()
+    public function testLengthAwarePaginatorGetAndSetPageName(): void
     {
         $this->assertEquals('page', $this->p->getPageName());
 
@@ -25,7 +25,7 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEquals('p', $this->p->getPageName());
     }
 
-    public function testLengthAwarePaginatorCanGiveMeRelevantPageInformation()
+    public function testLengthAwarePaginatorCanGiveMeRelevantPageInformation(): void
     {
         $this->assertEquals(2, $this->p->lastPage());
         $this->assertEquals(2, $this->p->currentPage());
@@ -34,7 +34,7 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEquals(['item1', 'item2', 'item3', 'item4'], $this->p->items());
     }
 
-    public function testLengthAwarePaginatorSetCorrectInformationWithNoItems()
+    public function testLengthAwarePaginatorSetCorrectInformationWithNoItems(): void
     {
         $paginator = new LengthAwarePaginator([], 0, 2, 1);
 
@@ -45,7 +45,7 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEmpty($paginator->items());
     }
 
-    public function testLengthAwarePaginatorCanGenerateUrls()
+    public function testLengthAwarePaginatorCanGenerateUrls(): void
     {
         $this->p->setPath('http://website.com');
         $this->p->setPageName('foo');
@@ -60,7 +60,7 @@ class LengthAwarePaginatorTest extends TestCase
                             $this->p->url($this->p->currentPage() - 2));
     }
 
-    public function testLengthAwarePaginatorCanGenerateUrlsWithQuery()
+    public function testLengthAwarePaginatorCanGenerateUrlsWithQuery(): void
     {
         $this->p->setPath('http://website.com?sort_by=date');
         $this->p->setPageName('foo');
@@ -69,7 +69,7 @@ class LengthAwarePaginatorTest extends TestCase
                             $this->p->url($this->p->currentPage()));
     }
 
-    public function testLengthAwarePaginatorCanGenerateUrlsWithoutTrailingSlashes()
+    public function testLengthAwarePaginatorCanGenerateUrlsWithoutTrailingSlashes(): void
     {
         $this->p->setPath('http://website.com/test');
         $this->p->setPageName('foo');

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -7,7 +7,7 @@ use Illuminate\Pagination\Paginator;
 
 class PaginatorTest extends TestCase
 {
-    public function testSimplePaginatorReturnsRelevantContextInformation()
+    public function testSimplePaginatorReturnsRelevantContextInformation(): void
     {
         $p = new Paginator($array = ['item3', 'item4', 'item5'], 2, 2);
 
@@ -31,7 +31,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals($pageInfo, $p->toArray());
     }
 
-    public function testPaginatorRemovesTrailingSlashes()
+    public function testPaginatorRemovesTrailingSlashes(): void
     {
         $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test/']);
@@ -39,7 +39,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
     }
 
-    public function testPaginatorGeneratesUrlsWithoutTrailingSlash()
+    public function testPaginatorGeneratesUrlsWithoutTrailingSlash(): void
     {
         $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test']);

--- a/tests/Pagination/UrlWindowTest.php
+++ b/tests/Pagination/UrlWindowTest.php
@@ -8,21 +8,21 @@ use Illuminate\Pagination\LengthAwarePaginator;
 
 class UrlWindowTest extends TestCase
 {
-    public function testPresenterCanDetermineIfThereAreAnyPagesToShow()
+    public function testPresenterCanDetermineIfThereAreAnyPagesToShow(): void
     {
         $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
         $window = new UrlWindow($p);
         $this->assertTrue($window->hasPages());
     }
 
-    public function testPresenterCanGetAUrlRangeForASmallNumberOfUrls()
+    public function testPresenterCanGetAUrlRangeForASmallNumberOfUrls(): void
     {
         $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
         $window = new UrlWindow($p);
         $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => null, 'last' => null], $window->get());
     }
 
-    public function testPresenterCanGetAUrlRangeForAWindowOfLinks()
+    public function testPresenterCanGetAUrlRangeForAWindowOfLinks(): void
     {
         $array = [];
         for ($i = 1; $i <= 13; $i++) {

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -7,7 +7,7 @@ use Illuminate\Pipeline\Pipeline;
 
 class PipelineTest extends TestCase
 {
-    public function testPipelineBasicUsage()
+    public function testPipelineBasicUsage(): void
     {
         $pipeTwo = function ($piped, $next) {
             $_SERVER['__test.pipe.two'] = $piped;
@@ -30,7 +30,7 @@ class PipelineTest extends TestCase
         unset($_SERVER['__test.pipe.two']);
     }
 
-    public function testPipelineUsageWithObjects()
+    public function testPipelineUsageWithObjects(): void
     {
         $result = (new Pipeline(new \Illuminate\Container\Container))
             ->send('foo')
@@ -45,7 +45,7 @@ class PipelineTest extends TestCase
         unset($_SERVER['__test.pipe.one']);
     }
 
-    public function testPipelineUsageWithInvokableObjects()
+    public function testPipelineUsageWithInvokableObjects(): void
     {
         $result = (new Pipeline(new \Illuminate\Container\Container))
             ->send('foo')
@@ -62,7 +62,7 @@ class PipelineTest extends TestCase
         unset($_SERVER['__test.pipe.one']);
     }
 
-    public function testPipelineUsageWithCallable()
+    public function testPipelineUsageWithCallable(): void
     {
         $function = function ($piped, $next) {
             $_SERVER['__test.pipe.one'] = 'foo';
@@ -85,7 +85,7 @@ class PipelineTest extends TestCase
         unset($_SERVER['__test.pipe.one']);
     }
 
-    public function testPipelineUsageWithInvokableClass()
+    public function testPipelineUsageWithInvokableClass(): void
     {
         $result = (new Pipeline(new \Illuminate\Container\Container))
             ->send('foo')
@@ -102,7 +102,7 @@ class PipelineTest extends TestCase
         unset($_SERVER['__test.pipe.one']);
     }
 
-    public function testPipelineUsageWithParameters()
+    public function testPipelineUsageWithParameters(): void
     {
         $parameters = ['one', 'two'];
 
@@ -119,7 +119,7 @@ class PipelineTest extends TestCase
         unset($_SERVER['__test.pipe.parameters']);
     }
 
-    public function testPipelineViaChangesTheMethodBeingCalledOnThePipes()
+    public function testPipelineViaChangesTheMethodBeingCalledOnThePipes(): void
     {
         $pipelineInstance = new Pipeline(new \Illuminate\Container\Container);
         $result = $pipelineInstance->send('data')
@@ -135,7 +135,7 @@ class PipelineTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage A container instance has not been passed to the Pipeline.
      */
-    public function testPipelineThrowsExceptionOnResolveWithoutContainer()
+    public function testPipelineThrowsExceptionOnResolveWithoutContainer(): void
     {
         (new Pipeline)->send('data')
             ->through('Illuminate\Tests\Pipeline\PipelineTestPipeOne')

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class QueueBeanstalkdJobTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testFireProperlyCallsTheJobHandler()
+    public function testFireProperlyCallsTheJobHandler(): void
     {
         $job = $this->getJob();
         $job->getPheanstalkJob()->shouldReceive('getData')->once()->andReturn(json_encode(['job' => 'foo', 'data' => ['data']]));
@@ -22,7 +22,7 @@ class QueueBeanstalkdJobTest extends TestCase
         $job->fire();
     }
 
-    public function testFailedProperlyCallsTheJobHandler()
+    public function testFailedProperlyCallsTheJobHandler(): void
     {
         $job = $this->getJob();
         $job->getPheanstalkJob()->shouldReceive('getData')->once()->andReturn(json_encode(['job' => 'foo', 'data' => ['data']]));
@@ -32,7 +32,7 @@ class QueueBeanstalkdJobTest extends TestCase
         $job->failed(new \Exception);
     }
 
-    public function testDeleteRemovesTheJobFromBeanstalkd()
+    public function testDeleteRemovesTheJobFromBeanstalkd(): void
     {
         $job = $this->getJob();
         $job->getPheanstalk()->shouldReceive('delete')->once()->with($job->getPheanstalkJob());
@@ -40,7 +40,7 @@ class QueueBeanstalkdJobTest extends TestCase
         $job->delete();
     }
 
-    public function testReleaseProperlyReleasesJobOntoBeanstalkd()
+    public function testReleaseProperlyReleasesJobOntoBeanstalkd(): void
     {
         $job = $this->getJob();
         $job->getPheanstalk()->shouldReceive('release')->once()->with($job->getPheanstalkJob(), \Pheanstalk\Pheanstalk::DEFAULT_PRIORITY, 0);
@@ -48,7 +48,7 @@ class QueueBeanstalkdJobTest extends TestCase
         $job->release();
     }
 
-    public function testBuryProperlyBuryTheJobFromBeanstalkd()
+    public function testBuryProperlyBuryTheJobFromBeanstalkd(): void
     {
         $job = $this->getJob();
         $job->getPheanstalk()->shouldReceive('bury')->once()->with($job->getPheanstalkJob());

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class QueueBeanstalkdQueueTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testPushProperlyPushesJobOntoBeanstalkd()
+    public function testPushProperlyPushesJobOntoBeanstalkd(): void
     {
         $queue = new \Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
         $pheanstalk = $queue->getPheanstalk();
@@ -24,7 +24,7 @@ class QueueBeanstalkdQueueTest extends TestCase
         $queue->push('foo', ['data']);
     }
 
-    public function testDelayedPushProperlyPushesJobOntoBeanstalkd()
+    public function testDelayedPushProperlyPushesJobOntoBeanstalkd(): void
     {
         $queue = new \Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
         $pheanstalk = $queue->getPheanstalk();
@@ -36,7 +36,7 @@ class QueueBeanstalkdQueueTest extends TestCase
         $queue->later(5, 'foo', ['data']);
     }
 
-    public function testPopProperlyPopsJobOffOfBeanstalkd()
+    public function testPopProperlyPopsJobOffOfBeanstalkd(): void
     {
         $queue = new \Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
         $queue->setContainer(m::mock('Illuminate\Container\Container'));
@@ -50,7 +50,7 @@ class QueueBeanstalkdQueueTest extends TestCase
         $this->assertInstanceOf('Illuminate\Queue\Jobs\BeanstalkdJob', $result);
     }
 
-    public function testDeleteProperlyRemoveJobsOffBeanstalkd()
+    public function testDeleteProperlyRemoveJobsOffBeanstalkd(): void
     {
         $queue = new \Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
         $pheanstalk = $queue->getPheanstalk();

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -27,7 +27,7 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
      */
     protected $container;
 
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -95,7 +95,7 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema()->drop('jobs');
     }
@@ -103,7 +103,7 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
     /**
      * Test that jobs that are not reserved and have an available_at value less then now, are popped.
      */
-    public function testAvailableAndUnReservedJobsArePopped()
+    public function testAvailableAndUnReservedJobsArePopped(): void
     {
         $this->connection()
             ->table('jobs')
@@ -125,7 +125,7 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
     /**
      * Test that when jobs are popped, the attempts attribute is incremented.
      */
-    public function testPoppedJobsIncrementAttempts()
+    public function testPoppedJobsIncrementAttempts(): void
     {
         $job = [
             'id' => 1,
@@ -150,7 +150,7 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
     /**
      * Test that jobs that are not reserved and have an available_at value in the future, are not popped.
      */
-    public function testUnavailableJobsAreNotPopped()
+    public function testUnavailableJobsAreNotPopped(): void
     {
         $this->connection()
             ->table('jobs')
@@ -172,7 +172,7 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
     /**
      * Test that jobs that are reserved and have expired are popped.
      */
-    public function testThatReservedAndExpiredJobsArePopped()
+    public function testThatReservedAndExpiredJobsArePopped(): void
     {
         $this->connection()
             ->table('jobs')
@@ -194,7 +194,7 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
     /**
      * Test that jobs that are reserved and not expired and available are not popped.
      */
-    public function testThatReservedJobsAreNotPopped()
+    public function testThatReservedJobsAreNotPopped(): void
     {
         $this->connection()
             ->table('jobs')

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -9,12 +9,12 @@ use PHPUnit\Framework\TestCase;
 
 class QueueDatabaseQueueUnitTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testPushProperlyPushesJobOntoDatabase()
+    public function testPushProperlyPushesJobOntoDatabase(): void
     {
         $queue = $this->getMockBuilder('Illuminate\Queue\DatabaseQueue')->setMethods(['currentTime'])->setConstructorArgs([$database = m::mock('Illuminate\Database\Connection'), 'table', 'default'])->getMock();
         $queue->expects($this->any())->method('currentTime')->will($this->returnValue('time'));
@@ -30,7 +30,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $queue->push('foo', ['data']);
     }
 
-    public function testDelayedPushProperlyPushesJobOntoDatabase()
+    public function testDelayedPushProperlyPushesJobOntoDatabase(): void
     {
         $queue = $this->getMockBuilder(
             'Illuminate\Queue\DatabaseQueue')->setMethods(
@@ -50,7 +50,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $queue->later(10, 'foo', ['data']);
     }
 
-    public function testFailureToCreatePayloadFromObject()
+    public function testFailureToCreatePayloadFromObject(): void
     {
         $this->expectException('InvalidArgumentException');
 
@@ -67,7 +67,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         ]);
     }
 
-    public function testFailureToCreatePayloadFromArray()
+    public function testFailureToCreatePayloadFromArray(): void
     {
         $this->expectException('InvalidArgumentException');
 
@@ -81,7 +81,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         ]);
     }
 
-    public function testBulkBatchPushesOntoDatabase()
+    public function testBulkBatchPushesOntoDatabase(): void
     {
         $database = m::mock('Illuminate\Database\Connection');
         $queue = $this->getMockBuilder('Illuminate\Queue\DatabaseQueue')->setMethods(['currentTime', 'availableAt'])->setConstructorArgs([$database, 'table', 'default'])->getMock();
@@ -109,7 +109,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $queue->bulk(['foo', 'bar'], ['data'], 'queue');
     }
 
-    public function testBuildDatabaseRecordWithPayloadAtTheEnd()
+    public function testBuildDatabaseRecordWithPayloadAtTheEnd(): void
     {
         $queue = m::mock('Illuminate\Queue\DatabaseQueue');
         $record = $queue->buildDatabaseRecord('queue', 'any_payload', 0);

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class QueueListenerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testRunProcessCallsProcess()
+    public function testRunProcessCallsProcess(): void
     {
         $process = m::mock('Symfony\Component\Process\Process')->makePartial();
         $process->shouldReceive('run')->once();
@@ -22,7 +22,7 @@ class QueueListenerTest extends TestCase
         $listener->runProcess($process, 1);
     }
 
-    public function testListenerStopsWhenMemoryIsExceeded()
+    public function testListenerStopsWhenMemoryIsExceeded(): void
     {
         $process = m::mock('Symfony\Component\Process\Process')->makePartial();
         $process->shouldReceive('run')->once();
@@ -33,7 +33,7 @@ class QueueListenerTest extends TestCase
         $listener->runProcess($process, 1);
     }
 
-    public function testMakeProcessCorrectlyFormatsCommandLine()
+    public function testMakeProcessCorrectlyFormatsCommandLine(): void
     {
         $listener = new \Illuminate\Queue\Listener(__DIR__);
         $options = new \Illuminate\Queue\ListenerOptions;

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -8,12 +8,12 @@ use Illuminate\Queue\QueueManager;
 
 class QueueManagerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testDefaultConnectionCanBeResolved()
+    public function testDefaultConnectionCanBeResolved(): void
     {
         $app = [
             'config' => [
@@ -36,7 +36,7 @@ class QueueManagerTest extends TestCase
         $this->assertSame($queue, $manager->connection('sync'));
     }
 
-    public function testOtherConnectionCanBeResolved()
+    public function testOtherConnectionCanBeResolved(): void
     {
         $app = [
             'config' => [
@@ -59,7 +59,7 @@ class QueueManagerTest extends TestCase
         $this->assertSame($queue, $manager->connection('foo'));
     }
 
-    public function testNullConnectionCanBeResolved()
+    public function testNullConnectionCanBeResolved(): void
     {
         $app = [
             'config' => [

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class QueueRedisJobTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testFireProperlyCallsTheJobHandler()
+    public function testFireProperlyCallsTheJobHandler(): void
     {
         $job = $this->getJob();
         $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('stdClass'));
@@ -21,7 +21,7 @@ class QueueRedisJobTest extends TestCase
         $job->fire();
     }
 
-    public function testDeleteRemovesTheJobFromRedis()
+    public function testDeleteRemovesTheJobFromRedis(): void
     {
         $job = $this->getJob();
         $job->getRedisQueue()->shouldReceive('deleteReserved')->once()
@@ -30,7 +30,7 @@ class QueueRedisJobTest extends TestCase
         $job->delete();
     }
 
-    public function testReleaseProperlyReleasesJobOntoRedis()
+    public function testReleaseProperlyReleasesJobOntoRedis(): void
     {
         $job = $this->getJob();
         $job->getRedisQueue()->shouldReceive('deleteAndRelease')->once()

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class QueueRedisQueueTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testPushProperlyPushesJobOntoRedis()
+    public function testPushProperlyPushesJobOntoRedis(): void
     {
         $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
@@ -23,7 +23,7 @@ class QueueRedisQueueTest extends TestCase
         $this->assertEquals('foo', $id);
     }
 
-    public function testDelayedPushProperlyPushesJobOntoRedis()
+    public function testDelayedPushProperlyPushesJobOntoRedis(): void
     {
         $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
@@ -40,7 +40,7 @@ class QueueRedisQueueTest extends TestCase
         $this->assertEquals('foo', $id);
     }
 
-    public function testDelayedPushWithDateTimeProperlyPushesJobOntoRedis()
+    public function testDelayedPushWithDateTimeProperlyPushesJobOntoRedis(): void
     {
         $date = \Illuminate\Support\Carbon::now();
         $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class QueueSqsJobTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->key = 'AMAZONSQSKEY';
         $this->secret = 'AmAz0n+SqSsEcReT+aLpHaNuM3R1CsTr1nG';
@@ -45,12 +45,12 @@ class QueueSqsJobTest extends TestCase
         ];
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testFireProperlyCallsTheJobHandler()
+    public function testFireProperlyCallsTheJobHandler(): void
     {
         $job = $this->getJob();
         $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('stdClass'));
@@ -58,7 +58,7 @@ class QueueSqsJobTest extends TestCase
         $job->fire();
     }
 
-    public function testDeleteRemovesTheJobFromSqs()
+    public function testDeleteRemovesTheJobFromSqs(): void
     {
         $this->mockedSqsClient = $this->getMockBuilder('Aws\Sqs\SqsClient')
             ->setMethods(['deleteMessage'])
@@ -71,7 +71,7 @@ class QueueSqsJobTest extends TestCase
         $job->delete();
     }
 
-    public function testReleaseProperlyReleasesTheJobOntoSqs()
+    public function testReleaseProperlyReleasesTheJobOntoSqs(): void
     {
         $this->mockedSqsClient = $this->getMockBuilder('Aws\Sqs\SqsClient')
             ->setMethods(['changeMessageVisibility'])

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -8,12 +8,12 @@ use PHPUnit\Framework\TestCase;
 
 class QueueSqsQueueTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         // Use Mockery to mock the SqsClient
         $this->sqs = m::mock('Aws\Sqs\SqsClient');
@@ -63,7 +63,7 @@ class QueueSqsQueueTest extends TestCase
         ]);
     }
 
-    public function testPopProperlyPopsJobOffOfSqs()
+    public function testPopProperlyPopsJobOffOfSqs(): void
     {
         $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->setContainer(m::mock('Illuminate\Container\Container'));
@@ -73,7 +73,7 @@ class QueueSqsQueueTest extends TestCase
         $this->assertInstanceOf('Illuminate\Queue\Jobs\SqsJob', $result);
     }
 
-    public function testPopProperlyHandlesEmptyMessage()
+    public function testPopProperlyHandlesEmptyMessage(): void
     {
         $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->setContainer(m::mock('Illuminate\Container\Container'));
@@ -83,7 +83,7 @@ class QueueSqsQueueTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs()
+    public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs(): void
     {
         $now = \Illuminate\Support\Carbon::now();
         $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
@@ -95,7 +95,7 @@ class QueueSqsQueueTest extends TestCase
         $this->assertEquals($this->mockedMessageId, $id);
     }
 
-    public function testDelayedPushProperlyPushesJobOntoSqs()
+    public function testDelayedPushProperlyPushesJobOntoSqs(): void
     {
         $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
@@ -106,7 +106,7 @@ class QueueSqsQueueTest extends TestCase
         $this->assertEquals($this->mockedMessageId, $id);
     }
 
-    public function testPushProperlyPushesJobOntoSqs()
+    public function testPushProperlyPushesJobOntoSqs(): void
     {
         $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['createPayload', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
@@ -116,7 +116,7 @@ class QueueSqsQueueTest extends TestCase
         $this->assertEquals($this->mockedMessageId, $id);
     }
 
-    public function testSizeProperlyReadsSqsQueueSize()
+    public function testSizeProperlyReadsSqsQueueSize(): void
     {
         $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
@@ -125,7 +125,7 @@ class QueueSqsQueueTest extends TestCase
         $this->assertEquals($size, 1);
     }
 
-    public function testGetQueueProperlyResolvesUrlWithPrefix()
+    public function testGetQueueProperlyResolvesUrlWithPrefix(): void
     {
         $queue = new \Illuminate\Queue\SqsQueue($this->sqs, $this->queueName, $this->prefix);
         $this->assertEquals($this->queueUrl, $queue->getQueue(null));
@@ -133,7 +133,7 @@ class QueueSqsQueueTest extends TestCase
         $this->assertEquals($queueUrl, $queue->getQueue('test'));
     }
 
-    public function testGetQueueProperlyResolvesUrlWithoutPrefix()
+    public function testGetQueueProperlyResolvesUrlWithoutPrefix(): void
     {
         $queue = new \Illuminate\Queue\SqsQueue($this->sqs, $this->queueUrl);
         $this->assertEquals($this->queueUrl, $queue->getQueue(null));

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -9,12 +9,12 @@ use Illuminate\Container\Container;
 
 class QueueSyncQueueTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testPushShouldFireJobInstantly()
+    public function testPushShouldFireJobInstantly(): void
     {
         unset($_SERVER['__sync.test']);
 
@@ -27,7 +27,7 @@ class QueueSyncQueueTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $_SERVER['__sync.test'][1]);
     }
 
-    public function testFailedJobGetsHandledWhenAnExceptionIsThrown()
+    public function testFailedJobGetsHandledWhenAnExceptionIsThrown(): void
     {
         unset($_SERVER['__sync.failed']);
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -21,7 +21,7 @@ class QueueWorkerTest extends TestCase
     public $events;
     public $exceptionHandler;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->events = Mockery::spy(Dispatcher::class);
         $this->exceptionHandler = Mockery::spy(ExceptionHandler::class);
@@ -32,12 +32,12 @@ class QueueWorkerTest extends TestCase
         $container->instance(ExceptionHandler::class, $this->exceptionHandler);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Container::setInstance();
     }
 
-    public function test_job_can_be_fired()
+    public function test_job_can_be_fired(): void
     {
         $worker = $this->getWorker('default', ['queue' => [$job = new WorkerFakeJob]]);
         $worker->runNextJob('default', 'queue', new WorkerOptions);
@@ -46,7 +46,7 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobProcessed::class))->once();
     }
 
-    public function test_job_can_be_fired_based_on_priority()
+    public function test_job_can_be_fired_based_on_priority(): void
     {
         $worker = $this->getWorker('default', [
             'high' => [$highJob = new WorkerFakeJob, $secondHighJob = new WorkerFakeJob], 'low' => [$lowJob = new WorkerFakeJob],
@@ -65,7 +65,7 @@ class QueueWorkerTest extends TestCase
         $this->assertTrue($lowJob->fired);
     }
 
-    public function test_exception_is_reported_if_connection_throws_exception_on_job_pop()
+    public function test_exception_is_reported_if_connection_throws_exception_on_job_pop(): void
     {
         $worker = new InsomniacWorker(
             new WorkerFakeManager('default', new BrokenQueueConnection($e = new RuntimeException)),
@@ -78,14 +78,14 @@ class QueueWorkerTest extends TestCase
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
     }
 
-    public function test_worker_sleeps_when_queue_is_empty()
+    public function test_worker_sleeps_when_queue_is_empty(): void
     {
         $worker = $this->getWorker('default', ['queue' => []]);
         $worker->runNextJob('default', 'queue', $this->workerOptions(['sleep' => 5]));
         $this->assertEquals(5, $worker->sleptFor);
     }
 
-    public function test_job_is_released_on_exception()
+    public function test_job_is_released_on_exception(): void
     {
         $e = new RuntimeException;
 
@@ -103,7 +103,7 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(JobProcessed::class)]);
     }
 
-    public function test_job_is_not_released_if_it_has_exceeded_max_attempts()
+    public function test_job_is_not_released_if_it_has_exceeded_max_attempts(): void
     {
         $e = new RuntimeException;
 
@@ -127,7 +127,7 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(JobProcessed::class)]);
     }
 
-    public function test_job_is_not_released_if_it_has_expired()
+    public function test_job_is_not_released_if_it_has_expired(): void
     {
         $e = new RuntimeException;
 
@@ -158,7 +158,7 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(JobProcessed::class)]);
     }
 
-    public function test_job_is_failed_if_it_has_already_exceeded_max_attempts()
+    public function test_job_is_failed_if_it_has_already_exceeded_max_attempts(): void
     {
         $job = new WorkerFakeJob(function ($job) {
             $job->attempts++;
@@ -178,7 +178,7 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(JobProcessed::class)]);
     }
 
-    public function test_job_is_failed_if_it_has_already_expired()
+    public function test_job_is_failed_if_it_has_already_expired(): void
     {
         $job = new WorkerFakeJob(function ($job) {
             $job->attempts++;
@@ -204,7 +204,7 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(JobProcessed::class)]);
     }
 
-    public function test_job_based_max_retries()
+    public function test_job_based_max_retries(): void
     {
         $job = new WorkerFakeJob(function ($job) {
             $job->attempts++;

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -20,14 +20,14 @@ class RedisQueueIntegrationTest extends TestCase
      */
     private $queue;
 
-    public function setUp()
+    public function setUp(): void
     {
         Carbon::setTestNow(Carbon::now());
         parent::setUp();
         $this->setUpRedis();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Carbon::setTestNow(null);
         parent::tearDown();
@@ -40,7 +40,7 @@ class RedisQueueIntegrationTest extends TestCase
      *
      * @param string $driver
      */
-    public function testExpiredJobsArePopped($driver)
+    public function testExpiredJobsArePopped($driver): void
     {
         $this->setQueue($driver);
 
@@ -70,7 +70,7 @@ class RedisQueueIntegrationTest extends TestCase
      *
      * @param string $driver
      */
-    public function testPopProperlyPopsJobOffOfRedis($driver)
+    public function testPopProperlyPopsJobOffOfRedis($driver): void
     {
         $this->setQueue($driver);
 
@@ -105,7 +105,7 @@ class RedisQueueIntegrationTest extends TestCase
      *
      * @param string $driver
      */
-    public function testPopProperlyPopsDelayedJobOffOfRedis($driver)
+    public function testPopProperlyPopsDelayedJobOffOfRedis($driver): void
     {
         $this->setQueue($driver);
         // Push an item into queue
@@ -132,7 +132,7 @@ class RedisQueueIntegrationTest extends TestCase
      *
      * @param string $driver
      */
-    public function testPopPopsDelayedJobOffOfRedisWhenExpireNull($driver)
+    public function testPopPopsDelayedJobOffOfRedisWhenExpireNull($driver): void
     {
         $this->queue = new RedisQueue($this->redis[$driver], 'default', null, null);
         $this->queue->setContainer(m::mock(Container::class));
@@ -161,7 +161,7 @@ class RedisQueueIntegrationTest extends TestCase
      *
      * @param string $driver
      */
-    public function testNotExpireJobsWhenExpireNull($driver)
+    public function testNotExpireJobsWhenExpireNull($driver): void
     {
         $this->queue = new RedisQueue($this->redis[$driver], 'default', null, null);
         $this->queue->setContainer(m::mock(Container::class));
@@ -205,7 +205,7 @@ class RedisQueueIntegrationTest extends TestCase
      *
      * @param string $driver
      */
-    public function testExpireJobsWhenExpireSet($driver)
+    public function testExpireJobsWhenExpireSet($driver): void
     {
         $this->queue = new RedisQueue($this->redis[$driver], 'default', null, 30);
         $this->queue->setContainer(m::mock(Container::class));
@@ -234,7 +234,7 @@ class RedisQueueIntegrationTest extends TestCase
      *
      * @param string $driver
      */
-    public function testRelease($driver)
+    public function testRelease($driver): void
     {
         $this->setQueue($driver);
 
@@ -275,7 +275,7 @@ class RedisQueueIntegrationTest extends TestCase
      *
      * @param string $driver
      */
-    public function testReleaseInThePast($driver)
+    public function testReleaseInThePast($driver): void
     {
         $this->setQueue($driver);
         $job = new RedisQueueIntegrationTestJob(30);
@@ -293,7 +293,7 @@ class RedisQueueIntegrationTest extends TestCase
      *
      * @param string $driver
      */
-    public function testDelete($driver)
+    public function testDelete($driver): void
     {
         $this->setQueue($driver);
 
@@ -317,7 +317,7 @@ class RedisQueueIntegrationTest extends TestCase
      *
      * @param string $driver
      */
-    public function testSize($driver)
+    public function testSize($driver): void
     {
         $this->setQueue($driver);
         $this->assertEquals(0, $this->queue->size());

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -14,7 +14,7 @@ class ConcurrentLimiterTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -14,7 +14,7 @@ class DurationLimiterTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -10,7 +10,7 @@ class RedisConnectionTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->setUpRedis();
@@ -24,7 +24,7 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         $this->tearDownRedis();

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -14,19 +14,19 @@ class RouteCollectionTest extends TestCase
      */
     protected $routeCollection;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->routeCollection = new RouteCollection;
     }
 
-    public function testRouteCollectionCanBeConstructed()
+    public function testRouteCollectionCanBeConstructed(): void
     {
         $this->assertInstanceOf(RouteCollection::class, $this->routeCollection);
     }
 
-    public function testRouteCollectionCanAddRoute()
+    public function testRouteCollectionCanAddRoute(): void
     {
         $this->routeCollection->add(new Route('GET', 'foo', [
             'uses' => 'FooController@index',
@@ -35,7 +35,7 @@ class RouteCollectionTest extends TestCase
         $this->assertCount(1, $this->routeCollection);
     }
 
-    public function testRouteCollectionAddReturnsTheRoute()
+    public function testRouteCollectionAddReturnsTheRoute(): void
     {
         $outputRoute = $this->routeCollection->add($inputRoute = new Route('GET', 'foo', [
             'uses' => 'FooController@index',
@@ -45,7 +45,7 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($inputRoute, $outputRoute);
     }
 
-    public function testRouteCollectionCanRetrieveByName()
+    public function testRouteCollectionCanRetrieveByName(): void
     {
         $this->routeCollection->add($routeIndex = new Route('GET', 'foo/index', [
             'uses' => 'FooController@index',
@@ -57,7 +57,7 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($routeIndex, $this->routeCollection->getByName('route_name'));
     }
 
-    public function testRouteCollectionCanRetrieveByAction()
+    public function testRouteCollectionCanRetrieveByAction(): void
     {
         $this->routeCollection->add($routeIndex = new Route('GET', 'foo/index', $action = [
             'uses' => 'FooController@index',
@@ -67,7 +67,7 @@ class RouteCollectionTest extends TestCase
         $this->assertSame($action, $routeIndex->getAction());
     }
 
-    public function testRouteCollectionCanGetIterator()
+    public function testRouteCollectionCanGetIterator(): void
     {
         $this->routeCollection->add(new Route('GET', 'foo/index', [
             'uses' => 'FooController@index',
@@ -76,13 +76,13 @@ class RouteCollectionTest extends TestCase
         $this->assertInstanceOf(ArrayIterator::class, $this->routeCollection->getIterator());
     }
 
-    public function testRouteCollectionCanGetIteratorWhenEmpty()
+    public function testRouteCollectionCanGetIteratorWhenEmpty(): void
     {
         $this->assertCount(0, $this->routeCollection);
         $this->assertInstanceOf(ArrayIterator::class, $this->routeCollection->getIterator());
     }
 
-    public function testRouteCollectionCanGetIteratorWhenRouteAreAdded()
+    public function testRouteCollectionCanGetIteratorWhenRouteAreAdded(): void
     {
         $this->routeCollection->add($routeIndex = new Route('GET', 'foo/index', [
             'uses' => 'FooController@index',
@@ -99,7 +99,7 @@ class RouteCollectionTest extends TestCase
         $this->assertInstanceOf(ArrayIterator::class, $this->routeCollection->getIterator());
     }
 
-    public function testRouteCollectionCanHandleSameRoute()
+    public function testRouteCollectionCanHandleSameRoute(): void
     {
         $routeIndex = new Route('GET', 'foo/index', [
             'uses' => 'FooController@index',
@@ -121,7 +121,7 @@ class RouteCollectionTest extends TestCase
         $this->assertCount(2, $this->routeCollection);
     }
 
-    public function testRouteCollectionCanRefreshNameLookups()
+    public function testRouteCollectionCanRefreshNameLookups(): void
     {
         $routeIndex = new Route('GET', 'foo/index', [
             'uses' => 'FooController@index',
@@ -141,7 +141,7 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($routeIndex, $this->routeCollection->getByName('route_name'));
     }
 
-    public function testRouteCollectionCanGetAllRoutes()
+    public function testRouteCollectionCanGetAllRoutes(): void
     {
         $this->routeCollection->add($routeIndex = new Route('GET', 'foo/index', [
             'uses' => 'FooController@index',
@@ -166,7 +166,7 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($allRoutes, $this->routeCollection->getRoutes());
     }
 
-    public function testRouteCollectionCanGetRoutesByName()
+    public function testRouteCollectionCanGetRoutesByName(): void
     {
         $routesByName = [
             'foo_index' => new Route('GET', 'foo/index', [
@@ -190,7 +190,7 @@ class RouteCollectionTest extends TestCase
         $this->assertSame($routesByName, $this->routeCollection->getRoutesByName());
     }
 
-    public function testRouteCollectionCleansUpOverwrittenRoutes()
+    public function testRouteCollectionCleansUpOverwrittenRoutes(): void
     {
         // Create two routes with the same path and method.
         $routeA = new Route('GET', 'product', ['controller' => 'View@view', 'as' => 'routeA']);

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -16,19 +16,19 @@ class RouteRegistrarTest extends TestCase
      */
     protected $router;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->router = new Router(m::mock(Dispatcher::class), Container::getInstance());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testMiddlewareFluentRegistration()
+    public function testMiddlewareFluentRegistration(): void
     {
         $this->router->middleware(['one', 'two'])->get('users', function () {
             return 'all-users';
@@ -59,7 +59,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals(['seven'], $this->getRoute()->middleware());
     }
 
-    public function testCanRegisterGetRouteWithClosureAction()
+    public function testCanRegisterGetRouteWithClosureAction(): void
     {
         $this->router->middleware('get-middleware')->get('users', function () {
             return 'all-users';
@@ -69,7 +69,7 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('get-middleware');
     }
 
-    public function testCanRegisterPostRouteWithClosureAction()
+    public function testCanRegisterPostRouteWithClosureAction(): void
     {
         $this->router->middleware('post-middleware')->post('users', function () {
             return 'saved';
@@ -79,7 +79,7 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('post-middleware');
     }
 
-    public function testCanRegisterAnyRouteWithClosureAction()
+    public function testCanRegisterAnyRouteWithClosureAction(): void
     {
         $this->router->middleware('test-middleware')->any('users', function () {
             return 'anything';
@@ -89,7 +89,7 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('test-middleware');
     }
 
-    public function testCanRegisterMatchRouteWithClosureAction()
+    public function testCanRegisterMatchRouteWithClosureAction(): void
     {
         $this->router->middleware('match-middleware')->match(['DELETE'], 'users', function () {
             return 'deleted';
@@ -99,7 +99,7 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('match-middleware');
     }
 
-    public function testCanRegisterRouteWithArrayAndClosureAction()
+    public function testCanRegisterRouteWithArrayAndClosureAction(): void
     {
         $this->router->middleware('patch-middleware')->patch('users', [function () {
             return 'updated';
@@ -109,7 +109,7 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('patch-middleware');
     }
 
-    public function testCanRegisterRouteWithArrayAndClosureUsesAction()
+    public function testCanRegisterRouteWithArrayAndClosureUsesAction(): void
     {
         $this->router->middleware('put-middleware')->put('users', ['uses' => function () {
             return 'replaced';
@@ -119,7 +119,7 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('put-middleware');
     }
 
-    public function testCanRegisterRouteWithControllerAction()
+    public function testCanRegisterRouteWithControllerAction(): void
     {
         $this->router->middleware('controller-middleware')
                      ->get('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub@index');
@@ -128,7 +128,7 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('controller-middleware');
     }
 
-    public function testCanRegisterRouteWithArrayAndControllerAction()
+    public function testCanRegisterRouteWithArrayAndControllerAction(): void
     {
         $this->router->middleware('controller-middleware')->put('users', [
             'uses' => 'Illuminate\Tests\Routing\RouteRegistrarControllerStub@index',
@@ -138,7 +138,7 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('controller-middleware');
     }
 
-    public function testCanRegisterGroupWithMiddleware()
+    public function testCanRegisterGroupWithMiddleware(): void
     {
         $this->router->middleware('group-middleware')->group(function ($router) {
             $router->get('users', function () {
@@ -150,7 +150,7 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('group-middleware');
     }
 
-    public function testCanRegisterGroupWithNamespace()
+    public function testCanRegisterGroupWithNamespace(): void
     {
         $this->router->namespace('App\Http\Controllers')->group(function ($router) {
             $router->get('users', 'UsersController@index');
@@ -162,7 +162,7 @@ class RouteRegistrarTest extends TestCase
         );
     }
 
-    public function testCanRegisterGroupWithPrefix()
+    public function testCanRegisterGroupWithPrefix(): void
     {
         $this->router->prefix('api')->group(function ($router) {
             $router->get('users', 'UsersController@index');
@@ -171,7 +171,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals('api/users', $this->getRoute()->uri());
     }
 
-    public function testCanRegisterGroupWithNamePrefix()
+    public function testCanRegisterGroupWithNamePrefix(): void
     {
         $this->router->name('api.')->group(function ($router) {
             $router->get('users', 'UsersController@index')->name('users');
@@ -180,7 +180,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals('api.users', $this->getRoute()->getName());
     }
 
-    public function testCanRegisterGroupWithDomain()
+    public function testCanRegisterGroupWithDomain(): void
     {
         $this->router->domain('{account}.myapp.com')->group(function ($router) {
             $router->get('users', 'UsersController@index');
@@ -189,7 +189,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals('{account}.myapp.com', $this->getRoute()->getDomain());
     }
 
-    public function testCanRegisterGroupWithDomainAndNamePrefix()
+    public function testCanRegisterGroupWithDomainAndNamePrefix(): void
     {
         $this->router->domain('{account}.myapp.com')->name('api.')->group(function ($router) {
             $router->get('users', 'UsersController@index')->name('users');
@@ -203,14 +203,14 @@ class RouteRegistrarTest extends TestCase
      * @expectedException \BadMethodCallException
      * @expectedExceptionMessage Method Illuminate\Routing\RouteRegistrar::missing does not exist.
      */
-    public function testRegisteringNonApprovedAttributesThrows()
+    public function testRegisteringNonApprovedAttributesThrows(): void
     {
         $this->router->domain('foo')->missing('bar')->group(function ($router) {
             //
         });
     }
 
-    public function testCanRegisterResource()
+    public function testCanRegisterResource(): void
     {
         $this->router->middleware('resource-middleware')
                      ->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub');
@@ -219,7 +219,7 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('resource-middleware');
     }
 
-    public function testCanLimitMethodsOnRegisteredResource()
+    public function testCanLimitMethodsOnRegisteredResource(): void
     {
         $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
                      ->only('index', 'show', 'destroy');
@@ -231,7 +231,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
     }
 
-    public function testCanExcludeMethodsOnRegisteredResource()
+    public function testCanExcludeMethodsOnRegisteredResource(): void
     {
         $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
                      ->except(['index', 'create', 'store', 'show', 'edit']);
@@ -242,7 +242,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
     }
 
-    public function testUserCanRegisterApiResource()
+    public function testUserCanRegisterApiResource(): void
     {
         $this->router->apiResource('users', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class);
 
@@ -252,7 +252,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertFalse($this->router->getRoutes()->hasNamedRoute('users.edit'));
     }
 
-    public function testCanNameRoutesOnRegisteredResource()
+    public function testCanNameRoutesOnRegisteredResource(): void
     {
         $this->router->resource('comments', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
                      ->only('create', 'store')->names('reply');
@@ -276,7 +276,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('posts.remove'));
     }
 
-    public function testCanOverrideParametersOnRegisteredResource()
+    public function testCanOverrideParametersOnRegisteredResource(): void
     {
         $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
                      ->parameters(['users' => 'admin_user']);
@@ -288,7 +288,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertContains('topic', $this->router->getRoutes()->getByName('posts.show')->uri);
     }
 
-    public function testCanSetMiddlewareOnRegisteredResource()
+    public function testCanSetMiddlewareOnRegisteredResource(): void
     {
         $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
                      ->middleware('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub');
@@ -296,7 +296,7 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub');
     }
 
-    public function testCanSetRouteName()
+    public function testCanSetRouteName(): void
     {
         $this->router->as('users.index')->get('users', function () {
             return 'all-users';
@@ -306,7 +306,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals('users.index', $this->getRoute()->getName());
     }
 
-    public function testCanSetRouteNameUsingNameAlias()
+    public function testCanSetRouteNameUsingNameAlias(): void
     {
         $this->router->name('users.index')->get('users', function () {
             return 'all-users';

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -14,7 +14,7 @@ class RoutingRedirectorTest extends TestCase
     protected $session;
     protected $redirect;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->headers = m::mock('Symfony\Component\HttpFoundation\HeaderBag');
 
@@ -35,12 +35,12 @@ class RoutingRedirectorTest extends TestCase
         $this->redirect->setSession($this->session);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBasicRedirectTo()
+    public function testBasicRedirectTo(): void
     {
         $response = $this->redirect->to('bar');
 
@@ -50,7 +50,7 @@ class RoutingRedirectorTest extends TestCase
         $this->assertEquals($this->session, $response->getSession());
     }
 
-    public function testComplexRedirectTo()
+    public function testComplexRedirectTo(): void
     {
         $response = $this->redirect->to('bar', 303, ['X-RateLimit-Limit' => 60, 'X-RateLimit-Remaining' => 59], true);
 
@@ -60,7 +60,7 @@ class RoutingRedirectorTest extends TestCase
         $this->assertEquals(59, $response->headers->get('X-RateLimit-Remaining'));
     }
 
-    public function testGuestPutCurrentUrlInSession()
+    public function testGuestPutCurrentUrlInSession(): void
     {
         $this->url->shouldReceive('full')->andReturn('http://foo.com/bar');
         $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
@@ -70,7 +70,7 @@ class RoutingRedirectorTest extends TestCase
         $this->assertEquals('http://foo.com/login', $response->getTargetUrl());
     }
 
-    public function testIntendedRedirectToIntendedUrlInSession()
+    public function testIntendedRedirectToIntendedUrlInSession(): void
     {
         $this->session->shouldReceive('pull')->with('url.intended', '/')->andReturn('http://foo.com/bar');
 
@@ -79,7 +79,7 @@ class RoutingRedirectorTest extends TestCase
         $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
     }
 
-    public function testIntendedWithoutIntendedUrlInSession()
+    public function testIntendedWithoutIntendedUrlInSession(): void
     {
         $this->session->shouldReceive('forget')->with('url.intended');
 
@@ -94,14 +94,14 @@ class RoutingRedirectorTest extends TestCase
         $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
     }
 
-    public function testRefreshRedirectToCurrentUrl()
+    public function testRefreshRedirectToCurrentUrl(): void
     {
         $this->request->shouldReceive('path')->andReturn('http://foo.com/bar');
         $response = $this->redirect->refresh();
         $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
     }
 
-    public function testBackRedirectToHttpReferer()
+    public function testBackRedirectToHttpReferer(): void
     {
         $this->headers->shouldReceive('has')->with('referer')->andReturn(true);
         $this->url->shouldReceive('previous')->andReturn('http://foo.com/bar');
@@ -109,26 +109,26 @@ class RoutingRedirectorTest extends TestCase
         $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
     }
 
-    public function testAwayDoesntValidateTheUrl()
+    public function testAwayDoesntValidateTheUrl(): void
     {
         $response = $this->redirect->away('bar');
         $this->assertEquals('bar', $response->getTargetUrl());
     }
 
-    public function testSecureRedirectToHttpsUrl()
+    public function testSecureRedirectToHttpsUrl(): void
     {
         $response = $this->redirect->secure('bar');
         $this->assertEquals('https://foo.com/bar', $response->getTargetUrl());
     }
 
-    public function testAction()
+    public function testAction(): void
     {
         $this->url->shouldReceive('action')->with('bar@index', [])->andReturn('http://foo.com/bar');
         $response = $this->redirect->action('bar@index');
         $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
     }
 
-    public function testRoute()
+    public function testRoute(): void
     {
         $this->url->shouldReceive('route')->with('home')->andReturn('http://foo.com/bar');
         $this->url->shouldReceive('route')->with('home', [])->andReturn('http://foo.com/bar');

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -23,7 +23,7 @@ use Illuminate\Routing\Middleware\SubstituteBindings;
 
 class RoutingRouteTest extends TestCase
 {
-    public function testBasicDispatchingOfRoutes()
+    public function testBasicDispatchingOfRoutes(): void
     {
         $router = $this->getRouter();
         $router->get('foo/bar', function () {
@@ -154,7 +154,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('closure', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
-    public function testNotModifiedResponseIsProperlyReturned()
+    public function testNotModifiedResponseIsProperlyReturned(): void
     {
         $router = $this->getRouter();
         $router->get('test', function () {
@@ -168,7 +168,7 @@ class RoutingRouteTest extends TestCase
         $this->assertNull($response->getLastModified());
     }
 
-    public function testClosureMiddleware()
+    public function testClosureMiddleware(): void
     {
         $router = $this->getRouter();
         $middleware = function ($request, $next) {
@@ -180,7 +180,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
-    public function testDefinedClosureMiddleware()
+    public function testDefinedClosureMiddleware(): void
     {
         $router = $this->getRouter();
         $router->get('foo/bar', ['middleware' => 'foo', function () {
@@ -192,7 +192,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
-    public function testControllerClosureMiddleware()
+    public function testControllerClosureMiddleware(): void
     {
         $router = $this->getRouter();
         $router->get('foo/bar', [
@@ -215,7 +215,7 @@ class RoutingRouteTest extends TestCase
      * @expectedException \LogicException
      * @expectedExceptionMessage Route for [foo/bar] has no action.
      */
-    public function testFluentRouting()
+    public function testFluentRouting(): void
     {
         $router = $this->getRouter();
         $router->get('foo/bar')->uses(function () {
@@ -235,7 +235,7 @@ class RoutingRouteTest extends TestCase
         $router->dispatch(Request::create('foo/bar', 'GET'));
     }
 
-    public function testFluentRoutingWithControllerAction()
+    public function testFluentRoutingWithControllerAction(): void
     {
         $router = $this->getRouter();
         $router->get('foo/bar')->uses('Illuminate\Tests\Routing\RouteTestControllerStub@index');
@@ -249,7 +249,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('App\\Illuminate\Tests\Routing\RouteTestControllerStub@index', $action['controller']);
     }
 
-    public function testMiddlewareGroups()
+    public function testMiddlewareGroups(): void
     {
         unset($_SERVER['__middleware.group']);
         $router = $this->getRouter();
@@ -266,7 +266,7 @@ class RoutingRouteTest extends TestCase
         unset($_SERVER['__middleware.group']);
     }
 
-    public function testMiddlewareGroupsCanReferenceOtherGroups()
+    public function testMiddlewareGroupsCanReferenceOtherGroups(): void
     {
         unset($_SERVER['__middleware.group']);
         $router = $this->getRouter();
@@ -284,7 +284,7 @@ class RoutingRouteTest extends TestCase
         unset($_SERVER['__middleware.group']);
     }
 
-    public function testFluentRouteNamingWithinAGroup()
+    public function testFluentRouteNamingWithinAGroup(): void
     {
         $router = $this->getRouter();
         $router->group(['as' => 'foo.'], function () use ($router) {
@@ -296,7 +296,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foo.bar', $router->currentRouteName());
     }
 
-    public function testRouteGetAction()
+    public function testRouteGetAction(): void
     {
         $router = $this->getRouter();
 
@@ -310,7 +310,7 @@ class RoutingRouteTest extends TestCase
         $this->assertNull($route->getAction('unknown_property'));
     }
 
-    public function testMacro()
+    public function testMacro(): void
     {
         $router = $this->getRouter();
         $router->macro('webhook', function () use ($router) {
@@ -323,7 +323,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('OK', $router->dispatch(Request::create('webhook', 'POST'))->getContent());
     }
 
-    public function testRouteMacro()
+    public function testRouteMacro(): void
     {
         $router = $this->getRouter();
 
@@ -342,7 +342,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('fooBreadcrumb', $router->getRoutes()->getByName('foo')->getAction()['breadcrumb']);
     }
 
-    public function testClassesCanBeInjectedIntoRoutes()
+    public function testClassesCanBeInjectedIntoRoutes(): void
     {
         unset($_SERVER['__test.route_inject']);
         $router = $this->getRouter();
@@ -359,7 +359,7 @@ class RoutingRouteTest extends TestCase
         unset($_SERVER['__test.route_inject']);
     }
 
-    public function testOptionsResponsesAreGeneratedByDefault()
+    public function testOptionsResponsesAreGeneratedByDefault(): void
     {
         $router = $this->getRouter();
         $router->get('foo/bar', function () {
@@ -374,7 +374,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('GET,HEAD,POST', $response->headers->get('Allow'));
     }
 
-    public function testHeadDispatcher()
+    public function testHeadDispatcher(): void
     {
         $router = $this->getRouter();
         $router->match(['GET', 'POST'], 'foo', function () {
@@ -408,7 +408,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('POST', $response->headers->get('Allow'));
     }
 
-    public function testNonGreedyMatches()
+    public function testNonGreedyMatches(): void
     {
         $route = new Route('GET', 'images/{id}.{ext}', function () {
         });
@@ -437,7 +437,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('bar', $route->parameter('foo', 'bar'));
     }
 
-    public function testRouteParametersDefaultValue()
+    public function testRouteParametersDefaultValue(): void
     {
         $router = $this->getRouter();
         $router->get('foo/{bar?}', ['uses' => 'Illuminate\Tests\Routing\RouteTestControllerWithParameterStub@returnParameter'])->defaults('bar', 'foo');
@@ -452,7 +452,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foo', $router->dispatch(Request::create('foo', 'GET'))->getContent());
     }
 
-    public function testControllerCallActionMethodParameters()
+    public function testControllerCallActionMethodParameters(): void
     {
         $router = $this->getRouter();
 
@@ -502,7 +502,7 @@ class RoutingRouteTest extends TestCase
         $this->assertNull($values[3]);
     }
 
-    public function testLeadingParamDoesntReceiveForwardSlashOnEmptyPath()
+    public function testLeadingParamDoesntReceiveForwardSlashOnEmptyPath(): void
     {
         $router = $this->getRouter();
         $outer_one = 'abc1234'; // a string that is not one we're testing
@@ -527,7 +527,7 @@ class RoutingRouteTest extends TestCase
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
-    public function testRoutesDontMatchNonMatchingPathsWithLeadingOptionals()
+    public function testRoutesDontMatchNonMatchingPathsWithLeadingOptionals(): void
     {
         $router = $this->getRouter();
         $router->get('{baz?}', function ($age = 25) {
@@ -539,7 +539,7 @@ class RoutingRouteTest extends TestCase
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
-    public function testRoutesDontMatchNonMatchingDomain()
+    public function testRoutesDontMatchNonMatchingDomain(): void
     {
         $router = $this->getRouter();
         $router->get('foo/bar', ['domain' => 'api.foo.bar', function () {
@@ -548,7 +548,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('hello', $router->dispatch(Request::create('http://api.baz.boom/foo/bar', 'GET'))->getContent());
     }
 
-    public function testRouteDomainRegistration()
+    public function testRouteDomainRegistration(): void
     {
         $router = $this->getRouter();
         $router->get('/foo/bar')->domain('api.foo.bar')->uses(function () {
@@ -557,7 +557,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('hello', $router->dispatch(Request::create('http://api.foo.bar/foo/bar', 'GET'))->getContent());
     }
 
-    public function testMatchesMethodAgainstRequests()
+    public function testMatchesMethodAgainstRequests(): void
     {
         /*
          * Basic
@@ -635,7 +635,7 @@ class RoutingRouteTest extends TestCase
         $this->assertTrue($route->matches($request));
     }
 
-    public function testWherePatternsProperlyFilter()
+    public function testWherePatternsProperlyFilter(): void
     {
         $request = Request::create('foo/123', 'GET');
         $route = new Route('GET', 'foo/{bar}', function () {
@@ -689,7 +689,7 @@ class RoutingRouteTest extends TestCase
         $this->assertFalse($route->matches($request));
     }
 
-    public function testDotDoesNotMatchEverything()
+    public function testDotDoesNotMatchEverything(): void
     {
         $route = new Route('GET', 'images/{id}.{ext}', function () {
         });
@@ -707,7 +707,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('png', $route->parameter('ext'));
     }
 
-    public function testRouteBinding()
+    public function testRouteBinding(): void
     {
         $router = $this->getRouter();
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
@@ -719,7 +719,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
-    public function testRouteClassBinding()
+    public function testRouteClassBinding(): void
     {
         $router = $this->getRouter();
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
@@ -729,7 +729,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
-    public function testRouteClassMethodBinding()
+    public function testRouteClassMethodBinding(): void
     {
         $router = $this->getRouter();
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
@@ -739,7 +739,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('dragon', $router->dispatch(Request::create('foo/Dragon', 'GET'))->getContent());
     }
 
-    public function testMiddlewarePrioritySorting()
+    public function testMiddlewarePrioritySorting(): void
     {
         $middleware = [
             Placeholder1::class,
@@ -766,7 +766,7 @@ class RoutingRouteTest extends TestCase
         ], $router->gatherRouteMiddleware($route));
     }
 
-    public function testModelBinding()
+    public function testModelBinding(): void
     {
         $router = $this->getRouter();
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
@@ -780,7 +780,7 @@ class RoutingRouteTest extends TestCase
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      * @expectedExceptionMessage No query results for model [Illuminate\Tests\Routing\RouteModelBindingNullStub].
      */
-    public function testModelBindingWithNullReturn()
+    public function testModelBindingWithNullReturn(): void
     {
         $router = $this->getRouter();
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
@@ -790,7 +790,7 @@ class RoutingRouteTest extends TestCase
         $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent();
     }
 
-    public function testModelBindingWithCustomNullReturn()
+    public function testModelBindingWithCustomNullReturn(): void
     {
         $router = $this->getRouter();
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
@@ -802,7 +802,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('missing', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
-    public function testModelBindingWithBindingClosure()
+    public function testModelBindingWithBindingClosure(): void
     {
         $router = $this->getRouter();
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
@@ -814,14 +814,14 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('tayloralt', $router->dispatch(Request::create('foo/TAYLOR', 'GET'))->getContent());
     }
 
-    public function testModelBindingWithCompoundParameterName()
+    public function testModelBindingWithCompoundParameterName(): void
     {
         $router = $this->getRouter();
         $router->resource('foo-bar', 'Illuminate\Tests\Routing\RouteTestResourceControllerWithModelParameter', ['middleware' => SubstituteBindings::class]);
         $this->assertEquals('12345', $router->dispatch(Request::create('foo-bar/12345', 'GET'))->getContent());
     }
 
-    public function testModelBindingWithCompoundParameterNameAndRouteBinding()
+    public function testModelBindingWithCompoundParameterNameAndRouteBinding(): void
     {
         $router = $this->getRouter();
         $router->model('foo_bar', 'Illuminate\Tests\Routing\RoutingTestUserModel');
@@ -829,7 +829,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('12345', $router->dispatch(Request::create('foo-bar/12345', 'GET'))->getContent());
     }
 
-    public function testModelBindingThroughIOC()
+    public function testModelBindingThroughIOC(): void
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
@@ -844,7 +844,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
-    public function testGroupMerging()
+    public function testGroupMerging(): void
     {
         $old = ['prefix' => 'foo/bar/'];
         $this->assertEquals(['prefix' => 'foo/bar/baz', 'namespace' => null, 'where' => []], RouteGroup::merge(['prefix' => 'baz'], $old));
@@ -866,7 +866,7 @@ class RoutingRouteTest extends TestCase
         ]], RouteGroup::merge(['where' => ['var1' => 'foo', 'var2' => 'bar']], $old));
     }
 
-    public function testRouteGrouping()
+    public function testRouteGrouping(): void
     {
         /*
          * getPrefix() method
@@ -882,7 +882,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foo', $routes[0]->getPrefix());
     }
 
-    public function testRouteGroupingOutsideOfInheritedNamespace()
+    public function testRouteGroupingOutsideOfInheritedNamespace(): void
     {
         $router = $this->getRouter();
 
@@ -901,7 +901,7 @@ class RoutingRouteTest extends TestCase
         );
     }
 
-    public function testCurrentRouteUses()
+    public function testCurrentRouteUses(): void
     {
         $router = $this->getRouter();
         $router->get('foo/bar', ['as' => 'foo.bar', 'uses' => 'Illuminate\Tests\Routing\RouteTestControllerStub@index']);
@@ -920,7 +920,7 @@ class RoutingRouteTest extends TestCase
         $this->assertTrue($router->currentRouteUses('Illuminate\Tests\Routing\RouteTestControllerStub@index'));
     }
 
-    public function testRouteGroupingFromFile()
+    public function testRouteGroupingFromFile(): void
     {
         $router = $this->getRouter();
         $router->group(['prefix' => 'api'], __DIR__.'/fixtures/routes.php');
@@ -932,7 +932,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('all-users', $route->bind($request)->run($request));
     }
 
-    public function testRouteGroupingWithAs()
+    public function testRouteGroupingWithAs(): void
     {
         $router = $this->getRouter();
         $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
@@ -945,7 +945,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foo/bar', $route->uri());
     }
 
-    public function testNestedRouteGroupingWithAs()
+    public function testNestedRouteGroupingWithAs(): void
     {
         /*
          * nested with all layers present
@@ -978,7 +978,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foo/bar/baz', $route->uri());
     }
 
-    public function testRouteMiddlewareMergeWithMiddlewareAttributesAsStrings()
+    public function testRouteMiddlewareMergeWithMiddlewareAttributesAsStrings(): void
     {
         $router = $this->getRouter();
         $router->group(['prefix' => 'foo', 'middleware' => 'boo:foo'], function () use ($router) {
@@ -994,7 +994,7 @@ class RoutingRouteTest extends TestCase
         );
     }
 
-    public function testRoutePrefixing()
+    public function testRoutePrefixing(): void
     {
         /*
          * Prefix route
@@ -1033,7 +1033,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('prefix', $routes[0]->uri());
     }
 
-    public function testMergingControllerUses()
+    public function testMergingControllerUses(): void
     {
         $router = $this->getRouter();
         $router->group(['namespace' => 'Namespace'], function () use ($router) {
@@ -1071,7 +1071,7 @@ class RoutingRouteTest extends TestCase
      * @expectedException \UnexpectedValueException
      * @expectedExceptionMessage Invalid route action: [Illuminate\Tests\Routing\RouteTestControllerStub].
      */
-    public function testInvalidActionException()
+    public function testInvalidActionException(): void
     {
         $router = $this->getRouter();
         $router->get('/', ['uses' => 'Illuminate\Tests\Routing\RouteTestControllerStub']);
@@ -1079,7 +1079,7 @@ class RoutingRouteTest extends TestCase
         $router->dispatch(Request::create('/'));
     }
 
-    public function testResourceRouting()
+    public function testResourceRouting(): void
     {
         $router = $this->getRouter();
         $router->resource('foo', 'FooController');
@@ -1138,7 +1138,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foo/{foo}/modifier', $routes->getByName('foo.edit')->uri());
     }
 
-    public function testResourceRoutingParameters()
+    public function testResourceRoutingParameters(): void
     {
         ResourceRegistrar::singularParameters();
 
@@ -1187,7 +1187,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foos/{foo}/bars/{bar}', $routes[3]->uri());
     }
 
-    public function testResourceRouteNaming()
+    public function testResourceRouteNaming(): void
     {
         $router = $this->getRouter();
         $router->resource('foo', 'FooController');
@@ -1243,7 +1243,7 @@ class RoutingRouteTest extends TestCase
         $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.destroy'));
     }
 
-    public function testRouterFiresRoutedEvent()
+    public function testRouterFiresRoutedEvent(): void
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
@@ -1277,7 +1277,7 @@ class RoutingRouteTest extends TestCase
         unset($_SERVER['__router.route']);
     }
 
-    public function testRouterPatternSetting()
+    public function testRouterPatternSetting(): void
     {
         $router = $this->getRouter();
         $router->pattern('test', 'pattern');
@@ -1288,7 +1288,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(['test' => 'pattern', 'test2' => 'pattern2'], $router->getPatterns());
     }
 
-    public function testControllerRouting()
+    public function testControllerRouting(): void
     {
         unset(
             $_SERVER['route.test.controller.middleware'], $_SERVER['route.test.controller.except.middleware'],
@@ -1308,7 +1308,7 @@ class RoutingRouteTest extends TestCase
         $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
     }
 
-    public function testCallableControllerRouting()
+    public function testCallableControllerRouting(): void
     {
         $router = $this->getRouter();
 
@@ -1319,7 +1319,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('baz', $router->dispatch(Request::create('foo/baz', 'GET'))->getContent());
     }
 
-    public function testControllerMiddlewareGroups()
+    public function testControllerMiddlewareGroups(): void
     {
         unset(
             $_SERVER['route.test.controller.middleware'],
@@ -1340,7 +1340,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('Illuminate\Http\Response', $_SERVER['route.test.controller.middleware.class']);
     }
 
-    public function testImplicitBindings()
+    public function testImplicitBindings(): void
     {
         $phpunit = $this;
         $router = $this->getRouter();
@@ -1355,7 +1355,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
-    public function testImplicitBindingsWithOptionalParameterWithExistingKeyInUri()
+    public function testImplicitBindingsWithOptionalParameterWithExistingKeyInUri(): void
     {
         $phpunit = $this;
         $router = $this->getRouter();
@@ -1370,7 +1370,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
-    public function testImplicitBindingsWithOptionalParameterWithNoKeyInUri()
+    public function testImplicitBindingsWithOptionalParameterWithNoKeyInUri(): void
     {
         $phpunit = $this;
         $router = $this->getRouter();
@@ -1386,7 +1386,7 @@ class RoutingRouteTest extends TestCase
     /**
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function testImplicitBindingsWithOptionalParameterWithNonExistingKeyInUri()
+    public function testImplicitBindingsWithOptionalParameterWithNonExistingKeyInUri(): void
     {
         $phpunit = $this;
         $router = $this->getRouter();
@@ -1399,7 +1399,7 @@ class RoutingRouteTest extends TestCase
         $router->dispatch(Request::create('foo/nonexisting', 'GET'))->getContent();
     }
 
-    public function testImplicitBindingThroughIOC()
+    public function testImplicitBindingThroughIOC(): void
     {
         $phpunit = $this;
         $container = new Container;
@@ -1418,7 +1418,7 @@ class RoutingRouteTest extends TestCase
         $router->dispatch(Request::create('foo/baz', 'GET'))->getContent();
     }
 
-    public function testDispatchingCallableActionClasses()
+    public function testDispatchingCallableActionClasses(): void
     {
         $router = $this->getRouter();
         $router->get('foo/bar', 'Illuminate\Tests\Routing\ActionStub');
@@ -1432,7 +1432,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar2', 'GET'))->getContent());
     }
 
-    public function testResponseIsReturned()
+    public function testResponseIsReturned(): void
     {
         $router = $this->getRouter();
         $router->get('foo/bar', function () {
@@ -1444,7 +1444,7 @@ class RoutingRouteTest extends TestCase
         $this->assertNotInstanceOf(\Illuminate\Http\JsonResponse::class, $response);
     }
 
-    public function testJsonResponseIsReturned()
+    public function testJsonResponseIsReturned(): void
     {
         $router = $this->getRouter();
         $router->get('foo/bar', function () {
@@ -1456,7 +1456,7 @@ class RoutingRouteTest extends TestCase
         $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $response);
     }
 
-    public function testRouteRedirect()
+    public function testRouteRedirect(): void
     {
         $router = $this->getRouter();
         $router->get('contact_us', function () {

--- a/tests/Routing/RoutingSortedMiddlewareTest.php
+++ b/tests/Routing/RoutingSortedMiddlewareTest.php
@@ -7,7 +7,7 @@ use Illuminate\Routing\SortedMiddleware;
 
 class RoutingSortedMiddlewareTest extends TestCase
 {
-    public function testMiddlewareCanBeSortedByPriority()
+    public function testMiddlewareCanBeSortedByPriority(): void
     {
         $priority = [
             'First',

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class RoutingUrlGeneratorTest extends TestCase
 {
-    public function testBasicGeneration()
+    public function testBasicGeneration(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -46,7 +46,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
     }
 
-    public function testBasicGenerationWithFormatting()
+    public function testBasicGenerationWithFormatting(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -67,7 +67,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('/something/named-route', $url->route('plain', [], false));
     }
 
-    public function testBasicRouteGeneration()
+    public function testBasicRouteGeneration(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -158,7 +158,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('http://en.example.com/foo', $url->route('defaults'));
     }
 
-    public function testFluentRouteNameDefinitions()
+    public function testFluentRouteNameDefinitions(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -176,7 +176,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('http://www.foo.com/foo/bar', $url->route('foo'));
     }
 
-    public function testControllerRoutesWithADefaultNamespace()
+    public function testControllerRoutesWithADefaultNamespace(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -202,7 +202,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('http://www.foo.com/foo/invoke', $url->action('InvokableActionStub'));
     }
 
-    public function testControllerRoutesOutsideOfDefaultNamespace()
+    public function testControllerRoutesOutsideOfDefaultNamespace(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -221,7 +221,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('http://www.foo.com/invokable/namespace', $url->action('\root\namespace\InvokableActionStub'));
     }
 
-    public function testRoutableInterfaceRouting()
+    public function testRoutableInterfaceRouting(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -237,7 +237,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('/foo/routable', $url->route('routable', [$model], false));
     }
 
-    public function testRoutableInterfaceRoutingWithSingleParameter()
+    public function testRoutableInterfaceRoutingWithSingleParameter(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -253,7 +253,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('/foo/routable', $url->route('routable', $model, false));
     }
 
-    public function testRoutesMaintainRequestScheme()
+    public function testRoutesMaintainRequestScheme(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -269,7 +269,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('https://www.foo.com/foo/bar', $url->route('foo'));
     }
 
-    public function testHttpOnlyRoutes()
+    public function testHttpOnlyRoutes(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -285,7 +285,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('http://www.foo.com/foo/bar', $url->route('foo'));
     }
 
-    public function testRoutesWithDomains()
+    public function testRoutesWithDomains(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -306,7 +306,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('/foo/bar/otwell', $url->route('bar', ['taylor', 'otwell'], false));
     }
 
-    public function testRoutesWithDomainsAndPorts()
+    public function testRoutesWithDomainsAndPorts(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -326,7 +326,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('http://sub.taylor.com:8080/foo/bar/otwell', $url->route('bar', ['taylor', 'otwell']));
     }
 
-    public function testRoutesWithDomainsStripsProtocols()
+    public function testRoutesWithDomainsStripsProtocols(): void
     {
         /*
          * http:// Route
@@ -355,7 +355,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('https://sub.foo.com/foo/bar', $url->route('foo'));
     }
 
-    public function testHttpsRoutesWithDomains()
+    public function testHttpsRoutesWithDomains(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -371,7 +371,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('https://sub.foo.com/foo/bar', $url->route('baz'));
     }
 
-    public function testRoutesWithDomainsThroughProxy()
+    public function testRoutesWithDomainsThroughProxy(): void
     {
         Request::setTrustedProxies(['10.0.0.1'], SymfonyRequest::HEADER_X_FORWARDED_ALL);
 
@@ -389,7 +389,7 @@ class RoutingUrlGeneratorTest extends TestCase
     /**
      * @expectedException \Illuminate\Routing\Exceptions\UrlGenerationException
      */
-    public function testUrlGenerationForControllersRequiresPassingOfRequiredParameters()
+    public function testUrlGenerationForControllersRequiresPassingOfRequiredParameters(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -403,7 +403,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('http://www.foo.com:8080/foo', $url->route('foo'));
     }
 
-    public function testForceRootUrl()
+    public function testForceRootUrl(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
@@ -435,7 +435,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('https://www.bar.com/foo', $url->route('plain'));
     }
 
-    public function testPrevious()
+    public function testPrevious(): void
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -8,12 +8,12 @@ use PHPUnit\Framework\TestCase;
 
 class EncryptedSessionStoreTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testSessionIsProperlyEncrypted()
+    public function testSessionIsProperlyEncrypted(): void
     {
         $session = $this->getSession();
         $session->getEncrypter()->shouldReceive('decrypt')->once()->with(serialize([]))->andReturn(serialize([]));

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -8,12 +8,12 @@ use PHPUnit\Framework\TestCase;
 
 class SessionStoreTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testSessionIsLoadedFromHandler()
+    public function testSessionIsLoadedFromHandler(): void
     {
         $session = $this->getSession();
         $session->getHandler()->shouldReceive('read')->once()->with($this->getSessionId())->andReturn(serialize(['foo' => 'bar', 'bagged' => ['name' => 'taylor']]));
@@ -29,7 +29,7 @@ class SessionStoreTest extends TestCase
         $this->assertTrue($session->has('baz'));
     }
 
-    public function testSessionMigration()
+    public function testSessionMigration(): void
     {
         $session = $this->getSession();
         $oldId = $session->getId();
@@ -44,7 +44,7 @@ class SessionStoreTest extends TestCase
         $this->assertNotEquals($oldId, $session->getId());
     }
 
-    public function testSessionRegeneration()
+    public function testSessionRegeneration(): void
     {
         $session = $this->getSession();
         $oldId = $session->getId();
@@ -53,7 +53,7 @@ class SessionStoreTest extends TestCase
         $this->assertNotEquals($oldId, $session->getId());
     }
 
-    public function testCantSetInvalidId()
+    public function testCantSetInvalidId(): void
     {
         $session = $this->getSession();
         $this->assertTrue($session->isValidId($session->getId()));
@@ -69,7 +69,7 @@ class SessionStoreTest extends TestCase
         $this->assertNotEquals('wrong', $session->getId());
     }
 
-    public function testSessionInvalidate()
+    public function testSessionInvalidate(): void
     {
         $session = $this->getSession();
         $oldId = $session->getId();
@@ -88,7 +88,7 @@ class SessionStoreTest extends TestCase
         $this->assertCount(0, $session->all());
     }
 
-    public function testSessionIsProperlySaved()
+    public function testSessionIsProperlySaved(): void
     {
         $session = $this->getSession();
         $session->getHandler()->shouldReceive('read')->once()->andReturn(serialize([]));
@@ -113,7 +113,7 @@ class SessionStoreTest extends TestCase
         $this->assertFalse($session->isStarted());
     }
 
-    public function testOldInputFlashing()
+    public function testOldInputFlashing(): void
     {
         $session = $this->getSession();
         $session->put('boom', 'baz');
@@ -132,7 +132,7 @@ class SessionStoreTest extends TestCase
         $this->assertFalse($session->hasOldInput('boom'));
     }
 
-    public function testDataFlashing()
+    public function testDataFlashing(): void
     {
         $session = $this->getSession();
         $session->flash('foo', 'bar');
@@ -156,7 +156,7 @@ class SessionStoreTest extends TestCase
         $this->assertNull($session->get('foo'));
     }
 
-    public function testDataFlashingNow()
+    public function testDataFlashingNow(): void
     {
         $session = $this->getSession();
         $session->now('foo', 'bar');
@@ -172,7 +172,7 @@ class SessionStoreTest extends TestCase
         $this->assertNull($session->get('foo'));
     }
 
-    public function testDataMergeNewFlashes()
+    public function testDataMergeNewFlashes(): void
     {
         $session = $this->getSession();
         $session->flash('foo', 'bar');
@@ -187,7 +187,7 @@ class SessionStoreTest extends TestCase
         $this->assertFalse(array_search('qu', $session->get('_flash.old')));
     }
 
-    public function testReflash()
+    public function testReflash(): void
     {
         $session = $this->getSession();
         $session->flash('foo', 'bar');
@@ -197,7 +197,7 @@ class SessionStoreTest extends TestCase
         $this->assertFalse(array_search('foo', $session->get('_flash.old')));
     }
 
-    public function testReflashWithNow()
+    public function testReflashWithNow(): void
     {
         $session = $this->getSession();
         $session->now('foo', 'bar');
@@ -206,7 +206,7 @@ class SessionStoreTest extends TestCase
         $this->assertFalse(array_search('foo', $session->get('_flash.old')));
     }
 
-    public function testReplace()
+    public function testReplace(): void
     {
         $session = $this->getSession();
         $session->put('foo', 'bar');
@@ -216,7 +216,7 @@ class SessionStoreTest extends TestCase
         $this->assertEquals('ux', $session->get('qu'));
     }
 
-    public function testRemove()
+    public function testRemove(): void
     {
         $session = $this->getSession();
         $session->put('foo', 'bar');
@@ -225,7 +225,7 @@ class SessionStoreTest extends TestCase
         $this->assertEquals('bar', $pulled);
     }
 
-    public function testClear()
+    public function testClear(): void
     {
         $session = $this->getSession();
         $session->put('foo', 'bar');
@@ -239,7 +239,7 @@ class SessionStoreTest extends TestCase
         $this->assertFalse($session->has('foo'));
     }
 
-    public function testIncrement()
+    public function testIncrement(): void
     {
         $session = $this->getSession();
 
@@ -256,7 +256,7 @@ class SessionStoreTest extends TestCase
         $this->assertEquals(1, $session->get('bar'));
     }
 
-    public function testDecrement()
+    public function testDecrement(): void
     {
         $session = $this->getSession();
 
@@ -273,7 +273,7 @@ class SessionStoreTest extends TestCase
         $this->assertEquals(-1, $session->get('bar'));
     }
 
-    public function testHasOldInputWithoutKey()
+    public function testHasOldInputWithoutKey(): void
     {
         $session = $this->getSession();
         $session->flash('boom', 'baz');
@@ -283,7 +283,7 @@ class SessionStoreTest extends TestCase
         $this->assertTrue($session->hasOldInput());
     }
 
-    public function testHandlerNeedsRequest()
+    public function testHandlerNeedsRequest(): void
     {
         $session = $this->getSession();
         $this->assertFalse($session->handlerNeedsRequest());
@@ -296,13 +296,13 @@ class SessionStoreTest extends TestCase
         $session->setRequestOnHandler($request);
     }
 
-    public function testToken()
+    public function testToken(): void
     {
         $session = $this->getSession();
         $this->assertEquals($session->token(), $session->token());
     }
 
-    public function testRegenerateToken()
+    public function testRegenerateToken(): void
     {
         $session = $this->getSession();
         $token = $session->token();
@@ -310,7 +310,7 @@ class SessionStoreTest extends TestCase
         $this->assertNotEquals($token, $session->token());
     }
 
-    public function testName()
+    public function testName(): void
     {
         $session = $this->getSession();
         $this->assertEquals($session->getName(), $this->getSessionName());
@@ -318,7 +318,7 @@ class SessionStoreTest extends TestCase
         $this->assertEquals($session->getName(), 'foo');
     }
 
-    public function testKeyExists()
+    public function testKeyExists(): void
     {
         $session = $this->getSession();
         $session->put('foo', 'bar');
@@ -334,7 +334,7 @@ class SessionStoreTest extends TestCase
         $this->assertFalse($session->exists(['hulk.two']));
     }
 
-    public function testRememberMethodCallsPutAndReturnsDefault()
+    public function testRememberMethodCallsPutAndReturnsDefault(): void
     {
         $session = $this->getSession();
         $session->getHandler()->shouldReceive('get')->andReturn(null);

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -9,12 +9,12 @@ use Illuminate\Session\Console\SessionTableCommand;
 
 class SessionTableCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testCreateMakesMigration()
+    public function testCreateMakesMigration(): void
     {
         $command = new SessionTableCommandTestStub(
             $files = m::mock('Illuminate\Filesystem\Filesystem'),

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Collection;
 
 class SupportArrTest extends TestCase
 {
-    public function testAccessible()
+    public function testAccessible(): void
     {
         $this->assertTrue(Arr::accessible([]));
         $this->assertTrue(Arr::accessible([1, 2]));
@@ -24,19 +24,19 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::accessible((object) ['a' => 1, 'b' => 2]));
     }
 
-    public function testAdd()
+    public function testAdd(): void
     {
         $array = Arr::add(['name' => 'Desk'], 'price', 100);
         $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
     }
 
-    public function testCollapse()
+    public function testCollapse(): void
     {
         $data = [['foo', 'bar'], ['baz']];
         $this->assertEquals(['foo', 'bar', 'baz'], Arr::collapse($data));
     }
 
-    public function testCrossJoin()
+    public function testCrossJoin(): void
     {
         // Single dimension
         $this->assertSame(
@@ -81,14 +81,14 @@ class SupportArrTest extends TestCase
         $this->assertSame([[]], Arr::crossJoin());
     }
 
-    public function testDivide()
+    public function testDivide(): void
     {
         list($keys, $values) = Arr::divide(['name' => 'Desk']);
         $this->assertEquals(['name'], $keys);
         $this->assertEquals(['Desk'], $values);
     }
 
-    public function testDot()
+    public function testDot(): void
     {
         $array = Arr::dot(['foo' => ['bar' => 'baz']]);
         $this->assertEquals(['foo.bar' => 'baz'], $array);
@@ -103,14 +103,14 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['foo.bar' => []], $array);
     }
 
-    public function testExcept()
+    public function testExcept(): void
     {
         $array = ['name' => 'Desk', 'price' => 100];
         $array = Arr::except($array, ['price']);
         $this->assertEquals(['name' => 'Desk'], $array);
     }
 
-    public function testExists()
+    public function testExists(): void
     {
         $this->assertTrue(Arr::exists([1], 0));
         $this->assertTrue(Arr::exists([null], 0));
@@ -124,7 +124,7 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::exists(new Collection(['a' => null]), 'b'));
     }
 
-    public function testFirst()
+    public function testFirst(): void
     {
         $array = [100, 200, 300];
 
@@ -136,7 +136,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(100, Arr::first($array));
     }
 
-    public function testLast()
+    public function testLast(): void
     {
         $array = [100, 200, 300];
 
@@ -153,7 +153,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(300, Arr::last($array));
     }
 
-    public function testFlatten()
+    public function testFlatten(): void
     {
         // Flat arrays are unaffected
         $array = ['#foo', '#bar', '#baz'];
@@ -192,7 +192,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['#foo', '#bar', '#zap', '#baz'], Arr::flatten($array));
     }
 
-    public function testFlattenWithDepth()
+    public function testFlattenWithDepth(): void
     {
         // No depth flattens recursively
         $array = [['#foo', ['#bar', ['#baz']]], '#zap'];
@@ -206,7 +206,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], Arr::flatten($array, 2));
     }
 
-    public function testGet()
+    public function testGet(): void
     {
         $array = ['products.desk' => ['price' => 100]];
         $this->assertEquals(['price' => 100], Arr::get($array, 'products.desk'));
@@ -273,7 +273,7 @@ class SupportArrTest extends TestCase
         $this->assertEmpty(Arr::get([], null, 'default'));
     }
 
-    public function testHas()
+    public function testHas(): void
     {
         $array = ['products.desk' => ['price' => 100]];
         $this->assertTrue(Arr::has($array, 'products.desk'));
@@ -322,7 +322,7 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::has(null, [null]));
     }
 
-    public function testIsAssoc()
+    public function testIsAssoc(): void
     {
         $this->assertTrue(Arr::isAssoc(['a' => 'a', 0 => 'b']));
         $this->assertTrue(Arr::isAssoc([1 => 'a', 0 => 'b']));
@@ -331,14 +331,14 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::isAssoc(['a', 'b']));
     }
 
-    public function testOnly()
+    public function testOnly(): void
     {
         $array = ['name' => 'Desk', 'price' => 100, 'orders' => 10];
         $array = Arr::only($array, ['name', 'price']);
         $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
     }
 
-    public function testPluck()
+    public function testPluck(): void
     {
         $array = [
             ['developer' => ['name' => 'Taylor']],
@@ -350,7 +350,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['Taylor', 'Abigail'], $array);
     }
 
-    public function testPluckWithArrayValue()
+    public function testPluckWithArrayValue(): void
     {
         $array = [
             ['developer' => ['name' => 'Taylor']],
@@ -360,7 +360,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['Taylor', 'Abigail'], $array);
     }
 
-    public function testPluckWithKeys()
+    public function testPluckWithKeys(): void
     {
         $array = [
             ['name' => 'Taylor', 'role' => 'developer'],
@@ -381,7 +381,7 @@ class SupportArrTest extends TestCase
         ], $test2);
     }
 
-    public function testPluckWithCarbonKeys()
+    public function testPluckWithCarbonKeys(): void
     {
         $array = [
             ['start' => new Carbon('2017-07-25 00:00:00'), 'end' => new Carbon('2017-07-30 00:00:00')],
@@ -390,7 +390,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['2017-07-25 00:00:00' => '2017-07-30 00:00:00'], $array);
     }
 
-    public function testPrepend()
+    public function testPrepend(): void
     {
         $array = Arr::prepend(['one', 'two', 'three', 'four'], 'zero');
         $this->assertEquals(['zero', 'one', 'two', 'three', 'four'], $array);
@@ -399,7 +399,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['zero' => 0, 'one' => 1, 'two' => 2], $array);
     }
 
-    public function testPull()
+    public function testPull(): void
     {
         $array = ['name' => 'Desk', 'price' => 100];
         $name = Arr::pull($array, 'name');
@@ -419,7 +419,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']], $array);
     }
 
-    public function testRandom()
+    public function testRandom(): void
     {
         $random = Arr::random(['foo', 'bar', 'baz']);
         $this->assertContains($random, ['foo', 'bar', 'baz']);
@@ -455,7 +455,7 @@ class SupportArrTest extends TestCase
         $this->assertContains($random[1], ['foo', 'bar', 'baz']);
     }
 
-    public function testRandomOnEmptyArray()
+    public function testRandomOnEmptyArray(): void
     {
         $random = Arr::random([], 0);
         $this->assertInternalType('array', $random);
@@ -466,7 +466,7 @@ class SupportArrTest extends TestCase
         $this->assertCount(0, $random);
     }
 
-    public function testRandomThrowsAnErrorWhenRequestingMoreItemsThanAreAvailable()
+    public function testRandomThrowsAnErrorWhenRequestingMoreItemsThanAreAvailable(): void
     {
         $exceptions = 0;
 
@@ -491,14 +491,14 @@ class SupportArrTest extends TestCase
         $this->assertSame(3, $exceptions);
     }
 
-    public function testSet()
+    public function testSet(): void
     {
         $array = ['products' => ['desk' => ['price' => 100]]];
         Arr::set($array, 'products.desk.price', 200);
         $this->assertEquals(['products' => ['desk' => ['price' => 200]]], $array);
     }
 
-    public function testSort()
+    public function testSort(): void
     {
         $unsorted = [
             ['name' => 'Desk'],
@@ -524,7 +524,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals($expected, $sortedWithDotNotation);
     }
 
-    public function testSortRecursive()
+    public function testSortRecursive(): void
     {
         $array = [
             'users' => [
@@ -582,7 +582,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals($expect, Arr::sortRecursive($array));
     }
 
-    public function testWhere()
+    public function testWhere(): void
     {
         $array = [100, '200', 300, '400', 500];
 
@@ -593,7 +593,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals([1 => 200, 3 => 400], $array);
     }
 
-    public function testWhereKey()
+    public function testWhereKey(): void
     {
         $array = ['10' => 1, 'foo' => 3, 20 => 2];
 
@@ -604,7 +604,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['10' => 1, 20 => 2], $array);
     }
 
-    public function testForget()
+    public function testForget(): void
     {
         $array = ['products' => ['desk' => ['price' => 100]]];
         Arr::forget($array, null);
@@ -653,7 +653,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['emails' => ['joe@example.com' => ['name' => 'Joe']]], $array);
     }
 
-    public function testWrap()
+    public function testWrap(): void
     {
         $string = 'a';
         $array = ['a'];

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -11,12 +11,12 @@ class SupportCapsuleManagerTraitTest extends TestCase
 {
     use CapsuleManagerTrait;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testSetupContainerForCapsule()
+    public function testSetupContainerForCapsule(): void
     {
         $this->container = null;
         $app = new Container;
@@ -26,7 +26,7 @@ class SupportCapsuleManagerTraitTest extends TestCase
         $this->assertInstanceOf('Illuminate\Support\Fluent', $app['config']);
     }
 
-    public function testSetupContainerForCapsuleWhenConfigIsBound()
+    public function testSetupContainerForCapsuleWhenConfigIsBound(): void
     {
         $this->container = null;
         $app = new Container;

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -15,14 +15,14 @@ class SupportCarbonTest extends TestCase
      */
     protected $now;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         Carbon::setTestNow($this->now = Carbon::create(2017, 6, 27, 13, 14, 15, 'UTC'));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Carbon::setTestNow();
         Carbon::serializeUsing(null);
@@ -30,7 +30,7 @@ class SupportCarbonTest extends TestCase
         parent::tearDown();
     }
 
-    public function testInstance()
+    public function testInstance(): void
     {
         $this->assertInstanceOf(DateTime::class, $this->now);
         $this->assertInstanceOf(DateTimeInterface::class, $this->now);
@@ -38,7 +38,7 @@ class SupportCarbonTest extends TestCase
         $this->assertInstanceOf(Carbon::class, $this->now);
     }
 
-    public function testCarbonIsMacroableWhenNotCalledStatically()
+    public function testCarbonIsMacroableWhenNotCalledStatically(): void
     {
         Carbon::macro('diffInDecades', function (Carbon $dt = null, $abs = true) {
             return (int) ($this->diffInYears($dt, $abs) / 10);
@@ -47,7 +47,7 @@ class SupportCarbonTest extends TestCase
         $this->assertSame(2, $this->now->diffInDecades(Carbon::now()->addYears(25)));
     }
 
-    public function testCarbonIsMacroableWhenCalledStatically()
+    public function testCarbonIsMacroableWhenCalledStatically(): void
     {
         Carbon::macro('twoDaysAgoAtNoon', function () {
             return Carbon::now()->subDays(2)->setTime(12, 0, 0);
@@ -60,7 +60,7 @@ class SupportCarbonTest extends TestCase
      * @expectedException \BadMethodCallException
      * @expectedExceptionMessage Method Illuminate\Support\Carbon::nonExistingStaticMacro does not exist.
      */
-    public function testCarbonRaisesExceptionWhenStaticMacroIsNotFound()
+    public function testCarbonRaisesExceptionWhenStaticMacroIsNotFound(): void
     {
         Carbon::nonExistingStaticMacro();
     }
@@ -69,12 +69,12 @@ class SupportCarbonTest extends TestCase
      * @expectedException \BadMethodCallException
      * @expectedExceptionMessage Method Illuminate\Support\Carbon::nonExistingMacro does not exist.
      */
-    public function testCarbonRaisesExceptionWhenMacroIsNotFound()
+    public function testCarbonRaisesExceptionWhenMacroIsNotFound(): void
     {
         Carbon::now()->nonExistingMacro();
     }
 
-    public function testCarbonAllowsCustomSerializer()
+    public function testCarbonAllowsCustomSerializer(): void
     {
         Carbon::serializeUsing(function (Carbon $carbon) {
             return $carbon->getTimestamp();
@@ -85,7 +85,7 @@ class SupportCarbonTest extends TestCase
         $this->assertSame(1498569255, $result);
     }
 
-    public function testCarbonCanSerializeToJson()
+    public function testCarbonCanSerializeToJson(): void
     {
         $this->assertSame([
             'date' => '2017-06-27 13:14:15.000000',
@@ -94,7 +94,7 @@ class SupportCarbonTest extends TestCase
         ], $this->now->jsonSerialize());
     }
 
-    public function testSetStateReturnsCorrectType()
+    public function testSetStateReturnsCorrectType(): void
     {
         $carbon = Carbon::__set_state([
             'date' => '2017-06-27 13:14:15.000000',
@@ -105,7 +105,7 @@ class SupportCarbonTest extends TestCase
         $this->assertInstanceOf(Carbon::class, $carbon);
     }
 
-    public function testDeserializationOccursCorrectly()
+    public function testDeserializationOccursCorrectly(): void
     {
         $carbon = new Carbon('2017-06-27 13:14:15.000000');
         $serialized = 'return '.var_export($carbon, true).';';

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -15,13 +15,13 @@ use Illuminate\Contracts\Support\Arrayable;
 
 class SupportCollectionTest extends TestCase
 {
-    public function testFirstReturnsFirstItemInCollection()
+    public function testFirstReturnsFirstItemInCollection(): void
     {
         $c = new Collection(['foo', 'bar']);
         $this->assertEquals('foo', $c->first());
     }
 
-    public function testFirstWithCallback()
+    public function testFirstWithCallback(): void
     {
         $data = new Collection(['foo', 'bar', 'baz']);
         $result = $data->first(function ($value) {
@@ -30,7 +30,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('bar', $result);
     }
 
-    public function testFirstWithCallbackAndDefault()
+    public function testFirstWithCallbackAndDefault(): void
     {
         $data = new Collection(['foo', 'bar']);
         $result = $data->first(function ($value) {
@@ -39,14 +39,14 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('default', $result);
     }
 
-    public function testFirstWithDefaultAndWithoutCallback()
+    public function testFirstWithDefaultAndWithoutCallback(): void
     {
         $data = new Collection;
         $result = $data->first(null, 'default');
         $this->assertEquals('default', $result);
     }
 
-    public function testFirstWhere()
+    public function testFirstWhere(): void
     {
         $data = new Collection([
             ['material' => 'paper', 'type' => 'book'],
@@ -59,13 +59,13 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($data->firstWhere('nonexistant', 'key'));
     }
 
-    public function testLastReturnsLastItemInCollection()
+    public function testLastReturnsLastItemInCollection(): void
     {
         $c = new Collection(['foo', 'bar']);
         $this->assertEquals('bar', $c->last());
     }
 
-    public function testLastWithCallback()
+    public function testLastWithCallback(): void
     {
         $data = new Collection([100, 200, 300]);
         $result = $data->last(function ($value) {
@@ -78,7 +78,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(200, $result);
     }
 
-    public function testLastWithCallbackAndDefault()
+    public function testLastWithCallbackAndDefault(): void
     {
         $data = new Collection(['foo', 'bar']);
         $result = $data->last(function ($value) {
@@ -87,14 +87,14 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('default', $result);
     }
 
-    public function testLastWithDefaultAndWithoutCallback()
+    public function testLastWithDefaultAndWithoutCallback(): void
     {
         $data = new Collection;
         $result = $data->last(null, 'default');
         $this->assertEquals('default', $result);
     }
 
-    public function testPopReturnsAndRemovesLastItemInCollection()
+    public function testPopReturnsAndRemovesLastItemInCollection(): void
     {
         $c = new Collection(['foo', 'bar']);
 
@@ -102,7 +102,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('foo', $c->first());
     }
 
-    public function testShiftReturnsAndRemovesFirstItemInCollection()
+    public function testShiftReturnsAndRemovesFirstItemInCollection(): void
     {
         $c = new Collection(['foo', 'bar']);
 
@@ -110,14 +110,14 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('bar', $c->first());
     }
 
-    public function testEmptyCollectionIsEmpty()
+    public function testEmptyCollectionIsEmpty(): void
     {
         $c = new Collection;
 
         $this->assertTrue($c->isEmpty());
     }
 
-    public function testEmptyCollectionIsNotEmpty()
+    public function testEmptyCollectionIsNotEmpty(): void
     {
         $c = new Collection(['foo', 'bar']);
 
@@ -125,7 +125,7 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue($c->isNotEmpty());
     }
 
-    public function testCollectionIsConstructed()
+    public function testCollectionIsConstructed(): void
     {
         $collection = new Collection('foo');
         $this->assertSame(['foo'], $collection->all());
@@ -143,7 +143,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEmpty($collection->all());
     }
 
-    public function testCollectionShuffleWithSeed()
+    public function testCollectionShuffleWithSeed(): void
     {
         $collection = new Collection((range(0, 100, 10)));
 
@@ -153,7 +153,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($firstRandom, $secondRandom);
     }
 
-    public function testGetArrayableItems()
+    public function testGetArrayableItems(): void
     {
         $collection = new Collection;
 
@@ -182,7 +182,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $array);
     }
 
-    public function testToArrayCallsToArrayOnEachItemInCollection()
+    public function testToArrayCallsToArrayOnEachItemInCollection(): void
     {
         $item1 = m::mock('Illuminate\Contracts\Support\Arrayable');
         $item1->shouldReceive('toArray')->once()->andReturn('foo.array');
@@ -194,7 +194,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo.array', 'bar.array'], $results);
     }
 
-    public function testJsonSerializeCallsToArrayOrJsonSerializeOnEachItemInCollection()
+    public function testJsonSerializeCallsToArrayOrJsonSerializeOnEachItemInCollection(): void
     {
         $item1 = m::mock('JsonSerializable');
         $item1->shouldReceive('jsonSerialize')->once()->andReturn('foo.json');
@@ -206,7 +206,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo.json', 'bar.array'], $results);
     }
 
-    public function testToJsonEncodesTheJsonSerializeResult()
+    public function testToJsonEncodesTheJsonSerializeResult(): void
     {
         $c = $this->getMockBuilder(Collection::class)->setMethods(['jsonSerialize'])->getMock();
         $c->expects($this->once())->method('jsonSerialize')->will($this->returnValue('foo'));
@@ -215,7 +215,7 @@ class SupportCollectionTest extends TestCase
         $this->assertJsonStringEqualsJsonString(json_encode('foo'), $results);
     }
 
-    public function testCastingToStringJsonEncodesTheToArrayResult()
+    public function testCastingToStringJsonEncodesTheToArrayResult(): void
     {
         $c = $this->getMockBuilder(Collection::class)->setMethods(['jsonSerialize'])->getMock();
         $c->expects($this->once())->method('jsonSerialize')->will($this->returnValue('foo'));
@@ -223,7 +223,7 @@ class SupportCollectionTest extends TestCase
         $this->assertJsonStringEqualsJsonString(json_encode('foo'), (string) $c);
     }
 
-    public function testOffsetAccess()
+    public function testOffsetAccess(): void
     {
         $c = new Collection(['name' => 'taylor']);
         $this->assertEquals('taylor', $c['name']);
@@ -236,7 +236,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('jason', $c[0]);
     }
 
-    public function testArrayAccessOffsetExists()
+    public function testArrayAccessOffsetExists(): void
     {
         $c = new Collection(['foo', 'bar']);
         $this->assertTrue($c->offsetExists(0));
@@ -244,14 +244,14 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse($c->offsetExists(1000));
     }
 
-    public function testArrayAccessOffsetGet()
+    public function testArrayAccessOffsetGet(): void
     {
         $c = new Collection(['foo', 'bar']);
         $this->assertEquals('foo', $c->offsetGet(0));
         $this->assertEquals('bar', $c->offsetGet(1));
     }
 
-    public function testArrayAccessOffsetSet()
+    public function testArrayAccessOffsetSet(): void
     {
         $c = new Collection(['foo', 'foo']);
 
@@ -262,7 +262,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('qux', $c[2]);
     }
 
-    public function testArrayAccessOffsetUnset()
+    public function testArrayAccessOffsetUnset(): void
     {
         $c = new Collection(['foo', 'bar']);
 
@@ -270,7 +270,7 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse(isset($c[1]));
     }
 
-    public function testForgetSingleKey()
+    public function testForgetSingleKey(): void
     {
         $c = new Collection(['foo', 'bar']);
         $c->forget(0);
@@ -281,7 +281,7 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse(isset($c['foo']));
     }
 
-    public function testForgetArrayOfKeys()
+    public function testForgetArrayOfKeys(): void
     {
         $c = new Collection(['foo', 'bar', 'baz']);
         $c->forget([0, 2]);
@@ -296,26 +296,26 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue(isset($c['name']));
     }
 
-    public function testCountable()
+    public function testCountable(): void
     {
         $c = new Collection(['foo', 'bar']);
         $this->assertCount(2, $c);
     }
 
-    public function testIterable()
+    public function testIterable(): void
     {
         $c = new Collection(['foo']);
         $this->assertInstanceOf('ArrayIterator', $c->getIterator());
         $this->assertEquals(['foo'], $c->getIterator()->getArrayCopy());
     }
 
-    public function testCachingIterator()
+    public function testCachingIterator(): void
     {
         $c = new Collection(['foo']);
         $this->assertInstanceOf('CachingIterator', $c->getCachingIterator());
     }
 
-    public function testFilter()
+    public function testFilter(): void
     {
         $c = new Collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);
         $this->assertEquals([1 => ['id' => 2, 'name' => 'World']], $c->filter(function ($item) {
@@ -331,7 +331,7 @@ class SupportCollectionTest extends TestCase
         })->all());
     }
 
-    public function testHigherOrderKeyBy()
+    public function testHigherOrderKeyBy(): void
     {
         $c = new Collection([
             ['id' => 'id1', 'name' => 'first'],
@@ -341,7 +341,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['id1' => 'first', 'id2' => 'second'], $c->keyBy->id->map->name->all());
     }
 
-    public function testHigherOrderUnique()
+    public function testHigherOrderUnique(): void
     {
         $c = new Collection([
             ['id' => '1', 'name' => 'first'],
@@ -351,7 +351,7 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(1, $c->unique->id);
     }
 
-    public function testHigherOrderFilter()
+    public function testHigherOrderFilter(): void
     {
         $c = new Collection([
             new class {
@@ -375,7 +375,7 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(1, $c->filter->active());
     }
 
-    public function testWhere()
+    public function testWhere(): void
     {
         $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
 
@@ -485,7 +485,7 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testWhereStrict()
+    public function testWhereStrict(): void
     {
         $c = new Collection([['v' => 3], ['v' => '3']]);
 
@@ -495,37 +495,37 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testWhereInstanceOf()
+    public function testWhereInstanceOf(): void
     {
         $c = new Collection([new stdClass, new stdClass, new Collection, new stdClass]);
         $this->assertCount(3, $c->whereInstanceOf(stdClass::class));
     }
 
-    public function testWhereIn()
+    public function testWhereIn(): void
     {
         $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
         $this->assertEquals([['v' => 1], ['v' => 3], ['v' => '3']], $c->whereIn('v', [1, 3])->values()->all());
     }
 
-    public function testWhereInStrict()
+    public function testWhereInStrict(): void
     {
         $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
         $this->assertEquals([['v' => 1], ['v' => 3]], $c->whereInStrict('v', [1, 3])->values()->all());
     }
 
-    public function testWhereNotIn()
+    public function testWhereNotIn(): void
     {
         $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
         $this->assertEquals([['v' => 2], ['v' => 4]], $c->whereNotIn('v', [1, 3])->values()->all());
     }
 
-    public function testWhereNotInStrict()
+    public function testWhereNotInStrict(): void
     {
         $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
         $this->assertEquals([['v' => 2], ['v' => '3'], ['v' => 4]], $c->whereNotInStrict('v', [1, 3])->values()->all());
     }
 
-    public function testValues()
+    public function testValues(): void
     {
         $c = new Collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);
         $this->assertEquals([['id' => 2, 'name' => 'World']], $c->filter(function ($item) {
@@ -533,7 +533,7 @@ class SupportCollectionTest extends TestCase
         })->values()->all());
     }
 
-    public function testFlatten()
+    public function testFlatten(): void
     {
         // Flat arrays are unaffected
         $c = new Collection(['#foo', '#bar', '#baz']);
@@ -568,7 +568,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['#foo', '#bar', '#zap', '#baz'], $c->flatten()->all());
     }
 
-    public function testFlattenWithDepth()
+    public function testFlattenWithDepth(): void
     {
         // No depth flattens recursively
         $c = new Collection([['#foo', ['#bar', ['#baz']]], '#zap']);
@@ -582,7 +582,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], $c->flatten(2)->all());
     }
 
-    public function testFlattenIgnoresKeys()
+    public function testFlattenIgnoresKeys(): void
     {
         // No depth ignores keys
         $c = new Collection(['#foo', ['key' => '#bar'], ['key' => '#baz'], 'key' => '#zap']);
@@ -593,49 +593,49 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten(1)->all());
     }
 
-    public function testMergeNull()
+    public function testMergeNull(): void
     {
         $c = new Collection(['name' => 'Hello']);
         $this->assertEquals(['name' => 'Hello'], $c->merge(null)->all());
     }
 
-    public function testMergeArray()
+    public function testMergeArray(): void
     {
         $c = new Collection(['name' => 'Hello']);
         $this->assertEquals(['name' => 'Hello', 'id' => 1], $c->merge(['id' => 1])->all());
     }
 
-    public function testMergeCollection()
+    public function testMergeCollection(): void
     {
         $c = new Collection(['name' => 'Hello']);
         $this->assertEquals(['name' => 'World', 'id' => 1], $c->merge(new Collection(['name' => 'World', 'id' => 1]))->all());
     }
 
-    public function testUnionNull()
+    public function testUnionNull(): void
     {
         $c = new Collection(['name' => 'Hello']);
         $this->assertEquals(['name' => 'Hello'], $c->union(null)->all());
     }
 
-    public function testUnionArray()
+    public function testUnionArray(): void
     {
         $c = new Collection(['name' => 'Hello']);
         $this->assertEquals(['name' => 'Hello', 'id' => 1], $c->union(['id' => 1])->all());
     }
 
-    public function testUnionCollection()
+    public function testUnionCollection(): void
     {
         $c = new Collection(['name' => 'Hello']);
         $this->assertEquals(['name' => 'Hello', 'id' => 1], $c->union(new Collection(['name' => 'World', 'id' => 1]))->all());
     }
 
-    public function testDiffCollection()
+    public function testDiffCollection(): void
     {
         $c = new Collection(['id' => 1, 'first_word' => 'Hello']);
         $this->assertEquals(['id' => 1], $c->diff(new Collection(['first_word' => 'Hello', 'last_word' => 'World']))->all());
     }
 
-    public function testDiffUsingWithCollection()
+    public function testDiffUsingWithCollection(): void
     {
         $c = new Collection(['en_GB', 'fr', 'HR']);
         // demonstrate that diffKeys wont support case insensitivity
@@ -644,26 +644,26 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['fr'], $c->diffUsing(new Collection(['en_gb', 'hr']), 'strcasecmp')->values()->toArray());
     }
 
-    public function testDiffUsingWithNull()
+    public function testDiffUsingWithNull(): void
     {
         $c = new Collection(['en_GB', 'fr', 'HR']);
         $this->assertEquals(['en_GB', 'fr', 'HR'], $c->diffUsing(null, 'strcasecmp')->values()->toArray());
     }
 
-    public function testDiffNull()
+    public function testDiffNull(): void
     {
         $c = new Collection(['id' => 1, 'first_word' => 'Hello']);
         $this->assertEquals(['id' => 1, 'first_word' => 'Hello'], $c->diff(null)->all());
     }
 
-    public function testDiffKeys()
+    public function testDiffKeys(): void
     {
         $c1 = new Collection(['id' => 1, 'first_word' => 'Hello']);
         $c2 = new Collection(['id' => 123, 'foo_bar' => 'Hello']);
         $this->assertEquals(['first_word' => 'Hello'], $c1->diffKeys($c2)->all());
     }
 
-    public function testDiffKeysUsing()
+    public function testDiffKeysUsing(): void
     {
         $c1 = new Collection(['id' => 1, 'first_word' => 'Hello']);
         $c2 = new Collection(['ID' => 123, 'foo_bar' => 'Hello']);
@@ -673,14 +673,14 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first_word' => 'Hello'], $c1->diffKeysUsing($c2, 'strcasecmp')->all());
     }
 
-    public function testDiffAssoc()
+    public function testDiffAssoc(): void
     {
         $c1 = new Collection(['id' => 1, 'first_word' => 'Hello', 'not_affected' => 'value']);
         $c2 = new Collection(['id' => 123, 'foo_bar' => 'Hello', 'not_affected' => 'value']);
         $this->assertEquals(['id' => 1, 'first_word' => 'Hello'], $c1->diffAssoc($c2)->all());
     }
 
-    public function testDiffAssocUsing()
+    public function testDiffAssocUsing(): void
     {
         $c1 = new Collection(['a' => 'green', 'b' => 'brown', 'c' => 'blue', 'red']);
         $c2 = new Collection(['A' => 'green', 'yellow', 'red']);
@@ -690,7 +690,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['b' => 'brown', 'c' => 'blue', 'red'], $c1->diffAssocUsing($c2, 'strcasecmp')->all());
     }
 
-    public function testEach()
+    public function testEach(): void
     {
         $c = new Collection($original = [1, 2, 'foo' => 'bar', 'bam' => 'baz']);
 
@@ -710,7 +710,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1, 2, 'foo' => 'bar'], $result);
     }
 
-    public function testEachSpread()
+    public function testEachSpread(): void
     {
         $c = new Collection([[1, 'a'], [2, 'b']]);
 
@@ -742,31 +742,31 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([[1, 'a', 0], [2, 'b', 1]], $result);
     }
 
-    public function testIntersectNull()
+    public function testIntersectNull(): void
     {
         $c = new Collection(['id' => 1, 'first_word' => 'Hello']);
         $this->assertEquals([], $c->intersect(null)->all());
     }
 
-    public function testIntersectCollection()
+    public function testIntersectCollection(): void
     {
         $c = new Collection(['id' => 1, 'first_word' => 'Hello']);
         $this->assertEquals(['first_word' => 'Hello'], $c->intersect(new Collection(['first_world' => 'Hello', 'last_word' => 'World']))->all());
     }
 
-    public function testIntersectByKeysNull()
+    public function testIntersectByKeysNull(): void
     {
         $c = new Collection(['name' => 'Mateus', 'age' => 18]);
         $this->assertEquals([], $c->intersectByKeys(null)->all());
     }
 
-    public function testIntersectByKeys()
+    public function testIntersectByKeys(): void
     {
         $c = new Collection(['name' => 'Mateus', 'age' => 18]);
         $this->assertEquals(['name' => 'Mateus'], $c->intersectByKeys(new Collection(['name' => 'Mateus', 'surname' => 'Guimaraes']))->all());
     }
 
-    public function testUnique()
+    public function testUnique(): void
     {
         $c = new Collection(['Hello', 'World', 'World']);
         $this->assertEquals(['Hello', 'World'], $c->unique()->all());
@@ -775,7 +775,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([[1, 2], [2, 3], [3, 4]], $c->unique()->values()->all());
     }
 
-    public function testUniqueWithCallback()
+    public function testUniqueWithCallback(): void
     {
         $c = new Collection([
             1 => ['id' => 1, 'first' => 'Taylor', 'last' => 'Otwell'],
@@ -807,7 +807,7 @@ class SupportCollectionTest extends TestCase
         })->all());
     }
 
-    public function testUniqueStrict()
+    public function testUniqueStrict(): void
     {
         $c = new Collection([
             [
@@ -836,19 +836,19 @@ class SupportCollectionTest extends TestCase
         ], $c->uniqueStrict('id')->all());
     }
 
-    public function testCollapse()
+    public function testCollapse(): void
     {
         $data = new Collection([[$object1 = new stdClass], [$object2 = new stdClass]]);
         $this->assertEquals([$object1, $object2], $data->collapse()->all());
     }
 
-    public function testCollapseWithNestedCollections()
+    public function testCollapseWithNestedCollections(): void
     {
         $data = new Collection([new Collection([1, 2, 3]), new Collection([4, 5, 6])]);
         $this->assertEquals([1, 2, 3, 4, 5, 6], $data->collapse()->all());
     }
 
-    public function testCrossJoin()
+    public function testCrossJoin(): void
     {
         // Cross join with an array
         $this->assertEquals(
@@ -877,7 +877,7 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testSort()
+    public function testSort(): void
     {
         $data = (new Collection([5, 3, 1, 2, 4]))->sort();
         $this->assertEquals([1, 2, 3, 4, 5], $data->values()->all());
@@ -889,7 +889,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['bar-1', 'bar-10', 'foo'], $data->values()->all());
     }
 
-    public function testSortWithCallback()
+    public function testSortWithCallback(): void
     {
         $data = (new Collection([5, 3, 1, 2, 4]))->sort(function ($a, $b) {
             if ($a === $b) {
@@ -902,7 +902,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(range(1, 5), array_values($data->all()));
     }
 
-    public function testSortBy()
+    public function testSortBy(): void
     {
         $data = new Collection(['taylor', 'dayle']);
         $data = $data->sortBy(function ($x) {
@@ -919,7 +919,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['taylor', 'dayle'], array_values($data->all()));
     }
 
-    public function testSortByString()
+    public function testSortByString(): void
     {
         $data = new Collection([['name' => 'taylor'], ['name' => 'dayle']]);
         $data = $data->sortBy('name', SORT_STRING);
@@ -932,7 +932,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
     }
 
-    public function testSortByAlwaysReturnsAssoc()
+    public function testSortByAlwaysReturnsAssoc(): void
     {
         $data = new Collection(['a' => 'taylor', 'b' => 'dayle']);
         $data = $data->sortBy(function ($x) {
@@ -949,21 +949,21 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => 'dayle', 0 => 'taylor'], $data->all());
     }
 
-    public function testSortKeys()
+    public function testSortKeys(): void
     {
         $data = new Collection(['b' => 'dayle', 'a' => 'taylor']);
 
         $this->assertEquals(['a' => 'taylor', 'b' => 'dayle'], $data->sortKeys()->all());
     }
 
-    public function testSortKeysDesc()
+    public function testSortKeysDesc(): void
     {
         $data = new Collection(['a' => 'taylor', 'b' => 'dayle']);
 
         $this->assertEquals(['b' => 'dayle', 'a' => 'taylor'], $data->sortKeys()->all());
     }
 
-    public function testReverse()
+    public function testReverse(): void
     {
         $data = new Collection(['zaeed', 'alan']);
         $reversed = $data->reverse();
@@ -976,13 +976,13 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['framework' => 'laravel', 'name' => 'taylor'], $reversed->all());
     }
 
-    public function testFlip()
+    public function testFlip(): void
     {
         $data = new Collection(['name' => 'taylor', 'framework' => 'laravel']);
         $this->assertEquals(['taylor' => 'name', 'laravel' => 'framework'], $data->flip()->toArray());
     }
 
-    public function testChunk()
+    public function testChunk(): void
     {
         $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         $data = $data->chunk(3);
@@ -994,7 +994,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([9 => 10], $data[3]->toArray());
     }
 
-    public function testChunkWhenGivenZeroAsSize()
+    public function testChunkWhenGivenZeroAsSize(): void
     {
         $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
@@ -1004,7 +1004,7 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testChunkWhenGivenLessThanZero()
+    public function testChunkWhenGivenLessThanZero(): void
     {
         $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
@@ -1014,7 +1014,7 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testEvery()
+    public function testEvery(): void
     {
         $c = new Collection([]);
         $this->assertTrue($c->every('key', 'value'));
@@ -1043,7 +1043,7 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse($c->push(['active' => false])->every->active);
     }
 
-    public function testExcept()
+    public function testExcept(): void
     {
         $data = new Collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);
 
@@ -1055,20 +1055,20 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->except('last')->all());
     }
 
-    public function testExceptSelf()
+    public function testExceptSelf(): void
     {
         $data = new Collection(['first' => 'Taylor', 'last' => 'Otwell']);
         $this->assertEquals(['first' => 'Taylor', 'last' => 'Otwell'], $data->except($data)->all());
     }
 
-    public function testPluckWithArrayAndObjectValues()
+    public function testPluckWithArrayAndObjectValues(): void
     {
         $data = new Collection([(object) ['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
         $this->assertEquals(['taylor' => 'foo', 'dayle' => 'bar'], $data->pluck('email', 'name')->all());
         $this->assertEquals(['foo', 'bar'], $data->pluck('email')->all());
     }
 
-    public function testPluckWithArrayAccessValues()
+    public function testPluckWithArrayAccessValues(): void
     {
         $data = new Collection([
             new TestArrayAccessImplementation(['name' => 'taylor', 'email' => 'foo']),
@@ -1079,7 +1079,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $data->pluck('email')->all());
     }
 
-    public function testHas()
+    public function testHas(): void
     {
         $data = new Collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
         $this->assertTrue($data->has('first'));
@@ -1088,7 +1088,7 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse($data->has(['third', 'first']));
     }
 
-    public function testImplode()
+    public function testImplode(): void
     {
         $data = new Collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
         $this->assertEquals('foobar', $data->implode('email'));
@@ -1099,28 +1099,28 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('taylor,dayle', $data->implode(','));
     }
 
-    public function testTake()
+    public function testTake(): void
     {
         $data = new Collection(['taylor', 'dayle', 'shawn']);
         $data = $data->take(2);
         $this->assertEquals(['taylor', 'dayle'], $data->all());
     }
 
-    public function testPut()
+    public function testPut(): void
     {
         $data = new Collection(['name' => 'taylor', 'email' => 'foo']);
         $data = $data->put('name', 'dayle');
         $this->assertEquals(['name' => 'dayle', 'email' => 'foo'], $data->all());
     }
 
-    public function testPutWithNoKey()
+    public function testPutWithNoKey(): void
     {
         $data = new Collection(['taylor', 'shawn']);
         $data = $data->put(null, 'dayle');
         $this->assertEquals(['taylor', 'shawn', 'dayle'], $data->all());
     }
 
-    public function testRandom()
+    public function testRandom(): void
     {
         $data = new Collection([1, 2, 3, 4, 5, 6]);
 
@@ -1153,7 +1153,7 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(2, $random);
     }
 
-    public function testRandomOnEmptyCollection()
+    public function testRandomOnEmptyCollection(): void
     {
         $data = new Collection();
 
@@ -1166,14 +1166,14 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(0, $random);
     }
 
-    public function testTakeLast()
+    public function testTakeLast(): void
     {
         $data = new Collection(['taylor', 'dayle', 'shawn']);
         $data = $data->take(-2);
         $this->assertEquals([1 => 'dayle', 2 => 'shawn'], $data->all());
     }
 
-    public function testMacroable()
+    public function testMacroable(): void
     {
         // Foo() macro : unique values starting with A
         Collection::macro('foo', function () {
@@ -1189,7 +1189,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['a', 'aa', 'aaa'], $c->foo()->all());
     }
 
-    public function testCanAddMethodsToProxy()
+    public function testCanAddMethodsToProxy(): void
     {
         Collection::macro('adults', function ($callback) {
             return $this->filter(function ($item) use ($callback) {
@@ -1204,13 +1204,13 @@ class SupportCollectionTest extends TestCase
         $this->assertSame([['age' => 18], ['age' => 56]], $c->adults->age->values()->all());
     }
 
-    public function testMakeMethod()
+    public function testMakeMethod(): void
     {
         $collection = Collection::make('foo');
         $this->assertEquals(['foo'], $collection->all());
     }
 
-    public function testMakeMethodFromNull()
+    public function testMakeMethodFromNull(): void
     {
         $collection = Collection::make(null);
         $this->assertEquals([], $collection->all());
@@ -1219,79 +1219,79 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([], $collection->all());
     }
 
-    public function testMakeMethodFromCollection()
+    public function testMakeMethodFromCollection(): void
     {
         $firstCollection = Collection::make(['foo' => 'bar']);
         $secondCollection = Collection::make($firstCollection);
         $this->assertEquals(['foo' => 'bar'], $secondCollection->all());
     }
 
-    public function testMakeMethodFromArray()
+    public function testMakeMethodFromArray(): void
     {
         $collection = Collection::make(['foo' => 'bar']);
         $this->assertEquals(['foo' => 'bar'], $collection->all());
     }
 
-    public function testWrapWithScalar()
+    public function testWrapWithScalar(): void
     {
         $collection = Collection::wrap('foo');
         $this->assertEquals(['foo'], $collection->all());
     }
 
-    public function testWrapWithArray()
+    public function testWrapWithArray(): void
     {
         $collection = Collection::wrap(['foo']);
         $this->assertEquals(['foo'], $collection->all());
     }
 
-    public function testWrapWithArrayable()
+    public function testWrapWithArrayable(): void
     {
         $collection = Collection::wrap($o = new TestArrayableObject);
         $this->assertEquals([$o], $collection->all());
     }
 
-    public function testWrapWithJsonable()
+    public function testWrapWithJsonable(): void
     {
         $collection = Collection::wrap($o = new TestJsonableObject);
         $this->assertEquals([$o], $collection->all());
     }
 
-    public function testWrapWithJsonSerialize()
+    public function testWrapWithJsonSerialize(): void
     {
         $collection = Collection::wrap($o = new TestJsonSerializeObject);
         $this->assertEquals([$o], $collection->all());
     }
 
-    public function testWrapWithCollectionClass()
+    public function testWrapWithCollectionClass(): void
     {
         $collection = Collection::wrap(Collection::make(['foo']));
         $this->assertEquals(['foo'], $collection->all());
     }
 
-    public function testWrapWithCollectionSubclass()
+    public function testWrapWithCollectionSubclass(): void
     {
         $collection = TestCollectionSubclass::wrap(Collection::make(['foo']));
         $this->assertEquals(['foo'], $collection->all());
         $this->assertInstanceOf(TestCollectionSubclass::class, $collection);
     }
 
-    public function testUnwrapCollection()
+    public function testUnwrapCollection(): void
     {
         $collection = new Collection(['foo']);
         $this->assertEquals(['foo'], Collection::unwrap($collection));
     }
 
-    public function testUnwrapCollectionWithArray()
+    public function testUnwrapCollectionWithArray(): void
     {
         $this->assertEquals(['foo'], Collection::unwrap(['foo']));
     }
 
-    public function testUnwrapCollectionWithScalar()
+    public function testUnwrapCollectionWithScalar(): void
     {
         $this->assertEquals('foo', Collection::unwrap('foo'));
     }
 
-    public function testTimesMethod()
+    public function testTimesMethod(): void
     {
         $two = Collection::times(2, function ($number) {
             return 'slug-'.$number;
@@ -1313,7 +1313,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(range(1, 5), $range->all());
     }
 
-    public function testConstructMakeFromObject()
+    public function testConstructMakeFromObject(): void
     {
         $object = new stdClass;
         $object->foo = 'bar';
@@ -1321,13 +1321,13 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $collection->all());
     }
 
-    public function testConstructMethod()
+    public function testConstructMethod(): void
     {
         $collection = new Collection('foo');
         $this->assertEquals(['foo'], $collection->all());
     }
 
-    public function testConstructMethodFromNull()
+    public function testConstructMethodFromNull(): void
     {
         $collection = new Collection(null);
         $this->assertEquals([], $collection->all());
@@ -1336,20 +1336,20 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([], $collection->all());
     }
 
-    public function testConstructMethodFromCollection()
+    public function testConstructMethodFromCollection(): void
     {
         $firstCollection = new Collection(['foo' => 'bar']);
         $secondCollection = new Collection($firstCollection);
         $this->assertEquals(['foo' => 'bar'], $secondCollection->all());
     }
 
-    public function testConstructMethodFromArray()
+    public function testConstructMethodFromArray(): void
     {
         $collection = new Collection(['foo' => 'bar']);
         $this->assertEquals(['foo' => 'bar'], $collection->all());
     }
 
-    public function testConstructMethodFromObject()
+    public function testConstructMethodFromObject(): void
     {
         $object = new stdClass;
         $object->foo = 'bar';
@@ -1357,7 +1357,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $collection->all());
     }
 
-    public function testSplice()
+    public function testSplice(): void
     {
         $data = new Collection(['foo', 'baz']);
         $data->splice(1);
@@ -1377,7 +1377,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['baz'], $cut->all());
     }
 
-    public function testGetPluckValueWithAccessors()
+    public function testGetPluckValueWithAccessors(): void
     {
         $model = new TestAccessorEloquentTestStub(['some' => 'foo']);
         $modelTwo = new TestAccessorEloquentTestStub(['some' => 'bar']);
@@ -1386,7 +1386,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $data->pluck('some')->all());
     }
 
-    public function testMap()
+    public function testMap(): void
     {
         $data = new Collection(['first' => 'taylor', 'last' => 'otwell']);
         $data = $data->map(function ($item, $key) {
@@ -1395,7 +1395,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
     }
 
-    public function testMapSpread()
+    public function testMapSpread(): void
     {
         $c = new Collection([[1, 'a'], [2, 'b']]);
 
@@ -1416,7 +1416,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['1-a-0', '2-b-1'], $result->all());
     }
 
-    public function testFlatMap()
+    public function testFlatMap(): void
     {
         $data = new Collection([
             ['name' => 'taylor', 'hobbies' => ['programming', 'basketball']],
@@ -1428,7 +1428,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['programming', 'basketball', 'music', 'powerlifting'], $data->all());
     }
 
-    public function testMapToDictionary()
+    public function testMapToDictionary(): void
     {
         $data = new Collection([
             ['id' => 1, 'name' => 'A'],
@@ -1446,7 +1446,7 @@ class SupportCollectionTest extends TestCase
         $this->assertInternalType('array', $groups['A']);
     }
 
-    public function testMapToDictionaryWithNumericKeys()
+    public function testMapToDictionaryWithNumericKeys(): void
     {
         $data = new Collection([1, 2, 3, 2, 1]);
 
@@ -1457,7 +1457,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => [0, 4], 2 => [1, 3], 3 => [2]], $groups->toArray());
     }
 
-    public function testMapToGroups()
+    public function testMapToGroups(): void
     {
         $data = new Collection([
             ['id' => 1, 'name' => 'A'],
@@ -1475,7 +1475,7 @@ class SupportCollectionTest extends TestCase
         $this->assertInstanceOf(Collection::class, $groups['A']);
     }
 
-    public function testMapToGroupsWithNumericKeys()
+    public function testMapToGroupsWithNumericKeys(): void
     {
         $data = new Collection([1, 2, 3, 2, 1]);
 
@@ -1486,7 +1486,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => [0, 4], 2 => [1, 3], 3 => [2]], $groups->toArray());
     }
 
-    public function testMapWithKeys()
+    public function testMapWithKeys(): void
     {
         $data = new Collection([
             ['name' => 'Blastoise', 'type' => 'Water', 'idx' => 9],
@@ -1502,7 +1502,7 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testMapWithKeysIntegerKeys()
+    public function testMapWithKeysIntegerKeys(): void
     {
         $data = new Collection([
             ['id' => 1, 'name' => 'A'],
@@ -1518,7 +1518,7 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testMapWithKeysMultipleRows()
+    public function testMapWithKeysMultipleRows(): void
     {
         $data = new Collection([
             ['id' => 1, 'name' => 'A'],
@@ -1541,7 +1541,7 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testMapWithKeysCallbackKey()
+    public function testMapWithKeysCallbackKey(): void
     {
         $data = new Collection([
             3 => ['id' => 1, 'name' => 'A'],
@@ -1557,7 +1557,7 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testMapInto()
+    public function testMapInto(): void
     {
         $data = new Collection([
             'first', 'second',
@@ -1569,7 +1569,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('second', $data[1]->value);
     }
 
-    public function testNth()
+    public function testNth(): void
     {
         $data = new Collection([
             6 => 'a',
@@ -1586,7 +1586,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['d'], $data->nth(4, 3)->all());
     }
 
-    public function testTransform()
+    public function testTransform(): void
     {
         $data = new Collection(['first' => 'taylor', 'last' => 'otwell']);
         $data->transform(function ($item, $key) {
@@ -1595,7 +1595,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
     }
 
-    public function testGroupByAttribute()
+    public function testGroupByAttribute(): void
     {
         $data = new Collection([['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1'], ['rating' => 2, 'url' => '2']]);
 
@@ -1606,7 +1606,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]], $result->toArray());
     }
 
-    public function testGroupByAttributePreservingKeys()
+    public function testGroupByAttributePreservingKeys(): void
     {
         $data = new Collection([10 => ['rating' => 1, 'url' => '1'],  20 => ['rating' => 1, 'url' => '1'],  30 => ['rating' => 2, 'url' => '2']]);
 
@@ -1620,7 +1620,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected_result, $result->toArray());
     }
 
-    public function testGroupByClosureWhereItemsHaveSingleGroup()
+    public function testGroupByClosureWhereItemsHaveSingleGroup(): void
     {
         $data = new Collection([['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1'], ['rating' => 2, 'url' => '2']]);
 
@@ -1631,7 +1631,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]], $result->toArray());
     }
 
-    public function testGroupByClosureWhereItemsHaveSingleGroupPreservingKeys()
+    public function testGroupByClosureWhereItemsHaveSingleGroupPreservingKeys(): void
     {
         $data = new Collection([10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1'], 30 => ['rating' => 2, 'url' => '2']]);
 
@@ -1647,7 +1647,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected_result, $result->toArray());
     }
 
-    public function testGroupByClosureWhereItemsHaveMultipleGroups()
+    public function testGroupByClosureWhereItemsHaveMultipleGroups(): void
     {
         $data = new Collection([
             ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
@@ -1676,7 +1676,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected_result, $result->toArray());
     }
 
-    public function testGroupByClosureWhereItemsHaveMultipleGroupsPreservingKeys()
+    public function testGroupByClosureWhereItemsHaveMultipleGroupsPreservingKeys(): void
     {
         $data = new Collection([
             10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
@@ -1705,7 +1705,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected_result, $result->toArray());
     }
 
-    public function testGroupByMultiLevelAndClosurePreservingKeys()
+    public function testGroupByMultiLevelAndClosurePreservingKeys(): void
     {
         $data = new Collection([
             10 => ['user' => 1, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_3']],
@@ -1747,7 +1747,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected_result, $result->toArray());
     }
 
-    public function testKeyByAttribute()
+    public function testKeyByAttribute(): void
     {
         $data = new Collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => '2'], ['rating' => 3, 'name' => '3']]);
 
@@ -1760,7 +1760,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([2 => ['rating' => 1, 'name' => '1'], 4 => ['rating' => 2, 'name' => '2'], 6 => ['rating' => 3, 'name' => '3']], $result->all());
     }
 
-    public function testKeyByClosure()
+    public function testKeyByClosure(): void
     {
         $data = new Collection([
             ['firstname' => 'Taylor', 'lastname' => 'Otwell', 'locale' => 'US'],
@@ -1775,7 +1775,7 @@ class SupportCollectionTest extends TestCase
         ], $result->all());
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $c = new Collection([1, 3, 5]);
 
@@ -1813,7 +1813,7 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-    public function testContainsStrict()
+    public function testContainsStrict(): void
     {
         $c = new Collection([1, 3, 5, '02']);
 
@@ -1843,7 +1843,7 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue($c->containsStrict(''));
     }
 
-    public function testContainsWithOperator()
+    public function testContainsWithOperator(): void
     {
         $c = new Collection([['v' => 1], ['v' => 3], ['v' => '4'], ['v' => 5]]);
 
@@ -1853,7 +1853,7 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue($c->contains('v', '>', 4));
     }
 
-    public function testGettingSumFromCollection()
+    public function testGettingSumFromCollection(): void
     {
         $c = new Collection([(object) ['foo' => 50], (object) ['foo' => 50]]);
         $this->assertEquals(100, $c->sum('foo'));
@@ -1864,19 +1864,19 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-    public function testCanSumValuesWithoutACallback()
+    public function testCanSumValuesWithoutACallback(): void
     {
         $c = new Collection([1, 2, 3, 4, 5]);
         $this->assertEquals(15, $c->sum());
     }
 
-    public function testGettingSumFromEmptyCollection()
+    public function testGettingSumFromEmptyCollection(): void
     {
         $c = new Collection;
         $this->assertEquals(0, $c->sum('foo'));
     }
 
-    public function testValueRetrieverAcceptsDotNotation()
+    public function testValueRetrieverAcceptsDotNotation(): void
     {
         $c = new Collection([
             (object) ['id' => 1, 'foo' => ['bar' => 'B']], (object) ['id' => 2, 'foo' => ['bar' => 'A']],
@@ -1886,28 +1886,28 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([2, 1], $c->pluck('id')->all());
     }
 
-    public function testPullRetrievesItemFromCollection()
+    public function testPullRetrievesItemFromCollection(): void
     {
         $c = new Collection(['foo', 'bar']);
 
         $this->assertEquals('foo', $c->pull(0));
     }
 
-    public function testPullRemovesItemFromCollection()
+    public function testPullRemovesItemFromCollection(): void
     {
         $c = new Collection(['foo', 'bar']);
         $c->pull(0);
         $this->assertEquals([1 => 'bar'], $c->all());
     }
 
-    public function testPullReturnsDefault()
+    public function testPullReturnsDefault(): void
     {
         $c = new Collection([]);
         $value = $c->pull(0, 'foo');
         $this->assertEquals('foo', $value);
     }
 
-    public function testRejectRemovesElementsPassingTruthTest()
+    public function testRejectRemovesElementsPassingTruthTest(): void
     {
         $c = new Collection(['foo', 'bar']);
         $this->assertEquals(['foo'], $c->reject('bar')->values()->all());
@@ -1934,7 +1934,7 @@ class SupportCollectionTest extends TestCase
         })->all());
     }
 
-    public function testSearchReturnsIndexOfFirstFoundItem()
+    public function testSearchReturnsIndexOfFirstFoundItem(): void
     {
         $c = new Collection([1, 2, 3, 4, 5, 2, 5, 'foo' => 'bar']);
 
@@ -1948,7 +1948,7 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-    public function testSearchReturnsFalseWhenItemIsNotFound()
+    public function testSearchReturnsFalseWhenItemIsNotFound(): void
     {
         $c = new Collection([1, 2, 3, 4, 5, 'foo' => 'bar']);
 
@@ -1962,13 +1962,13 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-    public function testKeys()
+    public function testKeys(): void
     {
         $c = new Collection(['name' => 'taylor', 'framework' => 'laravel']);
         $this->assertEquals(['name', 'framework'], $c->keys()->all());
     }
 
-    public function testPaginate()
+    public function testPaginate(): void
     {
         $c = new Collection(['one', 'two', 'three', 'four']);
         $this->assertEquals(['one', 'two'], $c->forPage(0, 2)->all());
@@ -1977,7 +1977,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([], $c->forPage(3, 2)->all());
     }
 
-    public function testPrepend()
+    public function testPrepend(): void
     {
         $c = new Collection(['one', 'two', 'three', 'four']);
         $this->assertEquals(['zero', 'one', 'two', 'three', 'four'], $c->prepend('zero')->all());
@@ -1986,7 +1986,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['zero' => 0, 'one' => 1, 'two' => 2], $c->prepend(0, 'zero')->all());
     }
 
-    public function testZip()
+    public function testZip(): void
     {
         $c = new Collection([1, 2, 3]);
         $c = $c->zip(new Collection([4, 5, 6]));
@@ -2014,7 +2014,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([3, 6, null], $c[2]->all());
     }
 
-    public function testPadPadsArrayWithValue()
+    public function testPadPadsArrayWithValue(): void
     {
         $c = new Collection([1, 2, 3]);
         $c = $c->pad(4, 0);
@@ -2025,7 +2025,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1, 2, 3, 4, 5], $c->all());
     }
 
-    public function testGettingMaxItemsFromCollection()
+    public function testGettingMaxItemsFromCollection(): void
     {
         $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
         $this->assertEquals(20, $c->max(function ($item) {
@@ -2043,7 +2043,7 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($c->max());
     }
 
-    public function testGettingMinItemsFromCollection()
+    public function testGettingMinItemsFromCollection(): void
     {
         $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
         $this->assertEquals(10, $c->min(function ($item) {
@@ -2067,7 +2067,7 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($c->min());
     }
 
-    public function testOnly()
+    public function testOnly(): void
     {
         $data = new Collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);
 
@@ -2081,7 +2081,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->only(collect(['first', 'email']))->all());
     }
 
-    public function testGettingAvgItemsFromCollection()
+    public function testGettingAvgItemsFromCollection(): void
     {
         $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
         $this->assertEquals(15, $c->avg(function ($item) {
@@ -2101,7 +2101,7 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($c->avg());
     }
 
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $c = new Collection([
             new TestArrayableObject,
@@ -2118,7 +2118,7 @@ class SupportCollectionTest extends TestCase
         ], $c->jsonSerialize());
     }
 
-    public function testCombineWithArray()
+    public function testCombineWithArray(): void
     {
         $expected = [
             1 => 4,
@@ -2132,7 +2132,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testCombineWithCollection()
+    public function testCombineWithCollection(): void
     {
         $expected = [
             1 => 4,
@@ -2147,7 +2147,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testConcatWithArray()
+    public function testConcatWithArray(): void
     {
         $expected = [
             0 => 4,
@@ -2172,7 +2172,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testConcatWithCollection()
+    public function testConcatWithCollection(): void
     {
         $expected = [
             0 => 4,
@@ -2199,7 +2199,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testReduce()
+    public function testReduce(): void
     {
         $data = new Collection([1, 2, 3]);
         $this->assertEquals(6, $data->reduce(function ($carry, $element) {
@@ -2210,13 +2210,13 @@ class SupportCollectionTest extends TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testRandomThrowsAnExceptionUsingAmountBiggerThanCollectionSize()
+    public function testRandomThrowsAnExceptionUsingAmountBiggerThanCollectionSize(): void
     {
         $data = new Collection([1, 2, 3]);
         $data->random(4);
     }
 
-    public function testPipe()
+    public function testPipe(): void
     {
         $collection = new Collection([1, 2, 3]);
 
@@ -2225,14 +2225,14 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-    public function testMedianValueWithArrayCollection()
+    public function testMedianValueWithArrayCollection(): void
     {
         $collection = new Collection([1, 2, 2, 4]);
 
         $this->assertEquals(2, $collection->median());
     }
 
-    public function testMedianValueByKey()
+    public function testMedianValueByKey(): void
     {
         $collection = new Collection([
             (object) ['foo' => 1],
@@ -2243,7 +2243,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(2, $collection->median('foo'));
     }
 
-    public function testEvenMedianCollection()
+    public function testEvenMedianCollection(): void
     {
         $collection = new Collection([
             (object) ['foo' => 0],
@@ -2252,7 +2252,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(1.5, $collection->median('foo'));
     }
 
-    public function testMedianOutOfOrderCollection()
+    public function testMedianOutOfOrderCollection(): void
     {
         $collection = new Collection([
             (object) ['foo' => 0],
@@ -2262,25 +2262,25 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(3, $collection->median('foo'));
     }
 
-    public function testMedianOnEmptyCollectionReturnsNull()
+    public function testMedianOnEmptyCollectionReturnsNull(): void
     {
         $collection = new Collection;
         $this->assertNull($collection->median());
     }
 
-    public function testModeOnNullCollection()
+    public function testModeOnNullCollection(): void
     {
         $collection = new Collection;
         $this->assertNull($collection->mode());
     }
 
-    public function testMode()
+    public function testMode(): void
     {
         $collection = new Collection([1, 2, 3, 4, 4, 5]);
         $this->assertEquals([4], $collection->mode());
     }
 
-    public function testModeValueByKey()
+    public function testModeValueByKey(): void
     {
         $collection = new Collection([
             (object) ['foo' => 1],
@@ -2291,61 +2291,61 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1], $collection->mode('foo'));
     }
 
-    public function testWithMultipleModeValues()
+    public function testWithMultipleModeValues(): void
     {
         $collection = new Collection([1, 2, 2, 1]);
         $this->assertEquals([1, 2], $collection->mode());
     }
 
-    public function testSliceOffset()
+    public function testSliceOffset(): void
     {
         $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
         $this->assertEquals([4, 5, 6, 7, 8], $collection->slice(3)->values()->toArray());
     }
 
-    public function testSliceNegativeOffset()
+    public function testSliceNegativeOffset(): void
     {
         $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
         $this->assertEquals([6, 7, 8], $collection->slice(-3)->values()->toArray());
     }
 
-    public function testSliceOffsetAndLength()
+    public function testSliceOffsetAndLength(): void
     {
         $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
         $this->assertEquals([4, 5, 6], $collection->slice(3, 3)->values()->toArray());
     }
 
-    public function testSliceOffsetAndNegativeLength()
+    public function testSliceOffsetAndNegativeLength(): void
     {
         $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
         $this->assertEquals([4, 5, 6, 7], $collection->slice(3, -1)->values()->toArray());
     }
 
-    public function testSliceNegativeOffsetAndLength()
+    public function testSliceNegativeOffsetAndLength(): void
     {
         $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
         $this->assertEquals([4, 5, 6], $collection->slice(-5, 3)->values()->toArray());
     }
 
-    public function testSliceNegativeOffsetAndNegativeLength()
+    public function testSliceNegativeOffsetAndNegativeLength(): void
     {
         $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
         $this->assertEquals([3, 4, 5, 6], $collection->slice(-6, -2)->values()->toArray());
     }
 
-    public function testCollectionFromTraversable()
+    public function testCollectionFromTraversable(): void
     {
         $collection = new Collection(new \ArrayObject([1, 2, 3]));
         $this->assertEquals([1, 2, 3], $collection->toArray());
     }
 
-    public function testCollectionFromTraversableWithKeys()
+    public function testCollectionFromTraversableWithKeys(): void
     {
         $collection = new Collection(new \ArrayObject(['foo' => 1, 'bar' => 2, 'baz' => 3]));
         $this->assertEquals(['foo' => 1, 'bar' => 2, 'baz' => 3], $collection->toArray());
     }
 
-    public function testSplitCollectionWithADivisableCount()
+    public function testSplitCollectionWithADivisableCount(): void
     {
         $collection = new Collection(['a', 'b', 'c', 'd']);
 
@@ -2357,7 +2357,7 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testSplitCollectionWithAnUndivisableCount()
+    public function testSplitCollectionWithAnUndivisableCount(): void
     {
         $collection = new Collection(['a', 'b', 'c']);
 
@@ -2369,7 +2369,7 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testSplitCollectionWithCountLessThenDivisor()
+    public function testSplitCollectionWithCountLessThenDivisor(): void
     {
         $collection = new Collection(['a']);
 
@@ -2381,7 +2381,7 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testSplitEmptyCollection()
+    public function testSplitEmptyCollection(): void
     {
         $collection = new Collection;
 
@@ -2393,7 +2393,7 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testHigherOrderCollectionMap()
+    public function testHigherOrderCollectionMap(): void
     {
         $person1 = (object) ['name' => 'Taylor'];
         $person2 = (object) ['name' => 'Yaz'];
@@ -2407,7 +2407,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['TAYLOR', 'TAYLOR'], $collection->each->uppercase()->map->name->toArray());
     }
 
-    public function testHigherOrderCollectionMapFromArrays()
+    public function testHigherOrderCollectionMapFromArrays(): void
     {
         $person1 = ['name' => 'Taylor'];
         $person2 = ['name' => 'Yaz'];
@@ -2421,7 +2421,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['TAYLOR', 'TAYLOR'], $collection->each->uppercase()->map->name->toArray());
     }
 
-    public function testPartition()
+    public function testPartition(): void
     {
         $collection = new Collection(range(1, 10));
 
@@ -2433,7 +2433,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([6, 7, 8, 9, 10], $secondPartition->values()->toArray());
     }
 
-    public function testPartitionCallbackWithKey()
+    public function testPartitionCallbackWithKey(): void
     {
         $collection = new Collection(['zero', 'one', 'two', 'three']);
 
@@ -2446,7 +2446,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['one', 'three'], $odd->values()->toArray());
     }
 
-    public function testPartitionByKey()
+    public function testPartitionByKey(): void
     {
         $courses = new Collection([
             ['free' => true, 'title' => 'Basic'], ['free' => false, 'title' => 'Premium'],
@@ -2459,7 +2459,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame([['free' => false, 'title' => 'Premium']], $premium->values()->toArray());
     }
 
-    public function testPartitionWithOperators()
+    public function testPartitionWithOperators(): void
     {
         $collection = new Collection([
             ['name' => 'Tim', 'age' => 17],
@@ -2493,7 +2493,7 @@ class SupportCollectionTest extends TestCase
         ]);
     }
 
-    public function testPartitionPreservesKeys()
+    public function testPartitionPreservesKeys(): void
     {
         $courses = new Collection([
             'a' => ['free' => true], 'b' => ['free' => false], 'c' => ['free' => true],
@@ -2506,7 +2506,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['b' => ['free' => false]], $premium->toArray());
     }
 
-    public function testPartitionEmptyCollection()
+    public function testPartitionEmptyCollection(): void
     {
         $collection = new Collection;
 
@@ -2515,7 +2515,7 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-    public function testHigherOrderPartition()
+    public function testHigherOrderPartition(): void
     {
         $courses = new Collection([
             'a' => ['free' => true], 'b' => ['free' => false], 'c' => ['free' => true],
@@ -2528,7 +2528,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['b' => ['free' => false]], $premium->toArray());
     }
 
-    public function testTap()
+    public function testTap(): void
     {
         $collection = new Collection([1, 2, 3]);
 
@@ -2541,7 +2541,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame([1, 2, 3], $collection->toArray());
     }
 
-    public function testWhen()
+    public function testWhen(): void
     {
         $collection = new Collection(['michael', 'tom']);
 
@@ -2560,7 +2560,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['michael', 'tom'], $collection->toArray());
     }
 
-    public function testWhenDefault()
+    public function testWhenDefault(): void
     {
         $collection = new Collection(['michael', 'tom']);
 
@@ -2573,7 +2573,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
 
-    public function testUnless()
+    public function testUnless(): void
     {
         $collection = new Collection(['michael', 'tom']);
 
@@ -2592,7 +2592,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['michael', 'tom'], $collection->toArray());
     }
 
-    public function testUnlessDefault()
+    public function testUnlessDefault(): void
     {
         $collection = new Collection(['michael', 'tom']);
 
@@ -2605,7 +2605,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
 
-    public function testHasReturnsValidResults()
+    public function testHasReturnsValidResults(): void
     {
         $collection = new Collection(['foo' => 'one', 'bar' => 'two', 1 => 'three']);
         $this->assertTrue($collection->has('foo'));
@@ -2614,7 +2614,7 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse($collection->has('baz'));
     }
 
-    public function testPutAddsItemToCollection()
+    public function testPutAddsItemToCollection(): void
     {
         $collection = new Collection();
         $this->assertSame([], $collection->toArray());
@@ -2626,7 +2626,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['foo' => 3, 'bar' => ['nested' => 'two']], $collection->toArray());
     }
 
-    public function testItThrowsExceptionWhenTryingToAccessNoProxyProperty()
+    public function testItThrowsExceptionWhenTryingToAccessNoProxyProperty(): void
     {
         $collection = new Collection();
         $this->expectException(Exception::class);
@@ -2634,7 +2634,7 @@ class SupportCollectionTest extends TestCase
         $collection->foo;
     }
 
-    public function testGetWithNullReturnsNull()
+    public function testGetWithNullReturnsNull(): void
     {
         $collection = new Collection([1, 2, 3]);
         $this->assertNull($collection->get(null));

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -9,18 +9,18 @@ use PHPUnit\Framework\TestCase;
 
 class SupportFacadeTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         \Illuminate\Support\Facades\Facade::clearResolvedInstances();
         FacadeStub::setFacadeApplication(null);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testFacadeCallsUnderlyingApplication()
+    public function testFacadeCallsUnderlyingApplication(): void
     {
         $app = new ApplicationStub;
         $app->setAttributes(['foo' => $mock = m::mock('stdClass')]);
@@ -29,7 +29,7 @@ class SupportFacadeTest extends TestCase
         $this->assertEquals('baz', FacadeStub::bar());
     }
 
-    public function testShouldReceiveReturnsAMockeryMock()
+    public function testShouldReceiveReturnsAMockeryMock(): void
     {
         $app = new ApplicationStub;
         $app->setAttributes(['foo' => new stdClass]);
@@ -39,7 +39,7 @@ class SupportFacadeTest extends TestCase
         $this->assertEquals('baz', $app['foo']->foo('bar'));
     }
 
-    public function testShouldReceiveCanBeCalledTwice()
+    public function testShouldReceiveCanBeCalledTwice(): void
     {
         $app = new ApplicationStub;
         $app->setAttributes(['foo' => new stdClass]);
@@ -51,7 +51,7 @@ class SupportFacadeTest extends TestCase
         $this->assertEquals('baz2', $app['foo']->foo2('bar2'));
     }
 
-    public function testCanBeMockedWithoutUnderlyingInstance()
+    public function testCanBeMockedWithoutUnderlyingInstance(): void
     {
         FacadeStub::shouldReceive('foo')->once()->andReturn('bar');
         $this->assertEquals('bar', FacadeStub::foo());

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class SupportFluentTest extends TestCase
 {
-    public function testAttributesAreSetByConstructor()
+    public function testAttributesAreSetByConstructor(): void
     {
         $array = ['name' => 'Taylor', 'age' => 25];
         $fluent = new Fluent($array);
@@ -22,7 +22,7 @@ class SupportFluentTest extends TestCase
         $this->assertEquals($array, $fluent->getAttributes());
     }
 
-    public function testAttributesAreSetByConstructorGivenstdClass()
+    public function testAttributesAreSetByConstructorGivenstdClass(): void
     {
         $array = ['name' => 'Taylor', 'age' => 25];
         $fluent = new Fluent((object) $array);
@@ -35,7 +35,7 @@ class SupportFluentTest extends TestCase
         $this->assertEquals($array, $fluent->getAttributes());
     }
 
-    public function testAttributesAreSetByConstructorGivenArrayIterator()
+    public function testAttributesAreSetByConstructorGivenArrayIterator(): void
     {
         $array = ['name' => 'Taylor', 'age' => 25];
         $fluent = new Fluent(new FluentArrayIteratorStub($array));
@@ -48,7 +48,7 @@ class SupportFluentTest extends TestCase
         $this->assertEquals($array, $fluent->getAttributes());
     }
 
-    public function testGetMethodReturnsAttribute()
+    public function testGetMethodReturnsAttribute(): void
     {
         $fluent = new Fluent(['name' => 'Taylor']);
 
@@ -58,7 +58,7 @@ class SupportFluentTest extends TestCase
         $this->assertNull($fluent->foo);
     }
 
-    public function testArrayAccessToAttributes()
+    public function testArrayAccessToAttributes(): void
     {
         $fluent = new Fluent(['attributes' => '1']);
 
@@ -70,7 +70,7 @@ class SupportFluentTest extends TestCase
         $this->assertTrue($fluent['attributes']);
     }
 
-    public function testMagicMethodsCanBeUsedToSetAttributes()
+    public function testMagicMethodsCanBeUsedToSetAttributes(): void
     {
         $fluent = new Fluent;
 
@@ -84,7 +84,7 @@ class SupportFluentTest extends TestCase
         $this->assertInstanceOf('Illuminate\Support\Fluent', $fluent->programmer());
     }
 
-    public function testIssetMagicMethod()
+    public function testIssetMagicMethod(): void
     {
         $array = ['name' => 'Taylor', 'age' => 25];
         $fluent = new Fluent($array);
@@ -96,7 +96,7 @@ class SupportFluentTest extends TestCase
         $this->assertFalse(isset($fluent->name));
     }
 
-    public function testToArrayReturnsAttribute()
+    public function testToArrayReturnsAttribute(): void
     {
         $array = ['name' => 'Taylor', 'age' => 25];
         $fluent = new Fluent($array);
@@ -104,7 +104,7 @@ class SupportFluentTest extends TestCase
         $this->assertEquals($array, $fluent->toArray());
     }
 
-    public function testToJsonEncodesTheToArrayResult()
+    public function testToJsonEncodesTheToArrayResult(): void
     {
         $fluent = $this->getMockBuilder('Illuminate\Support\Fluent')->setMethods(['toArray'])->getMock();
         $fluent->expects($this->once())->method('toArray')->will($this->returnValue('foo'));

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -13,18 +13,18 @@ use Illuminate\Support\Optional;
 
 class SupportHelpersTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testArrayDot()
+    public function testArrayDot(): void
     {
         $array = Arr::dot(['name' => 'taylor', 'languages' => ['php' => true]]);
         $this->assertEquals($array, ['name' => 'taylor', 'languages.php' => true]);
     }
 
-    public function testArrayGet()
+    public function testArrayGet(): void
     {
         $array = ['names' => ['developer' => 'taylor']];
         $this->assertEquals('taylor', Arr::get($array, 'names.developer'));
@@ -34,7 +34,7 @@ class SupportHelpersTest extends TestCase
         }));
     }
 
-    public function testArrayHas()
+    public function testArrayHas(): void
     {
         $array = ['names' => ['developer' => 'taylor']];
         $this->assertTrue(Arr::has($array, 'names'));
@@ -43,14 +43,14 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(Arr::has($array, 'foo.bar'));
     }
 
-    public function testArraySet()
+    public function testArraySet(): void
     {
         $array = [];
         Arr::set($array, 'names.developer', 'taylor');
         $this->assertEquals('taylor', $array['names']['developer']);
     }
 
-    public function testArrayForget()
+    public function testArrayForget(): void
     {
         $array = ['names' => ['developer' => 'taylor', 'otherDeveloper' => 'dayle']];
         Arr::forget($array, 'names.developer');
@@ -69,14 +69,14 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals($expected, $array);
     }
 
-    public function testArrayPluckWithArrayAndObjectValues()
+    public function testArrayPluckWithArrayAndObjectValues(): void
     {
         $array = [(object) ['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']];
         $this->assertEquals(['taylor', 'dayle'], Arr::pluck($array, 'name'));
         $this->assertEquals(['taylor' => 'foo', 'dayle' => 'bar'], Arr::pluck($array, 'email', 'name'));
     }
 
-    public function testArrayPluckWithNestedKeys()
+    public function testArrayPluckWithNestedKeys(): void
     {
         $array = [['user' => ['taylor', 'otwell']], ['user' => ['dayle', 'rees']]];
         $this->assertEquals(['taylor', 'dayle'], Arr::pluck($array, 'user.0'));
@@ -85,7 +85,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(['taylor' => 'otwell', 'dayle' => 'rees'], Arr::pluck($array, ['user', 1], ['user', 0]));
     }
 
-    public function testArrayPluckWithNestedArrays()
+    public function testArrayPluckWithNestedArrays(): void
     {
         $array = [
             [
@@ -108,7 +108,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals([['taylorotwell@gmail.com'], [null, null]], Arr::pluck($array, 'users.*.email'));
     }
 
-    public function testArrayExcept()
+    public function testArrayExcept(): void
     {
         $array = ['name' => 'taylor', 'age' => 26];
         $this->assertEquals(['age' => 26], Arr::except($array, ['name']));
@@ -120,20 +120,20 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(['framework' => ['language' => 'PHP']], Arr::except($array, ['name', 'framework.name']));
     }
 
-    public function testArrayOnly()
+    public function testArrayOnly(): void
     {
         $array = ['name' => 'taylor', 'age' => 26];
         $this->assertEquals(['name' => 'taylor'], Arr::only($array, ['name']));
         $this->assertEmpty(Arr::only($array, ['nonExistingKey']));
     }
 
-    public function testArrayCollapse()
+    public function testArrayCollapse(): void
     {
         $array = [[1], [2], [3], ['foo', 'bar'], collect(['baz', 'boom'])];
         $this->assertEquals([1, 2, 3, 'foo', 'bar', 'baz', 'boom'], Arr::collapse($array));
     }
 
-    public function testArrayDivide()
+    public function testArrayDivide(): void
     {
         $array = ['name' => 'taylor'];
         list($keys, $values) = Arr::divide($array);
@@ -141,7 +141,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(['taylor'], $values);
     }
 
-    public function testArrayFirst()
+    public function testArrayFirst(): void
     {
         $array = ['name' => 'taylor', 'otherDeveloper' => 'dayle'];
         $this->assertEquals('dayle', Arr::first($array, function ($value) {
@@ -149,7 +149,7 @@ class SupportHelpersTest extends TestCase
         }));
     }
 
-    public function testArrayLast()
+    public function testArrayLast(): void
     {
         $array = [100, 250, 290, 320, 500, 560, 670];
         $this->assertEquals(670, Arr::last($array, function ($value) {
@@ -157,7 +157,7 @@ class SupportHelpersTest extends TestCase
         }));
     }
 
-    public function testArrayPluck()
+    public function testArrayPluck(): void
     {
         $data = [
             'post-1' => [
@@ -194,7 +194,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals([null, null], Arr::pluck($data, 'foo.bar'));
     }
 
-    public function testArrayPrepend()
+    public function testArrayPrepend(): void
     {
         $array = Arr::prepend(['one', 'two', 'three', 'four'], 'zero');
         $this->assertEquals(['zero', 'one', 'two', 'three', 'four'], $array);
@@ -203,12 +203,12 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(['zero' => 0, 'one' => 1, 'two' => 2], $array);
     }
 
-    public function testArrayFlatten()
+    public function testArrayFlatten(): void
     {
         $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten([['#foo', '#bar'], ['#baz']]));
     }
 
-    public function testStrIs()
+    public function testStrIs(): void
     {
         $this->assertTrue(Str::is('*.dev', 'localhost.dev'));
         $this->assertTrue(Str::is('a', 'a'));
@@ -235,14 +235,14 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(Str::is([], 'localhost.dev'));
     }
 
-    public function testStrRandom()
+    public function testStrRandom(): void
     {
         $result = Str::random(20);
         $this->assertInternalType('string', $result);
         $this->assertEquals(20, strlen($result));
     }
 
-    public function testStartsWith()
+    public function testStartsWith(): void
     {
         $this->assertTrue(Str::startsWith('jason', 'jas'));
         $this->assertTrue(Str::startsWith('jason', ['jas']));
@@ -250,7 +250,7 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(Str::startsWith('jason', ['day']));
     }
 
-    public function testE()
+    public function testE(): void
     {
         $str = 'A \'quote\' is <b>bold</b>';
         $this->assertEquals('A &#039;quote&#039; is &lt;b&gt;bold&lt;/b&gt;', e($str));
@@ -259,7 +259,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals($str, e($html));
     }
 
-    public function testEndsWith()
+    public function testEndsWith(): void
     {
         $this->assertTrue(Str::endsWith('jason', 'on'));
         $this->assertTrue(Str::endsWith('jason', ['on']));
@@ -267,14 +267,14 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(Str::endsWith('jason', ['no']));
     }
 
-    public function testStrAfter()
+    public function testStrAfter(): void
     {
         $this->assertEquals('nah', str_after('hannah', 'han'));
         $this->assertEquals('nah', str_after('hannah', 'n'));
         $this->assertEquals('hannah', str_after('hannah', 'xxxx'));
     }
 
-    public function testStrContains()
+    public function testStrContains(): void
     {
         $this->assertTrue(Str::contains('taylor', 'ylo'));
         $this->assertTrue(Str::contains('taylor', ['ylo']));
@@ -283,27 +283,27 @@ class SupportHelpersTest extends TestCase
         $this->assertTrue(Str::contains('taylor', ['xxx', 'taylor']));
     }
 
-    public function testStrFinish()
+    public function testStrFinish(): void
     {
         $this->assertEquals('test/string/', Str::finish('test/string', '/'));
         $this->assertEquals('test/string/', Str::finish('test/string/', '/'));
         $this->assertEquals('test/string/', Str::finish('test/string//', '/'));
     }
 
-    public function testStrStart()
+    public function testStrStart(): void
     {
         $this->assertEquals('/test/string', Str::start('test/string', '/'));
         $this->assertEquals('/test/string', Str::start('/test/string', '/'));
         $this->assertEquals('/test/string', Str::start('//test/string', '/'));
     }
 
-    public function testSnakeCase()
+    public function testSnakeCase(): void
     {
         $this->assertEquals('foo_bar', Str::snake('fooBar'));
         $this->assertEquals('foo_bar', Str::snake('fooBar')); // test cache
     }
 
-    public function testStrLimit()
+    public function testStrLimit(): void
     {
         $string = 'The PHP framework for web artisans.';
         $this->assertEquals('The PHP...', Str::limit($string, 7));
@@ -315,7 +315,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('这是一', Str::limit($nonAsciiString, 6, ''));
     }
 
-    public function testCamelCase()
+    public function testCamelCase(): void
     {
         $this->assertEquals('fooBar', Str::camel('FooBar'));
         $this->assertEquals('fooBar', Str::camel('foo_bar'));
@@ -324,7 +324,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('fooBarBaz', Str::camel('foo-bar_baz'));
     }
 
-    public function testStudlyCase()
+    public function testStudlyCase(): void
     {
         $this->assertEquals('FooBar', Str::studly('fooBar'));
         $this->assertEquals('FooBar', Str::studly('foo_bar'));
@@ -333,13 +333,13 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('FooBarBaz', Str::studly('foo-bar_baz'));
     }
 
-    public function testClassBasename()
+    public function testClassBasename(): void
     {
         $this->assertEquals('Baz', class_basename('Foo\Bar\Baz'));
         $this->assertEquals('Baz', class_basename('Baz'));
     }
 
-    public function testValue()
+    public function testValue(): void
     {
         $this->assertEquals('foo', value('foo'));
         $this->assertEquals('foo', value(function () {
@@ -347,7 +347,7 @@ class SupportHelpersTest extends TestCase
         }));
     }
 
-    public function testObjectGet()
+    public function testObjectGet(): void
     {
         $class = new stdClass;
         $class->name = new stdClass;
@@ -356,7 +356,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('Taylor', object_get($class, 'name.first'));
     }
 
-    public function testDataGet()
+    public function testDataGet(): void
     {
         $object = (object) ['users' => ['name' => ['Taylor', 'Otwell']]];
         $array = [(object) ['users' => [(object) ['name' => 'Taylor']]]];
@@ -382,7 +382,7 @@ class SupportHelpersTest extends TestCase
         $this->assertNull(data_get($arrayAccess, 'email', 'Not found'));
     }
 
-    public function testDataGetWithNestedArrays()
+    public function testDataGetWithNestedArrays(): void
     {
         $array = [
             ['name' => 'taylor', 'email' => 'taylorotwell@gmail.com'],
@@ -408,7 +408,7 @@ class SupportHelpersTest extends TestCase
         $this->assertNull(data_get($array, 'posts.*.date'));
     }
 
-    public function testDataGetWithDoubleNestedArraysCollapsesResult()
+    public function testDataGetWithDoubleNestedArraysCollapsesResult(): void
     {
         $array = [
             'posts' => [
@@ -439,7 +439,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals([], data_get($array, 'posts.*.users.*.name'));
     }
 
-    public function testDataFill()
+    public function testDataFill(): void
     {
         $data = ['foo' => 'bar'];
 
@@ -452,7 +452,7 @@ class SupportHelpersTest extends TestCase
         );
     }
 
-    public function testDataFillWithStar()
+    public function testDataFillWithStar(): void
     {
         $data = ['foo' => 'bar'];
 
@@ -477,7 +477,7 @@ class SupportHelpersTest extends TestCase
         );
     }
 
-    public function testDataFillWithDoubleStar()
+    public function testDataFillWithDoubleStar(): void
     {
         $data = [
             'posts' => [
@@ -516,7 +516,7 @@ class SupportHelpersTest extends TestCase
         ], $data);
     }
 
-    public function testDataSet()
+    public function testDataSet(): void
     {
         $data = ['foo' => 'bar'];
 
@@ -551,7 +551,7 @@ class SupportHelpersTest extends TestCase
         );
     }
 
-    public function testDataSetWithStar()
+    public function testDataSetWithStar(): void
     {
         $data = ['foo' => 'bar'];
 
@@ -576,7 +576,7 @@ class SupportHelpersTest extends TestCase
         );
     }
 
-    public function testDataSetWithDoubleStar()
+    public function testDataSetWithDoubleStar(): void
     {
         $data = [
             'posts' => [
@@ -615,7 +615,7 @@ class SupportHelpersTest extends TestCase
         ], $data);
     }
 
-    public function testArraySort()
+    public function testArraySort(): void
     {
         $array = [
             ['name' => 'baz'],
@@ -632,7 +632,7 @@ class SupportHelpersTest extends TestCase
         })));
     }
 
-    public function testArraySortRecursive()
+    public function testArraySortRecursive(): void
     {
         $array = [
             [
@@ -663,7 +663,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals($assumedArray, Arr::sortRecursive($array));
     }
 
-    public function testArrayWhere()
+    public function testArrayWhere(): void
     {
         $array = ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'f' => 6, 'g' => 7, 'h' => 8];
         $this->assertEquals(['b' => 2, 'd' => 4, 'f' => 6, 'h' => 8], Arr::where(
@@ -674,7 +674,7 @@ class SupportHelpersTest extends TestCase
         ));
     }
 
-    public function testArrayWrap()
+    public function testArrayWrap(): void
     {
         $string = 'a';
         $array = ['a'];
@@ -685,19 +685,19 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals([$object], Arr::wrap($object));
     }
 
-    public function testHead()
+    public function testHead(): void
     {
         $array = ['a', 'b', 'c'];
         $this->assertEquals('a', head($array));
     }
 
-    public function testLast()
+    public function testLast(): void
     {
         $array = ['a', 'b', 'c'];
         $this->assertEquals('c', last($array));
     }
 
-    public function testClassUsesRecursiveShouldReturnTraitsOnParentClasses()
+    public function testClassUsesRecursiveShouldReturnTraitsOnParentClasses(): void
     {
         $this->assertSame([
             'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
@@ -706,7 +706,7 @@ class SupportHelpersTest extends TestCase
         class_uses_recursive('Illuminate\Tests\Support\SupportTestClassTwo'));
     }
 
-    public function testClassUsesRecursiveAcceptsObject()
+    public function testClassUsesRecursiveAcceptsObject(): void
     {
         $this->assertSame([
             'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
@@ -715,7 +715,7 @@ class SupportHelpersTest extends TestCase
         class_uses_recursive(new SupportTestClassTwo));
     }
 
-    public function testClassUsesRecursiveReturnParentTraitsFirst()
+    public function testClassUsesRecursiveReturnParentTraitsFirst(): void
     {
         $this->assertSame([
             'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
@@ -725,20 +725,20 @@ class SupportHelpersTest extends TestCase
         class_uses_recursive(SupportTestClassThree::class));
     }
 
-    public function testArrayAdd()
+    public function testArrayAdd(): void
     {
         $this->assertEquals(['surname' => 'Mövsümov'], Arr::add([], 'surname', 'Mövsümov'));
         $this->assertEquals(['developer' => ['name' => 'Ferid']], Arr::add([], 'developer.name', 'Ferid'));
     }
 
-    public function testArrayPull()
+    public function testArrayPull(): void
     {
         $developer = ['firstname' => 'Ferid', 'surname' => 'Mövsümov'];
         $this->assertEquals('Mövsümov', Arr::pull($developer, 'surname'));
         $this->assertEquals(['firstname' => 'Ferid'], $developer);
     }
 
-    public function testTap()
+    public function testTap(): void
     {
         $object = (object) ['id' => 1];
         $this->assertEquals(2, tap($object, function ($object) {
@@ -753,12 +753,12 @@ class SupportHelpersTest extends TestCase
     /**
      * @expectedException \RuntimeException
      */
-    public function testThrow()
+    public function testThrow(): void
     {
         throw_if(true, new RuntimeException);
     }
 
-    public function testThrowReturnIfNotThrown()
+    public function testThrowReturnIfNotThrown(): void
     {
         $this->assertSame('foo', throw_unless('foo', new RuntimeException));
     }
@@ -767,12 +767,12 @@ class SupportHelpersTest extends TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Test Message
      */
-    public function testThrowWithString()
+    public function testThrowWithString(): void
     {
         throw_if(true, RuntimeException::class, 'Test Message');
     }
 
-    public function testOptional()
+    public function testOptional(): void
     {
         $this->assertNull(optional(null)->something());
 
@@ -784,28 +784,28 @@ class SupportHelpersTest extends TestCase
         })->something());
     }
 
-    public function testOptionalWithArray()
+    public function testOptionalWithArray(): void
     {
         $this->assertEquals('here', optional(['present' => 'here'])['present']);
         $this->assertNull(optional(null)['missing']);
         $this->assertNull(optional(['present' => 'here'])->missing);
     }
 
-    public function testOptionalReturnsObjectPropertyOrNull()
+    public function testOptionalReturnsObjectPropertyOrNull(): void
     {
         $this->assertSame('bar', optional((object) ['foo' => 'bar'])->foo);
         $this->assertNull(optional(['foo' => 'bar'])->foo);
         $this->assertNull(optional((object) ['foo' => 'bar'])->bar);
     }
 
-    public function testOptionalDeterminesWhetherKeyIsSet()
+    public function testOptionalDeterminesWhetherKeyIsSet(): void
     {
         $this->assertTrue(isset(optional(['foo' => 'bar'])['foo']));
         $this->assertFalse(isset(optional(['foo' => 'bar'])['bar']));
         $this->assertFalse(isset(optional()['bar']));
     }
 
-    public function testOptionalAllowsToSetKey()
+    public function testOptionalAllowsToSetKey(): void
     {
         $optional = optional([]);
         $optional['foo'] = 'bar';
@@ -816,7 +816,7 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(isset($optional['foo']));
     }
 
-    public function testOptionalAllowToUnsetKey()
+    public function testOptionalAllowToUnsetKey(): void
     {
         $optional = optional(['foo' => 'bar']);
         $this->assertTrue(isset($optional['foo']));
@@ -829,7 +829,7 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(isset($optional['foo']));
     }
 
-    public function testOptionalIsMacroable()
+    public function testOptionalIsMacroable(): void
     {
         Optional::macro('present', function () {
             if (is_object($this->value)) {
@@ -854,7 +854,7 @@ class SupportHelpersTest extends TestCase
         })->present()->something());
     }
 
-    public function testTransform()
+    public function testTransform(): void
     {
         $this->assertEquals(10, transform(5, function ($value) {
             return $value * 2;
@@ -865,7 +865,7 @@ class SupportHelpersTest extends TestCase
         }));
     }
 
-    public function testWith()
+    public function testWith(): void
     {
         $this->assertEquals(10, with(10));
 

--- a/tests/Support/SupportHtmlStringTest.php
+++ b/tests/Support/SupportHtmlStringTest.php
@@ -7,14 +7,14 @@ use Illuminate\Support\HtmlString;
 
 class SupportHtmlStringTest extends TestCase
 {
-    public function testToHtml()
+    public function testToHtml(): void
     {
         $str = '<h1>foo</h1>';
         $html = new HtmlString('<h1>foo</h1>');
         $this->assertEquals($str, $html->toHtml());
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $str = '<h1>foo</h1>';
         $html = new HtmlString('<h1>foo</h1>');

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -9,7 +9,7 @@ class SupportMacroableTest extends TestCase
 {
     private $macroable;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->macroable = $this->createObjectForTrait();
     }
@@ -19,7 +19,7 @@ class SupportMacroableTest extends TestCase
         return $this->getObjectForTrait(Macroable::class);
     }
 
-    public function testRegisterMacro()
+    public function testRegisterMacro(): void
     {
         $macroable = $this->macroable;
         $macroable::macro(__CLASS__, function () {
@@ -28,7 +28,7 @@ class SupportMacroableTest extends TestCase
         $this->assertEquals('Taylor', $macroable::{__CLASS__}());
     }
 
-    public function testRegisterMacroAndCallWithoutStatic()
+    public function testRegisterMacroAndCallWithoutStatic(): void
     {
         $macroable = $this->macroable;
         $macroable::macro(__CLASS__, function () {
@@ -37,7 +37,7 @@ class SupportMacroableTest extends TestCase
         $this->assertEquals('Taylor', $macroable->{__CLASS__}());
     }
 
-    public function testWhenCallingMacroClosureIsBoundToObject()
+    public function testWhenCallingMacroClosureIsBoundToObject(): void
     {
         TestMacroable::macro('tryInstance', function () {
             return $this->protectedVariable;
@@ -54,7 +54,7 @@ class SupportMacroableTest extends TestCase
         $this->assertEquals('static', $result);
     }
 
-    public function testClassBasedMacros()
+    public function testClassBasedMacros(): void
     {
         TestMacroable::mixin(new TestMixin);
         $instance = new TestMacroable;

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -9,12 +9,12 @@ use Illuminate\Support\MessageBag;
 
 class SupportMessageBagTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testUniqueness()
+    public function testUniqueness(): void
     {
         $container = new MessageBag;
         $container->add('foo', 'bar');
@@ -23,7 +23,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals(['bar'], $messages['foo']);
     }
 
-    public function testMessagesAreAdded()
+    public function testMessagesAreAdded(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -35,7 +35,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals(['bust'], $messages['boom']);
     }
 
-    public function testKeys()
+    public function testKeys(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -45,14 +45,14 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals(['foo', 'boom'], $container->keys());
     }
 
-    public function testMessagesMayBeMerged()
+    public function testMessagesMayBeMerged(): void
     {
         $container = new MessageBag(['username' => ['foo']]);
         $container->merge(['username' => ['bar']]);
         $this->assertEquals(['username' => ['foo', 'bar']], $container->getMessages());
     }
 
-    public function testMessageBagsCanBeMerged()
+    public function testMessageBagsCanBeMerged(): void
     {
         $container = new MessageBag(['foo' => ['bar']]);
         $otherContainer = new MessageBag(['foo' => ['baz'], 'bar' => ['foo']]);
@@ -60,7 +60,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals(['foo' => ['bar', 'baz'], 'bar' => ['foo']], $container->getMessages());
     }
 
-    public function testMessageBagsCanConvertToArrays()
+    public function testMessageBagsCanConvertToArrays(): void
     {
         $container = new MessageBag([
             Collection::make(['foo', 'bar']),
@@ -69,7 +69,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertSame([['foo', 'bar'], ['baz', 'qux']], $container->getMessages());
     }
 
-    public function testGetReturnsArrayOfMessagesByKey()
+    public function testGetReturnsArrayOfMessagesByKey(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -78,7 +78,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals(['bar', 'baz'], $container->get('foo'));
     }
 
-    public function testGetReturnsArrayOfMessagesByImplicitKey()
+    public function testGetReturnsArrayOfMessagesByImplicitKey(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -87,7 +87,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals(['foo.1' => ['bar'], 'foo.2' => ['baz']], $container->get('foo.*'));
     }
 
-    public function testFirstReturnsSingleMessage()
+    public function testFirstReturnsSingleMessage(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -97,7 +97,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals('bar', $container->first('foo'));
     }
 
-    public function testFirstReturnsEmptyStringIfNoMessagesFound()
+    public function testFirstReturnsEmptyStringIfNoMessagesFound(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -105,7 +105,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals('', $container->first('foo'));
     }
 
-    public function testFirstReturnsSingleMessageFromDotKeys()
+    public function testFirstReturnsSingleMessageFromDotKeys(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -115,7 +115,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals('jon', $container->first('name.*'));
     }
 
-    public function testHasIndicatesExistence()
+    public function testHasIndicatesExistence(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -124,7 +124,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertFalse($container->has('bar'));
     }
 
-    public function testHasWithKeyNull()
+    public function testHasWithKeyNull(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -132,7 +132,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertTrue($container->has(null));
     }
 
-    public function testHasAnyIndicatesExistence()
+    public function testHasAnyIndicatesExistence(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -148,7 +148,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertFalse($container->hasAny('baz', 'biz'));
     }
 
-    public function testHasIndicatesExistenceOfAllKeys()
+    public function testHasIndicatesExistenceOfAllKeys(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -160,7 +160,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertFalse($container->has(['foo', 'baz']));
     }
 
-    public function testHasIndicatesNoneExistence()
+    public function testHasIndicatesNoneExistence(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -168,7 +168,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertFalse($container->has('foo'));
     }
 
-    public function testAllReturnsAllMessages()
+    public function testAllReturnsAllMessages(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -177,7 +177,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals(['bar', 'baz'], $container->all());
     }
 
-    public function testFormatIsRespected()
+    public function testFormatIsRespected(): void
     {
         $container = new MessageBag;
         $container->setFormat('<p>:message</p>');
@@ -194,7 +194,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals('foo bar', $container->first('foo'));
     }
 
-    public function testUnique()
+    public function testUnique(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -204,7 +204,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals([0 => 'bar', 2 => 'baz'], $container->unique());
     }
 
-    public function testMessageBagReturnsCorrectArray()
+    public function testMessageBagReturnsCorrectArray(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -214,7 +214,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals(['foo' => ['bar'], 'boom' => ['baz']], $container->toArray());
     }
 
-    public function testMessageBagReturnsExpectedJson()
+    public function testMessageBagReturnsExpectedJson(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -224,7 +224,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals('{"foo":["bar"],"boom":["baz"]}', $container->toJson());
     }
 
-    public function testCountReturnsCorrectValue()
+    public function testCountReturnsCorrectValue(): void
     {
         $container = new MessageBag;
         $this->assertCount(0, $container);
@@ -236,7 +236,7 @@ class SupportMessageBagTest extends TestCase
         $this->assertCount(3, $container);
     }
 
-    public function testCountable()
+    public function testCountable(): void
     {
         $container = new MessageBag;
         $container->add('foo', 'bar');
@@ -245,13 +245,13 @@ class SupportMessageBagTest extends TestCase
         $this->assertCount(2, $container);
     }
 
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $messageBag = new MessageBag(['country' => 'Azerbaijan', 'capital' => 'Baku']);
         $this->assertEquals(['country' => ['Azerbaijan'], 'capital' => ['Baku']], $messageBag->getMessages());
     }
 
-    public function testFirstFindsMessageForWildcardKey()
+    public function testFirstFindsMessageForWildcardKey(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
@@ -259,47 +259,47 @@ class SupportMessageBagTest extends TestCase
         $this->assertEquals('baz', $container->first('foo.*'));
     }
 
-    public function testIsEmptyTrue()
+    public function testIsEmptyTrue(): void
     {
         $container = new MessageBag;
         $this->assertTrue($container->isEmpty());
     }
 
-    public function testIsEmptyFalse()
+    public function testIsEmptyFalse(): void
     {
         $container = new MessageBag;
         $container->add('foo.bar', 'baz');
         $this->assertFalse($container->isEmpty());
     }
 
-    public function testIsNotEmptyTrue()
+    public function testIsNotEmptyTrue(): void
     {
         $container = new MessageBag;
         $container->add('foo.bar', 'baz');
         $this->assertTrue($container->isNotEmpty());
     }
 
-    public function testIsNotEmptyFalse()
+    public function testIsNotEmptyFalse(): void
     {
         $container = new MessageBag;
         $this->assertFalse($container->isNotEmpty());
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $container = new MessageBag;
         $container->add('foo.bar', 'baz');
         $this->assertEquals('{"foo.bar":["baz"]}', (string) $container);
     }
 
-    public function testGetFormat()
+    public function testGetFormat(): void
     {
         $container = new MessageBag;
         $container->setFormat(':message');
         $this->assertEquals(':message', $container->getFormat());
     }
 
-    public function testConstructorUniquenessConsistency()
+    public function testConstructorUniquenessConsistency(): void
     {
         $messageBag = new MessageBag(['messages' => ['first', 'second', 'third', 'third']]);
         $messages = $messageBag->getMessages();

--- a/tests/Support/SupportNamespacedItemResolverTest.php
+++ b/tests/Support/SupportNamespacedItemResolverTest.php
@@ -7,7 +7,7 @@ use Illuminate\Support\NamespacedItemResolver;
 
 class SupportNamespacedItemResolverTest extends TestCase
 {
-    public function testResolution()
+    public function testResolution(): void
     {
         $r = new NamespacedItemResolver;
 
@@ -17,7 +17,7 @@ class SupportNamespacedItemResolverTest extends TestCase
         $this->assertEquals([null, 'bar', null], $r->parseKey('bar'));
     }
 
-    public function testParsedItemsAreCached()
+    public function testParsedItemsAreCached(): void
     {
         $r = $this->getMockBuilder('Illuminate\Support\NamespacedItemResolver')->setMethods(['parseBasicSegments', 'parseNamespacedSegments'])->getMock();
         $r->setParsedKey('foo.bar', ['foo']);

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -7,32 +7,32 @@ use PHPUnit\Framework\TestCase;
 
 class SupportPluralizerTest extends TestCase
 {
-    public function testBasicSingular()
+    public function testBasicSingular(): void
     {
         $this->assertEquals('child', Str::singular('children'));
     }
 
-    public function testBasicPlural()
+    public function testBasicPlural(): void
     {
         $this->assertEquals('children', Str::plural('child'));
         $this->assertEquals('cod', Str::plural('cod'));
     }
 
-    public function testCaseSensitiveSingularUsage()
+    public function testCaseSensitiveSingularUsage(): void
     {
         $this->assertEquals('Child', Str::singular('Children'));
         $this->assertEquals('CHILD', Str::singular('CHILDREN'));
         $this->assertEquals('Test', Str::singular('Tests'));
     }
 
-    public function testCaseSensitiveSingularPlural()
+    public function testCaseSensitiveSingularPlural(): void
     {
         $this->assertEquals('Children', Str::plural('Child'));
         $this->assertEquals('CHILDREN', Str::plural('CHILD'));
         $this->assertEquals('Tests', Str::plural('Test'));
     }
 
-    public function testIfEndOfWordPlural()
+    public function testIfEndOfWordPlural(): void
     {
         $this->assertEquals('VortexFields', Str::plural('VortexField'));
         $this->assertEquals('MatrixFields', Str::plural('MatrixField'));

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\ServiceProvider;
 
 class SupportServiceProviderTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         ServiceProvider::$publishes = [];
         ServiceProvider::$publishGroups = [];
@@ -20,12 +20,12 @@ class SupportServiceProviderTest extends TestCase
         $two->boot();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testPublishableServiceProviders()
+    public function testPublishableServiceProviders(): void
     {
         $toPublish = ServiceProvider::publishableProviders();
         $expected = [
@@ -35,13 +35,13 @@ class SupportServiceProviderTest extends TestCase
         $this->assertEquals($expected, $toPublish, 'Publishable service providers do not return expected set of providers.');
     }
 
-    public function testPublishableGroups()
+    public function testPublishableGroups(): void
     {
         $toPublish = ServiceProvider::publishableGroups();
         $this->assertEquals(['some_tag'], $toPublish, 'Publishable groups do not return expected set of groups.');
     }
 
-    public function testSimpleAssetsArePublishedCorrectly()
+    public function testSimpleAssetsArePublishedCorrectly(): void
     {
         $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingOne');
         $this->assertArrayHasKey('source/unmarked/one', $toPublish, 'Service provider does not return expected published path key.');
@@ -49,7 +49,7 @@ class SupportServiceProviderTest extends TestCase
         $this->assertEquals(['source/unmarked/one' => 'destination/unmarked/one', 'source/tagged/one' => 'destination/tagged/one'], $toPublish, 'Service provider does not return expected set of published paths.');
     }
 
-    public function testMultipleAssetsArePublishedCorrectly()
+    public function testMultipleAssetsArePublishedCorrectly(): void
     {
         $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingTwo');
         $this->assertArrayHasKey('source/unmarked/two/a', $toPublish, 'Service provider does not return expected published path key.');
@@ -67,7 +67,7 @@ class SupportServiceProviderTest extends TestCase
         $this->assertEquals($expected, $toPublish, 'Service provider does not return expected set of published paths.');
     }
 
-    public function testSimpleTaggedAssetsArePublishedCorrectly()
+    public function testSimpleTaggedAssetsArePublishedCorrectly(): void
     {
         $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingOne', 'some_tag');
         $this->assertArrayNotHasKey('source/tagged/two/a', $toPublish, 'Service provider does return unexpected tagged path key.');
@@ -76,7 +76,7 @@ class SupportServiceProviderTest extends TestCase
         $this->assertEquals(['source/tagged/one' => 'destination/tagged/one'], $toPublish, 'Service provider does not return expected set of published tagged paths.');
     }
 
-    public function testMultipleTaggedAssetsArePublishedCorrectly()
+    public function testMultipleTaggedAssetsArePublishedCorrectly(): void
     {
         $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingTwo', 'some_tag');
         $this->assertArrayHasKey('source/tagged/two/a', $toPublish, 'Service provider does not return expected tagged path key.');
@@ -90,7 +90,7 @@ class SupportServiceProviderTest extends TestCase
         $this->assertEquals($expected, $toPublish, 'Service provider does not return expected set of published tagged paths.');
     }
 
-    public function testMultipleTaggedAssetsAreMergedCorrectly()
+    public function testMultipleTaggedAssetsAreMergedCorrectly(): void
     {
         $toPublish = ServiceProvider::pathsToPublish(null, 'some_tag');
         $this->assertArrayHasKey('source/tagged/two/a', $toPublish, 'Service provider does not return expected tagged path key.');

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -8,45 +8,45 @@ use PHPUnit\Framework\TestCase;
 
 class SupportStrTest extends TestCase
 {
-    public function testStringCanBeLimitedByWords()
+    public function testStringCanBeLimitedByWords(): void
     {
         $this->assertEquals('Taylor...', Str::words('Taylor Otwell', 1));
         $this->assertEquals('Taylor___', Str::words('Taylor Otwell', 1, '___'));
         $this->assertEquals('Taylor Otwell', Str::words('Taylor Otwell', 3));
     }
 
-    public function testStringTrimmedOnlyWhereNecessary()
+    public function testStringTrimmedOnlyWhereNecessary(): void
     {
         $this->assertEquals(' Taylor Otwell ', Str::words(' Taylor Otwell ', 3));
         $this->assertEquals(' Taylor...', Str::words(' Taylor Otwell ', 1));
     }
 
-    public function testStringTitle()
+    public function testStringTitle(): void
     {
         $this->assertEquals('Jefferson Costella', Str::title('jefferson costella'));
         $this->assertEquals('Jefferson Costella', Str::title('jefFErson coSTella'));
     }
 
-    public function testStringWithoutWordsDoesntProduceError()
+    public function testStringWithoutWordsDoesntProduceError(): void
     {
         $nbsp = chr(0xC2).chr(0xA0);
         $this->assertEquals(' ', Str::words(' '));
         $this->assertEquals($nbsp, Str::words($nbsp));
     }
 
-    public function testStringAscii()
+    public function testStringAscii(): void
     {
         $this->assertEquals('@', Str::ascii('@'));
         $this->assertEquals('u', Str::ascii('ü'));
     }
 
-    public function testStringAsciiWithSpecificLocale()
+    public function testStringAsciiWithSpecificLocale(): void
     {
         $this->assertSame('h H sht SHT a A y Y', Str::ascii('х Х щ Щ ъ Ъ ь Ь', 'bg'));
         $this->assertSame('ae oe ue AE OE UE', Str::ascii('ä ö ü Ä Ö Ü', 'de'));
     }
 
-    public function testStartsWith()
+    public function testStartsWith(): void
     {
         $this->assertTrue(Str::startsWith('jason', 'jas'));
         $this->assertTrue(Str::startsWith('jason', 'jason'));
@@ -70,7 +70,7 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::startsWith('Malmö', 'Malmo'));
     }
 
-    public function testEndsWith()
+    public function testEndsWith(): void
     {
         $this->assertTrue(Str::endsWith('jason', 'on'));
         $this->assertTrue(Str::endsWith('jason', 'jason'));
@@ -94,7 +94,7 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::endsWith('Malmö', 'mo'));
     }
 
-    public function testStrBefore()
+    public function testStrBefore(): void
     {
         $this->assertEquals('han', Str::before('hannah', 'nah'));
         $this->assertEquals('ha', Str::before('hannah', 'n'));
@@ -106,7 +106,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('han', Str::before('han2nah', 2));
     }
 
-    public function testStrAfter()
+    public function testStrAfter(): void
     {
         $this->assertEquals('nah', Str::after('hannah', 'han'));
         $this->assertEquals('nah', Str::after('hannah', 'n'));
@@ -118,7 +118,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('nah', Str::after('han2nah', 2));
     }
 
-    public function testStrContains()
+    public function testStrContains(): void
     {
         $this->assertTrue(Str::contains('taylor', 'ylo'));
         $this->assertTrue(Str::contains('taylor', 'taylor'));
@@ -129,13 +129,13 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::contains('taylor', ''));
     }
 
-    public function testParseCallback()
+    public function testParseCallback(): void
     {
         $this->assertEquals(['Class', 'method'], Str::parseCallback('Class@method', 'foo'));
         $this->assertEquals(['Class', 'foo'], Str::parseCallback('Class', 'foo'));
     }
 
-    public function testSlug()
+    public function testSlug(): void
     {
         $this->assertEquals('hello-world', Str::slug('hello world'));
         $this->assertEquals('hello-world', Str::slug('hello-world'));
@@ -144,14 +144,14 @@ class SupportStrTest extends TestCase
         $this->assertEquals('user-at-host', Str::slug('user@host'));
     }
 
-    public function testFinish()
+    public function testFinish(): void
     {
         $this->assertEquals('abbc', Str::finish('ab', 'bc'));
         $this->assertEquals('abbc', Str::finish('abbcbc', 'bc'));
         $this->assertEquals('abcbbc', Str::finish('abcbbcbc', 'bc'));
     }
 
-    public function testIs()
+    public function testIs(): void
     {
         $this->assertTrue(Str::is('/', '/'));
         $this->assertFalse(Str::is('/', ' /'));
@@ -166,35 +166,35 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::is($patternObject, $valueObject));
     }
 
-    public function testKebab()
+    public function testKebab(): void
     {
         $this->assertEquals('laravel-php-framework', Str::kebab('LaravelPhpFramework'));
     }
 
-    public function testLower()
+    public function testLower(): void
     {
         $this->assertEquals('foo bar baz', Str::lower('FOO BAR BAZ'));
         $this->assertEquals('foo bar baz', Str::lower('fOo Bar bAz'));
     }
 
-    public function testUpper()
+    public function testUpper(): void
     {
         $this->assertEquals('FOO BAR BAZ', Str::upper('foo bar baz'));
         $this->assertEquals('FOO BAR BAZ', Str::upper('foO bAr BaZ'));
     }
 
-    public function testLimit()
+    public function testLimit(): void
     {
         $this->assertEquals('Laravel is...', Str::limit('Laravel is a free, open source PHP web application framework.', 10));
         $this->assertEquals('这是一...', Str::limit('这是一段中文', 6));
     }
 
-    public function testLength()
+    public function testLength(): void
     {
         $this->assertEquals(11, Str::length('foo bar baz'));
     }
 
-    public function testRandom()
+    public function testRandom(): void
     {
         $this->assertEquals(16, strlen(Str::random()));
         $randomInteger = random_int(1, 100);
@@ -202,7 +202,7 @@ class SupportStrTest extends TestCase
         $this->assertInternalType('string', Str::random());
     }
 
-    public function testReplaceArray()
+    public function testReplaceArray(): void
     {
         $this->assertEquals('foo/bar/baz', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?/?'));
         $this->assertEquals('foo/bar/baz/?', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?/?/?'));
@@ -210,7 +210,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('?/?/?', Str::replaceArray('x', ['foo', 'bar', 'baz'], '?/?/?'));
     }
 
-    public function testReplaceFirst()
+    public function testReplaceFirst(): void
     {
         $this->assertEquals('fooqux foobar', Str::replaceFirst('bar', 'qux', 'foobar foobar'));
         $this->assertEquals('foo/qux? foo/bar?', Str::replaceFirst('bar?', 'qux?', 'foo/bar? foo/bar?'));
@@ -222,7 +222,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('Jönköping Malmö', Str::replaceFirst('', 'yyy', 'Jönköping Malmö'));
     }
 
-    public function testReplaceLast()
+    public function testReplaceLast(): void
     {
         $this->assertEquals('foobar fooqux', Str::replaceLast('bar', 'qux', 'foobar foobar'));
         $this->assertEquals('foo/bar? foo/qux?', Str::replaceLast('bar?', 'qux?', 'foo/bar? foo/bar?'));
@@ -234,7 +234,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('Malmö Jönköping', Str::replaceLast('', 'yyy', 'Malmö Jönköping'));
     }
 
-    public function testSnake()
+    public function testSnake(): void
     {
         $this->assertEquals('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));
         $this->assertEquals('laravel_php_framework', Str::snake('LaravelPhpFramework'));
@@ -248,7 +248,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('laravel_php_frame_work', Str::snake('laravel php FrameWork'));
     }
 
-    public function testStudly()
+    public function testStudly(): void
     {
         $this->assertEquals('LaravelPHPFramework', Str::studly('laravel_p_h_p_framework'));
         $this->assertEquals('LaravelPhpFramework', Str::studly('laravel_php_framework'));
@@ -256,7 +256,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('LaravelPhpFramework', Str::studly('laravel  -_-  php   -_-   framework   '));
     }
 
-    public function testCamel()
+    public function testCamel(): void
     {
         $this->assertEquals('laravelPHPFramework', Str::camel('Laravel_p_h_p_framework'));
         $this->assertEquals('laravelPhpFramework', Str::camel('Laravel_php_framework'));
@@ -264,7 +264,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('laravelPhpFramework', Str::camel('Laravel  -_-  php   -_-   framework   '));
     }
 
-    public function testSubstr()
+    public function testSubstr(): void
     {
         $this->assertEquals('Ё', Str::substr('БГДЖИЛЁ', -1));
         $this->assertEquals('ЛЁ', Str::substr('БГДЖИЛЁ', -2));
@@ -279,7 +279,7 @@ class SupportStrTest extends TestCase
         $this->assertEmpty(Str::substr('Б', 2));
     }
 
-    public function testUcfirst()
+    public function testUcfirst(): void
     {
         $this->assertEquals('Laravel', Str::ucfirst('laravel'));
         $this->assertEquals('Laravel framework', Str::ucfirst('laravel framework'));
@@ -287,7 +287,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('Мама мыла раму', Str::ucfirst('мама мыла раму'));
     }
 
-    public function testUuid()
+    public function testUuid(): void
     {
         $this->assertInstanceOf(Uuid::class, Str::uuid());
         $this->assertInstanceOf(Uuid::class, Str::orderedUuid());

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -11,13 +11,13 @@ use PHPUnit\Framework\Constraint\ExceptionMessage;
 
 class SupportTestingEventFakeTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fake = new EventFake(m::mock(Dispatcher::class));
     }
 
-    public function testAssertDispacthed()
+    public function testAssertDispacthed(): void
     {
         try {
             $this->fake->assertDispatched(EventStub::class);
@@ -31,7 +31,7 @@ class SupportTestingEventFakeTest extends TestCase
         $this->fake->assertDispatched(EventStub::class);
     }
 
-    public function testAssertDispatchedWithCallbackInt()
+    public function testAssertDispatchedWithCallbackInt(): void
     {
         $this->fake->dispatch(EventStub::class);
         $this->fake->dispatch(EventStub::class);
@@ -46,7 +46,7 @@ class SupportTestingEventFakeTest extends TestCase
         $this->fake->assertDispatched(EventStub::class, 2);
     }
 
-    public function testAssertDispatchedTimes()
+    public function testAssertDispatchedTimes(): void
     {
         $this->fake->dispatch(EventStub::class);
         $this->fake->dispatch(EventStub::class);
@@ -61,7 +61,7 @@ class SupportTestingEventFakeTest extends TestCase
         $this->fake->assertDispatchedTimes(EventStub::class, 2);
     }
 
-    public function testAssertNotDispatched()
+    public function testAssertNotDispatched(): void
     {
         $this->fake->assertNotDispatched(EventStub::class);
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -11,14 +11,14 @@ use PHPUnit\Framework\Constraint\ExceptionMessage;
 
 class MailFakeTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fake = new MailFake;
         $this->mailable = new MailableStub;
     }
 
-    public function testAssertSent()
+    public function testAssertSent(): void
     {
         try {
             $this->fake->assertSent(MailableStub::class);
@@ -32,7 +32,7 @@ class MailFakeTest extends TestCase
         $this->fake->assertSent(MailableStub::class);
     }
 
-    public function testAssertNotSent()
+    public function testAssertNotSent(): void
     {
         $this->fake->assertNotSent(MailableStub::class);
 
@@ -46,7 +46,7 @@ class MailFakeTest extends TestCase
         }
     }
 
-    public function testAssertSentTimes()
+    public function testAssertSentTimes(): void
     {
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
@@ -61,7 +61,7 @@ class MailFakeTest extends TestCase
         $this->fake->assertSent(MailableStub::class, 2);
     }
 
-    public function testAssertQueued()
+    public function testAssertQueued(): void
     {
         try {
             $this->fake->assertQueued(MailableStub::class);
@@ -75,7 +75,7 @@ class MailFakeTest extends TestCase
         $this->fake->assertQueued(MailableStub::class);
     }
 
-    public function testAssertQueuedTimes()
+    public function testAssertQueuedTimes(): void
     {
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
@@ -90,7 +90,7 @@ class MailFakeTest extends TestCase
         $this->fake->assertQueued(MailableStub::class, 2);
     }
 
-    public function testSendQueuesAMailableThatShouldBeQueued()
+    public function testSendQueuesAMailableThatShouldBeQueued(): void
     {
         $this->fake->to('taylor@laravel.com')->send(new QueueableMailableStub);
 
@@ -104,7 +104,7 @@ class MailFakeTest extends TestCase
         }
     }
 
-    public function testAssertNothingSent()
+    public function testAssertNothingSent(): void
     {
         $this->fake->assertNothingSent();
 

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Testing\Fakes\NotificationFake;
 
 class NotificationFakeTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fake = new NotificationFake;
@@ -19,7 +19,7 @@ class NotificationFakeTest extends TestCase
         $this->user = new UserStub;
     }
 
-    public function testAssertSentTo()
+    public function testAssertSentTo(): void
     {
         try {
             $this->fake->assertSentTo($this->user, NotificationStub::class);
@@ -33,7 +33,7 @@ class NotificationFakeTest extends TestCase
         $this->fake->assertSentTo($this->user, NotificationStub::class);
     }
 
-    public function testAssertNotSentTo()
+    public function testAssertNotSentTo(): void
     {
         $this->fake->assertNotSentTo($this->user, NotificationStub::class);
 
@@ -47,7 +47,7 @@ class NotificationFakeTest extends TestCase
         }
     }
 
-    public function testResettingNotificationId()
+    public function testResettingNotificationId(): void
     {
         $notification = new NotificationStub();
 

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -10,14 +10,14 @@ use PHPUnit\Framework\Constraint\ExceptionMessage;
 
 class QueueFakeTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fake = new QueueFake(new Application);
         $this->job = new JobStub;
     }
 
-    public function testAssertPushed()
+    public function testAssertPushed(): void
     {
         try {
             $this->fake->assertPushed(JobStub::class);
@@ -31,7 +31,7 @@ class QueueFakeTest extends TestCase
         $this->fake->assertPushed(JobStub::class);
     }
 
-    public function testAssertNotPushed()
+    public function testAssertNotPushed(): void
     {
         $this->fake->assertNotPushed(JobStub::class);
 
@@ -45,7 +45,7 @@ class QueueFakeTest extends TestCase
         }
     }
 
-    public function testAssertPushedOn()
+    public function testAssertPushedOn(): void
     {
         $this->fake->push($this->job, '', 'foo');
 
@@ -59,7 +59,7 @@ class QueueFakeTest extends TestCase
         $this->fake->assertPushedOn('foo', JobStub::class);
     }
 
-    public function testAssertPushedTimes()
+    public function testAssertPushedTimes(): void
     {
         $this->fake->push($this->job);
         $this->fake->push($this->job);
@@ -74,7 +74,7 @@ class QueueFakeTest extends TestCase
         $this->fake->assertPushed(JobStub::class, 2);
     }
 
-    public function testAssertNothingPushed()
+    public function testAssertNothingPushed(): void
     {
         $this->fake->assertNothingPushed();
 
@@ -88,7 +88,7 @@ class QueueFakeTest extends TestCase
         }
     }
 
-    public function testAssertPushedUsingBulk()
+    public function testAssertPushedUsingBulk(): void
     {
         $this->fake->assertNothingPushed();
 

--- a/tests/Support/SupportViewErrorBagTest.php
+++ b/tests/Support/SupportViewErrorBagTest.php
@@ -8,20 +8,20 @@ use Illuminate\Support\ViewErrorBag;
 
 class SupportViewErrorBagTest extends TestCase
 {
-    public function testHasBagTrue()
+    public function testHasBagTrue(): void
     {
         $viewErrorBag = new ViewErrorBag();
         $viewErrorBag->put('default', new MessageBag(['msg1', 'msg2']));
         $this->assertTrue($viewErrorBag->hasBag());
     }
 
-    public function testHasBagFalse()
+    public function testHasBagFalse(): void
     {
         $viewErrorBag = new ViewErrorBag();
         $this->assertFalse($viewErrorBag->hasBag());
     }
 
-    public function testGet()
+    public function testGet(): void
     {
         $messageBag = new MessageBag();
         $viewErrorBag = new ViewErrorBag();
@@ -29,13 +29,13 @@ class SupportViewErrorBagTest extends TestCase
         $this->assertEquals($messageBag, $viewErrorBag->getBag('default'));
     }
 
-    public function testGetBagWithNew()
+    public function testGetBagWithNew(): void
     {
         $viewErrorBag = new ViewErrorBag();
         $this->assertInstanceOf(MessageBag::class, $viewErrorBag->getBag('default'));
     }
 
-    public function testGetBags()
+    public function testGetBags(): void
     {
         $messageBag1 = new MessageBag();
         $messageBag2 = new MessageBag();
@@ -48,7 +48,7 @@ class SupportViewErrorBagTest extends TestCase
         ], $viewErrorBag->getBags());
     }
 
-    public function testPut()
+    public function testPut(): void
     {
         $messageBag = new MessageBag();
         $viewErrorBag = new ViewErrorBag();
@@ -56,54 +56,54 @@ class SupportViewErrorBagTest extends TestCase
         $this->assertEquals(['default' => $messageBag], $viewErrorBag->getBags());
     }
 
-    public function testAnyTrue()
+    public function testAnyTrue(): void
     {
         $viewErrorBag = new ViewErrorBag();
         $viewErrorBag->put('default', new MessageBag(['message']));
         $this->assertTrue($viewErrorBag->any());
     }
 
-    public function testAnyFalse()
+    public function testAnyFalse(): void
     {
         $viewErrorBag = new ViewErrorBag();
         $viewErrorBag->put('default', new MessageBag());
         $this->assertFalse($viewErrorBag->any());
     }
 
-    public function testAnyFalseWithEmptyErrorBag()
+    public function testAnyFalseWithEmptyErrorBag(): void
     {
         $viewErrorBag = new ViewErrorBag();
         $this->assertFalse($viewErrorBag->any());
     }
 
-    public function testCount()
+    public function testCount(): void
     {
         $viewErrorBag = new ViewErrorBag();
         $viewErrorBag->put('default', new MessageBag(['message', 'second']));
         $this->assertEquals(2, $viewErrorBag->count());
     }
 
-    public function testCountWithNoMessagesInMessageBag()
+    public function testCountWithNoMessagesInMessageBag(): void
     {
         $viewErrorBag = new ViewErrorBag();
         $viewErrorBag->put('default', new MessageBag());
         $this->assertEquals(0, $viewErrorBag->count());
     }
 
-    public function testCountWithNoMessageBags()
+    public function testCountWithNoMessageBags(): void
     {
         $viewErrorBag = new ViewErrorBag();
         $this->assertEquals(0, $viewErrorBag->count());
     }
 
-    public function testDynamicCallToDefaultMessageBag()
+    public function testDynamicCallToDefaultMessageBag(): void
     {
         $viewErrorBag = new ViewErrorBag();
         $viewErrorBag->put('default', new MessageBag(['message', 'second']));
         $this->assertEquals(['message', 'second'], $viewErrorBag->all());
     }
 
-    public function testDynamicallyGetBag()
+    public function testDynamicallyGetBag(): void
     {
         $messageBag = new MessageBag();
         $viewErrorBag = new ViewErrorBag();
@@ -111,7 +111,7 @@ class SupportViewErrorBagTest extends TestCase
         $this->assertEquals($messageBag, $viewErrorBag->default);
     }
 
-    public function testDynamicallyPutBag()
+    public function testDynamicallyPutBag(): void
     {
         $messageBag = new MessageBag();
         $viewErrorBag = new ViewErrorBag();
@@ -119,7 +119,7 @@ class SupportViewErrorBagTest extends TestCase
         $this->assertEquals(['default2' => $messageBag], $viewErrorBag->getBags());
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $viewErrorBag = new ViewErrorBag();
         $viewErrorBag = $viewErrorBag->put('default', new MessageBag(['message' => 'content']));

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -8,12 +8,12 @@ use Illuminate\Translation\FileLoader;
 
 class TranslationFileLoaderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testLoadMethodWithoutNamespacesProperlyCallsLoader()
+    public function testLoadMethodWithoutNamespacesProperlyCallsLoader(): void
     {
         $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en/foo.php')->andReturn(true);
@@ -22,7 +22,7 @@ class TranslationFileLoaderTest extends TestCase
         $this->assertEquals(['messages'], $loader->load('en', 'foo', null));
     }
 
-    public function testLoadMethodWithNamespacesProperlyCallsLoader()
+    public function testLoadMethodWithNamespacesProperlyCallsLoader(): void
     {
         $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
         $files->shouldReceive('exists')->once()->with('bar/en/foo.php')->andReturn(true);
@@ -33,7 +33,7 @@ class TranslationFileLoaderTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $loader->load('en', 'foo', 'namespace'));
     }
 
-    public function testLoadMethodWithNamespacesProperlyCallsLoaderAndLoadsLocalOverrides()
+    public function testLoadMethodWithNamespacesProperlyCallsLoaderAndLoadsLocalOverrides(): void
     {
         $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
         $files->shouldReceive('exists')->once()->with('bar/en/foo.php')->andReturn(true);
@@ -45,7 +45,7 @@ class TranslationFileLoaderTest extends TestCase
         $this->assertEquals(['foo' => 'override', 'baz' => 'boom'], $loader->load('en', 'foo', 'namespace'));
     }
 
-    public function testEmptyArraysReturnedWhenFilesDontExist()
+    public function testEmptyArraysReturnedWhenFilesDontExist(): void
     {
         $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en/foo.php')->andReturn(false);
@@ -54,7 +54,7 @@ class TranslationFileLoaderTest extends TestCase
         $this->assertEquals([], $loader->load('en', 'foo', null));
     }
 
-    public function testEmptyArraysReturnedWhenFilesDontExistForNamespacedItems()
+    public function testEmptyArraysReturnedWhenFilesDontExistForNamespacedItems(): void
     {
         $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
         $files->shouldReceive('getRequire')->never();
@@ -62,7 +62,7 @@ class TranslationFileLoaderTest extends TestCase
         $this->assertEquals([], $loader->load('en', 'foo', 'bar'));
     }
 
-    public function testLoadMethodForJSONProperlyCallsLoader()
+    public function testLoadMethodForJSONProperlyCallsLoader(): void
     {
         $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en.json')->andReturn(true);
@@ -71,7 +71,7 @@ class TranslationFileLoaderTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $loader->load('en', '*', '*'));
     }
 
-    public function testLoadMethodForJSONProperlyCallsLoaderForMultiplePaths()
+    public function testLoadMethodForJSONProperlyCallsLoaderForMultiplePaths(): void
     {
         $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
         $loader->addJsonPath(__DIR__.'/another');

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -10,7 +10,7 @@ class TranslationMessageSelectorTest extends TestCase
     /**
      * @dataProvider chooseTestData
      */
-    public function testChoose($expected, $id, $number)
+    public function testChoose($expected, $id, $number): void
     {
         $selector = new MessageSelector;
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class TranslationTranslatorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
+    public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull(): void
     {
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->will($this->returnValue('foo'));
@@ -41,7 +41,7 @@ class TranslationTranslatorTest extends TestCase
         $this->assertFalse($t->hasForLocale('foo'));
     }
 
-    public function testGetMethodProperlyLoadsAndRetrievesItem()
+    public function testGetMethodProperlyLoadsAndRetrievesItem(): void
     {
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo']);
@@ -49,7 +49,7 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('foo', $t->get('foo::bar.foo'));
     }
 
-    public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization()
+    public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization(): void
     {
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(null)->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :Foo :BAR']);
@@ -57,7 +57,7 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('foo', $t->get('foo::bar.foo'));
     }
 
-    public function testGetMethodProperlyLoadsAndRetrievesItemWithLongestReplacementsFirst()
+    public function testGetMethodProperlyLoadsAndRetrievesItemWithLongestReplacementsFirst(): void
     {
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo :foobar']);
@@ -66,7 +66,7 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('foo', $t->get('foo::bar.foo'));
     }
 
-    public function testGetMethodProperlyLoadsAndRetrievesItemForFallback()
+    public function testGetMethodProperlyLoadsAndRetrievesItemForFallback(): void
     {
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->setFallback('lv');
@@ -76,14 +76,14 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('foo', $t->get('foo::bar.foo'));
     }
 
-    public function testGetMethodProperlyLoadsAndRetrievesItemForGlobalNamespace()
+    public function testGetMethodProperlyLoadsAndRetrievesItemForGlobalNamespace(): void
     {
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze :foo']);
         $this->assertEquals('breeze bar', $t->get('foo.bar', ['foo' => 'bar']));
     }
 
-    public function testChoiceMethodProperlyLoadsAndRetrievesItem()
+    public function testChoiceMethodProperlyLoadsAndRetrievesItem(): void
     {
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->will($this->returnValue('line'));
@@ -93,7 +93,7 @@ class TranslationTranslatorTest extends TestCase
         $t->choice('foo', 10, ['replace']);
     }
 
-    public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()
+    public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem(): void
     {
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->will($this->returnValue('line'));
@@ -107,35 +107,35 @@ class TranslationTranslatorTest extends TestCase
         $t->choice('foo', $values, ['replace']);
     }
 
-    public function testGetJsonMethod()
+    public function testGetJsonMethod(): void
     {
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => 'one']);
         $this->assertEquals('one', $t->getFromJson('foo'));
     }
 
-    public function testGetJsonReplaces()
+    public function testGetJsonReplaces(): void
     {
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
         $this->assertEquals('bar onetwo three', $t->getFromJson('foo :i:c :u', ['i' => 'one', 'c' => 'two', 'u' => 'three']));
     }
 
-    public function testGetJsonReplacesForAssociativeInput()
+    public function testGetJsonReplacesForAssociativeInput(): void
     {
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i :c' => 'bar :i :c']);
         $this->assertEquals('bar eye see', $t->getFromJson('foo :i :c', ['i' => 'eye', 'c' => 'see']));
     }
 
-    public function testGetJsonPreservesOrder()
+    public function testGetJsonPreservesOrder(): void
     {
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['to :name I give :greeting' => ':greeting :name']);
         $this->assertEquals('Greetings David', $t->getFromJson('to :name I give :greeting', ['name' => 'David', 'greeting' => 'Greetings']));
     }
 
-    public function testGetJsonForNonExistingJsonKeyLooksForRegularKeys()
+    public function testGetJsonForNonExistingJsonKeyLooksForRegularKeys(): void
     {
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
@@ -143,7 +143,7 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('one', $t->getFromJson('foo.bar'));
     }
 
-    public function testGetJsonForNonExistingJsonKeyLooksForRegularKeysAndReplace()
+    public function testGetJsonForNonExistingJsonKeyLooksForRegularKeysAndReplace(): void
     {
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
@@ -151,7 +151,7 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('one two', $t->getFromJson('foo.bar', ['message' => 'two']));
     }
 
-    public function testGetJsonForNonExistingReturnsSameKey()
+    public function testGetJsonForNonExistingReturnsSameKey(): void
     {
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
@@ -159,7 +159,7 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('Foo that bar', $t->getFromJson('Foo that bar'));
     }
 
-    public function testGetJsonForNonExistingReturnsSameKeyAndReplaces()
+    public function testGetJsonForNonExistingReturnsSameKeyAndReplaces(): void
     {
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class ValidationDatabasePresenceVerifierTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBasicCount()
+    public function testBasicCount(): void
     {
         $verifier = new \Illuminate\Validation\DatabasePresenceVerifier($db = m::mock('Illuminate\Database\ConnectionResolverInterface'));
         $verifier->setConnection('connection');
@@ -31,7 +31,7 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
         $this->assertEquals(100, $verifier->getCount('table', 'column', 'value', null, null, $extra));
     }
 
-    public function testBasicCountWithClosures()
+    public function testBasicCountWithClosures(): void
     {
         $verifier = new \Illuminate\Validation\DatabasePresenceVerifier($db = m::mock('Illuminate\Database\ConnectionResolverInterface'));
         $verifier->setConnection('connection');

--- a/tests/Validation/ValidationDimensionsRuleTest.php
+++ b/tests/Validation/ValidationDimensionsRuleTest.php
@@ -8,7 +8,7 @@ use Illuminate\Validation\Rules\Dimensions;
 
 class ValidationDimensionsRuleTest extends TestCase
 {
-    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    public function testItCorrectlyFormatsAStringVersionOfTheRule(): void
     {
         $rule = new Dimensions(['min_width' => 100, 'min_height' => 100]);
 

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -16,7 +16,7 @@ class ValidationExistsRuleTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -31,7 +31,7 @@ class ValidationExistsRuleTest extends TestCase
         $this->createSchema();
     }
 
-    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    public function testItCorrectlyFormatsAStringVersionOfTheRule(): void
     {
         $rule = new Exists('table');
         $rule->where('foo', 'bar');
@@ -42,7 +42,7 @@ class ValidationExistsRuleTest extends TestCase
         $this->assertEquals('exists:table,column,foo,bar', (string) $rule);
     }
 
-    public function testItChoosesValidRecordsUsingWhereInRule()
+    public function testItChoosesValidRecordsUsingWhereInRule(): void
     {
         $rule = new Exists('users', 'id');
         $rule->whereIn('type', ['foo', 'bar']);
@@ -66,7 +66,7 @@ class ValidationExistsRuleTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testItChoosesValidRecordsUsingWhereNotInRule()
+    public function testItChoosesValidRecordsUsingWhereNotInRule(): void
     {
         $rule = new Exists('users', 'id');
         $rule->whereNotIn('type', ['foo', 'bar']);
@@ -90,7 +90,7 @@ class ValidationExistsRuleTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testItChoosesValidRecordsUsingWhereNotInAndWhereNotInRulesTogether()
+    public function testItChoosesValidRecordsUsingWhereNotInAndWhereNotInRulesTogether(): void
     {
         $rule = new Exists('users', 'id');
         $rule->whereIn('type', ['foo', 'bar', 'baz'])->whereNotIn('type', ['foo', 'bar']);
@@ -157,7 +157,7 @@ class ValidationExistsRuleTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema('default')->drop('users');
     }

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -11,12 +11,12 @@ use Illuminate\Contracts\Translation\Translator as TranslatorInterface;
 
 class ValidationFactoryTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testMakeMethodCreatesValidValidator()
+    public function testMakeMethodCreatesValidValidator(): void
     {
         $translator = m::mock(TranslatorInterface::class);
         $factory = new Factory($translator);
@@ -53,7 +53,7 @@ class ValidationFactoryTest extends TestCase
         $this->assertEquals($presence, $validator->getPresenceVerifier());
     }
 
-    public function testValidateCallsValidateOnTheValidator()
+    public function testValidateCallsValidateOnTheValidator(): void
     {
         $validator = m::mock(Validator::class);
         $translator = m::mock(TranslatorInterface::class);
@@ -68,7 +68,7 @@ class ValidationFactoryTest extends TestCase
         $factory->validate(['foo' => 'bar'], ['foo' => 'required']);
     }
 
-    public function testCustomResolverIsCalled()
+    public function testCustomResolverIsCalled(): void
     {
         unset($_SERVER['__validator.factory']);
         $translator = m::mock(TranslatorInterface::class);
@@ -87,7 +87,7 @@ class ValidationFactoryTest extends TestCase
         unset($_SERVER['__validator.factory']);
     }
 
-    public function testValidateMethodCanBeCalledPublicly()
+    public function testValidateMethodCanBeCalledPublicly(): void
     {
         $translator = m::mock(TranslatorInterface::class);
         $factory = new Factory($translator);

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -8,7 +8,7 @@ use Illuminate\Validation\Rules\In;
 
 class ValidationInRuleTest extends TestCase
 {
-    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    public function testItCorrectlyFormatsAStringVersionOfTheRule(): void
     {
         $rule = new In(['Laravel', 'Framework', 'PHP']);
 

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -8,7 +8,7 @@ use Illuminate\Validation\Rules\NotIn;
 
 class ValidationNotInRuleTest extends TestCase
 {
-    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    public function testItCorrectlyFormatsAStringVersionOfTheRule(): void
     {
         $rule = new NotIn(['Laravel', 'Framework', 'PHP']);
 

--- a/tests/Validation/ValidationRuleTest.php
+++ b/tests/Validation/ValidationRuleTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class ValidationRuleTest extends TestCase
 {
-    public function testMacroable()
+    public function testMacroable(): void
     {
         // phone macro : validate a phone number
         Rule::macro('phone', function () {

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class ValidationUniqueRuleTest extends TestCase
 {
-    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    public function testItCorrectlyFormatsAStringVersionOfTheRule(): void
     {
         $rule = new \Illuminate\Validation\Rules\Unique('table');
         $rule->where('foo', 'bar');

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -17,13 +17,13 @@ use Illuminate\Contracts\Validation\ImplicitRule;
 
 class ValidationValidatorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Carbon::setTestNow();
         m::close();
     }
 
-    public function testSometimesWorksOnNestedArrays()
+    public function testSometimesWorksOnNestedArrays(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => ['bar' => ['baz' => '']]], ['foo.bar.baz' => 'sometimes|required']);
@@ -35,7 +35,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testAfterCallbacksAreCalledWithValidatorInstance()
+    public function testAfterCallbacksAreCalledWithValidatorInstance(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'Same:baz']);
@@ -54,7 +54,7 @@ class ValidationValidatorTest extends TestCase
         unset($_SERVER['__validator.after.test']);
     }
 
-    public function testSometimesWorksOnArrays()
+    public function testSometimesWorksOnArrays(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => ['bar', 'baz', 'moo']], ['foo' => 'sometimes|required|between:5,10']);
@@ -69,7 +69,7 @@ class ValidationValidatorTest extends TestCase
     /**
      * @expectedException \Illuminate\Validation\ValidationException
      */
-    public function testValidateThrowsOnFail()
+    public function testValidateThrowsOnFail(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar'], ['baz' => 'required']);
@@ -77,7 +77,7 @@ class ValidationValidatorTest extends TestCase
         $v->validate();
     }
 
-    public function testValidateDoesntThrowOnPass()
+    public function testValidateDoesntThrowOnPass(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'required']);
@@ -85,7 +85,7 @@ class ValidationValidatorTest extends TestCase
         $v->validate();
     }
 
-    public function testHasFailedValidationRules()
+    public function testHasFailedValidationRules(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'Same:baz']);
@@ -93,7 +93,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['foo' => ['Same' => ['baz']]], $v->failed());
     }
 
-    public function testFailingOnce()
+    public function testFailingOnce(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'Bail|Same:baz|In:qux']);
@@ -101,7 +101,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['foo' => ['Same' => ['baz']]], $v->failed());
     }
 
-    public function testHasNotFailedValidationRules()
+    public function testHasNotFailedValidationRules(): void
     {
         $trans = $this->getTranslator();
         $trans->shouldReceive('trans')->never();
@@ -110,7 +110,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEmpty($v->failed());
     }
 
-    public function testSometimesCanSkipRequiredRules()
+    public function testSometimesCanSkipRequiredRules(): void
     {
         $trans = $this->getTranslator();
         $trans->shouldReceive('trans')->never();
@@ -119,7 +119,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEmpty($v->failed());
     }
 
-    public function testInValidatableRulesReturnsValid()
+    public function testInValidatableRulesReturnsValid(): void
     {
         $trans = $this->getTranslator();
         $trans->shouldReceive('trans')->never();
@@ -127,7 +127,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateEmptyStringsAlwaysPasses()
+    public function testValidateEmptyStringsAlwaysPasses(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -135,7 +135,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testEmptyExistingAttributesAreValidated()
+    public function testEmptyExistingAttributesAreValidated(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -158,7 +158,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testNullable()
+    public function testNullable(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -182,7 +182,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('validation.boolean', $v->messages()->get('b')[0]);
     }
 
-    public function testNullableMakesNoDifferenceIfImplicitRuleExists()
+    public function testNullableMakesNoDifferenceIfImplicitRuleExists(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -213,7 +213,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('validation.required_with', $v->messages()->get('y')[0]);
     }
 
-    public function testProperLanguageLineIsSet()
+    public function testProperLanguageLineIsSet(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required' => 'required!'], 'en');
@@ -224,7 +224,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('required!', $v->messages()->first('name'));
     }
 
-    public function testCustomReplacersAreCalled()
+    public function testCustomReplacersAreCalled(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required' => 'foo bar'], 'en');
@@ -237,7 +237,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('foo taylor', $v->messages()->first('name'));
     }
 
-    public function testClassBasedCustomReplacers()
+    public function testClassBasedCustomReplacers(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.foo' => 'foo!'], 'en');
@@ -251,7 +251,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('replaced!', $v->messages()->first('name'));
     }
 
-    public function testNestedAttributesAreReplacedInDimensions()
+    public function testNestedAttributesAreReplacedInDimensions(): void
     {
         // Knowing that demo image.png has width = 3 and height = 2
         $uploadedFile = new \Symfony\Component\HttpFoundation\File\UploadedFile(__DIR__.'/fixtures/image.png', '', null, null, null, true);
@@ -271,7 +271,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(':width :height 1', $v->messages()->first('x'));
     }
 
-    public function testAttributeNamesAreReplaced()
+    public function testAttributeNamesAreReplaced(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
@@ -320,7 +320,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('NAME is required!', $v->messages()->first('name'));
     }
 
-    public function testAttributeNamesAreReplacedInArrays()
+    public function testAttributeNamesAreReplacedInArrays(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
@@ -375,7 +375,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('First name is required!', $v->messages()->first('names.0'));
     }
 
-    public function testInputIsReplaced()
+    public function testInputIsReplaced(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.email' => ':input is not a valid email'], 'en');
@@ -392,7 +392,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(' is not a valid email', $v->messages()->first('email'));
     }
 
-    public function testDisplayableValuesAreReplaced()
+    public function testDisplayableValuesAreReplaced(): void
     {
         //required_if:foo,bar
         $trans = $this->getIlluminateArrayTranslator();
@@ -444,7 +444,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('type must be included in Short, Long.', $v->messages()->first('type'));
     }
 
-    public function testDisplayableAttributesAreReplacedInCustomReplacers()
+    public function testDisplayableAttributesAreReplacedInCustomReplacers(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.alliteration' => ':attribute needs to begin with the same letter as :other'], 'en');
@@ -486,7 +486,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['firstname' => 'Bob', 'lastname' => 'Smith'], ['lastname' => 'alliteration:firstname']);
     }
 
-    public function testCustomValidationLinesAreRespected()
+    public function testCustomValidationLinesAreRespected(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->getLoader()->addMessages('en', 'validation', [
@@ -503,7 +503,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('really required!', $v->messages()->first('name'));
     }
 
-    public function testCustomValidationLinesAreRespectedWithAsterisks()
+    public function testCustomValidationLinesAreRespectedWithAsterisks(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->getLoader()->addMessages('en', 'validation', [
@@ -530,7 +530,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('english is required!', $v->messages()->first('lang.en'));
     }
 
-    public function testValidationDotCustomDotAnythingCanBeTranslated()
+    public function testValidationDotCustomDotAnythingCanBeTranslated(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->getLoader()->addMessages('en', 'validation', [
@@ -550,7 +550,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('should be integer!', $v->messages()->first('validation.custom.1'));
     }
 
-    public function testInlineValidationMessagesAreRespected()
+    public function testInlineValidationMessagesAreRespected(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required'], ['name.required' => 'require it please!']);
@@ -571,7 +571,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('name should be of length 9', $v->messages()->first('name'));
     }
 
-    public function testInlineValidationMessagesAreRespectedWithAsterisks()
+    public function testInlineValidationMessagesAreRespectedWithAsterisks(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => ['', '']], ['name.*' => 'required|max:255'], ['name.*.required' => 'all must be required!']);
@@ -581,7 +581,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('all must be required!', $v->messages()->first('name.1'));
     }
 
-    public function testIfRulesAreSuccessfullyAdded()
+    public function testIfRulesAreSuccessfullyAdded(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['foo' => 'Required']);
@@ -593,7 +593,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->hasRule('bar', 'Required'));
     }
 
-    public function testValidateArray()
+    public function testValidateArray(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -604,7 +604,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateFilled()
+    public function testValidateFilled(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['name' => 'filled']);
@@ -623,7 +623,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidationStopsAtFailedPresenceCheck()
+    public function testValidationStopsAtFailedPresenceCheck(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -644,7 +644,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['validation.present'], $v->errors()->get('name'));
     }
 
-    public function testValidatePresent()
+    public function testValidatePresent(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['name' => 'present']);
@@ -672,7 +672,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateRequired()
+    public function testValidateRequired(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['name' => 'Required']);
@@ -701,7 +701,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateRequiredWith()
+    public function testValidateRequiredWith(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'Taylor'], ['last' => 'required_with:first']);
@@ -734,7 +734,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testRequiredWithAll()
+    public function testRequiredWithAll(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'foo'], ['last' => 'required_with_all:first,foo']);
@@ -744,7 +744,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateRequiredWithout()
+    public function testValidateRequiredWithout(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'Taylor'], ['last' => 'required_without:first']);
@@ -798,7 +798,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testRequiredWithoutMultiple()
+    public function testRequiredWithoutMultiple(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -833,7 +833,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testRequiredWithoutAll()
+    public function testRequiredWithoutAll(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -868,7 +868,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testRequiredIf()
+    public function testRequiredIf(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'taylor'], ['last' => 'required_if:first,taylor']);
@@ -902,7 +902,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('The last field is required when first is dayle.', $v->messages()->first('last'));
     }
 
-    public function testRequiredUnless()
+    public function testRequiredUnless(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'sven'], ['last' => 'required_unless:first,taylor']);
@@ -932,7 +932,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('The last field is required unless first is in taylor, sven.', $v->messages()->first('last'));
     }
 
-    public function testFailedFileUploads()
+    public function testFailedFileUploads(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -968,7 +968,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['validation.uploaded'], $v->errors()->get('photo'));
     }
 
-    public function testValidateInArray()
+    public function testValidateInArray(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => [1, 2, 3], 'bar' => [1, 2]], ['foo.*' => 'in_array:bar.*']);
@@ -991,7 +991,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('The value of foo.2 does not exist in bar.*.', $v->messages()->first('foo.2'));
     }
 
-    public function testValidateConfirmed()
+    public function testValidateConfirmed(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['password' => 'foo'], ['password' => 'Confirmed']);
@@ -1007,7 +1007,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateSame()
+    public function testValidateSame(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'Same:baz']);
@@ -1026,7 +1026,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateDifferent()
+    public function testValidateDifferent(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'Different:baz']);
@@ -1051,7 +1051,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateAccepted()
+    public function testValidateAccepted(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Accepted']);
@@ -1091,7 +1091,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateString()
+    public function testValidateString(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'string']);
@@ -1102,7 +1102,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateJson()
+    public function testValidateJson(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'aslksd'], ['foo' => 'json']);
@@ -1117,7 +1117,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateBoolean()
+    public function testValidateBoolean(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Boolean']);
@@ -1154,7 +1154,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateBool()
+    public function testValidateBool(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Bool']);
@@ -1191,7 +1191,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateNumeric()
+    public function testValidateNumeric(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Numeric']);
@@ -1207,7 +1207,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateInteger()
+    public function testValidateInteger(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Integer']);
@@ -1223,7 +1223,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateInt()
+    public function testValidateInt(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Int']);
@@ -1239,7 +1239,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateDigits()
+    public function testValidateDigits(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => '12345'], ['foo' => 'Digits:5']);
@@ -1268,7 +1268,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateSize()
+    public function testValidateSize(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Size:3']);
@@ -1300,7 +1300,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateBetween()
+    public function testValidateBetween(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Between:3,4']);
@@ -1338,7 +1338,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateMin()
+    public function testValidateMin(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => '3'], ['foo' => 'Min:3']);
@@ -1370,7 +1370,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateMax()
+    public function testValidateMax(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'aslksd'], ['foo' => 'Max:3']);
@@ -1409,7 +1409,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testProperMessagesAreReturnedForSizes()
+    public function testProperMessagesAreReturnedForSizes(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.min.numeric' => 'numeric', 'validation.size.string' => 'string', 'validation.max.file' => 'file'], 'en');
@@ -1432,7 +1432,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('file', $v->messages()->first('photo'));
     }
 
-    public function testValidateIn()
+    public function testValidateIn(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => 'foo'], ['name' => 'In:bar,baz']);
@@ -1467,7 +1467,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateNotIn()
+    public function testValidateNotIn(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => 'foo'], ['name' => 'NotIn:bar,baz']);
@@ -1477,7 +1477,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateDistinct()
+    public function testValidateDistinct(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -1542,7 +1542,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('There is a duplication!', $v->messages()->first('foo.1'));
     }
 
-    public function testValidateUnique()
+    public function testValidateUnique(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users']);
@@ -1588,7 +1588,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateUniqueAndExistsSendsCorrectFieldNameToDBWithArrays()
+    public function testValidateUniqueAndExistsSendsCorrectFieldNameToDBWithArrays(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [['email' => 'foo', 'type' => 'bar']], [
@@ -1616,7 +1616,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidationExists()
+    public function testValidationExists(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users']);
@@ -1656,7 +1656,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidationExistsIsNotCalledUnnecessarily()
+    public function testValidationExistsIsNotCalledUnnecessarily(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['id' => 'foo'], ['id' => 'Integer|Exists:users,id']);
@@ -1674,7 +1674,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateIp()
+    public function testValidateIp(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['ip' => 'aslsdlks'], ['ip' => 'Ip']);
@@ -1696,7 +1696,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
-    public function testValidateEmail()
+    public function testValidateEmail(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'Email']);
@@ -1709,7 +1709,7 @@ class ValidationValidatorTest extends TestCase
     /**
      * @dataProvider validUrls
      */
-    public function testValidateUrlWithValidUrls($validUrl)
+    public function testValidateUrlWithValidUrls($validUrl): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => $validUrl], ['x' => 'Url']);
@@ -1719,7 +1719,7 @@ class ValidationValidatorTest extends TestCase
     /**
      * @dataProvider invalidUrls
      */
-    public function testValidateUrlWithInvalidUrls($invalidUrl)
+    public function testValidateUrlWithInvalidUrls($invalidUrl): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => $invalidUrl], ['x' => 'Url']);
@@ -1985,7 +1985,7 @@ class ValidationValidatorTest extends TestCase
         ];
     }
 
-    public function testValidateActiveUrl()
+    public function testValidateActiveUrl(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'active_url']);
@@ -2004,7 +2004,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateImage()
+    public function testValidateImage(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $uploadedFile = [__FILE__, '', null, null, null, true];
@@ -2046,7 +2046,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateImageDoesNotAllowPhpExtensionsOnImageMime()
+    public function testValidateImageDoesNotAllowPhpExtensionsOnImageMime(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $uploadedFile = [__FILE__, '', null, null, null, true];
@@ -2058,7 +2058,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateImageDimensions()
+    public function testValidateImageDimensions(): void
     {
         // Knowing that demo image.png has width = 3 and height = 2
         $uploadedFile = new \Symfony\Component\HttpFoundation\File\UploadedFile(__DIR__.'/fixtures/image.png', '', null, null, null, true);
@@ -2143,7 +2143,7 @@ class ValidationValidatorTest extends TestCase
     /**
      * @requires extension fileinfo
      */
-    public function testValidatePhpMimetypes()
+    public function testValidatePhpMimetypes(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $uploadedFile = [__FILE__, '', null, null, null, true];
@@ -2156,7 +2156,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateMime()
+    public function testValidateMime(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $uploadedFile = [__FILE__, '', null, null, null, true];
@@ -2174,7 +2174,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateMimeEnforcesPhpCheck()
+    public function testValidateMimeEnforcesPhpCheck(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $uploadedFile = [__FILE__, '', null, null, null, true];
@@ -2195,7 +2195,7 @@ class ValidationValidatorTest extends TestCase
     /**
      * @requires extension fileinfo
      */
-    public function testValidateFile()
+    public function testValidateFile(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $file = new \Symfony\Component\HttpFoundation\File\UploadedFile(__FILE__, '', null, null, null, true);
@@ -2207,7 +2207,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testEmptyRulesSkipped()
+    public function testEmptyRulesSkipped(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => ['alpha', [], '']]);
@@ -2217,14 +2217,14 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testAlternativeFormat()
+    public function testAlternativeFormat(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => ['alpha', ['min', 3], ['max', 10]]]);
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateAlpha()
+    public function testValidateAlpha(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'Alpha']);
@@ -2270,7 +2270,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateAlphaNum()
+    public function testValidateAlphaNum(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'asls13dlks'], ['x' => 'AlphaNum']);
@@ -2289,7 +2289,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateAlphaDash()
+    public function testValidateAlphaDash(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'asls1-_3dlks'], ['x' => 'AlphaDash']);
@@ -2305,7 +2305,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateTimezone()
+    public function testValidateTimezone(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone']);
@@ -2327,7 +2327,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateRegex()
+    public function testValidateRegex(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'asdasdf'], ['x' => 'Regex:/^[a-z]+$/i']);
@@ -2347,7 +2347,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateNotRegex()
+    public function testValidateNotRegex(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'foo bar'], ['x' => 'NotRegex:/[xyz]/i']);
@@ -2361,7 +2361,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateDateAndFormat()
+    public function testValidateDateAndFormat(): void
     {
         date_default_timezone_set('UTC');
         $trans = $this->getIlluminateArrayTranslator();
@@ -2433,7 +2433,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testDateEquals()
+    public function testDateEquals(): void
     {
         date_default_timezone_set('UTC');
         $trans = $this->getIlluminateArrayTranslator();
@@ -2495,7 +2495,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
-    public function testDateEqualsRespectsCarbonTestNowWhenParameterIsRelative()
+    public function testDateEqualsRespectsCarbonTestNowWhenParameterIsRelative(): void
     {
         date_default_timezone_set('UTC');
         $trans = $this->getIlluminateArrayTranslator();
@@ -2541,7 +2541,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
-    public function testBeforeAndAfter()
+    public function testBeforeAndAfter(): void
     {
         date_default_timezone_set('UTC');
         $trans = $this->getIlluminateArrayTranslator();
@@ -2621,7 +2621,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
-    public function testBeforeAndAfterWithFormat()
+    public function testBeforeAndAfterWithFormat(): void
     {
         date_default_timezone_set('UTC');
         $trans = $this->getIlluminateArrayTranslator();
@@ -2716,7 +2716,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
-    public function testWeakBeforeAndAfter()
+    public function testWeakBeforeAndAfter(): void
     {
         date_default_timezone_set('UTC');
         $trans = $this->getIlluminateArrayTranslator();
@@ -2796,7 +2796,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
-    public function testSometimesAddingRules()
+    public function testSometimesAddingRules(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'foo'], ['x' => 'Required']);
@@ -2841,7 +2841,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['foo.0.name' => ['Required', 'String']], $v->getRules());
     }
 
-    public function testCustomValidators()
+    public function testCustomValidators(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.foo' => 'foo!'], 'en');
@@ -2884,7 +2884,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('foo!', $v->messages()->first('name'));
     }
 
-    public function testClassBasedCustomValidators()
+    public function testClassBasedCustomValidators(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.foo' => 'foo!'], 'en');
@@ -2898,7 +2898,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('foo!', $v->messages()->first('name'));
     }
 
-    public function testClassBasedCustomValidatorsUsingConventionalMethod()
+    public function testClassBasedCustomValidatorsUsingConventionalMethod(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.foo' => 'foo!'], 'en');
@@ -2912,7 +2912,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('foo!', $v->messages()->first('name'));
     }
 
-    public function testCustomImplicitValidators()
+    public function testCustomImplicitValidators(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['implicit_rule' => 'foo']);
@@ -2922,7 +2922,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testCustomDependentValidators()
+    public function testCustomDependentValidators(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans,
@@ -2941,14 +2941,14 @@ class ValidationValidatorTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Validation rule required_if requires at least 2 parameters.
      */
-    public function testExceptionThrownOnIncorrectParameterCount()
+    public function testExceptionThrownOnIncorrectParameterCount(): void
     {
         $trans = $this->getTranslator();
         $v = new Validator($trans, [], ['foo' => 'required_if:foo']);
         $v->passes();
     }
 
-    public function testValidateImplicitEachWithAsterisks()
+    public function testValidateImplicitEachWithAsterisks(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $data = ['foo' => [5, 10, 15]];
@@ -3016,7 +3016,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testSometimesOnArraysInImplicitRules()
+    public function testSometimesOnArraysInImplicitRules(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3030,7 +3030,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['validation.string'], $v->errors()->get('names.0.second'));
     }
 
-    public function testValidateImplicitEachWithAsterisksForRequiredNonExistingKey()
+    public function testValidateImplicitEachWithAsterisksForRequiredNonExistingKey(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3101,7 +3101,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testParsingArrayKeysWithDot()
+    public function testParsingArrayKeysWithDot(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3118,14 +3118,14 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
-    public function testCoveringEmptyKeys()
+    public function testCoveringEmptyKeys(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => ['' => ['bar' => '']]], ['foo.*.bar' => 'required']);
         $this->assertTrue($v->fails());
     }
 
-    public function testImplicitEachWithAsterisksWithArrayValues()
+    public function testImplicitEachWithAsterisksWithArrayValues(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3160,7 +3160,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateNestedArrayWithCommonParentChildKey()
+    public function testValidateNestedArrayWithCommonParentChildKey(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3184,7 +3184,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateNestedArrayWithNonNumericKeys()
+    public function testValidateNestedArrayWithNonNumericKeys(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3198,7 +3198,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateImplicitEachWithAsterisksConfirmed()
+    public function testValidateImplicitEachWithAsterisksConfirmed(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3243,7 +3243,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->messages()->has('foo.0.bar.1.password'));
     }
 
-    public function testValidateImplicitEachWithAsterisksDifferent()
+    public function testValidateImplicitEachWithAsterisksDifferent(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3284,7 +3284,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
     }
 
-    public function testValidateImplicitEachWithAsterisksSame()
+    public function testValidateImplicitEachWithAsterisksSame(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3325,7 +3325,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
     }
 
-    public function testValidateImplicitEachWithAsterisksRequired()
+    public function testValidateImplicitEachWithAsterisksRequired(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3364,7 +3364,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
     }
 
-    public function testValidateImplicitEachWithAsterisksRequiredIf()
+    public function testValidateImplicitEachWithAsterisksRequiredIf(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3403,7 +3403,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
     }
 
-    public function testValidateImplicitEachWithAsterisksRequiredUnless()
+    public function testValidateImplicitEachWithAsterisksRequiredUnless(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3442,7 +3442,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
     }
 
-    public function testValidateImplicitEachWithAsterisksRequiredWith()
+    public function testValidateImplicitEachWithAsterisksRequiredWith(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3487,7 +3487,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
     }
 
-    public function testValidateImplicitEachWithAsterisksRequiredWithAll()
+    public function testValidateImplicitEachWithAsterisksRequiredWithAll(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3526,7 +3526,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
     }
 
-    public function testValidateImplicitEachWithAsterisksRequiredWithout()
+    public function testValidateImplicitEachWithAsterisksRequiredWithout(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3565,7 +3565,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
     }
 
-    public function testValidateImplicitEachWithAsterisksRequiredWithoutAll()
+    public function testValidateImplicitEachWithAsterisksRequiredWithoutAll(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3606,7 +3606,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
     }
 
-    public function testValidateImplicitEachWithAsterisksBeforeAndAfter()
+    public function testValidateImplicitEachWithAsterisksBeforeAndAfter(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3631,7 +3631,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
-    public function testGetLeadingExplicitAttributePath()
+    public function testGetLeadingExplicitAttributePath(): void
     {
         $this->assertNull(\Illuminate\Validation\ValidationData::getLeadingExplicitAttributePath('*.email'));
         $this->assertEquals('foo', \Illuminate\Validation\ValidationData::getLeadingExplicitAttributePath('foo.*'));
@@ -3639,7 +3639,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('foo.bar.1', \Illuminate\Validation\ValidationData::getLeadingExplicitAttributePath('foo.bar.1'));
     }
 
-    public function testExtractDataFromPath()
+    public function testExtractDataFromPath(): void
     {
         $data = [['email' => 'mail'], ['email' => 'mail2']];
         $this->assertEquals([['email' => 'mail'], ['email' => 'mail2']], \Illuminate\Validation\ValidationData::extractDataFromPath(null, $data));
@@ -3651,11 +3651,11 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['cat' => ['cat1' => ['name' => '1']]], \Illuminate\Validation\ValidationData::extractDataFromPath('cat.cat1.name', $data));
     }
 
-    public function testInlineMessagesMayUseAsteriskForEachRules()
+    public function testInlineMessagesMayUseAsteriskForEachRules(): void
     {
     }
 
-    public function testUsingSettersWithImplicitRules()
+    public function testUsingSettersWithImplicitRules(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => ['a', 'b', 'c']], ['foo.*' => 'string']);
@@ -3668,7 +3668,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testInvalidMethod()
+    public function testInvalidMethod(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3700,7 +3700,7 @@ class ValidationValidatorTest extends TestCase
         ]);
     }
 
-    public function testValidMethod()
+    public function testValidMethod(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -3738,7 +3738,7 @@ class ValidationValidatorTest extends TestCase
         ]);
     }
 
-    public function testMultipleFileUploads()
+    public function testMultipleFileUploads(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $file = new File(__FILE__, false);
@@ -3747,7 +3747,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testFileUploads()
+    public function testFileUploads(): void
     {
         $trans = $this->getIlluminateArrayTranslator();
         $file = new File(__FILE__, false);
@@ -3755,7 +3755,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testCustomValidationObject()
+    public function testCustomValidationObject(): void
     {
         // Test passing case...
         $v = new Validator(
@@ -3862,7 +3862,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('number must be divisible by 4', $v->errors()->get('number')[0]);
     }
 
-    public function testImplicitCustomValidationObjects()
+    public function testImplicitCustomValidationObjects(): void
     {
         // Test passing case...
         $v = new Validator(
@@ -3889,7 +3889,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($rule->called);
     }
 
-    public function testValidateReturnsValidatedData()
+    public function testValidateReturnsValidatedData(): void
     {
         $post = ['first' => 'john',  'preferred'=>'john', 'last' => 'doe', 'type' => 'admin'];
 

--- a/tests/View/Blade/AbstractBladeTestCase.php
+++ b/tests/View/Blade/AbstractBladeTestCase.php
@@ -10,13 +10,13 @@ abstract class AbstractBladeTestCase extends TestCase
 {
     protected $compiler;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->compiler = new BladeCompiler(m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
         parent::setUp();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
 

--- a/tests/View/Blade/BladeAppendTest.php
+++ b/tests/View/Blade/BladeAppendTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeAppendTest extends AbstractBladeTestCase
 {
-    public function testAppendSectionsAreCompiled()
+    public function testAppendSectionsAreCompiled(): void
     {
         $this->assertEquals('<?php $__env->appendSection(); ?>', $this->compiler->compileString('@append'));
     }

--- a/tests/View/Blade/BladeBreakStatementsTest.php
+++ b/tests/View/Blade/BladeBreakStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeBreakStatementsTest extends AbstractBladeTestCase
 {
-    public function testBreakStatementsAreCompiled()
+    public function testBreakStatementsAreCompiled(): void
     {
         $string = '@for ($i = 0; $i < 10; $i++)
 test
@@ -17,7 +17,7 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testBreakStatementsWithExpressionAreCompiled()
+    public function testBreakStatementsWithExpressionAreCompiled(): void
     {
         $string = '@for ($i = 0; $i < 10; $i++)
 test
@@ -30,7 +30,7 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testBreakStatementsWithArgumentAreCompiled()
+    public function testBreakStatementsWithArgumentAreCompiled(): void
     {
         $string = '@for ($i = 0; $i < 10; $i++)
 test
@@ -43,7 +43,7 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testBreakStatementsWithSpacedArgumentAreCompiled()
+    public function testBreakStatementsWithSpacedArgumentAreCompiled(): void
     {
         $string = '@for ($i = 0; $i < 10; $i++)
 test
@@ -56,7 +56,7 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testBreakStatementsWithFaultyArgumentAreCompiled()
+    public function testBreakStatementsWithFaultyArgumentAreCompiled(): void
     {
         $string = '@for ($i = 0; $i < 10; $i++)
 test

--- a/tests/View/Blade/BladeCanStatementsTest.php
+++ b/tests/View/Blade/BladeCanStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeCanStatementsTest extends AbstractBladeTestCase
 {
-    public function testCanStatementsAreCompiled()
+    public function testCanStatementsAreCompiled(): void
     {
         $string = '@can (\'update\', [$post])
 breeze

--- a/tests/View/Blade/BladeCannotStatementsTest.php
+++ b/tests/View/Blade/BladeCannotStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeCannotStatementsTest extends AbstractBladeTestCase
 {
-    public function testCannotStatementsAreCompiled()
+    public function testCannotStatementsAreCompiled(): void
     {
         $string = '@cannot (\'update\', [$post])
 breeze

--- a/tests/View/Blade/BladeCommentsTest.php
+++ b/tests/View/Blade/BladeCommentsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeCommentsTest extends AbstractBladeTestCase
 {
-    public function testCommentsAreCompiled()
+    public function testCommentsAreCompiled(): void
     {
         $string = '{{--this is a comment--}}';
         $this->assertEmpty($this->compiler->compileString($string));
@@ -18,7 +18,7 @@ this is a comment
         $this->assertEmpty($this->compiler->compileString($string));
     }
 
-    public function testBladeCodeInsideCommentsIsNotCompiled()
+    public function testBladeCodeInsideCommentsIsNotCompiled(): void
     {
         $string = '{{-- @foreach() --}}';
 

--- a/tests/View/Blade/BladeContinueStatementsTest.php
+++ b/tests/View/Blade/BladeContinueStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeContinueStatementsTest extends AbstractBladeTestCase
 {
-    public function testContinueStatementsAreCompiled()
+    public function testContinueStatementsAreCompiled(): void
     {
         $string = '@for ($i = 0; $i < 10; $i++)
 test
@@ -17,7 +17,7 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testContinueStatementsWithExpressionAreCompiled()
+    public function testContinueStatementsWithExpressionAreCompiled(): void
     {
         $string = '@for ($i = 0; $i < 10; $i++)
 test
@@ -30,7 +30,7 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testContinueStatementsWithArgumentAreCompiled()
+    public function testContinueStatementsWithArgumentAreCompiled(): void
     {
         $string = '@for ($i = 0; $i < 10; $i++)
 test
@@ -43,7 +43,7 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testContinueStatementsWithSpacedArgumentAreCompiled()
+    public function testContinueStatementsWithSpacedArgumentAreCompiled(): void
     {
         $string = '@for ($i = 0; $i < 10; $i++)
 test
@@ -56,7 +56,7 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testContinueStatementsWithFaultyArgumentAreCompiled()
+    public function testContinueStatementsWithFaultyArgumentAreCompiled(): void
     {
         $string = '@for ($i = 0; $i < 10; $i++)
 test

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -4,17 +4,17 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeCustomTest extends AbstractBladeTestCase
 {
-    public function testCustomPhpCodeIsCorrectlyHandled()
+    public function testCustomPhpCodeIsCorrectlyHandled(): void
     {
         $this->assertEquals('<?php if($test): ?> <?php @show(\'test\'); ?> <?php endif; ?>', $this->compiler->compileString("@if(\$test) <?php @show('test'); ?> @endif"));
     }
 
-    public function testMixingYieldAndEcho()
+    public function testMixingYieldAndEcho(): void
     {
         $this->assertEquals('<?php echo $__env->yieldContent(\'title\'); ?> - <?php echo e(Config::get(\'site.title\')); ?>', $this->compiler->compileString("@yield('title') - {{Config::get('site.title')}}"));
     }
 
-    public function testCustomExtensionsAreCompiled()
+    public function testCustomExtensionsAreCompiled(): void
     {
         $this->compiler->extend(function ($value) {
             return str_replace('foo', 'bar', $value);
@@ -22,7 +22,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals('bar', $this->compiler->compileString('foo'));
     }
 
-    public function testCustomStatements()
+    public function testCustomStatements(): void
     {
         $this->assertCount(0, $this->compiler->getCustomDirectives());
         $this->compiler->directive('customControl', function ($expression) {
@@ -39,7 +39,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testCustomShortStatements()
+    public function testCustomShortStatements(): void
     {
         $this->compiler->directive('customControl', function ($expression) {
             return '<?php echo custom_control(); ?>';
@@ -50,7 +50,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testCustomExtensionOverwritesCore()
+    public function testCustomExtensionOverwritesCore(): void
     {
         $this->compiler->directive('foreach', function ($expression) {
             return '<?php custom(); ?>';
@@ -61,7 +61,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testCustomConditions()
+    public function testCustomConditions(): void
     {
         $this->compiler->if('custom', function ($user) {
             return true;
@@ -74,7 +74,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testCustomIfElseConditions()
+    public function testCustomIfElseConditions(): void
     {
         $this->compiler->if('custom', function ($anything) {
             return true;
@@ -91,7 +91,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testCustomComponents()
+    public function testCustomComponents(): void
     {
         $this->compiler->component('app.components.alert', 'alert');
 
@@ -102,7 +102,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testCustomComponentsWithSlots()
+    public function testCustomComponentsWithSlots(): void
     {
         $this->compiler->component('app.components.alert', 'alert');
 
@@ -113,7 +113,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testCustomComponentsDefaultAlias()
+    public function testCustomComponentsDefaultAlias(): void
     {
         $this->compiler->component('app.components.alert');
 
@@ -124,7 +124,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testCustomComponentsWithExistingDirective()
+    public function testCustomComponentsWithExistingDirective(): void
     {
         $this->compiler->component('app.components.foreach');
 
@@ -135,7 +135,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testCustomIncludes()
+    public function testCustomIncludes(): void
     {
         $this->compiler->include('app.includes.input', 'input');
 
@@ -144,7 +144,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testCustomIncludesWithData()
+    public function testCustomIncludesWithData(): void
     {
         $this->compiler->include('app.includes.input', 'input');
 
@@ -153,7 +153,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testCustomIncludesDefaultAlias()
+    public function testCustomIncludesDefaultAlias(): void
     {
         $this->compiler->include('app.includes.input');
 
@@ -162,7 +162,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testCustomIncludesWithExistingDirective()
+    public function testCustomIncludesWithExistingDirective(): void
     {
         $this->compiler->include('app.includes.foreach');
 

--- a/tests/View/Blade/BladeEachTest.php
+++ b/tests/View/Blade/BladeEachTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeEachTest extends AbstractBladeTestCase
 {
-    public function testShowEachAreCompiled()
+    public function testShowEachAreCompiled(): void
     {
         $this->assertEquals('<?php echo $__env->renderEach(\'foo\', \'bar\'); ?>', $this->compiler->compileString('@each(\'foo\', \'bar\')'));
         $this->assertEquals('<?php echo $__env->renderEach(name(foo)); ?>', $this->compiler->compileString('@each(name(foo))'));

--- a/tests/View/Blade/BladeEchoTest.php
+++ b/tests/View/Blade/BladeEchoTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeEchoTest extends AbstractBladeTestCase
 {
-    public function testEchosAreCompiled()
+    public function testEchosAreCompiled(): void
     {
         $this->assertEquals('<?php echo $name; ?>', $this->compiler->compileString('{!!$name!!}'));
         $this->assertEquals('<?php echo $name; ?>', $this->compiler->compileString('{!! $name !!}'));
@@ -48,7 +48,7 @@ class BladeEchoTest extends AbstractBladeTestCase
             $this->compiler->compileString('{{ myfunc("$name or \'foo\'") }}'));
     }
 
-    public function testEscapedWithAtEchosAreCompiled()
+    public function testEscapedWithAtEchosAreCompiled(): void
     {
         $this->assertEquals('{{$name}}', $this->compiler->compileString('@{{$name}}'));
         $this->assertEquals('{{ $name }}', $this->compiler->compileString('@{{ $name }}'));

--- a/tests/View/Blade/BladeElseIfStatementsTest.php
+++ b/tests/View/Blade/BladeElseIfStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeElseIfStatementsTest extends AbstractBladeTestCase
 {
-    public function testElseIfStatementsAreCompiled()
+    public function testElseIfStatementsAreCompiled(): void
     {
         $string = '@if(name(foo(bar)))
 breeze

--- a/tests/View/Blade/BladeElseStatementsTest.php
+++ b/tests/View/Blade/BladeElseStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeElseStatementsTest extends AbstractBladeTestCase
 {
-    public function testElseStatementsAreCompiled()
+    public function testElseStatementsAreCompiled(): void
     {
         $string = '@if (name(foo(bar)))
 breeze
@@ -19,7 +19,7 @@ boom
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testElseIfStatementsAreCompiled()
+    public function testElseIfStatementsAreCompiled(): void
     {
         $string = '@if(name(foo(bar)))
 breeze

--- a/tests/View/Blade/BladeEndSectionsTest.php
+++ b/tests/View/Blade/BladeEndSectionsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeEndSectionsTest extends AbstractBladeTestCase
 {
-    public function testEndSectionsAreCompiled()
+    public function testEndSectionsAreCompiled(): void
     {
         $this->assertEquals('<?php $__env->stopSection(); ?>', $this->compiler->compileString('@endsection'));
     }

--- a/tests/View/Blade/BladeEscapedTest.php
+++ b/tests/View/Blade/BladeEscapedTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeEscapedTest extends AbstractBladeTestCase
 {
-    public function testEscapedWithAtDirectivesAreCompiled()
+    public function testEscapedWithAtDirectivesAreCompiled(): void
     {
         $this->assertEquals('@foreach', $this->compiler->compileString('@@foreach'));
         $this->assertEquals('@verbatim @continue @endverbatim', $this->compiler->compileString('@@verbatim @@continue @@endverbatim'));

--- a/tests/View/Blade/BladeExpressionTest.php
+++ b/tests/View/Blade/BladeExpressionTest.php
@@ -4,12 +4,12 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeExpressionTest extends AbstractBladeTestCase
 {
-    public function testExpressionsOnTheSameLine()
+    public function testExpressionsOnTheSameLine(): void
     {
         $this->assertEquals('<?php echo app(\'translator\')->getFromJson(foo(bar(baz(qux(breeze()))))); ?> space () <?php echo app(\'translator\')->getFromJson(foo(bar)); ?>', $this->compiler->compileString('@lang(foo(bar(baz(qux(breeze()))))) space () @lang(foo(bar))'));
     }
 
-    public function testExpressionWithinHTML()
+    public function testExpressionWithinHTML(): void
     {
         $this->assertEquals('<html <?php echo e($foo); ?>>', $this->compiler->compileString('<html {{ $foo }}>'));
         $this->assertEquals('<html<?php echo e($foo); ?>>', $this->compiler->compileString('<html{{ $foo }}>'));

--- a/tests/View/Blade/BladeExtendsTest.php
+++ b/tests/View/Blade/BladeExtendsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeExtendsTest extends AbstractBladeTestCase
 {
-    public function testExtendsAreCompiled()
+    public function testExtendsAreCompiled(): void
     {
         $string = '@extends(\'foo\')
 test';
@@ -16,7 +16,7 @@ test';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testSequentialCompileStringCalls()
+    public function testSequentialCompileStringCalls(): void
     {
         $string = '@extends(\'foo\')
 test';

--- a/tests/View/Blade/BladeForStatementsTest.php
+++ b/tests/View/Blade/BladeForStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeForStatementsTest extends AbstractBladeTestCase
 {
-    public function testForStatementsAreCompiled()
+    public function testForStatementsAreCompiled(): void
     {
         $string = '@for ($i = 0; $i < 10; $i++)
 test
@@ -15,7 +15,7 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testNestedForStatementsAreCompiled()
+    public function testNestedForStatementsAreCompiled(): void
     {
         $string = '@for ($i = 0; $i < 10; $i++)
 @for ($j = 0; $j < 20; $j++)

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeForeachStatementsTest extends AbstractBladeTestCase
 {
-    public function testForeachStatementsAreCompiled()
+    public function testForeachStatementsAreCompiled(): void
     {
         $string = '@foreach ($this->getUsers() as $user)
 test
@@ -15,7 +15,7 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testForeachStatementsAreCompileWithUppercaseSyntax()
+    public function testForeachStatementsAreCompileWithUppercaseSyntax(): void
     {
         $string = '@foreach ($this->getUsers() AS $user)
 test
@@ -26,7 +26,7 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testForeachStatementsAreCompileWithMultipleLine()
+    public function testForeachStatementsAreCompileWithMultipleLine(): void
     {
         $string = '@foreach ([
 foo,
@@ -43,7 +43,7 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testNestedForeachStatementsAreCompiled()
+    public function testNestedForeachStatementsAreCompiled(): void
     {
         $string = '@foreach ($this->getUsers() as $user)
 user info
@@ -60,7 +60,7 @@ tag info
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testLoopContentHolderIsExtractedFromForeachStatements()
+    public function testLoopContentHolderIsExtractedFromForeachStatements(): void
     {
         $string = '@foreach ($some_uSers1 as $user)';
         $expected = '<?php $__currentLoopData = $some_uSers1; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';

--- a/tests/View/Blade/BladeForelseStatementsTest.php
+++ b/tests/View/Blade/BladeForelseStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeForelseStatementsTest extends AbstractBladeTestCase
 {
-    public function testForelseStatementsAreCompiled()
+    public function testForelseStatementsAreCompiled(): void
     {
         $string = '@forelse ($this->getUsers() as $user)
 breeze
@@ -19,7 +19,7 @@ empty
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testForelseStatementsAreCompiledWithUppercaseSyntax()
+    public function testForelseStatementsAreCompiledWithUppercaseSyntax(): void
     {
         $string = '@forelse ($this->getUsers() AS $user)
 breeze
@@ -34,7 +34,7 @@ empty
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testForelseStatementsAreCompiledWithMultipleLine()
+    public function testForelseStatementsAreCompiledWithMultipleLine(): void
     {
         $string = '@forelse ([
 foo,
@@ -55,7 +55,7 @@ empty
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testNestedForelseStatementsAreCompiled()
+    public function testNestedForelseStatementsAreCompiled(): void
     {
         $string = '@forelse ($this->getUsers() as $user)
 @forelse ($user->tags as $tag)

--- a/tests/View/Blade/BladeHasSectionTest.php
+++ b/tests/View/Blade/BladeHasSectionTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeHasSectionTest extends AbstractBladeTestCase
 {
-    public function testHasSectionStatementsAreCompiled()
+    public function testHasSectionStatementsAreCompiled(): void
     {
         $string = '@hasSection("section")
 breeze

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeHelpersTest extends AbstractBladeTestCase
 {
-    public function testEchosAreCompiled()
+    public function testEchosAreCompiled(): void
     {
         $this->assertEquals('<?php echo csrf_field(); ?>', $this->compiler->compileString('@csrf'));
         $this->assertEquals('<?php echo method_field(\'patch\'); ?>', $this->compiler->compileString("@method('patch')"));

--- a/tests/View/Blade/BladeIfAuthStatementsTest.php
+++ b/tests/View/Blade/BladeIfAuthStatementsTest.php
@@ -8,12 +8,12 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeIfAuthStatementsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testIfStatementsAreCompiled()
+    public function testIfStatementsAreCompiled(): void
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $string = '@auth("api")
@@ -25,7 +25,7 @@ breeze
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
-    public function testPlainIfStatementsAreCompiled()
+    public function testPlainIfStatementsAreCompiled(): void
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $string = '@auth

--- a/tests/View/Blade/BladeIfEmptyStatementsTest.php
+++ b/tests/View/Blade/BladeIfEmptyStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeIfEmptyStatementsTest extends AbstractBladeTestCase
 {
-    public function testIfStatementsAreCompiled()
+    public function testIfStatementsAreCompiled(): void
     {
         $string = '@empty ($test)
 breeze

--- a/tests/View/Blade/BladeIfGuestStatementsTest.php
+++ b/tests/View/Blade/BladeIfGuestStatementsTest.php
@@ -8,12 +8,12 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeIfGuestStatementsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testIfStatementsAreCompiled()
+    public function testIfStatementsAreCompiled(): void
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $string = '@guest("api")

--- a/tests/View/Blade/BladeIfIssetStatementsTest.php
+++ b/tests/View/Blade/BladeIfIssetStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeIfIssetStatementsTest extends AbstractBladeTestCase
 {
-    public function testIfStatementsAreCompiled()
+    public function testIfStatementsAreCompiled(): void
     {
         $string = '@isset ($test)
 breeze

--- a/tests/View/Blade/BladeIfStatementsTest.php
+++ b/tests/View/Blade/BladeIfStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeIfStatementsTest extends AbstractBladeTestCase
 {
-    public function testIfStatementsAreCompiled()
+    public function testIfStatementsAreCompiled(): void
     {
         $string = '@if (name(foo(bar)))
 breeze
@@ -15,7 +15,7 @@ breeze
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testSwitchstatementsAreCompiled()
+    public function testSwitchstatementsAreCompiled(): void
     {
         $string = '@switch(true)
 @case(1)

--- a/tests/View/Blade/BladeIncludeFirstTest.php
+++ b/tests/View/Blade/BladeIncludeFirstTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeIncludeFirstTest extends AbstractBladeTestCase
 {
-    public function testIncludeFirstsAreCompiled()
+    public function testIncludeFirstsAreCompiled(): void
     {
         $this->assertEquals('<?php echo $__env->first(["one", "two"], array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"])'));
         $this->assertEquals('<?php echo $__env->first(["one", "two"], ["foo" => "bar"], array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"], ["foo" => "bar"])'));

--- a/tests/View/Blade/BladeIncludeIfTest.php
+++ b/tests/View/Blade/BladeIncludeIfTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeIncludeIfTest extends AbstractBladeTestCase
 {
-    public function testIncludeIfsAreCompiled()
+    public function testIncludeIfsAreCompiled(): void
     {
         $this->assertEquals('<?php if ($__env->exists(\'foo\')) echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@includeIf(\'foo\')'));
         $this->assertEquals('<?php if ($__env->exists(name(foo))) echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@includeIf(name(foo))'));

--- a/tests/View/Blade/BladeIncludeTest.php
+++ b/tests/View/Blade/BladeIncludeTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeIncludeTest extends AbstractBladeTestCase
 {
-    public function testIncludesAreCompiled()
+    public function testIncludesAreCompiled(): void
     {
         $this->assertEquals('<?php echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@include(\'foo\')'));
         $this->assertEquals('<?php echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@include(name(foo))'));

--- a/tests/View/Blade/BladeIncludeWhenTest.php
+++ b/tests/View/Blade/BladeIncludeWhenTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeIncludeWhenTest extends AbstractBladeTestCase
 {
-    public function testIncludeWhensAreCompiled()
+    public function testIncludeWhensAreCompiled(): void
     {
         $this->assertEquals('<?php echo $__env->renderWhen(true, \'foo\', ["foo" => "bar"], array_except(get_defined_vars(), array(\'__data\', \'__path\'))); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\', ["foo" => "bar"])'));
         $this->assertEquals('<?php echo $__env->renderWhen(true, \'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\'))); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\')'));

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeJsonTest extends AbstractBladeTestCase
 {
-    public function testStatementIsCompiledWithSafeDefaultEncodingOptions()
+    public function testStatementIsCompiledWithSafeDefaultEncodingOptions(): void
     {
         $string = 'var foo = @json($var);';
         $expected = 'var foo = <?php echo json_encode($var, 15, 512) ?>;';
@@ -12,7 +12,7 @@ class BladeJsonTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testEncodingOptionsCanBeOverwritten()
+    public function testEncodingOptionsCanBeOverwritten(): void
     {
         $string = 'var foo = @json($var, JSON_HEX_TAG);';
         $expected = 'var foo = <?php echo json_encode($var, JSON_HEX_TAG, 512) ?>;';

--- a/tests/View/Blade/BladeLangTest.php
+++ b/tests/View/Blade/BladeLangTest.php
@@ -4,14 +4,14 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeLangTest extends AbstractBladeTestCase
 {
-    public function testStatementThatContainsNonConsecutiveParenthesisAreCompiled()
+    public function testStatementThatContainsNonConsecutiveParenthesisAreCompiled(): void
     {
         $string = "Foo @lang(function_call('foo(blah)')) bar";
         $expected = "Foo <?php echo app('translator')->getFromJson(function_call('foo(blah)')); ?> bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testLanguageAndChoicesAreCompiled()
+    public function testLanguageAndChoicesAreCompiled(): void
     {
         $this->assertEquals('<?php echo app(\'translator\')->getFromJson(\'foo\'); ?>', $this->compiler->compileString("@lang('foo')"));
         $this->assertEquals('<?php echo app(\'translator\')->choice(\'foo\', 1); ?>', $this->compiler->compileString("@choice('foo', 1)"));

--- a/tests/View/Blade/BladeOverwriteSectionTest.php
+++ b/tests/View/Blade/BladeOverwriteSectionTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeOverwriteSectionTest extends AbstractBladeTestCase
 {
-    public function testOverwriteSectionsAreCompiled()
+    public function testOverwriteSectionsAreCompiled(): void
     {
         $this->assertEquals('<?php $__env->stopSection(true); ?>', $this->compiler->compileString('@overwrite'));
     }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -4,14 +4,14 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladePhpStatementsTest extends AbstractBladeTestCase
 {
-    public function testPhpStatementsWithExpressionAreCompiled()
+    public function testPhpStatementsWithExpressionAreCompiled(): void
     {
         $string = '@php($set = true)';
         $expected = '<?php ($set = true); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testPhpStatementsWithoutExpressionAreIgnored()
+    public function testPhpStatementsWithoutExpressionAreIgnored(): void
     {
         $string = '@php';
         $expected = '@php';
@@ -22,14 +22,14 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testPhpStatementsDontParseBladeCode()
+    public function testPhpStatementsDontParseBladeCode(): void
     {
         $string = '@php echo "{{ This is a blade tag }}" @endphp';
         $expected = '<?php echo "{{ This is a blade tag }}" ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testVerbatimAndPhpStatementsDontGetMixedUp()
+    public function testVerbatimAndPhpStatementsDontGetMixedUp(): void
     {
         $string = "@verbatim {{ Hello, I'm not blade! }}"
                 ."\n@php echo 'And I'm not PHP!' @endphp"

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladePushTest extends AbstractBladeTestCase
 {
-    public function testPushIsCompiled()
+    public function testPushIsCompiled(): void
     {
         $string = '@push(\'foo\')
 test

--- a/tests/View/Blade/BladeSectionTest.php
+++ b/tests/View/Blade/BladeSectionTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeSectionTest extends AbstractBladeTestCase
 {
-    public function testSectionStartsAreCompiled()
+    public function testSectionStartsAreCompiled(): void
     {
         $this->assertEquals('<?php $__env->startSection(\'foo\'); ?>', $this->compiler->compileString('@section(\'foo\')'));
         $this->assertEquals('<?php $__env->startSection(name(foo)); ?>', $this->compiler->compileString('@section(name(foo))'));

--- a/tests/View/Blade/BladeShowTest.php
+++ b/tests/View/Blade/BladeShowTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeShowTest extends AbstractBladeTestCase
 {
-    public function testShowsAreCompiled()
+    public function testShowsAreCompiled(): void
     {
         $this->assertEquals('<?php echo $__env->yieldSection(); ?>', $this->compiler->compileString('@show'));
     }

--- a/tests/View/Blade/BladeStackTest.php
+++ b/tests/View/Blade/BladeStackTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeStackTest extends AbstractBladeTestCase
 {
-    public function testStackIsCompiled()
+    public function testStackIsCompiled(): void
     {
         $string = '@stack(\'foo\')';
         $expected = '<?php echo $__env->yieldPushContent(\'foo\'); ?>';

--- a/tests/View/Blade/BladeStopSectionTest.php
+++ b/tests/View/Blade/BladeStopSectionTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeStopSectionTest extends AbstractBladeTestCase
 {
-    public function testStopSectionsAreCompiled()
+    public function testStopSectionsAreCompiled(): void
     {
         $this->assertEquals('<?php $__env->stopSection(); ?>', $this->compiler->compileString('@stop'));
     }

--- a/tests/View/Blade/BladeUnlessStatementsTest.php
+++ b/tests/View/Blade/BladeUnlessStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeUnlessStatementsTest extends AbstractBladeTestCase
 {
-    public function testUnlessStatementsAreCompiled()
+    public function testUnlessStatementsAreCompiled(): void
     {
         $string = '@unless (name(foo(bar)))
 breeze

--- a/tests/View/Blade/BladeUnsetStatementsTest.php
+++ b/tests/View/Blade/BladeUnsetStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeUnsetStatementsTest extends AbstractBladeTestCase
 {
-    public function testUnsetStatementsAreCompiled()
+    public function testUnsetStatementsAreCompiled(): void
     {
         $string = '@unset ($unset)';
         $expected = '<?php unset($unset); ?>';

--- a/tests/View/Blade/BladeVerbatimTest.php
+++ b/tests/View/Blade/BladeVerbatimTest.php
@@ -4,14 +4,14 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeVerbatimTest extends AbstractBladeTestCase
 {
-    public function testVerbatimBlocksAreCompiled()
+    public function testVerbatimBlocksAreCompiled(): void
     {
         $string = '@verbatim {{ $a }} @if($b) {{ $b }} @endif @endverbatim';
         $expected = ' {{ $a }} @if($b) {{ $b }} @endif ';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testVerbatimBlocksWithMultipleLinesAreCompiled()
+    public function testVerbatimBlocksWithMultipleLinesAreCompiled(): void
     {
         $string = 'Some text
 @verbatim
@@ -30,14 +30,14 @@ class BladeVerbatimTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testMultipleVerbatimBlocksAreCompiled()
+    public function testMultipleVerbatimBlocksAreCompiled(): void
     {
         $string = '@verbatim {{ $a }} @endverbatim {{ $b }} @verbatim {{ $c }} @endverbatim';
         $expected = ' {{ $a }}  <?php echo e($b); ?>  {{ $c }} ';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testRawBlocksAreRenderedInTheRightOrder()
+    public function testRawBlocksAreRenderedInTheRightOrder(): void
     {
         $string = '@php echo "#1"; @endphp @verbatim {{ #2 }} @endverbatim @verbatim {{ #3 }} @endverbatim @php echo "#4"; @endphp';
 
@@ -46,7 +46,7 @@ class BladeVerbatimTest extends AbstractBladeTestCase
         $this->assertSame($expected, $this->compiler->compileString($string));
     }
 
-    public function testMultilineTemplatesWithRawBlocksAreRenderedInTheRightOrder()
+    public function testMultilineTemplatesWithRawBlocksAreRenderedInTheRightOrder(): void
     {
         $string = '{{ $first }}
 @php
@@ -79,7 +79,7 @@ class BladeVerbatimTest extends AbstractBladeTestCase
         $this->assertSame($expected, $this->compiler->compileString($string));
     }
 
-    public function testRawBlocksDontGetMixedUpWhenSomeAreRemovedByBladeComments()
+    public function testRawBlocksDontGetMixedUpWhenSomeAreRemovedByBladeComments(): void
     {
         $string = '{{-- @verbatim Block #1 @endverbatim --}} @php "Block #2" @endphp';
         $expected = ' <?php "Block #2" ?>';

--- a/tests/View/Blade/BladeWhileStatementsTest.php
+++ b/tests/View/Blade/BladeWhileStatementsTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeWhileStatementsTest extends AbstractBladeTestCase
 {
-    public function testWhileStatementsAreCompiled()
+    public function testWhileStatementsAreCompiled(): void
     {
         $string = '@while ($foo)
 test
@@ -15,7 +15,7 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testNestedWhileStatementsAreCompiled()
+    public function testNestedWhileStatementsAreCompiled(): void
     {
         $string = '@while ($foo)
 @while ($bar)

--- a/tests/View/Blade/BladeYieldTest.php
+++ b/tests/View/Blade/BladeYieldTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeYieldTest extends AbstractBladeTestCase
 {
-    public function testYieldsAreCompiled()
+    public function testYieldsAreCompiled(): void
     {
         $this->assertEquals('<?php echo $__env->yieldContent(\'foo\'); ?>', $this->compiler->compileString('@yield(\'foo\')'));
         $this->assertEquals('<?php echo $__env->yieldContent(\'foo\', \'bar\'); ?>', $this->compiler->compileString('@yield(\'foo\', \'bar\')'));

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -8,12 +8,12 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class ViewBladeCompilerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testIsExpiredReturnsTrueIfCompiledFileDoesntExist()
+    public function testIsExpiredReturnsTrueIfCompiledFileDoesntExist(): void
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/'.sha1('foo').'.php')->andReturn(false);
@@ -24,12 +24,12 @@ class ViewBladeCompilerTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Please provide a valid cache path.
      */
-    public function testCannotConstructWithBadCachePath()
+    public function testCannotConstructWithBadCachePath(): void
     {
         new BladeCompiler($this->getFiles(), null);
     }
 
-    public function testIsExpiredReturnsTrueWhenModificationTimesWarrant()
+    public function testIsExpiredReturnsTrueWhenModificationTimesWarrant(): void
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/'.sha1('foo').'.php')->andReturn(true);
@@ -38,13 +38,13 @@ class ViewBladeCompilerTest extends TestCase
         $this->assertTrue($compiler->isExpired('foo'));
     }
 
-    public function testCompilePathIsProperlyCreated()
+    public function testCompilePathIsProperlyCreated(): void
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $this->assertEquals(__DIR__.'/'.sha1('foo').'.php', $compiler->getCompiledPath('foo'));
     }
 
-    public function testCompileCompilesFileAndReturnsContents()
+    public function testCompileCompilesFileAndReturnsContents(): void
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
@@ -52,7 +52,7 @@ class ViewBladeCompilerTest extends TestCase
         $compiler->compile('foo');
     }
 
-    public function testCompileCompilesAndGetThePath()
+    public function testCompileCompilesAndGetThePath(): void
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
@@ -61,14 +61,14 @@ class ViewBladeCompilerTest extends TestCase
         $this->assertEquals('foo', $compiler->getPath());
     }
 
-    public function testCompileSetAndGetThePath()
+    public function testCompileSetAndGetThePath(): void
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $compiler->setPath('foo');
         $this->assertEquals('foo', $compiler->getPath());
     }
 
-    public function testCompileWithPathSetBefore()
+    public function testCompileWithPathSetBefore(): void
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
@@ -80,7 +80,7 @@ class ViewBladeCompilerTest extends TestCase
         $this->assertEquals('foo', $compiler->getPath());
     }
 
-    public function testRawTagsCanBeSetToLegacyValues()
+    public function testRawTagsCanBeSetToLegacyValues(): void
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $compiler->setEchoFormat('%s');

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -8,12 +8,12 @@ use Illuminate\View\Engines\CompilerEngine;
 
 class ViewCompilerEngineTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testViewsMayBeRecompiledAndRendered()
+    public function testViewsMayBeRecompiledAndRendered(): void
     {
         $engine = $this->getEngine();
         $engine->getCompiler()->shouldReceive('getCompiledPath')->with(__DIR__.'/fixtures/foo.php')->andReturn(__DIR__.'/fixtures/basic.php');
@@ -25,7 +25,7 @@ class ViewCompilerEngineTest extends TestCase
 ', $results);
     }
 
-    public function testViewsAreNotRecompiledIfTheyAreNotExpired()
+    public function testViewsAreNotRecompiledIfTheyAreNotExpired(): void
     {
         $engine = $this->getEngine();
         $engine->getCompiler()->shouldReceive('getCompiledPath')->with(__DIR__.'/fixtures/foo.php')->andReturn(__DIR__.'/fixtures/basic.php');

--- a/tests/View/ViewEngineResolverTest.php
+++ b/tests/View/ViewEngineResolverTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class ViewEngineResolverTest extends TestCase
 {
-    public function testResolversMayBeResolved()
+    public function testResolversMayBeResolved(): void
     {
         $resolver = new \Illuminate\View\Engines\EngineResolver;
         $resolver->register('foo', function () {
@@ -21,7 +21,7 @@ class ViewEngineResolverTest extends TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testResolverThrowsExceptionOnUnknownEngine()
+    public function testResolverThrowsExceptionOnUnknownEngine(): void
     {
         $resolver = new \Illuminate\View\Engines\EngineResolver;
         $resolver->resolve('foo');

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -9,12 +9,12 @@ use PHPUnit\Framework\TestCase;
 
 class ViewFactoryTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testMakeCreatesNewViewInstanceWithProperPathAndEngine()
+    public function testMakeCreatesNewViewInstanceWithProperPathAndEngine(): void
     {
         unset($_SERVER['__test.view']);
 
@@ -35,7 +35,7 @@ class ViewFactoryTest extends TestCase
         unset($_SERVER['__test.view']);
     }
 
-    public function testExistsPassesAndFailsViews()
+    public function testExistsPassesAndFailsViews(): void
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->once()->with('foo')->andThrow('InvalidArgumentException');
@@ -45,7 +45,7 @@ class ViewFactoryTest extends TestCase
         $this->assertTrue($factory->exists('bar'));
     }
 
-    public function testFirstCreatesNewViewInstanceWithProperPath()
+    public function testFirstCreatesNewViewInstanceWithProperPath(): void
     {
         unset($_SERVER['__test.view']);
 
@@ -70,7 +70,7 @@ class ViewFactoryTest extends TestCase
     /**
      * @expectedException InvalidArgumentException
      */
-    public function testFirstThrowsInvalidArgumentExceptionIfNoneFound()
+    public function testFirstThrowsInvalidArgumentExceptionIfNoneFound(): void
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->once()->with('view')->andThrow('InvalidArgumentException');
@@ -81,7 +81,7 @@ class ViewFactoryTest extends TestCase
         $view = $factory->first(['bar', 'view'], ['foo' => 'bar'], ['baz' => 'boom']);
     }
 
-    public function testRenderEachCreatesViewForEachItemInArray()
+    public function testRenderEachCreatesViewForEachItemInArray(): void
     {
         $factory = m::mock('Illuminate\View\Factory[make]', $this->getFactoryArgs());
         $factory->shouldReceive('make')->once()->with('foo', ['key' => 'bar', 'value' => 'baz'])->andReturn($mockView1 = m::mock('stdClass'));
@@ -94,7 +94,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('daylerees', $result);
     }
 
-    public function testEmptyViewsCanBeReturnedFromRenderEach()
+    public function testEmptyViewsCanBeReturnedFromRenderEach(): void
     {
         $factory = m::mock('Illuminate\View\Factory[make]', $this->getFactoryArgs());
         $factory->shouldReceive('make')->once()->with('foo')->andReturn($mockView = m::mock('stdClass'));
@@ -103,12 +103,12 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('empty', $factory->renderEach('view', [], 'iterator', 'foo'));
     }
 
-    public function testRawStringsMayBeReturnedFromRenderEach()
+    public function testRawStringsMayBeReturnedFromRenderEach(): void
     {
         $this->assertEquals('foo', $this->getFactory()->renderEach('foo', [], 'item', 'raw|foo'));
     }
 
-    public function testEnvironmentAddsExtensionWithCustomResolver()
+    public function testEnvironmentAddsExtensionWithCustomResolver(): void
     {
         $factory = $this->getFactory();
 
@@ -128,7 +128,7 @@ class ViewFactoryTest extends TestCase
         $this->assertSame($engine, $view->getEngine());
     }
 
-    public function testAddingExtensionPrependsNotAppends()
+    public function testAddingExtensionPrependsNotAppends(): void
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('addExtension')->once()->with('foo');
@@ -140,7 +140,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('foo', key($extensions));
     }
 
-    public function testPrependedExtensionOverridesExistingExtensions()
+    public function testPrependedExtensionOverridesExistingExtensions(): void
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('addExtension')->once()->with('foo');
@@ -154,7 +154,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('baz', key($extensions));
     }
 
-    public function testComposersAreProperlyRegistered()
+    public function testComposersAreProperlyRegistered(): void
     {
         $factory = $this->getFactory();
         $factory->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type('Closure'));
@@ -166,7 +166,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('bar', $callback());
     }
 
-    public function testComposersCanBeMassRegistered()
+    public function testComposersCanBeMassRegistered(): void
     {
         $factory = $this->getFactory();
         $factory->getDispatcher()->shouldReceive('listen')->once()->with('composing: bar', m::type('Closure'));
@@ -186,7 +186,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals(['class' => 'baz', 'method' => 'baz'], $reflections[1]->getStaticVariables());
     }
 
-    public function testClassCallbacks()
+    public function testClassCallbacks(): void
     {
         $factory = $this->getFactory();
         $factory->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type('Closure'));
@@ -199,7 +199,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('composed', $callback('view'));
     }
 
-    public function testClassCallbacksWithMethods()
+    public function testClassCallbacksWithMethods(): void
     {
         $factory = $this->getFactory();
         $factory->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type('Closure'));
@@ -212,7 +212,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('composed', $callback('view'));
     }
 
-    public function testCallComposerCallsProperEvent()
+    public function testCallComposerCallsProperEvent(): void
     {
         $factory = $this->getFactory();
         $view = m::mock(\Illuminate\View\View::class);
@@ -222,7 +222,7 @@ class ViewFactoryTest extends TestCase
         $factory->callComposer($view);
     }
 
-    public function testComposersAreRegisteredWithSlashAndDot()
+    public function testComposersAreRegisteredWithSlashAndDot(): void
     {
         $factory = $this->getFactory();
         $factory->getDispatcher()->shouldReceive('listen')->with('composing: foo.bar', m::any())->twice();
@@ -230,7 +230,7 @@ class ViewFactoryTest extends TestCase
         $factory->composer('foo/bar', '');
     }
 
-    public function testRenderCountHandling()
+    public function testRenderCountHandling(): void
     {
         $factory = $this->getFactory();
         $factory->incrementRender();
@@ -239,19 +239,19 @@ class ViewFactoryTest extends TestCase
         $this->assertTrue($factory->doneRendering());
     }
 
-    public function testYieldDefault()
+    public function testYieldDefault(): void
     {
         $factory = $this->getFactory();
         $this->assertEquals('hi', $factory->yieldContent('foo', 'hi'));
     }
 
-    public function testYieldDefaultIsEscaped()
+    public function testYieldDefaultIsEscaped(): void
     {
         $factory = $this->getFactory();
         $this->assertEquals('&lt;p&gt;hi&lt;/p&gt;', $factory->yieldContent('foo', '<p>hi</p>'));
     }
 
-    public function testYieldDefaultViewIsNotEscapedTwice()
+    public function testYieldDefaultViewIsNotEscapedTwice(): void
     {
         $factory = $this->getFactory();
         $view = m::mock('Illuminate\View\View');
@@ -259,7 +259,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('<p>hi</p>&lt;p&gt;already escaped&lt;/p&gt;', $factory->yieldContent('foo', $view));
     }
 
-    public function testBasicSectionHandling()
+    public function testBasicSectionHandling(): void
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');
@@ -268,21 +268,21 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('hi', $factory->yieldContent('foo'));
     }
 
-    public function testBasicSectionDefault()
+    public function testBasicSectionDefault(): void
     {
         $factory = $this->getFactory();
         $factory->startSection('foo', 'hi');
         $this->assertEquals('hi', $factory->yieldContent('foo'));
     }
 
-    public function testBasicSectionDefaultIsEscaped()
+    public function testBasicSectionDefaultIsEscaped(): void
     {
         $factory = $this->getFactory();
         $factory->startSection('foo', '<p>hi</p>');
         $this->assertEquals('&lt;p&gt;hi&lt;/p&gt;', $factory->yieldContent('foo'));
     }
 
-    public function testBasicSectionDefaultViewIsNotEscapedTwice()
+    public function testBasicSectionDefaultViewIsNotEscapedTwice(): void
     {
         $factory = $this->getFactory();
         $view = m::mock('Illuminate\View\View');
@@ -291,7 +291,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('<p>hi</p>&lt;p&gt;already escaped&lt;/p&gt;', $factory->yieldContent('foo'));
     }
 
-    public function testSectionExtending()
+    public function testSectionExtending(): void
     {
         $placeholder = \Illuminate\View\Factory::parentPlaceholder('foo');
         $factory = $this->getFactory();
@@ -304,7 +304,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('hi there', $factory->yieldContent('foo'));
     }
 
-    public function testSectionMultipleExtending()
+    public function testSectionMultipleExtending(): void
     {
         $placeholder = \Illuminate\View\Factory::parentPlaceholder('foo');
         $factory = $this->getFactory();
@@ -320,7 +320,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('hello my friend nice to see you my friend', $factory->yieldContent('foo'));
     }
 
-    public function testComponentHandling()
+    public function testComponentHandling(): void
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->andReturn(__DIR__.'/fixtures/component.php');
@@ -336,7 +336,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('title<hr> component Taylor laravel.com', $contents);
     }
 
-    public function testTranslation()
+    public function testTranslation(): void
     {
         $container = new \Illuminate\Container\Container;
         $container->instance('translator', $translator = m::mock('stdClass'));
@@ -350,7 +350,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('Bar', $string);
     }
 
-    public function testSingleStackPush()
+    public function testSingleStackPush(): void
     {
         $factory = $this->getFactory();
         $factory->startPush('foo');
@@ -359,7 +359,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('hi', $factory->yieldPushContent('foo'));
     }
 
-    public function testMultipleStackPush()
+    public function testMultipleStackPush(): void
     {
         $factory = $this->getFactory();
         $factory->startPush('foo');
@@ -371,7 +371,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('hi, Hello!', $factory->yieldPushContent('foo'));
     }
 
-    public function testSessionAppending()
+    public function testSessionAppending(): void
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');
@@ -383,7 +383,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('hithere', $factory->yieldContent('foo'));
     }
 
-    public function testYieldSectionStopsAndYields()
+    public function testYieldSectionStopsAndYields(): void
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');
@@ -391,20 +391,20 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('hi', $factory->yieldSection());
     }
 
-    public function testInjectStartsSectionWithContent()
+    public function testInjectStartsSectionWithContent(): void
     {
         $factory = $this->getFactory();
         $factory->inject('foo', 'hi');
         $this->assertEquals('hi', $factory->yieldContent('foo'));
     }
 
-    public function testEmptyStringIsReturnedForNonSections()
+    public function testEmptyStringIsReturnedForNonSections(): void
     {
         $factory = $this->getFactory();
         $this->assertEmpty($factory->yieldContent('foo'));
     }
 
-    public function testSectionFlushing()
+    public function testSectionFlushing(): void
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');
@@ -418,7 +418,7 @@ class ViewFactoryTest extends TestCase
         $this->assertCount(0, $factory->getSections());
     }
 
-    public function testHasSection()
+    public function testHasSection(): void
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');
@@ -429,7 +429,7 @@ class ViewFactoryTest extends TestCase
         $this->assertFalse($factory->hasSection('bar'));
     }
 
-    public function testGetSection()
+    public function testGetSection(): void
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');
@@ -441,7 +441,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('default', $factory->getSection('bar', 'default'));
     }
 
-    public function testMakeWithSlashAndDot()
+    public function testMakeWithSlashAndDot(): void
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->twice()->with('foo.bar')->andReturn('path.php');
@@ -451,7 +451,7 @@ class ViewFactoryTest extends TestCase
         $factory->make('foo.bar');
     }
 
-    public function testNamespacedViewNamesAreNormalizedProperly()
+    public function testNamespacedViewNamesAreNormalizedProperly(): void
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->twice()->with('vendor/package::foo.bar')->andReturn('path.php');
@@ -464,7 +464,7 @@ class ViewFactoryTest extends TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testExceptionIsThrownForUnknownExtension()
+    public function testExceptionIsThrownForUnknownExtension(): void
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->once()->with('view')->andReturn('view.foo');
@@ -475,7 +475,7 @@ class ViewFactoryTest extends TestCase
      * @expectedException \ErrorException
      * @expectedExceptionMessage section exception message
      */
-    public function testExceptionsInSectionsAreThrown()
+    public function testExceptionsInSectionsAreThrown(): void
     {
         $engine = new \Illuminate\View\Engines\CompilerEngine(m::mock(\Illuminate\View\Compilers\CompilerInterface::class));
         $engine->getCompiler()->shouldReceive('getCompiledPath')->andReturnUsing(function ($path) {
@@ -495,7 +495,7 @@ class ViewFactoryTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Cannot end a section without first starting one.
      */
-    public function testExtraStopSectionCallThrowsException()
+    public function testExtraStopSectionCallThrowsException(): void
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');
@@ -508,7 +508,7 @@ class ViewFactoryTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Cannot end a section without first starting one.
      */
-    public function testExtraAppendSectionCallThrowsException()
+    public function testExtraAppendSectionCallThrowsException(): void
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');
@@ -517,7 +517,7 @@ class ViewFactoryTest extends TestCase
         $factory->appendSection();
     }
 
-    public function testAddingLoops()
+    public function testAddingLoops(): void
     {
         $factory = $this->getFactory();
 
@@ -555,7 +555,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals([$expectedLoop], $factory->getLoopStack());
     }
 
-    public function testAddingTraversableLoop()
+    public function testAddingTraversableLoop(): void
     {
         $factory = $this->getFactory();
 
@@ -577,7 +577,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals([$expectedLoop], $factory->getLoopStack());
     }
 
-    public function testAddingUncountableLoop()
+    public function testAddingUncountableLoop(): void
     {
         $factory = $this->getFactory();
 
@@ -597,7 +597,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals([$expectedLoop], $factory->getLoopStack());
     }
 
-    public function testIncrementingLoopIndices()
+    public function testIncrementingLoopIndices(): void
     {
         $factory = $this->getFactory();
 
@@ -612,7 +612,7 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals(2, $factory->getLoopStack()[0]['remaining']);
     }
 
-    public function testReachingEndOfLoop()
+    public function testReachingEndOfLoop(): void
     {
         $factory = $this->getFactory();
 
@@ -625,7 +625,7 @@ class ViewFactoryTest extends TestCase
         $this->assertTrue($factory->getLoopStack()[0]['last']);
     }
 
-    public function testIncrementingLoopIndicesOfUncountable()
+    public function testIncrementingLoopIndicesOfUncountable(): void
     {
         $factory = $this->getFactory();
 

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class ViewFileViewFinderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testBasicViewFinding()
+    public function testBasicViewFinding(): void
     {
         $finder = $this->getFinder();
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(true);
@@ -20,7 +20,7 @@ class ViewFileViewFinderTest extends TestCase
         $this->assertEquals(__DIR__.'/foo.blade.php', $finder->find('foo'));
     }
 
-    public function testCascadingFileLoading()
+    public function testCascadingFileLoading(): void
     {
         $finder = $this->getFinder();
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(false);
@@ -29,7 +29,7 @@ class ViewFileViewFinderTest extends TestCase
         $this->assertEquals(__DIR__.'/foo.php', $finder->find('foo'));
     }
 
-    public function testDirectoryCascadingFileLoading()
+    public function testDirectoryCascadingFileLoading(): void
     {
         $finder = $this->getFinder();
         $finder->addLocation(__DIR__.'/nested');
@@ -41,7 +41,7 @@ class ViewFileViewFinderTest extends TestCase
         $this->assertEquals(__DIR__.'/nested/foo.blade.php', $finder->find('foo'));
     }
 
-    public function testNamespacedBasicFileLoading()
+    public function testNamespacedBasicFileLoading(): void
     {
         $finder = $this->getFinder();
         $finder->addNamespace('foo', __DIR__.'/foo');
@@ -50,7 +50,7 @@ class ViewFileViewFinderTest extends TestCase
         $this->assertEquals(__DIR__.'/foo/bar/baz.blade.php', $finder->find('foo::bar.baz'));
     }
 
-    public function testCascadingNamespacedFileLoading()
+    public function testCascadingNamespacedFileLoading(): void
     {
         $finder = $this->getFinder();
         $finder->addNamespace('foo', __DIR__.'/foo');
@@ -60,7 +60,7 @@ class ViewFileViewFinderTest extends TestCase
         $this->assertEquals(__DIR__.'/foo/bar/baz.php', $finder->find('foo::bar.baz'));
     }
 
-    public function testDirectoryCascadingNamespacedFileLoading()
+    public function testDirectoryCascadingNamespacedFileLoading(): void
     {
         $finder = $this->getFinder();
         $finder->addNamespace('foo', [__DIR__.'/foo', __DIR__.'/bar']);
@@ -75,7 +75,7 @@ class ViewFileViewFinderTest extends TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testExceptionThrownWhenViewNotFound()
+    public function testExceptionThrownWhenViewNotFound(): void
     {
         $finder = $this->getFinder();
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(false);
@@ -89,7 +89,7 @@ class ViewFileViewFinderTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage No hint path defined for [name].
      */
-    public function testExceptionThrownOnInvalidViewName()
+    public function testExceptionThrownOnInvalidViewName(): void
     {
         $finder = $this->getFinder();
         $finder->find('name::');
@@ -99,13 +99,13 @@ class ViewFileViewFinderTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage No hint path defined for [name].
      */
-    public function testExceptionThrownWhenNoHintPathIsRegistered()
+    public function testExceptionThrownWhenNoHintPathIsRegistered(): void
     {
         $finder = $this->getFinder();
         $finder->find('name::foo');
     }
 
-    public function testAddingExtensionPrependsNotAppends()
+    public function testAddingExtensionPrependsNotAppends(): void
     {
         $finder = $this->getFinder();
         $finder->addExtension('baz');
@@ -113,7 +113,7 @@ class ViewFileViewFinderTest extends TestCase
         $this->assertEquals('baz', reset($extensions));
     }
 
-    public function testAddingExtensionsReplacesOldOnes()
+    public function testAddingExtensionsReplacesOldOnes(): void
     {
         $finder = $this->getFinder();
         $finder->addExtension('baz');
@@ -122,21 +122,21 @@ class ViewFileViewFinderTest extends TestCase
         $this->assertCount(4, $finder->getExtensions());
     }
 
-    public function testPassingViewWithHintReturnsTrue()
+    public function testPassingViewWithHintReturnsTrue(): void
     {
         $finder = $this->getFinder();
 
         $this->assertTrue($finder->hasHintInformation('hint::foo.bar'));
     }
 
-    public function testPassingViewWithoutHintReturnsFalse()
+    public function testPassingViewWithoutHintReturnsFalse(): void
     {
         $finder = $this->getFinder();
 
         $this->assertFalse($finder->hasHintInformation('foo.bar'));
     }
 
-    public function testPassingViewWithFalseHintReturnsFalse()
+    public function testPassingViewWithFalseHintReturnsFalse(): void
     {
         $finder = $this->getFinder();
 

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -8,12 +8,12 @@ use Illuminate\View\Engines\PhpEngine;
 
 class ViewPhpEngineTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testViewsMayBeProperlyRendered()
+    public function testViewsMayBeProperlyRendered(): void
     {
         $engine = new PhpEngine;
         $this->assertEquals('Hello World

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -8,12 +8,12 @@ use PHPUnit\Framework\TestCase;
 
 class ViewTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testDataCanBeSetOnView()
+    public function testDataCanBeSetOnView(): void
     {
         $view = $this->getView();
         $view->with('foo', 'bar');
@@ -25,7 +25,7 @@ class ViewTest extends TestCase
         $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], $view->getData());
     }
 
-    public function testRenderProperlyRendersView()
+    public function testRenderProperlyRendersView(): void
     {
         $view = $this->getView(['foo' => 'bar']);
         $view->getFactory()->shouldReceive('incrementRender')->once()->ordered();
@@ -43,7 +43,7 @@ class ViewTest extends TestCase
         $this->assertEquals('contents', $view->render($callback));
     }
 
-    public function testRenderHandlingCallbackReturnValues()
+    public function testRenderHandlingCallbackReturnValues(): void
     {
         $view = $this->getView();
         $view->getFactory()->shouldReceive('incrementRender');
@@ -66,7 +66,7 @@ class ViewTest extends TestCase
         }));
     }
 
-    public function testRenderSectionsReturnsEnvironmentSections()
+    public function testRenderSectionsReturnsEnvironmentSections(): void
     {
         $view = m::mock('Illuminate\View\View[render]', [
             m::mock('Illuminate\View\Factory'),
@@ -81,7 +81,7 @@ class ViewTest extends TestCase
         $this->assertEquals($sections, $view->renderSections());
     }
 
-    public function testSectionsAreNotFlushedWhenNotDoneRendering()
+    public function testSectionsAreNotFlushedWhenNotDoneRendering(): void
     {
         $view = $this->getView(['foo' => 'bar']);
         $view->getFactory()->shouldReceive('incrementRender')->twice();
@@ -95,7 +95,7 @@ class ViewTest extends TestCase
         $this->assertEquals('contents', (string) $view);
     }
 
-    public function testViewNestBindsASubView()
+    public function testViewNestBindsASubView(): void
     {
         $view = $this->getView();
         $view->getFactory()->shouldReceive('make')->once()->with('foo', ['data']);
@@ -104,7 +104,7 @@ class ViewTest extends TestCase
         $this->assertInstanceOf('Illuminate\View\View', $result);
     }
 
-    public function testViewAcceptsArrayableImplementations()
+    public function testViewAcceptsArrayableImplementations(): void
     {
         $arrayable = m::mock('Illuminate\Contracts\Support\Arrayable');
         $arrayable->shouldReceive('toArray')->once()->andReturn(['foo' => 'bar', 'baz' => ['qux', 'corge']]);
@@ -115,7 +115,7 @@ class ViewTest extends TestCase
         $this->assertEquals(['qux', 'corge'], $view->baz);
     }
 
-    public function testViewGettersSetters()
+    public function testViewGettersSetters(): void
     {
         $view = $this->getView(['foo' => 'bar']);
         $this->assertEquals($view->getName(), 'view');
@@ -126,7 +126,7 @@ class ViewTest extends TestCase
         $this->assertEquals($view->getPath(), 'newPath');
     }
 
-    public function testViewArrayAccess()
+    public function testViewArrayAccess(): void
     {
         $view = $this->getView(['foo' => 'bar']);
         $this->assertInstanceOf('ArrayAccess', $view);
@@ -138,7 +138,7 @@ class ViewTest extends TestCase
         $this->assertFalse($view->offsetExists('foo'));
     }
 
-    public function testViewConstructedWithObjectData()
+    public function testViewConstructedWithObjectData(): void
     {
         $view = $this->getView(new DataObjectStub);
         $this->assertInstanceOf('ArrayAccess', $view);
@@ -150,7 +150,7 @@ class ViewTest extends TestCase
         $this->assertFalse($view->offsetExists('foo'));
     }
 
-    public function testViewMagicMethods()
+    public function testViewMagicMethods(): void
     {
         $view = $this->getView(['foo' => 'bar']);
         $this->assertTrue(isset($view->foo));
@@ -167,13 +167,13 @@ class ViewTest extends TestCase
      * @expectedException \BadMethodCallException
      * @expectedExceptionMessage Method Illuminate\View\View::badMethodCall does not exist.
      */
-    public function testViewBadMethod()
+    public function testViewBadMethod(): void
     {
         $view = $this->getView();
         $view->badMethodCall();
     }
 
-    public function testViewGatherDataWithRenderable()
+    public function testViewGatherDataWithRenderable(): void
     {
         $view = $this->getView();
         $view->getFactory()->shouldReceive('incrementRender')->once()->ordered();
@@ -188,7 +188,7 @@ class ViewTest extends TestCase
         $this->assertEquals('contents', $view->render());
     }
 
-    public function testViewRenderSections()
+    public function testViewRenderSections(): void
     {
         $view = $this->getView();
         $view->getFactory()->shouldReceive('incrementRender')->once()->ordered();
@@ -204,7 +204,7 @@ class ViewTest extends TestCase
         $this->assertEquals($sections[1], 'bar');
     }
 
-    public function testWithErrors()
+    public function testWithErrors(): void
     {
         $view = $this->getView();
         $errors = ['foo' => 'bar', 'qu' => 'ux'];


### PR DESCRIPTION
First of its kind, I'd like to propose the addition of return/parameters types to our codebase in the next version of Laravel.

I've first added `void` return type to all our tests, `setUp` and `tearDown` method.

Here're the two tests I've also removed useless return:
- `testDefaultUnauthenticatedThrowsWithGuards`
- `testMultipleDriversUnauthenticatedThrowsWithGuards`