### PR TITLE
[5.6] Remove duplicated code to retrieve validated data

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -38,11 +38,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
     public function registerRequestValidation()
     {
         Request::macro('validate', function (array $rules, ...$params) {
-            validator()->validate($this->all(), $rules, ...$params);
-
-            return $this->only(collect($rules)->keys()->map(function ($rule) {
-                return explode('.', $rule)[0];
-            })->unique()->toArray());
+            return validator()->validate($this->all(), $rules, ...$params);
         });
     }
 

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -127,13 +127,13 @@ class Factory implements FactoryContract
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $customAttributes
-     * @return void
+     * @return array
      *
      * @throws \Illuminate\Validation\ValidationException
      */
     public function validate(array $data, array $rules, array $messages = [], array $customAttributes = [])
     {
-        $this->make($data, $rules, $messages, $customAttributes)->validate();
+        return $this->make($data, $rules, $messages, $customAttributes)->validate();
     }
 
     /**

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -60,12 +60,17 @@ class ValidationFactoryTest extends TestCase
         $factory = m::mock(Factory::class.'[make]', [$translator]);
 
         $factory->shouldReceive('make')->once()
-                ->with(['foo' => 'bar'], ['foo' => 'required'], [], [])
+                ->with(['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'required'], [], [])
                 ->andReturn($validator);
 
-        $validator->shouldReceive('validate')->once();
+        $validator->shouldReceive('validate')->once()->andReturn(['foo' => 'bar']);
 
-        $factory->validate(['foo' => 'bar'], ['foo' => 'required']);
+        $validated = $factory->validate(
+            ['foo' => 'bar', 'baz' => 'boom'],
+            ['foo' => 'required']
+        );
+
+        $this->assertEquals($validated, ['foo' => 'bar']);
     }
 
     public function testCustomResolverIsCalled()


### PR DESCRIPTION
We can technically also remove it from the `ValidatesRequests` trait:

https://github.com/laravel/framework/blob/ee051fb44425a5cbf363f640b6dd33f492d90940/src/Illuminate/Foundation/Validation/ValidatesRequests.php#L59-L61

...but it may be considered a breaking change there, in case someone overwrote that for whatever reason.