### PR TITLE
Add optional foreign key override

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -62,6 +62,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public $incrementing = true;
 
     /**
+     * The foreign key for the model used in relationships.
+     *
+     * @var string
+     */
+    protected $foreignKey;
+
+    /**
      * The relations to eager load on every query.
      *
      * @var array
@@ -1372,7 +1379,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getForeignKey()
     {
-        return Str::snake(class_basename($this)).'_'.$this->getKeyName();
+        if (! isset($this->foreignKey)) {
+            return Str::snake(class_basename($this)) . '_' . $this->getKeyName();
+        }
+
+        return $this->foreignKey;
     }
 
     /**


### PR DESCRIPTION
I found a "sort-of" bug in the foreign key name resolving. In our projects database we call the table something separate to our model class name.

EG. Our class is called "PUIN" with filename "PUIN.php" is called "uin" in our database.

When resolving foreign key names for table relations it comes out as `table`.`p_u_i_n_id`. This is because of the snake case function.

I know you can set the foreign key name on the relationship but it would be nice if you could set it on the model itself if is to never change; then it would strip out a lot of un-needed paramaters when creating relationship functions.

EG. In our relationship functions in related models.

```return $this->hasMany(User::class, 'foreign_key_id');```

... becomes.

```return $this->hasMany(User::class);```

PS. Apologies for previous pull request I made. I selected wrong base.