### PR TITLE
[5.6] Implements `belongs` method to Schema Builder

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -6,6 +6,7 @@ use Closure;
 use BadMethodCallException;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Connection;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\Schema\Grammars\Grammar;
@@ -1320,5 +1321,25 @@ class Blueprint
         return array_filter($this->columns, function ($column) {
             return (bool) $column->change;
         });
+    }
+
+    /**
+     * Add the proper column and index for a related table.
+     *
+     * @param string      $relatedTable
+     * @param string      $foreignKey
+     * @param string      $ownerKey
+     * @param string|null $indexName
+     *
+     * @return \Illuminate\Support\Fluent
+     */
+    public function belongs($relatedTable, $foreignKey = null, $ownerKey = 'id', $indexName = null)
+    {
+        $relationName = Str::singular($relatedTable);
+        $foreignKey = $foreignKey ?? "{$relationName}_{$ownerKey}";
+
+        $this->foreign($foreignKey, $indexName)->references($ownerKey)->on($relatedTable);
+
+        return $this->unsignedInteger($foreignKey);
     }
 }


### PR DESCRIPTION
I've made this PR to solve the problem of https://github.com/laravel/ideas/issues/815 by creating a shorthand that creates both the column and the foreign index.

It allows the following usages:

```
$table->belongs('users');
> Creates a `user_id` column, and a foreign key referencing it to the `users.id`

$table->belongs('users', 'buyer_user_id');
> Creates a `buyer_user_id` column, and a foreign key referencing it to the `users.id`

$table->belongs('users', null, 'uuid');
> Creates a `user_uuid` column, and a foreign key referencing it to the `users.uuid`

$table->belongs('users', null, 'id', 'custom_index_name');
> Creates a `user_id` column, and a foreign key (named `custom_index_name`) referencing it to the `users.id`
```

This feature doesn't implement anything new, just a shorthand to **Laravel keep being awesome**.
It **doesn't* introduce any breaking changes.