### PR TITLE
[5.6] Add assertion to verify there are no errors

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -800,6 +800,18 @@ class TestResponse
     }
 
     /**
+     * Assert that the session has no errors.
+     *
+     * @return $this
+     */
+    public function assertSessionHasNoErrors()
+    {
+        $this->assertSessionMissing('errors');
+
+        return $this;
+    }
+
+    /**
      * Assert that the session has the given errors.
      *
      * @param  string  $errorBag


### PR DESCRIPTION
This allows to verify if there are errors without looking at Framework details. Now inside `assertSessionHasErrors()`, there is call:

```
$this->assertSessionHas('errors');
```

but if you want to make sure there are no errors, you need to really know that there shouldn't be `errors` key in session. After adding this method you don't need to care how it's implemented any more.