### PR TITLE
[5.6] Add Collection::loadMissing()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -44,7 +44,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationships onto the collection.
      *
-     * @param  mixed  $relations
+     * @param  array|string  $relations
      * @return $this
      */
     public function load($relations)
@@ -84,6 +84,62 @@ class Collection extends BaseCollection implements QueueableCollection
             });
 
         return $this;
+    }
+
+    /**
+     * Load a set of relationships onto the collection if they are not already eager loaded.
+     *
+     * @param  array|string  $relations
+     * @return $this
+     */
+    public function loadMissing($relations)
+    {
+        if (is_string($relations)) {
+            $relations = func_get_args();
+        }
+
+        foreach ($relations as $relation) {
+            $this->loadMissingRelation($this, explode('.', $relation));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Load a relationship path if it is not already eager loaded.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  array  $path
+     * @return void
+     */
+    protected function loadMissingRelation(Collection $models, array $path)
+    {
+        // Get the first relationship.
+        $relation = array_shift($path);
+
+        // Handle relationships with specific columns.
+        $name = explode(':', $relation)[0];
+
+        // Load the relationship where missing.
+        $models->filter(function ($model) use ($name) {
+            return ! is_null($model) && ! $model->relationLoaded($name);
+        })->load($relation);
+
+        // End the recursion.
+        if (empty($path)) {
+            return;
+        }
+
+        // Get the models for the next level.
+        $models = $models->pluck($name);
+
+        // Handle *-many relationships.
+        if ($models->first() instanceof BaseCollection) {
+            $models = $models->collapse();
+        };
+
+        // Load the remaining path.
+        $this->loadMissingRelation(new static($models), $path);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -136,7 +136,7 @@ class Collection extends BaseCollection implements QueueableCollection
         // Handle *-many relationships.
         if ($models->first() instanceof BaseCollection) {
             $models = $models->collapse();
-        };
+        }
 
         // Load the remaining path.
         $this->loadMissingRelation(new static($models), $path);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -405,9 +405,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $relations = is_string($relations) ? func_get_args() : $relations;
 
-        return $this->load(array_filter($relations, function ($relation) {
-            return ! $this->relationLoaded($relation);
-        }));
+        $this->newCollection([$this])->loadMissing($relations);
+
+        return $this;
     }
 
     /**

--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentCollectionLoadMissingTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentCollectionLoadMissingTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id');
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('parent_id')->nullable();
+            $table->unsignedInteger('post_id');
+        });
+
+        Schema::create('revisions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('comment_id');
+        });
+
+        User::create();
+
+        Post::create(['user_id' => 1]);
+
+        Comment::create(['parent_id' => null, 'post_id' => 1]);
+        Comment::create(['parent_id' => 1, 'post_id' => 1]);
+
+        Revision::create(['comment_id' => 1]);
+    }
+
+    public function testLoadMissing()
+    {
+        $posts = Post::with('comments', 'user')->get();
+
+        \DB::enableQueryLog();
+
+        $posts->loadMissing('comments.parent:id.revisions', 'user:id');
+
+        $this->assertCount(2, \DB::getQueryLog());
+        $this->assertTrue($posts[0]->comments[0]->relationLoaded('parent'));
+        $this->assertTrue($posts[0]->comments[1]->parent->relationLoaded('revisions'));
+        $this->assertFalse(array_key_exists('post_id', $posts[0]->comments[1]->parent->getAttributes()));
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = ['id'];
+
+    public function parent() {
+        return $this->belongsTo(Comment::class);
+    }
+
+    public function revisions() {
+        return $this->hasMany(Revision::class);
+    }
+}
+
+class Post extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = ['id'];
+
+    public function comments() {
+        return $this->hasMany(Comment::class);
+    }
+
+    public function user() {
+        return $this->belongsTo(User::class);
+    }
+}
+
+class Revision extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = ['id'];
+}
+
+class User extends Model
+{
+    public $timestamps = false;
+}

--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -67,11 +67,13 @@ class Comment extends Model
 
     protected $guarded = ['id'];
 
-    public function parent() {
+    public function parent()
+    {
         return $this->belongsTo(Comment::class);
     }
 
-    public function revisions() {
+    public function revisions()
+    {
         return $this->hasMany(Revision::class);
     }
 }
@@ -82,11 +84,13 @@ class Post extends Model
 
     protected $guarded = ['id'];
 
-    public function comments() {
+    public function comments()
+    {
         return $this->hasMany(Comment::class);
     }
 
-    public function user() {
+    public function user()
+    {
         return $this->belongsTo(User::class);
     }
 }

--- a/tests/Integration/Database/EloquentModelLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMissingTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelLoadMissingTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentModelLoadMissingTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('parent_id')->nullable();
+            $table->unsignedInteger('post_id');
+        });
+
+        Post::create();
+
+        Comment::create(['parent_id' => null, 'post_id' => 1]);
+        Comment::create(['parent_id' => 1, 'post_id' => 1]);
+    }
+
+    public function testLoadMissing()
+    {
+        $post = Post::with('comments')->first();
+
+        \DB::enableQueryLog();
+
+        $post->loadMissing('comments.parent');
+
+        $this->assertCount(1, \DB::getQueryLog());
+        $this->assertTrue($post->comments[0]->relationLoaded('parent'));
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = ['id'];
+
+    public function parent() {
+        return $this->belongsTo(Comment::class);
+    }
+}
+
+class Post extends Model
+{
+    public $timestamps = false;
+
+    public function comments() {
+        return $this->hasMany(Comment::class);
+    }
+}

--- a/tests/Integration/Database/EloquentModelLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMissingTest.php
@@ -51,7 +51,8 @@ class Comment extends Model
 
     protected $guarded = ['id'];
 
-    public function parent() {
+    public function parent()
+    {
         return $this->belongsTo(Comment::class);
     }
 }
@@ -60,7 +61,8 @@ class Post extends Model
 {
     public $timestamps = false;
 
-    public function comments() {
+    public function comments()
+    {
         return $this->hasMany(Comment::class);
     }
 }


### PR DESCRIPTION
We currently have `Model::loadMissing()`, which can only handle non-nested relationships and doesn't fully support loading specific columns.

This PR adds `Collection::loadMissing()`:

    $posts = Post::with('comments')->get();
    $posts->loadMissing('comments.parent');

The shortest way (I know) to achieve the same right now:

    (new \Illuminate\Database\Eloquent\Collection($posts->pluck('comments')->collapse()))->load('parent');

`Collection::loadMissing()` fully supports nested relationships and loading specific columns. There's no support for closures yet (`Model::loadMissing()` doesn't support closures either).

We can use it to bring the same features to `Model::loadMissing()`.

I added integration tests for both methods.

Fixes #23027 and #24121.