### PR TITLE
[5.6] Pass `$minutes` to the callback for `Cache::remember()`

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -324,7 +324,7 @@ class Repository implements CacheContract, ArrayAccess
             return $value;
         }
 
-        $this->put($key, $value = $callback(), $minutes);
+        $this->put($key, $value = $callback($minutes), $minutes);
 
         return $value;
     }


### PR DESCRIPTION
This allows for dynamically updating the cache time from within the callback itself.
e.g.

```
Cache::remember('some_key', $default_minutes, function (&$minutes) {
    $minutes = $minutes += $extendCacheTimeBy;
    return $someValue;
})
```

My use case is caching the `current_period_end` of a Stripe subscription - depending on the billing period length of the subscription(monthly/yearly/etc).