### PR TITLE
[5.6] The method of obtaining the current subdomain name is added

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -583,7 +583,7 @@ class Route
         $host = explode('.', $this->action['domain']);
 
         if (sizeof($host) >= 2) {
-            return $position ? $host[$position] : $host[0];
+            return $position ? ($host[$position] ?? null) : $host[0];
         }
 
         return null;

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -582,11 +582,7 @@ class Route
     {
         $host = explode('.', $this->action['domain']);
 
-        if (sizeof($host) >= 2) {
-            return $position ? ($host[$position] ?? null) : $host[0];
-        }
-
-        return null;
+        return $position ? ($host[$position] ?? null) : $host[0];
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -572,6 +572,22 @@ class Route
     }
 
     /**
+     * Retrieving the current subdomain name.
+     *
+     * @return string|null
+     */
+    public function getSubdomain()
+    {
+        $host = explode('.', $this->action['domain']);
+
+        if (sizeof($host) >= 2) {
+            return Arr::first($host);
+        }
+
+        return null;
+    }
+
+    /**
      * Get the prefix of the route instance.
      *
      * @return string

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -574,14 +574,16 @@ class Route
     /**
      * Retrieving the current subdomain name.
      *
+     * @param null|int $position The position of the subdomain key in multi-level domain names.
+     *
      * @return string|null
      */
-    public function getSubdomain()
+    public function getSubdomain($position = null)
     {
         $host = explode('.', $this->action['domain']);
 
         if (sizeof($host) >= 2) {
-            return Arr::first($host);
+            return $position ? $host[$position] : $host[0];
         }
 
         return null;


### PR DESCRIPTION
Example:
```php
return request()->route()->getSubdomain();
// from domain `test.mysite.local` will return `test` (string).

return request()->route()->getSubdomain(0);
// from domain `subdomain.example.co.uk` will return `subdomain` (string).

return request()->route()->getSubdomain(1);
// from domain `subdomain.example.co.uk` will return `example` (string).

return request()->route()->getSubdomain(3);
// from domain `subdomain.example.co.uk` will return `uk` (string).

return request()->route()->getSubdomain(5);
// from domain `subdomain.example.co.uk` will return `null` (null).
```

(recreating pr #23926 for branch 5.6)