### PR TITLE
[5.6] Add feature for sending scheduled commands output to log channels

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -5,13 +5,13 @@ namespace Illuminate\Console\Scheduling;
 use Closure;
 use Cron\CronExpression;
 use Illuminate\Support\Arr;
+use Illuminate\Log\LogManager;
 use Illuminate\Support\Carbon;
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Contracts\Mail\Mailer;
 use Symfony\Component\Process\Process;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Log\LogManager;
 
 class Event
 {
@@ -455,7 +455,7 @@ class Event
      *
      * @throws \LogicException
      */
-    public function logOutputTo($channels, bool $onlyIfOutputExists = false): Event
+    public function logOutputTo($channels, bool $onlyIfOutputExists = false)
     {
         $this->ensureOutputIsBeingCapturedForLog();
 
@@ -474,7 +474,7 @@ class Event
      *
      * @throws \LogicException
      */
-    public function logWrittenOutputTo($channels): Event
+    public function logWrittenOutputTo($channels)
     {
         return $this->logOutputTo($channels, true);
     }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Mail\Mailer;
 use Symfony\Component\Process\Process;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Log\LogManager;
 
 class Event
 {
@@ -180,8 +181,8 @@ class Event
         }
 
         $this->runInBackground
-                    ? $this->runCommandInBackground($container)
-                    : $this->runCommandInForeground($container);
+            ? $this->runCommandInBackground($container)
+            : $this->runCommandInForeground($container);
     }
 
     /**
@@ -275,7 +276,7 @@ class Event
         }
 
         return $this->expressionPasses() &&
-               $this->runsInEnvironment($app->environment());
+            $this->runsInEnvironment($app->environment());
     }
 
     /**
@@ -443,6 +444,80 @@ class Event
         }
 
         return "Scheduled Job Output For [{$this->command}]";
+    }
+
+    /**
+     * Log the results of the scheduled operation.
+     *
+     * @param  array|mixed  $channels
+     * @param  bool  $onlyIfOutputExists
+     * @return $this
+     *
+     * @throws \LogicException
+     */
+    public function logOutputTo($channels, bool $onlyIfOutputExists = false): Event
+    {
+        $this->ensureOutputIsBeingCapturedForLog();
+
+        $channels = Arr::wrap($channels);
+
+        return $this->then(function (LogManager $logger) use ($channels, $onlyIfOutputExists) {
+            $this->logOutput($logger, $channels, $onlyIfOutputExists);
+        });
+    }
+
+    /**
+     * Send to log the results of the scheduled operation if it produces output.
+     *
+     * @param  array|mixed  $channels
+     * @return $this
+     *
+     * @throws \LogicException
+     */
+    public function logWrittenOutputTo($channels): Event
+    {
+        return $this->logOutputTo($channels, true);
+    }
+
+    /**
+     * Ensure that output is being captured for log.
+     *
+     * @return void
+     */
+    protected function ensureOutputIsBeingCapturedForLog()
+    {
+        if (is_null($this->output) || $this->output == $this->getDefaultOutput()) {
+            $this->sendOutputTo(storage_path('logs/schedule-'.sha1($this->mutexName()).'.log'));
+        }
+    }
+
+    /**
+     * Log the output of the event to the channels.
+     *
+     * @param  \Illuminate\Log\LogManager  $logger
+     * @param  array  $channels
+     * @param  bool  $onlyIfOutputExists
+     * @return void
+     */
+    protected function logOutput(LogManager $logger, array $channels, bool $onlyIfOutputExists = false): void
+    {
+        $output = file_exists($this->output) ? file_get_contents($this->output) : '';
+
+        if ($onlyIfOutputExists && empty($output)) {
+            return;
+        }
+
+        $logger->stack($channels)->info($this->getLogMessage(), ['output' => $output]);
+    }
+
+    /**
+     * Get the log message for output results.
+     *
+     * @return string
+     */
+    protected function getLogMessage()
+    {
+        return $this->getEmailSubject();
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -497,7 +497,7 @@ class Event
      * @param  bool  $onlyIfOutputExists
      * @return void
      */
-    protected function logOutput(LogManager $logger, array $channels, bool $onlyIfOutputExists = false): void
+    protected function logOutput(LogManager $logger, array $channels, bool $onlyIfOutputExists = false)
     {
         $output = file_exists($this->output) ? file_get_contents($this->output) : '';
 

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -146,7 +146,7 @@ class Event
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Console\Scheduling\Mutex  $mutex
+     * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
      * @param  string  $command
      * @return void
      */

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -486,9 +486,7 @@ class Event
      */
     protected function ensureOutputIsBeingCapturedForLog()
     {
-        if (is_null($this->output) || $this->output == $this->getDefaultOutput()) {
-            $this->sendOutputTo(storage_path('logs/schedule-'.sha1($this->mutexName()).'.log'));
-        }
+        $this->ensureOutputIsBeingCapturedForEmail();
     }
 
     /**


### PR DESCRIPTION
This PR adds a feature for sending scheduled commands output to log channels (Related feature request https://github.com/laravel/ideas/issues/1092)

Added public method `logOutputTo($channels)`.

Usage: `logOutputTo('daily')` or  `logOutputTo(['daily', 'slack'])`

Few notes regarding to changes:
- Maybe its better to merge `getEmailSubject` and `getLogMessage` methods in to one method, something like `getCommandDescription`  or `getCommandTitle`
- Same for `ensureOutputIsBeingCapturedForEmail` and `ensureOutputIsBeingCapturedForLog`, move to `ensureOutputIsBeingCaptured` method 

