### PR TITLE
[5.6] Fix that you can't give a custom channel to notifications

### DIFF
--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -88,7 +88,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     {
         return array_merge($this->data, [
             'id' => $this->notification->id,
-            'type' => $this->broadcastType(),
+            'type' => $this->broadcastAs(),
         ]);
     }
 
@@ -97,7 +97,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
      *
      * @return string
      */
-    public function broadcastType()
+    public function broadcastAs()
     {
         return method_exists($this->notification, 'broadcastType')
                     ? $this->notification->broadcastType()

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -99,7 +99,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
      */
     public function broadcastAs()
     {
-        return method_exists($this->notification, 'broadcastType')
+        return method_exists($this->notification, 'broadcastAs')
                     ? $this->notification->broadcastAs()
                     : get_class($this->notification);
     }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -100,7 +100,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     public function broadcastAs()
     {
         return method_exists($this->notification, 'broadcastType')
-                    ? $this->notification->broadcastType()
+                    ? $this->notification->broadcastAs()
                     : get_class($this->notification);
     }
 }

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -52,7 +52,7 @@ class NotificationBroadcastChannelTest extends TestCase
             $notifiable, $notification, $notification->toArray($notifiable)
         );
 
-        $eventName = $event->broadcastType();
+        $eventName = $event->broadcastAs();
 
         $this->assertSame('custom.type', $eventName);
     }
@@ -115,7 +115,7 @@ class CustomEventNameTestNotification extends Notification
         return ['invoice_id' => 1];
     }
 
-    public function broadcastType()
+    public function broadcastAs()
     {
         return 'custom.type';
     }


### PR DESCRIPTION
In this commit https://github.com/laravel/framework/commit/4227bd78d5ab2743e694bfd34784a5ccced20bef Taylor broke the custom naming of channels. To fix this we have to rename broadcastType back to broadcastAs as the class that uses this looks at broadcastAs.