### PR TITLE
[5.6] Use Carbon 1.26

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "erusev/parsedown": "~1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "~1.12",
-        "nesbot/carbon": "^1.26",
+        "nesbot/carbon": "^1.26.3",
         "psr/container": "~1.0",
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^3.7",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "erusev/parsedown": "~1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "~1.12",
-        "nesbot/carbon": "1.25.*",
+        "nesbot/carbon": "^1.26",
         "psr/container": "~1.0",
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^3.7",

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -2,47 +2,8 @@
 
 namespace Illuminate\Support;
 
-use JsonSerializable;
 use Carbon\Carbon as BaseCarbon;
-use Illuminate\Support\Traits\Macroable;
 
-class Carbon extends BaseCarbon implements JsonSerializable
+class Carbon extends BaseCarbon
 {
-    use Macroable;
-
-    /**
-     * The custom Carbon JSON serializer.
-     *
-     * @var callable|null
-     */
-    protected static $serializer;
-
-    /**
-     * Prepare the object for JSON serialization.
-     *
-     * @return array|string
-     */
-    public function jsonSerialize()
-    {
-        if (static::$serializer) {
-            return call_user_func(static::$serializer, $this);
-        }
-
-        $carbon = $this;
-
-        return call_user_func(function () use ($carbon) {
-            return get_object_vars($carbon);
-        });
-    }
-
-    /**
-     * JSON serialize all Carbon instances using the given callback.
-     *
-     * @param  callable  $callback
-     * @return void
-     */
-    public static function serializeUsing($callback)
-    {
-        static::$serializer = $callback;
-    }
 }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -58,7 +58,7 @@ class SupportCarbonTest extends TestCase
 
     /**
      * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method Illuminate\Support\Carbon::nonExistingStaticMacro does not exist.
+     * @expectedExceptionMessage nonExistingStaticMacro does not exist.
      */
     public function testCarbonRaisesExceptionWhenStaticMacroIsNotFound()
     {
@@ -67,7 +67,7 @@ class SupportCarbonTest extends TestCase
 
     /**
      * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method Illuminate\Support\Carbon::nonExistingMacro does not exist.
+     * @expectedExceptionMessage nonExistingMacro does not exist.
      */
     public function testCarbonRaisesExceptionWhenMacroIsNotFound()
     {


### PR DESCRIPTION
Now that Carbon\Carbon supports macros and JSON, Illuminate\Support\Carbon should be emptied, then it would be the end of compatibility issues.