### PR TITLE
[5.6] Update php doc for `Pagination/AbstractPaginator.php:isEmpty`

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -483,7 +483,7 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
-     * Determine if the list of items is empty or not.
+     * Determine if the list of items is empty.
      *
      * @return bool
      */


### PR DESCRIPTION
 - in commit `f5932d78c50bd032f4878bd8401900f4cfbb3e4a` was added a isNotEmpty method, so isEmpty method should be used only for `Determine if the list of items is empty.` instead `Determine if the list of items is empty or not.`