### PR TITLE
[5.6] Added translations to default Password Reset notification

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -56,9 +56,9 @@ class ResetPassword extends Notification
         }
 
         return (new MailMessage)
-            ->line('You are receiving this email because we received a password reset request for your account.')
-            ->action('Reset Password', url(config('app.url').route('password.reset', $this->token, false)))
-            ->line('If you did not request a password reset, no further action is required.');
+            ->line(trans('passwords.mail.intro'))
+            ->action(trans('passwords.mail.button'), url(config('app.url').route('password.reset', $this->token, false)))
+            ->line(trans('passwords.mail.disclaimer'));
     }
 
     /**


### PR DESCRIPTION
I made the default ResetPassword notification translatable, so that developers won't have to create their own to change the text.

Related: https://github.com/laravel/laravel/pull/4666 (the actual translations)