### PR TITLE
[5.6] Adjust docblock in SessionGuard@logoutOtherDevices

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -535,13 +535,13 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
-     * Invalid other sessions for the current user.
+     * Invalidate other sessions for the current user.
      *
      * The application must be using the AuthenticateSession middleware.
      *
      * @param  string  $password
      * @param  string  $attribute
-     * @return $this
+     * @return null|bool
      */
     public function logoutOtherDevices($password, $attribute = 'password')
     {


### PR DESCRIPTION
Changed 'Invalid' to 'Invalidate' and adjusted the return. Seems the return is a left over from when this method was part of `Illuminate\Auth\Authenticatable`.