### PR TITLE
[5.6] PipelineTest refactoring

### DIFF
--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -17,7 +17,7 @@ class PipelineTest extends TestCase
 
         $result = (new Pipeline(new \Illuminate\Container\Container))
                     ->send('foo')
-                    ->through(['Illuminate\Tests\Pipeline\PipelineTestPipeOne', $pipeTwo])
+                    ->through([PipelineTestPipeOne::class, $pipeTwo])
                     ->then(function ($piped) {
                         return $piped;
                     });
@@ -108,7 +108,7 @@ class PipelineTest extends TestCase
 
         $result = (new Pipeline(new \Illuminate\Container\Container))
             ->send('foo')
-            ->through('Illuminate\Tests\Pipeline\PipelineTestParameterPipe:'.implode(',', $parameters))
+            ->through(PipelineTestParameterPipe::class.':'.implode(',', $parameters))
             ->then(function ($piped) {
                 return $piped;
             });
@@ -123,7 +123,7 @@ class PipelineTest extends TestCase
     {
         $pipelineInstance = new Pipeline(new \Illuminate\Container\Container);
         $result = $pipelineInstance->send('data')
-            ->through('Illuminate\Tests\Pipeline\PipelineTestPipeOne')
+            ->through(PipelineTestPipeOne::class)
             ->via('differentMethod')
             ->then(function ($piped) {
                 return $piped;
@@ -138,7 +138,7 @@ class PipelineTest extends TestCase
     public function testPipelineThrowsExceptionOnResolveWithoutContainer()
     {
         (new Pipeline)->send('data')
-            ->through('Illuminate\Tests\Pipeline\PipelineTestPipeOne')
+            ->through(PipelineTestPipeOne::class)
             ->then(function ($piped) {
                 return $piped;
             });


### PR DESCRIPTION
Changed `'Illuminate\Tests\Pipeline\PipelineTestPipeOne'` to `PipelieTestPipeOne::class` in PipelineTest

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
