### PR TITLE
[5.7] Update doc block

### DIFF
--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Contracts\Validation\Validator make(array $data, array $rules, array $messages = [], array $customAttributes = [])
+ * @method static \Illuminate\Validation\Validator make(array $data, array $rules, array $messages = [], array $customAttributes = [])
  * @method static void extend(string $rule, \Closure | string $extension, string $message = null)
  * @method static void extendImplicit(string $rule, \Closure | string $extension, string $message = null)
  * @method static void replacer(string $rule, \Closure | string $replacer)


### PR DESCRIPTION
Update doc block to match the method.

`\Illuminate\Validation\Factory::make` returns `\Illuminate\Validation\Validator` 

Validation and type hinting on the facade only pointed me toward the contract.  The actual factory method is documented to be the object.