### PR TITLE
[5.6] Update MySqlConnector to be compatible to MySQL 8.0

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -147,7 +147,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
             $this->setCustomModes($connection, $config);
         } elseif (isset($config['strict'])) {
             if ($config['strict']) {
-                $connection->prepare($this->strictMode())->execute();
+                $connection->prepare($this->strictMode($connection))->execute();
             } else {
                 $connection->prepare("set session sql_mode='NO_ENGINE_SUBSTITUTION'")->execute();
             }
@@ -171,10 +171,16 @@ class MySqlConnector extends Connector implements ConnectorInterface
     /**
      * Get the query to enable strict mode.
      *
+     * @param  \PDO  $connection
+     *
      * @return string
      */
-    protected function strictMode()
+    protected function strictMode(PDO $connection)
     {
+        if (version_compare($connection->getAttribute(PDO::ATTR_SERVER_VERSION), '8.0.11') >= 0) {
+            return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
+        }
+
         return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'";
     }
 }


### PR DESCRIPTION
With the release of MySQL 8.0.11 as GA (General Availability), the NO_AUTO_CREATE_USER sql_mode is invalid and the MySQL throws an error when trying to set it.

You can read more about removed features that should be noted before upgrading on:
https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html 
(NO_AUTO_CREATE_USER related item is the first bullet in the *Server Changes* section)

https://dev.mysql.com/doc/refman/8.0/en/mysql-nutshell.html#mysql-nutshell-removals

For those who are migrating their MySQL servers to 8.0 and want a workaround, you can set the `'modes'` array item in you `database.php` file:

~~~~php
// database.php

    'connections' => [

        'mysql' => [
            'driver'      => 'mysql',
            'host'        => env( 'DB_HOST', '127.0.0.1' ),
            'port'        => env( 'DB_PORT', '3306' ),
            'database'    => env( 'DB_DATABASE', 'forge' ),
            'username'    => env( 'DB_USERNAME', 'forge' ),
            'password'    => env( 'DB_PASSWORD', '' ),
            'unix_socket' => env( 'DB_SOCKET', '' ),
            'charset'     => 'utf8mb4',
            'collation'   => 'utf8mb4_unicode_ci',
            'prefix'      => '',
            'strict'      => true,
            'engine'      => null,
            'modes'       => [
                'ONLY_FULL_GROUP_BY',
                'STRICT_TRANS_TABLES',
                'NO_ZERO_IN_DATE',
                'NO_ZERO_DATE',
                'ERROR_FOR_DIVISION_BY_ZERO',
                'NO_ENGINE_SUBSTITUTION',
            ],
        ],
    ],
~~~~

The modes listed above are the ones MySQL 8.0 uses as the default mode:
https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sql-mode-setting