### PR TITLE
[5.6] Corrected several types in the docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -22,7 +22,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Support\Facades\Route name(string $value)
  * @method static \Illuminate\Support\Facades\Route namespace(string $value)
  * @method static \Illuminate\Support\Facades\Route where(array|string $name, string $expression = null)
- * @method static \Illuminate\Routing\Router group(\Closure|string|array $value)
+ * @method static \Illuminate\Routing\Router group(array $attributes, \Closure|string $routes)
  * @method static \Illuminate\Support\Facades\Route redirect(string $uri, string $destination, int $status = 301)
  * @method static \Illuminate\Support\Facades\Route view(string $uri, string $view, array $data = [])
  *


### PR DESCRIPTION
Corrected group
From: * @method static \Illuminate\Routing\Router group(\Closure|string|array $value)
To: * @method static \Illuminate\Routing\Router group(array $attributes, \Closure|string $routes)
Reason for change:
Route::group entry in the docblock is wrong. Group accepts two parameters (array and closure)
-> See \Illuminate\Routing\Router::group