### PR TITLE
[5.6] Fix today in date rule not being translated

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -307,7 +307,7 @@ trait ReplacesAttributes
      */
     protected function replaceBefore($message, $attribute, $rule, $parameters)
     {
-        if (is_string($parameters[0]) && !is_numeric(substr($parameters[0], 0, 1))) {
+        if (is_string($parameters[0]) && ! is_numeric(substr($parameters[0], 0, 1))) {
             return str_replace(':date', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -307,7 +307,7 @@ trait ReplacesAttributes
      */
     protected function replaceBefore($message, $attribute, $rule, $parameters)
     {
-        if (! (strtotime($parameters[0]))) {
+        if (is_string($parameters[0]) && !is_numeric(substr($parameters[0], 0, 1))) {
             return str_replace(':date', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -550,6 +550,38 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('should be integer!', $v->messages()->first('validation.custom.1'));
     }
 
+    public function testStringDateGetsTranslated()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->getLoader()->addMessages('en', 'validation', [
+            'after_or_equal' => ':attribute moet een datum na of gelijk aan :date zijn.',
+            'attributes' => [
+                'start_date' => 'begindatum',
+                'today' => 'vandaag',
+            ],
+        ]);
+        $v = new Validator($trans, ['start_date' => '01-01-2018'], ['start_date' => 'date|after_or_equal:today']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('begindatum moet een datum na of gelijk aan vandaag zijn.', $v->messages()->first('start_date'));
+    }
+
+    public function testDateStringNotGettingTranslated()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->getLoader()->addMessages('en', 'validation', [
+            'after_or_equal' => ':attribute moet een datum na of gelijk aan :date zijn.',
+            'attributes' => [
+                'start_date' => 'begindatum',
+                '01-02-2018' => 'vandaag',
+            ],
+        ]);
+        $v = new Validator($trans, ['start_date' => '01-01-2018'], ['start_date' => 'date|after_or_equal:01-02-2018']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('begindatum moet een datum na of gelijk aan 01-02-2018 zijn.', $v->messages()->first('start_date'));
+    }
+
     public function testInlineValidationMessagesAreRespected()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
When using validation rules like `after_or_equal:today` and you are using a different language than English you might end up with a string like: `begindatum moet een datum na of gelijk aan today zijn.`. As you can see the word today didn't get translated to `vandaag`. 

This PR fixes this with an ugly fix and adds tests for this. Anyone else is welcome to suggest a better fix, but I couldn't find it.