### PR TITLE
[5.7] Allow to disable CREATED_AT in Models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -42,7 +42,7 @@ trait HasTimestamps
             $this->setUpdatedAt($time);
         }
 
-        if (! $this->exists && ! $this->isDirty(static::CREATED_AT)) {
+        if (! $this->exists && ! is_null(static::CREATED_AT) && ! $this->isDirty(static::CREATED_AT)) {
             $this->setCreatedAt($time);
         }
     }

--- a/tests/Database/DatabaseEloquentTimestamps.php
+++ b/tests/Database/DatabaseEloquentTimestamps.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentTimestamps extends TestCase
+{
+    public function setUp()
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('users_created_at', function ($table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+            $table->string('created_at');
+        });
+
+        $this->schema()->create('users_updated_at', function ($table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+            $table->string('updated_at');
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('users_created_at');
+        $this->schema()->drop('users_updated_at');
+    }
+
+    /**
+     * Tests...
+     */
+    public function testUserWithCreatedAtAndUpdatedAt()
+    {
+        $now = Carbon::now();
+        $user = UserWithCreatedAndUpdated::create([
+            'email' => 'test@test.com',
+        ]);
+
+        $this->assertEquals($now->toDateTimeString(), $user->created_at->toDateTimeString());
+        $this->assertEquals($now->toDateTimeString(), $user->updated_at->toDateTimeString());
+    }
+
+
+    public function testUserWithCreatedAt()
+    {
+        $now = Carbon::now();
+        $user = UserWithCreated::create([
+            'email' => 'test@test.com',
+        ]);
+
+        $this->assertEquals($now->toDateTimeString(), $user->created_at->toDateTimeString());
+    }
+
+    public function testUserWithUpdatedAt()
+    {
+        $now = Carbon::now();
+        $user = UserWithUpdated::create([
+            'email' => 'test@test.com',
+        ]);
+
+        $this->assertEquals($now->toDateTimeString(), $user->updated_at->toDateTimeString());
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class UserWithCreatedAndUpdated extends Eloquent
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+}
+
+class UserWithCreated extends Eloquent
+{
+    public const UPDATED_AT = null;
+
+    protected $table = 'users_created_at';
+
+    protected $guarded = [];
+
+    protected $dateFormat = 'U';
+}
+
+class UserWithUpdated extends Eloquent
+{
+    public const CREATED_AT = null;
+
+    protected $table = 'users_updated_at';
+
+    protected $guarded = [];
+
+    protected $dateFormat = 'U';
+}


### PR DESCRIPTION
**Problem**

We can disable the UPDATED_AT timestamp in Eloquent (just set the const CREATET_AT to null).
```PHP
class UserWithCreated extends Eloquent
{
    public const UPDATED_AT = null;

    protected $table = 'users_created_at';
}
```
After this disabling CREATED_AT will work as expected.

But we cannot disable just CREATED_AT constant.
We got the error 

_Illuminate\Tests\Database\DatabaseEloquentTimestamps::testUserWithUpdatedAt
ArgumentCountError: Too few arguments to function Illuminate\Database\Eloquent\Model::setAttribute(), 1 passed in
/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php on line 548 and exactly 2 expected_


--- 
This PR is allowed to set CREATED_AT to null;

It was already proposed and rejected in 
https://github.com/laravel/framework/pull/22990
and
https://github.com/laravel/framework/pull/23638

I have created a Unit test as @tillkruss asked.

---

