### PR TITLE
[5.7] Added the ability to send an array to getJson method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -172,12 +172,13 @@ trait MakesHttpRequests
      * Visit the given URI with a GET request, expecting a JSON response.
      *
      * @param  string  $uri
+     * @param  array  $data
      * @param  array  $headers
      * @return \Illuminate\Foundation\Testing\TestResponse
      */
-    public function getJson($uri, array $headers = [])
+    public function getJson($uri, array $data = [], array $headers = [])
     {
-        return $this->json('GET', $uri, [], $headers);
+        return $this->json('GET', $uri, $data, $headers);
     }
 
     /**


### PR DESCRIPTION
Added the ability to send an array to getJson method.

Like:
`$this->getJson('path/to', ['param' => 'test'])`