### PR TITLE
[5.5] Fix release of unexpected mutex

### DIFF
--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -60,8 +60,11 @@ class CallbackEvent extends Event
             return;
         }
 
-        register_shutdown_function(function () {
-            $this->removeMutex();
+        $pid = getmypid();
+        register_shutdown_function(function () use ($pid) {
+            if ($pid === getmypid()) {
+                $this->removeMutex();
+            }
         });
 
         parent::callBeforeCallbacks($container);


### PR DESCRIPTION
Fix to not mistakenly release mutex when pcntl_fork function is used.

The Laravel console has multiple start prevention function by mutex.

However, since register_shutdown_function is used, if you write processing that uses process fork, the locking mechanism will be released in the child process.

When creating a mutex, keeping the parent process ID and checking it when calling removeMutex prevents operation in the child process.