### PR TITLE
[5.7] Test CheckForMaintenanceMode middleware

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -920,7 +920,17 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function isDownForMaintenance()
     {
-        return file_exists($this->storagePath().'/framework/down');
+        return file_exists($this->getMaintenanceFilePath());
+    }
+
+    /**
+     * Get the path to maintance file.
+     *
+     * @return string
+     */
+    public function getMaintenanceFilePath()
+    {
+        return $this->storagePath().'/framework/down';
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -32,7 +32,7 @@ class DownCommand extends Command
     public function handle()
     {
         file_put_contents(
-            storage_path('framework/down'),
+            $this->laravel->getMaintenanceFilePath(),
             json_encode($this->getDownFilePayload(), JSON_PRETTY_PRINT)
         );
 

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -27,7 +27,7 @@ class UpCommand extends Command
      */
     public function handle()
     {
-        @unlink(storage_path('framework/down'));
+        @unlink($this->laravel->getMaintenanceFilePath());
 
         $this->info('Application is now live.');
     }

--- a/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
+++ b/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
@@ -38,7 +38,7 @@ class CheckForMaintenanceMode
     public function handle($request, Closure $next)
     {
         if ($this->app->isDownForMaintenance()) {
-            $data = json_decode(file_get_contents($this->app->storagePath().'/framework/down'), true);
+            $data = json_decode(file_get_contents($this->app->getMaintenanceFilePath()), true);
 
             throw new MaintenanceModeException($data['time'], $data['retry'], $data['message']);
         }

--- a/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
+++ b/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode;
+use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
+
+class CheckForMaintenanceModeTest extends TestCase
+{
+    public function tearDown()
+    {
+        @unlink(MaintenanceApplication::MAINTENANCE_FILE);
+    }
+
+    public function testApplicationIsRunnning()
+    {
+        $middleware = new CheckForMaintenanceMode(new RunningApplication);
+        $response = $middleware->handle(Request::create('/'), function ($request) {
+            return Response::create('The application is running.');
+        });
+
+        $this->assertEquals('The application is running.', $response->getContent());
+    }
+
+    public function testApplicationIsInMaintenanceMode()
+    {
+        $this->expectException(MaintenanceModeException::class);
+        $this->expectExceptionMessage(MaintenanceApplication::MAINTENANCE_MESSAGE);
+
+        $middleware = new CheckForMaintenanceMode(new MaintenanceApplication);
+        $middleware->handle(Request::create('/'), function () {
+            return Response::create();
+        });
+    }
+}
+
+class MaintenanceApplication extends Application
+{
+    const MAINTENANCE_FILE = __DIR__.'/down';
+    const MAINTENANCE_MESSAGE = 'Be right back!';
+
+    public function getMaintenanceFilePath()
+    {
+        if (! file_exists($path = static::MAINTENANCE_FILE)) {
+            file_put_contents($path, json_encode([
+                'time' => time(),
+                'message' => static::MAINTENANCE_MESSAGE,
+                'retry' => null,
+            ]));
+        }
+
+        return static::MAINTENANCE_FILE;
+    }
+}
+
+class RunningApplication extends Application
+{
+    public function getMaintenanceFilePath()
+    {
+        return '/non-exists-directory/down';
+    }
+}


### PR DESCRIPTION
Here are four methods I have read about the maintance mode:
+ One in [Illuminate\Foundation\Application](https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Application.php)
```
public function isDownForMaintenance()
{
    return file_exists($this->storagePath().'/framework/down');
}
```
+ One in [Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode](Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode)
```
public function handle($request, Closure $next)
{
    if ($this->app->isDownForMaintenance()) {
        $data = json_decode(file_get_contents($this->app->storagePath().'/framework/down'), true);
        throw new MaintenanceModeException($data['time'], $data['retry'], $data['message']);
    }
    return $next($request);
}
```

+ One in [Illuminate\Foundation\Console\DownCommand](https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Console/DownCommand.php)

```
public function handle()
{
    file_put_contents(
        storage_path('framework/down'),
        json_encode($this->getDownFilePayload(), JSON_PRETTY_PRINT)
    );
    $this->comment('Application is now in maintenance mode.');
}
```

+ And one in [Illuminate\Foundation\Console\UpCommand](https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Console/UpCommand.php)
```
public function handle()
{
    @unlink(storage_path('framework/down'));

    $this->info('Application is now live.');
}
```

The maintenance file path **storagePath().'/framework/down'** exists in four methods but we only need one, right? I think it's better if we resolve this case such as some couples of methods in [Illuminate\Foundation\Application](https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Application.php) below:
+ Application::routesAreCached() and Application::getCachedRoutesPath().
+ Application::configurationIsCached and Application::getCachedConfigPath().

So I create a new method called Application::getMaintenanceFilePath() that associated with Application::isDownForMaintenance() method. Then, we should only access the maintenance file from one method. Anyway, I wrote some tests of the middleware. You can take a look. Thank you!
