### PR TITLE
[5.2] Fix count() usage

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -774,7 +774,6 @@ class Builder
             $query = $this->model->newQueryWithoutScopes();
 
             call_user_func($column, $query);
-
             $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
         } else {
             call_user_func_array([$this->query, 'where'], func_get_args());
@@ -1182,7 +1181,7 @@ class Builder
         // We will keep track of how many wheres are on the query before running the
         // scope so that we can properly group the added scope constraints in the
         // query as their own isolated nested where statement and avoid issues.
-        $originalWhereCount = count($query->wheres);
+        $originalWhereCount = is_null($query->wheres) ? 0 : count($query->wheres);
 
         $result = call_user_func_array($scope, $parameters) ?: $this;
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -769,7 +769,7 @@ class Builder
      */
     public function addNestedWhereQuery($query, $boolean = 'and')
     {
-        if (count($query->wheres)) {
+        if (!is_null($query->wheres) and count($query->wheres)) {
             $type = 'Nested';
 
             $this->wheres[] = compact('type', 'query', 'boolean');


### PR DESCRIPTION
This PR updates `Eloquent/Builder` and` Query/Builder` to run Laravel 5.2 in PHP version 7.2.

It was necessary to do this due to the update of the native count () function of PHP, where in version 7.2 it stopped accepting null parameter, and accepting only Array or Countable

Reference: http://php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types