### PR TITLE
[5.6] Adds withDefault to Optional object

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -29,6 +29,22 @@ class Optional implements ArrayAccess
     }
 
     /**
+     * Returns a default value when the underlying object is null.
+     *
+     * @param  mixed $default
+     *
+     * @return $this|mixed
+     */
+    public function withDefault($default)
+    {
+        if (is_null($this->value)) {
+            return value($default);
+        }
+
+        return $this;
+    }
+
+    /**
      * Dynamically access a property on the underlying object.
      *
      * @param  string  $key

--- a/tests/Support/SupportOptionalTest.php
+++ b/tests/Support/SupportOptionalTest.php
@@ -88,4 +88,28 @@ class SupportOptionalTest extends TestCase
 
         $this->assertFalse(isset($optional['item']));
     }
+
+    public function testWithDefaultReturnsDefaultWhenNull()
+    {
+        $defaultObj = new \stdClass;
+
+        $optional = new Optional(null);
+
+        $result = $optional->withDefault($defaultObj);
+
+        $this->assertSame($result, $defaultObj);
+    }
+
+    public function testWithDefaultReturnsOptionalWhenNotNull()
+    {
+        $targetObj = new \stdClass;
+
+        $defaultObj = new \stdClass;
+
+        $optional = new Optional($targetObj);
+
+        $result = $optional->withDefault($defaultObj);
+
+        $this->assertSame($result, $optional);
+    }
 }


### PR DESCRIPTION
Adds a `withDefault()` method to `Optional` object.

it allows to use the Null Object Pattern helper with the `optional` helper:

~~~~php
// in controller
$user = auth()->user();

// in a  view
Hello {{ optional($user)->withDefault(new App\GuestUser)->name }}
~~~~

I wrote tests for this new method.

---

Motivation:

I read about other people asking for a default parameter in the `optional` helper and back then I agreed it was a logical step. Although after the introduction of the pipe callback to the helper I think it was a better addition to that helper.

But rarely I still faced cases where I wished there were someway to use a default value with that helper, mainly in cases where you call a chained method after the first call to helper (sorry if my English is not clear, please look in the example below).

~~~~php
// if $user is null, the chained ->name will fail
optional($user)->present()->name

// to make it work one approach is to nest optional calls
optional(optional($user)->present())->name

// with the ability to use a $default one could better handle this case 
optional($user)->withDefault(new GuestUser)->present()->name
~~~~

After many years without touching any Java code (last time I coded for Java in a daily basis I was using Java 1.4), I faced the need to review some code written in Java 8 and noticed they have an `Optional` object there too. And one of this object methods is the `.orElse(...)` which gives the programmer the ability to provide a default value when the value encapsulated by the `Optional` object is null.

So I thought: "why not?". I chose to name `withDefault` to be more consistent with the relation ship methods that provide a default model when there is no relation.

It is more a convenience method and does not improve my codebase **a lot**, but I think it would be a nice addition and does not clutter the helper with a lot of parameters, which was an argument against the addition of the default parameter in some issues I read before (if my memory is not tricking me).


