### PR TITLE
[5.6] Default to an empty string when validating the signature hash query parameter

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -347,7 +347,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         $signature = hash_hmac('sha256', $original, call_user_func($this->keyResolver));
 
-        return  hash_equals($signature, $request->query('signature')) &&
+        return  hash_equals($signature, $request->query('signature', '')) &&
                ! ($expires && Carbon::now()->getTimestamp() > $expires);
     }
 

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -39,6 +39,15 @@ class UrlSigningTest extends TestCase
         $this->assertEquals('invalid', $this->get($url)->original);
     }
 
+    public function test_signed_url_with_url_without_signature_parameter()
+    {
+        Route::get('/foo/{id}', function (Request $request, $id) {
+            return $request->hasValidSignature() ? 'valid' : 'invalid';
+        })->name('foo');
+
+        $this->assertEquals('invalid', $this->get('/foo/1')->original);
+    }
+
     public function test_signed_middleware()
     {
         Route::get('/foo/{id}', function (Request $request, $id) {


### PR DESCRIPTION
This PR is a follow up to #23618 fixing the problem explained in https://github.com/laravel/framework/pull/23618#issuecomment-376805474

When validating a signature and the signature query param is not present in the request, `hash_equals` will throw an `ErrorException` since it expects a string to compare but `$request->query('signature')` will return `null`