### PR TITLE
[5.6] Fix *scan methods for phpredis

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -27,30 +27,20 @@ trait InteractsWithRedis
      */
     public function setUpRedis()
     {
-        $host = getenv('REDIS_HOST') ?: '127.0.0.1';
-        $port = getenv('REDIS_PORT') ?: 6379;
-
         if (static::$connectionFailedOnceWithDefaultsSkip) {
             $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
 
             return;
         }
 
-        foreach ($this->redisDriverProvider() as $driver) {
-            $this->redis[$driver[0]] = new RedisManager($driver[0], [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 5,
-                    'timeout' => 0.5,
-                ],
-            ]);
-        }
+        $this->configureConnections();
 
         try {
             $this->redis['predis']->connection()->flushdb();
         } catch (\Exception $e) {
+            $host = getenv('REDIS_HOST') ?: '127.0.0.1';
+            $port = getenv('REDIS_PORT') ?: 6379;
+
             if ($host === '127.0.0.1' && $port === 6379 && getenv('REDIS_HOST') === false) {
                 $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
                 static::$connectionFailedOnceWithDefaultsSkip = true;
@@ -58,6 +48,59 @@ trait InteractsWithRedis
                 return;
             }
         }
+    }
+
+    /**
+     * Configure private redis connections with added prefix configurations.
+     *
+     * @return void
+     */
+    protected function configureConnections()
+    {
+        if (! $this->redis) {
+            $host = getenv('REDIS_HOST') ?: '127.0.0.1';
+            $port = getenv('REDIS_PORT') ?: 6379;
+
+            foreach ($this->redisDriverProvider() as $driver) {
+                $this->redis[$driver[0]] = new RedisManager($driver[0], [
+                    'cluster' => false,
+                    'default' => [
+                        'host' => $host,
+                        'port' => $port,
+                        'database' => 5,
+                        'timeout' => 0.5,
+                    ],
+                ]);
+
+                $this->redis["{$driver[0]}-prefixed"] = new RedisManager($driver[0], [
+                    'cluster' => false,
+                    'default' => [
+                        'host' => $host,
+                        'port' => $port,
+                        'options' => ['prefix' => 'laravel:'],
+                        'database' => 5,
+                        'timeout' => 0.5,
+                    ],
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Returns the connections for use as a dataProvider.
+     *
+     * @return array
+     */
+    public function redisConnections()
+    {
+        $connections = [];
+        $this->configureConnections();
+
+        foreach ($this->redis as $driver => $redis) {
+            $connections[$driver] = [$redis->connection()];
+        }
+
+        return $connections;
     }
 
     /**
@@ -69,8 +112,8 @@ trait InteractsWithRedis
     {
         $this->redis['predis']->connection()->flushdb();
 
-        foreach ($this->redisDriverProvider() as $driver) {
-            $this->redis[$driver[0]]->connection()->disconnect();
+        foreach ($this->redis as $driver) {
+            $driver->connection()->disconnect();
         }
     }
 

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -83,7 +83,8 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
-     * Runs the given scan type based on parsed options.
+     * Scans all keys in the redis database. Note,
+     * $counter is passed-by-reference to scan.
      *
      * @param  int  $counter
      * @param  array  $options
@@ -92,10 +93,13 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     public function scan($counter, $options = [])
     {
         $counter = $counter ?: null;
-        $opts = array_change_key_case($options, CASE_UPPER);
-        $match = array_get($opts, 'MATCH');
 
-        $result = $this->client->scan($counter, $match, array_get($opts, 'COUNT'));
+        $options = array_change_key_case($options, CASE_UPPER);
+
+        $result = $this->client->scan(
+            $counter, array_get($options, 'MATCH'),
+            array_get($options, 'COUNT')
+        );
 
         return [$counter, $result];
     }
@@ -162,7 +166,8 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
-     * Scan the given hash field for all values.
+     * Scan the given hash field for all values. Note,
+     * that $counter is pass-by-reference to hscan.
      *
      * @param  string  $key
      * @param  int  $counter
@@ -172,10 +177,13 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     public function hscan($key, $counter, $options = [])
     {
         $counter = $counter ?: null;
-        $opts = array_change_key_case($options, CASE_UPPER);
-        $match = array_get($opts, 'MATCH');
 
-        $result = $this->client->hscan($key, $counter, $match, array_get($opts, 'COUNT'));
+        $options = array_change_key_case($options, CASE_UPPER);
+
+        $result = $this->client->hscan(
+            $key, $counter, array_get($options, 'MATCH'),
+            array_get($options, 'COUNT')
+        );
 
         return [$counter, $result];
     }
@@ -206,7 +214,8 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
-     * Scan the given set for all values.
+     * Scans the given set for all values in set. Note,
+     * that $counter is passed-by-reference to call.
      *
      * @param  string  $key
      * @param  int  $counter
@@ -216,15 +225,15 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     public function sscan($key, $counter, $options = [])
     {
         $counter = $counter ?: null;
-        $opts = array_change_key_case($options, CASE_UPPER);
-        $match = array_get($opts, 'MATCH');
 
-        $result = $this->client->sscan($key, $counter, $match, array_get($opts, 'COUNT'));
-        if ($result == false) {
-            return [0, []];
-        }
+        $options = array_change_key_case($options, CASE_UPPER);
 
-        return [$counter, $result];
+        $result = $this->client->sscan(
+            $key, $counter, array_get($options, 'MATCH'),
+            array_get($options, 'COUNT')
+        );
+
+        return $result == false ? [0, []] : [$counter, $result];
     }
 
     /**
@@ -323,7 +332,8 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
-     * Scan the given set for all values.
+     * Scans the given set for all values based on options.
+     * Note, the $counter is pass-by-reference to zscan.
      *
      * @param  string  $key
      * @param  int  $counter
@@ -333,15 +343,15 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     public function zscan($key, $counter, $options = [])
     {
         $counter = $counter ?: null;
-        $opts = array_change_key_case($options, CASE_UPPER);
-        $match = array_get($opts, 'MATCH');
 
-        $result = $this->client->zscan($key, $counter, $match, array_get($opts, 'COUNT'));
-        if ($result == false) {
-            return [0, []];
-        }
+        $options = array_change_key_case($options, CASE_UPPER);
 
-        return [$counter, $result];
+        $result = $this->client->zscan(
+            $key, $counter, array_get($options, 'MATCH'),
+            array_get($options, 'COUNT')
+        );
+
+        return $result == false ? [0, []] : [$counter, $result];
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -83,6 +83,24 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
+     * Runs the given scan type based on parsed options.
+     *
+     * @param  int  $counter
+     * @param  array  $options
+     * @return array
+     */
+    public function scan($counter, $options = [])
+    {
+        $counter = $counter ?: null;
+        $opts = array_change_key_case($options, CASE_UPPER);
+        $match = array_get($opts, 'MATCH');
+
+        $result = $this->client->scan($counter, $match, array_get($opts, 'COUNT'));
+
+        return [$counter, $result];
+    }
+
+    /**
      * Set the given key if it doesn't exist.
      *
      * @param  string  $key
@@ -144,6 +162,25 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
+     * Scan the given hash field for all values.
+     *
+     * @param  string  $key
+     * @param  int  $counter
+     * @param  array  $options
+     * @return array
+     */
+    public function hscan($key, $counter, $options = [])
+    {
+        $counter = $counter ?: null;
+        $opts = array_change_key_case($options, CASE_UPPER);
+        $match = array_get($opts, 'MATCH');
+
+        $result = $this->client->hscan($key, $counter, $match, array_get($opts, 'COUNT'));
+
+        return [$counter, $result];
+    }
+
+    /**
      * Removes the first count occurrences of the value element from the list.
      *
      * @param  string  $key
@@ -166,6 +203,28 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     public function spop($key, $count = null)
     {
         return $this->command('spop', [$key]);
+    }
+
+    /**
+     * Scan the given set for all values.
+     *
+     * @param  string  $key
+     * @param  int  $counter
+     * @param  array  $options
+     * @return array
+     */
+    public function sscan($key, $counter, $options = [])
+    {
+        $counter = $counter ?: null;
+        $opts = array_change_key_case($options, CASE_UPPER);
+        $match = array_get($opts, 'MATCH');
+
+        $result = $this->client->sscan($key, $counter, $match, array_get($opts, 'COUNT'));
+        if ($result == false) {
+            return [0, []];
+        }
+
+        return [$counter, $result];
     }
 
     /**
@@ -261,6 +320,28 @@ class PhpRedisConnection extends Connection implements ConnectionContract
             $options['weights'] ?? null,
             $options['aggregate'] ?? 'sum'
         );
+    }
+
+    /**
+     * Scan the given set for all values.
+     *
+     * @param  string  $key
+     * @param  int  $counter
+     * @param  array  $options
+     * @return array
+     */
+    public function zscan($key, $counter, $options = [])
+    {
+        $counter = $counter ?: null;
+        $opts = array_change_key_case($options, CASE_UPPER);
+        $match = array_get($opts, 'MATCH');
+
+        $result = $this->client->zscan($key, $counter, $match, array_get($opts, 'COUNT'));
+        if ($result == false) {
+            return [0, []];
+        }
+
+        return [$counter, $result];
     }
 
     /**

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Redis;
 
 use PHPUnit\Framework\TestCase;
-use Illuminate\Redis\RedisManager;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 
 class RedisConnectionTest extends TestCase
@@ -32,30 +31,544 @@ class RedisConnectionTest extends TestCase
 
     /**
      * @test
+     * @dataProvider  redisConnections
      */
-    public function it_sets_values_with_expiry()
+    public function it_sets_values_with_expiry($redis)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed', 'EX', 5, 'NX');
-            $this->assertEquals('mohamed', $redis->get('one'));
-            $this->assertNotEquals(-1, $redis->ttl('one'));
+        $redis->set('one', 'mohamed', 'EX', 5, 'NX');
+        $this->assertEquals('mohamed', $redis->get('one'));
+        $this->assertNotEquals(-1, $redis->ttl('one'));
 
-            // It doesn't override when NX mode
-            $redis->set('one', 'taylor', 'EX', 5, 'NX');
-            $this->assertEquals('mohamed', $redis->get('one'));
+        // It doesn't override when NX mode
+        $redis->set('one', 'taylor', 'EX', 5, 'NX');
+        $this->assertEquals('mohamed', $redis->get('one'));
 
-            // It overrides when XX mode
-            $redis->set('one', 'taylor', 'EX', 5, 'XX');
-            $this->assertEquals('taylor', $redis->get('one'));
+        // It overrides when XX mode
+        $redis->set('one', 'taylor', 'EX', 5, 'XX');
+        $this->assertEquals('taylor', $redis->get('one'));
 
-            // It fails if XX mode is on and key doesn't exist
-            $redis->set('two', 'taylor', 'PX', 5, 'XX');
-            $this->assertNull($redis->get('two'));
+        // It fails if XX mode is on and key doesn't exist
+        $redis->set('two', 'taylor', 'PX', 5, 'XX');
+        $this->assertNull($redis->get('two'));
 
-            $redis->set('three', 'mohamed', 'PX', 5000);
-            $this->assertEquals('mohamed', $redis->get('three'));
-            $this->assertNotEquals(-1, $redis->ttl('three'));
-            $this->assertNotEquals(-1, $redis->pttl('three'));
+        $redis->set('three', 'mohamed', 'PX', 5000);
+        $this->assertEquals('mohamed', $redis->get('three'));
+        $this->assertNotEquals(-1, $redis->ttl('three'));
+        $this->assertNotEquals(-1, $redis->pttl('three'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_deletes_keys($redis)
+    {
+        $redis->set('one', 'mohamed');
+        $redis->set('two', 'mohamed');
+        $redis->set('three', 'mohamed');
+
+        $redis->del('one');
+        $this->assertNull($redis->get('one'));
+        $this->assertNotNull($redis->get('two'));
+        $this->assertNotNull($redis->get('three'));
+
+        $redis->del('two', 'three');
+        $this->assertNull($redis->get('two'));
+        $this->assertNull($redis->get('three'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_checks_for_existence($redis)
+    {
+        $redis->set('one', 'mohamed');
+        $redis->set('two', 'mohamed');
+
+        $this->assertEquals(1, $redis->exists('one'));
+        $this->assertEquals(0, $redis->exists('nothing'));
+        $this->assertEquals(2, $redis->exists('one', 'two'));
+        $this->assertEquals(2, $redis->exists('one', 'two', 'nothing'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_expires_keys($redis)
+    {
+        $redis->set('one', 'mohamed');
+        $this->assertEquals(-1, $redis->ttl('one'));
+        $this->assertEquals(1, $redis->expire('one', 10));
+        $this->assertNotEquals(-1, $redis->ttl('one'));
+
+        $this->assertEquals(0, $redis->expire('nothing', 10));
+
+        $redis->set('two', 'mohamed');
+        $this->assertEquals(-1, $redis->ttl('two'));
+        $this->assertEquals(1, $redis->pexpire('two', 10));
+        $this->assertNotEquals(-1, $redis->pttl('two'));
+
+        $this->assertEquals(0, $redis->pexpire('nothing', 10));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_renames_keys($redis)
+    {
+        $redis->set('one', 'mohamed');
+        $redis->rename('one', 'two');
+        $this->assertNull($redis->get('one'));
+        $this->assertEquals('mohamed', $redis->get('two'));
+
+        $redis->set('three', 'adam');
+        $redis->renamenx('two', 'three');
+        $this->assertEquals('mohamed', $redis->get('two'));
+        $this->assertEquals('adam', $redis->get('three'));
+
+        $redis->renamenx('two', 'four');
+        $this->assertNull($redis->get('two'));
+        $this->assertEquals('mohamed', $redis->get('four'));
+        $this->assertEquals('adam', $redis->get('three'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_adds_members_to_sorted_set($redis)
+    {
+        $redis->zadd('set', 1, 'mohamed');
+        $this->assertEquals(1, $redis->zcard('set'));
+
+        $redis->zadd('set', 2, 'taylor', 3, 'adam');
+        $this->assertEquals(3, $redis->zcard('set'));
+
+        $redis->zadd('set', ['jeffrey' => 4, 'matt' => 5]);
+        $this->assertEquals(5, $redis->zcard('set'));
+
+        $redis->zadd('set', 'NX', 1, 'beric');
+        $this->assertEquals(6, $redis->zcard('set'));
+
+        $redis->zadd('set', 'NX', ['joffrey' => 1]);
+        $this->assertEquals(7, $redis->zcard('set'));
+
+        $redis->zadd('set', 'XX', ['ned' => 1]);
+        $this->assertEquals(7, $redis->zcard('set'));
+
+        $this->assertEquals(1, $redis->zadd('set', ['sansa' => 10]));
+        $this->assertEquals(0, $redis->zadd('set', 'XX', 'CH', ['arya' => 11]));
+
+        $redis->zadd('set', ['mohamed' => 100]);
+        $this->assertEquals(100, $redis->zscore('set', 'mohamed'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_counts_members_in_sorted_set($redis)
+    {
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
+
+        $this->assertEquals(1, $redis->zcount('set', 1, 5));
+        $this->assertEquals(2, $redis->zcount('set', '-inf', '+inf'));
+        $this->assertEquals(2, $redis->zcard('set'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_increments_score_of_sorted_set($redis)
+    {
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
+        $redis->zincrby('set', 2, 'jeffrey');
+        $this->assertEquals(3, $redis->zscore('set', 'jeffrey'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_sets_key_if_not_exists($redis)
+    {
+        $redis->set('name', 'mohamed');
+
+        $this->assertSame(0, $redis->setnx('name', 'taylor'));
+        $this->assertEquals('mohamed', $redis->get('name'));
+
+        $this->assertSame(1, $redis->setnx('boss', 'taylor'));
+        $this->assertEquals('taylor', $redis->get('boss'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_sets_hash_field_if_not_exists($redis)
+    {
+        $redis->hset('person', 'name', 'mohamed');
+
+        $this->assertSame(0, $redis->hsetnx('person', 'name', 'taylor'));
+        $this->assertEquals('mohamed', $redis->hget('person', 'name'));
+
+        $this->assertSame(1, $redis->hsetnx('person', 'boss', 'taylor'));
+        $this->assertEquals('taylor', $redis->hget('person', 'boss'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_calculates_intersection_of_sorted_sets_and_stores($redis)
+    {
+        $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
+        $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
+
+        $redis->zinterstore('output', ['set1', 'set2']);
+        $this->assertEquals(2, $redis->zcard('output'));
+        $this->assertEquals(3, $redis->zscore('output', 'jeffrey'));
+        $this->assertEquals(5, $redis->zscore('output', 'matt'));
+
+        $redis->zinterstore('output2', ['set1', 'set2'], [
+            'weights' => [3, 2],
+            'aggregate' => 'sum',
+        ]);
+        $this->assertEquals(7, $redis->zscore('output2', 'jeffrey'));
+        $this->assertEquals(12, $redis->zscore('output2', 'matt'));
+
+        $redis->zinterstore('output3', ['set1', 'set2'], [
+            'weights' => [3, 2],
+            'aggregate' => 'min',
+        ]);
+        $this->assertEquals(3, $redis->zscore('output3', 'jeffrey'));
+        $this->assertEquals(6, $redis->zscore('output3', 'matt'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_calculates_union_of_sorted_sets_and_stores($redis)
+    {
+        $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
+        $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
+
+        $redis->zunionstore('output', ['set1', 'set2']);
+        $this->assertEquals(3, $redis->zcard('output'));
+        $this->assertEquals(3, $redis->zscore('output', 'jeffrey'));
+        $this->assertEquals(5, $redis->zscore('output', 'matt'));
+        $this->assertEquals(3, $redis->zscore('output', 'taylor'));
+
+        $redis->zunionstore('output2', ['set1', 'set2'], [
+            'weights' => [3, 2],
+            'aggregate' => 'sum',
+        ]);
+        $this->assertEquals(7, $redis->zscore('output2', 'jeffrey'));
+        $this->assertEquals(12, $redis->zscore('output2', 'matt'));
+        $this->assertEquals(9, $redis->zscore('output2', 'taylor'));
+
+        $redis->zunionstore('output3', ['set1', 'set2'], [
+            'weights' => [3, 2],
+            'aggregate' => 'min',
+        ]);
+        $this->assertEquals(3, $redis->zscore('output3', 'jeffrey'));
+        $this->assertEquals(6, $redis->zscore('output3', 'matt'));
+        $this->assertEquals(9, $redis->zscore('output3', 'taylor'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_returns_range_in_sorted_set($redis)
+    {
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+        $this->assertEquals(['jeffrey', 'matt'], $redis->zrange('set', 0, 1));
+        $this->assertEquals(['jeffrey', 'matt', 'taylor'], $redis->zrange('set', 0, -1));
+
+        $this->assertEquals(['jeffrey' => 1, 'matt' => 5], $redis->zrange('set', 0, 1, 'withscores'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_returns_rev_range_in_sorted_set($redis)
+    {
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+        $this->assertEquals(['taylor', 'matt'], $redis->ZREVRANGE('set', 0, 1));
+        $this->assertEquals(['taylor', 'matt', 'jeffrey'], $redis->ZREVRANGE('set', 0, -1));
+
+        $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->ZREVRANGE('set', 0, 1, 'withscores'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_returns_range_by_score_in_sorted_set($redis)
+    {
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+        $this->assertEquals(['jeffrey'], $redis->zrangebyscore('set', 0, 3));
+        $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->zrangebyscore('set', 0, 11, [
+            'withscores' => true,
+            'limit' => [
+                'offset' => 1,
+                'count' => 2,
+            ],
+        ]));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_returns_rev_range_by_score_in_sorted_set($redis)
+    {
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+        $this->assertEquals(['taylor'], $redis->ZREVRANGEBYSCORE('set', 10, 6));
+        $this->assertEquals(['matt' => 5, 'jeffrey' => 1], $redis->ZREVRANGEBYSCORE('set', 10, 0, [
+            'withscores' => true,
+            'limit' => [
+                'offset' => 1,
+                'count' => 2,
+            ],
+        ]));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_returns_rank_in_sorted_set($redis)
+    {
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+
+        $this->assertEquals(0, $redis->zrank('set', 'jeffrey'));
+        $this->assertEquals(2, $redis->zrank('set', 'taylor'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_returns_score_in_sorted_set($redis)
+    {
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+
+        $this->assertEquals(1, $redis->zscore('set', 'jeffrey'));
+        $this->assertEquals(10, $redis->zscore('set', 'taylor'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_removes_members_in_sorted_set($redis)
+    {
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
+
+        $redis->zrem('set', 'jeffrey');
+        $this->assertEquals(3, $redis->zcard('set'));
+
+        $redis->zrem('set', 'matt', 'adam');
+        $this->assertEquals(1, $redis->zcard('set'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_removes_members_by_score_in_sorted_set($redis)
+    {
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
+        $redis->ZREMRANGEBYSCORE('set', 5, '+inf');
+        $this->assertEquals(1, $redis->zcard('set'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_removes_members_by_rank_in_sorted_set($redis)
+    {
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
+        $redis->ZREMRANGEBYRANK('set', 1, -1);
+        $this->assertEquals(1, $redis->zcard('set'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_sets_multiple_hash_fields($redis)
+    {
+        $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
+        $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'], $redis->hgetall('hash'));
+
+        $redis->hmset('hash2', 'name', 'mohamed', 'hobby', 'diving');
+        $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'], $redis->hgetall('hash2'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_gets_multiple_hash_fields($redis)
+    {
+        $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
+
+        $this->assertEquals(['mohamed', 'diving'],
+            $redis->hmget('hash', 'name', 'hobby')
+        );
+
+        $this->assertEquals(['mohamed', 'diving'],
+            $redis->hmget('hash', ['name', 'hobby'])
+        );
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_runs_eval($redis)
+    {
+        $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', 'mohamed');
+        $this->assertEquals('mohamed', $redis->get('name'));
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_runs_pipes($redis)
+    {
+        $result = $redis->pipeline(function ($pipe) {
+            $pipe->set('test:pipeline:1', 1);
+            $pipe->get('test:pipeline:1');
+            $pipe->set('test:pipeline:2', 2);
+            $pipe->get('test:pipeline:2');
+        });
+
+        $this->assertCount(4, $result);
+        $this->assertEquals(1, $result[1]);
+        $this->assertEquals(2, $result[3]);
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_runs_transactions($redis)
+    {
+        $result = $redis->transaction(function ($pipe) {
+            $pipe->set('test:transaction:1', 1);
+            $pipe->get('test:transaction:1');
+            $pipe->set('test:transaction:2', 2);
+            $pipe->get('test:transaction:2');
+        });
+
+        $this->assertCount(4, $result);
+        $this->assertEquals(1, $result[1]);
+        $this->assertEquals(2, $result[3]);
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_runs_raw_command($redis)
+    {
+        $redis->executeRaw(['SET', 'test:raw:1', '1']);
+
+        $this->assertEquals(
+            1, $redis->executeRaw(['GET', 'test:raw:1'])
+        );
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     */
+    public function it_scans_all_keys()
+    {
+        foreach ($this->redis as $name => $driver) {
+            if (str_contains($name, 'prefixed')) {
+                return;
+            }
+
+            $redis = $driver->connection();
+
+            $redis->set('jeffrey', 1);
+            $redis->set('matt', 5);
+            $redis->set('matthew', 6);
+            $redis->set('taylor', 10);
+            $redis->set('dave', 12);
+
+            $result = $redis->scan(0);
+            $diff = array_diff(['jeffrey', 'matt', 'matthew', 'taylor', 'dave'], $result[1]);
+            $this->assertCount(2, $result);
+            $this->assertEquals(0, $result[0]);
+            $this->assertCount(5, $result[1]);
+            $this->assertEmpty($diff);
 
             $redis->flushall();
         }
@@ -64,473 +577,43 @@ class RedisConnectionTest extends TestCase
     /**
      * @test
      */
-    public function it_deletes_keys()
+    public function it_scans_all_keys_with_options()
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed');
-            $redis->set('two', 'mohamed');
-            $redis->set('three', 'mohamed');
-
-            $redis->del('one');
-            $this->assertNull($redis->get('one'));
-            $this->assertNotNull($redis->get('two'));
-            $this->assertNotNull($redis->get('three'));
-
-            $redis->del('two', 'three');
-            $this->assertNull($redis->get('two'));
-            $this->assertNull($redis->get('three'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_checks_for_existence()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed');
-            $redis->set('two', 'mohamed');
-
-            $this->assertEquals(1, $redis->exists('one'));
-            $this->assertEquals(0, $redis->exists('nothing'));
-            $this->assertEquals(2, $redis->exists('one', 'two'));
-            $this->assertEquals(2, $redis->exists('one', 'two', 'nothing'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_expires_keys()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed');
-            $this->assertEquals(-1, $redis->ttl('one'));
-            $this->assertEquals(1, $redis->expire('one', 10));
-            $this->assertNotEquals(-1, $redis->ttl('one'));
-
-            $this->assertEquals(0, $redis->expire('nothing', 10));
-
-            $redis->set('two', 'mohamed');
-            $this->assertEquals(-1, $redis->ttl('two'));
-            $this->assertEquals(1, $redis->pexpire('two', 10));
-            $this->assertNotEquals(-1, $redis->pttl('two'));
-
-            $this->assertEquals(0, $redis->pexpire('nothing', 10));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_renames_keys()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed');
-            $redis->rename('one', 'two');
-            $this->assertNull($redis->get('one'));
-            $this->assertEquals('mohamed', $redis->get('two'));
-
-            $redis->set('three', 'adam');
-            $redis->renamenx('two', 'three');
-            $this->assertEquals('mohamed', $redis->get('two'));
-            $this->assertEquals('adam', $redis->get('three'));
-
-            $redis->renamenx('two', 'four');
-            $this->assertNull($redis->get('two'));
-            $this->assertEquals('mohamed', $redis->get('four'));
-            $this->assertEquals('adam', $redis->get('three'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_adds_members_to_sorted_set()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', 1, 'mohamed');
-            $this->assertEquals(1, $redis->zcard('set'));
-
-            $redis->zadd('set', 2, 'taylor', 3, 'adam');
-            $this->assertEquals(3, $redis->zcard('set'));
-
-            $redis->zadd('set', ['jeffrey' => 4, 'matt' => 5]);
-            $this->assertEquals(5, $redis->zcard('set'));
-
-            $redis->zadd('set', 'NX', 1, 'beric');
-            $this->assertEquals(6, $redis->zcard('set'));
-
-            $redis->zadd('set', 'NX', ['joffrey' => 1]);
-            $this->assertEquals(7, $redis->zcard('set'));
-
-            $redis->zadd('set', 'XX', ['ned' => 1]);
-            $this->assertEquals(7, $redis->zcard('set'));
-
-            $this->assertEquals(1, $redis->zadd('set', ['sansa' => 10]));
-            $this->assertEquals(0, $redis->zadd('set', 'XX', 'CH', ['arya' => 11]));
-
-            $redis->zadd('set', ['mohamed' => 100]);
-            $this->assertEquals(100, $redis->zscore('set', 'mohamed'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_counts_members_in_sorted_set()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
-
-            $this->assertEquals(1, $redis->zcount('set', 1, 5));
-            $this->assertEquals(2, $redis->zcount('set', '-inf', '+inf'));
-            $this->assertEquals(2, $redis->zcard('set'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_increments_score_of_sorted_set()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
-            $redis->zincrby('set', 2, 'jeffrey');
-            $this->assertEquals(3, $redis->zscore('set', 'jeffrey'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_sets_key_if_not_exists()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->set('name', 'mohamed');
-
-            $this->assertSame(0, $redis->setnx('name', 'taylor'));
-            $this->assertEquals('mohamed', $redis->get('name'));
-
-            $this->assertSame(1, $redis->setnx('boss', 'taylor'));
-            $this->assertEquals('taylor', $redis->get('boss'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_sets_hash_field_if_not_exists()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->hset('person', 'name', 'mohamed');
-
-            $this->assertSame(0, $redis->hsetnx('person', 'name', 'taylor'));
-            $this->assertEquals('mohamed', $redis->hget('person', 'name'));
-
-            $this->assertSame(1, $redis->hsetnx('person', 'boss', 'taylor'));
-            $this->assertEquals('taylor', $redis->hget('person', 'boss'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_calculates_intersection_of_sorted_sets_and_stores()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
-            $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
-
-            $redis->zinterstore('output', ['set1', 'set2']);
-            $this->assertEquals(2, $redis->zcard('output'));
-            $this->assertEquals(3, $redis->zscore('output', 'jeffrey'));
-            $this->assertEquals(5, $redis->zscore('output', 'matt'));
-
-            $redis->zinterstore('output2', ['set1', 'set2'], [
-                'weights' => [3, 2],
-                'aggregate' => 'sum',
-            ]);
-            $this->assertEquals(7, $redis->zscore('output2', 'jeffrey'));
-            $this->assertEquals(12, $redis->zscore('output2', 'matt'));
-
-            $redis->zinterstore('output3', ['set1', 'set2'], [
-                'weights' => [3, 2],
-                'aggregate' => 'min',
-            ]);
-            $this->assertEquals(3, $redis->zscore('output3', 'jeffrey'));
-            $this->assertEquals(6, $redis->zscore('output3', 'matt'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_calculates_union_of_sorted_sets_and_stores()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
-            $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
-
-            $redis->zunionstore('output', ['set1', 'set2']);
-            $this->assertEquals(3, $redis->zcard('output'));
-            $this->assertEquals(3, $redis->zscore('output', 'jeffrey'));
-            $this->assertEquals(5, $redis->zscore('output', 'matt'));
-            $this->assertEquals(3, $redis->zscore('output', 'taylor'));
-
-            $redis->zunionstore('output2', ['set1', 'set2'], [
-                'weights' => [3, 2],
-                'aggregate' => 'sum',
-            ]);
-            $this->assertEquals(7, $redis->zscore('output2', 'jeffrey'));
-            $this->assertEquals(12, $redis->zscore('output2', 'matt'));
-            $this->assertEquals(9, $redis->zscore('output2', 'taylor'));
-
-            $redis->zunionstore('output3', ['set1', 'set2'], [
-                'weights' => [3, 2],
-                'aggregate' => 'min',
-            ]);
-            $this->assertEquals(3, $redis->zscore('output3', 'jeffrey'));
-            $this->assertEquals(6, $redis->zscore('output3', 'matt'));
-            $this->assertEquals(9, $redis->zscore('output3', 'taylor'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_range_in_sorted_set()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-            $this->assertEquals(['jeffrey', 'matt'], $redis->zrange('set', 0, 1));
-            $this->assertEquals(['jeffrey', 'matt', 'taylor'], $redis->zrange('set', 0, -1));
-
-            $this->assertEquals(['jeffrey' => 1, 'matt' => 5], $redis->zrange('set', 0, 1, 'withscores'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_rev_range_in_sorted_set()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-            $this->assertEquals(['taylor', 'matt'], $redis->ZREVRANGE('set', 0, 1));
-            $this->assertEquals(['taylor', 'matt', 'jeffrey'], $redis->ZREVRANGE('set', 0, -1));
-
-            $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->ZREVRANGE('set', 0, 1, 'withscores'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_range_by_score_in_sorted_set()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-            $this->assertEquals(['jeffrey'], $redis->zrangebyscore('set', 0, 3));
-            $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->zrangebyscore('set', 0, 11, [
-                'withscores' => true,
-                'limit' => [
-                    'offset' => 1,
-                    'count' => 2,
-                ],
-            ]));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_rev_range_by_score_in_sorted_set()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-            $this->assertEquals(['taylor'], $redis->ZREVRANGEBYSCORE('set', 10, 6));
-            $this->assertEquals(['matt' => 5, 'jeffrey' => 1], $redis->ZREVRANGEBYSCORE('set', 10, 0, [
-                'withscores' => true,
-                'limit' => [
-                    'offset' => 1,
-                    'count' => 2,
-                ],
-            ]));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_rank_in_sorted_set()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-
-            $this->assertEquals(0, $redis->zrank('set', 'jeffrey'));
-            $this->assertEquals(2, $redis->zrank('set', 'taylor'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_score_in_sorted_set()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-
-            $this->assertEquals(1, $redis->zscore('set', 'jeffrey'));
-            $this->assertEquals(10, $redis->zscore('set', 'taylor'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_removes_members_in_sorted_set()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
-
-            $redis->zrem('set', 'jeffrey');
-            $this->assertEquals(3, $redis->zcard('set'));
-
-            $redis->zrem('set', 'matt', 'adam');
-            $this->assertEquals(1, $redis->zcard('set'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_removes_members_by_score_in_sorted_set()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
-            $redis->ZREMRANGEBYSCORE('set', 5, '+inf');
-            $this->assertEquals(1, $redis->zcard('set'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_removes_members_by_rank_in_sorted_set()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
-            $redis->ZREMRANGEBYRANK('set', 1, -1);
-            $this->assertEquals(1, $redis->zcard('set'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_sets_multiple_hash_fields()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
-            $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'], $redis->hgetall('hash'));
-
-            $redis->hmset('hash2', 'name', 'mohamed', 'hobby', 'diving');
-            $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'], $redis->hgetall('hash2'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_gets_multiple_hash_fields()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
-
-            $this->assertEquals(['mohamed', 'diving'],
-                $redis->hmget('hash', 'name', 'hobby')
-            );
-
-            $this->assertEquals(['mohamed', 'diving'],
-                $redis->hmget('hash', ['name', 'hobby'])
-            );
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_runs_eval()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', 'mohamed');
-            $this->assertEquals('mohamed', $redis->get('name'));
-
-            $redis->flushall();
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function it_runs_pipes()
-    {
-        foreach ($this->connections() as $redis) {
-            $result = $redis->pipeline(function ($pipe) {
-                $pipe->set('test:pipeline:1', 1);
-                $pipe->get('test:pipeline:1');
-                $pipe->set('test:pipeline:2', 2);
-                $pipe->get('test:pipeline:2');
+        foreach ($this->redis as $name => $driver) {
+            if (str_contains($name, 'prefixed')) {
+                return;
+            }
+
+            $redis = $driver->connection();
+
+            $redis->pipeline(function ($pipe) {
+                for ($x = 0; $x < 1000; $x++) {
+                    $pipe->set($x * rand(0, 1000), $x);
+                }
             });
 
-            $this->assertCount(4, $result);
-            $this->assertEquals(1, $result[1]);
-            $this->assertEquals(2, $result[3]);
+            $result = $redis->scan(0, ['COUNT' => 10]);
+            $this->assertCount(2, $result);
+            $this->assertGreaterThan(0, $result[0]);
+            $this->assertGreaterThanOrEqual(10, count($result[1]));
+
+            $redis->flushall();
+
+            $redis->set('jeffrey', 1);
+            $redis->set('matt', 5);
+            $redis->set('matthew', 6);
+            $redis->set('taylor', 10);
+            $redis->set('dave', 12);
+
+            $result = $redis->scan(0, ['mAtCh' => 'matt*']);
+            $diff = array_diff(['matt', 'matthew'], $result[1]);
+            $this->assertEquals(0, $result[0]);
+            $this->assertCount(2, $result[1]);
+            $this->assertEmpty($diff);
+
+            $result = $redis->scan(0, ['MaTcH' => 'dave']);
+            $this->assertEquals(0, $result[0]);
+            $this->assertEquals(['dave'], $result[1]);
 
             $redis->flushall();
         }
@@ -538,66 +621,152 @@ class RedisConnectionTest extends TestCase
 
     /**
      * @test
+     * @dataProvider  redisConnections
      */
-    public function it_runs_transactions()
+    public function it_scans_unsorted_sets($redis)
     {
-        foreach ($this->connections() as $redis) {
-            $result = $redis->transaction(function ($pipe) {
-                $pipe->set('test:transaction:1', 1);
-                $pipe->get('test:transaction:1');
-                $pipe->set('test:transaction:2', 2);
-                $pipe->get('test:transaction:2');
-            });
+        $redis->sadd('set', 'foo');
+        $redis->sadd('set', 'bar');
+        $redis->sadd('set', 'foobar');
+        $redis->sadd('set', 'baz');
 
-            $this->assertCount(4, $result);
-            $this->assertEquals(1, $result[1]);
-            $this->assertEquals(2, $result[3]);
+        $result = $redis->sscan('set', 0);
+        $diff = array_diff(['foo', 'bar', 'foobar', 'baz'], $result[1]);
+        $this->assertCount(2, $result);
+        $this->assertEquals(0, $result[0]);
+        $this->assertCount(4, $result[1]);
+        $this->assertEmpty($diff);
 
-            $redis->flushall();
-        }
+        $redis->flushall();
     }
 
     /**
      * @test
+     * @dataProvider  redisConnections
      */
-    public function it_runs_raw_command()
+    public function it_scans_unsorted_sets_with_options($redis)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->executeRaw(['SET', 'test:raw:1', '1']);
+        $redis->sadd('set', ...range(0, 1000));
 
-            $this->assertEquals(
-                1, $redis->executeRaw(['GET', 'test:raw:1'])
-            );
+        $result = $redis->sscan('set', 0, ['count' => 10]);
+        $this->assertCount(2, $result);
+        $this->assertGreaterThan(0, $result[0]);
+        $this->assertLessThan(1000, count($result[1]));
+        $this->assertGreaterThanOrEqual(10, count($result[1]));
 
-            $redis->flushall();
-        }
+        $redis->sadd('set2', 'jeffrey', 'matt', 'taylor', 'dave', 'david');
+
+        $result = $redis->sscan('set2', 0, ['mAtCh' => 'd*']);
+        $diff = array_diff(['dave', 'david'], $result[1]);
+        $this->assertEquals(0, $result[0]);
+        $this->assertCount(2, $result[1]);
+        $this->assertEmpty($diff);
+
+        $result = $redis->sscan('set2', 0, ['MaTcH' => 'dave']);
+        $this->assertEquals(0, $result[0]);
+        $this->assertEquals(['dave'], $result[1]);
+
+        $redis->flushall();
     }
 
-    public function connections()
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_scans_hash_fields($redis)
     {
-        $connections = [
-            $this->redis['predis']->connection(),
-            $this->redis['phpredis']->connection(),
-        ];
+        $redis->hmset('hash', ['foo' => 'bar', 'foobar' => 'baz']);
 
-        if (extension_loaded('redis')) {
-            $host = getenv('REDIS_HOST') ?: '127.0.0.1';
-            $port = getenv('REDIS_PORT') ?: 6379;
+        $result = $redis->hscan('hash', 0);
+        $diff = array_diff(['foo' => 'bar', 'foobar' => 'baz'], $result[1]);
+        $this->assertEquals(0, $result[0]);
+        $this->assertCount(2, $result[1]);
+        $this->assertEmpty($diff);
 
-            $prefixedPhpredis = new RedisManager('phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 5,
-                    'options' => ['prefix' => 'laravel:'],
-                    'timeout' => 0.5,
-                ],
-            ]);
+        $result = $redis->hscan('hash_none', 0);
+        $this->assertEquals(0, $result[0]);
+        $this->assertEmpty($result[1]);
 
-            $connections[] = $prefixedPhpredis->connection();
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_scans_hash_fields_with_options($redis)
+    {
+        for ($x = 0; $x < 1000; $x++) {
+            $hash[$x] = $x;
         }
 
-        return $connections;
+        $redis->hmset('hash', $hash);
+
+        $result = $redis->hscan('hash', 0, ['COUNT' => 10]);
+        $this->assertCount(2, $result);
+        $this->assertGreaterThan(0, $result[0]);
+        $this->assertGreaterThanOrEqual(10, count($result[1]));
+
+        $redis->hmset('hash2', ['foo' => 'bar', 'foobar' => 'baz', 'bar' => 'baz']);
+
+        $result = $redis->hscan('hash2', 0, ['mAtCh' => 'foo*']);
+        $expected = ['foo' => 'bar', 'foobar' => 'baz'];
+        $this->assertEquals(0, $result[0]);
+        $this->assertCount(2, $result[1]);
+        $this->assertEquals(asort($expected), asort($result[1]));
+
+        $result = $redis->hscan('hash2', 0, ['MaTcH' => 'foo']);
+        $this->assertEquals(0, $result[0]);
+        $this->assertEquals(['foo' => 'bar'], $result[1]);
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_scans_sorted_set($redis)
+    {
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'matthew' => 6, 'taylor' => 10, 'dave' => 12]);
+
+        $result = $redis->zscan('set', 0);
+        $this->assertCount(2, $result);
+        $this->assertEquals(0, $result[0]);
+        $this->assertCount(5, $result[1]);
+
+        $redis->flushall();
+    }
+
+    /**
+     * @test
+     * @dataProvider  redisConnections
+     */
+    public function it_scans_sorted_set_with_options($redis)
+    {
+        for ($x = 0; $x < 1000; $x++) {
+            $set[$x] = $x * rand(0, 1000);
+        }
+
+        $redis->zadd('set', $set);
+
+        $result = $redis->zscan('set', 0, ['COUNT' => 10]);
+        $this->assertCount(2, $result);
+        $this->assertGreaterThan(0, $result[0]);
+        $this->assertGreaterThanOrEqual(10, $result[1]);
+
+        $redis->zadd('set2', ['jeffrey' => 1, 'matt' => 5, 'matthew' => 6, 'taylor' => 10, 'dave' => 12]);
+
+        $result = $redis->zscan('set2', 0, ['mAtCh' => 'matt*']);
+        $diff = array_diff(['matt' => 5, 'matthew' => 6], $result[1]);
+        $this->assertEquals(0, $result[0]);
+        $this->assertEmpty($diff);
+
+        $result = $redis->zscan('set2', 0, ['MaTcH' => 'dave']);
+        $diff = array_diff(['dave' => 12], $result[1]);
+        $this->assertEquals(0, $result[0]);
+        $this->assertEmpty($diff);
+
+        $redis->flushall();
     }
 }


### PR DESCRIPTION
This adds the adapter methods to properly utilize PhpRedis commands for scan, sscan, hscan, and zscan. fixes #24222 .... take 3.

I think there was some confusion caused by myself perhaps, I fell into an old work habit where if a PR was rejected, that meant a new branch because enough was wrong that it was beyond fixing. Clearly that is not what was expected, so I noticed the merge that caused the failed tests was drawing from the original branch. I won't be making that mistake again and will just continue on the same branch for a feature, but just to be clear the branch name changed and I added a v2 on the end. I apologize for that....still relatively new to contributing. 

To be clear the most current branch is fix-scan-methods-for-phpredis-v2. I do still have the old branch locally, so if it makes it easier I can just move the changes from this branch to the original and retarget the PR.