### PR TITLE
[5.6] call index.blade.php view by default in a declared folder

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -114,6 +114,18 @@ class Factory implements FactoryContract
         });
     }
 
+    public function viewIndexByDefault($view) 
+    {
+        $view = $this->normalizeName($view);
+        $viewIndex = "{$view}.index";
+
+        if(! $this->exists($view))
+        {
+            return $this->exists($viewIndex) ? $viewIndex : $view;
+        }
+        return $view;
+    }
+
     /**
      * Get the evaluated view contents for the given view.
      *
@@ -123,9 +135,9 @@ class Factory implements FactoryContract
      * @return \Illuminate\Contracts\View\View
      */
     public function make($view, $data = [], $mergeData = [])
-    {
+    {        
         $path = $this->finder->find(
-            $view = $this->normalizeName($view)
+            $view = $this->viewIndexByDefault($view)
         );
 
         // Next, we will create the view instance and call the view creator for the view


### PR DESCRIPTION
if you call an undefined view it will search for index.blade.php inside this folder and call it instead

Like i have this path on my views folder  `views/pages/dashboard/index.blade.php` i just need to do this 
```php
Route::get('/dashboard', function () {
    return view('pages.dashboard');
});
```
and it will open `index.blade.php`

i know it needs some refactoring but it is just an idea and something that i need in my projects.