### PR TITLE
Update make:model to remove namespace from ModelFactory filename

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -68,7 +68,7 @@ class ModelMakeCommand extends GeneratorCommand
     protected function createFactory()
     {
         $this->call('make:factory', [
-            'name' => $this->argument('name').'Factory',
+            'name' => Str::studly(class_basename($this->argument('name'))).'Factory',
             '--model' => $this->argument('name'),
         ]);
     }


### PR DESCRIPTION
This is so trivial I almost didn't submit it, but ...

`artisan make:model Models\Thingy -f` (or `artisan make:model Models\Thingy -a`) creates a Thingy model in the Models directory\namespace and creates a ModelsThingyFactory class. This is inconsistent with the creation of the controller and migration, which use only the un-namespaced class name (ThingyController and 2018_01_01_000001_create_thingy_table.

This PR changes the factory class name from ModelsThingyFactory to ThingyFactory.