### PR TITLE
[5.6] Add allowed ip's or networks to Maintenance Mode

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -15,7 +15,8 @@ class DownCommand extends Command
      * @var string
      */
     protected $signature = 'down {--message= : The message for the maintenance mode. }
-                                 {--retry= : The number of seconds after which the request may be retried.}';
+                                 {--retry= : The number of seconds after which the request may be retried.}
+                                 {--allow=* : Ip or network allowed to use App in the maintenance mode.}';
 
     /**
      * The console command description.
@@ -50,6 +51,7 @@ class DownCommand extends Command
             'time' => $this->currentTime(),
             'message' => $this->option('message'),
             'retry' => $this->getRetryTime(),
+            'allowed' => $this->option('allow'),
         ];
     }
 

--- a/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
+++ b/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Http\Middleware;
 use Closure;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
+use Symfony\Component\HttpFoundation\IpUtils;
 
 class CheckForMaintenanceMode
 {
@@ -39,6 +40,10 @@ class CheckForMaintenanceMode
     {
         if ($this->app->isDownForMaintenance()) {
             $data = json_decode(file_get_contents($this->app->storagePath().'/framework/down'), true);
+
+            if (isset($data['allowed']) && IpUtils::checkIp($request->ip(), (array)$data['allowed'])) {
+                return $next($request);
+            }
 
             throw new MaintenanceModeException($data['time'], $data['retry'], $data['message']);
         }


### PR DESCRIPTION
With this PR I can access to the App in maintenance mode from certain ip address or networks.

Example:
```bash
php artisan down --allow=127.0.0.1 --allow=192.168.0.0/16
```