### PR TITLE
[5.6] Add support for defining and enforcing a Spatial reference system for a Point column

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1061,12 +1061,13 @@ class Blueprint
     /**
      * Create a new point column on the table.
      *
-     * @param  string  $column
+     * @param  string $column
+     * @param  null|int $srid
      * @return \Illuminate\Support\Fluent
      */
-    public function point($column)
+    public function point($column, $srid = null)
     {
-        return $this->addColumn('point', $column);
+        return $this->addColumn('point', $column, compact('srid'));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -15,7 +15,7 @@ class MySqlGrammar extends Grammar
      */
     protected $modifiers = [
         'Unsigned', 'VirtualAs', 'StoredAs', 'Charset', 'Collate', 'Nullable',
-        'Default', 'Increment', 'Comment', 'After', 'First',
+        'Default', 'Increment', 'Comment', 'After', 'First', 'Srid',
     ];
 
     /**
@@ -963,6 +963,20 @@ class MySqlGrammar extends Grammar
     {
         if (! is_null($column->comment)) {
             return " comment '".addslashes($column->comment)."'";
+        }
+    }
+
+    /**
+     * Get the SQL for a SRID column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifySrid(Blueprint $blueprint, Fluent $column)
+    {
+        if (! is_null($column->srid) && is_int($column->srid) && $column->srid > 0) {
+            return ' srid '.$column->srid;
         }
     }
 


### PR DESCRIPTION
As of Mysql 8, there is support for spatial reference systems. Currently there is no way to create a Point column that refers to a specific SRS.  

The benefit of having this, is to ensure that when using point datatypes for geocoordinates, they on the correct scale. By default the column will refer to SRID 0, and when doing calculations ( e.g. distance between points ) the resulting deviation is huge.  

```
mysql> SELECT ST_distance_sphere( 
( SELECT location FROM locations_without_srsid LIMIT 1), 
(SELECT location FROM locations_without_srsid LIMIT 1, 1) 
)/1000 as distance_in_meters;
+--------------------+
| distance_in_meters |
+--------------------+
| 10.980785022158566 |
+--------------------+
1 row in set (0,00 sec)

mysql> SELECT ST_distance_sphere( 
( SELECT location FROM locations_with_srsid LIMIT 1), 
(SELECT location FROM locations_with_srsid LIMIT 1, 1) 
)/1000 as distance_in_meters;
+--------------------+
| distance_in_meters |
+--------------------+
|  7.221216762563222 |
+--------------------+
1 row in set (0,00 sec)

```

You can also set the SRID of a point column on INSERT or UPDATE, but with this in place you can prevent entry of incorrect points. 

With Mysql 8, I suspect these SRS systems will be used a lot. 

See: https://mysqlserverteam.com/spatial-reference-systems-in-mysql-8-0/
See: https://dev.mysql.com/doc/refman/8.0/en/spatial-reference-systems.html