### PR TITLE
[5.6] Match Eloquent's where() method signature with Builder::where()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -211,8 +211,8 @@ class Builder
      * Add a basic where clause to the query.
      *
      * @param  string|array|\Closure  $column
-     * @param  string  $operator
-     * @param  mixed  $value
+     * @param  mixed   $operator
+     * @param  mixed   $value
      * @param  string  $boolean
      * @return $this
      */


### PR DESCRIPTION
Fix Eloquent's `Builder::where()` method to match [`Query\Builder::where()`](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Database/Query/Builder.php#L582)