### PR TITLE
[5.6] Rename comparison validation rules ("gte" to "greater_than_or_equal", etc.)

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -249,7 +249,7 @@ trait ReplacesAttributes
     }
 
     /**
-     * Replace all place-holders for the greater_than rule.
+     * Replace all place-holders for the gt rule.
      *
      * @param  string  $message
      * @param  string  $attribute
@@ -257,13 +257,13 @@ trait ReplacesAttributes
      * @param  array   $parameters
      * @return string
      */
-    protected function replaceGreaterThan($message, $attribute, $rule, $parameters)
+    protected function replaceGt($message, $attribute, $rule, $parameters)
     {
         return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
     }
 
     /**
-     * Replace all place-holders for the less_than rule.
+     * Replace all place-holders for the lt rule.
      *
      * @param  string  $message
      * @param  string  $attribute
@@ -271,13 +271,13 @@ trait ReplacesAttributes
      * @param  array   $parameters
      * @return string
      */
-    protected function replaceLessThan($message, $attribute, $rule, $parameters)
+    protected function replaceLt($message, $attribute, $rule, $parameters)
     {
         return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
     }
 
     /**
-     * Replace all place-holders for the greater_than_or_equal rule.
+     * Replace all place-holders for the gte rule.
      *
      * @param  string  $message
      * @param  string  $attribute
@@ -285,13 +285,13 @@ trait ReplacesAttributes
      * @param  array   $parameters
      * @return string
      */
-    protected function replaceGreaterThanOrEqual($message, $attribute, $rule, $parameters)
+    protected function replaceGte($message, $attribute, $rule, $parameters)
     {
         return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
     }
 
     /**
-     * Replace all place-holders for the less_than_or_equal rule.
+     * Replace all place-holders for the lte rule.
      *
      * @param  string  $message
      * @param  string  $attribute
@@ -299,7 +299,7 @@ trait ReplacesAttributes
      * @param  array   $parameters
      * @return string
      */
-    protected function replaceLessThanOrEqual($message, $attribute, $rule, $parameters)
+    protected function replaceLte($message, $attribute, $rule, $parameters)
     {
         return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
     }

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -259,7 +259,7 @@ trait ReplacesAttributes
      */
     protected function replaceGreaterThan($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':value', $this->getSize($parameters[0], $parameters[0]), $message);
+        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
     }
 
     /**
@@ -273,7 +273,7 @@ trait ReplacesAttributes
      */
     protected function replaceLessThan($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':value', $this->getSize($parameters[0], $parameters[0]), $message);
+        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
     }
 
     /**
@@ -287,7 +287,7 @@ trait ReplacesAttributes
      */
     protected function replaceGreaterThanOrEqual($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':value', $this->getSize($parameters[0], $parameters[0]), $message);
+        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
     }
 
     /**
@@ -301,7 +301,7 @@ trait ReplacesAttributes
      */
     protected function replaceLessThanOrEqual($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':value', $this->getSize($parameters[0], $parameters[0]), $message);
+        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -249,6 +249,62 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the greater_than rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceGreaterThan($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':value', $this->getSize($parameters[0], $parameters[0]), $message);
+    }
+
+    /**
+     * Replace all place-holders for the less_than rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceLessThan($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':value', $this->getSize($parameters[0], $parameters[0]), $message);
+    }
+
+    /**
+     * Replace all place-holders for the greater_than_or_equal rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceGreaterThanOrEqual($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':value', $this->getSize($parameters[0], $parameters[0]), $message);
+    }
+
+    /**
+     * Replace all place-holders for the less_than_or_equal rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceLessThanOrEqual($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':value', $this->getSize($parameters[0], $parameters[0]), $message);
+    }
+
+    /**
      * Replace all place-holders for the required_if rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -834,13 +834,13 @@ trait ValidatesAttributes
      * @param  array   $parameters
      * @return bool
      */
