### PR TITLE
[5.6] Add unset event dispatcher for connections

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1097,6 +1097,16 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Unset the event dispatcher for this connection.
+     *
+     * @return void
+     */
+    public function unsetEventDispatcher()
+    {
+        $this->events = null;
+    }
+
+    /**
      * Determine if the connection in a "dry run".
      *
      * @return bool

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -70,14 +70,22 @@ trait RefreshDatabase
         $database = $this->app->make('db');
 
         foreach ($this->connectionsToTransact() as $name) {
-            $database->connection($name)->beginTransaction();
+            $connection = $database->connection($name);
+            $dispatcher = $connection->getEventDispatcher();
+
+            $connection->unsetEventDispatcher();
+            $connection->beginTransaction();
+            $connection->setEventDispatcher($dispatcher);
         }
 
         $this->beforeApplicationDestroyed(function () use ($database) {
             foreach ($this->connectionsToTransact() as $name) {
                 $connection = $database->connection($name);
+                $dispatcher = $connection->getEventDispatcher();
 
-                $connection->rollBack();
+                $connection->unsetEventDispatcher();
+                $connection->rollback();
+                $connection->setEventDispatcher($dispatcher);
                 $connection->disconnect();
             }
         });


### PR DESCRIPTION
Hello Laravel folks,

This Pull Request introduces the method unsetEventDispatcher for database connections.

This is motivated by the fact that in tests, when using the RefreshDatabase trait, transactions events are dispatched and may interfer with the application testing itself when it relies on events like these ( for further info, see laravel/ideas#1094).