### PR TITLE
[5.6] Delete duplicated config('app.debug') from Exception Handler

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -482,7 +482,7 @@ class Handler implements ExceptionHandlerContract
     /**
      * @return \Illuminate\Config\Repository|mixed
      */
-    private function isDebugMode()
+    protected function isDebugMode()
     {
         return config('app.debug');
     }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -276,7 +276,7 @@ class Handler implements ExceptionHandlerContract
      */
     protected function prepareResponse($request, Exception $e)
     {
-        if (! $this->isHttpException($e) && config('app.debug')) {
+        if (! $this->isHttpException($e) && $this->isDebugMode()) {
             return $this->toIlluminateResponse($this->convertExceptionToResponse($e), $e);
         }
 
@@ -313,11 +313,11 @@ class Handler implements ExceptionHandlerContract
     protected function renderExceptionContent(Exception $e)
     {
         try {
-            return config('app.debug') && class_exists(Whoops::class)
+            return $this->isDebugMode() && class_exists(Whoops::class)
                         ? $this->renderExceptionWithWhoops($e)
-                        : $this->renderExceptionWithSymfony($e, config('app.debug'));
+                        : $this->renderExceptionWithSymfony($e, $this->isDebugMode());
         } catch (Exception $e) {
-            return $this->renderExceptionWithSymfony($e, config('app.debug'));
+            return $this->renderExceptionWithSymfony($e, $this->isDebugMode());
         }
     }
 
@@ -443,7 +443,7 @@ class Handler implements ExceptionHandlerContract
      */
     protected function convertExceptionToArray(Exception $e)
     {
-        return config('app.debug') ? [
+        return $this->isDebugMode() ? [
             'message' => $e->getMessage(),
             'exception' => get_class($e),
             'file' => $e->getFile(),
@@ -477,5 +477,13 @@ class Handler implements ExceptionHandlerContract
     protected function isHttpException(Exception $e)
     {
         return $e instanceof HttpException;
+    }
+
+    /**
+     * @return \Illuminate\Config\Repository|mixed
+     */
+    private function isDebugMode()
+    {
+        return config('app.debug');
     }
 }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -276,7 +276,7 @@ class Handler implements ExceptionHandlerContract
      */
     protected function prepareResponse($request, Exception $e)
     {
-        if (! $this->isHttpException($e) && $this->isDebugMode()) {
+        if (! $this->isHttpException($e) && $this->inDebugMode()) {
             return $this->toIlluminateResponse($this->convertExceptionToResponse($e), $e);
         }
 
@@ -313,11 +313,11 @@ class Handler implements ExceptionHandlerContract
     protected function renderExceptionContent(Exception $e)
     {
         try {
-            return $this->isDebugMode() && class_exists(Whoops::class)
+            return $this->inDebugMode() && class_exists(Whoops::class)
                         ? $this->renderExceptionWithWhoops($e)
-                        : $this->renderExceptionWithSymfony($e, $this->isDebugMode());
+                        : $this->renderExceptionWithSymfony($e, $this->inDebugMode());
         } catch (Exception $e) {
-            return $this->renderExceptionWithSymfony($e, $this->isDebugMode());
+            return $this->renderExceptionWithSymfony($e, $this->inDebugMode());
         }
     }
 
@@ -443,7 +443,7 @@ class Handler implements ExceptionHandlerContract
      */
     protected function convertExceptionToArray(Exception $e)
     {
-        return $this->isDebugMode() ? [
+        return $this->inDebugMode() ? [
             'message' => $e->getMessage(),
             'exception' => get_class($e),
             'file' => $e->getFile(),
@@ -482,7 +482,7 @@ class Handler implements ExceptionHandlerContract
     /**
      * @return \Illuminate\Config\Repository|mixed
      */
-    protected function isDebugMode()
+    protected function inDebugMode()
     {
         return config('app.debug');
     }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -124,6 +124,22 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertNotContains('"line":', $response);
         $this->assertNotContains('"trace":', $response);
     }
+
+    public function testInDebugMode()
+    {
+        // prepare date
+        $reflection = new \ReflectionClass(get_class($this->handler));
+        $method = $reflection->getMethod('inDebugMode');
+        $method->setAccessible(true);
+
+        // app.debug false
+        $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(false);
+        $this->assertFalse($method->invokeArgs($this->handler, []));
+
+        // app.debug true
+        $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(true);
+        $this->assertTrue($method->invokeArgs($this->handler, []));
+    }
 }
 
 class CustomException extends Exception implements Responsable


### PR DESCRIPTION
Illuminate/Foundation/Exceptions/Handler.php refactoring about `config('app.debug')` 