### PR TITLE
[5.6] Add saveManyOrFail method to HasOneOrMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -276,18 +276,18 @@ abstract class HasOneOrMany extends Relation
     public function saveManyOrFail($models)
     {
         return $this->getConnection()->transaction(function () use ($models) {
-            if (!$this->getParentKey()) {
+            if (! $this->getParentKey()) {
                 $this->parent->save();
             }
-            
+
             foreach ($models as $model) {
                 $this->save($model);
             }
-            
+
             return $models;
         });
     }
-    
+
     /**
      * Create a new instance of the related model.
      *

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -266,6 +266,29 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Attach a collection of models to the parent instance using transaction.
+     *
+     * @param  \Traversable|array  $models
+     * @return \Traversable|array
+     *
+     * @throws \Throwable
+     */
+    public function saveManyOrFail($models)
+    {
+        return $this->getConnection()->transaction(function () use ($models) {
+            if (!$this->getParentKey()) {
+                $this->parent->save();
+            }
+            
+            foreach ($models as $model) {
+                $this->save($model);
+            }
+            
+            return $models;
+        });
+    }
+    
+    /**
      * Create a new instance of the related model.
      *
      * @param  array  $attributes


### PR DESCRIPTION
Based on `saveMany()` and `saveOrFail()` methods.

Two use cases

1. Save a new post with new post_images or fail
2. Save new post_images or fail

This way in both scenarios the developer can enforce using the transaction.