### PR TITLE
[5.6] Implement Responsable interface within Response and JsonResponse classes

### DIFF
--- a/src/Illuminate/Contracts/Support/Responsable.php
+++ b/src/Illuminate/Contracts/Support/Responsable.php
@@ -8,7 +8,7 @@ interface Responsable
      * Create an HTTP response that represents the object.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
      */
     public function toResponse($request);
 }

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http;
 
+use Illuminate\Contracts\Support\Responsable;
 use JsonSerializable;
 use InvalidArgumentException;
 use Illuminate\Support\Traits\Macroable;
@@ -9,7 +10,7 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Symfony\Component\HttpFoundation\JsonResponse as BaseJsonResponse;
 
-class JsonResponse extends BaseJsonResponse
+class JsonResponse extends BaseJsonResponse implements Responsable
 {
     use ResponseTrait, Macroable {
         Macroable::__call as macroCall;
@@ -117,5 +118,16 @@ class JsonResponse extends BaseJsonResponse
     public function hasEncodingOption($option)
     {
         return (bool) ($this->encodingOptions & $option);
+    }
+
+    /**
+     * Implement the Responsable interface by returning itself.
+     *
+     * @param  Request $request
+     * @return $this
+     */
+    public function toResponse($request)
+    {
+        return $this;
     }
 }

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http;
 
 use ArrayObject;
+use Illuminate\Contracts\Support\Responsable;
 use JsonSerializable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
@@ -10,7 +11,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Symfony\Component\HttpFoundation\Response as BaseResponse;
 
-class Response extends BaseResponse
+class Response extends BaseResponse implements Responsable
 {
     use ResponseTrait, Macroable {
         Macroable::__call as macroCall;
@@ -77,5 +78,16 @@ class Response extends BaseResponse
         }
 
         return json_encode($content);
+    }
+
+    /**
+     * Implement the Responsable interface by returning itself.
+     *
+     * @param  Request $request
+     * @return $this
+     */
+    public function toResponse($request)
+    {
+        return $this;
     }
 }


### PR DESCRIPTION
It would be nice if `\Illuminate\Http\Response` and `\Illuminate\Http\JsonResponse` implement the `Responsable` interface, so that those of us that use return type-hints within our implementations can simply return `Responsable`.

This is especially nice when building implementations that just return "something that we can respond with".

Changes made:
- Added `toResponse()` to both `Response` and `JsonResponse`
- Changed the doc @return in `Responsable` to be \Illuminate\Http\Response|\Illuminate\Http\JsonResponse`

