### PR TITLE
Simplify Fluent constructor

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -24,9 +24,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function __construct($attributes = [])
     {
-        foreach ($attributes as $key => $value) {
-            $this->attributes[$key] = $value;
-        }
+        $this->attributes = $attributes;
     }
 
     /**


### PR DESCRIPTION
When source-diving, I came across this, and I immediately asked myself why it was done that way, as when calling the constructor the object isn't instantiated yet and the attributes array is always empty.

This PR removes the loop and simplifies the Fluent constructor according to the above fact. I'd love to know if there's a special reason why it has to be like that.

:octocat: 