### PR TITLE
[5.6] Change ThrottlesLogins lockout response code to HTTP 429

### DIFF
--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -52,7 +52,7 @@ trait ThrottlesLogins
 
         throw ValidationException::withMessages([
             $this->username() => [Lang::get('auth.throttle', ['seconds' => $seconds])],
-        ])->status(423);
+        ])->status(429);
     }
 
     /**


### PR DESCRIPTION
This PR is identical to #23959, but applied to the head of 5.6 as a bugfix as requested.

Please let me know if there are any questions or issues. Thanks!