### PR TITLE
[5.6] Fix isDirty(null) and wasChanged(null)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -977,7 +977,7 @@ trait HasAttributes
     public function isDirty($attributes = null)
     {
         return $this->hasChanges(
-            $this->getDirty(), is_array($attributes) ? $attributes : func_get_args()
+            $this->getDirty(), is_null($attributes) || is_array($attributes) ? $attributes : func_get_args()
         );
     }
 
@@ -1001,7 +1001,7 @@ trait HasAttributes
     public function wasChanged($attributes = null)
     {
         return $this->hasChanges(
-            $this->getChanges(), is_array($attributes) ? $attributes : func_get_args()
+            $this->getChanges(), is_null($attributes) || is_array($attributes) ? $attributes : func_get_args()
         );
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -63,6 +63,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->baz = 30;
 
         $this->assertTrue($model->isDirty());
+        $this->assertTrue($model->isDirty(null));
         $this->assertFalse($model->isDirty('foo'));
         $this->assertTrue($model->isDirty('bar'));
         $this->assertTrue($model->isDirty('foo', 'bar'));
@@ -103,6 +104,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->baz = 30;
 
         $this->assertFalse($model->isClean());
+        $this->assertFalse($model->isClean(null));
         $this->assertTrue($model->isClean('foo'));
         $this->assertFalse($model->isClean('bar'));
         $this->assertFalse($model->isClean('foo', 'bar'));

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -64,6 +64,7 @@ class EloquentModelTest extends DatabaseTestCase
         $this->assertEmpty($user->getDirty());
         $this->assertEquals(['name' => $name], $user->getChanges());
         $this->assertTrue($user->wasChanged());
+        $this->assertTrue($user->wasChanged(null));
         $this->assertTrue($user->wasChanged('name'));
     }
 }


### PR DESCRIPTION
`HasAttributes::isDirty()` is defined like this:

    public function isDirty($attributes = null)

Calling `isDirty()` on a modified model returns `true`. But explicitly using the default value returns `false`:

    $model->isDirty(); // true
    $model->isDirty(null); // false

So something like `$model->isDirty($if ? ['foo'] : null)` doesn't work.

The same applies to `HasAttributes::wasChanged()`.

Fixes #23924.