### PR TITLE
[5.6] DocBlock code styling params & return types

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -406,7 +406,7 @@ class FactoryBuilder
      * Call after callbacks for each model and state.
      *
      * @param  array  $afterCallbacks
-     * @param  Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $state
      * @return void
      */

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -10,7 +10,7 @@ class HashManager extends Manager implements Hasher
     /**
      * Create an instance of the Bcrypt hash Driver.
      *
-     * @return BcryptHasher
+     * @return \Illuminate\Hashing\BcryptHasher
      */
     public function createBcryptDriver()
     {
@@ -20,7 +20,7 @@ class HashManager extends Manager implements Hasher
     /**
      * Create an instance of the Argon2 hash Driver.
      *
-     * @return ArgonHasher
+     * @return \Illuminate\Hashing\ArgonHasher
      */
     public function createArgonDriver()
     {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -620,8 +620,8 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Return the response for the given route.
      *
-     * @param  Route  $route
-     * @param  Request  $request
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Routing\Route  $route
      * @return mixed
      */
     protected function runRoute(Request $request, Route $route)

--- a/tests/Routing/fixtures/controller.php
+++ b/tests/Routing/fixtures/controller.php
@@ -5,7 +5,7 @@ class FooController extends \BaseController
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\Support\Facades\Response
+     * @return \Illuminate\Http\Response
      */
     public function index()
     {
@@ -15,7 +15,7 @@ class FooController extends \BaseController
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\Support\Facades\Response
+     * @return \Illuminate\Http\Response
      */
     public function create()
     {
@@ -25,7 +25,7 @@ class FooController extends \BaseController
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Support\Facades\Response
+     * @return \Illuminate\Http\Response
      */
     public function store()
     {
@@ -36,7 +36,7 @@ class FooController extends \BaseController
      * Display the specified resource.
      *
      * @param  int  $id
-     * @return \Illuminate\Support\Facades\Response
+     * @return \Illuminate\Http\Response
      */
     public function show($id)
     {
@@ -47,7 +47,7 @@ class FooController extends \BaseController
      * Show the form for editing the specified resource.
      *
      * @param  int  $id
-     * @return \Illuminate\Support\Facades\Response
+     * @return \Illuminate\Http\Response
      */
     public function edit($id)
     {
@@ -58,7 +58,7 @@ class FooController extends \BaseController
      * Update the specified resource in storage.
      *
      * @param  int  $id
-     * @return \Illuminate\Support\Facades\Response
+     * @return \Illuminate\Http\Response
      */
     public function update($id)
     {
@@ -69,7 +69,7 @@ class FooController extends \BaseController
      * Remove the specified resource from storage.
      *
      * @param  int  $id
-     * @return \Illuminate\Support\Facades\Response
+     * @return \Illuminate\Http\Response
      */
     public function destroy($id)
     {

--- a/tests/Routing/fixtures/except_controller.php
+++ b/tests/Routing/fixtures/except_controller.php
@@ -5,7 +5,7 @@ class FooController extends \BaseController
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\Support\Facades\Response
+     * @return \Illuminate\Http\Response
      */
     public function create()
     {
@@ -15,7 +15,7 @@ class FooController extends \BaseController
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Support\Facades\Response
+     * @return \Illuminate\Http\Response
      */
     public function store()
     {
@@ -26,7 +26,7 @@ class FooController extends \BaseController
      * Show the form for editing the specified resource.
      *
      * @param  int  $id
-     * @return \Illuminate\Support\Facades\Response
+     * @return \Illuminate\Http\Response
      */
     public function edit($id)
     {
@@ -37,7 +37,7 @@ class FooController extends \BaseController
      * Update the specified resource in storage.
      *
      * @param  int  $id
-     * @return \Illuminate\Support\Facades\Response
+     * @return \Illuminate\Http\Response
      */
     public function update($id)
     {
@@ -48,7 +48,7 @@ class FooController extends \BaseController
      * Remove the specified resource from storage.
      *
      * @param  int  $id
-     * @return \Illuminate\Support\Facades\Response
+     * @return \Illuminate\Http\Response
      */
     public function destroy($id)
     {

--- a/tests/Routing/fixtures/only_controller.php
+++ b/tests/Routing/fixtures/only_controller.php
@@ -5,7 +5,7 @@ class FooController extends \BaseController
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\Support\Facades\Response
+     * @return \Illuminate\Http\Response
      */
     public function index()
     {
@@ -16,7 +16,7 @@ class FooController extends \BaseController
      * Display the specified resource.
      *
      * @param  int  $id
-     * @return \Illuminate\Support\Facades\Response
+     * @return \Illuminate\Http\Response
      */
     public function show($id)
     {


### PR DESCRIPTION
As @sisve noted in https://github.com/laravel/framework/pull/24184#issuecomment-388531786 - I had mistaken with return type in controllers. This PR will fix my fault.

Additionally I've found a bit more code styling rule breaks related to FQCN and fixed them.