### PR TITLE
[5.6] Distinct validation rule can optionally ignore empty values

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -577,6 +577,12 @@ trait ValidatesAttributes
             return empty(preg_grep('/^'.preg_quote($value, '/').'$/iu', $data));
         }
 
+        if (in_array('ignore_empty_values', $parameters)) {
+            $data = array_filter($data, function ($value) {
+                return ! empty(trim($value));
+            });
+        }
+
         return ! in_array($value, array_values($data));
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1544,6 +1544,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['cat' => ['sub' => [['prod' => [['id' => 2]]], ['prod' => [['id' => 2]]]]]], ['cat.sub.*.prod.*.id' => 'distinct']);
         $this->assertFalse($v->passes());
 
+        $v = new Validator($trans,
+            ['authors' => [['email' => 'e1@test.com'], ['email' => 'e2@test.com'], ['email' => null], ['email' => null], ['email' => ''], ['email' => ''], ['email' => '  '], ['email' => '  ']]],
+            ['authors.*.email' => 'distinct:ignore_empty_values']
+        );
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => ['foo', 'foo']], ['foo.*' => 'distinct'], ['foo.*.distinct' => 'There is a duplication!']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');


### PR DESCRIPTION
`ignore_empty_values` parameter allows ignoring the empty values.

Use case
A table of 10 authors where only one is required at least.
Without this flag, the validation will fail because of the other 9 empty email fields.

--------------------------------------------------------

EDIT: By the client request, all the 10 rows must be visible from the start, which means the 10 email fields exists in the form and will be submitted to the server.