### PR TITLE
[5.7] Container bindMethod improvement

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -7,6 +7,7 @@ use ArrayAccess;
 use LogicException;
 use ReflectionClass;
 use ReflectionParameter;
+use InvalidArgumentException;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 
@@ -285,9 +286,17 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  array|string $method
      * @return string
+     *
+     * @throws \InvalidArgumentException
      */
     protected function parseBindMethod($method)
     {
+        if (is_array($method) && ($count = count($method) < 2)) {
+            throw new InvalidArgumentException(
+                "Method should be string or array with length >= 2, array with length [{$count}] given"
+            );
+        }
+
         if (is_array($method)) {
             return $method[0].'@'.$method[1];
         }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -593,6 +593,18 @@ class ContainerTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Method should be string or array with length >= 2, array with length [1] given
+     */
+    public function testBindMethodWithOneArrayParam()
+    {
+        $container = new Container;
+        $container->bindMethod([\Illuminate\Tests\Container\ContainerTestCallStub::class], function ($stub) {
+            return $stub->unresolvable('foo', 'bar');
+        });
+    }
+
     public function testContainerCanInjectDifferentImplementationsDependingOnContext()
     {
         $container = new Container;


### PR DESCRIPTION
resubmit of #24199 to master

Added a InvalidArgumentException if $method in bindMethod is array with array count < 2
added \ to phpdoc
Changed message formatting
Apply changes after review.
(cherry picked from commit d26c89c)

--------------------
**Problem:**
When we try to use  bindMethod with array count 1

```PHP
$container->bindMethod([\Illuminate\Tests\Container\ContainerTestCallStub::class], function ($stub) {
            return $stub->unresolvable('foo', 'bar');
        });
```
then we give a notice:

_Undefined offset: 1_

---

This PR will give a normal exception message for the user.


---

What are you think about this PR?
In case if it will be ok, then I can make a PR for 5.7 with strict comparing:

```PHP
if (count($method) === 2) 
```
instead
```PHP
if (count($method) > 1) 
```