### PR TITLE
Remove hashing from reset password function

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -5,7 +5,6 @@ namespace Illuminate\Foundation\Auth;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Auth\Events\PasswordReset;
 
@@ -102,7 +101,7 @@ trait ResetsPasswords
      */
     protected function resetPassword($user, $password)
     {
-        $user->password = Hash::make($password);
+        $user->password = $password;
 
         $user->setRememberToken(Str::random(60));
 


### PR DESCRIPTION
Instead of user hashing at time store user record, use setter for set hashing of password.

<!--
Need to create password setter in User model.
-->
