### PR TITLE
Allow validators to be rules class names

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -354,7 +354,7 @@ class Validator implements ValidatorContract
         // attribute is invalid and we will add a failure message for this failing attribute.
         $validatable = $this->isValidatable($rule, $attribute, $value);
 
-        if ($rule instanceof RuleContract) {
+        if (is_subclass_of($rule, RuleContract::class)) {
             return $validatable
                     ? $this->validateUsingCustomRule($attribute, $value, $rule)
                     : null;
@@ -531,11 +531,15 @@ class Validator implements ValidatorContract
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  \Illuminate\Contracts\Validation\Rule  $rule
+     * @param  \Illuminate\Contracts\Validation\Rule|string  $rule
      * @return void
      */
     protected function validateUsingCustomRule($attribute, $value, $rule)
     {
+        if (!is_string($rule)) {
+            $rule = $this->container->make($rule);
+        }
+
         if (! $rule->passes($attribute, $value)) {
             $this->failedRules[$attribute][get_class($rule)] = [];
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
 use Illuminate\Validation\Validator;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
@@ -3796,6 +3797,29 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
         $this->assertEquals('name must be taylor', $v->errors()->all()[0]);
 
+        // Test passing case with class name..
+        $v = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['name' => 'taylor'],
+            ['name' => TaylorRuleFake::class]
+        );
+
+        $v->setContainer(new Container());
+
+        $this->assertTrue($v->passes());
+
+        // Test failling case with class name..
+        $v = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['name' => 'adam'],
+            ['name' => [TaylorRuleFake::class]]
+        );
+
+        $v->setContainer(new Container());
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals('name must be taylor', $v->errors()->all()[0]);
+
         // Test passing case with Closure...
         $v = new Validator(
             $this->getIlluminateArrayTranslator(),
@@ -3912,5 +3936,18 @@ class ValidationValidatorTest extends TestCase
         return new \Illuminate\Translation\Translator(
             new \Illuminate\Translation\ArrayLoader, 'en'
         );
+    }
+}
+
+class TaylorRuleFake implements Rule
+{
+    public function passes($attribute, $value)
+    {
+        return $value === 'taylor';
+    }
+
+    public function message()
+    {
+        return ':attribute must be taylor';
     }
 }


### PR DESCRIPTION
Hey,

As I was developing some validation rules I felt the need to get some dependencies injected but found out this wasn't supported.

I haven't found any informations that would explain why this feature wasn't implemented
so here it is 😃 

If you need more context on why this feature could be useful here is a use case.

I often work with customers who happen to have their very own validation rules and in 
order to know if the data that I am a about to send them is valid I have to make a call
on their api, an api that I can request by using a service class.

Now, I could simply use `app()->make(Some::class)` but I tend to avoid such calls as
I prefer to have explicit dependencies.

Allowing rules to be resolved through the container will allow such services to get automatically injected.

Let me know what you think about it.