### PR TITLE
[5.7] Let Collection’s when(), unless() match their BuildQuery counterparts

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -461,7 +461,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  callable  $default
      * @return mixed
      */
-    public function when($value, callable $callback, callable $default = null)
+    public function when($value, $callback, $default = null)
     {
         if ($value) {
             return $callback($this, $value);
@@ -480,7 +480,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  callable  $default
      * @return mixed
      */
-    public function unless($value, callable $callback, callable $default = null)
+    public function unless($value, $callback, $default = null)
     {
         return $this->when(! $value, $callback, $default);
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2582,6 +2582,13 @@ class SupportCollectionTest extends TestCase
         });
 
         $this->assertSame(['michael', 'tom'], $collection->toArray());
+
+        $collection = new Collection(['michael', 'tom']);
+
+        $callback = null;
+        $collection->when($callback !== null, $callback);
+
+        $this->assertSame(['michael', 'tom'], $collection->toArray());
     }
 
     public function testWhenDefault()


### PR DESCRIPTION
Fixes #23394 by using the same method signature as the when() and unless() methods as the BuildsQueries trait