### PR TITLE
[5.6] Add Collection::some() method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -35,7 +35,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     protected static $proxies = [
         'average', 'avg', 'contains', 'each', 'every', 'filter', 'first',
         'flatMap', 'groupBy', 'keyBy', 'map', 'max', 'min', 'partition',
-        'reject', 'sortBy', 'sortByDesc', 'sum', 'unique',
+        'reject', 'sortBy', 'sortByDesc', 'some', 'sum', 'unique',
     ];
 
     /**
@@ -1502,6 +1502,31 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function sortKeysDesc($options = SORT_REGULAR)
     {
         return $this->sortKeys($options, true);
+    }
+
+    /**
+     * Determine if at least one item in the collection passes the given test.
+     *
+     * @param  string|callable  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function some($key, $operator = null, $value = null)
+    {
+        if (func_num_args() == 1) {
+            $callback = $this->valueRetriever($key);
+
+            foreach ($this->items as $k => $v) {
+                if ($callback($v, $k)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return $this->some($this->operatorForWhere(...func_get_args()));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2663,6 +2663,36 @@ class SupportCollectionTest extends TestCase
         $collection = new Collection([1, 2, 3]);
         $this->assertNull($collection->get(null));
     }
+
+    public function testSome()
+    {
+        $c = new Collection([]);
+        $this->assertFalse($c->some('key', 'value'));
+        $this->assertFalse($c->some(function () {
+            return true;
+        }));
+
+        $c = new Collection([['age' => 18], ['age' => 20], ['age' => 20]]);
+        $this->assertTrue($c->some('age', 18));
+        $this->assertFalse($c->some('age', '<', 18));
+        $this->assertFalse($c->some(function ($item) {
+            return $item['age'] < 18;
+        }));
+        $this->assertTrue($c->some(function ($item) {
+            return $item['age'] >= 20;
+        }));
+        $this->assertTrue($c->push(['age'=>16])->some('age', '<', 18));
+
+        $c = new Collection(['not null', null]);
+        $this->assertTrue($c->some(function ($item) {
+            return $item === null;
+        }));
+
+        $c = new Collection([['active' => false], ['active' => false]]);
+        $this->assertFalse($c->some('active'));
+        $this->assertFalse($c->some->active);
+        $this->assertTrue($c->push(['active' => true])->some->active);
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
Added method `some()` to `Collection`.
The method tests whether at least one item in the collection passes the given test.

Basic example of usage:
```php
$groupOfPeople = new Collection([['age' => 5], ['age' => 7], ['age' => 9], ['age' => 18]]);
$isThereAdult = $groupOfPeople->some('age', '>=', 18); // => true
```

Not sure about `$proxies` - should `some` be there or it is better to remove?

If you are ok with this PR, I will update docs as well.
