### PR TITLE
Multiple parameters in Collection Methods

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -11,6 +11,7 @@ use ArrayIterator;
 use CachingIterator;
 use JsonSerializable;
 use IteratorAggregate;
+use InvalidArgumentException;
 use Illuminate\Support\Debug\Dumper;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
@@ -294,7 +295,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function crossJoin(...$lists)
     {
         return new static(Arr::crossJoin(
-            $this->items, ...array_map([$this, 'getArrayableItems'], $lists)
+            $this->items, ...$this->getAllArrayableItems($lists)
         ));
     }
 
@@ -329,70 +330,102 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the items in the collection that are not present in the given items.
      *
-     * @param  mixed  $items
+     * @param  mixed  ...$items
      * @return static
      */
     public function diff($items)
     {
-        return new static(array_diff($this->items, $this->getArrayableItems($items)));
+        return new static(array_diff($this->items, ...$this->getAllArrayableItems(func_get_args())));
     }
 
     /**
      * Get the items in the collection that are not present in the given items.
      *
-     * @param  mixed  $items
+     * @param  mixed  ...$items
      * @param  callable  $callback
      * @return static
+     *
+     * @throws \InvalidArgumentException
      */
-    public function diffUsing($items, callable $callback)
+    public function diffUsing($items)
     {
-        return new static(array_udiff($this->items, $this->getArrayableItems($items), $callback));
+        $items = func_get_args();
+        if (!is_callable(end($items))) {
+            throw new InvalidArgumentException("The last parameter is not a callable");
+        }
+
+        $callable = array_pop($items);
+        $parameters = $this->getAllArrayableItems($items);
+        $parameters[] = $callable;
+
+        return new static(array_udiff($this->items, ...$parameters));
     }
 
     /**
      * Get the items in the collection whose keys and values are not present in the given items.
      *
-     * @param  mixed  $items
+     * @param  mixed  ...$items
      * @return static
      */
     public function diffAssoc($items)
     {
-        return new static(array_diff_assoc($this->items, $this->getArrayableItems($items)));
+        return new static(array_diff_assoc($this->items, ...$this->getAllArrayableItems(func_get_args())));
     }
 
     /**
      * Get the items in the collection whose keys and values are not present in the given items.
      *
-     * @param  mixed  $items
+     * @param  mixed  ...$items
      * @param  callable  $callback
      * @return static
+     *
+     * @throws \InvalidArgumentException
      */
-    public function diffAssocUsing($items, callable $callback)
+    public function diffAssocUsing($items)
     {
-        return new static(array_diff_uassoc($this->items, $this->getArrayableItems($items), $callback));
+        $items = func_get_args();
+        if (!is_callable(end($items))) {
+            throw new InvalidArgumentException("The last parameter is not a callable");
+        }
+        $callable = array_pop($items);
+        $parameters = $this->getAllArrayableItems($items);
+        $parameters[] = $callable;
+
+        return new static(array_diff_uassoc($this->items, ...$parameters));
     }
 
     /**
      * Get the items in the collection whose keys are not present in the given items.
      *
-     * @param  mixed  $items
+     * @param  mixed  ...$items
      * @return static
      */
     public function diffKeys($items)
     {
-        return new static(array_diff_key($this->items, $this->getArrayableItems($items)));
+        return new static(array_diff_key($this->items, ...$this->getAllArrayableItems(func_get_args())));
     }
 
     /**
      * Get the items in the collection whose keys are not present in the given items.
      *
-     * @param  mixed   $items
+     * @param  mixed   ...$items
      * @param  callable  $callback
      * @return static
+     *
+     * @throws \InvalidArgumentException
      */
-    public function diffKeysUsing($items, callable $callback)
+    public function diffKeysUsing($items)
     {
-        return new static(array_diff_ukey($this->items, $this->getArrayableItems($items), $callback));
+        $items = func_get_args();
+        if (!is_callable(end($items))) {
+            throw new InvalidArgumentException("The last parameter is not a callable");
+        }
+
+        $callable = array_pop($items);
+        $parameters = $this->getAllArrayableItems($items);
+        $parameters[] = $callable;
+
+        return new static(array_diff_ukey($this->items, ...$parameters));
     }
 
     /**
@@ -843,24 +876,24 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Intersect the collection with the given items.
      *
-     * @param  mixed  $items
+     * @param  mixed  ...$items
      * @return static
      */
     public function intersect($items)
     {
-        return new static(array_intersect($this->items, $this->getArrayableItems($items)));
+        return new static(array_intersect($this->items, ...$this->getAllArrayableItems(func_get_args())));
     }
 
     /**
      * Intersect the collection with the given items by key.
      *
-     * @param  mixed  $items
+     * @param  mixed  ...$items
      * @return static
      */
     public function intersectByKeys($items)
     {
         return new static(array_intersect_key(
-            $this->items, $this->getArrayableItems($items)
+            $this->items, ...$this->getAllArrayableItems(func_get_args())
         ));
     }
 
