### PR TITLE
[5.7] Add queue payload customization feature

### DIFF
--- a/src/Illuminate/Contracts/Queue/PayloadSerializer.php
+++ b/src/Illuminate/Contracts/Queue/PayloadSerializer.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Contracts\Queue;
+
+interface PayloadSerializer
+{
+    /**
+     * @param array $payloadArray
+     * @return string
+     */
+    public function serialize($payloadArray);
+
+    /**
+     * @param string $raw
+     * @param string $connectionName
+     * @param string $queueName
+     * @return array
+     */
+    public function unserialize($raw, $connectionName, $queueName);
+
+    /**
+     * Create a payload array from the given job and data.
+     *
+     * @param  string $connectionName
+     * @param  string $queueName
+     * @param  string $job
+     * @param  mixed  $data
+     * @return array
+     */
+    public function createPayloadArray($connectionName, $queueName, $job, $data = '');
+}

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -68,7 +68,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function push($job, $data = '', $queue = null)
     {
-        return $this->pushRaw($this->createPayload($job, $data), $queue);
+        return $this->pushRaw($this->createPayload($this->getQueue($queue), $job, $data), $queue);
     }
 
     /**

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -78,7 +78,7 @@ class DatabaseQueue extends Queue implements QueueContract
      */
     public function push($job, $data = '', $queue = null)
     {
-        return $this->pushToDatabase($queue, $this->createPayload($job, $data));
+        return $this->pushToDatabase($queue, $this->createPayload($this->getQueue($queue), $job, $data));
     }
 
     /**

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue\Jobs;
 
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Queue\PayloadSerializerManager;
 
 abstract class Job
 {
@@ -185,13 +186,31 @@ abstract class Job
     }
 
     /**
+     * @return \Illuminate\Queue\PayloadSerializerManager
+     */
+    protected function getPayloadSerializerManager()
+    {
+        return $this->container->make(PayloadSerializerManager::class);
+    }
+
+    /**
+     * @param $connectionName
+     * @return \Illuminate\Contracts\Queue\PayloadSerializer
+     */
+    protected function getPayloadSerializer($connectionName)
+    {
+        return $this->getPayloadSerializerManager()->getSerializer($connectionName);
+    }
+
+    /**
      * Get the decoded body of the job.
      *
      * @return array
      */
     public function payload()
     {
-        return json_decode($this->getRawBody(), true);
+        return $this->getPayloadSerializer($this->getConnectionName())
+            ->unserialize($this->getRawBody(), $this->getConnectionName(), $this->getQueue());
     }
 
     /**

--- a/src/Illuminate/Queue/PayloadSerializer.php
+++ b/src/Illuminate/Queue/PayloadSerializer.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use DateTimeInterface;
+use Illuminate\Contracts\Queue\PayloadSerializer as PayloadSerializerContract;
+
+class PayloadSerializer implements PayloadSerializerContract
+{
+    /**
+     * @param array $payloadArray
+     * @return string
+     */
+    public function serialize($payloadArray)
+    {
+        $payload = json_encode($payloadArray);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new InvalidPayloadException(
+                'Unable to JSON encode payload. Error code: ' . json_last_error()
+            );
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param string $raw
+     * @param string $connectionName
+     * @param string $queueName
+     * @return array
+     */
+    public function unserialize($raw, $connectionName, $queueName)
+    {
+        return json_decode($raw, true);
+    }
+
+    /**
+     * Create a payload array from the given job and data.
+     *
+     * @param  string $connectionName
+     * @param  string $queueName
+     * @param  string $job
+     * @param  mixed  $data
+     * @return array
+     */
+    public function createPayloadArray($connectionName, $queueName, $job, $data = '')
+    {
+        return is_object($job)
+            ? $this->createObjectPayload($job)
+            : $this->createStringPayload($job, $data);
+    }
+
+    /**
+     * Create a payload for an object-based queue handler.
+     *
+     * @param  mixed $job
+     * @return array
+     */
+    protected function createObjectPayload($job)
+    {
+        return [
+            'displayName' => $this->getDisplayName($job),
+            'job'         => 'Illuminate\Queue\CallQueuedHandler@call',
+            'maxTries'    => $job->tries ?? null,
+            'timeout'     => $job->timeout ?? null,
+            'timeoutAt'   => $this->getJobExpiration($job),
+            'data'        => [
+                'commandName' => get_class($job),
+                'command'     => serialize(clone $job),
+            ],
+        ];
+    }
+
+    /**
+     * Get the display name for the given job.
+     *
+     * @param  mixed $job
+     * @return string
+     */
+    protected function getDisplayName($job)
+    {
+        return method_exists($job, 'displayName')
+            ? $job->displayName() : get_class($job);
+    }
+
+    /**
+     * Get the expiration timestamp for an object-based queue handler.
+     *
+     * @param  mixed $job
+     * @return mixed
+     */
+    public function getJobExpiration($job)
+    {
+        if (! method_exists($job, 'retryUntil') && ! isset($job->timeoutAt)) {
+            return;
+        }
+
+        $expiration = $job->timeoutAt ?? $job->retryUntil();
+
+        return $expiration instanceof DateTimeInterface
+            ? $expiration->getTimestamp() : $expiration;
+    }
+
+    /**
+     * Create a typical, string based queue payload array.
+     *
+     * @param  string $job
+     * @param  mixed  $data
+     * @return array
+     */
+    protected function createStringPayload($job, $data)
+    {
+        return [
+            'displayName' => is_string($job) ? explode('@', $job)[0] : null,
+            'job'         => $job, 'maxTries' => null,
+            'timeout'     => null, 'data' => $data,
+        ];
+    }
+}

