### PR TITLE
[5.5] Fixes return doc type and makes array more precise

### DIFF
--- a/src/Illuminate/Contracts/Broadcasting/ShouldBroadcast.php
+++ b/src/Illuminate/Contracts/Broadcasting/ShouldBroadcast.php
@@ -2,12 +2,14 @@
 
 namespace Illuminate\Contracts\Broadcasting;
 
+use Illuminate\Broadcasting\Channel;
+
 interface ShouldBroadcast
 {
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return array
+     * @return Channel|Channel[]
      */
     public function broadcastOn();
 }


### PR DESCRIPTION
This updates the doc comment of the interface to be in line with the actual usage of the method. It also updates the array type include the value of its elements.