### PR TITLE
[5.6] Remove no longer required status code in dd helper

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -272,8 +272,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function dd(...$args)
     {
-        http_response_code(500);
-
         call_user_func_array([$this, 'dump'], $args);
 
         die(1);

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -553,8 +553,6 @@ if (! function_exists('dd')) {
      */
     function dd(...$args)
     {
-        http_response_code(500);
-
         foreach ($args as $x) {
             (new Dumper)->dump($x);
         }


### PR DESCRIPTION
Symfony [is having a discussion](https://github.com/symfony/symfony/pull/26970#issuecomment-382426251) related to this helper and when the subject of why Laravel's `dd` is returning a 500 status, and it was found that this is no longer required.

Chrome 65 has fixed the bug that required this workaround

https://bugs.chromium.org/p/chromium/issues/detail?id=785050