### PR TITLE
[5.6] Fix loadMissing() relationship parsing

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent;
 
 use LogicException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Contracts\Queue\QueueableCollection;
@@ -79,7 +80,13 @@ class Collection extends BaseCollection implements QueueableCollection
                 $key = $value;
             }
 
-            $path = array_combine($segments = explode('.', $key), $segments);
+            $segments = explode('.', explode(':', $key)[0]);
+
+            if (Str::contains($key, ':')) {
+                $segments[count($segments) - 1] .= ':'.explode(':', $key)[1];
+            }
+
+            $path = array_combine($segments, $segments);
 
             if (is_callable($value)) {
                 $path[end($segments)] = $value;

--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -52,12 +52,12 @@ class EloquentCollectionLoadMissingTest extends DatabaseTestCase
 
         \DB::enableQueryLog();
 
-        $posts->loadMissing('comments.parent:id.revisions', 'user:id');
+        $posts->loadMissing('comments.parent.revisions:revisions.comment_id', 'user:id');
 
         $this->assertCount(2, \DB::getQueryLog());
         $this->assertTrue($posts[0]->comments[0]->relationLoaded('parent'));
         $this->assertTrue($posts[0]->comments[1]->parent->relationLoaded('revisions'));
-        $this->assertFalse(array_key_exists('post_id', $posts[0]->comments[1]->parent->getAttributes()));
+        $this->assertFalse(array_key_exists('id', $posts[0]->comments[1]->parent->revisions[0]->getAttributes()));
     }
 
     public function testLoadMissingWithClosure()


### PR DESCRIPTION
`loadMissing()` currently parses nested relationships in a way that supports specifc columns in all levels:

    $posts->loadMissing('comments.parent:id.revisions');

However, this is different from the way `load()` and `with()` parse relationships. They only support specific columns in the last relationship. This is necessary to allow columns with table names (https://github.com/laravel/framework/pull/24166#issuecomment-391580473):

    $posts->loadMissing('comments.parent.revisions:revisions.comment_id');

This PR adjusts the parsing to match `load()` and `with()`.