### PR TITLE
[5.6] Add unset event dispatcher for connections

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1241,7 +1241,7 @@ class Connection implements ConnectionInterface
      *
      * @return void
      */
-    public static function unsetEventDispatcher()
+    public function unsetEventDispatcher()
     {
         $this->events = null;
     }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1235,4 +1235,14 @@ class Connection implements ConnectionInterface
     {
         return static::$resolvers[$driver] ?? null;
     }
+
+    /**
+     * Unset the event dispatcher for this connection.
+     *
+     * @return void
+     */
+    public static function unsetEventDispatcher()
+    {
+        $this->events = null;
+    }
 }

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -70,14 +70,22 @@ trait RefreshDatabase
         $database = $this->app->make('db');
 
         foreach ($this->connectionsToTransact() as $name) {
-            $database->connection($name)->beginTransaction();
+            $connection = $database->connection($name);
+            $dispatcher = $connection->getEventDispatcher();
+            
+            $connection->unsetEventDispatcher();
+            $connection->beginTransaction();
+            $connection->setEventDispatcher($dispatcher);
         }
 
         $this->beforeApplicationDestroyed(function () use ($database) {
             foreach ($this->connectionsToTransact() as $name) {
                 $connection = $database->connection($name);
+                $dispatcher = $connection->getEventDispatcher();
 
-                $connection->rollBack();
+                $connection->unsetEventDispatcher();
+                $connection->rollback();
+                $connection->setEventDispatcher($dispatcher);
                 $connection->disconnect();
             }
         });

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -72,7 +72,7 @@ trait RefreshDatabase
         foreach ($this->connectionsToTransact() as $name) {
             $connection = $database->connection($name);
             $dispatcher = $connection->getEventDispatcher();
-            
+
             $connection->unsetEventDispatcher();
             $connection->beginTransaction();
             $connection->setEventDispatcher($dispatcher);


### PR DESCRIPTION
Hello Laravel folks,

This Pull Request introduces the method `unsetEventDispatcher` for database connections.

This is motivated by the fact that in tests, when using the `RefreshDatabase` trait, transactions events are dispatched and may interfer with the application testing itself when it relies on events like these ( for further info, see https://github.com/laravel/ideas/issues/1094).

I believe it is backward compatible with Laravel 5.5 LTS also, since it does not change anything, just adds functionality.

However, and here I need your help, I am not sure if disabling events caused by transactions created by the `RefreshDatabase` trait is risky for Laravel 5.5 LTS and already-released 5.6.
I will commit it anyways, so if you want me to rollback, let me know.