### PR TITLE
[5.7] Throw on trying to drop foreign keys in SQLite

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -128,11 +128,18 @@ class Blueprint
      */
     protected function ensureCommandsAreValid(Connection $connection)
     {
-        if ($connection instanceof SQLiteConnection &&
-            $this->commandsNamed(['dropColumn', 'renameColumn'])->count() > 1) {
-            throw new BadMethodCallException(
-                "SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification."
-            );
+        if ($connection instanceof SQLiteConnection) {
+            if ($this->commandsNamed(['dropColumn', 'renameColumn'])->count() > 1) {
+                throw new BadMethodCallException(
+                    "SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification."
+                );
+            }
+
+            if ($this->commandsNamed(['dropForeign'])->count() > 1) {
+                throw new BadMethodCallException(
+                    "SQLite doesn't support dropping foreign keys (you would need to re-create the table)."
+                );
+            }
         }
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -135,7 +135,7 @@ class Blueprint
                 );
             }
 
-            if ($this->commandsNamed(['dropForeign'])->count() > 1) {
+            if ($this->commandsNamed(['dropForeign'])->count() > 0) {
                 throw new BadMethodCallException(
                     "SQLite doesn't support dropping foreign keys (you would need to re-create the table)."
                 );


### PR DESCRIPTION
SQLite doesn't support dropping foreign keys (you would need to re-create the table).

See https://github.com/laravel/framework/issues/24041