### PR TITLE
[5.6] Fix docblock return type for Filesystem

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -59,7 +59,7 @@ interface Filesystem
      *
      * @param  string  $path
      * @param  string  $visibility
-     * @return void
+     * @return bool
      */
     public function setVisibility($path, $visibility);
 

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -240,7 +240,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      *
      * @param  string  $path
      * @param  string  $visibility
-     * @return void
+     * @return bool
      */
     public function setVisibility($path, $visibility)
     {


### PR DESCRIPTION
The setVisibility method had the wrong return type documented. (See Flysystem FilesystemInterface)
The commit messages are a bit clumsy as I was 'experimenting' with the Github web edit interface...