### PR TITLE
[5.6] Fix ordering of migrations in status command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -86,14 +86,11 @@ class StatusCommand extends BaseCommand
                 return $this->migrator->getMigrationName($migration);
             })
             ->diff($ran)
-            ->map(function($migrationName) {
+            ->map(function ($migrationName) {
                 return ['<fg=red>N</fg=red>', $migrationName];
             });
 
-        $migrations->merge($diff);
-
-        return $migrations;
-        //return Collection::make($migrations);
+        return $migrations->merge($diff);
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -75,14 +75,23 @@ class StatusCommand extends BaseCommand
      */
     protected function getStatusFor(array $ran, array $batches)
     {
-        return Collection::make($this->getAllMigrationFiles())
-                    ->map(function ($migration) use ($ran, $batches) {
-                        $migrationName = $this->migrator->getMigrationName($migration);
+        $migrations = [];
 
-                        return in_array($migrationName, $ran)
-                                ? ['<info>Y</info>', $migrationName, $batches[$migrationName]]
-                                : ['<fg=red>N</fg=red>', $migrationName];
-                    });
+        foreach ($batches as $migration => $batch) {
+            $migrations[] = ['<info>Y</info>', $migration, $batch];
+        }
+
+        // Diff to find ones that aren't ran
+        $diff = Collection::make($this->getAllMigrationFiles())
+            ->map(function ($migration) {
+                return $this->migrator->getMigrationName($migration);
+            })->diff($ran);
+
+        foreach ($diff as $migrationName) {
+            $migrations[] = ['<fg=red>N</fg=red>', $migrationName];
+        }
+
+        return Collection::make($migrations);
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -76,7 +76,7 @@ class StatusCommand extends BaseCommand
     protected function getStatusFor(array $ran, array $batches)
     {
         $migrations = Collection::make($batches)
-            ->map(function ($migration, $batch) {
+            ->map(function ($batch, $migration) {
                 return ['<info>Y</info>', $migration, $batch];
             });
 

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -75,23 +75,25 @@ class StatusCommand extends BaseCommand
      */
     protected function getStatusFor(array $ran, array $batches)
     {
-        $migrations = [];
-
-        foreach ($batches as $migration => $batch) {
-            $migrations[] = ['<info>Y</info>', $migration, $batch];
-        }
+        $migrations = Collection::make($batches)
+            ->map(function ($migration, $batch) {
+                return ['<info>Y</info>', $migration, $batch];
+            });
 
         // Diff to find ones that aren't ran
         $diff = Collection::make($this->getAllMigrationFiles())
             ->map(function ($migration) {
                 return $this->migrator->getMigrationName($migration);
-            })->diff($ran);
+            })
+            ->diff($ran)
+            ->map(function($migrationName) {
+                return ['<fg=red>N</fg=red>', $migrationName];
+            });
 
-        foreach ($diff as $migrationName) {
-            $migrations[] = ['<fg=red>N</fg=red>', $migrationName];
-        }
+        $migrations->merge($diff);
 
-        return Collection::make($migrations);
+        return $migrations;
+        //return Collection::make($migrations);
     }
 
     /**

--- a/tests/Database/DatabaseMigrationStatusCommandTest.php
+++ b/tests/Database/DatabaseMigrationStatusCommandTest.php
@@ -2,14 +2,14 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Database\Migrations\MigrationRepositoryInterface;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Illuminate\Database\Migrations\Migrator;
-use Illuminate\Database\Console\Migrations\StatusCommand;
-use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\Console\Tester\CommandTester;
+use Illuminate\Database\Console\Migrations\StatusCommand;
+use Illuminate\Database\Migrations\MigrationRepositoryInterface;
+use Symfony\Component\Console\Application as ConsoleApplication;
 
 class DatabaseMigrationStatusCommandTest extends TestCase
 {
@@ -20,7 +20,6 @@ class DatabaseMigrationStatusCommandTest extends TestCase
 
     public function testStatusCommandOutputsMigrationsInCorrectOrder()
     {
-
         $expected = <<<'TABLE'
 +------+------------------------------------------------+-------+
 | Ran? | Migration                                      | Batch |
@@ -56,23 +55,23 @@ TABLE;
         $migrator->expects($this->once())
             ->method('paths')
             ->willReturn([
-                __DIR__ . '/migrations/one',
-                __DIR__ . '/migrations/two',
+                __DIR__.'/migrations/one',
+                __DIR__.'/migrations/two',
             ]);
 
         $migrator->method('getMigrationName')
             ->will($this->returnValueMap([
-                [__DIR__ . '/migrations/one/2016_01_01_000000_create_users_table.php', '2016_01_01_000000_create_users_table'],
-                [__DIR__ . '/migrations/one/2016_01_01_100000_create_password_resets_table.php', '2016_01_01_100000_create_password_resets_table'],
-                [__DIR__ . '/migrations/two/2016_01_01_200000_create_flights_table.php', '2016_01_01_200000_create_flights_table'],
+                [__DIR__.'/migrations/one/2016_01_01_000000_create_users_table.php', '2016_01_01_000000_create_users_table'],
+                [__DIR__.'/migrations/one/2016_01_01_100000_create_password_resets_table.php', '2016_01_01_100000_create_password_resets_table'],
+                [__DIR__.'/migrations/two/2016_01_01_200000_create_flights_table.php', '2016_01_01_200000_create_flights_table'],
             ]));
 
         $migrator->expects($this->once())
             ->method('getMigrationFiles')
             ->will($this->returnValue([
-                '2016_01_01_000000_create_users_table' => __DIR__ . '/migrations/one/2016_01_01_000000_create_users_table.php',
-                '2016_01_01_100000_create_password_resets_table' => __DIR__ . '/migrations/one/2016_01_01_100000_create_password_resets_table.php',
-                '2016_01_01_200000_create_flights_table' => __DIR__ . '/migrations/two/2016_01_01_200000_create_flights_table.php',
+                '2016_01_01_000000_create_users_table' => __DIR__.'/migrations/one/2016_01_01_000000_create_users_table.php',
+                '2016_01_01_100000_create_password_resets_table' => __DIR__.'/migrations/one/2016_01_01_100000_create_password_resets_table.php',
+                '2016_01_01_200000_create_flights_table' => __DIR__.'/migrations/two/2016_01_01_200000_create_flights_table.php',
             ]));
 
         $migrator->expects($this->once())

--- a/tests/Database/DatabaseMigrationStatusCommandTest.php
+++ b/tests/Database/DatabaseMigrationStatusCommandTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Migrations\MigrationRepositoryInterface;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Application;
+use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Database\Console\Migrations\StatusCommand;
+use Symfony\Component\Console\Application as ConsoleApplication;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DatabaseMigrationStatusCommandTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testStatusCommandOutputsMigrationsInCorrectOrder()
+    {
+
+        $expected = <<<'TABLE'
++------+------------------------------------------------+-------+
+| Ran? | Migration                                      | Batch |
++------+------------------------------------------------+-------+
+| Y    | 2016_01_01_000000_create_users_table           | 1     |
+| Y    | 2016_01_01_200000_create_flights_table         | 2     |
+| N    | 2016_01_01_100000_create_password_resets_table |       |
++------+------------------------------------------------+-------+
+
+TABLE;
+        $migratorRepository = $this->createMock(MigrationRepositoryInterface::class);
+
+        $migratorRepository->expects($this->once())
+            ->method('getRan')
+            ->will($this->returnValue([
+                '2016_01_01_000000_create_users_table',
+                '2016_01_01_200000_create_flights_table',
+            ]));
+
+        $migratorRepository->expects($this->once())
+            ->method('getMigrationBatches')
+            ->will($this->returnValue([
+                '2016_01_01_000000_create_users_table' => 1,
+                '2016_01_01_200000_create_flights_table' => 2,
+            ]));
+
+        $migrator = $this->createMock(Migrator::class);
+
+        $migrator->expects($this->once())
+            ->method('repositoryExists')
+            ->willReturn(true);
+
+        $migrator->expects($this->once())
+            ->method('paths')
+            ->willReturn([
+                __DIR__ . '/migrations/one',
+                __DIR__ . '/migrations/two',
+            ]);
+
+        $migrator->method('getMigrationName')
+            ->will($this->returnValueMap([
+                [__DIR__ . '/migrations/one/2016_01_01_000000_create_users_table.php', '2016_01_01_000000_create_users_table'],
+                [__DIR__ . '/migrations/one/2016_01_01_100000_create_password_resets_table.php', '2016_01_01_100000_create_password_resets_table'],
+                [__DIR__ . '/migrations/two/2016_01_01_200000_create_flights_table.php', '2016_01_01_200000_create_flights_table'],
+            ]));
+
+        $migrator->expects($this->once())
+            ->method('getMigrationFiles')
+            ->will($this->returnValue([
+                '2016_01_01_000000_create_users_table' => __DIR__ . '/migrations/one/2016_01_01_000000_create_users_table.php',
+                '2016_01_01_100000_create_password_resets_table' => __DIR__ . '/migrations/one/2016_01_01_100000_create_password_resets_table.php',
+                '2016_01_01_200000_create_flights_table' => __DIR__ . '/migrations/two/2016_01_01_200000_create_flights_table.php',
+            ]));
+
+        $migrator->expects($this->once())
+            ->method('setConnection');
+
+        $migrator->expects($this->atLeastOnce())
+            ->method('getRepository')
+            ->willReturn($migratorRepository);
+
+        $command = new StatusCommand($migrator);
+
+        $app = new ApplicationDatabaseStatusStub(['path.database' => __DIR__]);
+        $console = m::mock(ConsoleApplication::class)->makePartial();
+        $console->__construct();
+        $command->setLaravel($app);
+        $command->setApplication($console);
+
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            'command' => $command->getName(),
+        ]);
+
+        // the output of the command in the console
+        $output = $commandTester->getDisplay();
+
+        $this->assertEquals($expected, $output);
+    }
+}
+
+class ApplicationDatabaseStatusStub extends Application
+{
+    public function __construct(array $data = [])
+    {
+        foreach ($data as $abstract => $instance) {
+            $this->instance($abstract, $instance);
+        }
+    }
+
+    public function environment()
+    {
+        return 'development';
+    }
+}


### PR DESCRIPTION
First pull request so bear with me.

This relates to issue #24107 that I opened.

This PR uses the ran migrations and diffs with all the migration files to get any unran ones.

The resulting array thats passed to the table is ordered correctly by name and batch