### PR TITLE
[5.7] [WIP] [Experiment] Add assert view data

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCollectionData.php
+++ b/src/Illuminate/Foundation/Testing/TestCollectionData.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use PHPUnit\Framework\Assert;
+
+class TestCollectionData extends TestData
+{
+    public function contains($key)
+    {
+        Assert::assertTrue($this->data->contains($key));
+
+        return $this;
+    }
+
+    public function notContains($key)
+    {
+        Assert::assertFalse($this->data->contains($key));
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestData.php
+++ b/src/Illuminate/Foundation/Testing/TestData.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Foundation\Testing;
 
-use Illuminate\Contracts\Pagination\Paginator;
-use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Pagination\AbstractPaginator;
+use Illuminate\Contracts\Pagination\Paginator;
 
 class TestData
 {
@@ -25,6 +25,22 @@ class TestData
         }
 
         return new static($data, $fallback);
+    }
+
+    public function instanceOf($className)
+    {
+        PHPUnit::assertInstanceOf($className, $this->data);
+
+        return $this;
+    }
+
+    public function with($attribute, $value)
+    {
+        PHPUnit::assertSame(
+            $value, $this->data->$attribute ?? null
+        );
+
+        return $this;
     }
 
     public function contains($key)

--- a/src/Illuminate/Foundation/Testing/TestData.php
+++ b/src/Illuminate/Foundation/Testing/TestData.php
@@ -3,46 +3,46 @@
 namespace Illuminate\Foundation\Testing;
 
 use Illuminate\Contracts\Pagination\Paginator;
-use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Support\Collection;
 use Illuminate\Pagination\AbstractPaginator;
 
 class TestData
 {
     protected $data;
-    protected $response;
+    protected $fallback;
 
-    public function __construct($data, $response)
+    public function __construct($data, $fallback)
     {
         $this->data = $data;
-        $this->response = $response;
+        $this->fallback = $fallback;
     }
 
-    public static function make($data, $response)
+    public static function make($data, $fallback)
     {
         if ($data instanceof Collection || $data instanceof Paginator) {
-            return new TestCollectionData($data, $response);
+            return new TestCollectionData($data, $fallback);
         }
 
-        return new static($data, $response);
+        return new static($data, $fallback);
     }
 
     public function contains($key)
     {
-        Assert::assertContains($key, $this->data);
+        PHPUnit::assertContains($key, $this->data);
 
         return $this;
     }
 
     public function notContains($key)
     {
-        Assert::assertNotContains($key, $this->data);
+        PHPUnit::assertNotContains($key, $this->data);
 
         return $this;
     }
 
     public function __call($method, $arguments)
     {
-        return $this->response->$method(...$arguments);
+        return $this->fallback->$method(...$arguments);
     }
 }

--- a/src/Illuminate/Foundation/Testing/TestData.php
+++ b/src/Illuminate/Foundation/Testing/TestData.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Illuminate\Contracts\Pagination\Paginator;
+use PHPUnit\Framework\Assert;
+use Illuminate\Support\Collection;
+use Illuminate\Pagination\AbstractPaginator;
+
+class TestData
+{
+    protected $data;
+    protected $response;
+
+    public function __construct($data, $response)
+    {
+        $this->data = $data;
+        $this->response = $response;
+    }
+
+    public static function make($data, $response)
+    {
+        if ($data instanceof Collection || $data instanceof Paginator) {
+            return new TestCollectionData($data, $response);
+        }
+
+        return new static($data, $response);
+    }
+
+    public function contains($key)
+    {
+        Assert::assertContains($key, $this->data);
+
+        return $this;
+    }
+
+    public function notContains($key)
+    {
+        Assert::assertNotContains($key, $this->data);
+
+        return $this;
+    }
+
+    public function __call($method, $arguments)
+    {
+        return $this->response->$method(...$arguments);
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestMailable.php
+++ b/src/Illuminate/Foundation/Testing/TestMailable.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Illuminate\Contracts\Mail\Mailable;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class TestMailable
+{
+    /**
+     * @var Mailable
+     */
+    private $mailables;
+    /**
+     * @var int
+     */
+    private $times;
+
+    public function __construct($mailables, $times = 1)
+    {
+        $this->mailables = $mailables;
+        $this->times = $times;
+    }
+
+    /**
+     * Assert if the given recipient is set on the mailable.
+     *
+     * @param  object|array|string  $address
+     * @param  string|null  $name
+     * @return \Illuminate\Foundation\Testing\TestMailable
+     */
+    public function hasTo($address, $name = null)
+    {
+        return $this->assertFilter(function ($mailable) use ($address, $name) {
+            return $mailable->hasTo($address, $name);
+        }, "was not sent to {$address} {$name}");
+    }
+
+    /**
+     * Assert if the given recipient is set on the mailable.
+     *
+     * @param  object|array|string  $address
+     * @param  string|null  $name
+     * @return \Illuminate\Foundation\Testing\TestMailable
+     */
+    public function hasCc($address, $name = null)
+    {
+        return $this->assertFilter(function ($mailable) use ($address, $name) {
+            return $mailable->hasCc($address, $name);
+        }, "was not sent with CC to {$address} {$name}");
+    }
+
+    /**
+     * Assert if the given property is set on the mailable
+     */
+    public function has($property)
+    {
+        $result = $this->assertFilter(function ($mailable) use ($property) {
+            return isset($mailable->$property);
+        }, "does not contain the property {$property}");
+
+        return new TestData($result->mailables->first()->$property, $result);
+        //TODO: Need to create another object to assert multiple data, maybe TestMultipleData
+    }
+
+    protected function assertFilter($callback, $message)
+    {
+        $result = new static($this->mailables->filter($callback));
+
+        if ($result->mailables->count() < $this->times) {
+            PHPUnit::fail($this->failureDescription($message));
+        }
+
+        return $result;
+    }
+
+    protected function failureDescription($message)
+    {
+        $result = "The mailable {$this->name()} $message ";
+
+        if ($this->times > 1) {
+            $result .= " {$this->times} times";
+        }
+
+        return $result;
+    }
+
+    protected function name()
+    {
+        return class_basename($this->mailables->first());
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -664,6 +664,19 @@ class TestResponse
     }
 
     /**
+     * Explanation here.
+     *
+     * @param string $key
+     * @return \Illuminate\Foundation\Testing\TestData
+     */
+    public function assertViewData($key)
+    {
+        $this->assertViewHas($key);
+
+        return TestData::make($this->original->$key, $this);
+    }
+
+    /**
      * Get a piece of data from the original view.
      *
      * @param  string  $key

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -604,6 +604,17 @@ class TestResponse
     }
 
     /**
+     * Assert that the response has a view.
+     * @return \Illuminate\Foundation\Testing\TestView
+     */
+    public function assertView()
+    {
+        $this->ensureResponseHasView();
+
+        return new TestView($this);
+    }
+
+    /**
      * Assert that the response view equals the given value.
      *
      * @param  string $value
@@ -611,9 +622,7 @@ class TestResponse
      */
     public function assertViewIs($value)
     {
-        $this->ensureResponseHasView();
-
-        PHPUnit::assertEquals($value, $this->original->getName());
+        $this->assertView()->is($value);
 
         return $this;
     }
@@ -627,19 +636,7 @@ class TestResponse
      */
     public function assertViewHas($key, $value = null)
     {
-        if (is_array($key)) {
-            return $this->assertViewHasAll($key);
-        }
-
-        $this->ensureResponseHasView();
-
-        if (is_null($value)) {
-            PHPUnit::assertArrayHasKey($key, $this->original->getData());
-        } elseif ($value instanceof Closure) {
-            PHPUnit::assertTrue($value($this->original->$key));
-        } else {
-            PHPUnit::assertEquals($value, $this->original->$key);
-        }
+        $this->assertView()->has($key, $value);
 
         return $this;
     }
@@ -652,13 +649,7 @@ class TestResponse
      */
     public function assertViewHasAll(array $bindings)
     {
-        foreach ($bindings as $key => $value) {
-            if (is_int($key)) {
-                $this->assertViewHas($value);
-            } else {
-                $this->assertViewHas($key, $value);
-            }
-        }
+        $this->assertView()->hasAll($bindings);
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/TestView.php
+++ b/src/Illuminate/Foundation/Testing/TestView.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class TestView
+{
+    protected $view;
+    protected $response;
+
+    public function __construct($response)
+    {
+        $this->response = $response;
+        $this->view = $response->original;
+    }
+
+    /**
+     * Assert that the response view equals the given value.
+     *
+     * @param  string $value
+     * @return $this
+     */
+    public function is($value)
+    {
+        PHPUnit::assertEquals($value, $this->view->getName());
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response view has a given piece of bound data.
+     *
+     * @param  string|array  $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function has($key, $value = null)
+    {
+        if (is_array($key)) {
+            return $this->hasAll($key);
+        }
+
+        if (is_null($value)) {
+            PHPUnit::assertArrayHasKey($key, $this->view->getData());
+        } elseif ($value instanceof Closure) {
+            PHPUnit::assertTrue($value($this->view->$key));
+        } else {
+            PHPUnit::assertEquals($value, $this->view->$key);
+        }
+
+        return TestData::make($this->view->$key, $this);
+    }
+
+    /**
+     * Assert that the response view has a given list of bound data.
+     *
+     * @param  array  $bindings
+     * @return $this
+     */
+    public function hasAll(array $bindings)
+    {
+        foreach ($bindings as $key => $value) {
+            if (is_int($key)) {
+                $this->assertViewHas($value);
+            } else {
+                $this->assertViewHas($key, $value);
+            }
+        }
+
+        return $this;
+    }
+
+    public function __call($method, $arguments)
+    {
+        return $this->response->$method(...$arguments);
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestView.php
+++ b/src/Illuminate/Foundation/Testing/TestView.php
@@ -62,9 +62,9 @@ class TestView
     {
         foreach ($bindings as $key => $value) {
             if (is_int($key)) {
-                $this->assertViewHas($value);
+                $this->has($value);
             } else {
-                $this->assertViewHas($key, $value);
+                $this->has($key, $value);
             }
         }
 

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\Mailable;
+use Illuminate\Foundation\Testing\TestMailable;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
@@ -36,10 +37,14 @@ class MailFake implements Mailer
             return $this->assertSentTimes($mailable, $callback);
         }
 
+        $mailables = $this->sent($mailable, $callback);
+
         PHPUnit::assertTrue(
-            $this->sent($mailable, $callback)->count() > 0,
+            $mailables->count() > 0,
             "The expected [{$mailable}] mailable was not sent."
         );
+
+        return new TestMailable($mailables);
     }
 
     /**


### PR DESCRIPTION
Wanted to shared this idea for a new syntax that could be used to create/build more complex assertions over view data by chaining methods instead of using the closure or getting the data:

Notice the `->contains` and `->notContains` methods that can be chained after calling `assertViewData`

`assertViewData` checks the data is in the view and then allows you to chain methods to check that specific piece of data contains or not other data. More assertions like `withLength(3)` can be added and of course some unit tests as well.

I'd like to get some feedback.

```
        $response->assertStatus(200)
            ->assertViewIs('admin.posts.index')
            ->assertViewData('posts')
                ->contains($post1)
                ->contains($post2);
```


```
        $response->assertStatus(200)
            ->assertViewIs('admin.posts.index')
            ->assertViewData('posts')
                ->contains($postByCurrentUser1)
                ->contains($postByCurrentUser2)
                ->notContains($postByAnotherUser1)
                ->notContains($postByAnotherUser2)
            ->assertViewHas('title', 'Posts');
```