### PR TITLE
[5.6] Get Blade compiler from Engine Resolver

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -45,7 +45,7 @@ class ViewCacheCommand extends Command
      */
     protected function compileViews(Collection $views)
     {
-        $compiler = $this->laravel['blade.compiler'];
+        $compiler = $this->laravel['view']->getEngineResolver()->resolve('blade')->getCompiler();
 
         $views->map(function (SplFileInfo $file) use ($compiler) {
             $compiler->compile($file->getRealPath());


### PR DESCRIPTION
If one registers a custom Blade compiler ( such as https://github.com/HTMLMin/Laravel-HTMLMin ) that replaces the built-in compiler, all Blade directives registration through the Blade Façade are registered with the custom compiler and not the built-in one.

As the `view:cache` command didn't retrieve the compiler from the EngineResolver but used the built-in one, when a user that uses a custom compiler runs this command, no custom directive is compiled.

This commit fixes this by retrieving the compiler from the EngineResolver, so there are no conflicts with packages that register a custom Blade compiler.

(For reference see the Blade Façade: https://github.com/laravel/framework/blob/5.6/src/Illuminate/Support/Facades/Blade.php#L34 )