### PR TITLE
[5.6] Replace hard-coded numbers with HTTP constants

### DIFF
--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -6,6 +6,7 @@ use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Auth\EloquentUserProvider;
+use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
 /**
@@ -64,7 +65,7 @@ class AuthenticationTest extends TestCase
      */
     public function basic_auth_protects_route()
     {
-        $this->get('basic')->assertStatus(401);
+        $this->get('basic')->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
 
     /**
@@ -76,7 +77,7 @@ class AuthenticationTest extends TestCase
             'Authorization' => 'Basic '.base64_encode('email:password'),
         ]);
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
         $this->assertEquals('email', $response->decodeResponseJson()['email']);
     }
 
@@ -94,11 +95,11 @@ class AuthenticationTest extends TestCase
 
         $this->get('basicWithCondition', [
             'Authorization' => 'Basic '.base64_encode('email2:password2'),
-        ])->assertStatus(401);
+        ])->assertStatus(Response::HTTP_UNAUTHORIZED);
 
         $this->get('basicWithCondition', [
             'Authorization' => 'Basic '.base64_encode('email:password'),
-        ])->assertStatus(200);
+        ])->assertStatus(Response::HTTP_OK);
     }
 
     /**
@@ -108,7 +109,7 @@ class AuthenticationTest extends TestCase
     {
         $this->get('basic', [
             'Authorization' => 'Basic '.base64_encode('email:wrong_password'),
-        ])->assertStatus(401);
+        ])->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
 
     /**

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Http;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Http\Resources\MergeValue;
+use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Tests\Integration\Http\Fixtures\Post;
 use Illuminate\Tests\Integration\Http\Fixtures\Author;
@@ -21,6 +22,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalData;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationship;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalPivotRelationship;
+
 
 /**
  * @group integration
@@ -40,7 +42,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson([
             'data' => [
@@ -81,7 +83,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson([
             'data' => [
@@ -104,7 +106,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertExactJson([
             'data' => [
@@ -127,7 +129,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertExactJson([
             'data' => [
@@ -153,7 +155,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertExactJson([
             'data' => [
@@ -181,7 +183,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertExactJson([
             'data' => [
@@ -205,7 +207,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertExactJson([
             'data' => [
@@ -256,7 +258,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson([
             'data' => [
@@ -278,7 +280,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
         $response->assertHeader('X-Resource', 'True');
     }
 
@@ -333,14 +335,14 @@ class ResourceTest extends TestCase
             return (new PostResource(new Post([
                 'id' => 5,
                 'title' => 'Test Title',
-            ])))->response()->setStatusCode(202)->header('X-Custom', 'True');
+            ])))->response()->setStatusCode(Response::HTTP_ACCEPTED)->header('X-Custom', 'True');
         });
 
         $response = $this->withoutExceptionHandling()->get(
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(202);
+        $response->assertStatus(Response::HTTP_ACCEPTED);
         $response->assertHeader('X-Custom', 'True');
     }
 
@@ -361,7 +363,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(201);
+        $response->assertStatus(Response::HTTP_CREATED);
     }
 
     public function test_collections_are_not_doubled_wrapped()
@@ -377,7 +379,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson([
             'data' => [
@@ -404,7 +406,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson([
             'data' => [
@@ -444,7 +446,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson([
             'data' => [
@@ -485,7 +487,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson([
             'data' => [

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -23,7 +23,6 @@ use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationship;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalPivotRelationship;
 
-
 /**
  * @group integration
  */

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -8,6 +8,7 @@ use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Contracts\Routing\UrlRoutable;
+use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Routing\Middleware\ValidateSignature;
 
 /**
@@ -70,7 +71,7 @@ class UrlSigningTest extends TestCase
         Carbon::setTestNow(Carbon::create(2018, 1, 1)->addMinutes(10));
 
         $response = $this->get($url);
-        $response->assertStatus(403);
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
 
     public function test_signed_middleware_with_routable_parameter()


### PR DESCRIPTION
Instead of magic numbers, use HTTP constants in order to improve readability.