### PR TITLE
[5.6] Remove ineffective and breaking SQLite code

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -138,9 +138,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function dateBasedWhere($type, Builder $query, $where)
     {
-        $value = str_pad($where['value'], 2, '0', STR_PAD_LEFT);
-
-        $value = $this->parameter($value);
+        $value = $this->parameter($where['value']);
 
         return "strftime('{$type}', {$this->wrap($where['column'])}) {$where['operator']} {$value}";
     }


### PR DESCRIPTION
The code looks like it pads days/months from `1` to `01` when calling `whereDay()`/`whereMonth()`.

But since the value is added to the bindings before this is called, it has no effect. In the next line `$this->parameter()` replaces it with the placeholder `?`.

It also breaks raw expressions:

    DB::table('users')->whereMonth('created_at', DB::raw("strftime('%m', updated_at)"))->toSql();
    // expected: select * from "users" where strftime('%m', "created_at") = strftime('%m', updated_at)
    // actual:   select * from "users" where strftime('%m', "created_at") = ?