### PR TITLE
[5.6] Fix for HasManyThrough returning incorrect results with chunk()…

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -245,6 +245,36 @@ class HasManyThrough extends Relation
 
         return $instance;
     }
+    /**
+     * Chunk the results of the query.
+     *
+     * @param  int  $count
+     * @param  callable  $callback
+     * @return bool
+     */
+    public function chunk($count, callable $callback)
+    {
+        $builder = $this->getBuilder();
+        return $builder->chunk($count,$callback);
+    }
+
+    /**
+     * Execute a callback over each item while chunking.
+     *
+     * @param  callable  $callback
+     * @param  int  $count
+     * @return bool
+     */
+    public function each(callable $callback, $count = 1000)
+    {
+        return $this->chunk($count, function ($results) use ($callback) {
+            foreach ($results as $key => $value) {
+                if ($callback($value, $key) === false) {
+                    return false;
+                }
+            }
+        });
+    }
 
     /**
      * Execute the query and get the first related model.
@@ -354,16 +384,8 @@ class HasManyThrough extends Relation
      */
     public function get($columns = ['*'])
     {
-        // First we'll add the proper select columns onto the query so it is run with
-        // the proper columns. Then, we will get the results and hydrate out pivot
-        // models with the result of those columns as a separate model relation.
-        $columns = $this->query->getQuery()->columns ? [] : $columns;
-
-        $builder = $this->query->applyScopes();
-
-        $models = $builder->addSelect(
-            $this->shouldSelect($columns)
-        )->getModels();
+        $builder = $this->getBuilder($columns);
+        $models = $builder->getModels();
 
         // If we actually found models we will also eager load any relationships that
         // have been specified as needing to be eager loaded. This will solve the
@@ -516,5 +538,23 @@ class HasManyThrough extends Relation
     public function getQualifiedLocalKeyName()
     {
         return $this->farParent->qualifyColumn($this->localKey);
+    }
+
+    /**
+     * Add the proper select columns onto the query so it is run with the proper
+     * columns. and return a builder instance with the correct columns.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    private function getBuilder($columns = ['*']){
+
+        $columns = $this->query->getQuery()->columns ? [] : $columns;
+
+        $builder = $this->query->applyScopes();
+
+        return $builder->addSelect(
+            $this->shouldSelect($columns)
+        );
     }
 }

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -156,7 +156,6 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     {
         $this->seedData();
         $post = HasManyThroughTestCountry::first()->posts()->first();
-
         $this->assertEquals([
             'id',
             'user_id',
@@ -181,6 +180,43 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         ], array_keys($post->getAttributes()));
     }
 
+    public function testChunkReturnsCorrectModels(){
+        $this->seedData();
+        $this->seedDataExtended();
+        $country = HasManyThroughTestCountry::find(2);
+
+        $country->posts()->chunk(10,function($postsChunk){
+            $post = $postsChunk->first();
+            $this->assertEquals([
+                'id',
+                'user_id',
+                'title',
+                'body',
+                'email',
+                'created_at',
+                'updated_at',
+                'country_id'],array_keys($post->getAttributes()));
+
+        });
+    }
+    public function testEachReturnsCorrectModels(){
+        $this->seedData();
+        $this->seedDataExtended();
+        $country = HasManyThroughTestCountry::find(2);
+
+        $country->posts()->each(function($post){
+            $this->assertEquals([
+                'id',
+                'user_id',
+                'title',
+                'body',
+                'email',
+                'created_at',
+                'updated_at',
+                'country_id'],array_keys($post->getAttributes()));
+
+        });
+    }
     public function testIntermediateSoftDeletesAreIgnored()
     {
         $this->seedData();
@@ -213,6 +249,26 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
                 ['title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
                 ['title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
             ]);
+    }
+    protected function seedDataExtended(){
+        $country = HasManyThroughTestCountry::create(['id' => 2, 'name' => 'United Kingdom', 'shortname' => 'uk']);
+        $country->users()->create(['id' => 2, 'email' => 'example1@gmail.com', 'country_short' => 'uk'])
+            ->posts()->createMany([
+                ['title' => 'Example1 title1', 'body' => 'Example1 body1', 'email' => 'example1post1@gmail.com'],
+                ['title' => 'Example1 title2', 'body' => 'Example1 body2', 'email' => 'example1post2@gmail.com']
+            ]);
+        $country->users()->create(['id' => 3, 'email' => 'example2@gmail.com', 'country_short' => 'uk'])
+            ->posts()->createMany([
+                ['title' => 'Example2 title1', 'body' => 'Example2 body1', 'email' => 'example2post1@gmail.com'],
+                ['title' => 'Example2 title2', 'body' => 'Example2 body2', 'email' => 'example2post2@gmail.com']
+            ]);
+        $country->users()->create(['id' => 4, 'email' => 'example3@gmail.com', 'country_short' => 'uk'])
+            ->posts()->createMany([
+                ['title' => 'Example3 title1', 'body' => 'Example3 body1', 'email' => 'example3post1@gmail.com'],
+                ['title' => 'Example3 title2', 'body' => 'Example3 body2', 'email' => 'example3post2@gmail.com']
+            ]);
+
+
     }
 
     /**


### PR DESCRIPTION
Laravel Version: 5.6.17
PHP Version: 7.1.3 (MacOS 10.13.4)

## Description:
**Summary:** 
This is pull request addresses the issues reported on #21774. Using the `chunk()` method on a `HasManyThrough` relation object returns incorrect results. This is due to to the fact that Eloquent QueryBuilder attempts to hydrate the the related model with intermediate model attributes. 

> When querying models through a hasManyThrough relationship and using chunk() on the query, all the retrieved models have the same id (and probably a non-existent id for the model), even though their other attributes have the correct values. It creates a problem when eager loading other relations, since they all have the same id.
The aforementioned issue  is a resulted because the intermediate model id is inserted on the query instead of the related model.

With the current codebase `get()` method has fixes the issue by getting an instance of the builder with the correct table and columns selected to overcome the issue. This can be demonstrated by the different model structure that would be retrieved when running
`$country->posts()->get()` vs `$country->posts()->getQuery()->get()`

The same issue is manifested when using `each()` method. This is because `each()` uses the underlying `chunk()` method during its runtime. 

## Proposed fix
`chunk()` and `each()` methods were added to `HasManyThrough` class to correct the selection of columns before they operate. This would contain the behaviour change to `HasManyThrough` without affecting any other behaviours.  Hence, there are no breaking changes introduced.

### Tests
Added two extra tests to `DatabaseEloquentHasManyThroughIntegrationTest` to test `chunk()` and `each()`, where the models are checked to have the correct columns defined. 
