### PR TITLE
[5.6] Add truncate option to seed command

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -104,7 +104,7 @@ class SeedCommand extends Command
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
 
         $tableNames = Schema::getConnection()->getDoctrineSchemaManager()->listTableNames();
-        $this->info("Truncate tables...");
+        $this->info('Truncate tables...');
         foreach ($tableNames as $name) {
             //don't truncate migrations
             if ($name == 'migrations') {
@@ -112,7 +112,7 @@ class SeedCommand extends Command
             }
             DB::table($name)->truncate();
         }
-        $this->info("All tables truncated successfuly.");
+        $this->info('All tables truncated successfuly.');
 
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
     }

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -38,7 +38,7 @@ class SeedCommand extends Command
     /**
      * Create a new database seed command instance.
      *
-     * @param  \Illuminate\Database\ConnectionResolverInterface $resolver
+     * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
      * @return void
      */
     public function __construct(Resolver $resolver)

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Database\Console\Seeds;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Console\ConfirmableTrait;
 use Symfony\Component\Console\Input\InputOption;
@@ -36,7 +38,7 @@ class SeedCommand extends Command
     /**
      * Create a new database seed command instance.
      *
-     * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
+     * @param  \Illuminate\Database\ConnectionResolverInterface $resolver
      * @return void
      */
     public function __construct(Resolver $resolver)
@@ -58,6 +60,10 @@ class SeedCommand extends Command
         }
 
         $this->resolver->setDefaultConnection($this->getDatabase());
+
+        if ($this->input->getOption('truncate')) {
+            $this->truncateTables();
+        }
 
         Model::unguarded(function () {
             $this->getSeeder()->__invoke();
@@ -89,6 +95,29 @@ class SeedCommand extends Command
     }
 
     /**
+     * Truncate all tables in database.
+     *
+     * @return void
+     */
+    protected function truncateTables()
+    {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+
+        $tableNames = Schema::getConnection()->getDoctrineSchemaManager()->listTableNames();
+        $this->info("Truncate tables...");
+        foreach ($tableNames as $name) {
+            //don't truncate migrations
+            if ($name == 'migrations') {
+                continue;
+            }
+            DB::table($name)->truncate();
+        }
+        $this->info("All tables truncated successfuly.");
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+    }
+
+    /**
      * Get the console command options.
      *
      * @return array
@@ -101,6 +130,8 @@ class SeedCommand extends Command
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed'],
 
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
+
+            ['truncate', null, InputOption::VALUE_NONE, 'Truncate all tables before seed.'],
         ];
     }
 }


### PR DESCRIPTION
if you want to truncate all tables when seeding you should to run this command.
```
php artisan db:seed --trancate
```