### PR TITLE
[5.6] Ignore non-where bindings in nested where() constraints

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1289,7 +1289,7 @@ class Builder
 
             $this->wheres[] = compact('type', 'query', 'boolean');
 
-            $this->addBinding($query->getBindings(), 'where');
+            $this->addBinding($query->getRawBindings()['where'], 'where');
         }
 
         return $this;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -980,6 +980,15 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 'foo', 1 => 'bar', 2 => 25], $builder->getBindings());
     }
 
+    public function testNestedWhereBindings()
+    {
+        $builder = $this->getBuilder();
+        $builder->where('email', '=', 'foo')->where(function ($q) {
+            $q->selectRaw('?', ['ignore'])->where('name', '=', 'bar');
+        });
+        $this->assertEquals([0 => 'foo', 1 => 'bar'], $builder->getBindings());
+    }
+
     public function testFullSubSelects()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Nested `where()` constraints merge all bindings from the given query, even the ones from other query parts.

This breaks queries that reference a relationship with `WHERE` bindings (e.g. `MorphMany`) in `$withCount` and use a nested `where()` constraint:

    class ParentModel extends Model
    {
        protected $table = 'parent';
    
        protected $withCount = ['children'];
    
        public function children()
        {
            return $this->morphMany(ChildModel::class, 'morphable');
        }
    }
    
    class ChildModel extends Model
    {
        protected $table = 'child';
    }
 
    $query = ParentModel::where(function($q) {
        $q->where(1, 1);
    });

The query doesn't work as expected because an extra binding is added:

    dd($query->getBindings());
    // expected: ['App\ParentModel', 1];
    // actual: ['App\ParentModel', 'App\ParentModel', 1]

As a result `'App\ParentModel'` is used for the second placeholder and `1` is ignored.

This is caused by [`Model::newQueryWithoutScopes()`](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Database/Eloquent/Model.php#L875) adding `$withCount` to every query.
So the query received by [`Builder::where()`](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Database/Eloquent/Builder.php#L222) contains the `$withCount` bindings.

This PR solves the problem by ignoring non-where bindings when the nested query is merged.

Fixes #23957.