### PR TITLE
[5.6] Event for start request handling

### DIFF
--- a/src/Illuminate/Foundation/Http/Events/RequestStartHandling.php
+++ b/src/Illuminate/Foundation/Http/Events/RequestStartHandling.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Events;
+
+class RequestStartHandling
+{
+    /**
+     * The request instance.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
+
+    /**
+     * RequestStartHandling constructor.
+     *
+     * @param $request
+     */
+    public function __construct($request)
+    {
+        $this->request = $request;
+    }
+}

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -110,6 +110,9 @@ class Kernel implements KernelContract
      */
     public function handle($request)
     {
+        $this->app['events']->dispatch(
+            new Events\RequestStartHandling($request)
+        );
         try {
             $request->enableHttpMethodParameterOverride();
 


### PR DESCRIPTION
- I know, that we can use the middleware for getting request before request handling.
But I have tried to do logging for each request before any modification. 
As for me, it will be better to have an event like a Foundation/Http/Events/RequestHandled.php.

Could you say, what are you think about this?