### PR TITLE
[5.6] Allow higher order Collection::groupBy()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -33,8 +33,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @var array
      */
     protected static $proxies = [
-        'average', 'avg', 'contains', 'each', 'every', 'filter', 'first', 'flatMap', 'keyBy',
-        'map', 'max', 'min', 'partition', 'reject', 'sortBy', 'sortByDesc', 'sum', 'unique',
+        'average', 'avg', 'contains', 'each', 'every', 'filter', 'first',
+        'flatMap', 'groupBy', 'keyBy', 'map', 'max', 'min', 'partition',
+        'reject', 'sortBy', 'sortByDesc', 'sum', 'unique',
     ];
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2397,6 +2397,26 @@ class SupportCollectionTest extends TestCase
         );
     }
 
+    public function testHigherOrderCollectionGroupBy()
+    {
+        $collection = collect([
+            new TestSupportCollectionHigherOrderItem,
+            new TestSupportCollectionHigherOrderItem('TAYLOR'),
+            new TestSupportCollectionHigherOrderItem('foo'),
+        ]);
+
+        $this->assertEquals([
+            'taylor' => [$collection[0]],
+            'TAYLOR' => [$collection[1]],
+            'foo' => [$collection[2]],
+        ], $collection->groupBy->name->toArray());
+
+        $this->assertEquals([
+            'TAYLOR' => [$collection[0], $collection[1]],
+            'FOO' => [$collection[2]],
+        ], $collection->groupBy->uppercase()->toArray());
+    }
+
     public function testHigherOrderCollectionMap()
     {
         $person1 = (object) ['name' => 'Taylor'];
@@ -2647,11 +2667,16 @@ class SupportCollectionTest extends TestCase
 
 class TestSupportCollectionHigherOrderItem
 {
-    public $name = 'taylor';
+    public $name;
+
+    public function __construct($name = 'taylor')
+    {
+        $this->name = $name;
+    }
 
     public function uppercase()
     {
-        $this->name = strtoupper($this->name);
+        return $this->name = strtoupper($this->name);
     }
 }
 


### PR DESCRIPTION
`$collection->groupBy('attribute')` makes `$collection->groupBy->attribute` somewhat redundant (unless you prefer the latter syntax.)

This change is for method calls returning computed values.

```php
$collection->groupBy->computed()
```

Instead of:

```php
$collection->groupBy(function ($item) {
    return $item->computed();
})
```