### PR TITLE
[5.6] Fix relative route URL generation with custom host formatter

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -96,7 +96,7 @@ class RouteUrlGenerator
         $uri = strtr(rawurlencode($uri), $this->dontEncode);
 
         if (! $absolute) {
-            return '/'.ltrim(str_replace($root, '', $uri), '/');
+            return '/'.ltrim(preg_replace('#^(//|[^/?])+#', '', $uri), '/');
         }
 
         return $uri;

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -82,7 +82,7 @@ class RouteUrlGenerator
         // has been constructed, we'll make sure we don't have any missing parameters or we
         // will need to throw the exception to let the developers know one was not given.
         $uri = $this->addQueryString($this->url->format(
-            $root = $this->replaceRootParameters($route, $domain, $parameters),
+            $this->replaceRootParameters($route, $domain, $parameters),
             $this->replaceRouteParameters($route->uri(), $parameters)
         ), $parameters);
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -46,16 +46,31 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
     }
 
-    public function testBasicGenerationWithFormatting()
+    public function testBasicGenerationWithHostFormatting()
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
             $request = Request::create('http://www.foo.com/')
         );
 
-        /*
-         * Empty Named Route
-         */
+        $route = new Route(['GET'], '/named-route', ['as' => 'plain']);
+        $routes->add($route);
+
+        $url->formatHostUsing(function ($host) {
+            return str_replace('foo.com', 'foo.org', $host);
+        });
+
+        $this->assertEquals('http://www.foo.org/foo/bar', $url->to('foo/bar'));
+        $this->assertEquals('/named-route', $url->route('plain', [], false));
+    }
+
+    public function testBasicGenerationWithPathFormatting()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('http://www.foo.com/')
+        );
+
         $route = new Route(['GET'], '/named-route', ['as' => 'plain']);
         $routes->add($route);
 


### PR DESCRIPTION
Generating relative route URLs doesn't work with a custom host formatter:

    $url = new UrlGenerator(
        $routes = new RouteCollection,
        $request = Request::create('http://www.foo.com/')
    );

    $routes->add(
        new Route(['GET'], '/named-route', ['as' => 'plain'])
    );

    $url->formatHostUsing(function ($host) {
        return str_replace('foo.com', 'foo.org', $host);
    });

    dd($url->route('plain', [], false));
    // expected: '/named-route'
    // actual: '/http://www.foo.org/named-route'

`RouteUrlGenerator::to()` tries to remove the original root, but fails because the root has been modified.

Fixes #24047.