### PR TITLE
[5.6] Add helpers for subquery join clauses

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -424,6 +424,31 @@ class Builder
     }
 
     /**
+     * Add a subquery join clause to the query.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @param  string  $as
+     * @param  string  $first
+     * @param  string|null  $operator
+     * @param  string|null  $second
+     * @param  string  $type
+     * @param  bool    $where
+     * @return \Illuminate\Database\Query\Builder|static
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function joinSub($query, $as, $first, $operator = null, $second = null, $type = 'inner', $where = false)
+    {
+        list($query, $bindings) = $this->createSub($query);
+
+        $expression = '('.$query.') as '.$this->grammar->wrap($as);
+
+        $this->addBinding($bindings, 'join');
+
+        return $this->join(new Expression($expression), $first, $operator, $second, $type, $where);
+    }
+
+    /**
      * Add a left join to the query.
      *
      * @param  string  $table
@@ -452,6 +477,21 @@ class Builder
     }
 
     /**
+     * Add a subquery left join to the query.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @param  string  $as
+     * @param  string  $first
+     * @param  string|null  $operator
+     * @param  string|null  $second
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function leftJoinSub($query, $as, $first, $operator = null, $second = null)
+    {
+        return $this->joinSub($query, $as, $first, $operator, $second, 'left');
+    }
+
+    /**
      * Add a right join to the query.
      *
      * @param  string  $table
@@ -477,6 +517,21 @@ class Builder
     public function rightJoinWhere($table, $first, $operator, $second)
     {
         return $this->joinWhere($table, $first, $operator, $second, 'right');
+    }
+
+    /**
+     * Add a subquery right join to the query.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @param  string  $as
+     * @param  string  $first
+     * @param  string|null  $operator
+     * @param  string|null  $second
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function rightJoinSub($query, $as, $first, $operator = null, $second = null)
+    {
+        return $this->joinSub($query, $as, $first, $operator, $second, 'right');
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1286,6 +1286,39 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['1', 10000], $builder->getBindings());
     }
 
+    public function testJoinSub()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('users')->joinSub('select * from "contacts"', 'sub', 'users.id', '=', 'sub.id');
+        $this->assertEquals('select * from "users" inner join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->from('users')->joinSub(function ($q) {
+            $q->from('contacts');
+        }, 'sub', 'users.id', '=', 'sub.id');
+        $this->assertEquals('select * from "users" inner join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $query = $this->getBuilder()->from('contacts')->where('name', 'foo');
+        $builder->from('users')->joinSub($query, 'sub', 'users.id', '=', 1, 'inner', true);
+        $this->assertEquals('select * from "users" inner join (select * from "contacts" where "name" = ?) as "sub" on "users"."id" = ?', $builder->toSql());
+        $this->assertEquals(['foo', 1], $builder->getRawBindings()['join']);
+    }
+
+    public function testLeftJoinSub()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('users')->leftJoinSub($this->getBuilder()->from('contacts'), 'sub', 'users.id', '=', 'sub.id');
+        $this->assertEquals('select * from "users" left join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+    }
+
+    public function testRightJoinSub()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('users')->rightJoinSub($this->getBuilder()->from('contacts'), 'sub', 'users.id', '=', 'sub.id');
+        $this->assertEquals('select * from "users" right join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+    }
+
     public function testRawExpressionsInSelect()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This PR adds `joinSub()`, `leftJoinSub()` and `rightJoinSub()` to the query builder. The goal is to make subquery joins easier.

At the moment subquery joins are possible using raw SQL:

    $query = DB::table('subtable');
    $sql = '(' . $query->toSql() . ') as "sub"';
    DB::table('table')->join(DB::raw($sql), ...);

That's ok for simple subqueries but gets a bit tedious if the subquery has bindings:

    $query = DB::table('subtable')->where('foo', 'bar');
    $sql = '(' . $query->toSql() . ') as "sub"';
    DB::table('table')->addBinding($query->getBindings(), 'join')->join(DB::raw($sql), ...);

With the new helpers users can create subquery joins using raw SQL, a closure or a query builder: 

    DB::table('table')->joinSub('select * from "subtable"', 'sub', ...);
    DB::table('table')->joinSub(function ($q) { $q->from('subtable'); }, 'sub', ...);
    DB::table('table')->joinSub(DB::table('subtable')->where('foo', 'bar'), 'sub', ...);