### PR TITLE
[5.7] Allow matching routes against formatted path

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -48,6 +48,13 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     protected $routeResolver;
 
     /**
+     * The callback to use to format routing path.
+     *
+     * @var \Closure
+     */
+    protected $formatPathForRouting;
+
+    /**
      * Create a new Illuminate HTTP request from server variables.
      *
      * @return static
@@ -148,6 +155,37 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function decodedPath()
     {
         return rawurldecode($this->path());
+    }
+
+    /**
+     * Get the current path info for routing.
+     *
+     * @return string
+     */
+    public function routingPath()
+    {
+        $path = $this->path();
+
+        if ($this->formatPathForRouting) {
+            $path = call_user_func($this->formatPathForRouting, $path);
+        }
+
+        $path = '/'.trim($path, '/');
+
+        return rawurldecode($path);
+    }
+
+    /**
+     * Set a callback to be used to format routing path.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function formatPathForRouting(Closure $callback)
+    {
+        $this->formatPathForRouting = $callback;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -48,13 +48,6 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     protected $routeResolver;
 
     /**
-     * The callback to use to format routing path.
-     *
-     * @var \Closure
-     */
-    protected $formatPathForRouting;
-
-    /**
      * Create a new Illuminate HTTP request from server variables.
      *
      * @return static
@@ -155,37 +148,6 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function decodedPath()
     {
         return rawurldecode($this->path());
-    }
-
-    /**
-     * Get the current path info for routing.
-     *
-     * @return string
-     */
-    public function routingPath()
-    {
-        $path = $this->path();
-
-        if ($this->formatPathForRouting) {
-            $path = call_user_func($this->formatPathForRouting, $path);
-        }
-
-        $path = '/'.trim($path, '/');
-
-        return rawurldecode($path);
-    }
-
-    /**
-     * Set a callback to be used to format routing path.
-     *
-     * @param  \Closure  $callback
-     * @return $this
-     */
-    public function formatPathForRouting(Closure $callback)
-    {
-        $this->formatPathForRouting = $callback;
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Routing/Matching/UriValidator.php
+++ b/src/Illuminate/Routing/Matching/UriValidator.php
@@ -16,6 +16,13 @@ class UriValidator implements ValidatorInterface
      */
     public function matches(Route $route, Request $request)
     {
-        return preg_match($route->getCompiled()->getRegex(), $route->getRouter()->path());
+        if (($router = $route->getRouter()) && $router->getCurrentRequest()) {
+            $path = $router->path();
+        }
+        else {
+            $path = rawurldecode($request->path() == '/' ? '/' : '/'.$request->path());
+        }
+
+        return preg_match($route->getCompiled()->getRegex(), $path);
     }
 }

--- a/src/Illuminate/Routing/Matching/UriValidator.php
+++ b/src/Illuminate/Routing/Matching/UriValidator.php
@@ -16,6 +16,6 @@ class UriValidator implements ValidatorInterface
      */
     public function matches(Route $route, Request $request)
     {
-        return preg_match($route->getCompiled()->getRegex(), $request->routingPath());
+        return preg_match($route->getCompiled()->getRegex(), $route->getRouter()->path());
     }
 }

--- a/src/Illuminate/Routing/Matching/UriValidator.php
+++ b/src/Illuminate/Routing/Matching/UriValidator.php
@@ -16,13 +16,6 @@ class UriValidator implements ValidatorInterface
      */
     public function matches(Route $route, Request $request)
     {
-        if (($router = $route->getRouter()) && $router->getCurrentRequest()) {
-            $path = $router->path();
-        }
-        else {
-            $path = rawurldecode($request->path() == '/' ? '/' : '/'.$request->path());
-        }
-
-        return preg_match($route->getCompiled()->getRegex(), $path);
+        return preg_match($route->getCompiled()->getRegex(), $route->getRequestPath($request));
     }
 }

