### PR TITLE
Make default notifications translatable

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -56,9 +56,9 @@ class ResetPassword extends Notification
         }
 
         return (new MailMessage)
-            ->line('You are receiving this email because we received a password reset request for your account.')
-            ->action('Reset Password', url(config('app.url').route('password.reset', $this->token, false)))
-            ->line('If you did not request a password reset, no further action is required.');
+            ->line(__('You are receiving this email because we received a password reset request for your account.'))
+            ->action(__('Reset Password'), url(config('app.url').route('password.reset', $this->token, false)))
+            ->line(__('If you did not request a password reset, no further action is required.'));
     }
 
     /**

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -4,9 +4,9 @@
 # {{ $greeting }}
 @else
 @if ($level == 'error')
-# Whoops!
+# {{ __('Whoops!') }}
 @else
-# Hello!
+# {{ __('Hello!') }}
 @endif
 @endif
 
@@ -45,14 +45,20 @@
 @if (! empty($salutation))
 {{ $salutation }}
 @else
-Regards,<br>{{ config('app.name') }}
+{{ __('Regards') }},<br>{{ config('app.name') }}
 @endif
 
 {{-- Subcopy --}}
 @isset($actionText)
 @component('mail::subcopy')
-If you’re having trouble clicking the "{{ $actionText }}" button, copy and paste the URL below
-into your web browser: [{{ $actionUrl }}]({{ $actionUrl }})
+{{ __(
+    'If you’re having trouble clicking the ":actionText" button, copy and paste the URL below '.
+    'into your web browser: [:actionURL](:actionURL)',
+    [
+        'actionText' => $actionText,
+        'actionURL' => $actionUrl
+    ]
+) }}
 @endcomponent
 @endisset
 @endcomponent


### PR DESCRIPTION
This uses the JSON translation-strings feature to make it easier
to localize notifications and the password reset mail.