### PR TITLE
[5.6] Create assertion to determine if a cookie is not expired

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -243,6 +243,29 @@ class TestResponse
     }
 
     /**
+     * Asserts that the response contains the given cookie and is not expired.
+     *
+     * @param  string  $cookieName
+     * @return $this
+     */
+    public function assertCookieNotExpired($cookieName)
+    {
+        PHPUnit::assertNotNull(
+            $cookie = $this->getCookie($cookieName),
+            "Cookie [{$cookieName}] not present on response."
+        );
+
+        $expiresAt = Carbon::createFromTimestamp($cookie->getExpiresTime());
+
+        PHPUnit::assertTrue(
+            $expiresAt->greaterThan(Carbon::now()),
+            "Cookie [{$cookieName}] is expired, it expired at [{$expiresAt}]."
+        );
+
+        return $this;
+    }
+
+    /**
      * Asserts that the response does not contains the given cookie.
      *
      * @param  string  $cookieName


### PR DESCRIPTION
As @JamesAnelay pointed out in #21793, an `assertCookieNotExpired` is useful for pre-assertion scenarios.

This new assertion will:

- Fail if the cookie is not present at all
- Fail if the cookie is present but expired
- Pass if the cookie is present and not expired