### PR TITLE
[5.6] Add custom CSS config option for Whoops error handler

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/WhoopsHandler.php
+++ b/src/Illuminate/Foundation/Exceptions/WhoopsHandler.php
@@ -20,7 +20,8 @@ class WhoopsHandler
 
             $this->registerApplicationPaths($handler)
                  ->registerBlacklist($handler)
-                 ->registerEditor($handler);
+                 ->registerEditor($handler)
+                 ->registerWhoopsCss($handler);
         });
     }
 
@@ -79,6 +80,22 @@ class WhoopsHandler
     {
         if (config('app.editor', false)) {
             $handler->setEditor(config('app.editor'));
+        }
+
+        return $this;
+    }
+
+    /**
+    * Register custom CSS with the handler.
+    *
+    * @param  \Whoops\Handler\PrettyPageHandler $handler
+    * @return $this
+    */
+    protected function registerWhoopsCss($handler)
+    {
+        if (config('app.whoopsCss', false)) {
+            $handler->addCustomCss(substr(strrchr(config('app.whoopsCss'), "/"), 1));
+            $handler->addResourcePath(implode('/', explode('/', config('app.whoopsCss'), -1)));
         }
 
         return $this;


### PR DESCRIPTION
Adds `"whoopsCss": "/path/to/file"` option to the `app/config` file to allow custom CSS to be used with the Whoops error page

Default value of false so standard styling still used if not implemented 