### PR TITLE
[5.6] remove full baseUrl from generated url paths (follow up)

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -98,7 +98,7 @@ class RouteUrlGenerator
         if (! $absolute) {
             $uri = preg_replace('#^(//|[^/?])+#', '', $uri);
 
-            if ($base = $this->request->getBasePath()) {
+            if ($base = $this->request->getBaseUrl()) {
                 $uri = preg_replace('#^'.$base.'#i', '', $uri);
             }
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -64,7 +64,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('/named-route', $url->route('plain', [], false));
     }
 
-    public function testBasicGenerationWithRequestBaseUrl()
+    public function testBasicGenerationWithRequestBaseUrlWithSubfolder()
     {
         $request = Request::create('http://www.foo.com/subfolder/foo/bar/subfolder/');
 
@@ -83,7 +83,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('/foo/bar/subfolder', $url->route('foobar', [], false));
     }
 
-    public function testBasicGenerationWithRequestBaseUrlWithFileSuffix()
+    public function testBasicGenerationWithRequestBaseUrlWithSubfolderAndFileSuffix()
     {
         $request = Request::create('http://www.foo.com/subfolder/index.php');
 
@@ -100,6 +100,26 @@ class RoutingUrlGeneratorTest extends TestCase
 
         $this->assertEquals('/subfolder', $request->getBasePath());
         $this->assertEquals('/subfolder/index.php', $request->getBaseUrl());
+        $this->assertEquals('/foo/bar/subfolder', $url->route('foobar', [], false));
+    }
+
+    public function testBasicGenerationWithRequestBaseUrlWithFileSuffix()
+    {
+        $request = Request::create('http://www.foo.com/other.php');
+
+        $request->server->set('SCRIPT_FILENAME', '/var/www/laravel-project/public/other.php');
+        $request->server->set('PHP_SELF', '/other.php');
+
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request
+        );
+
+        $route = new Route(['GET'], 'foo/bar/subfolder', ['as' => 'foobar']);
+        $routes->add($route);
+
+        $this->assertEquals('', $request->getBasePath());
+        $this->assertEquals('/other.php', $request->getBaseUrl());
         $this->assertEquals('/foo/bar/subfolder', $url->route('foobar', [], false));
     }
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -64,7 +64,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('/named-route', $url->route('plain', [], false));
     }
 
-    public function testBasicGenerationWithRequestBasePath()
+    public function testBasicGenerationWithRequestBaseUrl()
     {
         $request = Request::create('http://www.foo.com/subfolder/foo/bar/subfolder/');
 
@@ -79,7 +79,27 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar/subfolder', ['as' => 'foobar']);
         $routes->add($route);
 
+        $this->assertEquals('/subfolder', $request->getBaseUrl());
+        $this->assertEquals('/foo/bar/subfolder', $url->route('foobar', [], false));
+    }
+
+    public function testBasicGenerationWithRequestBaseUrlWithFileSuffix()
+    {
+        $request = Request::create('http://www.foo.com/subfolder/index.php');
+
+        $request->server->set('SCRIPT_FILENAME', '/var/www/laravel-project/public/subfolder/index.php');
+        $request->server->set('PHP_SELF', '/subfolder/index.php');
+
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request
+        );
+
+        $route = new Route(['GET'], 'foo/bar/subfolder', ['as' => 'foobar']);
+        $routes->add($route);
+
         $this->assertEquals('/subfolder', $request->getBasePath());
+        $this->assertEquals('/subfolder/index.php', $request->getBaseUrl());
         $this->assertEquals('/foo/bar/subfolder', $url->route('foobar', [], false));
     }
 


### PR DESCRIPTION
This is a follow up to #24074 to fix cases where the current url contains a prefix (like `/subfolder/index.php`). The previous PR only fixed `/subfolder`.

Instead of using the `request()->getBasePath()` method it now uses `request()->getBaseUrl()`. That should take care of all cases.

Tests have been updated to reflect that change and two more were added to check all possible types of prefixes (`/subfolder`, `/subfolder/index.php`, `other.php`).

Sorry for not catching this in the original PR!