### PR TITLE
[5.5] Revert changes breaking blade templates using generators

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -3,7 +3,6 @@
 namespace Illuminate\View\Concerns;
 
 use Countable;
-use Traversable;
 use Illuminate\Support\Arr;
 
 trait ManagesLoops
@@ -23,13 +22,7 @@ trait ManagesLoops
      */
     public function addLoop($data)
     {
-        $length = null;
-
-        if (is_array($data) || $data instanceof Countable) {
-            $length = count($data);
-        } elseif ($data instanceof Traversable) {
-            $length = iterator_count($data);
-        }
+        $length = is_array($data) || $data instanceof Countable ? count($data) : null;
 
         $parent = Arr::last($this->loopsStack);
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -555,28 +555,6 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals([$expectedLoop], $factory->getLoopStack());
     }
 
-    public function testAddingTraversableLoop()
-    {
-        $factory = $this->getFactory();
-
-        $data = new \DatePeriod(\Carbon\Carbon::today(), \Carbon\CarbonInterval::day(), \Carbon\Carbon::tomorrow()->endOfDay());
-
-        $factory->addLoop($data);
-
-        $expectedLoop = [
-            'iteration' => 0,
-            'index' => 0,
-            'remaining' => 2,
-            'count' => 2,
-            'first' => true,
-            'last' => false,
-            'depth' => 1,
-            'parent' => null,
-        ];
-
-        $this->assertEquals([$expectedLoop], $factory->getLoopStack());
-    }
-
     public function testAddingLoopDoesNotCloseGenerator()
     {
         $factory = $this->getFactory();
@@ -595,7 +573,7 @@ class ViewFactoryTest extends TestCase
             $this->assertEquals(['a', 'b'], $chunk);
         }
     }
-
+    
     public function testAddingUncountableLoop()
     {
         $factory = $this->getFactory();

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -577,6 +577,25 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals([$expectedLoop], $factory->getLoopStack());
     }
 
+    public function testAddingLoopDoesNotCloseGenerator()
+    {
+        $factory = $this->getFactory();
+
+        $data = (new class {
+            public function generate() {
+                for($count = 0; $count < 3; $count++) {
+                    yield ['a', 'b'];
+                }
+            }
+        })->generate();
+
+        $factory->addLoop($data);
+
+        foreach ($data as $chunk) {
+            $this->assertEquals(['a', 'b'], $chunk);
+        }
+    }
+
     public function testAddingUncountableLoop()
     {
         $factory = $this->getFactory();

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -560,7 +560,8 @@ class ViewFactoryTest extends TestCase
         $factory = $this->getFactory();
 
         $data = (new class {
-            public function generate() {
+            public function generate()
+            {
                 for($count = 0; $count < 3; $count++) {
                     yield ['a', 'b'];
                 }
@@ -573,7 +574,7 @@ class ViewFactoryTest extends TestCase
             $this->assertEquals(['a', 'b'], $chunk);
         }
     }
-    
+
     public function testAddingUncountableLoop()
     {
         $factory = $this->getFactory();


### PR DESCRIPTION
As described in this issue https://github.com/laravel/framework/issues/23624, changes introduced in the 5.5.37 release break templates that use data from generators.

This pull request reverts those changes and adds a test ensuring that any future fix does not traverse (and close) the generator.