### PR TITLE
[5.6] broadcastWith() can return an Eloquent Resource

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Contracts\Broadcasting\Broadcaster;
 
 class BroadcastEvent implements ShouldQueue
@@ -59,7 +60,7 @@ class BroadcastEvent implements ShouldQueue
     {
         if (method_exists($event, 'broadcastWith')) {
             return array_merge(
-                $event->broadcastWith(), ['socket' => data_get($event, 'socket')]
+                $this->formatBroadcastWith($event->broadcastWith()), ['socket' => data_get($event, 'socket')]
             );
         }
 
@@ -84,6 +85,21 @@ class BroadcastEvent implements ShouldQueue
     {
         if ($value instanceof Arrayable) {
             return $value->toArray();
+        }
+
+        return $value;
+    }
+
+    /**
+     * Format the returned value from the broadcastWith method on the event.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function formatBroadcastWith($value)
+    {
+        if ($value instanceof JsonResource) {
+            return $value->toArray(request());
         }
 
         return $value;


### PR DESCRIPTION
This PR allows to return an eloquent resource directly from within an event.
I would like the return the eloquent resources from the event the same way i do from controller methods.

Before the PR we have to do this

```php
class MyEvent
{
    public function broadcastWith()
    {
        return (new MyResource($this->myModel))->toArray(request());
    }
}
```

After the PR
```php
class MyEvent
{
    public function broadcastWith()
    {
        return new MyResource($this->myModel);
    }
}
```

# Use case
I'm building a single page application with real time updates.
If a paper is updated by one user, all the other users should receive the new updated version of the paper.
I'm using the eloquent resources `for both` the `api endpoint` for fetching the list of papers when the page first loads and when a paper is updated and i'm `broadcasting the new data` to the other users.

# Concerns
There is one concern here is that the wrapping of the data with the `data` key is not going to happen because in this PR i'm using `toArray()` method of the Eloquent Resource and not  `toResponse` where the wrapping is happening.

I'm waiting for taylor to know how to proceed when it comes to the data wrapping. 
