### PR TITLE
[5.7] Added '--pending' option to only display migrations that are yet to be migrated.

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -76,6 +76,10 @@ class StatusCommand extends BaseCommand
     protected function getStatusFor(array $ran, array $batches)
     {
         return Collection::make($this->getAllMigrationFiles())
+                    ->filter(function($migration) use ($ran) {
+                        return ! $this->option('pending')
+                            || ! in_array($this->migrator->getMigrationName($migration), $ran);
+                    })
                     ->map(function ($migration) use ($ran, $batches) {
                         $migrationName = $this->migrator->getMigrationName($migration);
 
@@ -108,6 +112,8 @@ class StatusCommand extends BaseCommand
             ['path', null, InputOption::VALUE_OPTIONAL, 'The path to the migrations files to use.'],
 
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths.'],
+
+            ['pending', null, InputOption::VALUE_NONE, 'Indicate to only list the migrations that are yet to be migrated.'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -76,7 +76,7 @@ class StatusCommand extends BaseCommand
     protected function getStatusFor(array $ran, array $batches)
     {
         return Collection::make($this->getAllMigrationFiles())
-                    ->filter(function($migration) use ($ran) {
+                    ->filter(function ($migration) use ($ran) {
                         return ! $this->option('pending')
                             || ! in_array($this->migrator->getMigrationName($migration), $ran);
                     })

--- a/tests/Database/DatabaseMigrationStatusCommandTest.php
+++ b/tests/Database/DatabaseMigrationStatusCommandTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Database\Console\Migrations\StatusCommand;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Illuminate\Database\Console\Migrations\StatusCommand;
 
 class DatabaseMigrationStatusCommandTest extends TestCase
 {
@@ -70,7 +70,7 @@ class DatabaseMigrationStatusCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute(['--pending' => true]);
 
-        $expected = <<<OUTPUT
+        $expected = <<<'OUTPUT'
 +------+----------------------------------------+-------+
 | Ran? | Migration                              | Batch |
 +------+----------------------------------------+-------+

--- a/tests/Database/DatabaseMigrationStatusCommandTest.php
+++ b/tests/Database/DatabaseMigrationStatusCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Console\Migrations\StatusCommand;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DatabaseMigrationStatusCommandTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testStatusCommandOutputsOnlyPendingMigrations()
+    {
+        $command = new StatusCommand($migrator = $this->createMock('Illuminate\Database\Migrations\Migrator'));
+        $app = new ApplicationDatabaseStatusStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+
+        $migrator->expects($this->once())
+                 ->method('setConnection');
+
+        $migrator->expects($this->once())
+                 ->method('repositoryExists')
+                 ->will($this->returnValue(true));
+
+        $migrator->expects($this->atLeastOnce())
+                 ->method('getRepository')
+                 ->will($this->returnValue($repository = $this->createMock('Illuminate\Database\Migrations\MigrationRepositoryInterface')));
+
+        $migrator->expects($this->atLeastOnce())
+                 ->method('getMigrationName')
+                 ->will($this->returnValueMap([
+                     [__DIR__.'/migrations/one/2016_01_01_000000_create_users_table.php', '2016_01_01_000000_create_users_table'],
+                     [__DIR__.'/migrations/one/2016_01_01_100000_create_password_resets_table.php', '2016_01_01_100000_create_password_resets_table'],
+                     [__DIR__.'/migrations/two/2016_01_01_200000_create_flights_table.php', '2016_01_01_200000_create_flights_table'],
+                 ]));
+
+        $migrator->expects($this->once())
+                 ->method('getMigrationFiles')
+                 ->will($this->returnValue([
+                     '2016_01_01_000000_create_users_table' => __DIR__.'/migrations/one/2016_01_01_000000_create_users_table.php',
+                     '2016_01_01_100000_create_password_resets_table' => __DIR__.'/migrations/one/2016_01_01_100000_create_password_resets_table.php',
+                     '2016_01_01_200000_create_flights_table' => __DIR__.'/migrations/two/2016_01_01_200000_create_flights_table.php',
+                 ]));
+
+        $migrator->expects($this->once())
+                 ->method('paths')
+                 ->will($this->returnValue([]));
+
+        $repository->expects($this->once())
+                   ->method('getRan')
+                   ->will($this->returnValue([
+                       '2016_01_01_000000_create_users_table',
+                       '2016_01_01_100000_create_password_resets_table',
+                   ]));
+
+        $repository->expects($this->once())
+                   ->method('getMigrationBatches')
+                   ->will($this->returnValue([
+                       '2016_01_01_000000_create_users_table' => 1,
+                       '2016_01_01_100000_create_password_resets_table' => 1,
+                   ]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--pending' => true]);
+
+        $expected = <<<OUTPUT
++------+----------------------------------------+-------+
+| Ran? | Migration                              | Batch |
++------+----------------------------------------+-------+
+| No   | 2016_01_01_200000_create_flights_table |       |
++------+----------------------------------------+-------+
+
+OUTPUT;
+
+        $this->assertEquals($expected, $tester->getDisplay(true));
+    }
+}
+
+class ApplicationDatabaseStatusStub extends Application
+{
+    public function __construct(array $data = [])
+    {
+        foreach ($data as $abstract => $instance) {
+            $this->instance($abstract, $instance);
+        }
+    }
+
+    public function environment()
+    {
+        return 'development';
+    }
+}


### PR DESCRIPTION
As suggested on this thread: https://github.com/laravel/ideas/issues/1153

This PR adds a new option `--pending` to the `migrate:status` command that lists only the migrations that are yet to be run.

### Why?
As mentioned in the aforementioned thread, one would like to view pending migrations instead of the whole list for projects with huge number of migrations.