### PR TITLE
[5.7] Add "always" to complement "sometimes"

### DIFF
--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -21,6 +21,14 @@ interface Validator extends MessageProvider
     public function failed();
 
     /**
+     * Parse the given rules and merge them into current rules.
+     *
+     * @param  array  $rules
+     * @return $this
+     */
+    public function always($rules);
+
+    /**
      * Add conditions to a given field based on a Closure.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -814,6 +814,19 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Parse the given rules and merge them into current rules.
+     *
+     * @param  array  $rules
+     * @return $this
+     */
+    public function always($rules)
+    {
+        $this->addRules($rules);
+
+        return $this;
+    }
+
+    /**
      * Add conditions to a given field based on a Closure.
      *
      * @param  string|array  $attribute


### PR DESCRIPTION
I would like to propose a simple extension to the contract and implementation that adds rules after the validator has been created.  

Its a method I've searched for many times when a validator is created and returned.  Often, i run into an issue when the method only returns a validator contract.  Some code seems to assume that the validator object that implements the contract will implement `addRules`.  This works against programming to contracts.

It is possible to add rules using this contract by passing a closure that only returns true to the `sometimes` method.  It doesn't seem very easy to read.  `validator->sometimes(always = true)`.

The other (easier but less interesting) option is to just make `addRules` part of the interface.  I like the new method because of the name and it would be a fluent interface.