### PR TITLE
[5.6] Add @canany and @elsecanany blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
@@ -27,6 +27,17 @@ trait CompilesAuthorizations
     }
 
     /**
+     * Compile the canany statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileCanany($expression)
+    {
+        return "<?php if (app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->any{$expression}): ?>";
+    }
+
+    /**
      * Compile the else-can statements into valid PHP.
      *
      * @param  string  $expression
@@ -49,6 +60,17 @@ trait CompilesAuthorizations
     }
 
     /**
+     * Compile the else-canany statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileElsecanany($expression)
+    {
+        return "<?php elseif (app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->any{$expression}): ?>";
+    }
+
+    /**
      * Compile the end-can statements into valid PHP.
      *
      * @return string
@@ -64,6 +86,16 @@ trait CompilesAuthorizations
      * @return string
      */
     protected function compileEndcannot()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
+     * Compile the end-canany statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndcanany()
     {
         return '<?php endif; ?>';
     }

--- a/tests/View/Blade/BladeCananyStatementsTest.php
+++ b/tests/View/Blade/BladeCananyStatementsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeCananyStatementsTest extends AbstractBladeTestCase
+{
+    public function testCananyStatementsAreCompiled()
+    {
+        $string = '@canany ([\'create\', \'update\'], [$post])
+breeze
+@elsecanany([\'delete\', \'approve\'], [$post])
+sneeze
+@endcan';
+        $expected = '<?php if (app(\\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->any([\'create\', \'update\'], [$post])): ?>
+breeze
+<?php elseif (app(\\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->any([\'delete\', \'approve\'], [$post])): ?>
+sneeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
There is a use case for authorization directive
```html
<table>
  <tr>
    <th>...</th>
    @canany(['edit_post', 'delete_post'])
    <th>Actions</th>
    @endcanany
  </tr>
  <tr>
    <td>...</td>
    @canany(['edit_post', 'delete_post'])
    <td>
      @can('edit_post')
      <button>Edit</button>
      @endcan
      @can('delete_post')
      <button>Delete</button>
      @endcan
    </td>
    @endcanany
  </tr>
</table>
```
------------------
I know I can implement it in `AppServiceProvider::boot()` using `Custom If Statements` as follow 
```php
Blade::if('canany', function ($abilities) {
    return app(\Illuminate\Contracts\Auth\Access\Gate::class)->any($abilities);
});
```

But I think it maybe helpful for others.