### PR TITLE
[5.6] Schedule - Use is_subclass_of()

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -7,6 +7,7 @@ use Illuminate\Console\Application;
 use Illuminate\Container\Container;
 use Illuminate\Support\ProcessUtils;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 
 class Schedule
 {
@@ -74,7 +75,7 @@ class Schedule
      */
     public function command($command, array $parameters = [])
     {
-        if (class_exists($command)) {
+        if (is_subclass_of($command, SymfonyCommand::class)) {
             $command = Container::getInstance()->make($command)->getName();
         }
 


### PR DESCRIPTION
Following: https://github.com/laravel/framework/pull/23764

This is not a bug fix or anything, just being more specific in the evaluation.

Already tested here: https://github.com/laravel/framework/blob/5.6/tests/Console/ConsoleEventSchedulerTest.php#L89

So, all good. :)