### PR TITLE
[5.5] bug and fixed ,when there is a empty json object field would convent to be array .

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -316,10 +316,10 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * @param  mixed   $default
      * @return \Symfony\Component\HttpFoundation\ParameterBag|mixed
      */
-    public function json($key = null, $default = null)
+    public function json($key = null, $default = null, $assoc = true)
     {
         if (! isset($this->json)) {
-            $this->json = new ParameterBag((array) json_decode($this->getContent(), true));
+            $this->json = new ParameterBag((array) json_decode($this->getContent(), $assoc));
         }
 
         if (is_null($key)) {

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -314,6 +314,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      *
      * @param  string  $key
      * @param  mixed   $default
+     * @param  bool   $assoc
      * @return \Symfony\Component\HttpFoundation\ParameterBag|mixed
      */
     public function json($key = null, $default = null, $assoc = true)

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -478,7 +478,7 @@ class HttpRequestTest extends TestCase
         $data = $request->json(null, null, false)->all();
         $this->assertEquals($payload, json_encode($data));
     }
-    
+
     public function testJSONEmulatingPHPBuiltInServer()
     {
         $payload = ['name' => 'taylor'];

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -471,6 +471,14 @@ class HttpRequestTest extends TestCase
         $this->assertEquals($payload, $data);
     }
 
+    public function testJSONMethodByString()
+    {
+        $payload = '{"foo":[],"bar":{},"foobar":[1,2],"barfoo":{"test":"ok"}}';
+        $request = Request::create('/', 'GET', [], [], [], ['CONTENT_TYPE' => 'application/json'], $payload);
+        $data = $request->json(null,null,true)->all();
+        $this->assertEquals($payload, json_encode($data));
+    }
+
     public function testJSONEmulatingPHPBuiltInServer()
     {
         $payload = ['name' => 'taylor'];

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -478,7 +478,7 @@ class HttpRequestTest extends TestCase
         $data = $request->json(null, null, false)->all();
         $this->assertEquals($payload, json_encode($data));
     }
-
+    
     public function testJSONEmulatingPHPBuiltInServer()
     {
         $payload = ['name' => 'taylor'];

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -475,7 +475,7 @@ class HttpRequestTest extends TestCase
     {
         $payload = '{"foo":[],"bar":{},"foobar":[1,2],"barfoo":{"test":"ok"}}';
         $request = Request::create('/', 'GET', [], [], [], ['CONTENT_TYPE' => 'application/json'], $payload);
-        $data = $request->json(null,null,true)->all();
+        $data = $request->json(null,null,false)->all();
         $this->assertEquals($payload, json_encode($data));
     }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -475,7 +475,7 @@ class HttpRequestTest extends TestCase
     {
         $payload = '{"foo":[],"bar":{},"foobar":[1,2],"barfoo":{"test":"ok"}}';
         $request = Request::create('/', 'GET', [], [], [], ['CONTENT_TYPE' => 'application/json'], $payload);
-        $data = $request->json(null,null,false)->all();
+        $data = $request->json(null, null, false)->all();
         $this->assertEquals($payload, json_encode($data));
     }
 


### PR DESCRIPTION
* Laravel Version: 5.5.39
* PHP Version: 7.1.7
* Database Driver & Version: mysql 5.7 
Description:  hello. I found a bug when I using  `Illuminate\Http\Request::json` method . 
Steps To Reproduce:
```
Route::post("/test", function(Illuminate\Http\Request $request){
    $json = $request->json()->all();
    return response()->json($json);
});
```
* that was the request data
```
curl -H "Content-Type:application/json" \
     -X POST --data '{"foo":{},"bar":[],"foobar":[1,2],"barfoo":{"test":"ok"}}' http://localhost:8000/test
```
* get response 
```
{"foo":[],"bar":[],"foobar":[1,2],"barfoo":{"test":"ok"}}
```
* `"foo":[]` does not matched `"foo":{}` , when using rpc system , that will cause bug in java or go or nodejs,
because others give you an object and you returned an array .


* This is my unit test before add `$assoc` param to Illuminate\Http\Request::json() method .
and it is do not matched with the empty object json field . so I think there was a bug that 
cause json do not match when using api transport with java or golang project .

* unit test passed 
```
    public function testJSONMethodByString()
    {
        $payload = '{"foo":[],"bar":{},"foobar":[1,2],"barfoo":{"test":"ok"}}';
        $request = Request::create('/', 'GET', [], [], [], ['CONTENT_TYPE' => 'application/json'], $payload);
        $data = $request->json(null,null)->all();
        $this->assertEquals($payload, json_encode($data));
    }
```

```
$ phpunit
PHPUnit 7.0.2 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.6.0
Configuration: F:\framework\phpunit.xml.dist
...
...

F:\framework\tests\Filesystem\FilesystemTest.php:60

7) Illuminate\Tests\Http\HttpRequestTest::testJSONMethodByString
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'{"foo":[],"bar":{},"foobar":[1,2],"barfoo":{"test":"ok"}}'
+'{"foo":[],"bar":[],"foobar":[1,2],"barfoo":{"test":"ok"}}'

F:\framework\tests\Http\HttpRequestTest.php:479

--
...
...
```
* So that I add the param to control if the json has the empty object json field , 
when the request begin,empty object json field  will be  stdClass , when decode 
it will convent to `"bar":{}` 
```
Illuminate\Http\Request::json()
    /**
     * Get the JSON payload for the request.
     *
     * @param  string  $key
     * @param  mixed   $default
     * @param  bool    $assoc
     * @return \Symfony\Component\HttpFoundation\ParameterBag|mixed
     */
    public function json($key = null, $default = null, $assoc = true)
    {
        if (! isset($this->json)) {
            $this->json = new ParameterBag((array) json_decode($this->getContent(), $assoc));
        }

        if (is_null($key)) {
            return $this->json;
        }

        return data_get($this->json->all(), $key, $default);
    }
```

* unit test passed 
```
    public function testJSONMethodByString()
    {
        $payload = '{"foo":[],"bar":{},"foobar":[1,2],"barfoo":{"test":"ok"}}';
        $request = Request::create('/', 'GET', [], [], [], ['CONTENT_TYPE' => 'application/json'], $payload);
        $data = $request->json(null,null,true)->all();
        $this->assertEquals($payload, json_encode($data));
    }

```