### PR TITLE
[5.6] Redis queue bulk insertion with RPUSH

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -121,6 +121,26 @@ class RedisQueue extends Queue implements QueueContract
     }
 
     /**
+     * Push an array of jobs onto the queue.
+     *
+     * @param  array   $jobs
+     * @param  mixed   $data
+     * @param  string  $queue
+     * @return mixed
+     */
+    public function bulk($jobs, $data = '', $queue = null)
+    {
+        return $this->getConnection()->rpush(
+            $this->getQueue($queue),
+            ...collect((array) $jobs)->map(
+                function ($job) use ($data) {
+                    return $this->createPayload($job, $data);
+                }
+            )
+        );
+    }
+
+    /**
      * Push a raw job onto the queue after a delay.
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay


### PR DESCRIPTION
Idea ticket: https://github.com/laravel/ideas/issues/1082

Since Redis version >=2.4 [RPUSH allows multiple value arguments](https://redis.io/commands/rpush#history). This PR implements the `bulk` method for the `RedisQueue` driver mimicking the `DatabaseQueue::bulk` method.