### PR TITLE
[5.6] Add findOr metthod

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -352,6 +352,29 @@ class Builder
     }
 
     /**
+     * Find a model by its primary key or call a callback.
+     *
+     * @param  mixed $id
+     * @param  \Closure|array  $columns
+     * @param  \Closure|null  $callback
+     * @return \Illuminate\Database\Eloquent\Model|static|mixed
+     */
+    public function findOr($id, $columns = ['*'], Closure $callback = null)
+    {
+        if ($columns instanceof Closure) {
+            $callback = $columns;
+
+            $columns = ['*'];
+        }
+
+        if (! is_null($model = $this->find($id, $columns))) {
+            return $model;
+        }
+
+        return call_user_func($callback);
+    }
+
+    /**
      * Get the first record matching the attributes or instantiate it.
      *
      * @param  array  $attributes

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -59,6 +59,21 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertInstanceOf('Illuminate\Database\Eloquent\Model', $result);
     }
 
+    public function testFindOrMethodModelFound()
+    {
+        $model = $this->getMockModel();
+        $model->shouldReceive('findOr')->once()->andReturn('baz');
+
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($model);
+        $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
+        $builder->shouldReceive('first')->with(['column'])->andReturn('baz');
+
+        $expected = $model->findOr('bar', ['column']);
+        $result = $builder->find('bar', ['column']);
+        $this->assertEquals($expected, $result);
+    }
+
     /**
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      */


### PR DESCRIPTION
Not much to say -- pretty much a clone of `firstOrNew` but using `find` instead of having a query built and then calling `first`. 