### PR TITLE
php artisan down --message='foo'  not displaying 'foo'

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/503.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/503.blade.php
@@ -2,4 +2,4 @@
 
 @section('title', 'Service Unavailable')
 
-@section('message', 'Be right back.')
+@section('message', $exception->getMessage() ?: 'Be right back.')


### PR DESCRIPTION
### **Problem**
Hi,I found when I use the command `php artisan down --message='foo'` there would not be the view displaying foo message. 
I fixed this bug in this way:

### **Fix**
**F:\2018\lara\vendor\laravel\framework\src\Illuminate\Foundation\Exceptions\views\503.blade.php**
```
@extends('errors::layout')

@section('title', 'Service Unavailable')

@section('message', $exception->getMessage() ?: 'Be right back.')
```