### PR TITLE
[5.6] Check for timestamps when creating pivot model from raw attributes as well

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -84,6 +84,8 @@ class Pivot extends Model
 
         $instance->setRawAttributes($attributes, true);
 
+        $instance->timestamps = $instance->hasTimestampAttributes();
+
         return $instance;
     }
 

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -89,6 +89,14 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertFalse($pivot->timestamps);
     }
 
+    public function testTimestampPropertyIsTrueWhenCreatingFromRawAttributes()
+    {
+        $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName,getDates]');
+        $parent->shouldReceive('getConnectionName')->andReturn('connection');
+        $pivot = Pivot::fromRawAttributes($parent, ['foo' => 'bar', 'created_at' => 'foo'], 'table');
+        $this->assertTrue($pivot->timestamps);
+    }
+
     public function testKeysCanBeSetProperly()
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');


### PR DESCRIPTION
By doing the timestamps check again after actually having the attributes filled.

Fixes https://github.com/laravel/framework/issues/23601
This fix also applies to 5.5