### PR TITLE
[5.6] Test Trait: RefreshAndSeedDatabase

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/RefreshAndSeedDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/RefreshAndSeedDatabase.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\RefreshDatabaseState;
+
+trait RefreshAndSeedDatabase
+{
+    use RefreshDatabase {
+        refreshInMemoryDatabase as baseRefreshInMemoryDatabase;
+    }
+
+    /**
+     * Refresh the in-memory database.
+     *
+     * @return void
+     */
+    protected function refreshInMemoryDatabase()
+    {
+        $this->baseRefreshInMemoryDatabase();
+
+        $this->artisan('db:seed', ['--class' => $this->databaseSeederClass()]);
+
+        $this->app[Kernel::class]->setArtisan(null);
+    }
+
+    /**
+     * Refresh a conventional test database.
+     *
+     * @return void
+     */
+    protected function refreshTestDatabase()
+    {
+        if (!RefreshDatabaseState::$migrated) {
+            $this->artisan('migrate:fresh');
+
+            $this->app[Kernel::class]->setArtisan(null);
+
+            RefreshDatabaseState::$migrated = true;
+        }
+
+        if (!RefreshDatabaseState::$seeded) {
+            $this->artisan('db:seed', ['--class' => $this->databaseSeederClass()]);
+
+            $this->app[Kernel::class]->setArtisan(null);
+
+            RefreshDatabaseState::$seeded = true;
+        }
+
+        $this->beginDatabaseTransaction();
+    }
+
+    /**
+     * Get the database seeder class to seed with.
+     *
+     * @return string
+     */
+    protected function databaseSeederClass()
+    {
+        return 'DatabaseSeeder';
+    }
+}

--- a/src/Illuminate/Foundation/Testing/RefreshDatabaseState.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabaseState.php
@@ -10,4 +10,11 @@ class RefreshDatabaseState
      * @var bool
      */
     public static $migrated = false;
+
+    /**
+     * Indicates if the test database has been seeded.
+     *
+     * @var bool
+     */
+    public static $seeded = false;
 }


### PR DESCRIPTION
This PR adds the `RefreshAndSeedDatabase` test trait. It replicates the behavior of the `RefreshDatabase` test trait and calls `db:seed` allowing the test database to be seeded only once.

This will allow more efficient tests for applications that require seeded database data to function such as countries or immutable record types.

I initially tried to implement this without editing laravel core code. I discovered that the test traits have become somewhat tangled and difficult or impossible to extend (Prompting this PR). What can we do about this?