### PR TITLE
[5.6] Refactor array_filter calls

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -198,9 +198,7 @@ class Kernel implements KernelContract
     {
         $paths = array_unique(Arr::wrap($paths));
 
-        $paths = array_filter($paths, function ($path) {
-            return is_dir($path);
-        });
+        $paths = array_filter($paths, 'is_dir');
 
         if (empty($paths)) {
             return;


### PR DESCRIPTION
If the callback only has a function, we can pass its name as a string in the second parameter