### PR TITLE
5.7 - Add "always" to complement "sometimes" in validators

### DIFF
--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -20,7 +20,7 @@ interface Validator extends MessageProvider
      */
     public function failed();
 
-     /**
+    /**
      * Parse the given rules and merge them into current rules.
      *
      * @param  array  $rules
@@ -37,7 +37,7 @@ interface Validator extends MessageProvider
      * @return $this
      */
     public function sometimes($attribute, $rules, callable $callback);
-    
+
     /**
      * After an after validation callback.
      *

--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -20,6 +20,14 @@ interface Validator extends MessageProvider
      */
     public function failed();
 
+     /**
+     * Parse the given rules and merge them into current rules.
+     *
+     * @param  array  $rules
+     * @return void
+     */
+    public function always($rules);
+
     /**
      * Add conditions to a given field based on a Closure.
      *
@@ -29,7 +37,7 @@ interface Validator extends MessageProvider
      * @return $this
      */
     public function sometimes($attribute, $rules, callable $callback);
-
+    
     /**
      * After an after validation callback.
      *

--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -24,7 +24,7 @@ interface Validator extends MessageProvider
      * Parse the given rules and merge them into current rules.
      *
      * @param  array  $rules
-     * @return void
+     * @return $this
      */
     public function always($rules);
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -29,7 +29,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.6.22';
+    const VERSION = '5.6.23';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -806,8 +806,8 @@ class Validator implements ValidatorContract
             $this->implicitAttributes, $response->implicitAttributes
         );
     }
-    
-     /**
+
+    /**
      * Parse the given rules and merge them into current rules.
      *
      * @param  array  $rules
@@ -819,7 +819,7 @@ class Validator implements ValidatorContract
         
         return $this;
     }
-
+    
     /**
      * Add conditions to a given field based on a Closure.
      *

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -816,10 +816,10 @@ class Validator implements ValidatorContract
     public function always($rules)
     {
         $this->addRules($rules);
-        
+
         return $this;
     }
-    
+
     /**
      * Add conditions to a given field based on a Closure.
      *

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -806,6 +806,19 @@ class Validator implements ValidatorContract
             $this->implicitAttributes, $response->implicitAttributes
         );
     }
+    
+     /**
+     * Parse the given rules and merge them into current rules.
+     *
+     * @param  array  $rules
+     * @return $this
+     */
+    public function always($rules)
+    {
+        $this->addRules($rules);
+        
+        return $this;
+    }
 
     /**
      * Add conditions to a given field based on a Closure.


### PR DESCRIPTION
I would like to propose a simple extension to the contract and implementation that adds rules after the validator has been created.  

Its a method I've searched for many times when a validator is created and returned.  Often, i run into an issue when the method only returns a validator contract.  Some code seems to assume that the validator object that implements the contract will implement `addRules`.  This works against programming to contracts.

It is possible to add rules using this contract by passing a closure that only returns true to the `sometimes` method.  It doesn't seem very easy to read.  `validator->sometimes(always = true)`.

The other (easier but less interesting) option is to just make `addRules` part of the interface.