### PR TITLE
[5.6] Support for SET MySql type column in migrations

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -812,7 +812,7 @@ class Blueprint
     {
         return $this->addColumn('enum', $column, compact('allowed'));
     }
-    
+
     /**
      * Create a new set column on the table.
      *

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -812,6 +812,18 @@ class Blueprint
     {
         return $this->addColumn('enum', $column, compact('allowed'));
     }
+    
+    /**
+     * Create a new set column on the table.
+     *
+     * @param  string  $column
+     * @param  array  $allowed
+     * @return \Illuminate\Support\Fluent
+     */
+    public function set($column, array $allowed)
+    {
+        return $this->addColumn('set', $column, compact('allowed'));
+    }
 
     /**
      * Create a new json column on the table.

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -551,6 +551,17 @@ class MySqlGrammar extends Grammar
     {
         return sprintf('enum(%s)', $this->quoteString($column->allowed));
     }
+    
+    /**
+     * Create the column definition for an set type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeSet(Fluent $column)
+    {
+        return sprintf('set(%s)', $this->quoteString($column->allowed));
+    }
 
     /**
      * Create the column definition for a json type.

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -551,9 +551,9 @@ class MySqlGrammar extends Grammar
     {
         return sprintf('enum(%s)', $this->quoteString($column->allowed));
     }
-    
+
     /**
-     * Create the column definition for an set type.
+     * Create the column definition for a set type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -607,6 +607,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `role` enum(\'member\', \'admin\') not null', $statements[0]);
     }
 
+    public function testAddingSet()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->set('status', ['a', 'b']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `status` set(\'a\', \'b\') not null', $statements[0]);
+    }
+
     public function testAddingJson()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
Hello,
Instead of extending Blueprint and MysqlGrammar (ex. : https://coderwall.com/p/mo1gew/custom-datatype-in-laravel-schema-builder), these so few lines of code make it work.
Thanks