### PR TITLE
[5.6] fixed LengthAwarePaginator Bug where the Data Output differs from page 1 and higher

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -162,7 +162,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     {
         return [
             'current_page' => $this->currentPage(),
-            'data' => $this->items->toArray(),
+            'data' => $this->items->values()->toArray(),
             'first_page_url' => $this->url(1),
             'from' => $this->firstItem(),
             'last_page' => $this->lastPage(),


### PR DESCRIPTION
When using LengthAwarePaginator the Data Output is different when page > 1
using values() on data to start the new array again from 0