@@ -1072,12 +1105,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Merge the collection with the given items.
      *
-     * @param  mixed  $items
+     * @param  mixed  ...$items
      * @return static
      */
     public function merge($items)
     {
-        return new static(array_merge($this->items, $this->getArrayableItems($items)));
+        return new static(array_merge($this->items, ...$this->getAllArrayableItems(func_get_args())));
     }
 
     /**
@@ -1094,12 +1127,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Union the collection with the given items.
      *
-     * @param  mixed  $items
+     * @param  mixed  ...$items
      * @return static
      */
     public function union($items)
     {
-        return new static($this->items + $this->getArrayableItems($items));
+        $items = $this->getAllArrayableItems(func_get_args());
+        array_unshift($items, $this->items);
+        return new static(array_reduce($items, function ($carry, $item) {
+                return $carry + $item;
+        }, []));
     }
 
     /**
@@ -1703,9 +1740,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function zip($items)
     {
-        $arrayableItems = array_map(function ($items) {
-            return $this->getArrayableItems($items);
-        }, func_get_args());
+        $arrayableItems = $this->getAllArrayableItems(func_get_args());
 
         $params = array_merge([function () {
             return new static(func_get_args());
@@ -1867,6 +1902,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function __toString()
     {
         return $this->toJson();
+    }
+
+    /**
+     * Results array of items from Collection or Arrayable from all parameters.
+     *
+     * @param  mixed  ...$items
+     * @return array
+     */
+    protected function getAllArrayableItems($items)
+    {
+        return array_map(array($this, 'getArrayableItems'), $items);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -350,8 +350,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function diffUsing($items)
     {
         $items = func_get_args();
-        if (!is_callable(end($items))) {
-            throw new InvalidArgumentException("The last parameter is not a callable");
+        if (! is_callable(end($items))) {
+            throw new InvalidArgumentException('The last parameter is not a callable');
         }
 
         $callable = array_pop($items);
@@ -384,8 +384,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function diffAssocUsing($items)
     {
         $items = func_get_args();
-        if (!is_callable(end($items))) {
-            throw new InvalidArgumentException("The last parameter is not a callable");
+        if (! is_callable(end($items))) {
+            throw new InvalidArgumentException('The last parameter is not a callable');
         }
         $callable = array_pop($items);
         $parameters = $this->getAllArrayableItems($items);
@@ -417,8 +417,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function diffKeysUsing($items)
     {
         $items = func_get_args();
-        if (!is_callable(end($items))) {
-            throw new InvalidArgumentException("The last parameter is not a callable");
+        if (! is_callable(end($items))) {
+            throw new InvalidArgumentException('The last parameter is not a callable');
         }
 
         $callable = array_pop($items);
@@ -1134,8 +1134,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $items = $this->getAllArrayableItems(func_get_args());
         array_unshift($items, $this->items);
+
         return new static(array_reduce($items, function ($carry, $item) {
-                return $carry + $item;
+            return $carry + $item;
         }, []));
     }
 
@@ -1912,7 +1913,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     protected function getAllArrayableItems($items)
     {
-        return array_map(array($this, 'getArrayableItems'), $items);
+        return array_map([$this, 'getArrayableItems'], $items);
     }
 
     /**


### PR DESCRIPTION
This PR allows collection methods (like diff, intersect, merge) to accept multiple parameters like their php counterpart. The only thing we would have to do is pass in a unpacked array using the new function `getAllArrayableItems` to the php function being called.

List of methods changed to allow for multiple parameters:

```
diff
diffUsing
diffAssoc
diffAssocUsing
diffKeys
diffKeysUsing
intersect
intersectbyKeys
merge
union
```
I changed the implementation from my previous PR, so that it doesn't change the function signature. The other breaking change I'm aware of is `diffUsing`, `diffAssocUsing`, and `diffKeysUsing` throwing an InvalidArgumentException rather than a php warning

Usage:
```php
$collection = new Collection(['foo' => true, 'baz' => 42, 'fooBar' => 'baz']);

$diff = $collection->diffKeys(['foo' => false], ['foobar' => null]);
dump($diff->all());
```
```
array:1 [
  "baz" => 42
]
```
I fixed the issue @sisve brought up in my previous PR and I'm hoping to get this into master, in at the very least 5.7