### PR TITLE
[5.7] Don’t execute query when passing NULL to find()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -286,6 +286,10 @@ class Builder
      */
     public function find($id, $columns = ['*'])
     {
+        if (is_null($id)) {
+            return;
+        }
+
         if (is_array($id) || $id instanceof Arrayable) {
             return $this->findMany($id, $columns);
         }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -28,6 +28,16 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('baz', $result);
     }
 
+    public function testFindMethodDoesNotQueryWhenGivenNull()
+    {
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($this->getMockModel());
+        $builder->getQuery()->shouldReceive('where')->never();
+
+        $result = $builder->find(null);
+        $this->assertNull($result);
+    }
+
     public function testFindOrNewMethodModelFound()
     {
         $model = $this->getMockModel();


### PR DESCRIPTION
This is somewhat of a shorthand to cleaner code and avoids conditionals of complicated chains. Sometimes I might pass `null` to `find()` and don't what it to execute a query: `where id = null`;