### PR TITLE
[5.5] Validation bypass for 'before' and 'after' rules when paired with 'date_format' rule.

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -147,9 +147,7 @@ trait ValidatesAttributes
         }
 
         if ($format = $this->getDateFormat($attribute)) {
-            return $this->checkDateTimeOrder(
-                $format, $value, $this->getValue($parameters[0]) ?: $parameters[0], $operator
-            );
+            return $this->checkDateTimeOrder($format, $value, $parameters[0], $operator);
         }
 
         if (! $date = $this->getDateTimestamp($parameters[0])) {
@@ -194,11 +192,13 @@ trait ValidatesAttributes
      */
     protected function checkDateTimeOrder($format, $first, $second, $operator)
     {
-        $first = $this->getDateTimeWithOptionalFormat($format, $first);
+        $firstDate = $this->getDateTimeWithOptionalFormat($format, $first);
 
-        $second = $this->getDateTimeWithOptionalFormat($format, $second);
+        if (! $secondDate = $this->getDateTimeWithOptionalFormat($format, $second)) {
+            $secondDate = $this->getDateTimeWithOptionalFormat($format, $this->getValue($second));
+        }
 
-        return ($first && $second) && ($this->compare($first, $second, $operator));
+        return ($firstDate && $secondDate) && ($this->compare($firstDate, $secondDate, $operator));
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2600,6 +2600,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '17:44'], ['x' => 'date_format:H:i|after:17:44']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '2038-01-18', '2018-05-12' => '2038-01-19'], ['x' => 'date_format:Y-m-d|before:2018-05-12']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '1970-01-02', '2018-05-12' => '1970-01-01'], ['x' => 'date_format:Y-m-d|after:2018-05-12']);
+        $this->assertTrue($v->fails());
     }
 
     public function testWeakBeforeAndAfter()


### PR DESCRIPTION
When using the validation rules 'before' and/or 'after' together with the 'date_format' rule, it is possible to have what should be considered invalid data be accepted by the validator as valid.

My understanding from reading the code is that the 'before' and 'after' rules, when used without de 'date_format' rule, will compare two fields relative to each other. e.g. given the rules:
```php
$rules = ['start' => 'before:finish', 'finish' => 'after:start'];
```
The 'start' field must have a date which is less than the 'finish' field, and the 'finish' field must have a date which is greater than the 'start' field.

But, when the 'date_format' rule is also used, you can compare a field to another field **or** a specific date. And therein lies the problem. If you know what date the field is being compared to (You can easily guess that through the error message) and all fields from the request is being passed directly to the validator as data to be validated (This is quite common, Laravel itself does that in the 'ValidatesRequests' trait[1]). You can then send an extra field in the request with the same name as that date and a value of your choosing. The validator will then give preference to compare the field being validate relative to the bogus field, which can have an arbitrary date. (the tests added illustrate this more clearly)

I honestly have no idea how to fix this without breaking backwards compatibility, so this pull request only adds tests that should pass but are now failing.

[1] https://github.com/laravel/framework/blob/e90a6bf785d740e88789700ad34e901238a45b16/src/Illuminate/Foundation/Validation/ValidatesRequests.php#L24