### PR TITLE
[5.6] Revert allowing null input in Arr::exists()

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -144,10 +144,6 @@ class Arr
      */
     public static function exists($array, $key)
     {
-        if (is_null($array)) {
-            return false;
-        }
-
         if ($array instanceof ArrayAccess) {
             return $array->offsetExists($key);
         }


### PR DESCRIPTION
As suggested by @ntzm, opening a dedicated PR.

This reverts #23792, where you can find the rationale.