### PR TITLE
[5.6] Allow Auth::routes() and Route::auth() to be reused with Multi-Auth/Multi-Guard

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1124,7 +1124,7 @@ class Router implements RegistrarContract, BindingRegistrar
     public function auth($name = null)
     {
         $name = $name ? "{$name}." : '';
-        
+
         // Authentication Routes...
         $this->get('login', 'Auth\LoginController@showLoginForm')->name($name.'login');
         $this->post('login', 'Auth\LoginController@login');

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1123,21 +1123,21 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function auth($name = null)
     {
-        $name = $name ? "{$name}." : '';
+        $prefix = $name ? "{$name}." : '';
 
         // Authentication Routes...
-        $this->get('login', 'Auth\LoginController@showLoginForm')->name($name.'login');
+        $this->get('login', 'Auth\LoginController@showLoginForm')->name($prefix.'login');
         $this->post('login', 'Auth\LoginController@login');
-        $this->post('logout', 'Auth\LoginController@logout')->name($name.'logout');
+        $this->post('logout', 'Auth\LoginController@logout')->name($prefix.'logout');
 
         // Registration Routes...
-        $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name($name.'register');
+        $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name($prefix.'register');
         $this->post('register', 'Auth\RegisterController@register');
 
         // Password Reset Routes...
-        $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name($name.'password.request');
-        $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name($name.'password.email');
-        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name($name.'password.reset');
+        $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name($prefix.'password.request');
+        $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name($prefix.'password.email');
+        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name($prefix.'password.reset');
         $this->post('password/reset', 'Auth\ResetPasswordController@reset');
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1118,23 +1118,26 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Register the typical authentication routes for an application.
      *
+     * @param string|null $name
      * @return void
      */
-    public function auth()
+    public function auth($name = null)
     {
+        $name = $name ? "{$name}." : '';
+        
         // Authentication Routes...
-        $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
+        $this->get('login', 'Auth\LoginController@showLoginForm')->name($name.'login');
         $this->post('login', 'Auth\LoginController@login');
-        $this->post('logout', 'Auth\LoginController@logout')->name('logout');
+        $this->post('logout', 'Auth\LoginController@logout')->name($name.'logout');
 
         // Registration Routes...
-        $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
+        $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name($name.'register');
         $this->post('register', 'Auth\RegisterController@register');
 
         // Password Reset Routes...
-        $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
-        $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
-        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
+        $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name($name.'password.request');
+        $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name($name.'password.email');
+        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name($name.'password.reset');
         $this->post('password/reset', 'Auth\ResetPasswordController@reset');
     }
 

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -39,10 +39,11 @@ class Auth extends Facade
     /**
      * Register the typical authentication routes for an application.
      *
+     * @param string|null $name
      * @return void
      */
-    public static function routes()
+    public static function routes($name = null)
     {
-        static::$app->make('router')->auth();
+        static::$app->make('router')->auth($name);
     }
 }


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Sometimes we have Multi-Auth/Mulit-Guard in our applications. We set it up in `config/auth.php`

But the authentication route helper methods that is provided with Laravel out of the box is not reusable.

Example: `Route::auth() & Auth::routes()`.

Reason being the names are hard coded in the helper method.

This PR attempts to fix that.

Previously we had the same route names no matter how many times we write the Helper methods,
```bash
$ php artisan route:list

+--------+----------+------------------------+------------------+------------------------------------------------------------------------+--------------+
| Domain | Method   | URI                    | Name             | Action                                                                 | Middleware   |
+--------+----------+------------------------+------------------+------------------------------------------------------------------------+--------------+
|        | GET|HEAD | /                      |                  | Closure                                                                | web          |
|        | GET|HEAD | api/user               |                  | Closure                                                                | api,auth:api |
|        | GET|HEAD | home                   | home             | App\Http\Controllers\HomeController@index                              | web,auth     |
|        | GET|HEAD | login                  | login            | App\Http\Controllers\Auth\LoginController@showLoginForm                | web,guest    |
|        | POST     | login                  |                  | App\Http\Controllers\Auth\LoginController@login                        | web,guest    |
|        | POST     | logout                 | logout           | App\Http\Controllers\Auth\LoginController@logout                       | web          |
|        | POST     | password/email         | password.email   | App\Http\Controllers\Auth\ForgotPasswordController@sendResetLinkEmail  | web,guest    |
|        | GET|HEAD | password/reset         | password.request | App\Http\Controllers\Auth\ForgotPasswordController@showLinkRequestForm | web,guest    |
|        | POST     | password/reset         |                  | App\Http\Controllers\Auth\ResetPasswordController@reset                | web,guest    |
|        | GET|HEAD | password/reset/{token} | password.reset   | App\Http\Controllers\Auth\ResetPasswordController@showResetForm        | web,guest    |
|        | GET|HEAD | register               | register         | App\Http\Controllers\Auth\RegisterController@showRegistrationForm      | web,guest    |
|        | POST     | register               |                  | App\Http\Controllers\Auth\RegisterController@register                  | web,guest    |
+--------+----------+------------------------+------------------+------------------------------------------------------------------------+--------------+

```

But in this PR we have a name prefix parameter in the Helper method like this,

```php
Route::auth('admin');
// OR
Auth::routes('admin');
```

That will generate the routes with the `admin` name prefix applied.

```bash
$ php artisan route:list
                                                                                                                                       
+--------+----------+------------------------+------------------------+------------------------------------------------------------------------+--------------+
| Domain | Method   | URI                    | Name                   | Action                                                                 | Middleware   |
+--------+----------+------------------------+------------------------+------------------------------------------------------------------------+--------------+
|        | GET|HEAD | /                      |                        | Closure                                                                | web          |
|        | GET|HEAD | api/user               |                        | Closure                                                                | api,auth:api |
|        | GET|HEAD | home                   | home                   | App\Http\Controllers\HomeController@index                              | web,auth     |
|        | GET|HEAD | login                  | admin.login            | App\Http\Controllers\Auth\LoginController@showLoginForm                | web,guest    |
|        | POST     | login                  |                        | App\Http\Controllers\Auth\LoginController@login                        | web,guest    |
|        | POST     | logout                 | admin.logout           | App\Http\Controllers\Auth\LoginController@logout                       | web          |
|        | POST     | password/email         | admin.password.email   | App\Http\Controllers\Auth\ForgotPasswordController@sendResetLinkEmail  | web,guest    |
|        | GET|HEAD | password/reset         | admin.password.request | App\Http\Controllers\Auth\ForgotPasswordController@showLinkRequestForm | web,guest    |
|        | POST     | password/reset         |                        | App\Http\Controllers\Auth\ResetPasswordController@reset                | web,guest    |
|        | GET|HEAD | password/reset/{token} | admin.password.reset   | App\Http\Controllers\Auth\ResetPasswordController@showResetForm        | web,guest    |
|        | GET|HEAD | register               | admin.register         | App\Http\Controllers\Auth\RegisterController@showRegistrationForm      | web,guest    |
|        | POST     | register               |                        | App\Http\Controllers\Auth\RegisterController@register                  | web,guest    |
+--------+----------+------------------------+------------------------+------------------------------------------------------------------------+--------------+
```

As for the **TESTS**, I couldn't find any tests related to `Route::auth()` method. I think because it is just a Helper.