### PR TITLE
[5.7] Align Mailable dynamic parameter case to View (camel).

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -776,7 +776,7 @@ class Mailable implements MailableContract, Renderable
     public function __call($method, $parameters)
     {
         if (Str::startsWith($method, 'with')) {
-            return $this->with(Str::snake(substr($method, 4)), $parameters[0]);
+            return $this->with(Str::camel(substr($method, 4)), $parameters[0]);
         }
 
         throw new BadMethodCallException(sprintf(

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -109,7 +109,7 @@ class MailMailableTest extends TestCase
 
         $expected = [
             'first_name' => 'Taylor',
-            'last_name' => 'Otwell',
+            'lastName' => 'Otwell',
             'framework' => 'Laravel',
         ];
 


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Currently dynamic `with` parameters on `Illuminate\Mail\Mailable` are snake cased, however `Illuminate\View\View` was updated to camel case in 5.5.
> #18083: [5.5] Camel case variables that get shared with a view

Breaking change, but for consistency, `Mailable` would now also use camel case.
