### PR TITLE
Loosen constraint for dragonmantank/cron-expression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "~1.1",
-        "dragonmantank/cron-expression": "~2.0",
+        "dragonmantank/cron-expression": "^2.0",
         "erusev/parsedown": "~1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "~1.12",


### PR DESCRIPTION
This loosens the constraint for `dragonmantank/cron-expression` to allow the new release `2.1.0` to be installed. See #23859 for more information.

It looks like this change has already been made on `master`.