### PR TITLE
[5.6] Allow JSONP auth when Broadcasting with Pusher

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -65,7 +65,9 @@ class BroadcastManager implements FactoryContract
         $attributes = $attributes ?: ['middleware' => ['web']];
 
         $this->app['router']->group($attributes, function ($router) {
-            $router->post('/broadcasting/auth', '\\'.BroadcastController::class.'@authenticate');
+            $router->match(['post', 'get'], '/broadcasting/auth',
+                '\\'.BroadcastController::class.'@authenticate'
+            );
         });
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -62,24 +62,31 @@ class PusherBroadcaster extends Broadcaster
     {
         if (Str::startsWith($request->channel_name, 'private')) {
             return $this->decodePusherResponse(
+                $request,
                 $this->pusher->socket_auth($request->channel_name, $request->socket_id)
             );
         }
 
         return $this->decodePusherResponse(
+            $request,
             $this->pusher->presence_auth(
                 $request->channel_name, $request->socket_id, $request->user()->getAuthIdentifier(), $result)
         );
     }
 
     /**
-     * Decode the given Pusher response.
+     * Decode the given Pusher response, apply the callback for JSONP support.
      *
+     * @param  mixed  $request
      * @param  mixed  $response
      * @return array
      */
-    protected function decodePusherResponse($response)
+    protected function decodePusherResponse($request, $response)
     {
+        if ($request->callback) {
+            return response()->json(json_decode($response, true))
+            ->withCallback($request->callback);
+        }
         return json_decode($response, true);
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -87,6 +87,7 @@ class PusherBroadcaster extends Broadcaster
             return response()->json(json_decode($response, true))
             ->withCallback($request->callback);
         }
+
         return json_decode($response, true);
     }
 


### PR DESCRIPTION
This addresses #24017 and #15746 allowing JSONP authentication when Broadcasting with Pusher, this is needed when using multiple domains (web, api, etc.).  More detail on this feature [here](https://pusher.com/docs/authenticating_users#jsonp_auth_endpoints) and a longer explanation [here](https://blog.pusher.com/jsonp-authentication-for-private-channels/)


