### PR TITLE
[5.7] Custom Eloquent attribute casts

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1607,6 +1607,23 @@ class DatabaseEloquentModelTest extends TestCase
         $model->getAttributes();
     }
 
+    public function testModelAttributesCanUseCustomCasts()
+    {
+        EloquentModelCastingStub::extendCasts('foo', function ($value) {
+            return $value[0];
+        }, function ($value) {
+            return [$value, 'foo'];
+        });
+
+        $model = new EloquentModelCastingStub;
+        $model->fooAttribute = 'some_value';
+
+        $this->assertEquals('some_value', $model->fooAttribute);
+
+        $attributes = $model->getAttributes();
+        $this->assertEquals(['some_value', 'foo'], $attributes['fooAttribute']);
+    }
+
     public function testUpdatingNonExistentModelFails()
     {
         $model = new EloquentModelStub;
@@ -2048,6 +2065,7 @@ class EloquentModelCastingStub extends Model
         'dateAttribute' => 'date',
         'datetimeAttribute' => 'datetime',
         'timestampAttribute' => 'timestamp',
+        'fooAttribute' => 'foo',
     ];
 
     public function jsonAttributeValue()


### PR DESCRIPTION
I often feel the need to define an accessor/mutator combination when I want certain attributes to be automatically converted from and to a dedicated value object. Since this logic is reusable across various models but not necessarily on equal named attributes, I think the most clean way to implement this kind of functionality is when custom casts can be defined.

```php
class AppServiceProvider extends ServiceProvider
{
    public function boot()
    {
        Model::extendCasts('phoneObject', function($value) {
            // First closure is the accessor closure.
            return new Phone($value);
        }, function($value) {
            // Second closure is the mutator closure.
            return $value instanceof Phone ? $value->getNormalizedValue() : $value;
        });
}

class SomeModel extends Model
{
    protected $casts = [
        'someAttribute' => 'phoneObject',
    ];
}
```

Looking forward to your feedback.