### PR TITLE
[5.6] Make all DocBlock return types fully qualified

### DIFF
--- a/src/Illuminate/Contracts/Broadcasting/ShouldBroadcast.php
+++ b/src/Illuminate/Contracts/Broadcasting/ShouldBroadcast.php
@@ -2,14 +2,12 @@
 
 namespace Illuminate\Contracts\Broadcasting;
 
-use Illuminate\Broadcasting\Channel;
-
 interface ShouldBroadcast
 {
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return Channel|Channel[]
+     * @return \Illuminate\Broadcasting\Channel|\Illuminate\Broadcasting\Channel[]
      */
     public function broadcastOn();
 }

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Database;
 
 use PHPUnit\Framework\TestCase;
-use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
@@ -326,7 +325,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     /**
      * Get a database connection instance.
      *
-     * @return Connection
+     * @return \Illuminate\Database\Connection
      */
     protected function connection()
     {
@@ -336,7 +335,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     /**
      * Get a schema builder instance.
      *
-     * @return Schema\Builder
+     * @return \Illuminate\Database\Schema\Builder
      */
     protected function schema()
     {

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Database;
 
 use PHPUnit\Framework\TestCase;
-use Illuminate\Database\Connection;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
@@ -153,7 +152,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
     /**
      * Get a database connection instance.
      *
-     * @return Connection
+     * @return \Illuminate\Database\Connection
      */
     protected function connection()
     {

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -654,7 +654,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
     /**
      * Get a database connection instance.
      *
-     * @return Connection
+     * @return \Illuminate\Database\Connection
      */
     protected function connection()
     {
@@ -664,7 +664,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
     /**
      * Get a schema builder instance.
      *
-     * @return Schema\Builder
+     * @return \Illuminate\Database\Schema\Builder
      */
     protected function schema()
     {

--- a/tests/Database/DatabaseEloquentTimestamps.php
+++ b/tests/Database/DatabaseEloquentTimestamps.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Database\Connection;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
@@ -100,7 +99,7 @@ class DatabaseEloquentTimestamps extends TestCase
     /**
      * Get a database connection instance.
      *
-     * @return Connection
+     * @return \Illuminate\Database\Connection
      */
     protected function connection()
     {
@@ -110,7 +109,7 @@ class DatabaseEloquentTimestamps extends TestCase
     /**
      * Get a schema builder instance.
      *
-     * @return Schema\Builder
+     * @return \Illuminate\Database\Schema\Builder
      */
     protected function schema()
     {

--- a/tests/Routing/fixtures/controller.php
+++ b/tests/Routing/fixtures/controller.php
@@ -5,7 +5,7 @@ class FooController extends \BaseController
     /**
      * Display a listing of the resource.
      *
-     * @return Response
+     * @return \Illuminate\Support\Facades\Response
      */
     public function index()
     {
@@ -15,7 +15,7 @@ class FooController extends \BaseController
     /**
      * Show the form for creating a new resource.
      *
-     * @return Response
+     * @return \Illuminate\Support\Facades\Response
      */
     public function create()
     {
@@ -25,7 +25,7 @@ class FooController extends \BaseController
     /**
      * Store a newly created resource in storage.
      *
-     * @return Response
+     * @return \Illuminate\Support\Facades\Response
      */
     public function store()
     {
@@ -36,7 +36,7 @@ class FooController extends \BaseController
      * Display the specified resource.
      *
      * @param  int  $id
-     * @return Response
+     * @return \Illuminate\Support\Facades\Response
      */
     public function show($id)
     {
@@ -47,7 +47,7 @@ class FooController extends \BaseController
      * Show the form for editing the specified resource.
      *
      * @param  int  $id
-     * @return Response
+     * @return \Illuminate\Support\Facades\Response
      */
     public function edit($id)
     {
@@ -58,7 +58,7 @@ class FooController extends \BaseController
      * Update the specified resource in storage.
      *
      * @param  int  $id
-     * @return Response
+     * @return \Illuminate\Support\Facades\Response
      */
     public function update($id)
     {
@@ -69,7 +69,7 @@ class FooController extends \BaseController
      * Remove the specified resource from storage.
      *
      * @param  int  $id
-     * @return Response
+     * @return \Illuminate\Support\Facades\Response
      */
     public function destroy($id)
     {

--- a/tests/Routing/fixtures/except_controller.php
+++ b/tests/Routing/fixtures/except_controller.php
@@ -5,7 +5,7 @@ class FooController extends \BaseController
     /**
      * Show the form for creating a new resource.
      *
-     * @return Response
+     * @return \Illuminate\Support\Facades\Response
      */
     public function create()
     {
@@ -15,7 +15,7 @@ class FooController extends \BaseController
     /**
      * Store a newly created resource in storage.
      *
-     * @return Response
+     * @return \Illuminate\Support\Facades\Response
      */
     public function store()
     {
@@ -26,7 +26,7 @@ class FooController extends \BaseController
      * Show the form for editing the specified resource.
      *
      * @param  int  $id
-     * @return Response
+     * @return \Illuminate\Support\Facades\Response
      */
     public function edit($id)
     {
@@ -37,7 +37,7 @@ class FooController extends \BaseController
      * Update the specified resource in storage.
      *
      * @param  int  $id
-     * @return Response
+     * @return \Illuminate\Support\Facades\Response
      */
     public function update($id)
     {
@@ -48,7 +48,7 @@ class FooController extends \BaseController
      * Remove the specified resource from storage.
      *
      * @param  int  $id
-     * @return Response
+     * @return \Illuminate\Support\Facades\Response
      */
     public function destroy($id)
     {

--- a/tests/Routing/fixtures/only_controller.php
+++ b/tests/Routing/fixtures/only_controller.php
@@ -5,7 +5,7 @@ class FooController extends \BaseController
     /**
      * Display a listing of the resource.
      *
-     * @return Response
+     * @return \Illuminate\Support\Facades\Response
      */
     public function index()
     {
@@ -16,7 +16,7 @@ class FooController extends \BaseController
      * Display the specified resource.
      *
      * @param  int  $id
-     * @return Response
+     * @return \Illuminate\Support\Facades\Response
      */
     public function show($id)
     {


### PR DESCRIPTION
Use only fully qualified class names in DocBlocks to keep code styling consistent.