### PR TITLE
ResourceCollections contain a flaw in the "links" object that prevent proper pagination

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -76,7 +76,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public static function collection($resource)
     {
-        return new AnonymousResourceCollection($resource, get_called_class());
+        return new AnonymousResourceCollection($resource->appends(request()->all()), get_called_class());
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -35,6 +35,7 @@ class ResourceCollection extends JsonResource implements IteratorAggregate
         parent::__construct($resource);
 
         $this->resource = $this->collectResource($resource);
+        $this->resource->appends(request()->all());
     }
 
     /**


### PR DESCRIPTION
There is currently a flaw in the links object that is generated for paginated resource collections passed to both ResourceCollections as well as Resource::collection(). Specifically, existing query string parameters are completely ignored when the links are being generated. Most notably this includes the limit parameter. This results in the inability to correctly process through a paginated result set. 

For example, lets suppose you have a Post Model with a PostResource or PostResourceCollection, your default limit is 10, and you visit the enpoint /Post?limit=5. Currently, the ResourceCollection object will return a result of Posts 1-5 that includes Links and Meta. The next link however is just /Post?page=2. All query strings parameters, including limit, are ignored. When following that link to the second page, instead of returning Posts 6-10, it would return posts 11-20. Again, this is true with both ResoruceCollection as well as Resource::collection(). 

The simplest way to reproduce this, assuming you have already migrated and seeded the User table is to use this for your `routes/web.php`:
```php
Route::apiResource('user', '\UsersController');

class UsersController extends App\Http\Controllers\Controller
{
    public function index()
    {
        return new UserResourceCollection(App\User::paginate(request()->get('limit') ?? 10));
        return UserResource::collection(App\User::paginate(request()->get('limit') ?? 10));
    }
}

class UserResourceCollection extends Illuminate\Http\Resources\Json\ResourceCollection{}
class UserResource extends Illuminate\Http\Resources\Json\Resource{}
```

It might be argued that not everyone will want query string parameters included in the link structure. While that may be true, it seems to me that the Resource and ResourceCollection are both attempting to be a base line, out of the box solution for establishing a Json based resource response. If the out of the box solution is unable to be compatible with query string options, the solution will be broken for most people. The solution to this issue is FAR from obvious and took quite a bit of time to track down. I know that I can fix this without a pull request by simply chaining the appends command to the resource, but again, this solution is far from obvious and in theory should just work out of the box.

I have put together a pull request that is one potential method to solve this issue. It simply adds the existing query string parameters to LengthAwarePaginator object via the appends method in an isolated way. 

It occurs to me, in the case of the Resource::collection, we could add a separate method, perhaps something like collectionWithQuery($resource), but that seems a bit unnecessary. 

Regardless, I am very open to other methods of fixing this. I am happy to put in the ground work to do so... Let me know what you think.