### PR TITLE
[5.6] Check for null when calling array_key_exists

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -144,6 +144,10 @@ class Arr
      */
     public static function exists($array, $key)
     {
+        if (is_null($array) {
+            return false;
+        }
+
         if ($array instanceof ArrayAccess) {
             return $array->offsetExists($key);
         }


### PR DESCRIPTION
When a provider is misconfigured (as one, but not the only example), `Support\Arr::exists()` can be called with a `null` for the `$array` argument. This would cause the subsequent call to `array_key_exists` to fail. The problem with this is that in some cases, the root of the problem (a badly configured provider, for example) might be covered by this exception.