### PR TITLE
[5.7] Change morphs columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -478,7 +478,7 @@ trait HasRelationships
         // instances, as well as the relationship instances we need for these.
         $instance = $this->newRelatedInstance($related);
 
-        $foreignPivotKey = $foreignPivotKey ?: $name.'_id';
+        $foreignPivotKey = $foreignPivotKey ?: $name.'_key';
 
         $relatedPivotKey = $relatedPivotKey ?: $instance->getForeignKey();
 
@@ -537,7 +537,7 @@ trait HasRelationships
         // For the inverse of the polymorphic many-to-many relations, we will change
         // the way we determine the foreign and other keys, as it is the opposite
         // of the morph-to-many method since we're figuring out these inverses.
-        $relatedPivotKey = $relatedPivotKey ?: $name.'_id';
+        $relatedPivotKey = $relatedPivotKey ?: $name.'_key';
 
         return $this->morphToMany(
             $related, $name, $table, $foreignPivotKey,
@@ -626,7 +626,7 @@ trait HasRelationships
      */
     protected function getMorphs($name, $type, $id)
     {
-        return [$type ?: $name.'_type', $id ?: $name.'_id'];
+        return [$type ?: $name.'_type', $id ?: $name.'_key'];
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -418,9 +418,9 @@ class Blueprint
      */
     public function dropMorphs($name, $indexName = null)
     {
-        $this->dropIndex($indexName ?: $this->createIndexName('index', ["{$name}_type", "{$name}_id"]));
+        $this->dropIndex($indexName ?: $this->createIndexName('index', ["{$name}_type", "{$name}_key"]));
 
-        $this->dropColumn("{$name}_type", "{$name}_id");
+        $this->dropColumn("{$name}_type", "{$name}_key");
     }
 
     /**
@@ -1137,9 +1137,9 @@ class Blueprint
     {
         $this->string("{$name}_type");
 
-        $this->unsignedBigInteger("{$name}_id");
+        $this->string("{$name}_key");
 
-        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+        $this->index(["{$name}_type", "{$name}_key"], $indexName);
     }
 
     /**
@@ -1153,9 +1153,9 @@ class Blueprint
     {
         $this->string("{$name}_type")->nullable();
 
-        $this->unsignedBigInteger("{$name}_id")->nullable();
+        $this->string("{$name}_key")->nullable();
 
-        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+        $this->index(["{$name}_type", "{$name}_key"], $indexName);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -46,7 +46,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->schema('default')->create('test_orders', function ($table) {
             $table->increments('id');
             $table->string('item_type');
-            $table->integer('item_id');
+            $table->integer('item_key');
             $table->timestamps();
         });
 
@@ -1058,7 +1058,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $item = null;
 
         EloquentTestItem::create(['id' => 1]);
-        EloquentTestOrder::create(['id' => 1, 'item_type' => EloquentTestItem::class, 'item_id' => 1]);
+        EloquentTestOrder::create(['id' => 1, 'item_type' => EloquentTestItem::class, 'item_key' => 1]);
         try {
             $item = EloquentTestOrder::first()->item;
         } catch (Exception $e) {
@@ -1284,7 +1284,7 @@ class EloquentTestUser extends Eloquent
     public function postWithPhotos()
     {
         return $this->post()->join('photo', function ($join) {
-            $join->on('photo.imageable_id', 'post.id');
+            $join->on('photo.imageable_key', 'post.id');
             $join->where('photo.imageable_type', 'EloquentTestPost');
         });
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1000,7 +1000,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->morphOne('Illuminate\Tests\Database\EloquentModelSaveStub', 'morph');
-        $this->assertEquals('save_stub.morph_id', $relation->getQualifiedForeignKeyName());
+        $this->assertEquals('save_stub.morph_key', $relation->getQualifiedForeignKeyName());
         $this->assertEquals('save_stub.morph_type', $relation->getQualifiedMorphType());
         $this->assertEquals('Illuminate\Tests\Database\EloquentModelStub', $relation->getMorphClass());
     }
@@ -1038,7 +1038,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->morphMany('Illuminate\Tests\Database\EloquentModelSaveStub', 'morph');
-        $this->assertEquals('save_stub.morph_id', $relation->getQualifiedForeignKeyName());
+        $this->assertEquals('save_stub.morph_key', $relation->getQualifiedForeignKeyName());
         $this->assertEquals('save_stub.morph_type', $relation->getQualifiedMorphType());
         $this->assertEquals('Illuminate\Tests\Database\EloquentModelStub', $relation->getMorphClass());
     }
@@ -1065,7 +1065,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         // $this->morphTo();
         $relation = $model->morphToStub();
-        $this->assertEquals('morph_to_stub_id', $relation->getForeignKey());
+        $this->assertEquals('morph_to_stub_key', $relation->getForeignKey());
         $this->assertEquals('morph_to_stub_type', $relation->getMorphType());
         $this->assertEquals('morphToStub', $relation->getRelation());
         $this->assertSame($model, $relation->getParent());
@@ -1079,7 +1079,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         // $this->morphTo('someName');
         $relation3 = $model->morphToStubWithName();
-        $this->assertEquals('some_name_id', $relation3->getForeignKey());
+        $this->assertEquals('some_name_key', $relation3->getForeignKey());
         $this->assertEquals('some_name_type', $relation3->getMorphType());
         $this->assertEquals('someName', $relation3->getRelation());
 

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -26,7 +26,7 @@ class DatabaseEloquentMorphTest extends TestCase
     public function testMorphOneEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getOneRelation();
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', [1, 2]);
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_key', [1, 2]);
         $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
 
         $model1 = new EloquentMorphResetModelStub;
@@ -48,7 +48,7 @@ class DatabaseEloquentMorphTest extends TestCase
     public function testMorphManyEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getManyRelation();
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', [1, 2]);
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_key', [1, 2]);
         $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
 
         $model1 = new EloquentMorphResetModelStub;
@@ -64,7 +64,7 @@ class DatabaseEloquentMorphTest extends TestCase
         // Doesn't matter which relation type we use since they share the code...
         $relation = $this->getOneRelation();
         $instance = m::mock('Illuminate\Database\Eloquent\Model');
-        $instance->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+        $instance->shouldReceive('setAttribute')->once()->with('morph_key', 1);
         $instance->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $instance->shouldReceive('save')->never();
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($instance);
@@ -77,7 +77,7 @@ class DatabaseEloquentMorphTest extends TestCase
         // Doesn't matter which relation type we use since they share the code...
         $relation = $this->getOneRelation();
         $created = m::mock('Illuminate\Database\Eloquent\Model');
-        $created->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+        $created->shouldReceive('setAttribute')->once()->with('morph_key', 1);
         $created->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($created);
         $created->shouldReceive('save')->once()->andReturn(true);
@@ -101,7 +101,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
-        $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+        $model->shouldReceive('setAttribute')->once()->with('morph_key', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->never();
 
@@ -138,7 +138,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
-        $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+        $model->shouldReceive('setAttribute')->once()->with('morph_key', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->never();
 
@@ -151,7 +151,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
-        $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+        $model->shouldReceive('setAttribute')->once()->with('morph_key', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->never();
 
@@ -188,7 +188,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
-        $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+        $model->shouldReceive('setAttribute')->once()->with('morph_key', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->once()->andReturn(true);
 
@@ -201,7 +201,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
-        $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+        $model->shouldReceive('setAttribute')->once()->with('morph_key', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->once()->andReturn(true);
 
@@ -227,7 +227,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
-        $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+        $model->shouldReceive('setAttribute')->once()->with('morph_key', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->once()->andReturn(true);
         $model->shouldReceive('fill')->once()->with(['bar']);
@@ -239,7 +239,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getNamespacedRelation('namespace');
         $created = m::mock('Illuminate\Database\Eloquent\Model');
-        $created->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+        $created->shouldReceive('setAttribute')->once()->with('morph_key', 1);
         $created->shouldReceive('setAttribute')->once()->with('morph_type', 'namespace');
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($created);
         $created->shouldReceive('save')->once()->andReturn(true);
@@ -250,8 +250,8 @@ class DatabaseEloquentMorphTest extends TestCase
     protected function getOneRelation()
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
-        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_key');
+        $builder->shouldReceive('where')->once()->with('table.morph_key', '=', 1);
         $related = m::mock('Illuminate\Database\Eloquent\Model');
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock('Illuminate\Database\Eloquent\Model');
@@ -259,14 +259,14 @@ class DatabaseEloquentMorphTest extends TestCase
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
 
-        return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+        return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_key', 'id');
     }
 
     protected function getManyRelation()
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
-        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_key');
+        $builder->shouldReceive('where')->once()->with('table.morph_key', '=', 1);
         $related = m::mock('Illuminate\Database\Eloquent\Model');
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock('Illuminate\Database\Eloquent\Model');
@@ -274,7 +274,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
 
-        return new MorphMany($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+        return new MorphMany($builder, $parent, 'table.morph_type', 'table.morph_key', 'id');
     }
 
     protected function getNamespacedRelation($alias)
@@ -286,8 +286,8 @@ class DatabaseEloquentMorphTest extends TestCase
         ]);
 
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
-        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_key');
+        $builder->shouldReceive('where')->once()->with('table.morph_key', '=', 1);
         $related = m::mock('Illuminate\Database\Eloquent\Model');
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock('Foo\Bar\EloquentModelNamespacedStub');
@@ -295,7 +295,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $parent->shouldReceive('getMorphClass')->andReturn($alias);
         $builder->shouldReceive('where')->once()->with('table.morph_type', $alias);
 
-        return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+        return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_key', 'id');
     }
 }
 

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -16,7 +16,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
     public function testEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getRelation();
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('taggables.taggable_id', [1, 2]);
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('taggables.taggable_key', [1, 2]);
         $relation->getQuery()->shouldReceive('where')->once()->with('taggables.taggable_type', get_class($relation->getParent()));
         $model1 = new EloquentMorphToManyModelStub;
         $model1->id = 1;
@@ -30,7 +30,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\MorphToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
-        $query->shouldReceive('insert')->once()->with([['taggable_id' => 1, 'taggable_type' => get_class($relation->getParent()), 'tag_id' => 2, 'foo' => 'bar']])->andReturn(true);
+        $query->shouldReceive('insert')->once()->with([['taggable_key' => 1, 'taggable_type' => get_class($relation->getParent()), 'tag_id' => 2, 'foo' => 'bar']])->andReturn(true);
         $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
@@ -43,7 +43,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\MorphToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
-        $query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
+        $query->shouldReceive('where')->once()->with('taggable_key', 1)->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('tag_id', [1, 2, 3]);
         $query->shouldReceive('delete')->once()->andReturn(true);
@@ -59,7 +59,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\MorphToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
-        $query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
+        $query->shouldReceive('where')->once()->with('taggable_key', 1)->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->never();
         $query->shouldReceive('delete')->once()->andReturn(true);
@@ -74,7 +74,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
     {
         list($builder, $parent) = $this->getRelationArguments();
 
-        return new MorphToMany($builder, $parent, 'taggable', 'taggables', 'taggable_id', 'tag_id', 'id', 'id');
+        return new MorphToMany($builder, $parent, 'taggable', 'taggables', 'taggable_key', 'tag_id', 'id', 'id');
     }
 
     public function getRelationArguments()
@@ -96,10 +96,10 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $related->shouldReceive('getMorphClass')->andReturn(get_class($related));
 
         $builder->shouldReceive('join')->once()->with('taggables', 'tags.id', '=', 'taggables.tag_id');
-        $builder->shouldReceive('where')->once()->with('taggables.taggable_id', '=', 1);
+        $builder->shouldReceive('where')->once()->with('taggables.taggable_key', '=', 1);
         $builder->shouldReceive('where')->once()->with('taggables.taggable_type', get_class($parent));
 
-        return [$builder, $parent, 'taggable', 'taggables', 'taggable_id', 'tag_id', 'id', 'id', 'relation_name', false];
+        return [$builder, $parent, 'taggable', 'taggables', 'taggable_key', 'tag_id', 'id', 'id', 'relation_name', false];
     }
 }
 

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -47,7 +47,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
 
         $this->schema()->create('comments', function ($table) {
             $table->increments('id');
-            $table->integer('commentable_id');
+            $table->integer('commentable_key');
             $table->string('commentable_type');
             $table->integer('user_id');
             $table->text('body');
@@ -56,7 +56,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
 
         $this->schema()->create('likes', function ($table) {
             $table->increments('id');
-            $table->integer('likeable_id');
+            $table->integer('likeable_key');
             $table->string('likeable_type');
             $table->timestamps();
         });

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -48,7 +48,7 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
 
         $this->schema('default')->create('taggables', function ($table) {
             $table->integer('eloquent_many_to_many_polymorphic_test_tag_id');
-            $table->integer('taggable_id');
+            $table->integer('taggable_key');
             $table->string('taggable_type');
         });
     }

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -54,7 +54,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
         $this->schema()->create('comments', function ($table) {
             $table->increments('id');
-            $table->integer('owner_id')->nullable();
+            $table->integer('owner_key')->nullable();
             $table->string('owner_type')->nullable();
             $table->integer('post_id');
             $table->string('body');
@@ -534,7 +534,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $post1->comments()->create([
             'body' => 'Comment Body',
             'owner_type' => SoftDeletesTestUser::class,
-            'owner_id' => $abigail->id,
+            'owner_key' => $abigail->id,
         ]);
 
         $abigail->delete();
@@ -571,7 +571,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $post1->comments()->create([
             'body' => 'Comment Body',
             'owner_type' => SoftDeletesTestUser::class,
-            'owner_id' => $abigail->id,
+            'owner_key' => $abigail->id,
         ]);
 
         TestCommentWithoutSoftDelete::with(['owner' => function ($q) {
@@ -588,7 +588,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $post1->comments()->create([
             'body' => 'Comment Body',
             'owner_type' => SoftDeletesTestUser::class,
-            'owner_id' => $abigail->id,
+            'owner_key' => $abigail->id,
         ]);
 
         $comment = SoftDeletesTestCommentWithTrashed::with(['owner' => function ($q) {
@@ -607,7 +607,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $comment1 = $post1->comments()->create([
             'body' => 'Comment Body',
             'owner_type' => SoftDeletesTestUser::class,
-            'owner_id' => $abigail->id,
+            'owner_key' => $abigail->id,
         ]);
 
         $comment = SoftDeletesTestCommentWithTrashed::with('owner')->first();
@@ -627,7 +627,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $post1->comments()->create([
             'body' => 'Comment Body',
             'owner_type' => TestUserWithoutSoftDelete::class,
-            'owner_id' => $taylor->id,
+            'owner_key' => $taylor->id,
         ]);
 
         $comment = SoftDeletesTestCommentWithTrashed::with('owner')->first();

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -265,8 +265,8 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('alter table `photos` drop index `photos_imageable_type_imageable_id_index`', $statements[0]);
-        $this->assertEquals('alter table `photos` drop `imageable_type`, drop `imageable_id`', $statements[1]);
+        $this->assertEquals('alter table `photos` drop index `photos_imageable_type_imageable_key_index`', $statements[0]);
+        $this->assertEquals('alter table `photos` drop `imageable_type`, drop `imageable_key`', $statements[1]);
     }
 
     public function testRenameTable()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -180,8 +180,8 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('drop index "photos_imageable_type_imageable_id_index"', $statements[0]);
-        $this->assertEquals('alter table "photos" drop column "imageable_type", drop column "imageable_id"', $statements[1]);
+        $this->assertEquals('drop index "photos_imageable_type_imageable_key_index"', $statements[0]);
+        $this->assertEquals('alter table "photos" drop column "imageable_type", drop column "imageable_key"', $statements[1]);
     }
 
     public function testRenameTable()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -190,8 +190,8 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('drop index "photos_imageable_type_imageable_id_index" on "photos"', $statements[0]);
-        $this->assertEquals('alter table "photos" drop column "imageable_type", "imageable_id"', $statements[1]);
+        $this->assertEquals('drop index "photos_imageable_type_imageable_key_index" on "photos"', $statements[0]);
+        $this->assertEquals('alter table "photos" drop column "imageable_type", "imageable_key"', $statements[1]);
     }
 
     public function testRenameTable()


### PR DESCRIPTION
This PR fixes issue when morphing to a model that its primary key is a `string` instead of `integer`, and morphing to the previous model like the following example:
```php
Schema::create('settings', function (Blueprint $table) {
      $table->string('key')->primary();
      $table->text('value')->nullable();
});

```
When inserting a table for [laravel-medialibrary](https://github.com/spatie/laravel-medialibrary) :
```php
Schema::create('media', function (Blueprint $table) {
     $table->increments('id');
     $table->morphs('model');
     $table->string('collection_name');
     $table->string('name');
     $table->string('file_name');
     $table->string('mime_type')->nullable();
     $table->string('disk');
     $table->unsignedInteger('size');
     $table->json('manipulations');
     $table->json('custom_properties');
     $table->json('responsive_images');
     $table->unsignedInteger('order_column')->nullable();
     $table->nullableTimestamps();
 });
```
The following error will occur:
```php
Illuminate \ Database \ QueryException (22007)
SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: 'logo' for column 'model_id' at row 1 (SQL: insert into `media` (`name`, `file_name`, `disk`, `collection_name`, `mime_type`, `size`, `custom_properties`, `responsive_images`, `manipulations`, `model_type`, `model_id`, `order_column`, `updated_at`, `created_at`) values (logo, logo.png, public, default, image/png, 12628, {"custom_headers":[]}, [], [], App\Models\Setting, logo, 91, 2018-04-23 14:07:01, 2018-04-23 14:07:01))

```