-    public function validateGreaterThan($attribute, $value, $parameters)
+    public function validateGt($attribute, $value, $parameters)
     {
-        $this->requireParameterCount(1, $parameters, 'greater_than');
+        $this->requireParameterCount(1, $parameters, 'gt');
 
         $comparedToValue = $this->getValue($parameters[0]);
 
-        $this->shouldBeNumeric($attribute, 'GreaterThan');
+        $this->shouldBeNumeric($attribute, 'Gt');
 
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) > $parameters[0];
@@ -859,13 +859,13 @@ trait ValidatesAttributes
      * @param  array   $parameters
      * @return bool
      */
-    public function validateLessThan($attribute, $value, $parameters)
+    public function validateLt($attribute, $value, $parameters)
     {
-        $this->requireParameterCount(1, $parameters, 'less_than');
+        $this->requireParameterCount(1, $parameters, 'lt');
 
         $comparedToValue = $this->getValue($parameters[0]);
 
-        $this->shouldBeNumeric($attribute, 'LessThan');
+        $this->shouldBeNumeric($attribute, 'Lt');
 
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) < $parameters[0];
@@ -884,13 +884,13 @@ trait ValidatesAttributes
      * @param  array   $parameters
      * @return bool
      */
-    public function validateGreaterThanOrEqual($attribute, $value, $parameters)
+    public function validateGte($attribute, $value, $parameters)
     {
-        $this->requireParameterCount(1, $parameters, 'greater_than_or_equal');
+        $this->requireParameterCount(1, $parameters, 'gte');
 
         $comparedToValue = $this->getValue($parameters[0]);
 
-        $this->shouldBeNumeric($attribute, 'GreaterThanOrEqual');
+        $this->shouldBeNumeric($attribute, 'Gte');
 
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) >= $parameters[0];
@@ -909,13 +909,13 @@ trait ValidatesAttributes
      * @param  array   $parameters
      * @return bool
      */
-    public function validateLessThanOrEqual($attribute, $value, $parameters)
+    public function validateLte($attribute, $value, $parameters)
     {
-        $this->requireParameterCount(1, $parameters, 'less_than_or_equal');
+        $this->requireParameterCount(1, $parameters, 'lte');
 
         $comparedToValue = $this->getValue($parameters[0]);
 
-        $this->shouldBeNumeric($attribute, 'LessThanOrEqual');
+        $this->shouldBeNumeric($attribute, 'Lte');
 
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) <= $parameters[0];

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -834,11 +834,13 @@ trait ValidatesAttributes
      * @param  array   $parameters
      * @return bool
      */
-    public function validateGt($attribute, $value, $parameters)
+    public function validateGreaterThan($attribute, $value, $parameters)
     {
-        $this->requireParameterCount(1, $parameters, 'gt');
+        $this->requireParameterCount(1, $parameters, 'greater_than');
 
         $comparedToValue = $this->getValue($parameters[0]);
+
+        $this->shouldBeNumeric($attribute, 'GreaterThan');
 
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) > $parameters[0];
@@ -857,11 +859,13 @@ trait ValidatesAttributes
      * @param  array   $parameters
      * @return bool
      */
-    public function validateLt($attribute, $value, $parameters)
+    public function validateLessThan($attribute, $value, $parameters)
     {
-        $this->requireParameterCount(1, $parameters, 'lt');
+        $this->requireParameterCount(1, $parameters, 'less_than');
 
         $comparedToValue = $this->getValue($parameters[0]);
+
+        $this->shouldBeNumeric($attribute, 'LessThan');
 
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) < $parameters[0];
@@ -880,11 +884,13 @@ trait ValidatesAttributes
      * @param  array   $parameters
      * @return bool
      */
-    public function validateGte($attribute, $value, $parameters)
+    public function validateGreaterThanOrEqual($attribute, $value, $parameters)
     {
-        $this->requireParameterCount(1, $parameters, 'gte');
+        $this->requireParameterCount(1, $parameters, 'greater_than_or_equal');
 
         $comparedToValue = $this->getValue($parameters[0]);
+
+        $this->shouldBeNumeric($attribute, 'GreaterThanOrEqual');
 
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) >= $parameters[0];
@@ -903,11 +909,13 @@ trait ValidatesAttributes
      * @param  array   $parameters
      * @return bool
      */
