### PR TITLE
[5.5] Fixes #20455 by adding a check to ensure the observer class exists

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use InvalidArgumentException;
 use Illuminate\Contracts\Events\Dispatcher;
 
 trait HasEvents
@@ -34,7 +35,15 @@ trait HasEvents
     {
         $instance = new static;
 
-        $className = is_string($class) ? $class : get_class($class);
+        $className = $class;
+
+        if (is_string($className)) {
+            if (!class_exists($className)) {
+                throw new InvalidArgumentException("Observer $className not found.");
+            }
+        } else {
+            $className = get_class($className);
+        }
 
         // When registering a model observer, we will spin through the possible events
         // and determine if this observer has that method. If it does, we will hook

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -38,7 +38,7 @@ trait HasEvents
         $className = $class;
 
         if (is_string($className)) {
-            if (!class_exists($className)) {
+            if (! class_exists($className)) {
                 throw new InvalidArgumentException("Observer $className not found.");
             }
         } else {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1703,7 +1703,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testMissingObserverClass()
     {
         $this->expectException(InvalidArgumentException::class);
-        EloquentModelStub::observe('foo');
+        EloquentModelStub::observe('NonExistentFoo');
     }
 
     protected function addMockConnection($model)

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -9,6 +9,7 @@ use Mockery as m;
 use ReflectionClass;
 use DateTimeImmutable;
 use DateTimeInterface;
+use InvalidArgumentException;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
@@ -1697,6 +1698,12 @@ class DatabaseEloquentModelTest extends TestCase
         $secondInstance->setConnection('foo');
         $result = $firstInstance->is($secondInstance);
         $this->assertFalse($result);
+    }
+
+    public function testMissingObserverClass()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        EloquentModelStub::observe('foo');
     }
 
     protected function addMockConnection($model)


### PR DESCRIPTION
This change ensures that an observer exists before attempting to register it. Previously it would silently fail and the expected observer event handlers would not be called. 

A test has been added to ensure the code works as expected. 
