### PR TITLE
[5.6] Allow HTML in default Notification email view template

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -1,7 +1,7 @@
 @component('mail::message')
 {{-- Greeting --}}
 @if (! empty($greeting))
-# {{ $greeting }}
+# {!! $greeting !!}
 @else
 @if ($level == 'error')
 # Whoops!
@@ -12,7 +12,7 @@
 
 {{-- Intro Lines --}}
 @foreach ($introLines as $line)
-{{ $line }}
+{!! $line !!}
 
 @endforeach
 
@@ -31,19 +31,19 @@
     }
 ?>
 @component('mail::button', ['url' => $actionUrl, 'color' => $color])
-{{ $actionText }}
+{!! $actionText !!}
 @endcomponent
 @endisset
 
 {{-- Outro Lines --}}
 @foreach ($outroLines as $line)
-{{ $line }}
+{!! $line !!}
 
 @endforeach
 
 {{-- Salutation --}}
 @if (! empty($salutation))
-{{ $salutation }}
+{!! $salutation !!}
 @else
 Regards,<br>{{ config('app.name') }}
 @endif
@@ -51,7 +51,7 @@ Regards,<br>{{ config('app.name') }}
 {{-- Subcopy --}}
 @isset($actionText)
 @component('mail::subcopy')
-If you’re having trouble clicking the "{{ $actionText }}" button, copy and paste the URL below
+If you’re having trouble clicking the "{!!  $actionText !!}" button, copy and paste the URL below
 into your web browser: [{{ $actionUrl }}]({{ $actionUrl }})
 @endcomponent
 @endisset


### PR DESCRIPTION
This is in reference to the [issue](https://github.com/laravel/ideas/issues/759) I added in the Laravel ideas repo, which enables HTML to be used in the default notification email blade: `src/Illuminate/Notifications/resources/views/email.blade.php`. 

It allows for HTML to be passed unescaped to the `$greeting`, `$line`,  `$actionText` and `$salutation` variables, which can be particularly useful for the salutation, since it is the only way to have a multi-line salutation.