### PR TITLE
[5.6] Add Builder::whereJsonContains()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1434,6 +1434,39 @@ class Builder
     }
 
     /**
+     * Add a "where JSON contains" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereJsonContains($column, $value, $boolean = 'and')
+    {
+        $type = 'JsonContains';
+
+        $this->wheres[] = compact('type', 'column', 'value', 'boolean');
+
+        if (! $value instanceof Expression) {
+            $this->addBinding(json_encode($value));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a "or where JSON contains" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhereJsonContains($column, $value)
+    {
+        return $this->whereJsonContains($column, $value, 'or');
+    }
+
+    /**
      * Handles dynamic "where" clauses to the query.
      *
      * @param  string  $method

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
+use RuntimeException;
 use Illuminate\Support\Arr;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
@@ -511,10 +512,11 @@ class Grammar extends BaseGrammar
      * @param  string  $column
      * @param  string  $value
      * @return string
+     * @throws \RuntimeException
      */
     protected function compileJsonContains($column, $value)
     {
-        return 'json_contains('.$column.', '.$value.')';
+        throw new RuntimeException('The database engine in use is not yet suppported.');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -490,6 +490,34 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where JSON contains" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereJsonContains(Builder $query, $where)
+    {
+        $column = $this->wrap($where['column']);
+
+        $value = $this->parameter($where['value']);
+
+        return $this->compileJsonContains($column, $value);
+    }
+
+    /**
+     * Compile a "JSON contains" statement into SQL.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileJsonContains($column, $value)
+    {
+        return 'json_contains('.$column.', '.$value.')';
+    }
+
+    /**
      * Compile the "group by" portions of the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -53,6 +53,18 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a "JSON contains" statement into SQL.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileJsonContains($column, $value)
+    {
+        return 'json_contains('.$column.', '.$value.')';
+    }
+
+    /**
      * Compile a single union statement.
      *
      * @param  array  $union

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -65,6 +65,20 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a "JSON contains" statement into SQL.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileJsonContains($column, $value)
+    {
+        $column = str_replace('->>', '->', $column);
+
+        return '('.$column.')::jsonb @> '.$value;
+    }
+
+    /**
      * Compile the lock into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2612,7 +2612,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('orders')->whereRowValues(['last_update'], '<', [1, 2]);
     }
 
-    public function testWhereJsonContains()
+    public function testWhereJsonContainsMySql()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereJsonContains('options->languages', ['en']);
@@ -2623,11 +2623,37 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonContains('options->languages', new Raw("'[\"en\"]'"));
         $this->assertEquals('select * from `users` where `id` = ? or json_contains(`options`->\'$."languages"\', \'["en"]\')', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
+    }
 
+    public function testWhereJsonContainsPostgres()
+    {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereJsonContains('options->languages', ['en']);
         $this->assertEquals('select * from "users" where ("options"->\'languages\')::jsonb @> ?', $builder->toSql());
         $this->assertEquals(['["en"]'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonContains('options->languages', new Raw("'[\"en\"]'"));
+        $this->assertEquals('select * from "users" where "id" = ? or ("options"->\'languages\')::jsonb @> \'["en"]\'', $builder->toSql());
+        $this->assertEquals([1], $builder->getBindings());
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testWhereJsonContainsSqlite()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereJsonContains('options->languages', ['en'])->toSql();
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testWhereJsonContainsSqlServer()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereJsonContains('options->languages', ['en'])->toSql();
     }
 
     public function testFromSub()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2612,6 +2612,24 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('orders')->whereRowValues(['last_update'], '<', [1, 2]);
     }
 
+    public function testWhereJsonContains()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereJsonContains('options->languages', ['en']);
+        $this->assertEquals('select * from `users` where json_contains(`options`->\'$."languages"\', ?)', $builder->toSql());
+        $this->assertEquals(['["en"]'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonContains('options->languages', new Raw("'[\"en\"]'"));
+        $this->assertEquals('select * from `users` where `id` = ? or json_contains(`options`->\'$."languages"\', \'["en"]\')', $builder->toSql());
+        $this->assertEquals([1], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereJsonContains('options->languages', ['en']);
+        $this->assertEquals('select * from "users" where ("options"->\'languages\')::jsonb @> ?', $builder->toSql());
+        $this->assertEquals(['["en"]'], $builder->getBindings());
+    }
+
     public function testFromSub()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
[At the moment](https://laravel.com/docs/5.6/queries#json-where-clauses) we can query JSON columns for exact matches: 

    DB::table('users')->where('options->language', 'en')->get();

This PR adds `whereJsonContains()` with support for [MySQL](https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html) and [PostgreSQL](https://www.postgresql.org/docs/current/static/functions-json.html):

    // Example value in the `options` column: {"languages":["de","en","fr"]}
    DB::table('users')->whereJsonContains('options->languages', 'en')->get();
    DB::table('users')->whereJsonContains('options->languages', ['en', 'de'])->get();
    DB::table('users')->whereJsonContains('options->languages', DB::raw("'\"en\"'"))->get();

The method expects a PHP value and converts it to JSON. Raw expressions are also supported.

The `PostgresGrammar` replaces the column name's last `->` with a `->>` . This is required for `where()`, but has to be undone for `whereJsonContains()`.

Resolves https://github.com/laravel/ideas/issues/296.