### PR TITLE
[5.6] Check UPDATED_AT column existence in HasOneOrMany::update()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -316,7 +316,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function update(array $attributes)
     {
-        if ($this->related->usesTimestamps()) {
+        if ($this->related->usesTimestamps() && ! is_null($this->relatedUpdatedAt())) {
             $attributes[$this->relatedUpdatedAt()] = $this->related->freshTimestampString();
         }
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -173,6 +173,16 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals('results', $relation->update(['foo' => 'bar']));
     }
 
+    public function testUpdateMethodUpdatesModelsWithNullUpdatedAt()
+    {
+        $relation = $this->getRelation();
+        $relation->getRelated()->shouldReceive('usesTimestamps')->once()->andReturn(true);
+        $relation->getRelated()->shouldReceive('getUpdatedAtColumn')->andReturn(null);
+        $relation->getQuery()->shouldReceive('update')->once()->with(['foo' => 'bar'])->andReturn('results');
+
+        $this->assertEquals('results', $relation->update(['foo' => 'bar']));
+    }
+
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -136,6 +136,16 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertEquals('results', $relation->update(['foo' => 'bar']));
     }
 
+    public function testUpdateMethodUpdatesModelsWithNullUpdatedAt()
+    {
+        $relation = $this->getRelation();
+        $relation->getRelated()->shouldReceive('usesTimestamps')->once()->andReturn(true);
+        $relation->getRelated()->shouldReceive('getUpdatedAtColumn')->andReturn(null);
+        $relation->getQuery()->shouldReceive('update')->once()->with(['foo' => 'bar'])->andReturn('results');
+
+        $this->assertEquals('results', $relation->update(['foo' => 'bar']));
+    }
+
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();


### PR DESCRIPTION
Running an update query on an `HasOne`/`HasMany` relationship fails if the related model uses timestamps, but doesn't have an `UPDATED_AT` column:

    class Bug extends Eloquent {
        const UPDATED_AT = null;
    }

    class Foo extends Eloquent {
        public function bugs() {
            return $this->hasMany(Bug::class);
        }
    }

    $foo->bugs()->update(['test' => 'bar']);

This PR checks whether the `UPDATED_AT` column exists before updating it.

Fixes #23741.