### PR TITLE
[5.7] Always return a collection when using random().

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1277,7 +1277,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return Arr::random($this->items);
         }
 
-        return new static(Arr::random($this->items, $number));
+        return new static(Arr::random($this->items, min(count($this->items), $number)));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2211,13 +2211,12 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testRandomThrowsAnExceptionUsingAmountBiggerThanCollectionSize()
+    public function testRandomReturnsWhatItHasWhenAmountBiggerThanCollectionSize()
     {
         $data = new Collection([1, 2, 3]);
-        $data->random(4);
+        $random = $data->random(4);
+        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertCount(3, $random);
     }
 
     public function testPipe()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2211,7 +2211,7 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-    public function testRandomReturnsWhatItHasWhenAmountBiggerThanCollectionSize()
+    public function testRandomReturnsCollectionWhenAmountBiggerThanCollectionSize()
     {
         $data = new Collection([1, 2, 3]);
         $random = $data->random(4);


### PR DESCRIPTION
https://github.com/laravel/ideas/issues/1035

**Issue: Documentation & Developer Expectations**
The Laravel documentation claims that passing an integer to the collection's random() method always returns a collection. This is not always true. It throws an InvalidArgumentException exception if it has less items than what is asked for. This is inconsistent with the documentation.

> **random()**
> <https://laravel.com/docs/5.6/collections#method-random>
> You may optionally pass an integer to random to specify how many items you would like to randomly retrieve. *A collection of items is always returned* when explicitly passing the number of items you wish to receive:

It has similar wording as the `take()` method.

> The take method returns a new collection with the specified number of items:

Additionally, to a new developer, these two code snippets seems to be interchangable, but they are not:

```php
collect([1,2,3])->random()->take(5); // [3,1,2]
collect([1,2,3])->random(5); // throws an exception
```

**Solution**
I updated the collection's random() method to always return a collection as documented. The `Arr::random()` method remains unchanged and will still throw an InvalidArgumentException exception when asked for more items than it contains.

```php
collect([1,2,3])->random()->take(5); // [1,3,2]
collect([1,2,3])->random(5); // [3,1,2]

Arr::random([1,2,3], 5); // InvalidArgumentException
```
