### PR TITLE
[5.7] Pass route to custom URL formatters

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -83,7 +83,8 @@ class RouteUrlGenerator
         // will need to throw the exception to let the developers know one was not given.
         $uri = $this->addQueryString($this->url->format(
             $root = $this->replaceRootParameters($route, $domain, $parameters),
-            $this->replaceRouteParameters($route->uri(), $parameters)
+            $this->replaceRouteParameters($route->uri(), $parameters),
+            $route
         ), $parameters);
 
         if (preg_match('/\{.*?\}/', $uri)) {

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -485,18 +485,19 @@ class UrlGenerator implements UrlGeneratorContract
      *
      * @param  string  $root
      * @param  string  $path
+     * @param  \Illuminate\Routing\Route|null  $route
      * @return string
      */
-    public function format($root, $path)
+    public function format($root, $path, $route = null)
     {
         $path = '/'.trim($path, '/');
 
         if ($this->formatHostUsing) {
-            $root = call_user_func($this->formatHostUsing, $root);
+            $root = call_user_func($this->formatHostUsing, $root, $route);
         }
 
         if ($this->formatPathUsing) {
-            $path = call_user_func($this->formatPathUsing, $path);
+            $path = call_user_func($this->formatPathUsing, $path, $route);
         }
 
         return trim($root.$path, '/');

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -59,12 +59,16 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], '/named-route', ['as' => 'plain']);
         $routes->add($route);
 
-        $url->formatPathUsing(function ($path) {
+        $url->formatPathUsing(function ($path, $route) {
+            if ($route) {
+                return '/something'.$path.'/'.$route->getName();
+            }
+
             return '/something'.$path;
         });
 
         $this->assertEquals('http://www.foo.com/something/foo/bar', $url->to('foo/bar'));
-        $this->assertEquals('/something/named-route', $url->route('plain', [], false));
+        $this->assertEquals('/something/named-route/plain', $url->route('plain', [], false));
     }
 
     public function testBasicRouteGeneration()

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -59,16 +59,34 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], '/named-route', ['as' => 'plain']);
         $routes->add($route);
 
-        $url->formatPathUsing(function ($path, $route) {
-            if ($route) {
-                return '/something'.$path.'/'.$route->getName();
-            }
-
+        $url->formatPathUsing(function ($path) {
             return '/something'.$path;
         });
 
         $this->assertEquals('http://www.foo.com/something/foo/bar', $url->to('foo/bar'));
-        $this->assertEquals('/something/named-route/plain', $url->route('plain', [], false));
+        $this->assertEquals('/something/named-route', $url->route('plain', [], false));
+    }
+
+    public function testUrlFormattersShouldReceiveTargetRoute()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('http://abc.com/')
+        );
+
+        $namedRoute = new Route(['GET'], '/bar', ['as' => 'plain', 'root' => 'bar.com', 'path' => 'foo']);
+        $routes->add($namedRoute);
+
+        $url->formatHostUsing(function ($root, $route) {
+            return $route ? 'http://'.$route->getAction('root') : $root;
+        });
+
+        $url->formatPathUsing(function ($path, $route) {
+            return $route ? '/'.$route->getAction('path') : $path;
+        });
+
+        $this->assertEquals('http://abc.com/foo/bar', $url->to('foo/bar'));
+        $this->assertEquals('http://bar.com/foo', $url->route('plain'));
     }
 
     public function testBasicRouteGeneration()


### PR DESCRIPTION
Pass route for which URL is currently generated to the custom host and path formatters.

---

This is a part of a series of pull requests simplifying localization of URLs, more details here https://github.com/laravel/framework/pull/24048.