### PR TITLE
[5.7] Replaced foreach() with reset() function

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -166,9 +166,7 @@ class Arr
                 return value($default);
             }
 
-            foreach ($array as $item) {
-                return $item;
-            }
+            return reset($array);
         }
 
         foreach ($array as $key => $value) {


### PR DESCRIPTION
This `foreach()` loop is just returning the first element, which can be done by `reset()` function in a much cleaned way. 