### PR TITLE
[5.6] Simplify validators

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -175,7 +175,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
         $rules = $this->container->call([$this, 'rules']);
 
         return $this->only(collect($rules)->keys()->map(function ($rule) {
-            return str_contains($rule, '.') ? explode('.', $rule)[0] : $rule;
+            return explode('.', $rule)[0];
         })->unique()->toArray());
     }
 

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Providers;
 
-use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\AggregateServiceProvider;
@@ -42,7 +41,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
             validator()->validate($this->all(), $rules, ...$params);
 
             return $this->only(collect($rules)->keys()->map(function ($rule) {
-                return Str::contains($rule, '.') ? explode('.', $rule)[0] : $rule;
+                return explode('.', $rule)[0];
             })->unique()->toArray());
         });
     }

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Validation;
 
-use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Validation\ValidationException;
@@ -58,7 +57,7 @@ trait ValidatesRequests
     protected function extractInputFromRules(Request $request, array $rules)
     {
         return $request->only(collect($rules)->keys()->map(function ($rule) {
-            return Str::contains($rule, '.') ? explode('.', $rule)[0] : $rule;
+            return explode('.', $rule)[0];
         })->unique()->toArray());
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -309,7 +309,7 @@ class Validator implements ValidatorContract
         $data = collect($this->getData());
 
         return $data->only(collect($this->getRules())->keys()->map(function ($rule) {
-            return Str::contains($rule, '.') ? explode('.', $rule)[0] : $rule;
+            return explode('.', $rule)[0];
         })->unique())->toArray();
     }
 


### PR DESCRIPTION
Checking whether the rule contains a dot is not necessary. Just using `explode()` handles all cases.