--- a/src/Illuminate/Queue/PayloadSerializerManager.php
+++ b/src/Illuminate/Queue/PayloadSerializerManager.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Queue;
+
+class PayloadSerializerManager
+{
+    /**
+     * @var \Illuminate\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     */
+    public function __construct($app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getConfig()
+    {
+        return $this->app['config']["queue.serializers"] ?? [];
+    }
+
+    /**
+     * @param string $connectionName
+     * @return string
+     */
+    protected function getSerializerClass($connectionName)
+    {
+        $config = $this->getConfig();
+
+        return $config[$connectionName] ?? PayloadSerializer::class;
+    }
+
+    /**
+     * @param string $connectionName
+     * @return PayloadSerializer
+     */
+    public function getSerializer($connectionName)
+    {
+        $class = $this->getSerializerClass($connectionName);
+
+        return $this->app->make($class);
+    }
+}

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -34,9 +34,9 @@ abstract class Queue
     /**
      * Push a new job onto the queue.
      *
-     * @param  string  $queue
-     * @param  string  $job
-     * @param  mixed   $data
+     * @param  string $queue
+     * @param  string $job
+     * @param  mixed  $data
      * @return mixed
      */
     public function pushOn($queue, $job, $data = '')
@@ -47,10 +47,10 @@ abstract class Queue
     /**
      * Push a new job onto the queue after a delay.
      *
-     * @param  string  $queue
-     * @param  \DateTimeInterface|\DateInterval|int  $delay
-     * @param  string  $job
-     * @param  mixed   $data
+     * @param  string                               $queue
+     * @param  \DateTimeInterface|\DateInterval|int $delay
+     * @param  string                               $job
+     * @param  mixed                                $data
      * @return mixed
      */
     public function laterOn($queue, $delay, $job, $data = '')
@@ -61,9 +61,9 @@ abstract class Queue
     /**
      * Push an array of jobs onto the queue.
      *
-     * @param  array   $jobs
-     * @param  mixed   $data
-     * @param  string  $queue
+     * @param  array  $jobs
+     * @param  mixed  $data
+     * @param  string $queue
      * @return mixed
      */
     public function bulk($jobs, $data = '', $queue = null)
@@ -74,106 +74,42 @@ abstract class Queue
     }
 
     /**
+     * @return PayloadSerializerManager
+     */
+    protected function getPayloadSerializerManager()
+    {
+        return $this->container->make(PayloadSerializerManager::class);
+    }
+
+    /**
+     * @param $connectionName
+     * @return \Illuminate\Contracts\Queue\PayloadSerializer
+     */
+    protected function getPayloadSerializer($connectionName)
+    {
+        return $this->getPayloadSerializerManager()->getSerializer($connectionName);
+    }
+
+    /**
      * Create a payload string from the given job and data.
      *
-     * @param  string  $job
-     * @param  mixed   $data
+     * @param string       $queueName
+     * @param string|mixed $job
+     * @param mixed        $data
      * @return string
      *
      * @throws \Illuminate\Queue\InvalidPayloadException
      */
