### PR TITLE
[5.6] Update cron-expression to version 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "~1.1",
-        "dragonmantank/cron-expression": "~2.0",
+        "dragonmantank/cron-expression": "~2.1",
         "erusev/parsedown": "~1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "~1.12",


### PR DESCRIPTION
Cron-expression has an update for 2.1.

It will fix [this](https://github.com/dragonmantank/cron-expression/issues/5) bug to allow lists and ranges in the same expression.

[Changelog](https://github.com/dragonmantank/cron-expression/blob/master/CHANGELOG.md)
