### PR TITLE
[5.7] Register routes with custom action array properties

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -741,6 +741,24 @@ class Route
     }
 
     /**
+     * Add property to the action array for the route.
+     *
+     * @param  array|string  $action
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function action($action, $value = null)
+    {
+        if (! is_array($action)) {
+            $action = [$action => $value];
+        }
+
+        $this->action = array_merge($this->action, $action);
+
+        return $this;
+    }
+
+    /**
      * Get all middleware, including the ones from the controller.
      *
      * @return array

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -82,6 +82,24 @@ class RouteRegistrar
     }
 
     /**
+     * Add property to the action array for the route.
+     *
+     * @param  array|string  $action
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function action($action, $value = null)
+    {
+        if (! is_array($action)) {
+            $action = [$action => $value];
+        }
+
+        $this->attributes = array_merge($this->attributes, $action);
+
+        return $this;
+    }
+
+    /**
      * Route a resource to a controller.
      *
      * @param  string  $name

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1215,6 +1215,10 @@ class Router implements RegistrarContract, BindingRegistrar
             return (new RouteRegistrar($this))->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
         }
 
+        if ($method == 'action') {
+            return (new RouteRegistrar($this))->action(...$parameters);
+        }
+
         return (new RouteRegistrar($this))->attribute($method, $parameters[0]);
     }
 }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -333,6 +333,23 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals('users.index', $this->getRoute()->getName());
     }
 
+    public function testCanSetCustomRouteAction()
+    {
+        $route = $this->router->action('foo', 123)->get('foo');
+
+        $this->assertEquals(123, $route->getAction('foo'));
+
+        $route = $this->router->action(['foo' => 456])->get('bar');
+
+        $this->assertEquals(456, $route->getAction('foo'));
+
+        $this->router->action('foo', 789)->group(function ($router) {
+            $router->get('baz');
+        });
+
+        $this->assertEquals(789, $this->getRoute()->getAction('foo'));
+    }
+
     /**
      * Get the last route registered with the router.
      *

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -310,6 +310,33 @@ class RoutingRouteTest extends TestCase
         $this->assertNull($route->getAction('unknown_property'));
     }
 
+    public function testRouteAddActions()
+    {
+        $route = $this->getRouter()->get('plain')
+            ->name('plain')
+            ->action('foo', 1)
+            ->action(['bar' => 2, 'baz' => 3]);
+
+        $this->assertArraySubset(
+            ['as' => 'plain', 'foo' => 1, 'bar' => 2, 'baz' => 3], $route->getAction()
+        );
+    }
+
+    public function testRegisterRouteWithCustomActions()
+    {
+        $router = $this->getRouter();
+
+        $route = $router->get('foo/bar', ['foo' => 123]);
+        $this->assertEquals(123, $route->getAction('foo'));
+
+        $router->group(['foo' => 456], function () use ($router) {
+            $router->get('bar')->name('bar');
+        });
+
+        $route = last($router->getRoutes()->get());
+        $this->assertEquals(456, $route->getAction('foo'));
+    }
+
     public function testMacro()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
Allow setting custom action array properties during fluent route registration.

This is currently possible:
```php
Route::get('users', ['foo' => 'bar']);
```

This pull requests implements also following syntax:
```php
Route::action('foo', 'bar')->get('users');
Route::get('users')->action('foo', 'bar');
```

---

This is a part of a series of pull requests simplifying localization of URLs, more details here https://github.com/laravel/framework/pull/24048.