### PR TITLE
[5.6] Allow using Blade @json statement with arrays or method calls

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -372,12 +372,12 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function parseArguments($expression)
     {
         $regex = '/^(\s*(?:' // Match just the first argument, composed of one or more of either:
-                . '"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"' // double quoted string,
-                . '|\'[^\'\\\\]*(?:\\\\.[^\'\\\\]*)*\'' // single quoted string,
-                . '|\[(?:(?1),?)*\]' // nested square arrays,
-                . '|(?:\w|->|::)+\s*\((?:(?1),?)*\)' // nested functions or arrays,
-                . '|[^,\'"\[\]\(\)]+' // something else but none of the above.
-            . ')+\s*)(?:$|(?>,\s*)(?!$))/i'; // Match end of string or argument separator.
+                .'"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"' // double quoted string,
+                .'|\'[^\'\\\\]*(?:\\\\.[^\'\\\\]*)*\'' // single quoted string,
+                .'|\[(?:(?1),?)*\]' // nested square arrays,
+                .'|(?:\w|->|::)+\s*\((?:(?1),?)*\)' // nested functions or arrays,
+                .'|[^,\'"\[\]\(\)]+' // something else but none of the above.
+            .')+\s*)(?:$|(?>,\s*)(?!$))/i'; // Match end of string or argument separator.
 
         $arguments = [];
         $expression = $this->stripParentheses($expression);

--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -19,11 +19,11 @@ trait CompilesJson
      */
     protected function compileJson($expression)
     {
-        $parts = explode(',', $this->stripParentheses($expression));
+        $parts = $this->parseArguments($expression);
 
-        $options = isset($parts[1]) ? trim($parts[1]) : $this->encodingOptions;
+        $options = $parts[1] ?? $this->encodingOptions;
 
-        $depth = isset($parts[2]) ? trim($parts[2]) : 512;
+        $depth = $parts[2] ?? 512;
 
         return "<?php echo json_encode($parts[0], $options, $depth) ?>";
     }

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -19,4 +19,28 @@ class BladeJsonTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testArgumentCanBeArray()
+    {
+        $string = 'var foo = @json(["abc", 12.34, [1, 2, false]]);';
+        $expected = 'var foo = <?php echo json_encode(["abc", 12.34, [1, 2, false]], 15, 512) ?>;';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testArgumentCanBeMethodCall()
+    {
+        $string = 'var foo = @json(Foo::bar("abc", 12.34, [1, 2, false]));';
+        $expected = 'var foo = <?php echo json_encode(Foo::bar("abc", 12.34, [1, 2, false]), 15, 512) ?>;';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testArrayArgumentWithOptions()
+    {
+        $string = 'var foo = @json(["abc", 12.34], JSON_HEX_TAG, 256);';
+        $expected = 'var foo = <?php echo json_encode(["abc", 12.34], JSON_HEX_TAG, 256) ?>;';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
### Introduction

Currently `@json` won't be compiled correctly if used with anything else than simple values or variables.

This PR allows following:

```php
@json(["foo" => "bar", "abc", 12.34, [1, 2, false]])
@json(Foo::bar("abc", 12.34), JSON_HEX_TAG, 256)
```

### Backward Compatibility

Above examples would previously result in either syntax errors or calling `json_encode` with incorrect options or depth. Nothing that worked before should break. If you however can think about some odd edge-case that will break I'll be glad to take a look!

### Details

I added new `BladeCompiler::parseArguments($expression)` method, which uses regex to split arguments list given as a string into a flat array. It's rather forgiving and won't complain about syntax errors.
This could lead to some non apparent issues when malformed arguments are used. However I decided not to fight an uphill battle and bet for simplicity instead.

If you're inclined to merge this I can add some tests for that method. It could be reused in other `compile*` methods or when defining custom directives. 
