### PR TITLE
[5.6] Match route()/action() signature with UrlGenerator methods

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -92,7 +92,7 @@ if (! function_exists('action')) {
      * Generate the URL to a controller action.
      *
      * @param  string  $name
-     * @param  array   $parameters
+     * @param  mixed   $parameters
      * @param  bool    $absolute
      * @return string
      */
@@ -801,7 +801,7 @@ if (! function_exists('route')) {
      * Generate the URL to a named route.
      *
      * @param  array|string  $name
-     * @param  array  $parameters
+     * @param  mixed  $parameters
      * @param  bool  $absolute
      * @return string
      */


### PR DESCRIPTION
Both [`UrlGenerator::route()`](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Routing/UrlGenerator.php#L364) and [`UrlGenerator::action()`](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Routing/UrlGenerator.php#L400) specify `$parameters` as `mixed` whereas `route()` & `action()` specify them as array, this fixes that discrepancy