### PR TITLE
[5.7] Add support for Gate::define() callback to be the name of an invokable class

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -11,15 +11,6 @@ use Illuminate\Auth\Access\HandlesAuthorization;
 
 class GateTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Callback must be a callable or a 'Class@method'
-     */
-    public function test_gate_throws_exception_on_invalid_callback_type()
-    {
-        $this->getBasicGate()->define('foo', 'foo');
-    }
-
     public function test_basic_closures_can_be_defined()
     {
         $gate = $this->getBasicGate();
@@ -167,6 +158,15 @@ class GateTest extends TestCase
         $gate = $this->getBasicGate();
 
         $gate->define('foo', '\Illuminate\Tests\Auth\AccessGateTestClass@foo');
+
+        $this->assertTrue($gate->check('foo'));
+    }
+
+    public function test_invokable_classes_can_be_defined()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->define('foo', '\Illuminate\Tests\Auth\AccessGateTestInvokableClass');
 
         $this->assertTrue($gate->check('foo'));
     }
@@ -378,6 +378,14 @@ class GateTest extends TestCase
 class AccessGateTestClass
 {
     public function foo()
+    {
+        return true;
+    }
+}
+
+class AccessGateTestInvokableClass
+{
+    public function __invoke()
     {
         return true;
     }


### PR DESCRIPTION
I've targeted `master` for this PR. I don't think it's a breaking change because it introduces functionality which doesn't exist in 5.6, but as it changes the behaviour of `Gate::define()` I decided to err on the side of the caution. I can do a PR to `5.6` instead if necessary.

Currently if a class name only is passed as the second argument to `Gate::define()` an `InvalidArgumentException` is thrown.

This surprised me as I assumed that I'd be able to pass the name of an invokable class, like it's possible to pass only a class name as a controller when defining routes. Since a function can be passed to as the second argument of `Gate::define()` it seems sensible that an invokable class name should also be accepted.

This change accepts any string as the second argument and _assumes_ that it's the name of an invokable class. I haven't added any validation of the string. I therefore removed the test to confirm that an `InvalidArgumentException` is throw when the second argument to `Gate::define()` is a string.

It may be desirable to have better validation of the passed string, but at the same time `Gate::define()` when called with `ClassName@methodName` also doesn't validate that the class or method names.