### PR TITLE
[5.6] Render the right view when using Mailables for sending mails just in plain text format

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -201,9 +201,7 @@ class Mailer implements MailerContract, MailQueueContract
 
         $data['message'] = $this->createMessage();
 
-        return $view
-            ? $this->renderView($view, $data)
-            : $this->renderView($plain, $data);
+        return $this->renderView($view ?: $plain, $data);
     }
 
     /**

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -201,7 +201,7 @@ class Mailer implements MailerContract, MailQueueContract
 
         $data['message'] = $this->createMessage();
 
-        return $this->renderView($view, $data);
+        return $view ? $this->renderView($view, $data) : $this->renderView($plain, $data);
     }
 
     /**

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -201,7 +201,9 @@ class Mailer implements MailerContract, MailQueueContract
 
         $data['message'] = $this->createMessage();
 
-        return $view ? $this->renderView($view, $data) : $this->renderView($plain, $data);
+        return $view
+            ? $this->renderView($view, $data)
+            : $this->renderView($plain, $data);
     }
 
     /**


### PR DESCRIPTION
This is supposed to fix the case from ticket [#23822](https://github.com/laravel/framework/issues/23822) and probably [#1058 ](https://github.com/laravel/ideas/issues/1058)

When using _Mailables_ to send e-mails just in plain text format, it was being sent to render only the HTML view. With this change, it will check first if the HTML is present, if not it will send to render the plain text view.

Apologies if this is very straight forward, this is my first PR to Laravel, even if I am using it for about 4 years.