### PR TITLE
[5.7] Add a named route for POST password/reset

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
@@ -8,7 +8,7 @@
                 <div class="card-header">{{ __('Reset Password') }}</div>
 
                 <div class="card-body">
-                    <form method="POST" action="{{ route('password.request') }}">
+                    <form method="POST" action="{{ route('password.update') }}">
                         @csrf
 
                         <input type="hidden" name="token" value="{{ $token }}">

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1135,7 +1135,7 @@ class Router implements RegistrarContract, BindingRegistrar
         $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
         $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
         $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
-        $this->post('password/reset', 'Auth\ResetPasswordController@reset');
+        $this->post('password/reset', 'Auth\ResetPasswordController@reset')->name('password.update');
     }
 
     /**


### PR DESCRIPTION
The [reset.stub](https://github.com/laravel/framework/blob/13f732ed617e41608e4ae021efc9d13e43375a26/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub#L11) is using the GET named route (`password.request`) for the POST password/reset request (changed in #17718). Although the route is the same path, relying on the name of another route is confusing and could lead to unexpected results.

I thought that although a small change, could be a b/c break in 5.6 because it introduces a new named route (`password.update`) that users might have defined in their own app. Let me know if this belongs in 5.6 instead.

Also, I went back and forth on the name and `password.update` is the best I could think of, so let me know if another named route or something else is preferred. I also thought about `password.do_reset` or `password.reset.update` ¯\\\_(ツ)\_/¯

---
_Notes: I noticed this when I was extending and overriding some password reset routes in one of my applications._