### PR TITLE
[5.6] Fixed league/flysystem-cached-adapter dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,6 +116,7 @@
         "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers and the ping methods on schedules (~6.0).",
         "laravel/tinker": "Required to use the tinker console command (~1.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (~1.0).",
+        "league/flysystem-cached-adapter": "Required to use the Flysystem cache (~1.0).",
         "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0).",
         "league/flysystem-cached-adapter": "Required to use Flysystem caching (~1.0).",
         "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (~1.0).",

--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
         "aws/aws-sdk-php": "~3.0",
         "doctrine/dbal": "~2.6",
         "filp/whoops": "^2.1.4",
+        "league/flysystem-cached-adapter": "~1.0",
         "mockery/mockery": "~1.0",
         "moontoast/math": "^1.1",
         "orchestra/testbench-core": "3.6.*",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "dragonmantank/cron-expression": "~2.0",
         "erusev/parsedown": "~1.7",
         "league/flysystem": "^1.0.8",
-        "league/flysystem-cached-adapter": "^1.0",
         "monolog/monolog": "~1.12",
         "nesbot/carbon": "^1.24.1",
         "psr/container": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,6 @@
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (~1.0).",
         "league/flysystem-cached-adapter": "Required to use the Flysystem cache (~1.0).",
         "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0).",
-        "league/flysystem-cached-adapter": "Required to use Flysystem caching (~1.0).",
         "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (~1.0).",
         "nexmo/client": "Required to use the Nexmo transport (~1.0).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (~3.0).",

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -32,6 +32,7 @@
     "suggest": {
         "league/flysystem": "Required to use the Flysystem local and FTP drivers (~1.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (~1.0).",
+        "league/flysystem-cached-adapter": "Required to use the Flysystem cache (~1.0).",
         "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0).",
         "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (~1.0)."
     },


### PR DESCRIPTION
This dependency is already listed as a suggested dependency. We need not install everything.

---

Reverts laravel/framework#23815. 