### PR TITLE
[5.7] Update the design of the list of commands in Artisan

### DIFF
--- a/src/Illuminate/Foundation/Console/ListCommand.php
+++ b/src/Illuminate/Foundation/Console/ListCommand.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\OutputStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Command\ListCommand as BaseListCommand;
+
+class ListCommand extends BaseListCommand
+{
+    /**
+     * The OutputStyle instance.
+     *
+     * @var \Illuminate\Console\OutputStyle|null
+     */
+    private $output;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($input->getOption('format') === 'txt' && ! $input->getOption('raw')) {
+            $this->output = new OutputStyle($input, $output);
+
+            $this->describeTitle()
+                ->describeUsage()
+                ->describeCommands();
+        } else {
+            parent::execute($input, $output);
+        }
+    }
+
+    /**
+     * Describes the application title.
+     *
+     * @return $this
+     */
+    protected function describeTitle()
+    {
+        $application = $this->getApplication();
+
+        $this->output->newLine();
+
+        $this->output->write(
+            "<fg=white;options=bold>{$application->getName()} </> <fg=green;options=bold>{$application->getVersion()}</>"
+        );
+
+        $this->output->newLine(2);
+
+        return $this;
+    }
+
+    /**
+     * Describes the application usage.
+     *
+     * @return $this
+     */
+    protected function describeUsage()
+    {
+        $binary = ARTISAN_BINARY;
+
+        $this->output->write("<fg=yellow;options=bold>USAGE:</> $binary <command> [options] [arguments]");
+
+        $this->output->newLine();
+
+        return $this;
+    }
+
+    /**
+     * Describes the application commands.
+     *
+     * @return $this
+     */
+    protected function describeCommands()
+    {
+        $width = 0;
+
+        $namespaces = collect($this->getApplication()->all())->filter(function ($command) {
+            return ! $command->isHidden();
+        })->groupBy(function ($command) use (&$width) {
+            $nameParts = explode(':', $name = $command->getName());
+            $width = max($width, mb_strlen($name));
+
+            return isset($nameParts[1]) ? $nameParts[0] : '';
+        })->sortKeys()->each(function ($commands) use ($width) {
+            $this->output->newLine();
+
+            foreach ($commands as $command) {
+                $this->output->write(sprintf(
+                    "  <fg=green>%s</>%s%s",
+                    $command->getName(),
+                    str_repeat(' ', $width - mb_strlen($command->getName()) + 1),
+                    $command->getDescription()
+                ));
+
+                $this->output->newLine();
+            }
+        });
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Foundation/Console/ListCommand.php
+++ b/src/Illuminate/Foundation/Console/ListCommand.php
@@ -89,7 +89,7 @@ class ListCommand extends BaseListCommand
 
             foreach ($commands as $command) {
                 $this->output->write(sprintf(
-                    "  <fg=green>%s</>%s%s",
+                    '  <fg=green>%s</>%s%s',
                     $command->getName(),
                     str_repeat(' ', $width - mb_strlen($command->getName()) + 1),
                     $command->getDescription()

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Queue\Console\TableCommand;
 use Illuminate\Auth\Console\AuthMakeCommand;
 use Illuminate\Foundation\Console\UpCommand;
 use Illuminate\Foundation\Console\DownCommand;
+use Illuminate\Foundation\Console\ListCommand;
 use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Foundation\Console\ServeCommand;
@@ -138,6 +139,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'ExceptionMake' => 'command.exception.make',
         'FactoryMake' => 'command.factory.make',
         'JobMake' => 'command.job.make',
+        'List' => 'command.list',
         'ListenerMake' => 'command.listener.make',
         'MailMake' => 'command.mail.make',
         'MiddlewareMake' => 'command.middleware.make',
@@ -431,10 +433,10 @@ class ArtisanServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function registerListenerMakeCommand()
+    protected function registerListCommand()
     {
-        $this->app->singleton('command.listener.make', function ($app) {
-            return new ListenerMakeCommand($app['files']);
+        $this->app->singleton('command.list', function () {
+            return new ListCommand();
         });
     }
 
@@ -443,6 +445,13 @@ class ArtisanServiceProvider extends ServiceProvider
      *
      * @return void
      */
+    protected function registerListenerMakeCommand()
+    {
+        $this->app->singleton('command.listener.make', function ($app) {
+            return new ListenerMakeCommand($app['files']);
+        });
+    }
+
     protected function registerMailMakeCommand()
     {
         $this->app->singleton('command.mail.make', function ($app) {


### PR DESCRIPTION
Hey 👋

This proposal addresses **modifications on the output of the artisan list command**.

> This proposal was already discussed in [https://github.com/laravel/ideas/issues/1148](https://github.com/laravel/ideas/issues/1148).

Currently, if you type `php artisan` the terminal will output this:

![screenshot 2018-05-01 18 20 40](https://user-images.githubusercontent.com/5457236/39481771-d68fe5b0-4d6c-11e8-837f-1efe292cb705.png)

**Proposal**: Perform minor modifications on the point 1 and point 2. Remove entirely the point 3 and remove subtitles ( the yellow text) from the point 4.

The end result will be:

![example-2](https://user-images.githubusercontent.com/5457236/39481843-166be8be-4d6d-11e8-9bfd-5e0e28be5442.png)

You can install the package [Laravel Console Summary](https://github.com/nunomaduro/laravel-console-summary) to see the end result locally in your machine. But I thought to perform a PR to the core with this exact same code instead of proposing the addition of a package.

**Tests**: I don't believe that we need tests on this PR.