### PR TITLE
[5.7] Collection avg() should ignore null

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -122,8 +122,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function avg($callback = null)
     {
-        if ($count = $this->count()) {
-            return $this->sum($callback) / $count;
+        $callback = $this->valueRetriever($callback);
+        
+        $items = $this->map(function ($value) use ($callback) {
+            return $callback($value);
+        })->filter(function ($value) {
+            return ! is_null($value);
+        });
+        
+        if ($count = $items->count()) {
+            return $items->sum() / $count;
         }
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -123,13 +123,13 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function avg($callback = null)
     {
         $callback = $this->valueRetriever($callback);
-        
+
         $items = $this->map(function ($value) use ($callback) {
             return $callback($value);
         })->filter(function ($value) {
             return ! is_null($value);
         });
-        
+
         if ($count = $items->count()) {
             return $items->sum() / $count;
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2098,6 +2098,13 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(15, $c->avg('foo'));
         $this->assertEquals(15, $c->avg->foo);
 
+        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20], (object) ['foo' => null]]);
+        $this->assertEquals(15, $c->avg(function ($item) {
+            return $item->foo;
+        }));
+        $this->assertEquals(15, $c->avg('foo'));
+        $this->assertEquals(15, $c->avg->foo);
+
         $c = new Collection([['foo' => 10], ['foo' => 20]]);
         $this->assertEquals(15, $c->avg('foo'));
         $this->assertEquals(15, $c->avg->foo);


### PR DESCRIPTION
The collection "avg()" method counts null as a value to divide by, resulting in an inaccurate calculation.

Examples:

- Before
```
$c = new Collection([1, 2, 3, 4, 5, null])
$c->avg(); // 2,5
```
- After
```
$c = new Collection([1, 2, 3, 4, 5, null])
$c->avg(); // 3
```
This PR is a follow up to #23909 