### PR TITLE
[5.6] Add phpdoc for Request macros

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -12,6 +12,10 @@ use Illuminate\Contracts\Support\Arrayable;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
+/**
+ * @method array validate(array $rules, ...$params)
+ * @method bool hasValidSignature()
+ */
 class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 {
     use Concerns\InteractsWithContentTypes,

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -41,6 +41,8 @@ namespace Illuminate\Support\Facades;
  * @method static mixed offsetGet(string $offset)
  * @method static void offsetSet(string $offset, $value)
  * @method static void offsetUnset(string $offset)
+ * @method static array validate(array $rules, ...$params)
+ * @method static bool hasValidSignature()
  *
  * @see \Illuminate\Http\Request
  */


### PR DESCRIPTION
Add PHPDoc for the `validate` and `hasValidSignature` macros defined in FoundationServiceProvider.

This allow user to have autocompletion for `$request->validate()`, `request()->validate()`, `Request::validate()` etc...