### PR TITLE
Fix bug when providing single id to requeue

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -55,6 +55,10 @@ class RetryCommand extends Command
         if (count($ids) === 1 && $ids[0] === 'all') {
             $ids = Arr::pluck($this->laravel['queue.failer']->all(), 'id');
         }
+        
+        if (! is_array($ids)) {
+            $ids = (array) $ids;
+        }
 
         return $ids;
     }


### PR DESCRIPTION
If the commands is called from a controller:

```
Artisan::call('queue:retry', ['id' => $job_id]);
```

The application will pass just a single id as string into the artisan command