-    public function validateLte($attribute, $value, $parameters)
+    public function validateLessThanOrEqual($attribute, $value, $parameters)
     {
-        $this->requireParameterCount(1, $parameters, 'lte');
+        $this->requireParameterCount(1, $parameters, 'less_than_or_equal');
 
         $comparedToValue = $this->getValue($parameters[0]);
+
+        $this->shouldBeNumeric($attribute, 'LessThanOrEqual');
 
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) <= $parameters[0];
@@ -1645,6 +1653,21 @@ trait ValidatesAttributes
     {
         if (gettype($first) != gettype($second)) {
             throw new InvalidArgumentException('The values under comparison must be of the same type');
+        }
+    }
+
+    /**
+     * Adds the existing rule to the numericRules array if the attribute's value is numeric.
+     *
+     * @param  string  $attribute
+     * @param  string  $rule
+     *
+     * @return void
+     */
+    protected function shouldBeNumeric($attribute, $rule)
+    {
+        if (is_numeric($this->getValue($attribute))) {
+            $this->numericRules[] = $rule;
         }
     }
 }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -175,14 +175,14 @@ class Validator implements ValidatorContract
      *
      * @var array
      */
-    protected $sizeRules = ['Size', 'Between', 'Min', 'Max'];
+    protected $sizeRules = ['Size', 'Between', 'Min', 'Max', 'Gt', 'Lt', 'Gte', 'Lte'];
 
     /**
      * The numeric related validation rules.
      *
      * @var array
      */
-    protected $numericRules = ['Numeric', 'Integer', 'Gt', 'Lt', 'Gte', 'Lte'];
+    protected $numericRules = ['Numeric', 'Integer'];
 
     /**
      * Create a new Validator instance.

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -175,7 +175,7 @@ class Validator implements ValidatorContract
      *
      * @var array
      */
-    protected $sizeRules = ['Size', 'Between', 'Min', 'Max', 'Gt', 'Lt', 'Gte', 'Lte'];
+    protected $sizeRules = ['Size', 'Between', 'Min', 'Max', 'greater_than', 'less_than', 'greater_than_or_equal', 'less_than_or_equal'];
 
     /**
      * The numeric related validation rules.

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -175,7 +175,7 @@ class Validator implements ValidatorContract
      *
      * @var array
      */
-    protected $sizeRules = ['Size', 'Between', 'Min', 'Max', 'GreaterThan', 'LessThan', 'GreaterThanOrEqual', 'LessThanOrEqual'];
+    protected $sizeRules = ['Size', 'Between', 'Min', 'Max', 'Gt', 'Lt', 'Gte', 'Lte'];
 
     /**
      * The numeric related validation rules.

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -175,7 +175,7 @@ class Validator implements ValidatorContract
      *
      * @var array
      */
