### PR TITLE
[5.6] Fix incorrect DocBlock for group method of Route facade

### DIFF
--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -21,7 +21,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar domain(string $value)
  * @method static \Illuminate\Routing\RouteRegistrar name(string $value)
  * @method static \Illuminate\Routing\RouteRegistrar namespace(string $value)
- * @method static \Illuminate\Routing\Router group(array $attributes, \Closure|string $routes)
+ * @method static \Illuminate\Routing\Router|\Illuminate\Routing\RouteRegistrar group(array|\Closure|string $attributes, \Closure|string $routes)
  * @method static \Illuminate\Routing\Route redirect(string $uri, string $destination, int $status = 301)
  * @method static \Illuminate\Routing\Route view(string $uri, string $view, array $data = [])
  * @method static void bind(string $key, string|callable $binder)


### PR DESCRIPTION
Fixes a regression created by https://github.com/laravel/framework/pull/24040. I found this while performing static analysis because the signature is incorrect for ` Illuminate\Routing\RouteRegistrar::group`.
before regression
```
 * @method static \Illuminate\Routing\Router group(\Closure|string|array $value)
```
regression breaking static analysis
```
 * @method static \Illuminate\Routing\Router group(array $attributes, \Closure|string $routes)
```
correct:
```
 * @method static \Illuminate\Routing\Router|\Illuminate\Routing\RouteRegistrar group(array|\Closure|string $attributes, \Closure|string $routes)
```