### PR TITLE
[5.6] Support URLs for custom filesystem drivers

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -379,6 +379,8 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
 
         if (method_exists($adapter, 'getUrl')) {
             return $adapter->getUrl($path);
+        } elseif (method_exists($this->driver, 'getUrl')) {
+            return $this->driver->getUrl($path);
         } elseif ($adapter instanceof AwsS3Adapter) {
             return $this->getAwsUrl($adapter, $path);
         } elseif ($adapter instanceof RackspaceAdapter) {


### PR DESCRIPTION
Some custom filesystem drivers don’t include URL support at the adapter level, but can be added to the driver through the creation of custom [Flysystem plugins](http://flysystem.thephpleague.com/plugins/). Applications can detect the plugin, but the Filesystem framework currently neglects to check for the ‘getUrl’ method on the driver level.

For example, I have [created a plugin](https://github.com/collectivemediateam/flysystem-azure-url) for the Microsoft Azure driver which adds URL support, but at present cannot be used with this framework due to this small omission.