### PR TITLE
[5.6] Allow to pass collection to validation rules

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Validation;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 
 class Rule
@@ -34,22 +35,30 @@ class Rule
     /**
      * Get an in constraint builder instance.
      *
-     * @param  array|string  $values
+     * @param  array|string|\Illuminate\Support\Collection  $values
      * @return \Illuminate\Validation\Rules\In
      */
     public static function in($values)
     {
+        if ($values instanceof Collection) {
+            $values = $values->toArray();
+        }
+
         return new Rules\In(is_array($values) ? $values : func_get_args());
     }
 
     /**
      * Get a not_in constraint builder instance.
      *
-     * @param  array|string  $values
+     * @param  array|string|\Illuminate\Support\Collection  $values
      * @return \Illuminate\Validation\Rules\NotIn
      */
     public static function notIn($values)
     {
+        if ($values instanceof Collection) {
+            $values = $values->toArray();
+        }
+
         return new Rules\NotIn(is_array($values) ? $values : func_get_args());
     }
 

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -26,6 +26,10 @@ class ValidationInRuleTest extends TestCase
 
         $this->assertEquals('in:"1","2","3","4"', (string) $rule);
 
+        $rule = Rule::in(collect([1, 2, 3, 4]));
+
+        $this->assertEquals('in:"1","2","3","4"', (string) $rule);
+
         $rule = Rule::in('1', '2', '3', '4');
 
         $this->assertEquals('in:"1","2","3","4"', (string) $rule);

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -18,6 +18,10 @@ class ValidationNotInRuleTest extends TestCase
 
         $this->assertEquals('not_in:"1","2","3","4"', (string) $rule);
 
+        $rule = Rule::notIn(collect([1, 2, 3, 4]));
+
+        $this->assertEquals('not_in:"1","2","3","4"', (string) $rule);
+
         $rule = Rule::notIn('1', '2', '3', '4');
 
         $this->assertEquals('not_in:"1","2","3","4"', (string) $rule);


### PR DESCRIPTION
This PR makes necessary changes to allow for passing `Illuminate\Support\Collection` objects to `Rule::in()` and `Rule::notIn()` methods.

Thanks