### PR TITLE
[5.6] Add Http2ServerPush Middleware

### DIFF
--- a/src/Illuminate/Http/Middleware/Http2ServerPush.php
+++ b/src/Illuminate/Http/Middleware/Http2ServerPush.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Middleware;
 
 use Closure;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Symfony\Component\DomCrawler\Crawler;
@@ -28,7 +29,7 @@ class Http2ServerPush
     {
         $response = $next($request);
 
-        if ($response->isRedirection() || ! $response instanceof Response || $request->isJson()) {
+        if (! $response instanceof Response || $response->isRedirection() || $this->isJson($response)) {
             return $response;
         }
 
@@ -131,5 +132,10 @@ class Http2ServerPush
         }
 
         $response->header('Link', $link);
+    }
+
+    private function isJson(Response $response)
+    {
+        return Str::contains($response->headers->get('Content-Type'), ['/json', '+json']);
     }
 }

--- a/src/Illuminate/Http/Middleware/Http2ServerPush.php
+++ b/src/Illuminate/Http/Middleware/Http2ServerPush.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Illuminate\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Symfony\Component\DomCrawler\Crawler;
+
+class Http2ServerPush
+{
+    /**
+     * The DomCrawler instance.
+     *
+     * @var \Symfony\Component\DomCrawler\Crawler
+     */
+    protected $crawler;
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure $next
+     *
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next, $limit = null)
+    {
+        $response = $next($request);
+
+        if ($response->isRedirection() || ! $response instanceof Response || $request->isJson()) {
+            return $response;
+        }
+
+        $this->generateAndAttachLinkHeaders($response, $limit);
+
+        return $response;
+    }
+
+    /**
+     * @param \Illuminate\Http\Response $response
+     *
+     * @return $this
+     */
+    protected function generateAndAttachLinkHeaders(Response $response, $limit = null)
+    {
+        $headers = $this->fetchLinkableNodes($response)
+            ->flatten(1)
+            ->map(function ($url) {
+                return $this->buildLinkHeaderString($url);
+            })
+            ->filter()
+            ->take($limit)
+            ->implode(',');
+
+        if (! empty(trim($headers))) {
+            $this->addLinkHeader($response, $headers);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the DomCrawler instance.
+     *
+     * @param \Illuminate\Http\Response $response
+     *
+     * @return \Symfony\Component\DomCrawler\Crawler
+     */
+    protected function getCrawler(Response $response)
+    {
+        if ($this->crawler) {
+            return $this->crawler;
+        }
+
+        return $this->crawler = new Crawler($response->getContent());
+    }
+
+    /**
+     * Get all nodes we are interested in pushing.
+     *
+     * @param \Illuminate\Http\Response $response
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function fetchLinkableNodes($response)
+    {
+        $crawler = $this->getCrawler($response);
+
+        return collect($crawler->filter('link, script[src], img[src]')->extract(['src', 'href']));
+    }
+
+    /**
+     * Build out header string based on asset extension.
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    private function buildLinkHeaderString($url)
+    {
+        $linkTypeMap = [
+            '.CSS'  => 'style',
+            '.JS'   => 'script',
+            '.BMP'  => 'image',
+            '.GIF'  => 'image',
+            '.JPG'  => 'image',
+            '.JPEG' => 'image',
+            '.PNG'  => 'image',
+            '.TIFF' => 'image',
+        ];
+
+        $type = collect($linkTypeMap)->first(function ($type, $extension) use ($url) {
+            return str_contains(strtoupper($url), $extension);
+        });
+
+        return is_null($type) ? null : "<{$url}>; rel=preload; as={$type}";
+    }
+
+    /**
+     * Add Link Header.
+     *
+     * @param \Illuminate\Http\Response $response
+     *
+     * @param $link
+     */
+    private function addLinkHeader(Response $response, $link)
+    {
+        if ($response->headers->get('Link')) {
+            $link = $response->headers->get('Link').','.$link;
+        }
+
+        $response->header('Link', $link);
+    }
+}

--- a/tests/Http/Middleware/Fixtures/pageWithCss.html
+++ b/tests/Http/Middleware/Fixtures/pageWithCss.html
@@ -1,0 +1,11 @@
+<html>
+
+    <head>
+        <title>Page title</title>
+        <link rel="stylesheet" href="css/test.css">
+    </head>
+
+    <body>
+    </body>
+
+</html>

--- a/tests/Http/Middleware/Fixtures/pageWithCssAndJs.html
+++ b/tests/Http/Middleware/Fixtures/pageWithCssAndJs.html
@@ -1,0 +1,12 @@
+<html>
+
+    <head>
+        <title>Page title</title>
+        <link rel="stylesheet" href="css/test.css">
+    </head>
+
+    <body>
+    <script type="text/javascript" src="js/thing.js"></script>
+    </body>
+
+</html>

--- a/tests/Http/Middleware/Fixtures/pageWithExternalAssets.html
+++ b/tests/Http/Middleware/Fixtures/pageWithExternalAssets.html
@@ -1,0 +1,13 @@
+<html>
+
+    <head>
+        <title>Page title</title>
+        <link rel="stylesheet" href="//buildwithbeard.com/beard.css">
+    </head>
+
+    <body>
+
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/vue/1.0.26/vue.min.js"></script>
+    </body>
+
+</html>

--- a/tests/Http/Middleware/Fixtures/pageWithImages.html
+++ b/tests/Http/Middleware/Fixtures/pageWithImages.html
@@ -1,0 +1,16 @@
+<html>
+
+    <head>
+        <title>Page title</title>
+    </head>
+
+    <body>
+        <img src="/images/mspaint.bmp" alt="">
+        <img src="/images/cats.gif" alt="">
+        <img src="/images/photo.jpg" alt="">
+        <img src="/images/photo.jpeg" alt="">
+        <img src="/images/logo.png" alt="">
+        <img src="/images/noidea.tiff" alt="">
+    </body>
+
+</html>

--- a/tests/Http/Middleware/Fixtures/pageWithJs.html
+++ b/tests/Http/Middleware/Fixtures/pageWithJs.html
@@ -1,0 +1,11 @@
+<html>
+
+    <head>
+        <title>Page title</title>
+    </head>
+
+    <body>
+        <script type="text/javascript" src="js/thing.js"></script>
+    </body>
+
+</html>

--- a/tests/Http/Middleware/Fixtures/pageWithJsInline.html
+++ b/tests/Http/Middleware/Fixtures/pageWithJsInline.html
@@ -1,0 +1,13 @@
+<html>
+
+    <head>
+        <title>Page title</title>
+    </head>
+
+    <body>
+        <script>
+            alert('zonda');
+        </script>
+    </body>
+
+</html>

--- a/tests/Http/Middleware/Fixtures/pageWithoutAssets.html
+++ b/tests/Http/Middleware/Fixtures/pageWithoutAssets.html
@@ -1,0 +1,11 @@
+<html>
+
+    <head>
+        <meta http-equiv="x-pjax-version" content="1.0.0">
+    </head>
+
+    <body>
+        <div id="pjax-container">Content</div>
+    </body>
+
+</html>

--- a/tests/Http/Middleware/Http2ServerPushTest.php
+++ b/tests/Http/Middleware/Http2ServerPushTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Illuminate\Tests\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Http\Middleware\Http2ServerPush as Push;
+
+class AddHttp2ServerPushTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->middleware = new Push();
+    }
+
+    /** @test */
+    public function it_will_not_modify_a_response_with_no_server_push_assets()
+    {
+        $request = new Request();
+
+        $response = $this->middleware->handle($request, $this->getNext('pageWithoutAssets'));
+
+        $this->assertFalse($this->isServerPushResponse($response));
+    }
+
+    /** @test */
+    public function it_will_return_a_css_link_header_for_css()
+    {
+        $request = new Request();
+
+        $response = $this->middleware->handle($request, $this->getNext('pageWithCss'));
+
+        $this->assertTrue($this->isServerPushResponse($response));
+        $this->assertStringEndsWith('as=style', $response->headers->get('link'));
+    }
+
+    /** @test */
+    public function it_will_return_a_js_link_header_for_js()
+    {
+        $request = new Request();
+
+        $response = $this->middleware->handle($request, $this->getNext('pageWithJs'));
+
+        $this->assertTrue($this->isServerPushResponse($response));
+        $this->assertStringEndsWith('as=script', $response->headers->get('link'));
+    }
+
+    /** @test */
+    public function it_will_return_an_image_link_header_for_images()
+    {
+        $request = new Request();
+
+        $response = $this->middleware->handle($request, $this->getNext('pageWithImages'));
+
+        $this->assertTrue($this->isServerPushResponse($response));
+        $this->assertStringEndsWith('as=image', $response->headers->get('link'));
+        $this->assertCount(6, explode(',', $response->headers->get('link')));
+    }
+
+    /** @test */
+    public function it_returns_well_formatted_link_headers()
+    {
+        $request = new Request();
+
+        $response = $this->middleware->handle($request, $this->getNext('pageWithCss'));
+
+        $this->assertEquals('<css/test.css>; rel=preload; as=style', $response->headers->get('link'));
+    }
+
+    /** @test */
+    public function it_will_return_correct_push_headers_for_multiple_assets()
+    {
+        $request = new Request();
+
+        $response = $this->middleware->handle($request, $this->getNext('pageWithCssAndJs'));
+
+        $this->assertTrue($this->isServerPushResponse($response));
+        $this->assertTrue(str_contains($response->headers, 'style'));
+        $this->assertTrue(str_contains($response->headers, 'script'));
+        $this->assertCount(2, explode(',', $response->headers->get('link')));
+    }
+
+    /** @test */
+    public function it_will_not_return_a_push_header_for_inline_js()
+    {
+        $request = new Request();
+
+        $response = $this->middleware->handle($request, $this->getNext('pageWithJsInline'));
+
+        $this->assertFalse($this->isServerPushResponse($response));
+    }
+
+    /** @test */
+    public function it_will_return_limit_count_of_links()
+    {
+        $request = new Request();
+        $limit = 2;
+
+        $response = $this->middleware->handle($request, $this->getNext('pageWithImages'), $limit);
+
+        $this->assertCount($limit, explode(',', $response->headers->get('link')));
+    }
+
+    /** @test */
+    public function it_will_append_to_header_if_already_present()
+    {
+        $request = new Request();
+
+        $next = $this->getNext('pageWithCss');
+
+        $response = $this->middleware->handle($request, function ($request) use ($next) {
+            $response = $next($request);
+            $response->headers->set('Link', '<https://example.com/en>; rel="alternate"; hreflang="en"');
+
+            return $response;
+        });
+
+        $this->assertTrue($this->isServerPushResponse($response));
+        $this->assertStringStartsWith('<https://example.com/en>; rel="alternate"; hreflang="en",', $response->headers->get('link'));
+        $this->assertStringEndsWith('as=style', $response->headers->get('link'));
+    }
+
+    /**
+     * @param string $pageName
+     *
+     * @return \Closure
+     */
+    protected function getNext($pageName)
+    {
+        $html = $this->getHtml($pageName);
+
+        $response = (new Response($html));
+
+        return function ($request) use ($response) {
+            return $response;
+        };
+    }
+
+    /**
+     * @param string $pageName
+     *
+     * @return string
+     */
+    protected function getHtml($pageName)
+    {
+        return file_get_contents(__DIR__."/Fixtures/{$pageName}.html");
+    }
+
+    private function isServerPushResponse($response)
+    {
+        return $response->headers->has('Link');
+    }
+}

--- a/tests/Http/Middleware/Http2ServerPushTest.php
+++ b/tests/Http/Middleware/Http2ServerPushTest.php
@@ -25,6 +25,23 @@ class AddHttp2ServerPushTest extends TestCase
     }
 
     /** @test */
+    public function it_will_not_modify_a_json_response()
+    {
+        $request = new Request();
+
+        $next = $this->getNext('pageWithCss');
+
+        $response = $this->middleware->handle($request, function ($request) use ($next) {
+            $response = $next($request);
+            $response->headers->set('Content-Type', 'application/json');
+
+            return $response;
+        });
+
+        $this->assertFalse($this->isServerPushResponse($response));
+    }
+
+    /** @test */
     public function it_will_return_a_css_link_header_for_css()
     {
         $request = new Request();


### PR DESCRIPTION
Allowing users to enable Http2 Server Push easily by adding this middleware to the `Http/Kernel.php` web middleware stack.

Would be accompanied by a PR to `laravel/laravel` if merged.

Know there are a few concerns that @GrahamCampbell had about this one and would welcome feedback on what we could do to improve this before merge. Thanks!