### PR TITLE
[5.6] Fix: Failed returning Responsable from Middleware

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -4,7 +4,9 @@ namespace Illuminate\Pipeline;
 
 use Closure;
 use RuntimeException;
+use Illuminate\Http\Request;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\Pipeline\Pipeline as PipelineContract;
 
 class Pipeline implements PipelineContract
@@ -145,9 +147,13 @@ class Pipeline implements PipelineContract
                     $parameters = [$passable, $stack];
                 }
 
-                return method_exists($pipe, $this->method)
+                $response = method_exists($pipe, $this->method)
                                 ? $pipe->{$this->method}(...$parameters)
                                 : $pipe(...$parameters);
+
+                return $response instanceof Responsable
+                    ? $response->toResponse($this->container->make(Request::class))
+                    : $response;
             };
         };
     }

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Pipeline;
 
 use PHPUnit\Framework\TestCase;
 use Illuminate\Pipeline\Pipeline;
+use Illuminate\Contracts\Support\Responsable;
 
 class PipelineTest extends TestCase
 {
@@ -60,6 +61,23 @@ class PipelineTest extends TestCase
         $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
 
         unset($_SERVER['__test.pipe.one']);
+    }
+
+    public function testPipelineUsageWithResponsableObjects()
+    {
+        $result = (new Pipeline(new \Illuminate\Container\Container))
+            ->send('foo')
+            ->through([new PipelineTestPipeResponsable])
+            ->then(
+                function ($piped) {
+                    return $piped;
+                }
+            );
+
+        $this->assertEquals('bar', $result);
+        $this->assertEquals('foo', $_SERVER['__test.pipe.responsable']);
+
+        unset($_SERVER['__test.pipe.responsable']);
     }
 
     public function testPipelineUsageWithCallable()
@@ -160,6 +178,14 @@ class PipelineTestPipeOne
     }
 }
 
+class PipeResponsable implements Responsable
+{
+    public function toResponse($request)
+    {
+        return 'bar';
+    }
+}
+
 class PipelineTestPipeTwo
 {
     public function __invoke($piped, $next)
@@ -167,6 +193,16 @@ class PipelineTestPipeTwo
         $_SERVER['__test.pipe.one'] = $piped;
 
         return $next($piped);
+    }
+}
+
+class PipelineTestPipeResponsable
+{
+    public function handle($piped, $next)
+    {
+        $_SERVER['__test.pipe.responsable'] = $piped;
+
+        return new PipeResponsable;
     }
 }
 


### PR DESCRIPTION
 - This is a fix for issue #24156 which states that. When we return Implementation of Responsable from middleware it fails.

--------
Actually, this PR was created by https://github.com/laravel/framework/pull/24164, but unfortunately, I have the same problem.
