### PR TITLE
[5.6] Allow asserting an integer with assertSee()

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -281,7 +281,7 @@ class TestResponse
      */
     public function assertSee($value)
     {
-        PHPUnit::assertContains($value, $this->getContent());
+        PHPUnit::assertContains((string) $value, $this->getContent());
 
         return $this;
     }
@@ -307,7 +307,7 @@ class TestResponse
      */
     public function assertSeeText($value)
     {
-        PHPUnit::assertContains($value, strip_tags($this->getContent()));
+        PHPUnit::assertContains((string) $value, strip_tags($this->getContent()));
 
         return $this;
     }
@@ -333,7 +333,7 @@ class TestResponse
      */
     public function assertDontSee($value)
     {
-        PHPUnit::assertNotContains($value, $this->getContent());
+        PHPUnit::assertNotContains((string) $value, $this->getContent());
 
         return $this;
     }
@@ -346,7 +346,7 @@ class TestResponse
      */
     public function assertDontSeeText($value)
     {
-        PHPUnit::assertNotContains($value, strip_tags($this->getContent()));
+        PHPUnit::assertNotContains((string) $value, strip_tags($this->getContent()));
 
         return $this;
     }


### PR DESCRIPTION
When trying to assert a number (example: id, downloads count ...) is seen or not seen on the page with any of these methods

`assertSee()` `assertDontSee()` `assertSeeText()` `assertDontSeeText()`

a phpunit exception will be raised, because the haystack (response content) is a string and the needle (what i'm asserting to be seen) is an integer (not a string)

Check the phpunit source code for that
https://github.com/sebastianbergmann/phpunit/blob/c1b35f210334bf1695af4fe6a16c3a72ebbe5e3d/src/Framework/Assert.php#L196

For example this assertion

```php
$response = $this->get("some url");

$response->assertSee($paper->id);
```

Will raise this exception

```
Argument #1 (No Value) of PHPUnit\Framework\Assert::assertContains() must be a string
 F:\projects\quick-conference\src\quick-conference\vendor\laravel\framework\src\Illuminate\Foundation\Testing\TestResponse.php:284
```

This PR tries to solve that by casting the $value to a string