### PR TITLE
[5.7] Collection median() should ignore null 

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -146,14 +146,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function median($key = null)
     {
-        $count = $this->count();
+        $values = (isset($key) ? $this->pluck($key) : $this)
+            ->filter(function ($item) {
+                return ! is_null($item);
+            })->sort()->values();
+
+        $count = $values->count();
 
         if ($count == 0) {
             return;
         }
-
-        $values = (isset($key) ? $this->pluck($key) : $this)
-                    ->sort()->values();
 
         $middle = (int) ($count / 2);
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2251,6 +2251,17 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(2, $collection->median('foo'));
     }
 
+    public function testMedianOnCollectionWithNull()
+    {
+        $collection = new Collection([
+            (object) ['foo' => 1],
+            (object) ['foo' => 2],
+            (object) ['foo' => 4],
+            (object) ['foo' => null],
+        ]);
+        $this->assertEquals(2, $collection->median('foo'));
+    }
+
     public function testEvenMedianCollection()
     {
         $collection = new Collection([


### PR DESCRIPTION
The collection "median()" method counts null as a value to divide by, resulting in an inaccurate calculation.

Examples:

- Before
```
$c = new Collection([1, 2, 3, 4, 5, null])
$c->median(); // 2,5
```
- After
```
$c = new Collection([1, 2, 3, 4, 5, null])
$c->median(); // 3
```
This PR is a follow up to #23909 