### PR TITLE
[5.2] Adds is_null check to Eloquent Builder callScope #19381

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1182,7 +1182,7 @@ class Builder
         // We will keep track of how many wheres are on the query before running the
         // scope so that we can properly group the added scope constraints in the
         // query as their own isolated nested where statement and avoid issues.
-        $originalWhereCount = count($query->wheres);
+        $originalWhereCount = is_null($query->wheres) ? 0 : count($query->wheres);
 
         $result = call_user_func_array($scope, $parameters) ?: $this;
 


### PR DESCRIPTION
This fixes #19380 by adding an is_null check before calling count() and defaulting to 0 if it is null.