### PR TITLE
[5.6] Add memoize() helper function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -701,10 +701,10 @@ if (! function_exists('memoize')) {
         $reflector = new ReflectionFunction($callback);
 
         $thumbprint = $reflector->getFilename()
-            . $reflector->getStartLine()
-            . $reflector->getEndLine()
-            . serialize($reflector->getParameters())
-            . serialize($reflector->getStaticVariables());
+            .$reflector->getStartLine()
+            .$reflector->getEndLine()
+            .serialize($reflector->getParameters())
+            .serialize($reflector->getStaticVariables());
 
         $hash = md5($thumbprint);
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -686,6 +686,32 @@ if (! function_exists('last')) {
     }
 }
 
+if (! function_exists('memoize')) {
+    /**
+     * Memoize (temporarily cache) the result of a
+     * callback for the duration of the request.
+     *
+     * @param  callable $callback
+     * @return mixed
+     */
+    function memoize($callback)
+    {
+        static $caches = [];
+
+        $reflector = new ReflectionFunction($callback);
+
+        $thumbprint = $reflector->getFilename()
+            . $reflector->getStartLine()
+            . $reflector->getEndLine()
+            . serialize($reflector->getParameters())
+            . serialize($reflector->getStaticVariables());
+
+        $hash = md5($thumbprint);
+
+        return $caches[$hash] = $caches[$hash] ?? $callback();
+    }
+}
+
 if (! function_exists('object_get')) {
     /**
      * Get an item from an object using "dot" notation.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -774,7 +774,7 @@ class SupportHelpersTest extends TestCase
 
     public function testMemoize()
     {
-        $memoized = function() {
+        $memoized = function () {
             return memoize(function () {
                 return microtime(true);
             });
@@ -790,7 +790,7 @@ class SupportHelpersTest extends TestCase
     {
         $this->memoizeFalsyRunCount = 0;
 
-        $memoized = function() {
+        $memoized = function () {
             return memoize(function () {
                 $this->memoizeFalsyRunCount++;
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -815,8 +815,10 @@ class SupportHelpersTest extends TestCase
 
         $resultFirst = $memoized('foo');
         $resultSecond = $memoized('bar');
+        $resultThird = $memoized('foo');
 
         $this->assertNotEquals($resultFirst, $resultSecond);
+        $this->assertEquals($resultFirst, $resultThird);
     }
 
     public function testOptional()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -980,30 +980,3 @@ class SupportTestArrayAccess implements ArrayAccess
         unset($this->attributes[$offset]);
     }
 }
-
-class SupportTestMemoize
-{
-    public static $falsyRunCount = 0;
-
-    public function simple()
-    {
-        return memoize(function () {
-            return microtime(true);
-        });
-    }
-
-    public function falsy()
-    {
-        return memoize(function () {
-            self::$falsyRunCount++;
-            return false;
-        });
-    }
-
-    public function varyingParameters($param)
-    {
-        return memoize(function () use ($param) {
-            return microtime(true) . $param;
-        });
-    }
-}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -788,11 +788,11 @@ class SupportHelpersTest extends TestCase
 
     public function testMemoizeWithFalsyReturnValueStillCaches()
     {
-        $this->memoizeFalsyRunTimes = 0;
+        $this->memoizeFalsyRunCount = 0;
 
         $memoized = function() {
             return memoize(function () {
-                $this->memoizeFalsyRunTimes++;
+                $this->memoizeFalsyRunCount++;
 
                 return false;
             });
@@ -802,7 +802,7 @@ class SupportHelpersTest extends TestCase
         $resultCached = $memoized();
 
         $this->assertEquals($resultFirst, $resultCached);
-        $this->assertEquals(1, $this->memoizeFalsyRunTimes);
+        $this->assertEquals(1, $this->memoizeFalsyRunCount);
     }
 
     public function testMemoizeWithVaryingParametersDoesntCache()


### PR DESCRIPTION
I often find myself using a simple memoize strategy like the following in my code (particularly around eloquent queries)

```
public function voteCount()
{
    static $cache;

    return $cache = $cache ?? $this->someExpensiveVoteCountQuery();
}
```

This PR introduces a helper function called `memoize()` to take care of this for us and cover some edge cases the aforementioned strategy doesn't handle well.

```
public function voteCount()
{
    return memoize(function() {
        return $this->someExpensiveVoteCountQuery();
    }
}
```