### PR TITLE
[5.7] Collection min() returns null with given key

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1081,11 +1081,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $callback = $this->valueRetriever($callback);
 
-        return $this->filter(function ($value) {
+        return $this->map(function ($value) use ($callback) {
+            return $callback($value);
+        })->filter(function ($value) {
             return ! is_null($value);
-        })->reduce(function ($result, $item) use ($callback) {
-            $value = $callback($item);
-
+        })->reduce(function ($result, $value) {
             return is_null($result) || $value < $result ? $value : $result;
         });
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2054,7 +2054,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(10, $c->min('foo'));
         $this->assertEquals(10, $c->min->foo);
 
-        $c = new Collection([['foo' => 10], ['foo' => 20]]);
+        $c = new Collection([['foo' => 10], ['foo' => 20], ['foo' => null]]);
         $this->assertEquals(10, $c->min('foo'));
         $this->assertEquals(10, $c->min->foo);
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2053,7 +2053,7 @@ class SupportCollectionTest extends TestCase
         }));
         $this->assertEquals(10, $c->min('foo'));
         $this->assertEquals(10, $c->min->foo);
-    
+
         $c = new Collection([['foo' => 10], ['foo' => 20]]);
         $this->assertEquals(10, $c->min('foo'));
         $this->assertEquals(10, $c->min->foo);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2056,9 +2056,11 @@ class SupportCollectionTest extends TestCase
     
         $c = new Collection([['foo' => 10], ['foo' => 20]]);
         $this->assertEquals(10, $c->min('foo'));
+        $this->assertEquals(10, $c->min->foo);
 
         $c = new Collection([['foo' => 10], ['foo' => 20], ['foo' => null]]);
         $this->assertEquals(10, $c->min('foo'));
+        $this->assertEquals(10, $c->min->foo);
 
         $c = new Collection([1, 2, 3, 4, 5]);
         $this->assertEquals(1, $c->min());

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2053,10 +2053,12 @@ class SupportCollectionTest extends TestCase
         }));
         $this->assertEquals(10, $c->min('foo'));
         $this->assertEquals(10, $c->min->foo);
+    
+        $c = new Collection([['foo' => 10], ['foo' => 20]]);
+        $this->assertEquals(10, $c->min('foo'));
 
         $c = new Collection([['foo' => 10], ['foo' => 20], ['foo' => null]]);
         $this->assertEquals(10, $c->min('foo'));
-        $this->assertEquals(10, $c->min->foo);
 
         $c = new Collection([1, 2, 3, 4, 5]);
         $this->assertEquals(1, $c->min());


### PR DESCRIPTION
Using the collection "min()" method with a key on a collection that contains null, will return null and not the smallest number as expected. Without a key the return value is 10.

Examples:
- Current
```
$c = new Collection([['foo' => 10], ['foo' => 20], ['foo' => null]]);
$c->min('foo'); // null
```
- Fix
```
$c = new Collection([['foo' => 10], ['foo' => 20], ['foo' => null]]);
$c->min('foo'); // 10
```
- Without key
```
$c = new Collection([10, 20, null]);
$c->min(); // 10
```

Methods like "avg()" or "median()" have similar issues and should be checked if this goes through.