### PR TITLE
[5.7] Moved the soft delete column name to the arg to make it consistent

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -389,7 +389,7 @@ class Blueprint
     }
 
     /**
-     * Indicate that the soft delete column should be dropped.
+     * Indicate that the soft delete column should be dropped..
      *
      * @param  string  $column
      * @return void

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -380,11 +380,12 @@ class Blueprint
     /**
      * Indicate that the soft delete column should be dropped.
      *
+     * @param  string  $column
      * @return void
      */
-    public function dropSoftDeletes()
+    public function dropSoftDeletes($column = 'deleted_at')
     {
-        $this->dropColumn('deleted_at');
+        $this->dropColumn($column);
     }
 
     /**
@@ -392,9 +393,9 @@ class Blueprint
      *
      * @return void
      */
-    public function dropSoftDeletesTz()
+    public function dropSoftDeletesTz($column = 'deleted_at')
     {
-        $this->dropSoftDeletes();
+        $this->dropSoftDeletes($column);
     }
 
     /**
@@ -972,12 +973,13 @@ class Blueprint
     /**
      * Add a "deleted at" timestampTz for the table.
      *
+     * @param  string  $column
      * @param  int  $precision
      * @return \Illuminate\Support\Fluent
      */
-    public function softDeletesTz($precision = 0)
+    public function softDeletesTz($column = 'deleted_at', $precision = 0)
     {
-        return $this->timestampTz('deleted_at', $precision)->nullable();
+        return $this->timestampTz($column, $precision)->nullable();
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -389,7 +389,7 @@ class Blueprint
     }
 
     /**
-     * Indicate that the soft delete column should be dropped..
+     * Indicate that the soft delete column should be dropped.
      *
      * @param  string  $column
      * @return void

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -391,6 +391,7 @@ class Blueprint
     /**
      * Indicate that the soft delete column should be dropped.
      *
+     * @param  string  $column
      * @return void
      */
     public function dropSoftDeletesTz($column = 'deleted_at')


### PR DESCRIPTION
To make it consistent with [this](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Schema/Blueprint.php#L967)

![screenshot from 2018-03-27 22-17-35](https://user-images.githubusercontent.com/9657132/37989705-e712cf9a-320c-11e8-8103-3a4ee984eb29.png)

And to leverage [this](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Eloquent/SoftDeletes.php#L159)

![screenshot from 2018-03-27 22-18-11](https://user-images.githubusercontent.com/9657132/37989780-0af0cc6e-320d-11e8-8044-45c349752223.png)

Thanks in advance.