### PR TITLE
[5.6] Add validation rules: validateArrayKeyExist, validateArrayKeyNotExist

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -319,6 +319,40 @@ trait ValidatesAttributes
     }
 
     /**
+     * @param string $attribute
+     * @param mixed  $value
+     * @param array  $parameters
+     *
+     * @return bool
+     */
+    public function validateArrayKeyExist($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'array_key_exist');
+        if (! is_array($value)) {
+            return false;
+        }
+
+        return array_key_exists($parameters[0], $value);
+    }
+
+    /**
+     * @param string $attribute
+     * @param mixed  $value
+     * @param array  $parameters
+     *
+     * @return bool
+     */
+    public function validateArrayKeyNotExist($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'array_key_not_exist');
+        if (! is_array($value)) {
+            return true;
+        }
+
+        return ! array_key_exists($parameters[0], $value);
+    }
+
+    /**
      * Validate the size of an attribute is between a set of values.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1152,6 +1152,45 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
+    public function testValidateArrayKeyExist()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['array' => ['key'=>null]], ['array' => 'array_key_exist:key']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['array' => ['key1'=>null]], ['array' => 'array_key_exist:key']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['array' => null], ['array' => 'array_key_exist:key']);
+        $this->assertTrue($v->fails());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $v = new Validator($trans, ['array' => null], ['array' => 'array_key_exist']);
+        $v->passes();
+    }
+
+    public function testValidateArrayKeyNotExist()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['array' => ['key'=>null]], ['array' => 'array_key_not_exist:key']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['array' => ['key1'=>null]], ['array' => 'array_key_not_exist:key']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['array' => null], ['array' => 'array_key_not_exist:key']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['array' => null], ['array' => 'array|array_key_not_exist:key']);
+        $this->assertTrue($v->fails());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $v = new Validator($trans, ['array' => null], ['array' => 'array_key_not_exist']);
+        $v->passes();
+    }
+
     public function testValidateAccepted()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Hi,
I have added 2 validation rules:
array_key_exist and array_key_no_exist for key validation in the array.

What are you think about this?

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
