### PR TITLE
[5.6] Fix: If the expiration is null, set it permanently when increments in file cache driver

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -91,7 +91,7 @@ class FileStore implements Store
         $raw = $this->getPayload($key);
 
         return tap(((int) $raw['data']) + $value, function ($newValue) use ($key, $raw) {
-            $this->put($key, $newValue, $raw['time']);
+            $this->put($key, $newValue, $raw['time'] ?? 0);
         });
     }
 


### PR DESCRIPTION
I meet a bug when using `increment` of file cache driver.

# Reproduce
Use file cache driver, config it in the `.env`
``` ini
CACHE_DRIVER=file
```
``` php
Cache::increment('key');    // return 1
Cache::increment('key');    // ERROR: return 1
```

# Fix
If the expiration is null, set it permanently when increments.

After fix:
``` php
Cache::increment('key');    // return 1
Cache::increment('key');    // return 2
```