### PR TITLE
[5.6] Suppress ramsey/uuid dependency in illuminate/notifications

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Notifications;
 
-use Ramsey\Uuid\Uuid;
+use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -83,7 +83,7 @@ class NotificationSender
                 continue;
             }
 
-            $notificationId = Uuid::uuid4()->toString();
+            $notificationId = Str::uuid()->toString();
 
             foreach ((array) $viaChannels as $channel) {
                 $this->sendToNotifiable($notifiable, $notificationId, clone $original, $channel);
@@ -146,7 +146,7 @@ class NotificationSender
         $original = clone $notification;
 
         foreach ($notifiables as $notifiable) {
-            $notificationId = Uuid::uuid4()->toString();
+            $notificationId = Str::uuid()->toString();
 
             foreach ($original->via($notifiable) as $channel) {
                 $notification = clone $original;

--- a/src/Illuminate/Notifications/composer.json
+++ b/src/Illuminate/Notifications/composer.json
@@ -22,8 +22,7 @@
         "illuminate/filesystem": "5.6.*",
         "illuminate/mail": "5.6.*",
         "illuminate/queue": "5.6.*",
-        "illuminate/support": "5.6.*",
-        "ramsey/uuid": "~3.0"
+        "illuminate/support": "5.6.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
-use Ramsey\Uuid\Uuid;
+use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
@@ -175,7 +175,7 @@ class NotificationFake implements NotificationFactory, NotificationDispatcher
 
         foreach ($notifiables as $notifiable) {
             if (! $notification->id) {
-                $notification->id = Uuid::uuid4()->toString();
+                $notification->id = Str::uuid()->toString();
             }
 
             $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)][] = [

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Support;
 
-use Ramsey\Uuid\Uuid;
 use Illuminate\Support\Str;
+use Ramsey\Uuid\UuidInterface;
 use PHPUnit\Framework\TestCase;
 
 class SupportStrTest extends TestCase
@@ -289,8 +289,8 @@ class SupportStrTest extends TestCase
 
     public function testUuid()
     {
-        $this->assertInstanceOf(Uuid::class, Str::uuid());
-        $this->assertInstanceOf(Uuid::class, Str::orderedUuid());
+        $this->assertInstanceOf(UuidInterface::class, Str::uuid());
+        $this->assertInstanceOf(UuidInterface::class, Str::orderedUuid());
     }
 }
 


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As `illuminate/notifications` already depends on `illuminate/support`, the `ramsey/uuid` dependency is useless, and thus can be removed.

This PR also fixes `testUuid()` and adjusts the assertions.
