### PR TITLE
Fix bug on retry queue command

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -56,6 +56,10 @@ class RetryCommand extends Command
             $ids = Arr::pluck($this->laravel['queue.failer']->all(), 'id');
         }
 
+        if (! is_array($ids)) {
+            $ids = (array) $ids;
+        }
+
         return $ids;
     }
 


### PR DESCRIPTION
If the commands is called from a controller:

```
Artisan::call('queue:retry', ['id' => $job_id]);
```

The application will pass just a single id as string into the artisan command