### PR TITLE
[5.6] Ignore tags in alert

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -506,9 +506,11 @@ class Command extends SymfonyCommand
      */
     public function alert($string)
     {
-        $this->comment(str_repeat('*', strlen($string) + 12));
-        $this->comment('*     '.$string.'     *');
-        $this->comment(str_repeat('*', strlen($string) + 12));
+        $length = strlen(strip_tags($string)) + 12;
+
+        $this->comment(str_repeat('*', $length));
+        $this->comment("*     {$string}     *");
+        $this->comment(str_repeat('*', $length));
 
         $this->output->newLine();
     }


### PR DESCRIPTION
This PR fixes behaviour of `Illuminate/Console/Command::alert()`.

If `$string` contains some kind of "formatting" tags (eg. `<options=bold>Done</>`), the length is calculated incorrectly as these tags are not displayed.

Thanks