### PR TITLE
[5.6] Allow eager-loading mixed relationships of polymorphic collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -63,6 +63,30 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Load a set of relationships onto the mixed relationship collection.
+     *
+     * @param  string $relation
+     * @param  array  $relations
+     * @return $this
+     */
+    public function loadMorph($relation, $relations)
+    {
+        $this->pluck($relation)
+            ->groupBy(function ($model) {
+                return get_class($model);
+            })
+            ->filter(function ($models, $className) use ($relations) {
+                return Arr::has($relations, $className);
+            })
+            ->each(function ($models, $className) use ($relations) {
+                $className::with($relations[$className])
+                    ->eagerLoadRelations($models->all());
+            });
+
+        return $this;
+    }
+
+    /**
      * Add an item to the collection.
      *
      * @param  mixed  $item

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -522,6 +522,20 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Load a set of relationships onto the mixed relationship collection.
+     *
+     * @param  string $relation
+     * @param  array  $relations
+     * @return $this
+     */
+    public function loadMorph($relation, $relations)
+    {
+        $this->getCollection()->loadMorph($relation, $relations);
+
+        return $this;
+    }
+
+    /**
      * Determine if the given item exists.
      *
      * @param  mixed  $key

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Database;
 
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Connection;
-use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
@@ -119,6 +118,26 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $this->assertEquals(TestUser::first(), $like->likeable->owner);
     }
 
+    public function testItLoadsNestedMorphRelationshipsOnDemand()
+    {
+        $this->seedData();
+
+        TestPost::first()->likes()->create([]);
+
+        $likes = TestLike::with('likeable.owner')->get()->loadMorph('likeable', [
+            TestComment::class => ['commentable'],
+            TestPost::class => 'comments',
+        ]);
+
+        $this->assertTrue($likes[0]->relationLoaded('likeable'));
+        $this->assertTrue($likes[0]->likeable->relationLoaded('owner'));
+        $this->assertTrue($likes[0]->likeable->relationLoaded('commentable'));
+
+        $this->assertTrue($likes[1]->relationLoaded('likeable'));
+        $this->assertTrue($likes[1]->likeable->relationLoaded('owner'));
+        $this->assertTrue($likes[1]->likeable->relationLoaded('comments'));
+    }
+
     /**
      * Helpers...
      */
@@ -144,7 +163,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
     /**
      * Get a schema builder instance.
      *
-     * @return Schema\Builder
+     * @return \Illuminate\Database\Schema\Builder
      */
     protected function schema()
     {
@@ -182,6 +201,11 @@ class TestPost extends Eloquent
     public function owner()
     {
         return $this->belongsTo(TestUser::class, 'user_id');
+    }
+
+    public function likes()
+    {
+        return $this->morphMany(TestLike::class, 'likeable');
     }
 }
 

--- a/tests/Pagination/PaginatorLoadMorphTest.php
+++ b/tests/Pagination/PaginatorLoadMorphTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Pagination;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\AbstractPaginator;
+
+class PaginatorLoadMorphTest extends TestCase
+{
+    public function testCollectionLoadMorphCanChainOnThePaginator()
+    {
+        $relations = [
+            'App\\User' => 'photos',
+            'App\\Company' => ['employees', 'calendars'],
+        ];
+
+        $items = Mockery::mock(Collection::class);
+        $items->shouldReceive('loadMorph')->once()->with('parentable', $relations);
+
+        $p = (new class extends AbstractPaginator {
+        })->setCollection($items);
+
+        $this->assertSame($p, $p->loadMorph('parentable', $relations));
+    }
+}


### PR DESCRIPTION
I've had this macro kicking around for awhile since the framework doesn't offer a way to avoid N+1 queries from `morphTo()` nested relationships. This adds `Illuminate\Database\Eloquent\Collection@loadMorph()` to allow nested eager loading by naming the unique relationship(s) for each class name.

Issue reported:

* https://github.com/laravel/framework/issues/15248

External Laravel community:

* https://github.com/laracasts/Lets-Build-a-Forum-in-Laravel/issues/4
  * In response to https://laracasts.com/series/lets-build-a-forum-with-laravel/episodes/26
* http://derekmd.com/2017/06/eager-loading-laravel-polymorphic-relations/
  * My long-winded write-up about what this is solving.

## Example Use Case

```php
class ActivityFeed
{
    public function parentable()
    {
        // e.g., hydrate a Collection of Event, Photo, or Post instances.
        return $this->morphTo();
    }
}
```

```php
$activities = ActivityFeed::with('parentable')
    ->get()
    ->loadMorph('parentable', [ // could instead be named loadMixed()? loadMorphed()?
        Event::class => 'calendar',
        Photo::class => 'tags',
        Post::class => ['author', 'commentsCount'],
    ]);
```

## In an ideal world...

...this would be supported:

```php
ActivityFeed::with([
    'parentable' => [
        Event::class => 'calendar',
        Photo::class => 'tags',
        Post::class => ['author', 'commentsCount'],
    ],
    'user:id,name',
    'zonda' => function ($query) {
        $query->ofSomeScope();
    },
])->get();
```

I really wanted to work this into the existing eager-load infrastructure:

* `Illuminate\Database\Eloquent\Builder@with()`
* `Illuminate\Database\Eloquent\Collection@load()`
* `Illuminate\Database\Eloquent\Model@with` (array object property)

However this is going to require a significant rewrite of the Eloquent internals that store an associative array of query constraint `Closure`s.

## Pagination

For better developer experience in controllers, an explicit `AbstractPaginator@loadMorph()` proxy is added to return the paginator. This allows it to be passed into the view or returned by an API response.

Then controllers don't have to awkwardly do:

```php
$tags = Tag::with('taggable')->latest()->paginate();

$tags->getCollection()->loadMorph('taggable', [
    Post::class => 'category', 'comments',
    Video::class => 'likes',
]);

return view('tags.index')->with('tags', $tags);
```

but:

```php
$tags = Tag::with('taggable')->latest()->paginate()->loadMorph('taggable', [
    Post::class => ['category', 'comments'],
    Video::class => 'likes',
]);

return view('tags.index')->with('tags', $tags);
```