### PR TITLE
[5.6] Revert #24000

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1289,7 +1289,7 @@ class Builder
 
             $this->wheres[] = compact('type', 'query', 'boolean');
 
-            $this->addBinding($query->getRawBindings()['where'], 'where');
+            $this->addBinding($query->getBindings(), 'where');
         }
 
         return $this;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1039,15 +1039,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 'foo', 1 => 'bar', 2 => 25], $builder->getBindings());
     }
 
-    public function testNestedWhereBindings()
-    {
-        $builder = $this->getBuilder();
-        $builder->where('email', '=', 'foo')->where(function ($q) {
-            $q->selectRaw('?', ['ignore'])->where('name', '=', 'bar');
-        });
-        $this->assertEquals([0 => 'foo', 1 => 'bar'], $builder->getBindings());
-    }
-
     public function testFullSubSelects()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
#24000 fixed a bindings problem with `$withCount` and nested `where()` constraints (#23957).

Since #24240 solves the underlying problem in a more general way, the fix from #24000 is not required anymore: `Builder::where()` now uses `Model::newModelQuery()` which creates a query without `$withCount`.