### PR TITLE
[5.7] Add view data method to the TestResponse class

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -664,6 +664,19 @@ class TestResponse
     }
 
     /**
+     * Get a piece of data from the original view.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function viewData($key)
+    {
+        $this->ensureResponseHasView();
+
+        return $this->original->$key;
+    }
+
+    /**
      * Assert that the response view is missing a piece of bound data.
      *
      * @param  string  $key


### PR DESCRIPTION
Just a little helper to get view data from the original response, it can be helpful as an alternative for more customised assertions:

```
        $this->assertTrue(
            $response->viewData('posts')->contains($postByCurrentUser),
            'The posts does not contain a post written by the current user.'
        );

        $this->assertFalse(
            $response->viewData('posts')->contains($postByAnotherUser),
            'The posts contain a post written by someone else.'
        );
```

This can also be written as:

```
            ->assertViewHas('posts', function ($posts) use ($postByCurrentUser, $postByAnotherUser) {
                return $posts->contains($postByCurrentUser) && ! $posts->contains($postByAnotherUser);
            });
```

But then the assertion message in case of failure won't be that helpful (even with my other PR).