### PR TITLE
[5.6] Cast model attribute to any class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Castable.php
+++ b/src/Illuminate/Database/Eloquent/Castable.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+interface Castable
+{
+    /**
+     * Create your object from DB value.
+     *
+     * @param $value
+     * @return mixed
+     */
+    public static function fromModelValue($value);
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -811,7 +811,7 @@ trait HasAttributes
             return $value;
         }
 
-        return call_user_func_array([$this->getCasts()[$key], "fromModelValue"], [$value]);
+        return call_user_func_array([$this->getCasts()[$key], 'fromModelValue'], [$value]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,13 +2,12 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use Illuminate\Database\Eloquent\Castable;
-use InvalidArgumentException;
 use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
+use Illuminate\Database\Eloquent\Castable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1485,7 +1485,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->dateAttribute = '1969-07-20';
         $model->datetimeAttribute = '1969-07-20 22:56:00';
         $model->timestampAttribute = '1969-07-20 22:56:00';
-        $model->customClassAttribute = json_encode(["test_value_1", "test_value_2"]);
+        $model->customClassAttribute = json_encode(['test_value_1', 'test_value_2']);
 
         $this->assertInternalType('int', $model->intAttribute);
         $this->assertInternalType('float', $model->floatAttribute);
@@ -1742,14 +1742,15 @@ class DatabaseEloquentModelTest extends TestCase
     }
 }
 
-class CastableAttributeStub implements Castable {
+class CastableAttributeStub implements Castable
+{
     protected $settings;
 
     public function __construct($value)
     {
         $value = json_decode($value);
         if ($value === false) {
-            throw new InvalidArgumentException("Invalid value");
+            throw new InvalidArgumentException('Invalid value');
         }
 
         $this->settings = $value;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Database;
 
 use DateTime;
+use Illuminate\Database\Eloquent\Castable;
+use InvalidArgumentException;
 use stdClass;
 use Exception;
 use Mockery as m;
@@ -1483,6 +1485,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->dateAttribute = '1969-07-20';
         $model->datetimeAttribute = '1969-07-20 22:56:00';
         $model->timestampAttribute = '1969-07-20 22:56:00';
+        $model->customClassAttribute = json_encode(["test_value_1", "test_value_2"]);
 
         $this->assertInternalType('int', $model->intAttribute);
         $this->assertInternalType('float', $model->floatAttribute);
@@ -1503,6 +1506,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('1969-07-20', $model->dateAttribute->toDateString());
         $this->assertEquals('1969-07-20 22:56:00', $model->datetimeAttribute->toDateTimeString());
         $this->assertEquals(-14173440, $model->timestampAttribute);
+        $this->assertInstanceOf(CastableAttributeStub::class, $model->customClassAttribute);
 
         $arr = $model->toArray();
         $this->assertInternalType('int', $arr['intAttribute']);
@@ -1521,6 +1525,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('1969-07-20 00:00:00', $arr['dateAttribute']);
         $this->assertEquals('1969-07-20 22:56:00', $arr['datetimeAttribute']);
         $this->assertEquals(-14173440, $arr['timestampAttribute']);
+        $this->assertInstanceOf(CastableAttributeStub::class, $arr['customClassAttribute']);
     }
 
     public function testModelDateAttributeCastingResetsTime()
@@ -1734,6 +1739,25 @@ class DatabaseEloquentModelTest extends TestCase
         $resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection'));
         $model->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
         $model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
+    }
+}
+
+class CastableAttributeStub implements Castable {
+    protected $settings;
+
+    public function __construct($value)
+    {
+        $value = json_decode($value);
+        if ($value === false) {
+            throw new InvalidArgumentException("Invalid value");
+        }
+
+        $this->settings = $value;
+    }
+
+    public static function fromModelValue($value)
+    {
+        return new static($value);
     }
 }
 
@@ -2048,6 +2072,7 @@ class EloquentModelCastingStub extends Model
         'dateAttribute' => 'date',
         'datetimeAttribute' => 'datetime',
         'timestampAttribute' => 'timestamp',
+        'customClassAttribute' => CastableAttributeStub::class,
     ];
 
     public function jsonAttributeValue()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3,19 +3,19 @@
 namespace Illuminate\Tests\Database;
 
 use DateTime;
-use Illuminate\Database\Eloquent\Castable;
-use InvalidArgumentException;
 use stdClass;
 use Exception;
 use Mockery as m;
 use ReflectionClass;
 use DateTimeImmutable;
 use DateTimeInterface;
+use InvalidArgumentException;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Database\Eloquent\Castable;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
 class DatabaseEloquentModelTest extends TestCase


### PR DESCRIPTION
Currently, you can cast a model attribute to a primitive type or JSON. This PR will let model attributes to cast to any class. Here's an example:

```
Class MyModel extends EloquentModel {
	protected $casts = [
		‘age’ => ‘int’,
		‘settings’ => Settings::class
	];
}

Class Settings implements Castable{
	protected $settings;

	public function __construct($value)
	{
		$value = json_decode($value);
		if ($value === false) {
			throw new InvalidArgumentException(“Invalid value”);
		}

		$this->settings = $value;
	}

	public static function fromModelValue($value) {
		return new static($value);
	}
}

$myModel = MyModel::first();

dump($myModel->settings);

// will return an instance of Settings class.
```