### PR TITLE
[5.6] Add closure support to loadMissing()

### DIFF
--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -59,6 +59,21 @@ class EloquentCollectionLoadMissingTest extends DatabaseTestCase
         $this->assertTrue($posts[0]->comments[1]->parent->relationLoaded('revisions'));
         $this->assertFalse(array_key_exists('post_id', $posts[0]->comments[1]->parent->getAttributes()));
     }
+
+    public function testLoadMissingWithClosure()
+    {
+        $posts = Post::with('comments')->get();
+
+        \DB::enableQueryLog();
+
+        $posts->loadMissing(['comments.parent' => function ($query) {
+            $query->select('id');
+        }]);
+
+        $this->assertCount(1, \DB::getQueryLog());
+        $this->assertTrue($posts[0]->comments[0]->relationLoaded('parent'));
+        $this->assertFalse(array_key_exists('post_id', $posts[0]->comments[1]->parent->getAttributes()));
+    }
 }
 
 class Comment extends Model


### PR DESCRIPTION
Add closure support to `Collection::loadMissing()` and `Model::loadMissing()` (#24166).