### PR TITLE
[5.7] Add the whereNot operator

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -647,6 +647,18 @@ class Builder
     }
 
     /**
+     * Add a where not clause to the query.
+     *
+     * @param  Closure  $callback
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNot(Closure $callback, $boolean = 'and')
+    {
+        return $this->whereNotNested($callback, $boolean);
+    }
+
+    /**
      * Add an array of where clauses to the query.
      *
      * @param  array  $column
@@ -730,6 +742,17 @@ class Builder
         );
 
         return $this->where($column, $operator, $value, 'or');
+    }
+
+    /**
+     * Add an "or where not" clause to the query.
+     *
+     * @param  Closure  $callback
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function orWhereNot(Closure $callback)
+    {
+        return $this->whereNot($callback, 'or');
     }
 
     /**
@@ -1266,6 +1289,20 @@ class Builder
     }
 
     /**
+     * Add a nested where not statement to the query.
+     *
+     * @param  \Closure $callback
+     * @param  string   $boolean
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function whereNotNested(Closure $callback, $boolean = 'and')
+    {
+        call_user_func($callback, $query = $this->forNestedWhere());
+
+        return $this->addNestedWhereNotQuery($query, $boolean);
+    }
+
+    /**
      * Create a new query instance for nested where condition.
      *
      * @return \Illuminate\Database\Query\Builder
@@ -1286,6 +1323,26 @@ class Builder
     {
         if (count($query->wheres)) {
             $type = 'Nested';
+
+            $this->wheres[] = compact('type', 'query', 'boolean');
+
+            $this->addBinding($query->getBindings(), 'where');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add another query builder as a nested where not to the query builder.
+     *
+     * @param  \Illuminate\Database\Query\Builder|static $query
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function addNestedWhereNotQuery($query, $boolean = 'and')
+    {
+        if (count($query->wheres)) {
+            $type = 'NotNested';
 
             $this->wheres[] = compact('type', 'query', 'boolean');
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -334,6 +334,18 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a where not nested where clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereNotNested(Builder $query, $where)
+    {
+        return 'not'.$this->whereNested($query, $where);
+    }
+
+    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -476,6 +476,26 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2014], $builder->getBindings());
     }
 
+    public function testWhereNot()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNot(function ($query) {
+            $query->where('id', 1);
+        });
+        $this->assertEquals('select * from "users" where not("id" = ?)', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+    }
+
+    public function testOrWhereNot()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('email', 'foo')->orWhereNot(function ($query) {
+            $query->where('id', 1);
+        });
+        $this->assertEquals('select * from "users" where "email" = ? or not("id" = ?)', $builder->toSql());
+        $this->assertEquals([0 => 'foo', 1 => 1], $builder->getBindings());
+    }
+
     public function testWhereBetweens()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
By adding this operator we can negate a complex query in a expressive way. For example, the query pointed by @DrowningElysium:

`select * from table where b=true and NOT (e != 1 and f < 5 and (g != null and h >= 150))`

To be done currently in laravel query builder it's necessary to invert all operators (`and` to `or`, `!=` to `==`, `<` to `>=`, `>=` to `<`). If we need to do the negation dynamically we will need to maintain two querys, increasing the possibility of bugs. For example:

```
DB::table('table')
  ->where('b', true)
  ->when($invert, function ($query) {
    return $query
      ->where('e', '!=', 1)
      ->where('f', '<', 5)
      ->where(function ($query) {
        return $query->whereNotNull('g')
          ->where('h', '>=', 150);
      });
   }, function ($query) {
    return $query
      ->where('e', '=', 1)
      ->orWhere('f', '>=', 5)
      ->orWhere(function ($query) {
        return $query->whereNull('g')
          ->orWhere('h', '<', 150);
      });
   });
```

With whereNot we can write this query as:

```
$subquery = function ($query) {
  return $query
    ->where('e', '!=', 1)
    ->where('f', '<', 5)
    ->where(function ($query) {
      return $query->whereNotNull('g')
        ->where('h', '>=', 150);
    });
};

DB::table('table')
  ->where('b', true)
  ->when($invert, function ($query) use ($subquery) {
      return $query->whereNot($subquery);
  }, function ($query) use ($subquery) {
      return $query->where($subquery);
  });

// or just

DB::table('table')
  ->where('b', true)
  ->{$invert ? 'where' : 'whereNot'}($subquery);
 ```

Which is more simple and legible.

We only allow calling whereNot in callback form: `$query->whereNot($callback);` because allowing the use as column `whereNot($column)` can confuse the developer since the behaviour of not() in some fields, like varchar, is different from php !$string.

Resolve: https://github.com/laravel/ideas/issues/708