### PR TITLE
[5.6] fix pivot timestamp columns without parent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -214,7 +214,7 @@ class Pivot extends Model
      */
     public function getCreatedAtColumn()
     {
-        return $this->pivotParent->getCreatedAtColumn();
+        return ($this->pivotParent) ? $this->pivotParent->getCreatedAtColumn() : parent::getCreatedAtColumn();
     }
 
     /**
@@ -224,7 +224,7 @@ class Pivot extends Model
      */
     public function getUpdatedAtColumn()
     {
-        return $this->pivotParent->getUpdatedAtColumn();
+        return ($this->pivotParent) ? $this->pivotParent->getUpdatedAtColumn() : parent::getUpdatedAtColumn();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class DatabaseEloquentPivotTest extends TestCase
@@ -119,6 +120,29 @@ class DatabaseEloquentPivotTest extends TestCase
 
         $this->assertEquals('pivot', $pivot->getTable());
     }
+
+    public function testPivotModelWithParentReturnsParentsTimestampColumns()
+    {
+        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent->shouldReceive('getCreatedAtColumn')->andReturn('parent_created_at');
+        $parent->shouldReceive('getUpdatedAtColumn')->andReturn('parent_updated_at');
+
+        $pivotWithParent = new Pivot();
+        $pivotWithParent->pivotParent = $parent;
+
+        $this->assertEquals('parent_created_at', $pivotWithParent->getCreatedAtColumn());
+        $this->assertEquals('parent_updated_at', $pivotWithParent->getUpdatedAtColumn());
+    }
+
+    public function testPivotModelWithoutParentReturnsModelTimestampColumns()
+    {
+        $model = new DummyModel();
+
+        $pivotWithoutParent = new Pivot();
+
+        $this->assertEquals($model->getCreatedAtColumn(), $pivotWithoutParent->getCreatedAtColumn());
+        $this->assertEquals($model->getUpdatedAtColumn(), $pivotWithoutParent->getUpdatedAtColumn());
+    }
 }
 
 class DatabaseEloquentPivotTestDateStub extends \Illuminate\Database\Eloquent\Relations\Pivot
@@ -151,4 +175,8 @@ class DatabaseEloquentPivotTestJsonCastStub extends \Illuminate\Database\Eloquen
     protected $casts = [
         'foo' => 'json',
     ];
+}
+
+class DummyModel extends Model
+{
 }


### PR DESCRIPTION
The motivation of this PR is to allow `Pivot` models to be queried and saved just like normal `Model`s.

Previously, when trying to save pivot models, an error would be thrown because no `pivotParent` existed on the model.

This was due to the `getCreatedAtColumn()` and `getUpdatedAtColumn()` methods being called. It erred with "Call to a member function getCreatedAtColumn() on null".

This PR makes sure we first check if the `pivotParent` property exists. If it does, we continue to use the pivot parent's methods.  However, if it doesn't, we fallback to the `Model`s methods.

The tests I've added cover both cases of having a `pivotParent` and not having one.