### PR TITLE
If the count passed to Pluralizer is 1, but the word is a plural, the singular form should be returned

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -64,8 +64,12 @@ class Pluralizer
      */
     public static function plural($value, $count = 2)
     {
-        if ((int) $count === 1 || static::uncountable($value)) {
+        if (static::uncountable($value)) {
             return $value;
+        }
+
+        if ((int) $count === 1) {
+            return static::singular($value);
         }
 
         $plural = Inflector::pluralize($value);

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -39,4 +39,11 @@ class SupportPluralizerTest extends TestCase
         $this->assertEquals('IndexFields', Str::plural('IndexField'));
         $this->assertEquals('VertexFields', Str::plural('VertexField'));
     }
+
+    public function testSingularIfPluralCountIsOne()
+    {
+        $this->assertEquals('child', Str::plural('children', 1));
+        $this->assertEquals('biscuit', Str::plural('biscuits', 1));
+        $this->assertEquals('accessory', Str::plural('accessories', 1));
+    }
 }


### PR DESCRIPTION
If the word passed into Pluralizer::plural is a plural word, and a count is passed with a value of 1, the value is returned unmanipulated - whereas it should be converted to the singular form of the word where possible

Added tests to assert that plural words are converted to their equivalent singular words if a count of 1 is passed to Pluralizer::plural