### PR TITLE
[5.7] Add closure support for cached config based from issue #24103

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "doctrine/inflector": "^1.1",
         "dragonmantank/cron-expression": "^2.0",
         "erusev/parsedown": "^1.7",
+        "jeremeamia/superclosure": "^2.4",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "^1.12",
         "nesbot/carbon": "^1.26.3",

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -38,6 +38,24 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
+     * Value analyzer and changer.
+     *
+     * @param  mixed $value
+     * @return mixed
+     */
+    public function realValue($value)
+    {
+        if (
+            is_string($value) &&
+            strpos($value, '"SuperClosure\\SerializableClosure"') !== false
+        ) {
+            return (new \SuperClosure\Serializer())->unserialize($value);
+        }
+
+        return $value;
+    }
+
+    /**
      * Get the specified configuration value.
      *
      * @param  array|string  $key
@@ -50,7 +68,7 @@ class Repository implements ArrayAccess, ConfigContract
             return $this->getMany($key);
         }
 
-        return Arr::get($this->items, $key, $default);
+        return $this->realValue(Arr::get($this->items, $key, $default));
     }
 
     /**
@@ -68,7 +86,7 @@ class Repository implements ArrayAccess, ConfigContract
                 list($key, $default) = [$default, null];
             }
 
-            $config[$key] = Arr::get($this->items, $key, $default);
+            $config[$key] = $this->realValue(Arr::get($this->items, $key, $default));
         }
 
         return $config;

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -43,6 +43,29 @@ class ConfigCacheCommand extends Command
     }
 
     /**
+     * Serialize the records.
+     *
+     * @param  array $data
+     * @return array
+     */
+    public static function transformClosure(array $data)
+    {
+        $serializer = new \SuperClosure\Serializer;
+
+        foreach ($data as $key => $val) {
+            if (is_array($val)) {
+                $data[$key] = static::transformClosure($val);
+            }
+
+            if ($val instanceof \Closure) {
+                $data[$key] = $serializer->serialize($val);
+            }
+        }
+
+        return $data;
+    }
+
+    /**
      * Execute the console command.
      *
      * @return void
@@ -51,7 +74,7 @@ class ConfigCacheCommand extends Command
     {
         $this->call('config:clear');
 
-        $config = $this->getFreshConfiguration();
+        $config = static::transformClosure($this->getFreshConfiguration());
 
         $this->files->put(
             $this->laravel->getCachedConfigPath(), '<?php return '.var_export($config, true).';'.PHP_EOL

--- a/tests/Config/CacheTest.php
+++ b/tests/Config/CacheTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Illuminate\Tests\Config;
+
+use Illuminate\Config\Repository;
+use Illuminate\Foundation\Console\ConfigCacheCommand;
+
+class CacheTest extends RepositoryTest
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        // we need to pull the existing repository config from RepositoryTest,
+        // then rebuild the config property.
+        $this->config = ConfigCacheCommand::transformClosure($this->repository->all());
+
+        // we need to reset the repository values using the closure
+        // since we need to test the get() and getMany() methods of the
+        // Illuminate\Config\Repository.
+        $this->repository = new Repository($this->config);
+    }
+
+    public function testHasSuperClosureStr()
+    {
+        $this->assertTrue(
+            strpos($this->config['callback_array'], '"SuperClosure\\SerializableClosure"') !== false
+        );
+
+        $this->assertTrue(
+            strpos($this->config['callback_instance'], '"SuperClosure\\SerializableClosure"') !== false
+        );
+    }
+
+    // public function testCallbackArray() {}
+    // public function testCallbackInstance() {}
+    // public function testConstruct() {}
+    // public function testHasIsTrue() {}
+    // public function testHasIsFalse() {}
+    // public function testGet() {}
+    // public function testGetWithArrayOfKeys() {}
+    // public function testGetMany() {}
+    // public function testGetWithDefault() {}
+    // public function testSet() {}
+    // public function testSetArray() {}
+    // public function testPrepend() {}
+    // public function testPush() {}
+    // public function testAll() {}
+    // public function testOffsetUnset() {}
+}

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -35,6 +35,17 @@ class RepositoryTest extends TestCase
             'x' => [
                 'z' => 'zoo',
             ],
+            'callback_array' => function () {
+                return [
+                    'name' => 'John Doe',
+                ];
+            },
+            'callback_instance' => function () {
+                $std = new \stdClass();
+                $std->name = 'Jane Doe';
+
+                return $std;
+            },
         ]);
 
         parent::setUp();
@@ -58,6 +69,24 @@ class RepositoryTest extends TestCase
     public function testGet()
     {
         $this->assertSame('bar', $this->repository->get('foo'));
+    }
+
+    public function testCallbackArray()
+    {
+        $data = call_user_func(
+            $this->repository->get('callback_array')
+        );
+
+        $this->assertEquals($data['name'], 'John Doe');
+    }
+
+    public function testCallbackInstance()
+    {
+        $data = call_user_func(
+            $this->repository->get('callback_instance')
+        );
+
+        $this->assertEquals($data->name, 'Jane Doe');
     }
 
     public function testGetWithArrayOfKeys()


### PR DESCRIPTION
Based from my post issue#24103.

#### Fixes
- Error thrown when running config:cache

---

#### Added
- Transformer method that iterates all config file when executing `config:cache`
- Config value analyzer to check if came from SuperClosure instance

#### Test Cases
- Test for closure (that returns array, across cached/non-cache)
- Test for closure (that returns object, across cached/non-cache)

#### Composer
- Added `jeremeamia/superclosure`