### PR TITLE
[5.6] Fix failed returning Responsable from Middleware

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -5,6 +5,7 @@ namespace Illuminate\Pipeline;
 use Closure;
 use RuntimeException;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\Pipeline\Pipeline as PipelineContract;
 
 class Pipeline implements PipelineContract
@@ -145,9 +146,12 @@ class Pipeline implements PipelineContract
                     $parameters = [$passable, $stack];
                 }
 
-                return method_exists($pipe, $this->method)
+                $response = method_exists($pipe, $this->method)
                                 ? $pipe->{$this->method}(...$parameters)
                                 : $pipe(...$parameters);
+
+                return $response instanceof Responsable ?
+                    $response->toResponse(request()) : $response;
             };
         };
     }

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -97,7 +97,9 @@ class Pipeline implements PipelineContract
     public function then(Closure $destination)
     {
         $pipeline = array_reduce(
-            array_reverse($this->pipes), $this->carry(), $this->prepareDestination($destination)
+            array_reverse($this->pipes),
+            $this->carry(),
+            $this->prepareDestination($destination)
         );
 
         return $pipeline($this->passable);
@@ -130,7 +132,7 @@ class Pipeline implements PipelineContract
                     // otherwise we'll resolve the pipes out of the container and call it with
                     // the appropriate method and arguments, returning the results back out.
                     return $pipe($passable, $stack);
-                } elseif (! is_object($pipe)) {
+                } elseif (!is_object($pipe)) {
                     list($name, $parameters) = $this->parsePipeString($pipe);
 
                     // If the pipe is a string we will parse the string and resolve the class out
@@ -151,7 +153,7 @@ class Pipeline implements PipelineContract
                     : $pipe(...$parameters);
 
                 return $response instanceof Responsable
-                    ? $response->toResponse(request())
+                    ? $response->toResponse($this->container->make('Illuminate\Http\Request'))
                     : $response;
             };
         };
@@ -182,7 +184,7 @@ class Pipeline implements PipelineContract
      */
     protected function getContainer()
     {
-        if (! $this->container) {
+        if (!$this->container) {
             throw new RuntimeException('A container instance has not been passed to the Pipeline.');
         }
 

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -132,7 +132,7 @@ class Pipeline implements PipelineContract
                     // otherwise we'll resolve the pipes out of the container and call it with
                     // the appropriate method and arguments, returning the results back out.
                     return $pipe($passable, $stack);
-                } elseif (!is_object($pipe)) {
+                } elseif (! is_object($pipe)) {
                     list($name, $parameters) = $this->parsePipeString($pipe);
 
                     // If the pipe is a string we will parse the string and resolve the class out
@@ -184,7 +184,7 @@ class Pipeline implements PipelineContract
      */
     protected function getContainer()
     {
-        if (!$this->container) {
+        if (! $this->container) {
             throw new RuntimeException('A container instance has not been passed to the Pipeline.');
         }
 

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -147,11 +147,12 @@ class Pipeline implements PipelineContract
                 }
 
                 $response = method_exists($pipe, $this->method)
-                                ? $pipe->{$this->method}(...$parameters)
-                                : $pipe(...$parameters);
+                    ? $pipe->{$this->method}(...$parameters)
+                    : $pipe(...$parameters);
 
-                return $response instanceof Responsable ?
-                    $response->toResponse(request()) : $response;
+                return $response instanceof Responsable
+                    ? $response->toResponse(request())
+                    : $response;
             };
         };
     }

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -125,7 +125,7 @@ class PipelineTest extends TestCase
 
         $result = (new Pipeline(new \Illuminate\Container\Container))
             ->send('foo')
-            ->through('Illuminate\Tests\Pipeline\PipelineTestParameterPipe:' . implode(',', $parameters))
+            ->through('Illuminate\Tests\Pipeline\PipelineTestParameterPipe:'.implode(',', $parameters))
             ->then(function ($piped) {
                 return $piped;
             });

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Pipeline;
 
 use PHPUnit\Framework\TestCase;
 use Illuminate\Pipeline\Pipeline;
+use Illuminate\Contracts\Support\Responsable;
 
 class PipelineTest extends TestCase
 {
@@ -26,8 +27,7 @@ class PipelineTest extends TestCase
         $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
         $this->assertEquals('foo', $_SERVER['__test.pipe.two']);
 
-        unset($_SERVER['__test.pipe.one']);
-        unset($_SERVER['__test.pipe.two']);
+        unset($_SERVER['__test.pipe.one'], $_SERVER['__test.pipe.two']);
     }
 
     public function testPipelineUsageWithObjects()
@@ -60,6 +60,23 @@ class PipelineTest extends TestCase
         $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
 
         unset($_SERVER['__test.pipe.one']);
+    }
+
+    public function testPipelineUsageWithResponsableObjects()
+    {
+        $result = (new Pipeline(new \Illuminate\Container\Container))
+            ->send('foo')
+            ->through([new PipelineTestPipeResponsable])
+            ->then(
+                function ($piped) {
+                    return $piped;
+                }
+            );
+
+        $this->assertEquals('bar', $result);
+        $this->assertEquals('foo', $_SERVER['__test.pipe.responsable']);
+
+        unset($_SERVER['__test.pipe.responsable']);
     }
 
     public function testPipelineUsageWithCallable()
@@ -108,7 +125,7 @@ class PipelineTest extends TestCase
 
         $result = (new Pipeline(new \Illuminate\Container\Container))
             ->send('foo')
-            ->through('Illuminate\Tests\Pipeline\PipelineTestParameterPipe:'.implode(',', $parameters))
+            ->through('Illuminate\Tests\Pipeline\PipelineTestParameterPipe:' . implode(',', $parameters))
             ->then(function ($piped) {
                 return $piped;
             });
@@ -160,6 +177,14 @@ class PipelineTestPipeOne
     }
 }
 
+class PipeResponsable implements Responsable
+{
+    public function toResponse($request)
+    {
+        return 'bar';
+    }
+}
+
 class PipelineTestPipeTwo
 {
     public function __invoke($piped, $next)
@@ -167,6 +192,16 @@ class PipelineTestPipeTwo
         $_SERVER['__test.pipe.one'] = $piped;
 
         return $next($piped);
+    }
+}
+
+class PipelineTestPipeResponsable
+{
+    public function handle($piped, $next)
+    {
+        $_SERVER['__test.pipe.responsable'] = $piped;
+
+        return new PipeResponsable;
     }
 }
 


### PR DESCRIPTION
When we return Implementation of Responsable from middleware it fails.

Fixes #24156 

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
