### PR TITLE
[5.6] Simplify JsonResource resolve method.

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -91,9 +91,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             $request = $request ?: Container::getInstance()->make('request')
         );
 
-        if (is_array($data)) {
-            $data = $data;
-        } elseif ($data instanceof Arrayable || $data instanceof Collection) {
+        if ($data instanceof Arrayable || $data instanceof Collection) {
             $data = $data->toArray();
         } elseif ($data instanceof JsonSerializable) {
             $data = $data->jsonSerialize();


### PR DESCRIPTION
Which is the reason for
```PHP
if (is_array($data)) {
 $data = $data;	
}
```
?

---

It was changed in commit:
https://github.com/laravel/framework/commit/88d5f21fb73b52578be3057b4f373f204955b1c8