### PR TITLE
[5.7] Enable auto-resolution of command arguments

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -180,7 +180,7 @@ class Command extends SymfonyCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        return $this->laravel->call([$this, 'handle']);
+        return $this->laravel->call([$this, 'handle'], $this->arguments());
     }
 
     /**


### PR DESCRIPTION
Passing the command arguments to the call() method enables auto-resolution of named arguments in the handle() command, similar to how route parameters are auto-resolved into Controller methods.

For example:
```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;

class TestCommand extends Command
{
    /**
     * The name and signature of the console command.
     *
     * @var string
     */
    protected $signature = 'test {filename} {count?}';

    ...

    /**
     * Execute the console command.
     *
     * @return mixed
     */
    public function handle(string $filename, int $count = null)
    {
        $this->line($filename);
        $this->line($count);
    }
}
```