### PR TITLE
[5.6] Improve nested rules in validated data

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Http;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Contracts\Container\Container;
@@ -175,7 +176,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
         $rules = $this->container->call([$this, 'rules']);
 
         return $this->only(collect($rules)->keys()->map(function ($rule) {
-            return explode('.', $rule)[0];
+            return Str::contains($rule, '*') ? explode('.', $rule)[0] : $rule;
         })->unique()->toArray());
     }
 

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Providers;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\AggregateServiceProvider;
@@ -41,7 +42,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
             validator()->validate($this->all(), $rules, ...$params);
 
             return $this->only(collect($rules)->keys()->map(function ($rule) {
-                return explode('.', $rule)[0];
+                return Str::contains($rule, '*') ? explode('.', $rule)[0] : $rule;
             })->unique()->toArray());
         });
     }

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Validation;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Validation\ValidationException;
@@ -57,7 +58,7 @@ trait ValidatesRequests
     protected function extractInputFromRules(Request $request, array $rules)
     {
         return $request->only(collect($rules)->keys()->map(function ($rule) {
-            return explode('.', $rule)[0];
+            return Str::contains($rule, '*') ? explode('.', $rule)[0] : $rule;
         })->unique()->toArray());
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -306,11 +306,17 @@ class Validator implements ValidatorContract
             throw new ValidationException($this);
         }
 
-        $data = collect($this->getData());
+        $results = [];
 
-        return $data->only(collect($this->getRules())->keys()->map(function ($rule) {
-            return explode('.', $rule)[0];
-        })->unique())->toArray();
+        $rules = collect($this->getRules())->keys()->map(function ($rule) {
+            return Str::contains($rule, '*') ? explode('.', $rule)[0] : $rule;
+        })->unique();
+
+        foreach ($rules as $rule) {
+            Arr::set($results, $rule, data_get($this->getData(), $rule));
+        }
+
+        return $results;
     }
 
     /**

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -31,10 +31,10 @@ class FoundationFormRequestTest extends TestCase
             'name' => 'specified',
             'nested' => [
                 'foo' => 'bar',
-                'baz' => ''
+                'baz' => '',
             ],
             'array' => [1, 2],
-            'with' => 'extras'
+            'with' => 'extras',
         ];
 
         $request = $this->createRequest($payload);
@@ -44,9 +44,9 @@ class FoundationFormRequestTest extends TestCase
         $expected = [
             'name' => 'specified',
             'nested' => [
-                'foo' => 'bar'
+                'foo' => 'bar',
             ],
-            'array' => [1, 2]
+            'array' => [1, 2],
         ];
 
         $this->assertEquals($expected, $request->validated());
@@ -186,7 +186,7 @@ class FoundationTestFormRequestStub extends FormRequest
         return [
             'name' => 'required',
             'nested.foo' => 'required',
-            'array.*' => 'integer'
+            'array.*' => 'integer',
         ];
     }
 

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -27,11 +27,29 @@ class FoundationFormRequestTest extends TestCase
 
     public function test_validated_method_returns_the_validated_data()
     {
-        $request = $this->createRequest(['name' => 'specified', 'with' => 'extras']);
+        $payload = [
+            'name' => 'specified',
+            'nested' => [
+                'foo' => 'bar',
+                'baz' => ''
+            ],
+            'array' => [1, 2],
+            'with' => 'extras'
+        ];
+
+        $request = $this->createRequest($payload);
 
         $request->validateResolved();
 
-        $this->assertEquals(['name' => 'specified'], $request->validated());
+        $expected = [
+            'name' => 'specified',
+            'nested' => [
+                'foo' => 'bar'
+            ],
+            'array' => [1, 2]
+        ];
+
+        $this->assertEquals($expected, $request->validated());
     }
 
     /**
@@ -165,7 +183,11 @@ class FoundationTestFormRequestStub extends FormRequest
 {
     public function rules()
     {
-        return ['name' => 'required'];
+        return [
+            'name' => 'required',
+            'nested.foo' => 'required',
+            'array.*' => 'integer'
+        ];
     }
 
     public function authorize()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3891,15 +3891,41 @@ class ValidationValidatorTest extends TestCase
 
     public function testValidateReturnsValidatedData()
     {
-        $post = ['first' => 'john',  'preferred'=>'john', 'last' => 'doe', 'type' => 'admin'];
+        $post = [
+            'first' => 'john',
+            'preferred' => 'john',
+            'last' => 'doe',
+            'type' => 'admin',
+            'nested' => [
+                'foo' => 'bar',
+                'baz' => ''
+            ],
+            'array' => [1, 2]
+        ];
 
-        $v = new Validator($this->getIlluminateArrayTranslator(), $post, ['first' => 'required', 'preferred'=> 'required']);
+        $rules = [
+            'first' => 'required',
+            'preferred' => 'required',
+            'nested.foo' => 'required',
+            'array.*' => 'integer'
+        ];
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), $post, $rules);
         $v->sometimes('type', 'required', function () {
             return false;
         });
         $data = $v->validate();
 
-        $this->assertEquals(['first' => 'john', 'preferred' => 'john'], $data);
+        $expected = [
+            'first' => 'john',
+            'preferred' => 'john',
+            'nested' => [
+                'foo' => 'bar'
+            ],
+            'array' => [1, 2]
+        ];
+
+        $this->assertEquals($expected, $data);
     }
 
     protected function getTranslator()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3898,16 +3898,16 @@ class ValidationValidatorTest extends TestCase
             'type' => 'admin',
             'nested' => [
                 'foo' => 'bar',
-                'baz' => ''
+                'baz' => '',
             ],
-            'array' => [1, 2]
+            'array' => [1, 2],
         ];
 
         $rules = [
             'first' => 'required',
             'preferred' => 'required',
             'nested.foo' => 'required',
-            'array.*' => 'integer'
+            'array.*' => 'integer',
         ];
 
         $v = new Validator($this->getIlluminateArrayTranslator(), $post, $rules);
@@ -3920,9 +3920,9 @@ class ValidationValidatorTest extends TestCase
             'first' => 'john',
             'preferred' => 'john',
             'nested' => [
-                'foo' => 'bar'
+                'foo' => 'bar',
             ],
-            'array' => [1, 2]
+            'array' => [1, 2],
         ];
 
         $this->assertEquals($expected, $data);


### PR DESCRIPTION
#20974 fixed an issue with array rules (`users.*.name`) when returning the validated data.
Nested rules now get reduced to the first key.

However, this wouldn't be necessary for rules without an asterisk:

    $data = Validator::make(['a' => ['b' => 'x', 'c' => 'y']], ['a.b' => 'required'])->validate();
    // Expected: ['a' => ['b' => 'x']]
    // Actual: ['a' => ['b' => 'x', 'c' => 'y']]

This PR differentiates between rules having and not having an asterisk. Only the former get reduced.

For the request validation this is easy to achieve because `Request::only()` already supports nested keys.

`Validator::validated()` however uses `Arr::only()` which doesn't support nested keys. So we have to use `data_get()` and `Arr::set()` to get the same result.

Fixes #23612.