### PR TITLE
[5.5] Update DocBlock to reflect actual behaviour

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -778,9 +778,9 @@ if (! function_exists('route')) {
     /**
      * Generate the URL to a named route.
      *
-     * @param  string  $name
-     * @param  array   $parameters
-     * @param  bool    $absolute
+     * @param  array|string  $name
+     * @param  array  $parameters
+     * @param  bool  $absolute
      * @return string
      */
     function route($name, $parameters = [], $absolute = true)


### PR DESCRIPTION
When using response([], 200) you get the same result as response()->json([], 200)