### PR TITLE
Handle array values for JSON columns

### DIFF
--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -76,7 +76,8 @@ class MySqlConnection extends Connection
     {
         foreach ($bindings as $key => $value) {
             $statement->bindValue(
-                is_string($key) ? $key : $key + 1, $value,
+                is_string($key) ? $key : $key + 1,
+                is_array($value) ? json_encode($value) : $value,
                 is_int($value) || is_float($value) ? PDO::PARAM_INT : PDO::PARAM_STR
             );
         }

--- a/src/Illuminate/Database/Query/JsonExpression.php
+++ b/src/Illuminate/Database/Query/JsonExpression.php
@@ -36,8 +36,9 @@ class JsonExpression extends Expression
             case 'string':
                 return '?';
             case 'object':
-            case 'array':
                 return '?';
+            case 'array':
+                return 'json_merge(?, \'[]\')';
         }
 
         throw new InvalidArgumentException("JSON value is of illegal type: {$type}");


### PR DESCRIPTION
Solves Issue #23684 

It allows you to pass an array as a parameter when bulk updating models' JSON column.