### PR TITLE
get and has method else removed (re-submission)

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -294,11 +294,11 @@ class Arr
         }
 
         foreach (explode('.', $key) as $segment) {
-            if (static::accessible($array) && static::exists($array, $segment)) {
-                $array = $array[$segment];
-            } else {
-                return value($default);
+            if (!static::accessible($array) && !static::exists($array, $segment)) {
+	            return value($default);
             }
+
+	        $array = $array[$segment];
         }
 
         return $array;
@@ -335,11 +335,11 @@ class Arr
             }
 
             foreach (explode('.', $key) as $segment) {
-                if (static::accessible($subKeyArray) && static::exists($subKeyArray, $segment)) {
-                    $subKeyArray = $subKeyArray[$segment];
-                } else {
-                    return false;
+                if (!static::accessible($subKeyArray) && !static::exists($subKeyArray, $segment)) {
+	                return false;
                 }
+
+	            $subKeyArray = $subKeyArray[$segment];
             }
         }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -294,7 +294,10 @@ class Arr
         }
 
         foreach (explode('.', $key) as $segment) {
-            if (!static::accessible($array) || !static::exists($array, $segment)) {
+            if (
+            	!static::exists($array, $segment)
+	            || !static::accessible($array)
+            ) {
 	            return value($default);
             }
 
@@ -335,7 +338,10 @@ class Arr
             }
 
             foreach (explode('.', $key) as $segment) {
-                if (!static::accessible($subKeyArray) || !static::exists($subKeyArray, $segment)) {
+                if (
+                	!static::exists($subKeyArray, $segment)
+	                || !static::accessible($subKeyArray)
+                ) {
 	                return false;
                 }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -294,7 +294,7 @@ class Arr
         }
 
         foreach (explode('.', $key) as $segment) {
-            if (!static::accessible($array) && !static::exists($array, $segment)) {
+            if (!static::accessible($array) || !static::exists($array, $segment)) {
 	            return value($default);
             }
 
@@ -335,7 +335,7 @@ class Arr
             }
 
             foreach (explode('.', $key) as $segment) {
-                if (!static::accessible($subKeyArray) && !static::exists($subKeyArray, $segment)) {
+                if (!static::accessible($subKeyArray) || !static::exists($subKeyArray, $segment)) {
 	                return false;
                 }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -294,10 +294,7 @@ class Arr
         }
 
         foreach (explode('.', $key) as $segment) {
-            if (
-            	!static::exists($array, $segment)
-	            || !static::accessible($array)
-            ) {
+            if (!static::accessible($array) || !static::exists($array, $segment)) {
 	            return value($default);
             }
 
@@ -338,10 +335,7 @@ class Arr
             }
 
             foreach (explode('.', $key) as $segment) {
-                if (
-                	!static::exists($subKeyArray, $segment)
-	                || !static::accessible($subKeyArray)
-                ) {
+                if (!static::accessible($subKeyArray) || !static::exists($subKeyArray, $segment)) {
 	                return false;
                 }
 


### PR DESCRIPTION
`get` and `has` method's redundant else condition removed.
This is actually the re-submission of #24029 and I appreciate @nunomaduro 's contribution on finding the issue with condition check.