### PR TITLE
[5.6] Execute an Artisan command using either its name or class

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -168,13 +168,17 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     public function call($command, array $parameters = [], $outputBuffer = null)
     {
-        $parameters = collect($parameters)->prepend($command);
+        if (class_exists($command)) {
+            $command = $this->laravel->make($command)->getName();
+        }
+
+        array_unshift($parameters, $command);
 
         $this->lastOutput = $outputBuffer ?: new BufferedOutput;
 
         $this->setCatchExceptions(false);
 
-        $result = $this->run(new ArrayInput($parameters->toArray()), $this->lastOutput);
+        $result = $this->run(new ArrayInput($parameters), $this->lastOutput);
 
         $this->setCatchExceptions(true);
 

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -168,7 +168,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     public function call($command, array $parameters = [], $outputBuffer = null)
     {
-        if (class_exists($command)) {
+        if (is_subclass_of($command, SymfonyCommand::class)) {
             $command = $this->laravel->make($command)->getName();
         }
 

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -17,16 +17,20 @@ class ConsoleApplicationTest extends TestCase
 
     public function test_artisan_call_using_command_name()
     {
-        $this->artisan('foo:bar', [
+        $exitCode = $this->artisan('foo:bar', [
             'id' => 1,
         ]);
+
+        $this->assertEquals($exitCode, 0);
     }
 
     public function test_artisan_call_using_command_class()
     {
-        $this->artisan(FooCommandStub::class, [
+        $exitCode = $this->artisan(FooCommandStub::class, [
             'id' => 1,
         ]);
+
+        $this->assertEquals($exitCode, 0);
     }
 
     /**

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Console\Command;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Contracts\Console\Kernel;
+
+class ConsoleApplicationTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->app[Kernel::class]->registerCommand(new FooCommandStub);
+    }
+
+    public function test_artisan_call_using_command_name()
+    {
+        $this->artisan('foo:bar', [
+            'id' => 1,
+        ]);
+    }
+
+    public function test_artisan_call_using_command_class()
+    {
+        $this->artisan(FooCommandStub::class, [
+            'id' => 1,
+        ]);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Console\Exception\CommandNotFoundException
+     */
+    public function test_artisan_call_invalid_command_name()
+    {
+        $this->artisan('foo:bars');
+    }
+}
+
+class FooCommandStub extends Command
+{
+    protected $signature = 'foo:bar {id}';
+
+    public function handle()
+    {
+        //
+    }
+}


### PR DESCRIPTION
This implementation adds the ability to execute a command using class notation:

```php
Artisan::call(FooCommand::class, [
    'user' => 1, '--queue' => 'default'
]);
```

Using the command name:

```php
Artisan::call('foo:bar', [
    'user' => 1, '--queue' => 'default'
]);
```