### PR TITLE
[5.6] Add unset() method in FilesystemManager

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -326,6 +326,19 @@ class FilesystemManager implements FactoryContract
     }
 
     /**
+     * Unset the given disks instances.
+     *
+     * @param  array  $names
+     * @return void
+     */
+    public function unset($names)
+    {
+        foreach ($names as $name) {
+            unset($this->disks[$name]);
+        }
+    }
+    
+    /**
      * Get the filesystem connection configuration.
      *
      * @param  string  $name

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -337,7 +337,7 @@ class FilesystemManager implements FactoryContract
             unset($this->disks[$name]);
         }
     }
-    
+
     /**
      * Get the filesystem connection configuration.
      *


### PR DESCRIPTION
I'm building a multi tenant system and I had to add this method to be able to update the disk's root property dynamically when switching tenants. For example, in this app we switch tenants when processing data inside queued jobs.
The disk config is cached, so this method needs to be called manually before making changes to the config. After the disk is used again the new config is cached automatically.

Here is an example of an app with disks for photos and videos:
```php
// First we unset the disks
app('filesystem')->unset(['photos', 'videos']);

// Apply the tenant's slug as the disk path root
Config::set('filesystems.disks.photos.root', $this->currentTenant->slug);
Config::set('filesystems.disks.videos.root', $this->currentTenant->slug);
```

The method accepts an array of names, but if a single string is more appropriate I can change it.