### PR TITLE
[5.6] Changed app helper to facade in Authorizable trait.

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/Authorizable.php
+++ b/src/Illuminate/Foundation/Auth/Access/Authorizable.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Foundation\Auth\Access;
 
-use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Support\Facades\Gate;
 
 trait Authorizable
 {
@@ -15,7 +15,7 @@ trait Authorizable
      */
     public function can($ability, $arguments = [])
     {
-        return app(Gate::class)->forUser($this)->check($ability, $arguments);
+        return Gate::forUser($this)->check($ability, $arguments);
     }
 
     /**


### PR DESCRIPTION
So,
I have a question,
Why in this case have we used an app helper instead of the facade?

Gate Facade code:

```
<?php

namespace Illuminate\Support\Facades;

use Illuminate\Contracts\Auth\Access\Gate as GateContract;

/**
 * @method static bool has(string $ability)
 * @method static \Illuminate\Contracts\Auth\Access\Gate define(string $ability, callable | string $callback)
 * @method static \Illuminate\Contracts\Auth\Access\Gate policy(string $class, string $policy)
 * @method static \Illuminate\Contracts\Auth\Access\Gate before(callable $callback)
 * @method static \Illuminate\Contracts\Auth\Access\Gate after(callable $callback)
 * @method static bool allows(string $ability, array | mixed $arguments = [])
 * @method static bool denies(string $ability, array | mixed $arguments = [])
 * @method static bool check(iterable | string $abilities, array | mixed $arguments = [])
 * @method static bool any(iterable | string $abilities, array | mixed $arguments = [])
 * @method static \Illuminate\Auth\Access\Response authorize(string $ability, array | mixed $arguments = [])
 * @method static mixed getPolicyFor(object | string $class)
 * @method static forUser(\Illuminate\Contracts\Auth\Authenticatable | mixed $user)
 * @method static array abilities()
 *
 * @see \Illuminate\Contracts\Auth\Access\Gate
 */
class Gate extends Facade
{
    /**
     * Get the registered name of the component.
     *
     * @return string
     */
    protected static function getFacadeAccessor()
    {
        return GateContract::class;
    }
}

```