### PR TITLE
[5.6] Allow not faking model events

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -34,6 +34,17 @@ class Event extends Facade
     }
 
     /**
+     * Replace the bound instance with a fake except for model events.
+     *
+     * @param  array|string  $eventsToFake
+     * @return void
+     */
+    public static function fakeExceptModels($eventsToFake = [])
+    {
+        static::swap(new EventFake(static::getFacadeRoot(), $eventsToFake));
+    }
+
+    /**
      * Get the registered name of the component.
      *
      * @return string


### PR DESCRIPTION
This will allow faking all the events except for the model events.
This is important when model events are used to fill database fields.

This was inspired by this package https://github.com/scorelabs/laravel-event-fake

The reason for this PR is that i have test where i need to check that events are being brodcasted and at the same time some models that i create in the test setup rely on the model events to fill some nullable fields which causes my tests to fail.