### PR TITLE
[5.6] Use isset instead of array_key_exists

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -144,15 +144,11 @@ class Arr
      */
     public static function exists($array, $key)
     {
-        if (is_null($array)) {
-            return false;
-        }
-
         if ($array instanceof ArrayAccess) {
             return $array->offsetExists($key);
         }
 
-        return array_key_exists($key, $array);
+        return isset($array[$key]);
     }
 
     /**


### PR DESCRIPTION
From [the documentation](https://php.net/isset):
```
Determine if a variable is set and is not NULL.
```