### PR TITLE
[5.6] Allowing IAM role SESSION_TOKEN to be used with SES

### DIFF
--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -91,7 +91,7 @@ class TransportManager extends Manager
     protected function addSesCredentials(array $config)
     {
         if ($config['key'] && $config['secret']) {
-            $config['credentials'] = Arr::only($config, ['key', 'secret']);
+            $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
         }
 
         return $config;


### PR DESCRIPTION
By default, the SES driver allows for the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to be passed to the SES driver - however for instances using an IAM role, rather than these credentials in the .env file, sending an email will fail with an invalid Session Token error.

This change adds the token attribute in to allow for the AWS_SESSION_TOKEN to be passed in. Config would look something like:

```<?php
return [
    'ses' => [
        'key'    => env('AWS_ACCESS_KEY_ID'),
        'secret' => env('AWS_SECRET_ACCESS_KEY'),
        'token'  => env('AWS_SESSION_TOKEN'),
        'region' => env('AWS_REGION', 'eu-west-1'),  // e.g. us-east-1
    ],
];
```
If the token does not exist, or if the request does not rely on one, this option is safely ignored as the AWS SDK gracefully ignores it (and uses null as default).