### PR TITLE
fix for HasManyThrough returning incorrect results with `chunk()` (#21774)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -517,4 +517,20 @@ class HasManyThrough extends Relation
     {
         return $this->farParent->qualifyColumn($this->localKey);
     }
+
+    /**
+     * Adds the correct column selection for HasManyThrough before handling dynamic method calls.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        $this->query->addSelect(
+            $this->shouldSelect(['*'])
+        );
+        return parent::__call($method,$parameters);
+
+    }
 }


### PR DESCRIPTION
fixes issues with `chunk()` and `each()` behaviour on `HasManyThrough`. Root cause of the issue is, unlike the `get()` method that is handled on the relationship, these methods are handled through Eloquent Query Builder without updating of the columns that should be selected.