### PR TITLE
[5.6] Container bindMethod improvement

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -287,7 +287,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  array|string $method
      * @return string
      *
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     protected function parseBindMethod($method)
     {
@@ -363,7 +363,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \Closure  $closure
      * @return void
      *
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     public function extend($abstract, Closure $closure)
     {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -7,6 +7,7 @@ use ArrayAccess;
 use LogicException;
 use ReflectionClass;
 use ReflectionParameter;
+use InvalidArgumentException;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 
@@ -285,11 +286,19 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  array|string $method
      * @return string
+     *
+     * @throws InvalidArgumentException
      */
     protected function parseBindMethod($method)
     {
         if (is_array($method)) {
-            return $method[0].'@'.$method[1];
+            if (count($method) > 1) {
+                return $method[0].'@'.$method[1];
+            }
+
+            throw new InvalidArgumentException(
+                sprintf('method should be array with 2 parameters, %s given', count($method))
+            );
         }
 
         return $method;
@@ -354,7 +363,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \Closure  $closure
      * @return void
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function extend($abstract, Closure $closure)
     {

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -593,6 +593,18 @@ class ContainerTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage method should be array with 2 parameters, 1 given
+     */
+    public function testBindMethodWithOneArrayParam()
+    {
+        $container = new Container;
+        $container->bindMethod([\Illuminate\Tests\Container\ContainerTestCallStub::class], function ($stub) {
+            return $stub->unresolvable('foo', 'bar');
+        });
+    }
+
     public function testContainerCanInjectDifferentImplementationsDependingOnContext()
     {
         $container = new Container;


### PR DESCRIPTION
**Problem:**
When we try to use  bindMethod with array count 1

```PHP
$container->bindMethod([\Illuminate\Tests\Container\ContainerTestCallStub::class], function ($stub) {
            return $stub->unresolvable('foo', 'bar');
        });
```
then we give a notice:

_Undefined offset: 1_

---

This PR will give a normal exception message for the user.


---

What are you think about this PR?
In case if it will be ok, then I can make a PR for 5.7 with strict comparing:

```PHP
if (count($method) === 2) 
```
instead
```PHP
if (count($method) > 1) 
```