### PR TITLE
[5.6] Add missing dependency on league/flysystem-cached-adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "dragonmantank/cron-expression": "~2.0",
         "erusev/parsedown": "~1.7",
         "league/flysystem": "^1.0.8",
+        "league/flysystem-cached-adapter": "^1.0",
         "monolog/monolog": "~1.12",
         "nesbot/carbon": "^1.24.1",
         "psr/container": "~1.0",


### PR DESCRIPTION
Illuminate\Filesystem\Cache extends League\Flysystem\Cached\Storage\AbstractCache which can only be found in the package added in this PR.

NOTE: As a side-effect this fixes phpunit's code coverage generation which was my original goal.