### PR TITLE
[5.6] Return $this in Eloquent Builder to allow for chaining

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1260,7 +1260,7 @@ class Builder
         if ($method === 'macro') {
             $this->localMacros[$parameters[0]] = $parameters[1];
 
-            return;
+            return $this;
         }
 
         if (isset($this->localMacros[$method])) {


### PR DESCRIPTION
I was planning on just returning `->macro()`. But I realized it was returning void instead of returning the Builder.

I'm pretty sure this was just an oversight, and that there's no reason why it can't return the instance