### PR TITLE
[5.6] Changed phpdoc from \Ramsey\Uuid\Uuid to \Ramsey\Uuid\UuidInterface

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -524,7 +524,7 @@ class Str
     /**
      * Generate a UUID (version 4).
      *
-     * @return \Ramsey\Uuid\Uuid
+     * @return \Ramsey\Uuid\UuidInterface
      */
     public static function uuid()
     {
@@ -534,7 +534,7 @@ class Str
     /**
      * Generate a time-ordered UUID (version 4).
      *
-     * @return \Ramsey\Uuid\Uuid
+     * @return \Ramsey\Uuid\UuidInterface
      */
     public static function orderedUuid()
     {


### PR DESCRIPTION
 - because Uuid::uuid4() in phpdoc returned the \Ramsey\Uuid\UuidInterface