### PR TITLE
[5.6] Allow faking events for only a specific part

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -32,14 +32,14 @@ class Event extends Facade
      */
     public static function fakeFor(callable $callable, array $eventsToFake = [])
     {
-        $initialDispatcher = Event::getFacadeRoot();
+        $initialDispatcher = static::getFacadeRoot();
 
-        Event::fake($eventsToFake);
+        static::fake($eventsToFake);
 
         return tap($callable(), function () use ($initialDispatcher) {
             Model::setEventDispatcher($initialDispatcher);
 
-            Event::swap($initialDispatcher);
+            static::swap($initialDispatcher);
         });
     }
 

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -24,6 +24,26 @@ class Event extends Facade
     }
 
     /**
+     * Replace the bound instance with a fake for the given callable only.
+     *
+     * @param  callable  $callable
+     * @param  array|string  $eventsToFake
+     * @return callable
+     */
+    public static function fakeFor(callable $callable, array $eventsToFake = [])
+    {
+        $initialDispatcher = Event::getFacadeRoot();
+
+        Event::fake($eventsToFake);
+
+        return tap($callable(), function () use ($initialDispatcher) {
+            Model::setEventDispatcher($initialDispatcher);
+
+            Event::swap($initialDispatcher);
+        });
+    }
+
+    /**
      * Get the registered name of the component.
      *
      * @return string

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Testing\Fakes\EventFake;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class SupportFacadesEventTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->events = Mockery::spy(Dispatcher::class);
+
+        $container = new Container;
+        $container->instance('events', $this->events);
+
+        Facade::setFacadeApplication($container);
+    }
+
+    public function tearDown()
+    {
+        Event::clearResolvedInstances();
+
+        Mockery::close();
+    }
+
+    public function testFakeFor()
+    {
+        Event::fakeFor(function () {
+            (new FakeForStub())->dispatch();
+
+            Event::assertDispatched(EventStub::class);
+        });
+
+        $this->events->shouldReceive('dispatch')->once();
+
+        (new FakeForStub())->dispatch();
+    }
+
+    public function testFakeForSwapsDispatchers()
+    {
+        Event::fakeFor(function () {
+            $this->assertInstanceOf(EventFake::class, Event::getFacadeRoot());
+            $this->assertInstanceOf(EventFake::class, Model::getEventDispatcher());
+        });
+
+        $this->assertSame($this->events, Event::getFacadeRoot());
+        $this->assertSame($this->events, Model::getEventDispatcher());
+    }
+}
+
+class FakeForStub
+{
+    public function dispatch()
+    {
+        Event::dispatch(EventStub::class);
+    }
+}

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -2,14 +2,14 @@
 
 namespace Illuminate\Tests\Support;
 
-use Illuminate\Container\Container;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Events\Dispatcher;
-use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Facade;
-use Illuminate\Support\Testing\Fakes\EventFake;
 use Mockery;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Testing\Fakes\EventFake;
 
 class SupportFacadesEventTest extends TestCase
 {


### PR DESCRIPTION
Sometimes you want to fake the events for only a part of your test and not the whole test. For example to create some factories for models that rely heavily on events. We could need those events to be faked for that part, but not for the actual feature test we are performing.

In the example below the subscription would have some actions being performed through event listeners. For example a `CreateUniqueNumberForSubscription` and a `CreateInvoiceForSubscription`. When creating the factory subscription we don't want those events to be triggered, but when making a child subscription (the actual feature test) we want to dispatch all the events and test the result of those events being triggerd. For example by testing if the invoice was created correctly.
```php
/** @test */
public function it_can_create_a_child_subscription() {
    $subscription = Event::fakeFor(function () {
        return factory(Subscription::class)->create();
    });

    $this->json('POST', '/subscriptions', [
        'parent_id' => $subscription->id,
    ])
        ->assertStatus(201);

    // assert this new created subscription has data filled by some event listener.
}
```

It would still have the possibility to only fake some events when passing those events to the second parameter:
```php
Event::fakeFor(function () {
    return factory(Subscription::class)->create();
}, [OnlyThisEvent::class]);
```

And it also would still be possible to check if events are being dispatched on the `EventFake` inside of this `fakeFor()` callable:
```php
Event::fakeFor(function () {
    return tap(
        factory(Subscription::class)->create(),
        function ($subscription) {
            Event::assertDispatched(OnlyThisEvent::class);
        }
    );
}, [OnlyThisEvent::class]);
```
