### PR TITLE
[5.6] allow children classes with a parent that has a primitive constructor…

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -877,6 +877,13 @@ class Container implements ArrayAccess, ContainerContract
     {
         if (! is_null($concrete = $this->getContextualConcrete('$'.$parameter->name))) {
             return $concrete instanceof Closure ? $concrete($this) : $concrete;
+        } else {
+            $this->buildStack[] = $parameter->getDeclaringClass()->name;
+            if (! is_null($concrete = $this->getContextualConcrete('$'.$parameter->name))) {
+                array_pop($this->buildStack);
+
+                return $concrete instanceof Closure ? $concrete($this) : $concrete;
+            }
         }
 
         if ($parameter->isDefaultValueAvailable()) {

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1049,6 +1049,12 @@ class ContainerTest extends TestCase
         $injectableValue = 28;
 
         $container->when(ContainerPrimitiveInjectParent::class)
+            ->needs(stdClass::class)
+            ->give(function () {
+                return new stdClass();
+            });
+
+        $container->when(ContainerPrimitiveInjectParent::class)
             ->needs('$injectableValue')
             ->give($injectableValue);
 
@@ -1056,22 +1062,18 @@ class ContainerTest extends TestCase
         $parent = $container->make(ContainerPrimitiveInjectParent::class);
         $this->assertInstanceOf(ContainerPrimitiveInjectParent::class, $parent);
         $this->assertEquals($injectableValue, $parent->injectableValue);
-
-        /** @var ContainerPrimitiveInjectChild $child */
-        $child = $container->make(ContainerPrimitiveInjectChild::class);
-        $this->assertInstanceOf(ContainerPrimitiveInjectChild::class, $child);
-        $this->assertEquals($injectableValue, $child->injectableValue);
-
-        /** @var ContainerPrimitiveInjectGrandChild $child */
-        $child = $container->make(ContainerPrimitiveInjectGrandChild::class);
-        $this->assertInstanceOf(ContainerPrimitiveInjectGrandChild::class, $child);
-        $this->assertEquals($injectableValue, $child->injectableValue);
     }
 
     public function testContextBindPrimitiveIntoChild()
     {
         $container = new Container;
         $injectableValue = 28;
+
+        $container->when(ContainerPrimitiveInjectParent::class)
+            ->needs(stdClass::class)
+            ->give(function () {
+                return new stdClass();
+            });
 
         $container->when(ContainerPrimitiveInjectParent::class)
             ->needs('$injectableValue')
@@ -1089,6 +1091,12 @@ class ContainerTest extends TestCase
         $injectableValue = 28;
 
         $container->when(ContainerPrimitiveInjectParent::class)
+            ->needs(stdClass::class)
+            ->give(function () {
+                return new stdClass();
+            });
+
+        $container->when(ContainerPrimitiveInjectParent::class)
             ->needs('$injectableValue')
             ->give($injectableValue);
 
@@ -1103,7 +1111,7 @@ class ContainerPrimitiveInjectParent
 {
     public $injectableValue;
 
-    public function __construct(int $injectableValue)
+    public function __construct(stdClass $class, int $injectableValue)
     {
         $this->injectableValue = $injectableValue;
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1042,6 +1042,40 @@ class ContainerTest extends TestCase
         $container = new Container;
         $container->get('Taylor');
     }
+
+    public function testContextBindPrimitive()
+    {
+        $container = new Container;
+        $injectableValue = 28;
+
+        $container->when(ContainerPrimitiveInjectParent::class)
+            ->needs('$injectableValue')
+            ->give($injectableValue);
+
+        /** @var ContainerPrimitiveInjectParent $parent */
+        $parent = $container->make(ContainerPrimitiveInjectParent::class);
+        $this->assertInstanceOf(ContainerPrimitiveInjectParent::class, $parent);
+        $this->assertEquals($injectableValue, $parent->injectableValue);
+
+        /** @var ContainerPrimitiveInjectChild $child */
+        $child = $container->make(ContainerPrimitiveInjectChild::class);
+        $this->assertInstanceOf(ContainerPrimitiveInjectChild::class, $child);
+        $this->assertEquals($injectableValue, $child->injectableValue);
+    }
+}
+
+class ContainerPrimitiveInjectParent
+{
+    public $injectableValue;
+
+    public function __construct(int $injectableValue)
+    {
+        $this->injectableValue = $injectableValue;
+    }
+}
+
+class ContainerPrimitiveInjectChild extends ContainerPrimitiveInjectParent
+{
 }
 
 class ContainerConcreteStub

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1061,6 +1061,41 @@ class ContainerTest extends TestCase
         $child = $container->make(ContainerPrimitiveInjectChild::class);
         $this->assertInstanceOf(ContainerPrimitiveInjectChild::class, $child);
         $this->assertEquals($injectableValue, $child->injectableValue);
+
+        /** @var ContainerPrimitiveInjectGrandChild $child */
+        $child = $container->make(ContainerPrimitiveInjectGrandChild::class);
+        $this->assertInstanceOf(ContainerPrimitiveInjectGrandChild::class, $child);
+        $this->assertEquals($injectableValue, $child->injectableValue);
+    }
+
+    public function testContextBindPrimitiveIntoChild()
+    {
+        $container = new Container;
+        $injectableValue = 28;
+
+        $container->when(ContainerPrimitiveInjectParent::class)
+            ->needs('$injectableValue')
+            ->give($injectableValue);
+
+        /** @var ContainerPrimitiveInjectChild $child */
+        $child = $container->make(ContainerPrimitiveInjectChild::class);
+        $this->assertInstanceOf(ContainerPrimitiveInjectChild::class, $child);
+        $this->assertEquals($injectableValue, $child->injectableValue);
+    }
+
+    public function testContextBindPrimitiveIntoGrandChild()
+    {
+        $container = new Container;
+        $injectableValue = 28;
+
+        $container->when(ContainerPrimitiveInjectParent::class)
+            ->needs('$injectableValue')
+            ->give($injectableValue);
+
+        /** @var ContainerPrimitiveInjectGrandChild $child */
+        $child = $container->make(ContainerPrimitiveInjectGrandChild::class);
+        $this->assertInstanceOf(ContainerPrimitiveInjectGrandChild::class, $child);
+        $this->assertEquals($injectableValue, $child->injectableValue);
     }
 }
 
@@ -1075,6 +1110,10 @@ class ContainerPrimitiveInjectParent
 }
 
 class ContainerPrimitiveInjectChild extends ContainerPrimitiveInjectParent
+{
+}
+
+class ContainerPrimitiveInjectGrandChild extends ContainerPrimitiveInjectChild
 {
 }
 


### PR DESCRIPTION
When contextually binding a primitive value to a parent class' constructor, instantiating the child through dependency injection does not find the parent class' bound value.

```
class ParentTestClass {
    public function __construct(int $testVal){
    }
}

class ChildTestClass extends ParentTestClass{
}

app()->when(ParentTestClass::class)->needs('$testVal')->give('28');

$child = app()->make(ChildTestClass::class);
```
 results in 
```
Unresolvable dependency resolving [Parameter #1 [ &lt;required&gt; integer $textVal ]] in class ParentTestClass
```
