### PR TITLE
[5.7] Fix return types and DocBlocks code styling

### DIFF
--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Hashing;
 
-use Exception;
 use RuntimeException;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 
@@ -59,6 +58,8 @@ class ArgonHasher implements HasherContract
      * @param  string  $value
      * @param  array  $options
      * @return string
+     *
+     * @throws \RuntimeException
      */
     public function make($value, array $options = [])
     {
@@ -83,7 +84,7 @@ class ArgonHasher implements HasherContract
      * @param  array  $options
      * @return bool
      *
-     * @throws Exception
+     * @throws \RuntimeException
      */
     public function check($value, $hashedValue, array $options = [])
     {
@@ -92,7 +93,7 @@ class ArgonHasher implements HasherContract
         }
 
         if ($this->info($hashedValue)['algoName'] !== 'argon2i') {
-            throw new Exception('This password does not use the Argon algorithm.');
+            throw new RuntimeException('This password does not use the Argon algorithm.');
         }
 
         return password_verify($value, $hashedValue);

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Hashing;
 
-use Exception;
 use RuntimeException;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 
@@ -67,7 +66,7 @@ class BcryptHasher implements HasherContract
      * @param  array   $options
      * @return bool
      *
-     * @throws Exception
+     * @throws \RuntimeException
      */
     public function check($value, $hashedValue, array $options = [])
     {
@@ -76,7 +75,7 @@ class BcryptHasher implements HasherContract
         }
 
         if ($this->info($hashedValue)['algoName'] !== 'bcrypt') {
-            throw new Exception('This password does not use the Bcrypt algorithm.');
+            throw new RuntimeException('This password does not use the Bcrypt algorithm.');
         }
 
         return password_verify($value, $hashedValue);

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -10,7 +10,7 @@ class HashManager extends Manager implements Hasher
     /**
      * Create an instance of the Bcrypt hash Driver.
      *
-     * @return BcryptHasher
+     * @return \Illuminate\Hashing\BcryptHasher
      */
     public function createBcryptDriver()
     {
@@ -20,7 +20,7 @@ class HashManager extends Manager implements Hasher
     /**
      * Create an instance of the Argon2 hash Driver.
      *
-     * @return ArgonHasher
+     * @return \Illuminate\Hashing\ArgonHasher
      */
     public function createArgonDriver()
     {


### PR DESCRIPTION
Related to: https://github.com/laravel/framework/pull/24178

Changed `\Exception` to `\RuntimeException` since it can only be found on runtime occurs.

Additionally add missing `@throws` to `ArgonHasher`'s `make` method. And use FQCN in `HashManager` DocBlock return types.