### PR TITLE
[5.6] Use hash_equals for verifying url signatures

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -347,7 +347,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         $signature = hash_hmac('sha256', $original, call_user_func($this->keyResolver));
 
-        return $request->query('signature') === $signature &&
+        return  hash_equals($signature, $request->query('signature')) &&
                ! ($expires && Carbon::now()->getTimestamp() > $expires);
     }
 


### PR DESCRIPTION
The PR updates the comparison of the URL signature to use the timing attack safe [hash_equals](http://php.net/manual/en/function.hash-equals.php) function instead of a simple `===`.

I don't know if this is strictly necessary for this use case. But since there exists a function for comparing hashes, I think it could/should be used.

Feel free to reject it if it is not needed.