### PR TITLE
[5.5] fix for HasManyThrough returning incorrect results with chunk() (#21774)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -245,6 +245,36 @@ class HasManyThrough extends Relation
 
         return $instance;
     }
+    /**
+     * Chunk the results of the query.
+     *
+     * @param  int  $count
+     * @param  callable  $callback
+     * @return bool
+     */
+    public function chunk($count, callable $callback)
+    {
+        $builder = $this->getBuilder();
+        return $builder->chunk($count,$callback);
+    }
+
+    /**
+     * Execute a callback over each item while chunking.
+     *
+     * @param  callable  $callback
+     * @param  int  $count
+     * @return bool
+     */
+    public function each(callable $callback, $count = 1000)
+    {
+        return $this->chunk($count, function ($results) use ($callback) {
+            foreach ($results as $key => $value) {
+                if ($callback($value, $key) === false) {
+                    return false;
+                }
+            }
+        });
+    }
 
     /**
      * Execute the query and get the first related model.
@@ -354,16 +384,8 @@ class HasManyThrough extends Relation
      */
     public function get($columns = ['*'])
     {
-        // First we'll add the proper select columns onto the query so it is run with
-        // the proper columns. Then, we will get the results and hydrate out pivot
-        // models with the result of those columns as a separate model relation.
-        $columns = $this->query->getQuery()->columns ? [] : $columns;
-
-        $builder = $this->query->applyScopes();
-
-        $models = $builder->addSelect(
-            $this->shouldSelect($columns)
-        )->getModels();
+        $builder = $this->getBuilder($columns);
+        $models = $builder->getModels();
 
         // If we actually found models we will also eager load any relationships that
         // have been specified as needing to be eager loaded. This will solve the
@@ -516,5 +538,23 @@ class HasManyThrough extends Relation
     public function getQualifiedLocalKeyName()
     {
         return $this->farParent->qualifyColumn($this->localKey);
+    }
+
+    /**
+     * Add the proper select columns onto the query so it is run with the proper
+     * columns. and return a builder instance with the correct columns.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    private function getBuilder($columns = ['*']){
+
+        $columns = $this->query->getQuery()->columns ? [] : $columns;
+
+        $builder = $this->query->applyScopes();
+
+        return $builder->addSelect(
+            $this->shouldSelect($columns)
+        );
     }
 }


### PR DESCRIPTION
fixes issues with `chunk()` and `each()` behaviour on `HasManyThrough`. Root cause of the issue is, unlike the `get()` method that is handled on the relationship, these methods are handled through Eloquent Query Builder without updating of the columns that should be selected.