### PR TITLE
[5.6] Allow user-defined Sparkpost endpoint

### DIFF
--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -54,7 +54,9 @@ class SparkPostTransport extends Transport
 
         $message->setBcc([]);
 
-        $response = $this->client->post('https://api.sparkpost.com/api/v1/transmissions', [
+        $endpoint = $this->getOptions()['endpoint'] ?? 'https://api.sparkpost.com/api/v1/transmissions';
+
+        $response = $this->client->post($endpoint, [
             'headers' => [
                 'Authorization' => $this->key,
             ],


### PR DESCRIPTION
Fixes #23864.

This allows the user to set an endpoint when using the Sparkpost transport by setting the 'services.sparkpost.options.endpoint' configuration key.

Currently, the options array is empty by default, and not actually used in the class, but the TransportManager still passes it into the constructor.

To use this, a user must add the sparkpost.options.endpoint key in config/services.php, for example:
```
'sparkpost' => [
        'secret' => env('SPARKPOST_SECRET'),
        'options' => [
                'endpoint' => env('SPARKPOST_ENDPOINT');
        ]
    ],
```

If the config option isn't set, or if it is null (default return from the `env()` helper), the default 'https://api.sparkpost.com/api/v1/transmissions' endpoint is used.

This approach allows a user to modify the endpoint of an existing SparkPostTransport through `setOptions()`. It also allows a user to have more complex endpoint logic by simply extending the class and overriding `getOptions()` rather than having to override `send()` or the constructor.

