### PR TITLE
[5.7] Argon and Bcrypt hasher classes do not verify hashing algorithm

### DIFF
--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -91,7 +91,7 @@ class ArgonHasher implements HasherContract
             return false;
         }
 
-        if ($this->info($hashedValue)['algo'] !== PASSWORD_ARGON2I) {
+        if ($this->info($hashedValue)['algoName'] !== 'argon2i') {
             throw new Exception('Hashing algorithm mismatch.');
         }
 

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Hashing;
 
+use Exception;
 use RuntimeException;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 
@@ -81,11 +82,17 @@ class ArgonHasher implements HasherContract
      * @param  string  $hashedValue
      * @param  array  $options
      * @return bool
+     *
+     * @throws Exception
      */
     public function check($value, $hashedValue, array $options = [])
     {
         if (strlen($hashedValue) === 0) {
             return false;
+        }
+
+        if ($this->info($hashedValue)['algo'] !== PASSWORD_ARGON2I) {
+            throw new Exception('Hashing algorithm mismatch.');
         }
 
         return password_verify($value, $hashedValue);

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Hashing;
 
+use Exception;
 use RuntimeException;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 
@@ -65,11 +66,17 @@ class BcryptHasher implements HasherContract
      * @param  string  $hashedValue
      * @param  array   $options
      * @return bool
+     *
+     * @throws Exception
      */
     public function check($value, $hashedValue, array $options = [])
     {
         if (strlen($hashedValue) === 0) {
             return false;
+        }
+
+        if ($this->info($hashedValue)['algo'] !== PASSWORD_BCRYPT) {
+            throw new Exception('Hashing algorithm mismatch.');
         }
 
         return password_verify($value, $hashedValue);

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -75,7 +75,7 @@ class BcryptHasher implements HasherContract
             return false;
         }
 
-        if ($this->info($hashedValue)['algo'] !== PASSWORD_BCRYPT) {
+        if ($this->info($hashedValue)['algoName'] !== 'bcrypt') {
             throw new Exception('Hashing algorithm mismatch.');
         }
 

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -36,6 +36,10 @@ class HasherTest extends TestCase
      */
     public function testBasicBcryptVerification()
     {
+        if (! defined('PASSWORD_ARGON2I')) {
+            $this->markTestSkipped('PHP not compiled with argon2 hashing support.');
+        }
+
         $argonHasher = new \Illuminate\Hashing\ArgonHasher;
         $argonHashed = $argonHasher->make('password');
         (new \Illuminate\Hashing\BcryptHasher)->check('password', $argonHashed);
@@ -45,7 +49,7 @@ class HasherTest extends TestCase
      * @expectedException \Exception
      * @expectedExceptionMessage Hashing algorithm mismatch.
      */
-    public function testBasicVerification()
+    public function testBasicArgonVerification()
     {
         $bcryptHasher = new \Illuminate\Hashing\BcryptHasher;
         $bcryptHashed = $bcryptHasher->make('password');

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -29,4 +29,26 @@ class HasherTest extends TestCase
         $this->assertFalse($hasher->needsRehash($value));
         $this->assertTrue($hasher->needsRehash($value, ['threads' => 1]));
     }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Hashing algorithm mismatch.
+     */
+    public function testBasicBcryptVerification()
+    {
+        $argonHasher = new \Illuminate\Hashing\ArgonHasher;
+        $argonHashed = $argonHasher->make('password');
+        (new \Illuminate\Hashing\BcryptHasher)->check('password', $argonHashed);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Hashing algorithm mismatch.
+     */
+    public function testBasicVerification()
+    {
+        $bcryptHasher = new \Illuminate\Hashing\BcryptHasher;
+        $bcryptHashed = $bcryptHasher->make('password');
+        (new \Illuminate\Hashing\ArgonHasher)->check('password', $bcryptHashed);
+    }
 }


### PR DESCRIPTION
Add additional check on hashing algorithm when checking a hashed value. An exception is thrown if algorithm does not match the one intended in the hasher.

Closes #24162.