### PR TITLE
[5.6] Added assertUri method to TestReponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -124,11 +124,24 @@ class TestResponse
             $this->isRedirect(), 'Response status code ['.$this->getStatusCode().'] is not a redirect status code.'
         );
 
-        if (! is_null($uri)) {
-            PHPUnit::assertEquals(
-                app('url')->to($uri), app('url')->to($this->headers->get('Location'))
-            );
+        if (!is_null($uri)) {
+            $this->assertUri($uri);
         }
+
+        return $this;
+    }
+
+    /**
+     * Assert whether the response location is to a given URI.
+     *
+     * @param  string  $uri
+     * @return $this
+     */
+    public function assertUri($uri)
+    {
+        PHPUnit::assertEquals(
+            app('url')->to($uri), app('url')->to($this->headers->get('Location'))
+        );
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -124,7 +124,7 @@ class TestResponse
             $this->isRedirect(), 'Response status code ['.$this->getStatusCode().'] is not a redirect status code.'
         );
 
-        if (!is_null($uri)) {
+        if (! is_null($uri)) {
             $this->assertUri($uri);
         }
 


### PR DESCRIPTION
This PR is to add a simple helper to facilitate the checking of the TestResponse URI to ensure that in a test, when doing a request, the `TestResponse` correctly goes to an expectant URI.

Example:
`$response->assertUri($uri);`
instead of
`$response->assertHeader('Location', $uri);`