### PR TITLE
[5.6] Adds new comparison validation rules to compare two fields against each other.

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -445,6 +445,44 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is greater than another attribute.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateGreaterThan($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'greaterThan');
+
+        $comparedToValue = $this->getValue($parameters[0]);
+
+        $this->requireSameTypeValues($value, $comparedToValue);
+
+        return $this->getSize($attribute, $value) > $this->getSize($attribute, $comparedToValue);
+    }
+
+    /**
+     * Validate that an attribute is less than another attribute.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateLessThan($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'greaterThan');
+
+        $comparedToValue = $this->getValue($parameters[0]);
+
+        $this->requireSameTypeValues($value, $comparedToValue);
+
+        return $this->getSize($attribute, $value) < $this->getSize($attribute, $comparedToValue);
+    }
+
+    /**
      * Validate that an attribute has a given number of digits.
      *
      * @param  string  $attribute
@@ -1537,6 +1575,19 @@ trait ValidatesAttributes
     {
         if (count($parameters) < $count) {
             throw new InvalidArgumentException("Validation rule $rule requires at least $count parameters.");
+        }
+    }
+
+    /**
+     * Require comparison values to be of the same type.
+     *
+     * @param $first
+     * @param $second
+     */
+    protected function requireSameTypeValues($first, $second)
+    {
+        if (gettype($first) != gettype($second)) {
+            throw new InvalidArgumentException('The values under comparison must be of the same type');
         }
     }
 }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1581,8 +1581,11 @@ trait ValidatesAttributes
     /**
      * Require comparison values to be of the same type.
      *
-     * @param $first
-     * @param $second
+     * @param  mixed  $first
+     * @param  mixed  $second
+     * @return void
+     *
+     * @throws \InvalidArgumentException
      */
     protected function requireSameTypeValues($first, $second)
     {

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -167,7 +167,7 @@ class Validator implements ValidatorContract
     protected $dependentRules = [
         'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
         'RequiredIf', 'RequiredUnless', 'Confirmed', 'Same', 'Different', 'Unique',
-        'Before', 'After', 'BeforeOrEqual', 'AfterOrEqual', 'GreaterThan', 'LessThan'
+        'Before', 'After', 'BeforeOrEqual', 'AfterOrEqual', 'GreaterThan', 'LessThan',
     ];
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -167,7 +167,7 @@ class Validator implements ValidatorContract
     protected $dependentRules = [
         'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
         'RequiredIf', 'RequiredUnless', 'Confirmed', 'Same', 'Different', 'Unique',
-        'Before', 'After', 'BeforeOrEqual', 'AfterOrEqual',
+        'Before', 'After', 'BeforeOrEqual', 'AfterOrEqual', 'GreaterThan', 'LessThan'
     ];
 
     /**
@@ -182,7 +182,7 @@ class Validator implements ValidatorContract
      *
      * @var array
      */
-    protected $numericRules = ['Numeric', 'Integer'];
+    protected $numericRules = ['Numeric', 'Integer', 'GreaterThan', 'LessThan'];
 
     /**
      * Create a new Validator instance.

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1051,6 +1051,46 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testGreaterThan()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'greater_than:rhs']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'greater_than:rhs']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1,'string']], ['lhs' => 'greater_than:rhs']);
+        $this->assertTrue($v->fails());
+
+        $fileOne = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
+        $fileTwo = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(3151));
+        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'greater_than:rhs']);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testLessThan()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'less_than:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'less_than:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1,'string']], ['lhs' => 'less_than:rhs']);
+        $this->assertTrue($v->passes());
+
+        $fileOne = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
+        $fileTwo = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(3151));
+        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'less_than:rhs']);
+        $this->assertTrue($v->fails());
+    }
+
     public function testValidateAccepted()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1060,7 +1060,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'greater_than:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1,'string']], ['lhs' => 'greater_than:rhs']);
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'greater_than:rhs']);
         $this->assertTrue($v->fails());
 
         $fileOne = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
@@ -1080,7 +1080,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'less_than:rhs']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1,'string']], ['lhs' => 'less_than:rhs']);
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'less_than:rhs']);
         $this->assertTrue($v->passes());
 
         $fileOne = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();


### PR DESCRIPTION
This PR adds two new validation rules `greater_than` & `less_than`, those two new rules will be used to compare two fields against each other, the two rules are different than `max/min` rules because the two fields under validation must be of the same type also they passed parameter cannot be a hard coded value..

An example:
Supposedly we have a form that takes two input min_salary & max_salary...

```
$rules = [
'min_salary' => 'less_than:max_salary',
'max_salary' => 'greater_than:min_salary'
];
```

The above rules will enforce the min_salary to respect the max_salary value and vice versa.
