### PR TITLE
[5.6] Allow for fluent registration of Route Resources to return a RouteCollection

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -12,6 +12,13 @@ class PendingResourceRegistration
     protected $registrar;
 
     /**
+     * The resource's registration status.
+     *
+     * @var bool
+     */
+    protected $registered = false;
+
+    /**
      * The resource name.
      *
      * @var string
@@ -143,12 +150,26 @@ class PendingResourceRegistration
     }
 
     /**
+     * Register the Resource.
+     *
+     * @return \Illuminate\Routing\RouteCollection
+     */
+    public function register()
+    {
+        $this->registered = true;
+
+        return $this->registrar->register($this->name, $this->controller, $this->options);
+    }
+
+    /**
      * Handle the object's destruction.
      *
      * @return void
      */
     public function __destruct()
     {
-        $this->registrar->register($this->name, $this->controller, $this->options);
+        if (! $this->registered) {
+            $this->register();
+        }
     }
 }

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -68,7 +68,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $controller
      * @param  array   $options
-     * @return void
+     * @return \Illuminate\Routing\RouteCollection
      */
     public function register($name, $controller, array $options = [])
     {
@@ -92,9 +92,13 @@ class ResourceRegistrar
 
         $defaults = $this->resourceDefaults;
 
+        $collection = new RouteCollection;
+
         foreach ($this->getResourceMethods($defaults, $options) as $m) {
-            $this->{'addResource'.ucfirst($m)}($name, $base, $controller, $options);
+            $collection->add($this->{'addResource'.ucfirst($m)}($name, $base, $controller, $options));
         }
+
+        return $collection;
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -7,7 +7,6 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
-use Illuminate\Routing\ResourceRegistrar;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class RouteRegistrarTest extends TestCase
@@ -222,8 +221,9 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanAccessRegisteredResourceRoutesAsRouteCollection()
     {
-        $registrar = new ResourceRegistrar($this->router);
-        $resource = $registrar->register('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub');
+        $resource = $this->router->middleware('resource-middleware')
+                     ->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+                     ->register();
 
         $this->assertCount(7, $resource->getRoutes());
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
+use Illuminate\Routing\ResourceRegistrar;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class RouteRegistrarTest extends TestCase
@@ -217,6 +218,22 @@ class RouteRegistrarTest extends TestCase
 
         $this->seeResponse('deleted', Request::create('users/1', 'DELETE'));
         $this->seeMiddleware('resource-middleware');
+    }
+
+    public function testCanAccessRegisteredResourceRoutesAsRouteCollection()
+    {
+        $registrar = new ResourceRegistrar($this->router);
+        $resource = $registrar->register('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub');
+
+        $this->assertCount(7, $resource->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.index'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.create'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.store'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.show'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.edit'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.update'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
     }
 
     public function testCanLimitMethodsOnRegisteredResource()


### PR DESCRIPTION
This PR allows for manual Registration of fluent Route Resource chains (which currently remain as a `PendingResourceRegistration` until destruction.

Now upon registration they return a `RouteCollection` like so:

```php
Route::resource('photos', 'PhotoController')->register() // Returns a RouteCollection
```

The `ResourceRegistrar::register()` method previously returned `void` but based on the fact that it's not publicly accessible, I don't think this should be considered a breaking change 🤞

While I recognize that this PR probably doesn't add a ton of value to the community at large, it won't make anyone's life _worse_ and will make my life much nicer 😄 