### PR TITLE
[5.6] Better type hints on magic methods.

### DIFF
--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -3,6 +3,23 @@
 namespace Illuminate\Support\Facades;
 
 /**
+ * @method static void compile($path = null)
+ * @method static string getPath()
+ * @method static void setPath($path)
+ * @method static string compileString($value)
+ * @method static string stripParentheses($expression)
+ * @method static void extend(callable $compiler)
+ * @method static array getExtensions()
+ * @method static void if($name, callable $callback)
+ * @method static bool check($name, ...$parameters)
+ * @method static void component($path, $alias = null)
+ * @method static void include($path, $alias = null)
+ * @method static void directive($name, callable $handler)
+ * @method static array getCustomDirectives()
+ * @method static void setEchoFormat($format)
+ * @method static void withDoubleEncoding()
+ * @method static void withoutDoubleEncoding()
+ *
  * @see \Illuminate\View\Compilers\BladeCompiler
  */
 class Blade extends Facade

--- a/src/Illuminate/Support/Facades/Broadcast.php
+++ b/src/Illuminate/Support/Facades/Broadcast.php
@@ -5,6 +5,8 @@ namespace Illuminate\Support\Facades;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactoryContract;
 
 /**
+ * @method static void connection($name = null);
+ *
  * @see \Illuminate\Contracts\Broadcasting\Factory
  */
 class Broadcast extends Facade

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -6,6 +6,13 @@ use Illuminate\Support\Testing\Fakes\BusFake;
 use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
 
 /**
+ * @method static mixed dispatch($command)
+ * @method static mixed dispatchNow($command, $handler = null)
+ * @method static bool hasCommandHandler($command)
+ * @method static bool|mixed getCommandHandler($command)
+ * @method static \Illuminate\Contracts\Bus\Dispatcher pipeThrough(array $pipes)
+ * @method static \Illuminate\Contracts\Bus\Dispatcher map(array $map)
+ *
  * @see \Illuminate\Contracts\Bus\Dispatcher
  */
 class Bus extends Facade


### PR DESCRIPTION
I have found the issue on 'ideas project' about type hints - https://github.com/laravel/ideas/issues/284
Also, I have found the PR for improvement https://github.com/laravel/framework/pull/16399

So, my proposition about doing again  improvements related to the ` Better type hints on magic methods.`

It is as a first PR.

Next step should cover all Facades within Support/Facades directory.