### PR TITLE
[5.6] Fix check on empty queue

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -229,7 +229,7 @@ class RedisQueue extends Queue implements QueueContract
     {
         $rawBody = $this->getConnection()->blpop($queue, $this->blockFor);
 
-        if (! is_null($rawBody)) {
+        if (! empty($rawBody)) {
             $payload = json_decode($rawBody[1], true);
 
             $payload['attempts']++;


### PR DESCRIPTION
When using phpredis, `blpop` returns an empty array if no elements are found in the list.
This can be easily deduced looking at [this test](https://github.com/phpredis/phpredis/blob/300c72510c48e210338826b713f260a4eda8abc7/tests/RedisTest.php#L833).

Fix #23756.