### PR TITLE
[5.5] Allow Policies to work for unauthenticated calls

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -296,9 +296,7 @@ class Gate implements GateContract
      */
     protected function raw($ability, $arguments = [])
     {
-        if (! $user = $this->resolveUser()) {
-            return false;
-        }
+        $user = $this->resolveUser();
 
         $arguments = Arr::wrap($arguments);
 


### PR DESCRIPTION
This change is to allow Policies to be used for unauthenticated Users.  Currently, Gate.php will return false if the authenticated User does not resolve.  This means that the entire Policy concept cannot be used with internal clients or unauthenticated endpoints.

There are cases where we want un-authenticated users to be able to manipulate certain models, but only if they meet some requirements.  E.g. we have models that are created by un-authed Users before registration, and we want them to be able to manipulate them as long as they haven't been associated with a real User yet.

Regarding backward compatibility and not breaking lots of existing code, Policies written with `User $user` as a parameter will still fail because they won't accept null as a value.  Only if the Policy is updated to `User $user = null` will it allow an anonymous call to proceed.

Here is an example of another user trying to accomplish this:
https://laracasts.com/discuss/channels/laravel/user-laravel-policies-with-anonymous-users?page=1
