### PR TITLE
[5.7] Improve assertion messages of assertViewIs and Has methods

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -613,7 +613,10 @@ class TestResponse
     {
         $this->ensureResponseHasView();
 
-        PHPUnit::assertEquals($value, $this->original->getName());
+        PHPUnit::assertEquals(
+            $value, $this->original->getName(),
+            "The view path is not [{$value}]."
+        );
 
         return $this;
     }
@@ -634,11 +637,20 @@ class TestResponse
         $this->ensureResponseHasView();
 
         if (is_null($value)) {
-            PHPUnit::assertArrayHasKey($key, $this->original->getData());
+            PHPUnit::assertArrayHasKey(
+                $key, $this->original->getData(),
+                "The view does not contain the [{$key}] data."
+            );
         } elseif ($value instanceof Closure) {
-            PHPUnit::assertTrue($value($this->original->$key));
+            PHPUnit::assertTrue(
+                $value($this->original->$key),
+                "The view data [{$key}] does not match the required criteria."
+            );
         } else {
-            PHPUnit::assertEquals($value, $this->original->$key);
+            PHPUnit::assertEquals(
+                $value, $this->original->$key,
+                "The view data [{$key}] does not equal the required value."
+            );
         }
 
         return $this;


### PR DESCRIPTION
I'll leave a simpler version although I like https://github.com/laravel/framework/pull/23872 more 😅

I was writing tests using assertViewIs/Has and found the errors confusing / not helpful. This PR fixes that.

`->assertViewIs('admin.posts.list')`

If the view does not match. Before and now:

> Failed asserting that two strings are equal.

> The view path is not [admin.posts.list].

---

`->assertViewHas('posts')`

If the view does not contain posts. Before and now:

> Failed asserting that an array has the key 'posts'.

> The view does not contain the [posts] data.

---

The view contains or not title but does not match the expected value:

> Failed asserting that two strings are equal.

> The view data [title] does not equal the required value.

---

And so on... I think these little changes will help to achieve a better flow when doing TDD.