### PR TITLE
[5.6] Update phpDoc for mix helper.

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -553,7 +553,7 @@ if (! function_exists('mix')) {
      *
      * @param  string  $path
      * @param  string  $manifestDirectory
-     * @return \Illuminate\Support\HtmlString
+     * @return \Illuminate\Support\HtmlString|string
      *
      * @throws \Exception
      */


### PR DESCRIPTION
actually
mix helper also can return the string:

```PHP
        if (! isset($manifest[$path])) {
            report(new Exception("Unable to locate Mix file: {$path}."));

            if (! app('config')->get('app.debug')) {
                return $path;
            }
        }
```