### PR TITLE
[5.6] API Resource wrapper bypass

### DIFF
--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -98,7 +98,7 @@ class ResourceResponse implements Responsable
     }
 
     /**
-     * Determine if data has been wrapped
+     * Determine if data has been wrapped.
      * @param  array  $data
      * @return bool
      */

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -79,7 +79,7 @@ class ResourceResponse implements Responsable
      */
     protected function haveDefaultWrapperAndDataIsUnwrapped($data)
     {
-        return $this->wrapper() && ! array_key_exists($this->wrapper(), $data);
+        return $this->wrapper() && ! $this->dataIsWrapped($data);
     }
 
     /**
@@ -94,7 +94,17 @@ class ResourceResponse implements Responsable
     {
         return (! empty($with) || ! empty($additional)) &&
                (! $this->wrapper() ||
-                ! array_key_exists($this->wrapper(), $data));
+                ! $this->dataIsWrapped($data));
+    }
+
+    /**
+     * Determine if data has been wrapped
+     * @param  array  $data
+     * @return bool
+     */
+    protected function dataIsWrapped($data)
+    {
+        return array_key_exists($this->wrapper(), $data) && count($data) === 1;
     }
 
     /**


### PR DESCRIPTION
ResourceResponse doesn't wraps response data if there is a model property with same name as wrapper keyword.