### PR TITLE
[5.6] Remove automatic detection of numeric attributes for the newly added comparison rules.

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -77,6 +77,62 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the gt rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceGt($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
+    }
+
+    /**
+     * Replace all place-holders for the lt rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceLt($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
+    }
+
+    /**
+     * Replace all place-holders for the gte rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceGte($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
+    }
+
+    /**
+     * Replace all place-holders for the lte rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceLte($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
+    }
+
+    /**
      * Replace all place-holders for the min rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -182,7 +182,7 @@ class Validator implements ValidatorContract
      *
      * @var array
      */
-    protected $numericRules = ['Numeric', 'Integer', 'Gt', 'Lt', 'Gte', 'Lte'];
+    protected $numericRules = ['Numeric', 'Integer'];
 
     /**
      * Create a new Validator instance.

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1063,7 +1063,7 @@ class ValidationValidatorTest extends TestCase
     public function testGreaterThan()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'gt:rhs']);
+        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'numeric|gt:rhs']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
@@ -1079,14 +1079,14 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'gt:10']);
+        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gt:10']);
         $this->assertTrue($v->passes());
     }
 
     public function testLessThan()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'lt:rhs']);
+        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'numeric|lt:rhs']);
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'lt:rhs']);
@@ -1102,14 +1102,14 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'lt:10']);
+        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lt:10']);
         $this->assertTrue($v->fails());
     }
 
     public function testGreaterThanOrEqual()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 15], ['lhs' => 'gte:rhs']);
+        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 15], ['lhs' => 'numeric|gte:rhs']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'gte:rhs']);
@@ -1125,14 +1125,14 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'gte:15']);
+        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gte:15']);
         $this->assertTrue($v->passes());
     }
 
     public function testLessThanOrEqual()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 15], ['lhs' => 'lte:rhs']);
+        $v = new Validator($trans, ['lhs' => 15, 'rhs' => 15], ['lhs' => 'numeric|lte:rhs']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'lte:rhs']);
@@ -1148,7 +1148,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'lte:10']);
+        $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lte:10']);
         $this->assertTrue($v->fails());
     }
 


### PR DESCRIPTION
According to #24120 magical detection of numerics should be removed and also it implements the replacement placeholders for the rules
