### PR TITLE
[5.7] Track abstracts being resolved, fire resolving events once

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1048,7 +1048,7 @@ class Container implements ArrayAccess, ContainerContract
         $results = [];
 
         foreach ($callbacksPerType as $type => $callbacks) {
-            if ($type === $abstract || ($object instanceof $type && ! in_array($type, $this->resolveStack))) {
+            if (! $this->pendingInResolveStack($object) && ($type === $abstract || $object instanceof $type)) {
                 $results = array_merge($results, $callbacks);
             }
         }
@@ -1068,6 +1068,24 @@ class Container implements ArrayAccess, ContainerContract
         foreach ($callbacks as $callback) {
             $callback($object, $this);
         }
+    }
+
+    /**
+     * Check if object or a generalisation is pending in the resolve stack.
+     *
+     * @param   object    $object
+     *
+     * @return  bool
+     */
+    protected function pendingInResolveStack($object)
+    {
+        foreach ($this->resolveStack as $resolving) {
+            if ($resolving !== end($this->resolveStack) && $object instanceof $resolving) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1046,7 +1046,7 @@ class Container implements ArrayAccess, ContainerContract
         $results = [];
 
         foreach ($callbacksPerType as $type => $callbacks) {
-            if ($type === $abstract || ( $object instanceof $type && !in_array( $type, $this->resolveStack ) ) ) {
+            if ($type === $abstract || ($object instanceof $type && ! in_array($type, $this->resolveStack))) {
                 $results = array_merge($results, $callbacks);
             }
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -641,6 +641,8 @@ class Container implements ArrayAccess, ContainerContract
         // just return an existing instance instead of instantiating new instances
         // so the developer can keep using the same objects instance every time.
         if (isset($this->instances[$abstract]) && ! $needsContextualBuild) {
+            array_pop($this->resolveStack);
+
             return $this->instances[$abstract];
         }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -381,20 +381,59 @@ class ContainerTest extends TestCase
     public function testResolvingCallbacksAreCalledOnceForImplementations()
     {
         $container = new Container;
-        $resolving_invocations = 0;
-        $after_resolving_invocations = 0;
+        $resolving_contract_invocations = 0;
+        $after_resolving_contract_invocations = 0;
+        $resolving_implementation_invocations = 0;
+        $after_resolving_implementation_invocations = 0;
 
-        $container->resolving(IContainerContractStub::class, function () use (&$resolving_invocations) {
-            $resolving_invocations++;
+        $container->resolving(IContainerContractStub::class, function () use (&$resolving_contract_invocations) {
+            $resolving_contract_invocations++;
         });
-        $container->afterResolving(IContainerContractStub::class, function () use (&$after_resolving_invocations) {
-            $after_resolving_invocations++;
+        $container->afterResolving(IContainerContractStub::class, function () use (&$after_resolving_contract_invocations) {
+            $after_resolving_contract_invocations++;
+        });
+        $container->resolving(ContainerImplementationStub::class, function () use (&$resolving_implementation_invocations) {
+            $resolving_implementation_invocations++;
+        });
+        $container->afterResolving(ContainerImplementationStub::class, function () use (&$after_resolving_implementation_invocations) {
+            $after_resolving_implementation_invocations++;
         });
         $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
         $container->make(IContainerContractStub::class);
 
-        $this->assertEquals(1, $resolving_invocations);
-        $this->assertEquals(1, $after_resolving_invocations);
+        $this->assertEquals(1, $resolving_contract_invocations);
+        $this->assertEquals(1, $after_resolving_contract_invocations);
+        $this->assertEquals(1, $resolving_implementation_invocations);
+        $this->assertEquals(1, $after_resolving_implementation_invocations);
+    }
+
+    public function testResolvingCallbacksAreCalledForNestedDependencies()
+    {
+        $container = new Container;
+        $resolving_dependency_interface_invocations = 0;
+        $resolving_dependency_implementation_invocations = 0;
+        $resolving_dependent_invocations = 0;
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->resolving(IContainerContractStub::class, function () use (&$resolving_dependency_interface_invocations) {
+            $resolving_dependency_interface_invocations++;
+        });
+
+        $container->resolving(ContainerImplementationStub::class, function () use (&$resolving_dependency_implementation_invocations) {
+            $resolving_dependency_implementation_invocations++;
+        });
+
+        $container->resolving(ContainerNestedDependentStubTwo::class, function () use (&$resolving_dependent_invocations) {
+            $resolving_dependent_invocations++;
+        });
+
+        $container->make(ContainerNestedDependentStubTwo::class);
+        $container->make(ContainerNestedDependentStubTwo::class);
+
+        $this->assertEquals(4, $resolving_dependency_interface_invocations);
+        $this->assertEquals(4, $resolving_dependency_implementation_invocations);
+        $this->assertEquals(2, $resolving_dependent_invocations);
     }
 
     public function testUnsetRemoveBoundInstances()
@@ -937,6 +976,19 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $instance->name);
     }
 
+    public function testInterfaceResolvingCallbacksShouldBeFiredWhenCalledWithAliases()
+    {
+        $container = new Container;
+        $container->alias(IContainerContractStub::class, 'foo');
+        $container->resolving(IContainerContractStub::class, function ($object) {
+            return $object->name = 'taylor';
+        });
+        $container->bind('foo', ContainerImplementationStub::class);
+        $instance = $container->make('foo');
+
+        $this->assertEquals('taylor', $instance->name);
+    }
+
     public function testMakeWithMethodIsAnAliasForMakeMethod()
     {
         $mock = $this->getMockBuilder(Container::class)
@@ -1089,11 +1141,33 @@ class ContainerDependentStub
     }
 }
 
+class ContainerDependentStubTwo
+{
+    public $implA;
+    public $implB;
+
+    public function __construct(IContainerContractStub $implA, IContainerContractStub $implB)
+    {
+        $this->implA = $implA;
+        $this->implB = $implB;
+    }
+}
+
 class ContainerNestedDependentStub
 {
     public $inner;
 
     public function __construct(ContainerDependentStub $inner)
+    {
+        $this->inner = $inner;
+    }
+}
+
+class ContainerNestedDependentStubTwo
+{
+    public $inner;
+
+    public function __construct(ContainerDependentStubTwo $inner)
     {
         $this->inner = $inner;
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -384,17 +384,17 @@ class ContainerTest extends TestCase
         $resolving_invocations = 0;
         $after_resolving_invocations = 0;
 
-        $container->resolving( IContainerContractStub::class, function( ) use ( &$resolving_invocations ) {
+        $container->resolving(IContainerContractStub::class, function () use (&$resolving_invocations) {
             $resolving_invocations++;
-        } );
-        $container->afterResolving( IContainerContractStub::class, function( ) use ( &$after_resolving_invocations ) {
+        });
+        $container->afterResolving(IContainerContractStub::class, function () use (&$after_resolving_invocations) {
             $after_resolving_invocations++;
-        } );
-        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class );
-        $container->make( IContainerContractStub::class );
+        });
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+        $container->make(IContainerContractStub::class);
 
-        $this->assertEquals( 1, $resolving_invocations );
-        $this->assertEquals( 1, $after_resolving_invocations );
+        $this->assertEquals(1, $resolving_invocations);
+        $this->assertEquals(1, $after_resolving_invocations);
     }
 
     public function testUnsetRemoveBoundInstances()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -378,6 +378,25 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $instance->name);
     }
 
+    public function testResolvingCallbacksAreCalledOnceForImplementations()
+    {
+        $container = new Container;
+        $resolving_invocations = 0;
+        $after_resolving_invocations = 0;
+
+        $container->resolving( IContainerContractStub::class, function( ) use ( &$resolving_invocations ) {
+            $resolving_invocations++;
+        } );
+        $container->afterResolving( IContainerContractStub::class, function( ) use ( &$after_resolving_invocations ) {
+            $after_resolving_invocations++;
+        } );
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class );
+        $container->make( IContainerContractStub::class );
+
+        $this->assertEquals( 1, $resolving_invocations );
+        $this->assertEquals( 1, $after_resolving_invocations );
+    }
+
     public function testUnsetRemoveBoundInstances()
     {
         $container = new Container;


### PR DESCRIPTION
Fixes #23699 by tracking abstracts that are currently being resolved. 
If an object is built that is an `instanceof` of an object that is already on the stack, firing the resolving() callbacks is inhibited. 
These callbacks are fired eventually when the `instanceof` object is resolved. 