-    protected $sizeRules = ['Size', 'Between', 'Min', 'Max', 'greater_than', 'less_than', 'greater_than_or_equal', 'less_than_or_equal'];
+    protected $sizeRules = ['Size', 'Between', 'Min', 'Max', 'GreaterThan', 'LessThan', 'GreaterThanOrEqual', 'LessThanOrEqual'];
 
     /**
      * The numeric related validation rules.

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1063,92 +1063,92 @@ class ValidationValidatorTest extends TestCase
     public function testGreaterThan()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'greater_than:rhs']);
+        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'greater_than:rhs']);
+        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'greater_than:rhs']);
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->fails());
 
         $fileOne = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(3151));
-        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'greater_than:rhs']);
+        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'greater_than:10']);
+        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'gt:10']);
         $this->assertTrue($v->passes());
     }
 
     public function testLessThan()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'less_than:rhs']);
+        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'less_than:rhs']);
+        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'less_than:rhs']);
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->passes());
 
         $fileOne = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(3151));
-        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'less_than:rhs']);
+        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'less_than:10']);
+        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'lt:10']);
         $this->assertTrue($v->fails());
     }
 
     public function testGreaterThanOrEqual()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 15], ['lhs' => 'greater_than_or_equal:rhs']);
+        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 15], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'greater_than_or_equal:rhs']);
+        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'greater_than_or_equal:rhs']);
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->fails());
 
         $fileOne = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(5472));
-        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'greater_than_or_equal:rhs']);
+        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'greater_than_or_equal:15']);
+        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'gte:15']);
         $this->assertTrue($v->passes());
     }
 
     public function testLessThanOrEqual()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 15], ['lhs' => 'less_than_or_equal:rhs']);
+        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 15], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'less_than_or_equal:rhs']);
+        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'less_than_or_equal:rhs']);
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->passes());
 
         $fileOne = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(5472));
-        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'less_than_or_equal:rhs']);
+        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'less_than_or_equal:10']);
+        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'lte:10']);
         $this->assertTrue($v->fails());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1063,92 +1063,92 @@ class ValidationValidatorTest extends TestCase
     public function testGreaterThan()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'gt:rhs']);
+        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'greater_than:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
+        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'greater_than:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gt:rhs']);
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'greater_than:rhs']);
         $this->assertTrue($v->fails());
 
         $fileOne = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(3151));
-        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gt:rhs']);
+        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'greater_than:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'gt:10']);
+        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'greater_than:10']);
         $this->assertTrue($v->passes());
     }
 
     public function testLessThan()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'lt:rhs']);
+        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'less_than:rhs']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'lt:rhs']);
+        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'less_than:rhs']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lt:rhs']);
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'less_than:rhs']);
         $this->assertTrue($v->passes());
 
         $fileOne = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(3151));
-        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lt:rhs']);
+        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'less_than:rhs']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'lt:10']);
+        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'less_than:10']);
         $this->assertTrue($v->fails());
     }
 
     public function testGreaterThanOrEqual()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 15], ['lhs' => 'gte:rhs']);
+        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 15], ['lhs' => 'greater_than_or_equal:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'gte:rhs']);
+        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'greater_than_or_equal:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gte:rhs']);
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'greater_than_or_equal:rhs']);
         $this->assertTrue($v->fails());
 
         $fileOne = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(5472));
-        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gte:rhs']);
+        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'greater_than_or_equal:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'gte:15']);
+        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'greater_than_or_equal:15']);
         $this->assertTrue($v->passes());
     }
 
     public function testLessThanOrEqual()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 15], ['lhs' => 'lte:rhs']);
+        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 15], ['lhs' => 'less_than_or_equal:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'lte:rhs']);
+        $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'less_than_or_equal:rhs']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lte:rhs']);
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'less_than_or_equal:rhs']);
         $this->assertTrue($v->passes());
 
         $fileOne = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(5472));
-        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lte:rhs']);
+        $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'less_than_or_equal:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'lte:10']);
+        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'less_than_or_equal:10']);
         $this->assertTrue($v->fails());
     }
 


### PR DESCRIPTION
This pull request introduces small modification to the newly added comparison validation rules (gt, lt, gte, lte) added previously in #24091  as follows:

First, it seems that people favour the long expressive form of the rules instead of the short names, therefore i changed the rules from gt to greater_than, lt to less_than, gte to greater_than_or_equal and lte to less_than_or_equal

Also, the previous implementation added the rules to the numericRules array in the Validator class by default which will cause strange output to the validation messages being translated always with the numeric type since the validation messages in the laravel/laravel repository will be something as follows: 

```
    'greater_than_or_equal'                  => [
        'numeric' => 'The :attribute must be greater than or equal :value.',
        'file'    => 'The :attribute must be greater than or equal :value kilobytes.',
        'string'  => 'The :attribute must be greater than or equal :value characters.',
        'array'   => 'The :attribute must have :value items or more.',
    ],
```

the proposed modification will add the current rule to the numeric rules if and only if the attribute under comparison is a passed numerical value, therefore the rule automatically detects if the attribute should be numeric or not instead of passing and additional numeric rule like that "Numeric|greater_than".

Finally, the PR add replacements methods for the place holders of the newly added rules.

