### PR TITLE
fix countable in php7.2

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -98,7 +98,7 @@ class Builder
      *
      * @var array
      */
-    public $wheres;
+    public $wheres = [];
 
     /**
      * The groupings for the query.


### PR DESCRIPTION
[2018-03-19 09:29:43] production.ERROR: ErrorException: count(): Parameter must be an array or an object that implements Countable in /xxxxxx/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:771