### PR TITLE
[5.6] Fixed failing tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,7 @@
         "orchestra/testbench-core": "3.6.*",
         "pda/pheanstalk": "~3.0",
         "phpunit/phpunit": "~7.0",
+        "phpunit/phpunit-mock-objects": "~6.1",
         "predis/predis": "^1.1.1",
         "symfony/css-selector": "~4.0",
         "symfony/dom-crawler": "~4.0"


### PR DESCRIPTION
This fixes failing tests on the minimum dependencies builds. The latest version of phpunit mock objects is required.