### PR TITLE
[5.6] Queue fake now correctly counts the number of jobs

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -229,7 +229,7 @@ class QueueFake extends QueueManager implements Queue
      */
     public function size($queue = null)
     {
-        return 0;
+        return count($this->jobs);
     }
 
     /**

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -32,6 +32,15 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->fake->assertPushed(JobStub::class);
     }
 
+    public function testQueueSize()
+    {
+        $this->assertEquals(0, $this->fake->size());
+
+        $this->fake->push($this->job);
+
+        $this->assertEquals(1, $this->fake->size());
+    }
+
     public function testAssertNotPushed()
     {
         $this->fake->assertNotPushed(JobStub::class);


### PR DESCRIPTION
Not sure why this was ever set to zero, but being set to zero it makes it impossible to assert based on queue size.  This PR properly counts the jobs rather than assuming it's zero.