### PR TITLE
[5.6] Use 403 status code for InvalidSignatureException

### DIFF
--- a/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
+++ b/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
@@ -14,6 +14,6 @@ class InvalidSignatureException extends HttpException
      */
     public function __construct()
     {
-        parent::__construct(401, 'Invalid signature.');
+        parent::__construct(403, 'Invalid signature.');
     }
 }


### PR DESCRIPTION
`401` usually refers to authentication, no authorization — so `403` is more appropriate in this case.

This means that the `InvalidSignatureException` would automatically render the `resources/views/errors/403.blade.php` template. 

- [In depth discussion on 401 vs 403](https://stackoverflow.com/questions/3297048/403-forbidden-vs-401-unauthorized-http-responses)
- [RFC2616](https://tools.ietf.org/html/rfc2616#section-10.4.2)