### PR TITLE
[5.6] Extract setting mutated attribute into method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -543,9 +543,7 @@ trait HasAttributes
         // which simply lets the developers tweak the attribute as it is set on
         // the model, such as "json_encoding" an listing of data for storage.
         if ($this->hasSetMutator($key)) {
-            $method = 'set'.Str::studly($key).'Attribute';
-
-            return $this->{$method}($value);
+            return $this->setMutatedAttributeValue($key, $value);
         }
 
         // If an attribute is listed as a "date", we'll convert it from a DateTime
@@ -580,6 +578,18 @@ trait HasAttributes
     public function hasSetMutator($key)
     {
         return method_exists($this, 'set'.Str::studly($key).'Attribute');
+    }
+
+    /**
+     * Set the value of an attribute using its mutator.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function setMutatedAttributeValue($key, $value)
+    {
+        return $this->{'set'.Str::studly($key).'Attribute'}($value);
     }
 
     /**


### PR DESCRIPTION
When dealing with accessors, code looks like now like this:

```
if ($this->hasGetMutator($key)) {
    return $this->mutateAttribute($key, $value);
}
```

so in case of custom method functionality, it's possible to override both  **hasGetMutator** and **mutateAttribute** for custom code.

But for mutator code looked so far like this:

```
if ($this->hasSetMutator($key)) {
    $method = 'set'.Str::studly($key).'Attribute';

    return $this->{$method}($value);
}
```

so it's impossible to do similar change for mutator. In fact you need to override the whole **setAttribute** method just to make similar change because setting mutated attribute is not extracted to external method. 

After this PR code for mutator condition would look like this:

```
if ($this->hasSetMutator($key)) {
    return $this->setMutatedAttributeValue($key, $value);
}
```

so now it would be enough just to override those 2 methods instead of touching **setAttribute** code. Also code is more consistent now I believe. 