### PR TITLE
[5.6] Add ability to override default api endpoint

### DIFF
--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -27,6 +27,13 @@ class SparkPostTransport extends Transport
      * @var array
      */
     protected $options = [];
+    
+    /**
+     * Serivce API Endpoint.
+     *
+     * @var array
+     */
+    protected $endpoint = 'https://api.sparkpost.com/api/v1/transmissions';
 
     /**
      * Create a new SparkPost transport instance.
@@ -41,6 +48,7 @@ class SparkPostTransport extends Transport
         $this->key = $key;
         $this->client = $client;
         $this->options = $options;
+        $this->endpoint = $options['endpoint'];
     }
 
     /**
@@ -54,7 +62,7 @@ class SparkPostTransport extends Transport
 
         $message->setBcc([]);
 
-        $response = $this->client->post(config('mail.endpoints.sparkpost', 'https://api.sparkpost.com/api/v1/transmissions'), [
+        $response = $this->client->post($this->endpoint, [
             'headers' => [
                 'Authorization' => $this->key,
             ],

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -54,7 +54,7 @@ class SparkPostTransport extends Transport
 
         $message->setBcc([]);
 
-        $response = $this->client->post('https://api.sparkpost.com/api/v1/transmissions', [
+        $response = $this->client->post(config('mail.endpoints.sparkpost', 'https://api.sparkpost.com/api/v1/transmissions'), [
             'headers' => [
                 'Authorization' => $this->key,
             ],


### PR DESCRIPTION
Fixes #23864 by allowing a user to set a "mail.endpoints.sparkpost" config key to choose between available endpoints found at https://developers.sparkpost.com/api/

example addition to config/mail.php:
```
/*
|--------------------------------------------------------------------------
| Mail Service Endpoints
|--------------------------------------------------------------------------
|
| When using an email service, you might need to override the default API
| endpoints. This allows you to configure different endpoints based on your
| environment.
|
*/
'endpoints' => [
  'sparkpost' =>  env('SPARKPOST_ENDPOINT', 'https://api.sparkpost.com/api/v1'),
],
```

I'm not sure how to test this, but I would argue that any test to this feature would just be a test of the config helper. 

I'm also unsure if other mail drivers should get the same treatment as I don't use any of them. It's an easy enough change to add to all the drivers for this PR if that makes sense at all.

It's a fairly simple change, and would only be a BC break if someone was using "mail.endpoints.*" already in their configuration. At a guess I would say that's unlikely, but if an argument is made for it we could easily change the config key at this stage.