### PR TITLE
[5.6] fix for route url generator when request()->basePath exists

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -96,7 +96,9 @@ class RouteUrlGenerator
         $uri = strtr(rawurlencode($uri), $this->dontEncode);
 
         if (! $absolute) {
-            return '/'.ltrim(preg_replace('#^(//|[^/?])+#', '', $uri), '/');
+            $uri = ltrim(preg_replace('#^(//|[^/?])+#', '', $uri), $this->request->getBasePath());
+
+            return '/'.ltrim($uri, '/');
         }
 
         return $uri;

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -96,7 +96,11 @@ class RouteUrlGenerator
         $uri = strtr(rawurlencode($uri), $this->dontEncode);
 
         if (! $absolute) {
-            $uri = ltrim(preg_replace('#^(//|[^/?])+#', '', $uri), $this->request->getBasePath());
+            $uri = preg_replace('#^(//|[^/?])+#', '', $uri);
+
+            if ($base = $this->request->getBasePath()) {
+                $uri = preg_replace('#^'.$base.'#i', '', $uri);
+            }
 
             return '/'.ltrim($uri, '/');
         }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -64,6 +64,25 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('/named-route', $url->route('plain', [], false));
     }
 
+    public function testBasicGenerationWithRequestBasePath()
+    {
+        $request = Request::create('http://www.foo.com/subfolder/foo/bar/subfolder/');
+
+        $request->server->set('SCRIPT_FILENAME', '/var/www/subfolder/index.php');
+        $request->server->set('PHP_SELF', '/subfolder/index.php');
+
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request
+        );
+
+        $route = new Route(['GET'], 'foo/bar/subfolder', ['as' => 'foobar']);
+        $routes->add($route);
+
+        $this->assertEquals('/subfolder', $request->getBasePath());
+        $this->assertEquals('/foo/bar/subfolder', $url->route('foobar', [], false));
+    }
+
     public function testBasicGenerationWithPathFormatting()
     {
         $url = new UrlGenerator(

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -68,7 +68,7 @@ class RoutingUrlGeneratorTest extends TestCase
     {
         $request = Request::create('http://www.foo.com/subfolder/foo/bar/subfolder/');
 
-        $request->server->set('SCRIPT_FILENAME', '/var/www/subfolder/index.php');
+        $request->server->set('SCRIPT_FILENAME', '/var/www/laravel-project/public/subfolder/index.php');
         $request->server->set('PHP_SELF', '/subfolder/index.php');
 
         $url = new UrlGenerator(


### PR DESCRIPTION
This is a fix for a bug that was introduced with #24051 and tagged in version `5.6.19` yesterday.

Basically, if you had another script (non Laravel) in a sub-folder in the public root that loaded Laravel (by requiring the bootstrap.php file), every route url would include that sub-folder path. 

This is a common thing to do in legacy code you are slowly converting to the framework, or when trying to utilize laravel resources in non laravel code (like with wordpress for instance).

In the past, [the url generator stripped the whole url root](https://github.com/laravel/framework/pull/24051/files#diff-9ffa9921c8542da8cb0059fcbc3ad48aL99) but that changed in #24051 and introduced this side effect.

This fix simply removes the base path string if it exists on the request.

/cc @staudenmeir
