### PR TITLE
[5.6] Optimize env() first and last characters check + tests

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -626,7 +626,7 @@ if (! function_exists('env')) {
                 return;
         }
 
-        if (strlen($value) > 1 && Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
+        if (($valueLength = strlen($value)) > 1 && $value[0] === '"' && $value[$valueLength - 1] === '"') {
             return substr($value, 1, -1);
         }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -886,6 +886,57 @@ class SupportHelpersTest extends TestCase
             return $five + 5;
         }));
     }
+
+    public function testEnv()
+    {
+        putenv('foo=bar');
+        $this->assertEquals('bar', env('foo'));
+    }
+
+    public function testEnvWithQuotes()
+    {
+        putenv('foo="bar"');
+        $this->assertEquals('bar', env('foo'));
+    }
+
+    public function testEnvTrue()
+    {
+        putenv('foo=true');
+        $this->assertTrue(env('foo'));
+
+        putenv('foo=(true)');
+        $this->assertTrue(env('foo'));
+    }
+
+    public function testEnvFalse()
+    {
+        putenv('foo=false');
+        $this->assertFalse(env('foo'));
+
+        putenv('foo=(false)');
+        $this->assertFalse(env('foo'));
+    }
+
+    public function testEnvEmpty()
+    {
+        putenv('foo=');
+        $this->assertEquals('', env('foo'));
+
+        putenv('foo=empty');
+        $this->assertEquals('', env('foo'));
+
+        putenv('foo=(empty)');
+        $this->assertEquals('', env('foo'));
+    }
+
+    public function testEnvNull()
+    {
+        putenv('foo=null');
+        $this->assertEquals('', env('foo'));
+
+        putenv('foo=(null)');
+        $this->assertEquals('', env('foo'));
+    }
 }
 
 trait SupportTestTraitOne


### PR DESCRIPTION
Currently env() is using `Str::start()` and `Str::end()` functions just for checking the first and last characters of a string.
These functions are using `foreach()`, `substr()` and `strlen()` functions.

This is an overkill solution comparing to a direct array index access (it's faster by an order of magnitude).

The commit is using only one `strlen()` and contains multiple tests for `env()` function.