### PR TITLE
[5.6] Added callable objects to query builder

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -83,7 +83,7 @@ trait BuildsQueries
      * @param  mixed  $value
      * @param  callable  $callback
      * @param  callable  $default
-     * @return mixed
+     * @return static|mixed
      */
     public function when($value, $callback, $default = null)
     {
@@ -113,7 +113,7 @@ trait BuildsQueries
      * @param  mixed  $value
      * @param  callable  $callback
      * @param  callable  $default
-     * @return mixed
+     * @return static|mixed
      */
     public function unless($value, $callback, $default = null)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use Closure;
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
@@ -18,10 +17,10 @@ trait QueriesRelationships
      * @param  string  $operator
      * @param  int     $count
      * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param  callable|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+    public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', callable $callback = null)
     {
         if (strpos($relation, '.') !== false) {
             return $this->hasNested($relation, $operator, $count, $boolean, $callback);
@@ -61,7 +60,7 @@ trait QueriesRelationships
      * @param  string  $operator
      * @param  int     $count
      * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param  callable|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     protected function hasNested($relations, $operator = '>=', $count = 1, $boolean = 'and', $callback = null)
@@ -70,7 +69,7 @@ trait QueriesRelationships
 
         $closure = function ($q) use (&$closure, &$relations, $operator, $count, $callback) {
             // In order to nest "has", we need to add count relation constraints on the
-            // callback Closure. We'll do this by simply passing the Closure its own
+            // callback callable. We'll do this by simply passing the callable its own
             // reference to itself so it calls itself recursively on each segment.
             count($relations) > 1
                 ? $q->whereHas(array_shift($relations), $closure)
@@ -98,10 +97,10 @@ trait QueriesRelationships
      *
      * @param  string  $relation
      * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param  callable|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function doesntHave($relation, $boolean = 'and', Closure $callback = null)
+    public function doesntHave($relation, $boolean = 'and', callable $callback = null)
     {
         return $this->has($relation, '<', 1, $boolean, $callback);
     }
@@ -121,12 +120,12 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query with where clauses.
      *
      * @param  string  $relation
-     * @param  \Closure|null  $callback
+     * @param  callable|null  $callback
      * @param  string  $operator
      * @param  int     $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    public function whereHas($relation, callable $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'and', $callback);
     }
@@ -135,12 +134,12 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
      * @param  string    $relation
-     * @param  \Closure  $callback
+     * @param  callable  $callback
      * @param  string    $operator
      * @param  int       $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function orWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    public function orWhereHas($relation, callable $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'or', $callback);
     }
@@ -149,10 +148,10 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query with where clauses.
      *
      * @param  string  $relation
-     * @param  \Closure|null  $callback
+     * @param  callable|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereDoesntHave($relation, Closure $callback = null)
+    public function whereDoesntHave($relation, callable $callback = null)
     {
         return $this->doesntHave($relation, 'and', $callback);
     }
@@ -161,10 +160,10 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
      * @param  string    $relation
-     * @param  \Closure  $callback
+     * @param  callable  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function orWhereDoesntHave($relation, Closure $callback = null)
+    public function orWhereDoesntHave($relation, callable $callback = null)
     {
         return $this->doesntHave($relation, 'or', $callback);
     }

--- a/src/Illuminate/Database/Query/Filters/Where.php
+++ b/src/Illuminate/Database/Query/Filters/Where.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Database\Query\Filters;
+
+use Illuminate\Database\Query\Builder;
+
+class Where
+{
+    /**
+     * Column name.
+     *
+     * @var string
+     */
+    protected $column;
+
+    /**
+     * The value.
+     *
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * The clause operator.
+     *
+     * @var null
+     */
+    protected $operator;
+
+    /**
+     * @var string
+     */
+    protected $boolean;
+
+    /**
+     * Create a new callable object instance.
+     *
+     * @param  $column
+     * @param  null  $operator
+     * @param  null  $value
+     * @param  string  $boolean
+     */
+    public function __construct($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        $this->column = $column;
+        $this->operator = $operator;
+        $this->value = $value;
+        $this->boolean = $boolean;
+    }
+
+    /**
+     * Add a basic where clause to then query.
+     *
+     * @param  Builder  $builder
+     * @return Builder
+     */
+    public function __invoke($builder)
+    {
+        return $builder->where($this->column, $this->operator, $this->value, $this->boolean);
+    }
+}

--- a/src/Illuminate/Database/Query/Filters/WhereEquals.php
+++ b/src/Illuminate/Database/Query/Filters/WhereEquals.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Query\Filters;
+
+class WhereEquals extends Where
+{
+    public function __construct(string $column, $value)
+    {
+        parent::__construct($column, '=', $value);
+    }
+}

--- a/src/Illuminate/Database/Query/Filters/WhereGreater.php
+++ b/src/Illuminate/Database/Query/Filters/WhereGreater.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Query\Filters;
+
+class WhereGreater extends Where
+{
+    public function __construct(string $column, $value, bool $include = false)
+    {
+        parent::__construct($column, $include ? '>=' : '>', $value);
+    }
+}

--- a/src/Illuminate/Database/Query/Filters/WhereIn.php
+++ b/src/Illuminate/Database/Query/Filters/WhereIn.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Database\Query\Filters;
+
+class WhereIn
+{
+    /**
+     * @var string
+     */
+    private $column;
+
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    public function __construct(string $column, $value)
+    {
+        $this->column = $column;
+        $this->value = $value;
+    }
+
+    /**
+     * @param \Illuminate\Database\Query\Builder $builder
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function __invoke($builder)
+    {
+        return $builder->whereIn($this->column, $this->value);
+    }
+}

--- a/src/Illuminate/Database/Query/Filters/WhereLess.php
+++ b/src/Illuminate/Database/Query/Filters/WhereLess.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Query\Filters;
+
+class WhereLess extends Where
+{
+    public function __construct(string $column, $value, bool $include = false)
+    {
+        parent::__construct($column, $include ? '<=' : '<', $value);
+    }
+}

--- a/src/Illuminate/Database/Query/Filters/WhereLike.php
+++ b/src/Illuminate/Database/Query/Filters/WhereLike.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Database\Query\Filters;
+
+class WhereLike extends Where
+{
+    public function __construct(string $column, $value, bool $includeBefore = true, bool $includeAfter = true)
+    {
+        parent::__construct($column, 'like', sprintf(
+            '%s%s%s',
+            $includeBefore ? '%' : '',
+            $value,
+            $includeAfter ? '%' : ''
+        ));
+    }
+}

--- a/src/Illuminate/Database/Query/Filters/WhereNotEquals.php
+++ b/src/Illuminate/Database/Query/Filters/WhereNotEquals.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Query\Filters;
+
+class WhereNotEquals extends Where
+{
+    public function __construct(string $column, $value)
+    {
+        parent::__construct($column, '!=', $value);
+    }
+}

--- a/src/Illuminate/Database/Query/Filters/WhereNotIn.php
+++ b/src/Illuminate/Database/Query/Filters/WhereNotIn.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Database\Query\Filters;
+
+class WhereNotIn
+{
+    /**
+     * @var string
+     */
+    private $column;
+
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    public function __construct(string $column, $value)
+    {
+        $this->column = $column;
+        $this->value = $value;
+    }
+
+    /**
+     * @param \Illuminate\Database\Query\Builder $builder
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function __invoke($builder)
+    {
+        return $builder->whereNotIn($this->column, $this->value);
+    }
+}


### PR DESCRIPTION
We use higher order function in query builderr very often, like this:
```php
$builder
    ->when($value, function ($builder) use ($value) {
        $builder->where('field', '>=', $value);
    })
    ->when(! is_null($otherValue), function ($builder) use ($otherValue) {
        $builder->where('field', $otherValue);
    })

    // ... chian
```

The problem is huge query builder. My idea for this issue is using callable objects for simplifying code, like this:
```php
$builder
    ->when($value, new WhereGreater('field', $value, true))
    ->when(! is_null($otherValue), new WhereEquals('field', $otherValue))

    // ... chian
```

This pr add a callable objects for basic queries. This objects may use in other conditions, for example:
```php
// With higher order functions
$model->whereHas('relation', function($builder) use ($search) {
    $builder->where('title', 'like', "%{$search}%");
});

// With callable object
$model->whereHas('relation', new WhereLike('status', $search));
```

This objects can be written in application code, but nice to have his out of box.

Also i added PHPDoc for autocomplete in builder methods chaining