### PR TITLE
[5.7] Added and implemented Arr::deepMerge()

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -637,11 +637,11 @@ class Arr
                 continue;
             }
 
-            if (static::isAssoc($value)) {
+            if (! static::exists($array2, $key)) {
                 continue;
             }
 
-            if (! static::exists($array2, $key)) {
+            if (is_integer($key)) {
                 continue;
             }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -620,4 +620,34 @@ class Arr
 
         return ! is_array($value) ? [$value] : $value;
     }
+
+    /**
+     * Merges two arrays and takes multi-dimensional arrays into account.
+     *
+     * @param  array  $array1
+     * @param  array  $array2
+     * @return array
+     */
+    public static function deepMerge(array $array1, array $array2)
+    {
+        $array = array_merge($array1, $array2);
+
+        foreach ($array1 as $key => $value) {
+            if (! is_array($value)) {
+                continue;
+            }
+
+            if (static::isAssoc($value)) {
+                continue;
+            }
+
+            if (! static::exists($array2, $key)) {
+                continue;
+            }
+
+            $array[$key] = static::deepMerge($value, $array2[$key]);
+        }
+
+        return $array;
+    }
 }

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -56,7 +56,7 @@ abstract class ServiceProvider
     {
         $config = $this->app['config']->get($key, []);
 
-        $this->app['config']->set($key, array_merge(require $path, $config));
+        $this->app['config']->set($key, Arr::deepMerge(require $path, $config));
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -331,6 +331,20 @@ if (! function_exists('array_wrap')) {
     }
 }
 
+if (! function_exists('array_deep_merge')) {
+    /**
+     * Merges two arrays and takes multi-dimensional arrays into account.
+     *
+     * @param  array  $array1
+     * @param  array  $array2
+     * @return array
+     */
+    function array_deep_merge($array1, $array2)
+    {
+        return Arr::deepMerge($array1, $array2);
+    }
+}
+
 if (! function_exists('blank')) {
     /**
      * Determine if the given value is "blank".

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -672,4 +672,77 @@ class SupportArrTest extends TestCase
         $this->assertEquals([$object], Arr::wrap($object));
         $this->assertEquals([], Arr::wrap(null));
     }
+
+    public function testDeepMerge()
+    {
+        $array1 = [
+            'foo'   => 'bar',
+            'names' => [
+                'developer' => 'Taylor',
+            ],
+        ];
+
+        $array2 = [
+            'foo'   => 'foo',
+            'names' => [
+                'developer' => 'Abigail',
+            ],
+        ];
+
+        $this->assertEquals([
+            'foo'   => 'foo',
+            'names' => [
+                'developer' => 'Abigail',
+            ],
+        ], Arr::deepMerge($array1, $array2));
+
+        $array1 = [
+            'foo'   => 'bar',
+            'names' => [
+                'Taylor',
+            ],
+        ];
+
+        $array2 = [
+            'foo'   => 'foo',
+            'names' => [
+                'Abigail',
+            ],
+        ];
+
+        $this->assertEquals([
+            'foo'   => 'foo',
+            'names' => [
+                'Taylor',
+                'Abigail',
+            ],
+        ], Arr::deepMerge($array1, $array2));
+
+        $array1 = [
+            'developers' => [
+                [
+                    'name' => 'Taylor',
+                ],
+            ],
+        ];
+
+        $array2 = [
+            'developers' => [
+                [
+                    'name' => 'Abigail',
+                ],
+            ],
+        ];
+
+        $this->assertEquals([
+            'developers' => [
+                [
+                    'name' => 'Taylor',
+                ],
+                [
+                    'name' => 'Abigail',
+                ],
+            ],
+        ], Arr::deepMerge($array1, $array2));
+    }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -744,5 +744,24 @@ class SupportArrTest extends TestCase
                 ],
             ],
         ], Arr::deepMerge($array1, $array2));
+
+        $array1 = [
+            'jobs' => [
+                'first'  => 'Programmer',
+            ],
+        ];
+
+        $array2 = [
+            'jobs' => [
+                'second' => 'Teacher',
+            ],
+        ];
+
+        $this->assertEquals([
+            'jobs'  => [
+                'first'  => 'Programmer',
+                'second' => 'Teacher',
+            ],
+        ], Arr::deepMerge($array1, $array2));
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -763,5 +763,26 @@ class SupportArrTest extends TestCase
                 'second' => 'Teacher',
             ],
         ], Arr::deepMerge($array1, $array2));
+
+        $array1 = [
+            0 => [
+                'first'  => 'Programmer',
+            ],
+        ];
+
+        $array2 = [
+            0 => [
+                'second' => 'Teacher',
+            ],
+        ];
+
+        $this->assertEquals([
+            0  => [
+                'first'  => 'Programmer',
+            ],
+            1 => [
+                'second' => 'Teacher',
+            ]
+        ], Arr::deepMerge($array1, $array2));
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -782,7 +782,7 @@ class SupportArrTest extends TestCase
             ],
             1 => [
                 'second' => 'Teacher',
-            ]
+            ],
         ], Arr::deepMerge($array1, $array2));
 
         $array1 = [
@@ -797,7 +797,7 @@ class SupportArrTest extends TestCase
             'first' => [
                 'name'    => 'Taylor',
                 'surname' => 'Otwell',
-            ]
+            ],
         ];
 
         $this->assertEquals([
@@ -806,7 +806,7 @@ class SupportArrTest extends TestCase
             'first' => [
                 'name'    => 'Taylor',
                 'surname' => 'Otwell',
-            ]
+            ],
         ], Arr::deepMerge($array1, $array2));
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -766,7 +766,7 @@ class SupportArrTest extends TestCase
 
         $array1 = [
             0 => [
-                'first'  => 'Programmer',
+                'first' => 'Programmer',
             ],
         ];
 
@@ -778,10 +778,34 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals([
             0  => [
-                'first'  => 'Programmer',
+                'first' => 'Programmer',
             ],
             1 => [
                 'second' => 'Teacher',
+            ]
+        ], Arr::deepMerge($array1, $array2));
+
+        $array1 = [
+            0 => 'a string',
+            'first' => [
+                'name' => 'Abigail',
+            ],
+        ];
+
+        $array2 = [
+            0 => 420,
+            'first' => [
+                'name'    => 'Taylor',
+                'surname' => 'Otwell',
+            ]
+        ];
+
+        $this->assertEquals([
+            0 => 'a string',
+            1 => 420,
+            'first' => [
+                'name'    => 'Taylor',
+                'surname' => 'Otwell',
             ]
         ], Arr::deepMerge($array1, $array2));
     }


### PR DESCRIPTION
Up until now it was impossible to merge configs which had multi-dimensional arrays in them, at least not to the extent that the "new" keys would be merged too.

This PR aims to fix this so that an application won't crash when a package updates their config and the user doesn't republish their config. (like in: #16991, #21541)

And in the meantime adds an `Arr` helper to merge multi-dimensional arrays.

```
$config1 = ['jobs' => ['first'  => 'Programmer']];
$config2 = ['jobs' => ['second' => 'Teacher']];
```

Before PR: 
```
// Expected result:
$config =  ['jobs' => ['first'  => 'Programmer', 'second' => 'Teacher']];

// Actual result:
$config =  ['jobs' => ['second' => 'Teacher']];
```

After PR: 
```
// Expected result:
$config =  ['jobs' => ['first'  => 'Programmer', 'second' => 'Teacher']];

// Actual result:
$config =  ['jobs' => ['first'  => 'Programmer', 'second' => 'Teacher']];
```
