### PR TITLE
[5.6] Improve nested rules in validated data

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Http;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Contracts\Container\Container;
@@ -175,7 +176,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
         $rules = $this->container->call([$this, 'rules']);
 
         return $this->only(collect($rules)->keys()->map(function ($rule) {
-            return explode('.', $rule)[0];
+            return Str::contains($rule, '*') ? explode('.', $rule)[0] : $rule;
         })->unique()->toArray());
     }
 

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Providers;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\AggregateServiceProvider;
@@ -41,7 +42,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
             validator()->validate($this->all(), $rules, ...$params);
 
             return $this->only(collect($rules)->keys()->map(function ($rule) {
-                return explode('.', $rule)[0];
+                return Str::contains($rule, '*') ? explode('.', $rule)[0] : $rule;
             })->unique()->toArray());
         });
     }

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Validation;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Validation\ValidationException;
@@ -57,7 +58,7 @@ trait ValidatesRequests
     protected function extractInputFromRules(Request $request, array $rules)
     {
         return $request->only(collect($rules)->keys()->map(function ($rule) {
-            return explode('.', $rule)[0];
+            return Str::contains($rule, '*') ? explode('.', $rule)[0] : $rule;
         })->unique()->toArray());
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -306,11 +306,17 @@ class Validator implements ValidatorContract
             throw new ValidationException($this);
         }
 
-        $data = collect($this->getData());
+        $results = [];
 
-        return $data->only(collect($this->getRules())->keys()->map(function ($rule) {
-            return explode('.', $rule)[0];
-        })->unique())->toArray();
+        $rules = collect($this->getRules())->keys()->map(function ($rule) {
+            return Str::contains($rule, '*') ? explode('.', $rule)[0] : $rule;
+        })->unique();
+
+        foreach ($rules as $rule) {
+            Arr::set($results, $rule, data_get($this->getData(), $rule));
+        }
+
+        return $results;
     }
 
     /**

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -34,6 +34,17 @@ class FoundationFormRequestTest extends TestCase
         $this->assertEquals(['name' => 'specified'], $request->validated());
     }
 
+    public function test_validated_method_returns_the_validated_data_nested_rules()
+    {
+        $payload = ['nested' => ['foo' => 'bar', 'baz' => ''], 'array' => [1, 2]];
+
+        $request = $this->createRequest($payload, FoundationTestFormRequestNestedStub::class);
+
+        $request->validateResolved();
+
+        $this->assertEquals(['nested' => ['foo' => 'bar'], 'array' => [1, 2]], $request->validated());
+    }
+
     /**
      * @expectedException \Illuminate\Validation\ValidationException
      */
@@ -166,6 +177,19 @@ class FoundationTestFormRequestStub extends FormRequest
     public function rules()
     {
         return ['name' => 'required'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+class FoundationTestFormRequestNestedStub extends FormRequest
+{
+    public function rules()
+    {
+        return ['nested.foo' => 'required', 'array.*' => 'integer'];
     }
 
     public function authorize()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3902,6 +3902,21 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['first' => 'john', 'preferred' => 'john'], $data);
     }
 
+    public function testValidateReturnsValidatedDataNestedRules()
+    {
+        $post = ['nested' => ['foo' => 'bar', 'baz' => ''], 'array' => [1, 2]];
+
+        $rules = ['nested.foo' => 'required', 'array.*' => 'integer'];
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), $post, $rules);
+        $v->sometimes('type', 'required', function () {
+            return false;
+        });
+        $data = $v->validate();
+
+        $this->assertEquals(['nested' => ['foo' => 'bar'], 'array' => [1, 2]], $data);
+    }
+
     protected function getTranslator()
     {
         return m::mock('Illuminate\Contracts\Translation\Translator');


### PR DESCRIPTION
(re-submit of #23693 with separate tests)

#20974 fixed an issue with array rules (`users.*.name`) when returning the validated data.
Nested rules now get reduced to the first key.

However, this wouldn't be necessary for rules without an asterisk:

    $data = Validator::make(['a' => ['b' => 'x', 'c' => 'y']], ['a.b' => 'required'])->validate();
    // Expected: ['a' => ['b' => 'x']]
    // Actual: ['a' => ['b' => 'x', 'c' => 'y']]

This PR differentiates between rules having and not having an asterisk. Only the former get reduced.

For the request validation this is easy to achieve because `Request::only()` already supports nested keys.

`Validator::validated()` however uses `Arr::only()` which doesn't support nested keys. So we have to use `data_get()` and `Arr::set()` to get the same result.

Fixes #23612.