### PR TITLE
[5.6] Multiple cc, bcc and reply to recipients on mail notifications

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -137,12 +137,16 @@ class MailChannel
 
         $mailMessage->to($this->getRecipients($notifiable, $notification, $message));
 
-        if ($message->cc) {
-            $mailMessage->cc($message->cc[0], Arr::get($message->cc, 1));
+        if (! empty($message->cc)) {
+            foreach ($message->cc as $cc) {
+                $mailMessage->cc($cc[0], Arr::get($cc, 1));
+            }
         }
 
-        if ($message->bcc) {
-            $mailMessage->bcc($message->bcc[0], Arr::get($message->bcc, 1));
+        if (! empty($message->bcc)) {
+            foreach ($message->bcc as $bcc) {
+                $mailMessage->bcc($bcc[0], Arr::get($bcc, 1));
+            }
         }
     }
 
@@ -160,7 +164,9 @@ class MailChannel
         }
 
         if (! empty($message->replyTo)) {
-            $mailMessage->replyTo($message->replyTo[0], Arr::get($message->replyTo, 1));
+            foreach ($message->replyTo as $replyTo) {
+                $mailMessage->replyTo($replyTo[0], Arr::get($replyTo, 1));
+            }
         }
     }
 

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -144,7 +144,7 @@ class MailMessage extends SimpleMessage
      */
     public function replyTo($address, $name = null)
     {
-        $this->replyTo = [$address, $name];
+        $this->replyTo[] = [$address, $name];
 
         return $this;
     }
@@ -158,7 +158,7 @@ class MailMessage extends SimpleMessage
      */
     public function cc($address, $name = null)
     {
-        $this->cc = [$address, $name];
+        $this->cc[] = [$address, $name];
 
         return $this;
     }
@@ -172,7 +172,7 @@ class MailMessage extends SimpleMessage
      */
     public function bcc($address, $name = null)
     {
-        $this->bcc = [$address, $name];
+        $this->bcc[] = [$address, $name];
 
         return $this;
     }

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -7,7 +7,6 @@ use Illuminate\Notifications\Messages\MailMessage;
 
 class NotificationMailMessageTest extends TestCase
 {
-
     public function testTemplate()
     {
         $message = new MailMessage;

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -7,17 +7,57 @@ use Illuminate\Notifications\Messages\MailMessage;
 
 class NotificationMailMessageTest extends TestCase
 {
-    public function setUp()
-    {
-        $this->message = new MailMessage;
-    }
 
     public function testTemplate()
     {
-        $this->assertEquals('notifications::email', $this->message->markdown);
+        $message = new MailMessage;
 
-        $this->message->template('notifications::foo');
+        $this->assertEquals('notifications::email', $message->markdown);
 
-        $this->assertEquals('notifications::foo', $this->message->markdown);
+        $message->template('notifications::foo');
+
+        $this->assertEquals('notifications::foo', $message->markdown);
+    }
+
+    public function testCcIsSetCorrectly()
+    {
+        $message = new MailMessage;
+        $message->cc('test@example.com');
+
+        $this->assertSame([['test@example.com', null]], $message->cc);
+
+        $message = new MailMessage;
+        $message->cc('test@example.com')
+                ->cc('test@example.com', 'Test');
+
+        $this->assertSame([['test@example.com', null], ['test@example.com', 'Test']], $message->cc);
+    }
+
+    public function testBccIsSetCorrectly()
+    {
+        $message = new MailMessage;
+        $message->bcc('test@example.com');
+
+        $this->assertSame([['test@example.com', null]], $message->bcc);
+
+        $message = new MailMessage;
+        $message->bcc('test@example.com')
+                ->bcc('test@example.com', 'Test');
+
+        $this->assertSame([['test@example.com', null], ['test@example.com', 'Test']], $message->bcc);
+    }
+
+    public function testReplyToIsSetCorrectly()
+    {
+        $message = new MailMessage;
+        $message->replyTo('test@example.com');
+
+        $this->assertSame([['test@example.com', null]], $message->replyTo);
+
+        $message = new MailMessage;
+        $message->replyTo('test@example.com')
+                ->replyTo('test@example.com', 'Test');
+
+        $this->assertSame([['test@example.com', null], ['test@example.com', 'Test']], $message->replyTo);
     }
 }


### PR DESCRIPTION
Added the ability to define multiple cc, bcc, reply to address on mail notifications. This can already be done on mailable's. Both classes look so similar I made the assumption in a live project that notifications could allow multiple cc's when sending emails.

Added minimal tests to assert multiple / singular items.