-    protected function createPayload($job, $data = '')
+    protected function createPayload($queueName, $job, $data = '')
     {
-        $payload = json_encode($this->createPayloadArray($job, $data));
+        $serializer = $this->getPayloadSerializer($this->getConnectionName());
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
-            throw new InvalidPayloadException(
-                'Unable to JSON encode payload. Error code: '.json_last_error()
-            );
-        }
-
-        return $payload;
-    }
-
-    /**
-     * Create a payload array from the given job and data.
-     *
-     * @param  string  $job
-     * @param  mixed   $data
-     * @return array
-     */
-    protected function createPayloadArray($job, $data = '')
-    {
-        return is_object($job)
-                    ? $this->createObjectPayload($job)
-                    : $this->createStringPayload($job, $data);
-    }
-
-    /**
-     * Create a payload for an object-based queue handler.
-     *
-     * @param  mixed  $job
-     * @return array
-     */
-    protected function createObjectPayload($job)
-    {
-        return [
-            'displayName' => $this->getDisplayName($job),
-            'job' => 'Illuminate\Queue\CallQueuedHandler@call',
-            'maxTries' => $job->tries ?? null,
-            'timeout' => $job->timeout ?? null,
-            'timeoutAt' => $this->getJobExpiration($job),
-            'data' => [
-                'commandName' => get_class($job),
-                'command' => serialize(clone $job),
-            ],
-        ];
-    }
-
-    /**
-     * Get the display name for the given job.
-     *
-     * @param  mixed  $job
-     * @return string
-     */
-    protected function getDisplayName($job)
-    {
-        return method_exists($job, 'displayName')
-                        ? $job->displayName() : get_class($job);
-    }
-
-    /**
-     * Get the expiration timestamp for an object-based queue handler.
-     *
-     * @param  mixed  $job
-     * @return mixed
-     */
-    public function getJobExpiration($job)
-    {
-        if (! method_exists($job, 'retryUntil') && ! isset($job->timeoutAt)) {
-            return;
-        }
-
-        $expiration = $job->timeoutAt ?? $job->retryUntil();
-
-        return $expiration instanceof DateTimeInterface
-                        ? $expiration->getTimestamp() : $expiration;
-    }
-
-    /**
-     * Create a typical, string based queue payload array.
-     *
-     * @param  string  $job
-     * @param  mixed  $data
-     * @return array
-     */
-    protected function createStringPayload($job, $data)
-    {
-        return [
-            'displayName' => is_string($job) ? explode('@', $job)[0] : null,
-            'job' => $job, 'maxTries' => null,
-            'timeout' => null, 'data' => $data,
-        ];
+        return $serializer->serialize($serializer->createPayloadArray(
+            $this->getConnectionName(),
+            $queueName,
+            $job,
+            $data
+        ));
     }
 
     /**
@@ -189,7 +125,7 @@ abstract class Queue
     /**
      * Set the connection name for the queue.
      *
-     * @param  string  $name
+     * @param  string $name
      * @return $this
      */
     public function setConnectionName($name)
@@ -202,7 +138,7 @@ abstract class Queue
     /**
      * Set the IoC container instance.
      *
-     * @param  \Illuminate\Container\Container  $container
+     * @param  \Illuminate\Container\Container $container
      * @return void
      */
     public function setContainer(Container $container)

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -33,6 +33,8 @@ class QueueServiceProvider extends ServiceProvider
 
         $this->registerConnection();
 
+        $this->registerPayloadSerializerManager();
+
         $this->registerWorker();
 
         $this->registerListener();
