### PR TITLE
[5.6] Fix params order in Broadcast Manager.

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -210,8 +210,8 @@ class BroadcastManager implements FactoryContract
     protected function createPusherDriver(array $config)
     {
         return new PusherBroadcaster(
-            new Pusher($config['key'], $config['secret'],
-            $config['app_id'], $config['options'] ?? [])
+            new Pusher($config['app_id'], $config['key'],
+            $config['secret'], $config['options'] ?? [])
         );
     }
 


### PR DESCRIPTION
Fix intended to reorder the parameters in the Pusher Broadcaster to match the order expected by the latest Pusher constructor.