### PR TITLE
Add a raw not where clause to the query

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -757,7 +757,7 @@ class Builder
     }
 
     /**
-     * Add a raw not where clause to the query
+     * Add a raw not where clause to the query.
      *
      * @param string $sql
      * @param mixed $bindings

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -757,15 +757,15 @@ class Builder
     }
 
     /**
-     * Add a raw not where clause to the query.
+     * Add a raw where not clause to the query.
      *
-     * @param string $sql
-     * @param mixed $bindings
+     * @param  string  $sql
+     * @param  mixed  $bindings
      * @return \Illuminate\Database\Query\Builder|static
      */
-    public function notWhereRaw($sql, $bindings = [])
+    public function whereNotRaw($sql, $bindings = [])
     {
-        return $this->whereRaw("Not ($sql)", $bindings, 'and');
+        return $this->whereRaw("not ($sql)", $bindings, 'and');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -757,6 +757,18 @@ class Builder
     }
 
     /**
+     * Add a raw not where clause to the query
+     *
+     * @param string $sql
+     * @param mixed $bindings
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function notWhereRaw($sql, $bindings = [])
+    {
+        return $this->whereRaw("Not ($sql)", $bindings, 'and');
+    }
+
+    /**
      * Add a "where in" clause to the query.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -505,6 +505,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
+    public function testRawNotWheres()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotRaw('id = ? and email = ?', [1, 'foo']);
+        $this->assertEquals('select * from "users" where not (id = ? and email = ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
+    }
+
     public function testRawOrWheres()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
```php
    /**
     * Add a raw not where clause to the query
     *
     * @param string $sql
     * @param mixed $bindings
     * @return \Illuminate\Database\Query\Builder|static
     */
    public function notWhereRaw($sql, $bindings = [])
    {
        return $this->whereRaw("Not ($sql)", $bindings, 'and');
    }
```