### PR TITLE
[5.6] Fix custom naming of notifications in non breaking way

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -40,8 +40,13 @@ class BroadcastEvent implements ShouldQueue
      */
     public function handle(Broadcaster $broadcaster)
     {
-        $name = method_exists($this->event, 'broadcastAs')
-                ? $this->event->broadcastAs() : get_class($this->event);
+        if (method_exists($this->event, 'broadcastAs')) {
+            $name = $this->event->broadcastAs();
+        } else if (method_exists($this->event, 'broadcastType')) {
+            $name = $this->event->broadcastType();
+        } else {
+            $name = get_class($this->event);
+        }
 
         $broadcaster->broadcast(
             Arr::wrap($this->event->broadcastOn()), $name,


### PR DESCRIPTION
As https://github.com/laravel/framework/pull/24223 was closed probably for breaking I have tried fixing it with this PR in a non breaking way.

Because the Notification Event has a broadcastType function but not a broadcastAs function we will first look at broadcastAs, after to broadcastType and if that is also not there we will just take the class namespace.

This allows users to choose a custom event name for front-end as the front-end doesn't need to know about the namespacing of the backend.