### PR TITLE
[5.6] Fix typo of missing underscore in not_regexp rule's name

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -250,7 +250,7 @@ class ValidationRuleParser
     {
         $rule = strtolower($rule);
 
-        if ($rule === 'regex' || $rule === 'notregex') {
+        if ($rule === 'regex' || $rule === 'not_regex') {
             return [$parameter];
         }
 

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -250,7 +250,7 @@ class ValidationRuleParser
     {
         $rule = strtolower($rule);
 
-        if ($rule === 'regex' || $rule === 'not_regex') {
+        if ($rule === 'regex' || $rule === 'not_regex' || $rule === 'notregex') {
             return [$parameter];
         }
 


### PR DESCRIPTION
Without this fix, properly using "not_regex" rule name in rule arrays will result in error, if using comma in the regexp without quotes, eg.

`'field' => 'string|not_regex:/.*, .*/'`

The error is: `preg_match(): No ending delimiter '/' found`
`Illuminate/Validation/Concerns/ValidatesAttributes.php:1233`

However, these rules work:
`'field' => 'string|regex:/.*, .*/'`
`'field' => 'string|not_regex:"/.*, .*/"'`

It's because function `parseParameters` will try to split the parameter list using `str_getcsv()` instead of properly returning the whole `$parameter`.

Since "regex" rule works without quoting the regular expression, but "not_regex" rule doesn't, this behavior is confusing and inconsistent.