### PR TITLE
Properly counting the number of jobs on the fake queue

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -229,7 +229,7 @@ class QueueFake extends QueueManager implements Queue
      */
     public function size($queue = null)
     {
-        return 0;
+        return count($this->jobs);
     }
 
     /**


### PR DESCRIPTION
Not sure why this was ever set to zero, but being set to zero it makes it impossible to assert based on queue size.  This PR properly counts the jobs rather than assuming it's zero.