### PR TITLE
[5.6] Allow disable CREATED_AT

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -42,7 +42,7 @@ trait HasTimestamps
             $this->setUpdatedAt($time);
         }
 
-        if (! $this->exists && ! $this->isDirty(static::CREATED_AT)) {
+        if (! $this->exists && ! is_null(static::CREATED_AT) && ! $this->isDirty(static::CREATED_AT)) {
             $this->setCreatedAt($time);
         }
     }


### PR DESCRIPTION
When we try to use only UPDATED_AT, without CREATED_AT,
then we have an error:

```
"message": "Type error: Too few arguments to function Illuminate\Database\Eloquent\Model::setAttribute(), 1 passed in /app/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php on line 525 and exactly 2 expected",
```

This PR for allowing to use UPDATED_AT without CREATED_AT.

---
class Email{
   const CREATED_AT = null;
   const UPDATED_AT = 'updated';
}

---

issue related to the problem with UPDATED_AT to null

https://github.com/laravel/framework/issues/21045

https://github.com/laravel/framework/pull/21178/files -PR for disable UPDATED_AT 

---
This PR will help to solve the problem with  disable CERATED_AT column in the same way as in the previous PR for UPDATED_AT