### PR TITLE
fix https bug

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -289,7 +289,26 @@ class UrlGenerator implements UrlGeneratorContract
         }
 
         if (is_null($this->cachedSchema)) {
-            $this->cachedSchema = $this->forceScheme ?: $this->request->getScheme().'://';
+
+            // On https proxy http like nginx
+            // If the outer layer is verified for HTTPS.
+            // The inner layer can't get ready scheme
+            // Get from env cache and fixed it
+            if (function_exists('env')) {
+                $appUrl = env('APP_URL');
+            } else {
+                $appUrl = getenv('APP_URL');
+            }
+
+            if (!empty($appUrl)) {
+                $urlInfo = parse_url($appUrl);
+                if ($urlInfo !== false and isset($urlInfo['scheme'])) {
+                    $this->cachedSchema = $urlInfo['scheme'];
+                    return $this->cachedSchema;
+                }
+            }
+
+            $this->cachedSchema = $this->forceScheme ?: $this->request->getScheme() . '://';
         }
 
         return $this->cachedSchema;


### PR DESCRIPTION
On https proxy http, If no auth(example https://domain):
```
 //Illuminate\Foundation\Exceptions\Handler
 protected function unauthenticated($request, AuthenticationException $exception)
    {
        return $request->expectsJson()
                    ? response()->json(['message' => $exception->getMessage()], 401)
                    : redirect()->guest(route('login'));
    }
```
The execution result of this method(route('login')) is http://domain/login;
It's want go to http://domain/login and error page;

So, I got this bugs and fixed it in  Illuminate\Routing\UrlGenerator;
I think It's want get env value

Like this:
```
public function formatScheme($secure)
    {
        if (! is_null($secure)) {
            return $secure ? 'https://' : 'http://';
        }

        if (is_null($this->cachedSchema)) {

            // On https proxy http like nginx
            // If the outer layer is verified for HTTPS.
            // The inner layer can't get ready scheme
            // Get from env cache and fixed it
            if (function_exists('env')) {
                $appUrl = env('APP_URL');
            } else {
                $appUrl = getenv('APP_URL');
            }

            if (!empty($appUrl)) {
                
                $urlInfo = parse_url($appUrl);
                if ($urlInfo !== false and isset($urlInfo['scheme'])) {
                    $this->cachedSchema = $urlInfo['scheme'];
                    return $this->cachedSchema;
                }
            }

            $this->cachedSchema = $this->forceScheme ?: $this->request->getScheme() . '://';
        }

        return $this->cachedSchema;
    }
```

Thank you for checking my pull request and  I hope the community gets better and better.