@@ -157,6 +159,16 @@ class QueueServiceProvider extends ServiceProvider
     {
         $manager->addConnector('sqs', function () {
             return new SqsConnector;
+        });
+    }
+
+    /**
+     *
+     */
+    protected function registerPayloadSerializerManager()
+    {
+        $this->app->singleton(PayloadSerializerManager::class, function ($app) {
+            return new PayloadSerializerManager($app);
         });
     }
 

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -34,7 +34,7 @@ class SyncQueue extends Queue implements QueueContract
      */
     public function push($job, $data = '', $queue = null)
     {
-        $queueJob = $this->resolveJob($this->createPayload($job, $data), $queue);
+        $queueJob = $this->resolveJob($this->createPayload('default', $job, $data), $queue);
 
         try {
             $this->raiseBeforeJobEvent($queueJob);

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -128,16 +128,16 @@ class QueueSqsQueueTest extends TestCase
     public function testGetQueueProperlyResolvesUrlWithPrefix()
     {
         $queue = new \Illuminate\Queue\SqsQueue($this->sqs, $this->queueName, $this->prefix);
-        $this->assertEquals($this->queueUrl, $queue->getQueue(null));
+        $this->assertEquals($this->queueUrl, $queue->getQueueUrl(null));
         $queueUrl = $this->baseUrl.'/'.$this->account.'/test';
-        $this->assertEquals($queueUrl, $queue->getQueue('test'));
+        $this->assertEquals($queueUrl, $queue->getQueueUrl('test'));
     }
 
     public function testGetQueueProperlyResolvesUrlWithoutPrefix()
     {
         $queue = new \Illuminate\Queue\SqsQueue($this->sqs, $this->queueUrl);
-        $this->assertEquals($this->queueUrl, $queue->getQueue(null));
+        $this->assertEquals($this->queueUrl, $queue->getQueueUrl(null));
         $queueUrl = $this->baseUrl.'/'.$this->account.'/test';
-        $this->assertEquals($queueUrl, $queue->getQueue($queueUrl));
+        $this->assertEquals($queueUrl, $queue->getQueueUrl($queueUrl));
     }
 }


### PR DESCRIPTION
## Goal

Allow developer to customize payload of queue job.


## Why

Developer using message queue to decouple logic into different services, some of these services may not be PHP application.

Here is how a Redis queue payload looks like:

```
{\"displayName\":\"App\\\\Jobs\\\\TestQueue\",\"job\":\"Illuminate\\\\Queue\\\\CallQueuedHandler@call\",\"maxTries\":null,\"timeout\":null,\"timeoutAt\":null,\"data\":{\"commandName\":\"App\\\\Jobs\\\\TestQueue\",\"command\":\"O:18:\\\"App\\\\Jobs\\\\TestQueue\\\":7:{s:6:\\\"\\u0000*\\u0000job\\\";N;s:10:\\\"connection\\\";N;s:5:\\\"queue\\\";N;s:15:\\\"chainConnection\\\";N;s:10:\\\"chainQueue\\\";N;s:5:\\\"delay\\\";N;s:7:\\\"chained\\\";a:0:{}}\"},\"id\":\"SNjXfGlL1QdB3G3CyCnfXI3pHjC2kNK8\",\"attempts\":0}
```

Use NodeJS to generating this? No way.

To achieve communication between different languages, the only way is customizing payload (in an out) to a simpler JSON (or other format) without the overhead, like this:

```json
{
    "productId": 1,
    "cost": "151.15"
}
```

Just let another adapter to translate this back to job handler (using payload, connection name and queue name, it's possible).

And that's what I did [for my project (using RabbitMQ)](https://github.com/AaronJan/Laravel-Rabbit).


## Changes

* I added a `PayloadSerializer` interface to handle serialization that is hard-coded originally.

* Allow developer configure `PayloadSerializer` in `config/queue.php` (Connection => PayloadSerializer).

* Backward compatible.


## Discussion

This is a huge change, but maybe few developers are really need this feature.

What are you think about this? 😃 
