### PR TITLE
[5.6] Pending Dispatch early dispatch

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -14,6 +14,13 @@ class PendingDispatch
     protected $job;
 
     /**
+     * The job.
+     *
+     * @var bool
+     */
+    protected $dispatched = false;
+
+    /**
      * Create a new pending job dispatch.
      *
      * @param  mixed  $job
@@ -103,12 +110,26 @@ class PendingDispatch
     }
 
     /**
+     * Dispatches the job.
+     *
+     * @return mixed
+     */
+    public function dispatch()
+    {
+        $this->dispatched = true;
+
+        return app(Dispatcher::class)->dispatch($this->job);
+    }
+
+    /**
      * Handle the object's destruction.
      *
      * @return void
      */
     public function __destruct()
     {
-        app(Dispatcher::class)->dispatch($this->job);
+        if (! $this->dispatched) {
+            $this->dispatch();
+        }
     }
 }

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -14,7 +14,7 @@ class PendingDispatch
     protected $job;
 
     /**
-     * The job.
+     * The job's dispatching status.
      *
      * @var bool
      */


### PR DESCRIPTION
This is related to https://github.com/laravel/framework/issues/23866 , which i didn't get much feedback unfortunately.

But looking at this PR that got merged today: https://github.com/laravel/framework/pull/23890 , which is a pretty similar solution, i basically decided to give it a shot.

In summary, this is for when you call `dispatch()`, you can dispatch it when you want, without having to unset the variable for example.

Useful for when you are at `php artisan tinker` or when you want to fetch the return of the job `handle` or `job id`