### PR TITLE
Update various blade array_ calls to use fully qualified Arr helper

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -433,7 +433,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function component($path, $alias = null)
     {
-        $alias = $alias ?: array_last(explode('.', $path));
+        $alias = $alias ?: Arr::last(explode('.', $path));
 
         $this->directive($alias, function ($expression) use ($path) {
             return $expression
@@ -455,12 +455,12 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function include($path, $alias = null)
     {
-        $alias = $alias ?: array_last(explode('.', $path));
+        $alias = $alias ?: Arr::last(explode('.', $path));
 
         $this->directive($alias, function ($expression) use ($path) {
             $expression = $this->stripParentheses($expression) ?: '[]';
 
-            return "<?php echo \$__env->make('{$path}', {$expression}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+            return "<?php echo \$__env->make('{$path}', {$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
         });
     }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -25,7 +25,7 @@ trait CompilesIncludes
     {
         $expression = $this->stripParentheses($expression);
 
-        return "<?php echo \$__env->make({$expression}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+        return "<?php echo \$__env->make({$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
     }
 
     /**
@@ -38,7 +38,7 @@ trait CompilesIncludes
     {
         $expression = $this->stripParentheses($expression);
 
-        return "<?php if (\$__env->exists({$expression})) echo \$__env->make({$expression}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+        return "<?php if (\$__env->exists({$expression})) echo \$__env->make({$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
     }
 
     /**
@@ -51,7 +51,7 @@ trait CompilesIncludes
     {
         $expression = $this->stripParentheses($expression);
 
-        return "<?php echo \$__env->renderWhen($expression, array_except(get_defined_vars(), array('__data', '__path'))); ?>";
+        return "<?php echo \$__env->renderWhen($expression, \Illuminate\Support\Arr::except(get_defined_vars(), array('__data', '__path'))); ?>";
     }
 
     /**
@@ -64,6 +64,6 @@ trait CompilesIncludes
     {
         $expression = $this->stripParentheses($expression);
 
-        return "<?php echo \$__env->first({$expression}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+        return "<?php echo \$__env->first({$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLayouts.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLayouts.php
@@ -23,7 +23,7 @@ trait CompilesLayouts
     {
         $expression = $this->stripParentheses($expression);
 
-        $echo = "<?php echo \$__env->make({$expression}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+        $echo = "<?php echo \$__env->make({$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
 
         $this->footer[] = $echo;
 

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -140,7 +140,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->compiler->include('app.includes.input', 'input');
 
         $string = '@input';
-        $expected = '<?php echo $__env->make(\'app.includes.input\', [], array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+        $expected = '<?php echo $__env->make(\'app.includes.input\', [], \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -149,7 +149,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->compiler->include('app.includes.input', 'input');
 
         $string = '@input([\'type\' => \'email\'])';
-        $expected = '<?php echo $__env->make(\'app.includes.input\', [\'type\' => \'email\'], array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+        $expected = '<?php echo $__env->make(\'app.includes.input\', [\'type\' => \'email\'], \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -158,7 +158,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->compiler->include('app.includes.input');
 
         $string = '@input';
-        $expected = '<?php echo $__env->make(\'app.includes.input\', [], array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+        $expected = '<?php echo $__env->make(\'app.includes.input\', [], \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -167,7 +167,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->compiler->include('app.includes.foreach');
 
         $string = '@foreach';
-        $expected = '<?php echo $__env->make(\'app.includes.foreach\', [], array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+        $expected = '<?php echo $__env->make(\'app.includes.foreach\', [], \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }

--- a/tests/View/Blade/BladeExtendsTest.php
+++ b/tests/View/Blade/BladeExtendsTest.php
@@ -8,11 +8,11 @@ class BladeExtendsTest extends AbstractBladeTestCase
     {
         $string = '@extends(\'foo\')
 test';
-        $expected = 'test'.PHP_EOL.'<?php echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+        $expected = 'test'.PHP_EOL.'<?php echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = '@extends(name(foo))'.PHP_EOL.'test';
-        $expected = 'test'.PHP_EOL.'<?php echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+        $expected = 'test'.PHP_EOL.'<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -20,12 +20,12 @@ test';
     {
         $string = '@extends(\'foo\')
 test';
-        $expected = 'test'.PHP_EOL.'<?php echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+        $expected = 'test'.PHP_EOL.'<?php echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         // use the same compiler instance to compile another template with @extends directive
         $string = '@extends(name(foo))'.PHP_EOL.'test';
-        $expected = 'test'.PHP_EOL.'<?php echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+        $expected = 'test'.PHP_EOL.'<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }

--- a/tests/View/Blade/BladeIncludeFirstTest.php
+++ b/tests/View/Blade/BladeIncludeFirstTest.php
@@ -6,7 +6,7 @@ class BladeIncludeFirstTest extends AbstractBladeTestCase
 {
     public function testIncludeFirstsAreCompiled()
     {
-        $this->assertEquals('<?php echo $__env->first(["one", "two"], array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"])'));
-        $this->assertEquals('<?php echo $__env->first(["one", "two"], ["foo" => "bar"], array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"], ["foo" => "bar"])'));
+        $this->assertEquals('<?php echo $__env->first(["one", "two"], \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"])'));
+        $this->assertEquals('<?php echo $__env->first(["one", "two"], ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"], ["foo" => "bar"])'));
     }
 }

--- a/tests/View/Blade/BladeIncludeIfTest.php
+++ b/tests/View/Blade/BladeIncludeIfTest.php
@@ -6,7 +6,7 @@ class BladeIncludeIfTest extends AbstractBladeTestCase
 {
     public function testIncludeIfsAreCompiled()
     {
-        $this->assertEquals('<?php if ($__env->exists(\'foo\')) echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@includeIf(\'foo\')'));
-        $this->assertEquals('<?php if ($__env->exists(name(foo))) echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@includeIf(name(foo))'));
+        $this->assertEquals('<?php if ($__env->exists(\'foo\')) echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@includeIf(\'foo\')'));
+        $this->assertEquals('<?php if ($__env->exists(name(foo))) echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@includeIf(name(foo))'));
     }
 }

--- a/tests/View/Blade/BladeIncludeTest.php
+++ b/tests/View/Blade/BladeIncludeTest.php
@@ -6,7 +6,7 @@ class BladeIncludeTest extends AbstractBladeTestCase
 {
     public function testIncludesAreCompiled()
     {
-        $this->assertEquals('<?php echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@include(\'foo\')'));
-        $this->assertEquals('<?php echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@include(name(foo))'));
+        $this->assertEquals('<?php echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@include(\'foo\')'));
+        $this->assertEquals('<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $this->compiler->compileString('@include(name(foo))'));
     }
 }

--- a/tests/View/Blade/BladeIncludeWhenTest.php
+++ b/tests/View/Blade/BladeIncludeWhenTest.php
@@ -6,7 +6,7 @@ class BladeIncludeWhenTest extends AbstractBladeTestCase
 {
     public function testIncludeWhensAreCompiled()
     {
-        $this->assertEquals('<?php echo $__env->renderWhen(true, \'foo\', ["foo" => "bar"], array_except(get_defined_vars(), array(\'__data\', \'__path\'))); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\', ["foo" => "bar"])'));
-        $this->assertEquals('<?php echo $__env->renderWhen(true, \'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\'))); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\')'));
+        $this->assertEquals('<?php echo $__env->renderWhen(true, \'foo\', ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\'))); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\', ["foo" => "bar"])'));
+        $this->assertEquals('<?php echo $__env->renderWhen(true, \'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\'))); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\')'));
     }
 }

--- a/tests/View/Blade/BladeVerbatimTest.php
+++ b/tests/View/Blade/BladeVerbatimTest.php
@@ -70,7 +70,7 @@ class BladeVerbatimTest extends AbstractBladeTestCase
     <?php echo e($third); ?>
 
 <?php endif; ?>
-<?php echo $__env->make("users", array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>
+<?php echo $__env->make("users", \Illuminate\Support\Arr::except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>
 
     {{ $fourth }} @include("test")
  

--- a/tests/View/fixtures/section-exception.php
+++ b/tests/View/fixtures/section-exception.php
@@ -1,4 +1,4 @@
-<?php echo $__env->make('layout', array_except(get_defined_vars(), ['__data', '__path']))->render(); ?>
+<?php echo $__env->make('layout', \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path']))->render(); ?>
 <?php $__env->startSection('content'); ?>
 <?php throw new Exception('section exception message') ?>
 <?php $__env->stopSection(); ?>


### PR DESCRIPTION
As mentioned in https://github.com/laravel/ideas/issues/194

> Probably Str and Arr helpers will be removed in the future and classes will be preferred for those. The other helpers I am fine with.

This PRs avoids unnecessary calls to `array_*`  and just prefer calling `Arr` class directly. Reduces the call stack, improves performance. Win win.