### PR TITLE
[5.6] Update Blueprint.php

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -944,7 +944,6 @@ class Blueprint
         $this->timestamp('updated_at', $precision)->default(date('Y-m-d H:i:s'));
     }
 
-
     /**
      * Add nullable creation and update timestamps to the table.
      *

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -932,7 +932,7 @@ class Blueprint
     }
     
     /**
-     * Add current creation and update timestamps to the table.
+     * Add current datetime creation and update timestamps to the table.
      *
      * @param  int  $precision
      * @return void

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -930,6 +930,20 @@ class Blueprint
 
         $this->timestamp('updated_at', $precision)->nullable();
     }
+    
+    /**
+     * Add current creation and update timestamps to the table.
+     *
+     * @param  int  $precision
+     * @return void
+     */
+    public function currentTimestamps($precision = 0)
+    {
+        $this->timestamp('created_at', $precision)->default(date('Y-m-d H:i:s'));
+
+        $this->timestamp('updated_at', $precision)->default(date('Y-m-d H:i:s'));
+    }
+
 
     /**
      * Add nullable creation and update timestamps to the table.


### PR DESCRIPTION
On Inserting multiple records the timestamps remains null be default using timestamps. using the current timestamp will prevent from making the timestamp null and use the current time as default.