### PR TITLE
[5.6] Delete code duplication in findOrFail and firstOrFail methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -7,11 +7,14 @@ use InvalidArgumentException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\Traits\FindOrFail;
+use Illuminate\Database\Eloquent\Relations\Traits\FirstOrFail;
 
 class BelongsToMany extends Relation
 {
-    use Concerns\InteractsWithPivotTable;
+    use Concerns\InteractsWithPivotTable,
+        FirstOrFail,
+        FindOrFail;
 
     /**
      * The intermediate table for the relation.
@@ -494,30 +497,6 @@ class BelongsToMany extends Relation
     }
 
     /**
-     * Find a related model by its primary key or throw an exception.
-     *
-     * @param  mixed  $id
-     * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
-     *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
-    public function findOrFail($id, $columns = ['*'])
-    {
-        $result = $this->find($id, $columns);
-
-        if (is_array($id)) {
-            if (count($result) == count(array_unique($id))) {
-                return $result;
-            }
-        } elseif (! is_null($result)) {
-            return $result;
-        }
-
-        throw (new ModelNotFoundException)->setModel(get_class($this->related));
-    }
-
-    /**
      * Execute the query and get the first result.
      *
      * @param  array   $columns
@@ -528,23 +507,6 @@ class BelongsToMany extends Relation
         $results = $this->take(1)->get($columns);
 
         return count($results) > 0 ? $results->first() : null;
-    }
-
-    /**
-     * Execute the query and get the first result or throw an exception.
-     *
-     * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|static
-     *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
-    public function firstOrFail($columns = ['*'])
-    {
-        if (! is_null($model = $this->first($columns))) {
-            return $model;
-        }
-
-        throw (new ModelNotFoundException)->setModel(get_class($this->related));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -6,10 +6,14 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\Traits\FindOrFail;
+use Illuminate\Database\Eloquent\Relations\Traits\FirstOrFail;
 
 class HasManyThrough extends Relation
 {
+    use FirstOrFail,
+        FindOrFail;
+
     /**
      * The "through" parent model instance.
      *
@@ -260,23 +264,6 @@ class HasManyThrough extends Relation
     }
 
     /**
-     * Execute the query and get the first result or throw an exception.
-     *
-     * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|static
-     *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
-    public function firstOrFail($columns = ['*'])
-    {
-        if (! is_null($model = $this->first($columns))) {
-            return $model;
-        }
-
-        throw (new ModelNotFoundException)->setModel(get_class($this->related));
-    }
-
-    /**
      * Find a related model by its primary key.
      *
      * @param  mixed  $id
@@ -310,30 +297,6 @@ class HasManyThrough extends Relation
         return $this->whereIn(
             $this->getRelated()->getQualifiedKeyName(), $ids
         )->get($columns);
-    }
-
-    /**
-     * Find a related model by its primary key or throw an exception.
-     *
-     * @param  mixed  $id
-     * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
-     *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
-    public function findOrFail($id, $columns = ['*'])
-    {
-        $result = $this->find($id, $columns);
-
-        if (is_array($id)) {
-            if (count($result) == count(array_unique($id))) {
-                return $result;
-            }
-        } elseif (! is_null($result)) {
-            return $result;
-        }
-
-        throw (new ModelNotFoundException)->setModel(get_class($this->related));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Traits/FindOrFail.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Traits/FindOrFail.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations\Traits;
+
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+/**
+ * Trait FindOrFail.
+ *
+ * @property $related
+ */
+trait FindOrFail
+{
+    /**
+     * Find a related model by its primary key or throw an exception.
+     *
+     * @param  mixed  $id
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function findOrFail($id, $columns = ['*'])
+    {
+        $result = $this->find($id, $columns);
+
+        if (is_array($id)) {
+            if (count($result) == count(array_unique($id))) {
+                return $result;
+            }
+        } elseif (! is_null($result)) {
+            return $result;
+        }
+
+        throw (new ModelNotFoundException)->setModel(get_class($this->related));
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/Traits/FirstOrFail.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Traits/FirstOrFail.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations\Traits;
+
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+/**
+ * Trait FirstOrFail.
+ *
+ * @property $related
+ */
+trait FirstOrFail
+{
+    /**
+     * Execute the query and get the first result or throw an exception.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function firstOrFail($columns = ['*'])
+    {
+        if (! is_null($model = $this->first($columns))) {
+            return $model;
+        }
+
+        throw (new ModelNotFoundException)->setModel(get_class($this->related));
+    }
+}


### PR DESCRIPTION
This PR reduces code duplication in FW.

---

Tests for findOrFail and firstOrFail was added in 

https://github.com/laravel/framework/pull/23771/files#diff-81d86665267a29f158ae5eea9af74711R54

and 
https://github.com/laravel/framework/blob/5.6/tests/Integration/Database/EloquentBelongsToManyTest.php#L256
https://github.com/laravel/framework/blob/5.6/tests/Integration/Database/EloquentBelongsToManyTest.php#L283

