### PR TITLE
Adds a bunch of nth item helpers

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -161,19 +161,106 @@ class Arr
      */
     public static function first($array, callable $callback = null, $default = null)
     {
+        return static::nth($array, 1, $callback, $default);
+    }
+
+    /**
+     * Return the second element in an array passing a given truth test.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function second($array, callable $callback = null, $default = null)
+    {
+        return static::nth($array, 2, $callback, $default);
+    }
+
+    /**
+     * Return the third element in an array passing a given truth test.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function third($array, callable $callback = null, $default = null)
+    {
+        return static::nth($array, 3, $callback, $default);
+    }
+
+    /**
+     * Return the fourth element in an array passing a given truth test.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function fourth($array, callable $callback = null, $default = null)
+    {
+        return static::nth($array, 4, $callback, $default);
+    }
+
+    /**
+     * Return the fifth element in an array passing a given truth test.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function fifth($array, callable $callback = null, $default = null)
+    {
+        return static::nth($array, 5, $callback, $default);
+    }
+
+    /**
+     * Return the reddit element in an array passing a given truth test.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function fortyTwo($array, callable $callback = null, $default = null)
+    {
+        return static::nth($array, 42, $callback, $default);
+    }
+
+    /**
+     * Return the nth element in an array passing a given truth test.
+     *
+     * @param  array  $array
+     * @param  int  $n
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    protected static function nth($array, $n, callable $callback = null, $default = null)
+    {
         if (is_null($callback)) {
             if (empty($array)) {
                 return value($default);
             }
 
             foreach ($array as $item) {
-                return $item;
+                if ($n == 1) {
+                    return $item;
+                }
+
+                $n--;
             }
         }
 
         foreach ($array as $key => $value) {
             if (call_user_func($callback, $value, $key)) {
-                return $value;
+                if ($n == 1) {
+                    return $value;
+                }
+
+                $n--;
             }
         }
 
@@ -195,6 +282,32 @@ class Arr
         }
 
         return static::first(array_reverse($array, true), $callback, $default);
+    }
+
+    /**
+     * Return the second to last element in an array passing a given truth test.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function secondToLast($array, callable $callback = null, $default = null)
+    {
+        return static::second(array_reverse($array, true), $callback, $default);
+    }
+
+    /**
+     * Return the third to last element in an array passing a given truth test.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function thirdToLast($array, callable $callback = null, $default = null)
+    {
+        return static::third(array_reverse($array, true), $callback, $default);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -636,6 +636,66 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the second item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function second(callable $callback = null, $default = null)
+    {
+        return Arr::second($this->items, $callback, $default);
+    }
+
+    /**
+     * Get the third item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function third(callable $callback = null, $default = null)
+    {
+        return Arr::third($this->items, $callback, $default);
+    }
+
+    /**
+     * Get the fourth item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function fourth(callable $callback = null, $default = null)
+    {
+        return Arr::fourth($this->items, $callback, $default);
+    }
+
+    /**
+     * Get the fifth item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function fifth(callable $callback = null, $default = null)
+    {
+        return Arr::fifth($this->items, $callback, $default);
+    }
+
+    /**
+     * Get the reddit item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function fortyTwo(callable $callback = null, $default = null)
+    {
+        return Arr::fortyTwo($this->items, $callback, $default);
+    }
+
+    /**
      * Get the first item by the given key value pair.
      *
      * @param  string  $key
@@ -883,6 +943,30 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function last(callable $callback = null, $default = null)
     {
         return Arr::last($this->items, $callback, $default);
+    }
+
+    /**
+     * Get the second to last item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function secondToLast(callable $callback = null, $default = null)
+    {
+        return Arr::secondToLast($this->items, $callback, $default);
+    }
+
+    /**
+     * Get the third to last item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function thirdToLast(callable $callback = null, $default = null)
+    {
+        return Arr::thirdToLast($this->items, $callback, $default);
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -136,6 +136,65 @@ class SupportArrTest extends TestCase
         $this->assertEquals(100, Arr::first($array));
     }
 
+    public function testSecond()
+    {
+        $array = [100, 200, 300];
+
+        $value = Arr::second($array, function ($value) {
+            return $value >= 150;
+        });
+
+        $this->assertEquals(300, $value);
+        $this->assertEquals(200, Arr::second($array));
+    }
+
+    public function testThird()
+    {
+        $array = [100, 200, 300, 400];
+
+        $value = Arr::third($array, function ($value) {
+            return $value >= 150;
+        });
+
+        $this->assertEquals(400, $value);
+        $this->assertEquals(300, Arr::third($array));
+    }
+
+    public function testFourth()
+    {
+        $array = [100, 200, 300, 400, 500];
+
+        $value = Arr::fourth($array, function ($value) {
+            return $value >= 150;
+        });
+
+        $this->assertEquals(500, $value);
+        $this->assertEquals(400, Arr::fourth($array));
+    }
+
+    public function testFifth()
+    {
+        $array = [100, 200, 300, 400, 500, 600];
+
+        $value = Arr::fifth($array, function ($value) {
+            return $value >= 150;
+        });
+
+        $this->assertEquals(600, $value);
+        $this->assertEquals(500, Arr::fifth($array));
+    }
+
+    public function testFortyTwo()
+    {
+        $array = range(1, 43);
+        $value = Arr::fortyTwo($array, function ($value) {
+            return $value >= 2;
+        });
+
+        $this->assertEquals(43, $value);
+        $this->assertEquals(42, Arr::fortyTwo($array));
+    }
+
     public function testLast()
     {
         $array = [100, 200, 300];
@@ -151,6 +210,40 @@ class SupportArrTest extends TestCase
         $this->assertEquals(200, $last);
 
         $this->assertEquals(300, Arr::last($array));
+    }
+
+    public function testSecondToLast()
+    {
+        $array = [100, 200, 300];
+
+        $last = Arr::secondToLast($array, function ($value) {
+            return $value < 250;
+        });
+        $this->assertEquals(100, $last);
+
+        $last = Arr::secondToLast($array, function ($value, $key) {
+            return $key < 2;
+        });
+        $this->assertEquals(100, $last);
+
+        $this->assertEquals(200, Arr::secondToLast($array));
+    }
+
+    public function testThirdToLast()
+    {
+        $array = [100, 200, 300, 400];
+
+        $last = Arr::thirdToLast($array, function ($value) {
+            return $value < 350;
+        });
+        $this->assertEquals(100, $last);
+
+        $last = Arr::thirdToLast($array, function ($value, $key) {
+            return $key < 3;
+        });
+        $this->assertEquals(100, $last);
+
+        $this->assertEquals(200, Arr::thirdToLast($array));
     }
 
     public function testFlatten()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -46,6 +46,57 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('default', $result);
     }
 
+    public function nthItemMethodsDataProvider()
+    {
+        // this seemed more sensible than typing them out again and again
+        return [
+            [range(1, 5), 'second', 2],
+            [range(1, 5), 'second', 3, function ($i) { return $i > 1;}],
+            [range(1, 5), 'second', 100, function ($i) { return $i < 1;}, 100],
+            [[], 'second', 100, null, 100],
+
+            [range(1, 5), 'third', 3],
+            [range(1, 5), 'third', 4, function ($i) { return $i > 1;}],
+            [range(1, 5), 'third', 100, function ($i) { return $i < 1;}, 100],
+            [[], 'third', 100, null, 100],
+
+            [range(1, 6), 'fourth', 4],
+            [range(1, 6), 'fourth', 5, function ($i) { return $i > 1;}],
+            [range(1, 6), 'fourth', 100, function ($i) { return $i < 1;}, 100],
+            [[], 'fourth', 100, null, 100],
+
+            [range(1, 7), 'fifth', 5],
+            [range(1, 7), 'fifth', 6, function ($i) { return $i > 1;}],
+            [range(1, 7), 'fifth', 100, function ($i) { return $i < 1;}, 100],
+            [[], 'fifth', 100, null, 100],
+
+            [range(1, 43), 'fortyTwo', 42],
+            [range(1, 43), 'fortyTwo', 43, function ($i) { return $i > 1;}],
+            [range(1, 43), 'fortyTwo', 100, function ($i) { return $i < 1;}, 100],
+            [[], 'fortyTwo', 100, null, 100],
+
+            [range(1, 5), 'secondToLast', 4],
+            [range(1, 5), 'secondToLast', 3, function ($i) { return $i < 5;}],
+            [range(1, 5), 'secondToLast', 100, function ($i) { return $i > 5;}, 100],
+            [[], 'secondToLast', 100, null, 100],
+
+            [range(1, 5), 'thirdToLast', 3],
+            [range(1, 5), 'thirdToLast', 2, function ($i) { return $i < 5;}],
+            [range(1, 5), 'thirdToLast', 100, function ($i) { return $i > 5;}, 100],
+            [[], 'thirdToLast', 100, null, 100],
+        ];
+    }
+
+    /**
+     * @dataProvider nthItemMethodsDataProvider
+     */
+    public function testNthItemMethods($data, $method, $expected, $callback = null, $default = null)
+    {
+        $c = new Collection($data);
+        $this->assertEquals($expected, $c->$method($callback, $default));
+    }
+
+
     public function testFirstWhere()
     {
         $data = new Collection([


### PR DESCRIPTION
I was surprised to find there wasn't a `Collection::second()` method, so thought I'd add one. 

Then I got kind of excited. My understanding is that many of the Laravel Artisans take inspiration from @DHH, and I've been told I have to ask myself ["What Would DHH Do?"](https://twitter.com/adamwathan/status/636118002199465984). Thankfully, I've a decent amount of experience with Rails and I knew **exactly** What DHH [Would](https://github.com/rails/rails/commit/22af62cf486721ee2e45bb720c42ac2f4121faf4) [Do](https://github.com/rails/rails/commit/e50530ca3ab5db53ebc74314c54b62b91b932389#diff-e3d63442dcd5dc00aa09c82c7daa4934) 😎

``` php
Collection::times(100)->second(); // int(2)
Collection::times(100)->third(); // int(3)
Collection::times(100)->fourth(); // int(4)
Collection::times(100)->fifth(); // int(5)
Collection::times(100)->fortyTwo(); // int(42)
Collection::times(100)->secondToLast(); // int(99)
Collection::times(100)->thirdToLast(); // int(98)
```

```