### PR TITLE
[5.6] Add callback support to "optional"

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -718,11 +718,16 @@ if (! function_exists('optional')) {
      * Provide access to optional objects.
      *
      * @param  mixed  $value
+     * @param  callable|null  $callback
      * @return mixed
      */
-    function optional($value = null)
+    function optional($value = null, callable $callback = null)
     {
-        return new Optional($value);
+        if (is_null($callback)) {
+            return new Optional($value);
+        } elseif (! is_null($value)) {
+            return $callback($value);
+        }
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -784,6 +784,19 @@ class SupportHelpersTest extends TestCase
         })->something());
     }
 
+    public function testOptionalWithCallback()
+    {
+        $this->assertNull(optional(null, function () {
+            throw new RuntimeException(
+                'The optional callback should not be called for null'
+            );
+        }));
+
+        $this->assertEquals(10, optional(5, function ($number) {
+            return $number * 2;
+        }));
+    }
+
     public function testOptionalWithArray()
     {
         $this->assertEquals('here', optional(['present' => 'here'])['present']);


### PR DESCRIPTION
Lets you pipe the value into an outside function, with the guarantee that you're not passing it `null`:

```php
return optional($modelOrNull, function ($definitelyTheModel) {
    return doSomethingWithTheModel($definitelyTheModel);
});
```