### PR TITLE
[5.7] Improve the return value of the caseKey method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -492,14 +492,17 @@ trait InteractsWithPivotTable
     }
 
     /**
-     * Cast the given key to an integer if it is numeric.
+     * Cast the given key to convert to primary key type.
      *
      * @param  mixed  $key
      * @return mixed
      */
     protected function castKey($key)
     {
-        return is_numeric($key) ? (int) $key : (string) $key;
+        return $this->getTypeSwapValue(
+            $this->related->getKeyType(),
+            $key
+        );
     }
 
     /**
@@ -513,5 +516,29 @@ trait InteractsWithPivotTable
         return $this->using
                     ? $this->newPivot()->fill($attributes)->getAttributes()
                     : $attributes;
+    }
+
+    /**
+     * Converts a given value to a given type value.
+     *
+     * @param  string $type
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function getTypeSwapValue($type, $value)
+    {
+        switch (strtolower($type)) {
+            case 'int':
+            case 'integer':
+                return (int) $value;
+            case 'real':
+            case 'float':
+            case 'double':
+                return (float) $value;
+            case 'string':
+                return (string) $value;
+            default:
+                return $value;
+        }
     }
 }

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
+{
+    public function setUp()
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+        });
+
+        $this->schema()->create('articles', function ($table) {
+            $table->string('id');
+            $table->string('title');
+
+            $table->primary('id');
+        });
+
+        $this->schema()->create('article_user', function ($table) {
+            $table->string('article_id');
+            $table->foreign('article_id')->references('id')->on('articles');
+            $table->integer('user_id')->unsigned();
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('articles');
+        $this->schema()->drop('article_user');
+    }
+
+    /**
+     * Helpers...
+     */
+    protected function seedData()
+    {
+        BelongsToManySyncTestTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        BelongsToManySyncTestTestArticle::insert([
+            ['id' => '7b7306ae-5a02-46fa-a84c-9538f45c7dd4', 'title' => 'uuid title'],
+            ['id' => (string)(PHP_INT_MAX+1), 'title' => 'Another title'],
+            ['id' => '1', 'title' => 'Another title']
+        ]);
+    }
+
+    public function testSyncReturnValueType()
+    {
+        $this->seedData();
+
+
+        $user = BelongsToManySyncTestTestUser::query()->first();
+        $articleIDs = BelongsToManySyncTestTestArticle::all()->pluck('id')->toArray();
+
+        $changes = $user->articles()->sync($articleIDs);
+
+        collect($changes['attached'])->map(function ($id) {
+           $this->assertTrue(gettype($id) === (new BelongsToManySyncTestTestArticle)->getKeyType());
+        });
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+class BelongsToManySyncTestTestUser extends Eloquent
+{
+    protected $table = 'users';
+    protected $fillable = ['id', 'email'];
+    public $timestamps = false;
+
+    public function articles()
+    {
+        return $this->belongsToMany(BelongsToManySyncTestTestArticle::class, 'article_user', 'user_id', 'article_id');
+    }
+}
+
+
+class BelongsToManySyncTestTestArticle extends Eloquent
+{
+    protected $table = 'articles';
+    protected $keyType = 'string';
+    public $incrementing = false;
+    public $timestamps = false;
+    protected $fillable = ['id', 'title'];
+}


### PR DESCRIPTION
* this PR is for improving  the return value of the caseKey method
* The castkey method should have returned the value of the primary key type, rather than judging by the is_number or is_string method
## Example
```
class User extends Eloquent
{
    protected $table = 'users';
    protected $fillable = ['id', 'email'];
    public $timestamps = false;

    public function articles()
    {
        return $this->belongsToMany(Article::class, 'article_user', 'user_id', 'article_id');
    }
}
class Article extends Eloquent
{
    protected $table = 'articles';
    protected $keyType = 'string';
    public $incrementing = false;
    public $timestamps = false;
    protected $fillable = ['id', 'title'];
}
## users
---------------------------------------------------   
id 
1  
## articles
id      
---------------------------------------------------                                                            
123                                                              
7b7306ae-5a02-46fa-a84c-9538f45c7dd4 
(string)PHP_INT_MAX+1                             
```
* In the past, I have set the primary key type of the Article model to string, but if I insert an integer overflow number through`$user->articles()->sync(), I can successfully insert the data, but if the type of the return value is a long numeric string, Will not get the right results.