### PR TITLE
[5.7] Improve the retry jobs command

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -96,7 +96,7 @@ class Command extends SymfonyCommand
     {
         // If the command has a staticSignature propriety we would
         // need to generate the command signature dynamically
-        if (isset($this->staticSignature)) {
+        if (isset($this->staticSignature) && isset($this->dynamicParameters)) {
             $dynamicPart = '';
             foreach ($this->dynamicParameters as $parameter => $description) {
                 $dynamicPart .= $description ? "{--{$parameter}= : {$description}}" : "{--{$parameter}=}";

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -94,16 +94,15 @@ class Command extends SymfonyCommand
      */
     public function __construct()
     {
-        // If the command has a staticSignature propriety we would 
+        // If the command has a staticSignature propriety we would
         // need to generate the command signature dynamically
-        if(isset($this->staticSignature)) {
-            $dynamicPart = "";
+        if (isset($this->staticSignature)) {
+            $dynamicPart = '';
             foreach ($this->dynamicParameters as $parameter => $description) {
                 $dynamicPart .= $description ? "{--{$parameter}= : {$description}}" : "{--{$parameter}=}";
             }
             $this->signature = "{$this->staticSignature} {$dynamicPart}";
         }
-        
         // We will go ahead and set the name, description, and parameters on console
         // commands just to make things a little easier on the developer. This is
         // so they don't have to all be manually specified in the constructors.

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -94,6 +94,16 @@ class Command extends SymfonyCommand
      */
     public function __construct()
     {
+        // If the command has a staticSignature propriety we would 
+        // need to generate the command signature dynamically
+        if(isset($this->staticSignature)) {
+            $dynamicPart = "";
+            foreach ($this->dynamicParameters as $parameter => $description) {
+                $dynamicPart .= $description ? "{--{$parameter}= : {$description}}" : "{--{$parameter}=}";
+            }
+            $this->signature = "{$this->staticSignature} {$dynamicPart}";
+        }
+        
         // We will go ahead and set the name, description, and parameters on console
         // commands just to make things a little easier on the developer. This is
         // so they don't have to all be manually specified in the constructors.

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -8,11 +8,24 @@ use Illuminate\Console\Command;
 class RetryCommand extends Command
 {
     /**
-     * The console command signature.
+     * The console command static part of its signature.
      *
      * @var string
      */
-    protected $signature = 'queue:retry {--id= : The ID of the failed job or "all" to retry all jobs.} {--queue=} {--id_from=} {--id_to=} {--failed_at_from=} {--failed_at_to=}';
+    protected $staticSignature = "queue:retry";
+
+     /**
+     * The console command dynamic part of its signature.
+     *
+     * @var string
+     */
+    protected $dynamicParameters = ['id' => "The ID of the failed job or 'all' to retry all jobs.",
+                                    'queue' => 'retry only the jobs that were in this queue.',
+                                    'id_from' => 'retry jobs that have and ID greater than or equals to id_from.',
+                                    'id_to' => 'retry jobs that have and ID greater than or equals to id_to.',
+                                    'failed_at_from' => 'retry jobs that have failed after this date.',
+                                    'failed_at_to' => 'retry jobs that have failed before this date.',
+                                    ];
 
     /**
      * The console command description.

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -12,9 +12,9 @@ class RetryCommand extends Command
      *
      * @var string
      */
-    protected $staticSignature = "queue:retry";
+    protected $staticSignature = 'queue:retry';
 
-     /**
+    /**
      * The console command dynamic part of its signature.
      *
      * @var string

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -28,6 +28,18 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
      */
     protected $table;
 
+    protected $query;
+
+    protected $filters = [
+                            'queue'             => ['filter_name' => 'queue', 'operator' => '='],
+                            'id_from'           => ['filter_name' => 'id', 'operator' => '>='],
+                            'id_to'             => ['filter_name' => 'id', 'operator' => '<'],
+                            'failed_at_from'    => ['filter_name' => 'failed_at', 'operator' => '>='],
+                            'failed_at_to'      => ['filter_name' => 'failed_at', 'operator' => '<'],
+                        ];
+
+    protected $filtrationOptions = ['queue', 'id_from', 'id_to', 'failed_at_from', 'failed_at_to'];
+
     /**
      * Create a new database failed job provider.
      *
@@ -113,5 +125,25 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
     protected function getTable()
     {
         return $this->resolver->connection($this->database)->table($this->table);
+    }
+
+    public function filter($options)
+    {
+        $this->query = $this->getTable();
+        foreach ($options as $option => $value) {
+            $this->query = $this->query->where($this->filters[$option]['filter_name'], $this->filters[$option]['operator'], $value);
+        }
+
+        return $this;
+    }
+
+    public function get()
+    {
+        return $this->query->orderBy('id', 'desc')->get();
+    }
+
+    public function getFiltrationOptions()
+    {
+        return $this->filtrationOptions;
     }
 }

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -44,4 +44,11 @@ interface FailedJobProviderInterface
      * @return void
      */
     public function flush();
+
+    /**
+     * get all the options we can filter the failed jobs with
+     *
+     * @return array
+     */
+    public function getFiltrationOptions();
 }

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -46,7 +46,7 @@ interface FailedJobProviderInterface
     public function flush();
 
     /**
-     * get all the options we can filter the failed jobs with
+     * get all the options we can filter the failed jobs with.
      *
      * @return array
      */

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -46,7 +46,7 @@ interface FailedJobProviderInterface
     public function flush();
 
     /**
-     * get all the options we can filter the failed jobs with.
+     * Get all the options we can filter the failed jobs with.
      *
      * @return array
      */

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -61,7 +61,7 @@ class NullFailedJobProvider implements FailedJobProviderInterface
     }
 
     /**
-     * get all the options we can filter the failed jobs with
+     * get all the options we can filter the failed jobs with.
      *
      * @return array
      */

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -59,4 +59,14 @@ class NullFailedJobProvider implements FailedJobProviderInterface
     {
         //
     }
+
+    /**
+     * get all the options we can filter the failed jobs with
+     *
+     * @return array
+     */
+    public function getFiltrationOptions()
+    {
+        return [];
+    }
 }


### PR DESCRIPTION
this PR is for improving the retry jobs command

the goal is to be able to retry jobs with more flexibility/filters

for instance, it would be possible to retry all the failed jobs that belong to a certain queue, or all the failed jobs that failed before/after a specific date/id, and it will be also possible to combine multiple filters at once

Examples:
- retry all failed jobs after a specific date:
`php artisan queue:retry --failed_at_from="2018-05-09 17:21:20"`

- retry all failed jobs before a specific date:
`php artisan queue:retry --failed_at_to="2018-05-09 17:30:00"`

- retry all failed jobs between an interval:
`php artisan queue:retry --failed_at_from="2018-05-09 17:21:20" --failed_at_to="2018-05-09 17:30:00"`
- retry all failed jobs that belongs to a specific queue:
`php artisan queue:retry --queue=jobs`

- retry all failed jobs that belongs to a specific queue and that failed after a specific date:
`php artisan queue:retry --queue=jobs  --failed_at_from="2018-05-09 17:21:20"`

- retry all failed jobs with an ID >= 40:
`php artisan queue:retry --id_from=40`

![image](https://user-images.githubusercontent.com/1019873/39832735-ef8afa92-53bf-11e8-9c30-e59dff17e482.png)

![image](https://user-images.githubusercontent.com/1019873/39832756-feccb810-53bf-11e8-87cd-86cf25ba9694.png)
