### PR TITLE
[5.7] Fix a unsuspected result from the split function in the Collection class

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1396,9 +1396,25 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return new static;
         }
 
-        $groupSize = ceil($this->count() / $numberOfGroups);
+        $groups = new static();
 
-        return $this->chunk($groupSize);
+        $groupSize = floor($this->count() / $numberOfGroups);
+
+        $remain = $this->count() % $numberOfGroups;
+
+        $start = 0;
+        for ($i = 0; $i < $numberOfGroups; $i++) {
+            $size = $groupSize;
+            if ($i < $remain) {
+                $size++;
+            }
+            if ($size) {
+                $groups->push(new static(array_slice($this->items, $start, $size)));
+                $start += $size;
+            }
+        }
+
+        return $groups;
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2407,6 +2407,42 @@ class SupportCollectionTest extends TestCase
         );
     }
 
+    public function testSplitCollectionIntoThreeWithCountOfFour()
+    {
+        $collection = new Collection(['a', 'b', 'c', 'd']);
+
+        $this->assertEquals(
+            [['a', 'b'], ['c'], ['d']],
+            $collection->split(3)->map(function (Collection $chunk) {
+                return $chunk->values()->toArray();
+            })->toArray()
+            );
+    }
+
+    public function testSplitCollectionIntoThreeWithCountOfFive()
+    {
+        $collection = new Collection(['a', 'b', 'c', 'd', 'e']);
+
+        $this->assertEquals(
+            [['a', 'b'], ['c', 'd'], ['e']],
+            $collection->split(3)->map(function (Collection $chunk) {
+                return $chunk->values()->toArray();
+            })->toArray()
+            );
+    }
+
+    public function testSplitCollectionIntoSixWithCountOfTen()
+    {
+        $collection = new Collection(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+
+        $this->assertEquals(
+            [['a', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i'], ['j']],
+            $collection->split(6)->map(function (Collection $chunk) {
+                return $chunk->values()->toArray();
+            })->toArray()
+            );
+    }
+
     public function testSplitEmptyCollection()
     {
         $collection = new Collection;


### PR DESCRIPTION
See: https://github.com/laravel/framework/issues/22090

This will change the result of the split function to return the requested amount of collections (except the total of items is less then the requested number)

Example
collect(['a', 'b', 'c', 'd'])->split(3);

// expected and new result
[['a', 'b'], ['c'], ['d']]

// result before this change
[['a', 'b'], ['c', 'd']]

It will change the split function and add 3 new tests to test some edge cases that are fixed with this change.

This was already provided for the 5.6 branch where @taylorotwell point out that he will not change this in a point release (See https://github.com/laravel/framework/pull/24083 ). That is something that I understand.

I think it is good to change this in the next release or explain it in the documentation.