### PR TITLE
[5.5] URL::forceScheme works for URL::full.

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -113,7 +113,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function full()
     {
-        return $this->request->fullUrl();
+        return $this->to($this->request->getRequestUri());
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -450,6 +450,19 @@ class RoutingUrlGeneratorTest extends TestCase
 
         $this->assertEquals($url->to('/foo'), $url->previous('/foo'));
     }
+
+    public function testFullUrl()
+    {
+        $url = new UrlGenerator(
+            new RouteCollection,
+            Request::create('http://www.foo.com/route?bar=baz#hash')
+        );
+
+        $this->assertEquals('http://www.foo.com/route?bar=baz', $url->full());
+
+        $url->forceScheme('https');
+        $this->assertEquals('https://www.foo.com/route?bar=baz', $url->full());
+    }
 }
 
 class RoutableInterfaceStub implements UrlRoutable


### PR DESCRIPTION
Hello everyone!

I have a Laravel project where I use `URL::forceScheme('https')`. 

When I enter an address like `http://www.foo.com/route?bar=baz`, `url()->current()` gives me `https://www.foo.com/route` (please note `https`). But when I call `url()->full()`, I get `http://www.foo.com/route?bar=baz`. It is not exactly what I expect, as I try to force links to be generated with `https`.

This pull requests removes this inconsistency by making `url()->full()` sensitive to `URL::forceScheme`.

Please let me know what do you think.
Cheers!