### PR TITLE
[5.7] Container bindMethod improvement

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -7,6 +7,7 @@ use ArrayAccess;
 use LogicException;
 use ReflectionClass;
 use ReflectionParameter;
+use InvalidArgumentException;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 
@@ -285,9 +286,17 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  array|string $method
      * @return string
+     *
+     * @throws \InvalidArgumentException
      */
     protected function parseBindMethod($method)
     {
+        if (is_array($method) && ($count = count($method) < 2)) {
+            throw new InvalidArgumentException(
+                "Method should be string or array with length >= 2, array with length [{$count}] given"
+            );
+        }
+
         if (is_array($method)) {
             return $method[0].'@'.$method[1];
         }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -593,6 +593,18 @@ class ContainerTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Method should be string or array with length >= 2, array with length [1] given
+     */
+    public function testBindMethodWithOneArrayParam()
+    {
+        $container = new Container;
+        $container->bindMethod([\Illuminate\Tests\Container\ContainerTestCallStub::class], function ($stub) {
+            return $stub->unresolvable('foo', 'bar');
+        });
+    }
+
     public function testContainerCanInjectDifferentImplementationsDependingOnContext()
     {
         $container = new Container;


### PR DESCRIPTION
resubmit of https://github.com/laravel/framework/pull/24199 to master 
 - Added a InvalidArgumentException if $method in bindMethod is array with array count < 2
 - added \ to phpdoc
 - Changed message formatting
 - Apply changes after review.

(cherry picked from commit d26c89c)

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
