### PR TITLE
[5.6] Remove null relationships in loadMorph before grouped by class name

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -135,6 +135,9 @@ class Collection extends BaseCollection implements QueueableCollection
     public function loadMorph($relation, $relations)
     {
         $this->pluck($relation)
+            ->reject(function ($value, $key) {
+                return is_null($value);
+            })
             ->groupBy(function ($model) {
                 return get_class($model);
             })

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -135,9 +135,7 @@ class Collection extends BaseCollection implements QueueableCollection
     public function loadMorph($relation, $relations)
     {
         $this->pluck($relation)
-            ->reject(function ($value, $key) {
-                return is_null($value);
-            })
+            ->filter()
             ->groupBy(function ($model) {
                 return get_class($model);
             })


### PR DESCRIPTION
Relationship model may be null when using with() to eager load them, which will cause error in loadMorph() because of the usage of get_class().
So, remove null relationships before group them by class name seems reasonable.
