### PR TITLE
[5.7] Allow overwriting discovered aliases

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -65,7 +65,8 @@ class BroadcastManager implements FactoryContract
         $attributes = $attributes ?: ['middleware' => ['web']];
 
         $this->app['router']->group($attributes, function ($router) {
-            $router->match(['post', 'get'], '/broadcasting/auth',
+            $router->match(
+                ['get', 'post'], '/broadcasting/auth',
                 '\\'.BroadcastController::class.'@authenticate'
             );
         });

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -65,7 +65,9 @@ class BroadcastManager implements FactoryContract
         $attributes = $attributes ?: ['middleware' => ['web']];
 
         $this->app['router']->group($attributes, function ($router) {
-            $router->post('/broadcasting/auth', '\\'.BroadcastController::class.'@authenticate');
+            $router->match(['post', 'get'], '/broadcasting/auth',
+                '\\'.BroadcastController::class.'@authenticate'
+            );
         });
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -62,24 +62,31 @@ class PusherBroadcaster extends Broadcaster
     {
         if (Str::startsWith($request->channel_name, 'private')) {
             return $this->decodePusherResponse(
+                $request,
                 $this->pusher->socket_auth($request->channel_name, $request->socket_id)
             );
         }
 
         return $this->decodePusherResponse(
+            $request,
             $this->pusher->presence_auth(
                 $request->channel_name, $request->socket_id, $request->user()->getAuthIdentifier(), $result)
         );
     }
 
     /**
-     * Decode the given Pusher response.
+     * Decode the given Pusher response, apply the callback for JSONP support.
      *
+     * @param  mixed  $request
      * @param  mixed  $response
      * @return array
      */
-    protected function decodePusherResponse($response)
+    protected function decodePusherResponse($request, $response)
     {
+        if ($request->callback) {
+            return response()->json(json_decode($response, true))
+            ->withCallback($request->callback);
+        }
         return json_decode($response, true);
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -62,33 +62,34 @@ class PusherBroadcaster extends Broadcaster
     {
         if (Str::startsWith($request->channel_name, 'private')) {
             return $this->decodePusherResponse(
-                $request,
-                $this->pusher->socket_auth($request->channel_name, $request->socket_id)
+                $request, $this->pusher->socket_auth($request->channel_name, $request->socket_id)
             );
         }
 
         return $this->decodePusherResponse(
             $request,
             $this->pusher->presence_auth(
-                $request->channel_name, $request->socket_id, $request->user()->getAuthIdentifier(), $result)
+                $request->channel_name, $request->socket_id,
+                $request->user()->getAuthIdentifier(), $result
+            )
         );
     }
 
     /**
-     * Decode the given Pusher response, apply the callback for JSONP support.
+     * Decode the given Pusher response.
      *
-     * @param  mixed  $request
+     * @param  \Illuminate\Http\Request  $request
      * @param  mixed  $response
      * @return array
      */
     protected function decodePusherResponse($request, $response)
     {
-        if ($request->callback) {
-            return response()->json(json_decode($response, true))
-            ->withCallback($request->callback);
+        if (! $request->callback) {
+            return json_decode($response, true);
         }
 
-        return json_decode($response, true);
+        return response()->json(json_decode($response, true))
+                    ->withCallback($request->callback);
     }
 
     /**

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -87,6 +87,7 @@ class PusherBroadcaster extends Broadcaster
             return response()->json(json_decode($response, true))
             ->withCallback($request->callback);
         }
+
         return json_decode($response, true);
     }
 

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Illuminate\Contracts\Console\Application as ApplicationContract;
 
 class Application extends SymfonyApplication implements ApplicationContract
@@ -170,6 +171,10 @@ class Application extends SymfonyApplication implements ApplicationContract
     {
         if (is_subclass_of($command, SymfonyCommand::class)) {
             $command = $this->laravel->make($command)->getName();
+        }
+
+        if (! $this->has($command)) {
+            throw new CommandNotFoundException(sprintf('The command "%s" does not exist.', $command));
         }
 
         array_unshift($parameters, $command);

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -504,7 +504,7 @@ class Connection implements ConnectionInterface
             }
 
             $this->recordsHaveBeenModified(
-                $change = ($this->getPdo()->exec($query) === false ? false : true)
+                $change = $this->getPdo()->exec($query) !== false
             );
 
             return $change;

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -147,7 +147,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
             $this->setCustomModes($connection, $config);
         } elseif (isset($config['strict'])) {
             if ($config['strict']) {
-                $connection->prepare($this->strictMode())->execute();
+                $connection->prepare($this->strictMode($connection))->execute();
             } else {
                 $connection->prepare("set session sql_mode='NO_ENGINE_SUBSTITUTION'")->execute();
             }
@@ -171,10 +171,16 @@ class MySqlConnector extends Connector implements ConnectorInterface
     /**
      * Get the query to enable strict mode.
      *
+     * @param  \PDO  $connection
+     *
      * @return string
      */
-    protected function strictMode()
+    protected function strictMode(PDO $connection)
     {
+        if (version_compare($connection->getAttribute(PDO::ATTR_SERVER_VERSION), '8.0.11') >= 0) {
+            return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
+        }
+
         return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'";
     }
 }

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -172,7 +172,6 @@ class MySqlConnector extends Connector implements ConnectorInterface
      * Get the query to enable strict mode.
      *
      * @param  \PDO  $connection
-     *
      * @return string
      */
     protected function strictMode(PDO $connection)

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -15,9 +15,10 @@ class PostgresGrammar extends Grammar
      */
     protected $operators = [
         '=', '<', '>', '<=', '>=', '<>', '!=',
-        'like', 'not like', 'ilike',
+        'like', 'not like', 'ilike', 'not ilike',
         '&', '|', '#', '<<', '>>', '>>=', '=<<',
         '&&', '@>', '<@', '?', '?|', '?&', '||', '-', '-', '#-',
+        'is distinct from', 'is not distinct from',
     ];
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -29,7 +29,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.6.17';
+    const VERSION = '5.6.18';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -52,7 +52,7 @@ trait ThrottlesLogins
 
         throw ValidationException::withMessages([
             $this->username() => [Lang::get('auth.throttle', ['seconds' => $seconds])],
-        ])->status(423);
+        ])->status(429);
     }
 
     /**

--- a/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
+++ b/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
@@ -22,8 +22,8 @@ class RegisterFacades
         Facade::setFacadeApplication($app);
 
         AliasLoader::getInstance(array_merge(
-            $app->make('config')->get('app.aliases', []),
-            $app->make(PackageManifest::class)->aliases()
+            $app->make(PackageManifest::class)->aliases(),
+            $app->make('config')->get('app.aliases', [])
         ))->register();
     }
 }

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -54,9 +54,7 @@ class SparkPostTransport extends Transport
 
         $message->setBcc([]);
 
-        $endpoint = $this->getOptions()['endpoint'] ?? 'https://api.sparkpost.com/api/v1/transmissions';
-
-        $response = $this->client->post($endpoint, [
+        $response = $this->client->post($this->getEndpoint(), [
             'headers' => [
                 'Authorization' => $this->key,
             ],
@@ -136,6 +134,16 @@ class SparkPostTransport extends Transport
     public function setKey($key)
     {
         return $this->key = $key;
+    }
+
+    /**
+     * Get the SparkPost API endpoint.
+     *
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        return $this->getOptions()['endpoint'] ?? 'https://api.sparkpost.com/api/v1/transmissions';
     }
 
     /**

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -54,7 +54,9 @@ class SparkPostTransport extends Transport
 
         $message->setBcc([]);
 
-        $response = $this->client->post('https://api.sparkpost.com/api/v1/transmissions', [
+        $endpoint = $this->getOptions()['endpoint'] ?? 'https://api.sparkpost.com/api/v1/transmissions';
+
+        $response = $this->client->post($endpoint, [
             'headers' => [
                 'Authorization' => $this->key,
             ],

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -4,9 +4,9 @@
 # {{ $greeting }}
 @else
 @if ($level == 'error')
-# Whoops!
+# @lang('Whoops!')
 @else
-# Hello!
+# @lang('Hello!')
 @endif
 @endif
 
@@ -45,14 +45,20 @@
 @if (! empty($salutation))
 {{ $salutation }}
 @else
-Regards,<br>{{ config('app.name') }}
+@lang('Regards'),<br>{{ config('app.name') }}
 @endif
 
 {{-- Subcopy --}}
 @isset($actionText)
 @component('mail::subcopy')
-If you’re having trouble clicking the "{{ $actionText }}" button, copy and paste the URL below
-into your web browser: [{{ $actionUrl }}]({{ $actionUrl }})
+@lang(
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
+    'into your web browser: [:actionURL](:actionURL)',
+    [
+        'actionText' => $actionText,
+        'actionURL' => $actionUrl
+    ]
+)
 @endcomponent
 @endisset
 @endcomponent

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -229,7 +229,7 @@ class QueueFake extends QueueManager implements Queue
      */
     public function size($queue = null)
     {
-        return 0;
+        return count($this->jobs);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -493,7 +493,7 @@ class Validator implements ValidatorContract
         $data = ValidationData::initializeAndGatherData($attribute, $this->data);
 
         return array_key_exists($attribute, $data)
-                    || in_array($attribute, array_keys($this->data));
+                    || array_key_exists($attribute, $this->data);
     }
 
     /**
@@ -558,7 +558,7 @@ class Validator implements ValidatorContract
         }
 
         if (isset($this->failedRules[$attribute]) &&
-            in_array('uploaded', array_keys($this->failedRules[$attribute]))) {
+            array_key_exists('uploaded', $this->failedRules[$attribute])) {
             return true;
         }
 

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -32,6 +32,15 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->fake->assertPushed(JobStub::class);
     }
 
+    public function testQueueSize()
+    {
+        $this->assertEquals(0, $this->fake->size());
+
+        $this->fake->push($this->job);
+
+        $this->assertEquals(1, $this->fake->size());
+    }
+
     public function testAssertNotPushed()
     {
         $this->fake->assertNotPushed(JobStub::class);


### PR DESCRIPTION
At the moment, auto-discovered aliases take precedence over ones defined in `app.aliases`. With this patch, users can overwrite these aliases if they like.

This is a BC break in theory. However I think it's unlikely that someone tries to define an existing alias and is not aware that it didn't work.