### PR TITLE
Add helper functions for encryptString / decryptString

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -380,6 +380,19 @@ if (! function_exists('decrypt')) {
     }
 }
 
+if (! function_exists('decryptString')) {
+    /**
+     * Decrypt the given non-serialized value.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    function decryptString($value)
+    {
+        return app('encrypter')->decryptString($value);
+    }
+}
+
 if (! function_exists('dispatch')) {
     /**
      * Dispatch a job to its appropriate handler.
@@ -457,6 +470,19 @@ if (! function_exists('encrypt')) {
     function encrypt($value)
     {
         return app('encrypter')->encrypt($value);
+    }
+}
+
+if (! function_exists('encryptString')) {
+    /**
+     * Encrypt the given value.
+     *
+     * @param  mixed  $value
+     * @return string
+     */
+    function encryptString($value)
+    {
+        return app('encrypter')->encryptString($value);
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -382,7 +382,7 @@ if (! function_exists('decrypt')) {
 
 if (! function_exists('decryptString')) {
     /**
-     * Decrypt the given non-serialized value.
+     * Decrypt the given value without unserialization.
      *
      * @param  string  $value
      * @return string
@@ -475,7 +475,7 @@ if (! function_exists('encrypt')) {
 
 if (! function_exists('encryptString')) {
     /**
-     * Encrypt the given value.
+     * Encrypt the given value without serialization.
      *
      * @param  mixed  $value
      * @return string


### PR DESCRIPTION
Added helper functions that are based on both encrpytString / decryptString for non-serialized values.

I thought since there are helpers for the serialized methods might as well include helpers for non-serialized as well. The methods are copied from @taylorotwell commit ea9432aa1036c45b9af78af7ab111d2da4ca32b5 so I did not see the need for a test since it was pretty straight forward.