### PR TITLE
[5.7] Add ability to autogenerate BelongsToMany accessor from custom pivot.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -311,6 +311,17 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Specify the custom pivot model to use for the relationship and to generate the accessor.
+     *
+     * @param  string  $class
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function usingAs($class)
+    {
+        return $this->using($class)->as($class);
+    }
+
+    /**
      * Set a where clause for a pivot table column.
      *
      * @param  string  $column
@@ -685,9 +696,11 @@ class BelongsToMany extends Relation
         // and create a new Pivot model, which is basically a dynamic model that we
         // will set the attributes, table, and connections on it so it will work.
         foreach ($models as $model) {
-            $model->setRelation($this->accessor, $this->newExistingPivot(
-                $this->migratePivotAttributes($model)
-            ));
+            $pivot = $this->newExistingPivot($this->migratePivotAttributes($model));
+
+            $accessor = $pivot instanceof $this->accessor ? $pivot->getTable() : $this->accessor;
+
+            $model->setRelation($accessor, $pivot);
         }
     }
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -149,6 +149,27 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     /**
      * @test
      */
+    public function custom_accessor_generated_from_custom_pivot()
+    {
+        $post = Post::create(['title' => str_random()]);
+
+        $tag = TagWithCustomPivot::create(['name' => str_random()]);
+
+        $post->tagsWithCustomPivot()->attach($tag->id);
+
+        $this->assertInstanceOf(
+            CustomPivot::class, $post->tagsWithCustomAccessorGeneratedFromCustomPivot[0]->posts_tags
+        );
+
+        $this->assertEquals([
+            'post_id' => '1',
+            'tag_id' => '1',
+        ], $post->tagsWithCustomAccessorGeneratedFromCustomPivot[0]->posts_tags->toArray());
+    }
+
+    /**
+     * @test
+     */
     public function attach_method()
     {
         $post = Post::create(['title' => str_random()]);
@@ -663,6 +684,12 @@ class Post extends Model
         return $this->belongsToMany(TagWithCustomPivot::class, 'posts_tags', 'post_id', 'tag_id')
             ->using(CustomPivot::class)
             ->as('tag');
+    }
+
+    public function tagsWithCustomAccessorGeneratedFromCustomPivot()
+    {
+        return $this->belongsToMany(TagWithCustomPivot::class, 'posts_tags', 'post_id', 'tag_id')
+            ->usingAs(CustomPivot::class);
     }
 }
 


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Provides a helper on `Illuminate\Database\Eloquent\Relations\BelongsToMany` to auto generate the pivot attribute from the provided custom `Pivot` model.

### Usage
`User::first()->plans->first()->subscription->expires_at;`

### Architecture
```
class User extends Model
{
    public function plans()
    {
        return $this->belongsToMany(Plan::class)->usingAs(Subscription::class);
    }
}

class Plan extends Model
{
    //
}


class Subscription extends Pivot
{
    // has attribute expires_at
}
```