### PR TITLE
[5.6] i18n of the default notification email view

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -4,9 +4,9 @@
 # {{ $greeting }}
 @else
 @if ($level == 'error')
-# Whoops!
+# @lang('Whoops!')
 @else
-# Hello!
+# @lang('Hello!')
 @endif
 @endif
 
@@ -45,14 +45,20 @@
 @if (! empty($salutation))
 {{ $salutation }}
 @else
-Regards,<br>{{ config('app.name') }}
+@lang('Regards'),<br>{{ config('app.name') }}
 @endif
 
 {{-- Subcopy --}}
 @isset($actionText)
 @component('mail::subcopy')
-If you’re having trouble clicking the "{{ $actionText }}" button, copy and paste the URL below
-into your web browser: [{{ $actionUrl }}]({{ $actionUrl }})
+@lang(
+    'If you’re having trouble clicking the ":actionText" button, copy and paste the URL below '.
+    'into your web browser: [:actionURL](:actionURL)',
+    [
+        'actionText' => $actionText,
+        'actionURL' => $actionUrl
+    ]
+)
 @endcomponent
 @endisset
 @endcomponent

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -52,7 +52,7 @@
 @isset($actionText)
 @component('mail::subcopy')
 @lang(
-    'If you’re having trouble clicking the ":actionText" button, copy and paste the URL below '.
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
     'into your web browser: [:actionURL](:actionURL)',
     [
         'actionText' => $actionText,


### PR DESCRIPTION
This uses json translations through the blade directive to allow easy
translations of mail notifications.

In contrast to my [previous PR](https://github.com/laravel/framework/pull/23885) this doesn't change the ResetPassword notification as that can be easily changed with the `toMailUsing()` method. It also doesn't use the `__()` helper so no extra dependencies are introduced.