### PR TITLE
[5.7] Fix PhpRedis return value of BLPOP/BRPOP

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -156,6 +156,34 @@ class PhpRedisConnection extends Connection
     }
 
     /**
+     * Removes and returns the first element of the list stored at key.
+     * It is the blocking version of LPOP.
+     *
+     * @param  dynamic  $arguments
+     * @return array|null
+     */
+    public function blpop(...$arguments)
+    {
+        $result = $this->command('blpop', $arguments);
+
+        return empty($result) ? null : $result;
+    }
+
+    /**
+     * Removes and returns the last element of the list stored at key.
+     * It is the blocking version of RPOP.
+     *
+     * @param  dynamic  $arguments
+     * @return array|null
+     */
+    public function brpop(...$arguments)
+    {
+        $result = $this->command('brpop', $arguments);
+
+        return empty($result) ? null : $result;
+    }
+
+    /**
      * Removes and returns a random element from the set value at key.
      *
      * @param  string  $key


### PR DESCRIPTION
The PR ensures that `BLPOP` and `BRPOP` on `PhpRedisConnection` return `null` like `PredisRedisConnection` does.

Targets v5.7, just in case people already rely on it return `[]`.

See #23757.