### PR TITLE
[5.6] RenameIndex support for migrations

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -303,6 +303,18 @@ class Blueprint
     }
 
     /**
+     * Indicate that the given indexes should be renamed.
+     *
+     * @param  string  $from
+     * @param  string  $to
+     * @return \Illuminate\Support\Fluent
+     */
+    public function renameIndex($from, $to)
+    {
+        return $this->addCommand('renameIndex', compact('from', 'to'));
+    }
+
+    /**
      * Indicate that the given primary key should be dropped.
      *
      * @param  string|array  $index

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -343,6 +343,22 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a rename index command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint $blueprint
+     * @param  \Illuminate\Support\Fluent $command
+     * @return string
+     */
+    public function compileRenameIndex(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf('alter table %s rename index %s to %s',
+            $this->wrapTable($blueprint),
+            $this->wrap($command->from),
+            $this->wrap($command->to)
+        );
+    }
+
+    /**
      * Compile the SQL needed to drop all tables.
      *
      * @param  array  $tables

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -311,6 +311,21 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a rename index command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint $blueprint
+     * @param  \Illuminate\Support\Fluent $command
+     * @return string
+     */
+    public function compileRenameIndex(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf('alter index %s rename to %s',
+            $this->wrap($command->from),
+            $this->wrap($command->to)
+        );
+    }
+
+    /**
      * Compile the command to enable foreign key constraints.
      *
      * @return string

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
-use Doctrine\DBAL\Schema\Index;
 use RuntimeException;
 use Illuminate\Support\Fluent;
+use Doctrine\DBAL\Schema\Index;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -322,7 +322,7 @@ class SQLiteGrammar extends Grammar
         $indexes = $schemaManager->listTableIndexes($this->getTablePrefix().$blueprint->getTable());
         $index = array_get($indexes, $command->from);
 
-        if(!$index) {
+        if (! $index) {
             throw new RuntimeException("Index '{$command->from}' doesn't seem to exist");
         }
 
@@ -334,7 +334,7 @@ class SQLiteGrammar extends Grammar
 
         return [
             $platform->getDropIndexSQL($command->from, $this->getTablePrefix().$blueprint->getTable()),
-            $platform->getCreateIndexSQL($newIndex, $this->getTablePrefix().$blueprint->getTable())
+            $platform->getCreateIndexSQL($newIndex, $this->getTablePrefix().$blueprint->getTable()),
         ];
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Doctrine\DBAL\Schema\Index;
 use RuntimeException;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Connection;
@@ -305,6 +306,36 @@ class SQLiteGrammar extends Grammar
         $from = $this->wrapTable($blueprint);
 
         return "alter table {$from} rename to ".$this->wrapTable($command->to);
+    }
+
+    /**
+     * Compile a rename index command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint $blueprint
+     * @param  \Illuminate\Support\Fluent $command
+     * @param  \Illuminate\Database\Connection $connection
+     * @return array
+     */
+    public function compileRenameIndex(Blueprint $blueprint, Fluent $command, Connection $connection)
+    {
+        $schemaManager = $connection->getDoctrineSchemaManager();
+        $indexes = $schemaManager->listTableIndexes($this->getTablePrefix().$blueprint->getTable());
+        $index = array_get($indexes, $command->from);
+
+        if(!$index) {
+            throw new RuntimeException("Index '{$command->from}' doesn't seem to exist");
+        }
+
+        /** @var \Doctrine\DBAL\Schema\Index $index */
+        $newIndex = new Index($command->to, $index->getColumns(), $index->isUnique(), $index->isPrimary(),
+            $index->getFlags(), $index->getOptions());
+
+        $platform = $schemaManager->getDatabasePlatform();
+
+        return [
+            $platform->getDropIndexSQL($command->from, $this->getTablePrefix().$blueprint->getTable()),
+            $platform->getCreateIndexSQL($newIndex, $this->getTablePrefix().$blueprint->getTable())
+        ];
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -287,7 +287,7 @@ class SqlServerGrammar extends Grammar
     public function compileRenameIndex(Blueprint $blueprint, Fluent $command)
     {
         return sprintf("sp_rename N'%s', %s, N'INDEX'",
-            $this->wrap($blueprint->getTable() . '.' . $command->from),
+            $this->wrap($blueprint->getTable().'.'.$command->from),
             $this->wrap($command->to)
         );
     }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -278,6 +278,21 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile a rename index command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint $blueprint
+     * @param  \Illuminate\Support\Fluent $command
+     * @return string
+     */
+    public function compileRenameIndex(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf("sp_rename N'%s', %s, N'INDEX'",
+            $this->wrap($blueprint->getTable() . '.' . $command->from),
+            $this->wrap($command->to)
+        );
+    }
+
+    /**
      * Compile the command to enable foreign key constraints.
      *
      * @return string

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -279,6 +279,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('rename table `users` to `foo`', $statements[0]);
     }
 
+    public function testRenameIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->renameIndex('foo', 'bar');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` rename index `foo` to `bar`', $statements[0]);
+    }
+
     public function testAddingPrimaryKey()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -194,6 +194,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" rename to "foo"', $statements[0]);
     }
 
+    public function testRenameIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->renameIndex('foo', 'bar');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter index "foo" rename to "bar"', $statements[0]);
+    }
+
     public function testAddingPrimaryKey()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -142,6 +142,47 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" rename to "foo"', $statements[0]);
     }
 
+    public function testRenameIndex()
+    {
+        if (! class_exists('Doctrine\DBAL\Schema\SqliteSchemaManager')) {
+            $this->markTestSkipped('Doctrine should be installed to run renameIndex tests');
+        }
+
+        $db = new \Illuminate\Database\Capsule\Manager;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => 'prefix_',
+        ]);
+
+        $schema = $db->getConnection()->getSchemaBuilder();
+
+        $schema->create('users', function (Blueprint $table) {
+            $table->string('name');
+            $table->string('email');
+        });
+
+        $schema->table('users', function (Blueprint $table) {
+            $table->index(['name', 'email'], 'index1');
+        });
+
+        $manager = $db->getConnection()->getDoctrineSchemaManager();
+        $details = $manager->listTableDetails('prefix_users');
+        $this->assertTrue($details->hasIndex('index1'));
+        $this->assertFalse($details->hasIndex('index2'));
+
+        $schema->table('users', function (Blueprint $table) {
+            $table->renameIndex('index1', 'index2');
+        });
+
+        $details = $manager->listTableDetails('prefix_users');
+        $this->assertFalse($details->hasIndex('index1'));
+        $this->assertTrue($details->hasIndex('index2'));
+
+        $this->assertEquals(['name', 'email'], $details->getIndex('index2')->getUnquotedColumns());
+    }
+
     public function testAddingPrimaryKey()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -116,6 +116,5 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         ];
 
         $this->assertEquals($expected, $queries);
-
     }
 }

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -204,6 +204,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('sp_rename "users", "foo"', $statements[0]);
     }
 
+    public function testRenameIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->renameIndex('foo', 'bar');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('sp_rename N\'"users"."foo"\', "bar", N\'INDEX\'', $statements[0]);
+    }
+
     public function testAddingPrimaryKey()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
As described here: https://github.com/laravel/ideas/issues/443 and as suggested by @tomschlick [here](https://github.com/laravel/ideas/issues/443#issuecomment-283739240), opening a PR for migration call to rename index (`->renameIndex('from', 'to')`).

Additionally tested on local installations of *MySQL, Postgres, MS SQL* - those support renaming indexes. 

*SQLite* doesn't support renaming indexes (as is correctly pointed in https://github.com/laravel/ideas/issues/443), so I'm using Doctrine and its `getRenameIndexSQL`, unfortunately it's `protected`, so basically, I've copied the implementation (this is from Doctrine's source): 

```php
protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
{
    return [
        $this->getDropIndexSQL($oldIndexName, $tableName),
        $this->getCreateIndexSQL($index, $tableName)
    ];
}
```

So, for SQLite  it's drop and re-create (and requires Doctrine), for others - it's native calls.

(Edit: wrong code snippet)