### PR TITLE
[5.6] Add SlackMessage::info()

### DIFF
--- a/src/Illuminate/Notifications/Messages/SlackMessage.php
+++ b/src/Illuminate/Notifications/Messages/SlackMessage.php
@@ -84,6 +84,18 @@ class SlackMessage
     public $http = [];
 
     /**
+     * Indicate that the notification gives information about an operation.
+     *
+     * @return $this
+     */
+    public function info()
+    {
+        $this->level = 'info';
+
+        return $this;
+    }
+
+    /**
      * Indicate that the notification gives information about a successful operation.
      *
      * @return $this


### PR DESCRIPTION
I know it defaults to `info` but it's useful to be explicit about it in some cases.