### PR TITLE
[5.6] startsWith() single character check

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -149,7 +149,7 @@ trait GuardsAttributes
             return false;
         }
 
-        return empty($this->getFillable()) && $key[0] !== '_';
+        return empty($this->getFillable()) && (empty($key) || $key[0] !== '_');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use Illuminate\Support\Str;
-
 trait GuardsAttributes
 {
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -151,8 +151,7 @@ trait GuardsAttributes
             return false;
         }
 
-        return empty($this->getFillable()) &&
-            ! Str::startsWith($key, '_');
+        return empty($this->getFillable()) && $key[0] !== '_';
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -362,7 +362,7 @@ trait MakesHttpRequests
      */
     protected function prepareUrlForRequest($uri)
     {
-        if (Str::startsWith($uri, '/')) {
+        if ($uri[0] === '/') {
             $uri = substr($uri, 1);
         }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -561,11 +561,11 @@ if (! function_exists('mix')) {
     {
         static $manifests = [];
 
-        if (! Str::startsWith($path, '/')) {
+        if ($path[0] !== '/') {
             $path = "/{$path}";
         }
 
-        if ($manifestDirectory && ! Str::startsWith($manifestDirectory, '/')) {
+        if ($manifestDirectory && $manifestDirectory[0] !== '/') {
             $manifestDirectory = "/{$manifestDirectory}";
         }
 

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -107,7 +107,7 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface
             $query->whereNull($key);
         } elseif ($extraValue === 'NOT_NULL') {
             $query->whereNotNull($key);
-        } elseif (Str::startsWith($extraValue, '!')) {
+        } elseif ($extraValue[0] === '!') {
             $query->where($key, '!=', mb_substr($extraValue, 1));
         } else {
             $query->where($key, $extraValue);

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Validation;
 
 use Closure;
-use Illuminate\Support\Str;
 use Illuminate\Database\ConnectionResolverInterface;
 
 class DatabasePresenceVerifier implements PresenceVerifierInterface

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -341,7 +341,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function callCustomDirective($name, $value)
     {
-        if (Str::startsWith($value, '(') && Str::endsWith($value, ')')) {
+        if (($valueLength = strlen($value)) > 1 && $value[0] === '(' && $value[$valueLength - 1] === ')') {
             $value = Str::substr($value, 1, -1);
         }
 
@@ -356,7 +356,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function stripParentheses($expression)
     {
-        if (Str::startsWith($expression, '(')) {
+        if (($expressionLength = strlen($expression)) > 1 && $expression[0] === '(' && $expression[$expressionLength - 1] === ')') {
             $expression = substr($expression, 1, -1);
         }
 


### PR DESCRIPTION
Like in https://github.com/laravel/framework/pull/23746 replacement made from `startsWith()` to array access (when checking the first character).
These changes implies performance improvements: no `foreach()`, `substr()` and `strlen()` functions are used.