### PR TITLE
[5.6] Highlight the discovered package name

### DIFF
--- a/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
+++ b/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
@@ -32,7 +32,7 @@ class PackageDiscoverCommand extends Command
         $manifest->build();
 
         foreach (array_keys($manifest->manifest) as $package) {
-            $this->line("<info>Discovered Package:</info> {$package}");
+            $this->line("Discovered Package: <info>{$package}</info>");
         }
 
         $this->info('Package manifest generated successfully.');


### PR DESCRIPTION
Highlight the discovered package name rather than the `Discovered package` string. This also maintains consistency with the composer output

Semi-related to this PR - https://github.com/laravel/laravel/pull/4635