### PR TITLE
[5.6] Remove JsonSerializable implementation now implemented in Carbon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "erusev/parsedown": "~1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "~1.12",
-        "nesbot/carbon": "^1.26.4",
+        "nesbot/carbon": "^1.24.1 !=1.26.0 !=1.26.1",
         "psr/container": "~1.0",
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^3.7",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "erusev/parsedown": "~1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "~1.12",
-        "nesbot/carbon": "1.25.*",
+        "nesbot/carbon": "^1.26.4",
         "psr/container": "~1.0",
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^3.7",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "erusev/parsedown": "~1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "~1.12",
-        "nesbot/carbon": "^1.24.1 !=1.26.0 !=1.26.1",
+        "nesbot/carbon": "^1.26.2",
         "psr/container": "~1.0",
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^3.7",

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -2,47 +2,10 @@
 
 namespace Illuminate\Support;
 
-use JsonSerializable;
 use Carbon\Carbon as BaseCarbon;
 use Illuminate\Support\Traits\Macroable;
 
-class Carbon extends BaseCarbon implements JsonSerializable
+class Carbon extends BaseCarbon
 {
     use Macroable;
-
-    /**
-     * The custom Carbon JSON serializer.
-     *
-     * @var callable|null
-     */
-    protected static $serializer;
-
-    /**
-     * Prepare the object for JSON serialization.
-     *
-     * @return array|string
-     */
-    public function jsonSerialize()
-    {
-        if (static::$serializer) {
-            return call_user_func(static::$serializer, $this);
-        }
-
-        $carbon = $this;
-
-        return call_user_func(function () use ($carbon) {
-            return get_object_vars($carbon);
-        });
-    }
-
-    /**
-     * JSON serialize all Carbon instances using the given callback.
-     *
-     * @param  callable  $callback
-     * @return void
-     */
-    public static function serializeUsing($callback)
-    {
-        static::$serializer = $callback;
-    }
 }


### PR DESCRIPTION
- As it's a strict duplicate the JsonSerializable can be removed safely.
- The "1.25.*" change need to be reverted as it prevent users for getting new methods, will conflicted with custom requirement (such as `"nesbot/carbon": "dev-master"`) and users will think they get the last 1.x version and will wrongly rely on the documentation, but it will not be accurate for them.