--- a/src/Illuminate/Routing/Matching/UriValidator.php
+++ b/src/Illuminate/Routing/Matching/UriValidator.php
@@ -16,8 +16,6 @@ class UriValidator implements ValidatorInterface
      */
     public function matches(Route $route, Request $request)
     {
-        $path = $request->path() == '/' ? '/' : '/'.$request->path();
-
-        return preg_match($route->getCompiled()->getRegex(), rawurldecode($path));
+        return preg_match($route->getCompiled()->getRegex(), $request->routingPath());
     }
 }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -855,6 +855,16 @@ class Route
     }
 
     /**
+     * Get the router instance.
+     *
+     * @param  \Illuminate\Routing\Router
+     */
+    public function getRouter()
+    {
+        return $this->router;
+    }
+
+    /**
      * Set the container instance on the route.
      *
      * @param  \Illuminate\Container\Container  $container

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -120,6 +120,13 @@ class Route
     public static $validators;
 
     /**
+     * The callback used to format the request path when matching and binding a route.
+     *
+     * @var \Closure
+     */
+    public static $requestPathFormatter;
+
+    /**
      * Create a new Route instance.
      *
      * @param  array|string  $methods
@@ -271,6 +278,25 @@ class Route
         }
 
         return true;
+    }
+
+    /**
+     * Format path of given request for matching and binding a route.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string
+     */
+    public function getRequestPath(Request $request)
+    {
+        $path = $request->path();
+
+        if (static::$requestPathFormatter) {
+            $path = call_user_func(static::$requestPathFormatter, $path);
+        }
+
+        $path = '/'.trim($path, '/');
+
+        return rawurldecode($path);
     }
 
     /**
@@ -852,16 +878,6 @@ class Route
         $this->router = $router;
 
         return $this;
-    }
-
-    /**
-     * Get the router instance.
-     *
-     * @param  \Illuminate\Routing\Router
-     */
-    public function getRouter()
-    {
-        return $this->router;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteParameterBinder.php
+++ b/src/Illuminate/Routing/RouteParameterBinder.php
@@ -57,14 +57,7 @@ class RouteParameterBinder
      */
     protected function bindPathParameters($request)
     {
-        if (($router = $this->route->getRouter()) && $router->getCurrentRequest()) {
-            $path = $router->path();
-        }
-        else {
-            $path = '/'.ltrim($request->decodedPath(), '/');
-        }
-
-        preg_match($this->route->compiled->getRegex(), $path, $matches);
+        preg_match($this->route->compiled->getRegex(), $this->route->getRequestPath($request), $matches);
 
         return $this->matchToKeys(array_slice($matches, 1));
     }

--- a/src/Illuminate/Routing/RouteParameterBinder.php
+++ b/src/Illuminate/Routing/RouteParameterBinder.php
@@ -57,9 +57,7 @@ class RouteParameterBinder
      */
     protected function bindPathParameters($request)
     {
-        $path = '/'.ltrim($request->decodedPath(), '/');
-
-        preg_match($this->route->compiled->getRegex(), $path, $matches);
+        preg_match($this->route->compiled->getRegex(), $request->routingPath(), $matches);
 
         return $this->matchToKeys(array_slice($matches, 1));
     }

--- a/src/Illuminate/Routing/RouteParameterBinder.php
+++ b/src/Illuminate/Routing/RouteParameterBinder.php
@@ -57,7 +57,14 @@ class RouteParameterBinder
      */
     protected function bindPathParameters($request)
     {
-        preg_match($this->route->compiled->getRegex(), $this->route->getRouter()->path(), $matches);
+        if (($router = $this->route->getRouter()) && $router->getCurrentRequest()) {
+            $path = $router->path();
+        }
+        else {
+            $path = '/'.ltrim($request->decodedPath(), '/');
+        }
+
+        preg_match($this->route->compiled->getRegex(), $path, $matches);
 
         return $this->matchToKeys(array_slice($matches, 1));
     }

--- a/src/Illuminate/Routing/RouteParameterBinder.php
+++ b/src/Illuminate/Routing/RouteParameterBinder.php
@@ -57,7 +57,7 @@ class RouteParameterBinder
      */
     protected function bindPathParameters($request)
     {
-        preg_match($this->route->compiled->getRegex(), $request->routingPath(), $matches);
+        preg_match($this->route->compiled->getRegex(), $this->route->getRouter()->path(), $matches);
 
         return $this->matchToKeys(array_slice($matches, 1));
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -109,13 +109,6 @@ class Router implements RegistrarContract, BindingRegistrar
     protected $groupStack = [];
 
     /**
-     * The callback to use to format paths.
-     *
-     * @var \Closure
-     */
-    protected $formatPathUsing;
-
-    /**
      * All of the verbs supported by the router.
      *
      * @var array
@@ -599,32 +592,14 @@ class Router implements RegistrarContract, BindingRegistrar
     }
 
     /**
-     * Get the current request path info for matching and binding a route.
-     *
-     * @return string
-     */
-    public function path()
-    {
-        $path = $this->currentRequest->path();
-
-        if ($this->formatPathUsing) {
-            $path = call_user_func($this->formatPathUsing, $path);
-        }
-
-        $path = '/'.trim($path, '/');
-
-        return rawurldecode($path);
-    }
-
-    /**
-     * Set a callback to be used to format the path before matching and binding a route.
+     * Set a callback to be used to format the request path when matching and binding a route.
      *
      * @param  \Closure  $callback
      * @return $this
      */
-    public function formatPathUsing(Closure $callback)
+    public function formatRequestPathUsing(Closure $callback)
     {
-        $this->formatPathUsing = $callback;
+        Route::$requestPathFormatter = $callback;
 
         return $this;
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -594,10 +594,10 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Set a callback to be used to format the request path when matching and binding a route.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure|null  $callback
      * @return $this
      */
-    public function formatRequestPathUsing(Closure $callback)
+    public function formatRequestPathUsing(Closure $callback = null)
     {
         Route::$requestPathFormatter = $callback;
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -109,6 +109,13 @@ class Router implements RegistrarContract, BindingRegistrar
     protected $groupStack = [];
 
     /**
+     * The callback to use to format paths.
+     *
+     * @var \Closure
+     */
+    protected $formatPathUsing;
+
+    /**
      * All of the verbs supported by the router.
      *
      * @var array
@@ -589,6 +596,37 @@ class Router implements RegistrarContract, BindingRegistrar
         $this->currentRequest = $request;
 
         return $this->dispatchToRoute($request);
+    }
+
+    /**
+     * Get the current request path info for matching and binding a route.
+     *
+     * @return string
+     */
+    public function path()
+    {
+        $path = $this->currentRequest->path();
+
+        if ($this->formatPathUsing) {
+            $path = call_user_func($this->formatPathUsing, $path);
+        }
+
+        $path = '/'.trim($path, '/');
+
+        return rawurldecode($path);
+    }
+
+    /**
+     * Set a callback to be used to format the path before matching and binding a route.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function formatPathUsing(Closure $callback)
+    {
+        $this->formatPathUsing = $callback;
+
+        return $this;
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -639,7 +639,7 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
 
-        $router->formatPathUsing(function ($path) {
+        $router->formatRequestPathUsing(function ($path) {
             return str_replace('foo', 'bar', $path);
         });
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -635,6 +635,23 @@ class RoutingRouteTest extends TestCase
         $this->assertTrue($route->matches($request));
     }
 
+    public function testMatchesUsingFormattedPath()
+    {
+        $request = Request::create('foo/123', 'GET');
+
+        $request->formatPathForRouting(function ($path) {
+            return str_replace('foo', 'bar', $path);
+        });
+
+        $route = new Route('GET', 'foo/{id}', function () {});
+        $this->assertFalse($route->matches($request));
+
+        $route = new Route('GET', 'bar/{id}', function () {});
+        $this->assertTrue($route->matches($request));
+        $route->bind($request);
+        $this->assertEquals('123', $route->parameter('id'));
+    }
+
     public function testWherePatternsProperlyFilter()
     {
         $request = Request::create('foo/123', 'GET');

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -661,6 +661,25 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('Param: bar-123', $response->getContent());
     }
 
+    public function testClearCustomPathFormatter()
+    {
+        $router = $this->getRouter();
+
+        $router->formatRequestPathUsing(function () {
+            $this->fail('Should never be called.');
+        });
+
+        $router->get('foo', function () {
+            return 'bar';
+        });
+
+        $router->formatRequestPathUsing();
+
+        $response = $router->dispatch(Request::create('foo', 'GET'));
+
+        $this->assertEquals('bar', $response->getContent());
+    }
+
     public function testWherePatternsProperlyFilter()
     {
         $request = Request::create('foo/123', 'GET');

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -23,6 +23,11 @@ use Illuminate\Routing\Middleware\SubstituteBindings;
 
 class RoutingRouteTest extends TestCase
 {
+    protected function setUp()
+    {
+        Route::$requestPathFormatter = null;
+    }
+
     public function testBasicDispatchingOfRoutes()
     {
         $router = $this->getRouter();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -643,10 +643,12 @@ class RoutingRouteTest extends TestCase
             return str_replace('foo', 'bar', $path);
         });
 
-        $route = new Route('GET', 'foo/{id}', function () {});
+        $route = new Route('GET', 'foo/{id}', function () {
+        });
         $this->assertFalse($route->matches($request));
 
-        $route = new Route('GET', 'bar/{id}', function () {});
+        $route = new Route('GET', 'bar/{id}', function () {
+        });
         $this->assertTrue($route->matches($request));
         $route->bind($request);
         $this->assertEquals('123', $route->parameter('id'));

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -644,14 +644,16 @@ class RoutingRouteTest extends TestCase
         });
 
         $router->get('foo/{param}', function () {
-            $this->fail();
+            $this->fail('Matched wrong route.');
         });
 
         $router->get('bar/{param}', function ($param) {
-            return $param;
+            return 'Param: '.$param;
         });
 
-        $this->assertEquals('bar-123', $router->dispatch(Request::create('foo/bar-123', 'GET'))->getContent());
+        $response = $router->dispatch(Request::create('foo/bar-123', 'GET'));
+
+        $this->assertEquals('Param: bar-123', $response->getContent());
     }
 
     public function testWherePatternsProperlyFilter()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -637,21 +637,21 @@ class RoutingRouteTest extends TestCase
 
     public function testMatchesUsingFormattedPath()
     {
-        $request = Request::create('foo/123', 'GET');
+        $router = $this->getRouter();
 
-        $request->formatPathForRouting(function ($path) {
+        $router->formatPathUsing(function ($path) {
             return str_replace('foo', 'bar', $path);
         });
 
-        $route = new Route('GET', 'foo/{id}', function () {
+        $router->get('foo/{param}', function () {
+            $this->fail();
         });
-        $this->assertFalse($route->matches($request));
 
-        $route = new Route('GET', 'bar/{id}', function () {
+        $router->get('bar/{param}', function ($param) {
+            return $param;
         });
-        $this->assertTrue($route->matches($request));
-        $route->bind($request);
-        $this->assertEquals('123', $route->parameter('id'));
+
+        $this->assertEquals('bar-123', $router->dispatch(Request::create('foo/bar-123', 'GET'))->getContent());
     }
 
     public function testWherePatternsProperlyFilter()


### PR DESCRIPTION
Add `routingPath` method to the `Request` class to allow customizing request path before it is used for matching current route and binding its parameters.

---

This pull request is a part of three independent, but related pull requests (https://github.com/laravel/framework/pull/24048, https://github.com/laravel/framework/pull/24049, https://github.com/laravel/framework/pull/24050). All together they let us implement localization in a very flexible manner. This one makes a crux of my idea, thus here I'll describe reasoning in a bit more detail.

Knowing Laravel I expected to implement simple URL localization in matter of hours. Instead it took almost a week and a lot of head ache. There is no built-in solution and all external packages are either over-complicated or naive and uniformly flawed in one way or another.

Localization was widely discussed (https://github.com/laravel/ideas/issues/2), many pull requests were proposed (https://github.com/laravel/framework/pull/13878, https://github.com/laravel/framework/pull/16453, https://github.com/laravel/framework/pull/16541), however for years not much have been changed (apart from f0b985831f72a896735d02bf14b1c6680e3d7092), probably because people's preferences regarding localization differ greatly.

Here is my (very simplified) proposal. I hardcoded some locales, but these can be taken from config, expanded with country codes (fe. `en-GB`), or be anything else really.

```php
Route::get('login');
Route::get('facebook/connect')->action('localize', false);

URL::formatPathUsing(function ($path, $route) {
    if ($route && $route->getAction('localize') === false) {
    	return $path;
    }

    return '/'.App::getLocale().$path;
});

Route::formatRequestPathUsing(function ($path) {
    return preg_replace("#^/(en|fr|de)(/|$|(?=\?))#", '', $path);
});

if (in_array($locale = Request::segment(1), ['en', 'fr', 'de'])) {
    App::setLocale($locale);
}
```

That's it, we have our app localized.

Example of generating URLs in given locale in a code snippet here https://github.com/laravel/framework/pull/24048#issuecomment-385403399.

Middleware may be added to handle locale redirects and disallow locale prefix on routes which should not be localized, example here https://github.com/laravel/framework/pull/24048#issuecomment-386261808.

Because of how difficult it was in the past to merge anything related to localization, I decided to split features into separate pull requests. All of them are useful on their own behalf, and will help developers even if not all are merged.

However if everything goes smoothly, I will be happy to add a section to the documentation as the solution may not be obvious.
