### PR TITLE
[5.6] Give ability to update dependencies block from preset

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/Preset.php
+++ b/src/Illuminate/Foundation/Console/Presets/Preset.php
@@ -25,19 +25,20 @@ class Preset
      *
      * @return void
      */
-    protected static function updatePackages()
+    protected static function updatePackages($devDependency = true)
     {
         if (! file_exists(base_path('package.json'))) {
             return;
         }
 
+        $dependenciesBlock = $devDependency ? 'devDependencies' : 'dependencies';
         $packages = json_decode(file_get_contents(base_path('package.json')), true);
 
-        $packages['devDependencies'] = static::updatePackageArray(
-            $packages['devDependencies']
+        $packages[$dependenciesBlock] = static::updatePackageArray(
+            array_key_exists($dependenciesBlock, $packages) ? $packages[$dependenciesBlock] : []
         );
 
-        ksort($packages['devDependencies']);
+        ksort($packages[$dependenciesBlock]);
 
         file_put_contents(
             base_path('package.json'),


### PR DESCRIPTION
The existing implementation of Preset does not allow changing the package.json "dependency" block. This non-breaking change will allow to pass a parameter that indicates that a set of packages need to be added to "dependency", not devDependency.

Motivation: ESLint with one of the most popular configurations (eslint-config-airbnb-base) produce a lint error when code-dependencies specified in devDependencies. And developers should be able to create presets which store dependencies in "dependencies" block.