### PR TITLE
[5.6] Update MySqlConnector to be compatible to MySQL 8.0

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -242,6 +242,7 @@ class ConnectionFactory
 
         switch ($config['driver']) {
             case 'mysql':
+            case 'mysql8':
                 return new MySqlConnector;
             case 'pgsql':
                 return new PostgresConnector;
@@ -274,6 +275,7 @@ class ConnectionFactory
 
         switch ($driver) {
             case 'mysql':
+            case 'mysql8':
                 return new MySqlConnection($connection, $database, $prefix, $config);
             case 'pgsql':
                 return new PostgresConnection($connection, $database, $prefix, $config);

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -147,7 +147,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
             $this->setCustomModes($connection, $config);
         } elseif (isset($config['strict'])) {
             if ($config['strict']) {
-                $connection->prepare($this->strictMode())->execute();
+                $connection->prepare($this->strictMode($config))->execute();
             } else {
                 $connection->prepare("set session sql_mode='NO_ENGINE_SUBSTITUTION'")->execute();
             }
@@ -171,10 +171,15 @@ class MySqlConnector extends Connector implements ConnectorInterface
     /**
      * Get the query to enable strict mode.
      *
+     * @param array $config
      * @return string
      */
-    protected function strictMode()
+    protected function strictMode(array $config)
     {
-        return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'";
+        if ($config['driver'] == 'mysql8') {
+            return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
+        } else {
+            return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'";
+        }
     }
 }

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -277,7 +277,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function supportedDrivers()
     {
-        return ['mysql', 'pgsql', 'sqlite', 'sqlsrv'];
+        return ['mysql', 'mysql8', 'pgsql', 'sqlite', 'sqlsrv'];
     }
 
     /**


### PR DESCRIPTION
This PR amends https://github.com/laravel/framework/pull/23948 and adds an additional database driver `mysql8`. 
See original PR for details.


