### PR TITLE
[5.6] Improve allowed method injection parameters

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -152,6 +152,10 @@ class BoundMethod
             $dependencies[] = $parameters[$parameter->name];
 
             unset($parameters[$parameter->name]);
+        } elseif ($parameter->getClass() && array_key_exists($parameter->getClass()->name, $parameters)) {
+            $dependencies[] = $parameters[$parameter->getClass()->name];
+
+            unset($parameters[$parameter->getClass()->name]);
         } elseif ($parameter->getClass()) {
             $dependencies[] = $container->make($parameter->getClass()->name);
         } elseif ($parameter->isDefaultValueAvailable()) {

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -490,6 +490,14 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf('stdClass', $result[0]);
         $this->assertEquals('taylor', $result[1]);
 
+        $stub = new ContainerConcreteStub;
+        $result = $container->call(function (stdClass $foo, ContainerConcreteStub $bar) {
+            return func_get_args();
+        }, [ContainerConcreteStub::class => $stub]);
+
+        $this->assertInstanceOf('stdClass', $result[0]);
+        $this->assertSame($stub, $result[1]);
+
         /*
          * Wrap a function...
          */


### PR DESCRIPTION
This PR adds the ability to pass a specific object instance to a method called from the container, regardless of the parameter name.

This can be useful in situations where you want to inject a specific object instance into a method call, no matter what name that parameter has.