### PR TITLE
[5.6] Add missing PostgreSQL operators

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -15,9 +15,10 @@ class PostgresGrammar extends Grammar
      */
     protected $operators = [
         '=', '<', '>', '<=', '>=', '<>', '!=',
-        'like', 'not like', 'ilike',
+        'like', 'not like', 'ilike', 'not ilike',
         '&', '|', '#', '<<', '>>', '>>=', '=<<',
         '&&', '@>', '<@', '?', '?|', '?&', '||', '-', '-', '#-',
+        'is distinct from', 'is not distinct from',
     ];
 
     /**


### PR DESCRIPTION
Adds the operators "not ilike", "is distinct from", and
"is not distinct from" to the Postgres query grammar. Backwards
compatible.

https://www.postgresql.org/docs/10/static/functions-comparison.html#FUNCTIONS-COMPARISON-PRED-TABLE