### PR TITLE
[5.6]Added dotsql method to execute raw .sql files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you're not in the mood to read, [Laracasts](https://laracasts.com) contains o
 
 ## Contributing
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](http://laravel.com/docs/contributions).
+Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
 
 ## Code of Conduct
 
@@ -42,4 +42,4 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 
 ## License
 
-The Laravel framework is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT).
+The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -491,6 +491,35 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Execute an .SQL file and return the boolean result.
+     *
+     * @param  string  $filename
+     * @param  bool    $continue
+     * @return bool
+     */
+    public function dotsql($filename, $continue)
+    {
+        $sqls = file_get_contents(database_path('/structures/'.$filename));
+        $sqls = explode(';', $sqls);
+        foreach ($sqls as &$sql) {
+            $sql = trim($sql);
+        }
+        $sqls[count($sqls) - 1] = '';
+        $a = true;
+        foreach ($sqls as $a => $sql) {
+            $t = $this->statement($sql);
+            if (! $t and ! $continue) {
+                return false;
+            }
+            if (! $t) {
+                $a = false;
+            }
+        }
+
+        return $a;
+    }
+
+    /**
      * Run a raw, unprepared query against the PDO connection.
      *
      * @param  string  $query

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1289,7 +1289,7 @@ class Builder
 
             $this->wheres[] = compact('type', 'query', 'boolean');
 
-            $this->addBinding($query->getBindings(), 'where');
+            $this->addBinding($query->getRawBindings()['where'], 'where');
         }
 
         return $this;

--- a/src/Illuminate/Notifications/HasDatabaseNotifications.php
+++ b/src/Illuminate/Notifications/HasDatabaseNotifications.php
@@ -6,28 +6,31 @@ trait HasDatabaseNotifications
 {
     /**
      * Get the entity's notifications.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */
     public function notifications()
     {
-        return $this->morphMany(DatabaseNotification::class, 'notifiable')
-                            ->orderBy('created_at', 'desc');
+        return $this->morphMany(DatabaseNotification::class, 'notifiable')->orderBy('created_at', 'desc');
     }
 
     /**
      * Get the entity's read notifications.
+     *
+     * @return \Illuminate\Database\Query\Builder
      */
     public function readNotifications()
     {
-        return $this->notifications()
-                            ->whereNotNull('read_at');
+        return $this->notifications()->whereNotNull('read_at');
     }
 
     /**
      * Get the entity's unread notifications.
+     *
+     * @return \Illuminate\Database\Query\Builder
      */
     public function unreadNotifications()
     {
-        return $this->notifications()
-                            ->whereNull('read_at');
+        return $this->notifications()->whereNull('read_at');
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
@@ -27,6 +27,17 @@ trait CompilesAuthorizations
     }
 
     /**
+     * Compile the canany statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileCanany($expression)
+    {
+        return "<?php if (app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->any{$expression}): ?>";
+    }
+
+    /**
      * Compile the else-can statements into valid PHP.
      *
      * @param  string  $expression
@@ -49,6 +60,17 @@ trait CompilesAuthorizations
     }
 
     /**
+     * Compile the else-canany statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileElsecanany($expression)
+    {
+        return "<?php elseif (app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->any{$expression}): ?>";
+    }
+
+    /**
      * Compile the end-can statements into valid PHP.
      *
      * @return string
@@ -64,6 +86,16 @@ trait CompilesAuthorizations
      * @return string
      */
     protected function compileEndcannot()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
+     * Compile the end-canany statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndcanany()
     {
         return '<?php endif; ?>';
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1039,6 +1039,15 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 'foo', 1 => 'bar', 2 => 25], $builder->getBindings());
     }
 
+    public function testNestedWhereBindings()
+    {
+        $builder = $this->getBuilder();
+        $builder->where('email', '=', 'foo')->where(function ($q) {
+            $q->selectRaw('?', ['ignore'])->where('name', '=', 'bar');
+        });
+        $this->assertEquals([0 => 'foo', 1 => 'bar'], $builder->getBindings());
+    }
+
     public function testFullSubSelects()
     {
         $builder = $this->getBuilder();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3752,10 +3752,6 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['cat' => ['cat1' => ['name' => '1']]], \Illuminate\Validation\ValidationData::extractDataFromPath('cat.cat1.name', $data));
     }
 
-    public function testInlineMessagesMayUseAsteriskForEachRules()
-    {
-    }
-
     public function testUsingSettersWithImplicitRules()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/View/Blade/BladeCananyStatementsTest.php
+++ b/tests/View/Blade/BladeCananyStatementsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeCananyStatementsTest extends AbstractBladeTestCase
+{
+    public function testCananyStatementsAreCompiled()
+    {
+        $string = '@canany ([\'create\', \'update\'], [$post])
+breeze
+@elsecanany([\'delete\', \'approve\'], [$post])
+sneeze
+@endcan';
+        $expected = '<?php if (app(\\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->any([\'create\', \'update\'], [$post])): ?>
+breeze
+<?php elseif (app(\\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->any([\'delete\', \'approve\'], [$post])): ?>
+sneeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
I am a chinese student, and sorry for my poor English : )

When I wanted to run [this repo](https://github.com/php-telegram-bot/core) in laravel, one problem i met was this repo requires a database connection, and i can only manually import those sql files to my database. I create this method to help build database migrations which running .sql files.

Usage:Put an sql file in app/database/structures and run this method in migration file:
```
DB::dotsql($filename,$continue);
```