### PR TITLE
[5.6] Add Builder::whereJsonContains()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1434,6 +1434,39 @@ class Builder
     }
 
     /**
+     * Add a "where JSON contains" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereJsonContains($column, $value, $boolean = 'and')
+    {
+        $type = 'JsonContains';
+
+        $this->wheres[] = compact('type', 'column', 'value', 'boolean');
+
+        if (! $value instanceof Expression) {
+            $this->addBinding(json_encode($value));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a "or where JSON contains" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhereJsonContains($column, $value)
+    {
+        return $this->whereJsonContains($column, $value, 'or');
+    }
+
+    /**
      * Handles dynamic "where" clauses to the query.
      *
      * @param  string  $method

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
+use RuntimeException;
 use Illuminate\Support\Arr;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
@@ -487,6 +488,35 @@ class Grammar extends BaseGrammar
         $values = $this->parameterize($where['values']);
 
         return '('.implode(', ', $where['columns']).') '.$where['operator'].' ('.$values.')';
+    }
+
+    /**
+     * Compile a "where JSON contains" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereJsonContains(Builder $query, $where)
+    {
+        $column = $this->wrap($where['column']);
+
+        $value = $this->parameter($where['value']);
+
+        return $this->compileJsonContains($column, $value);
+    }
+
+    /**
+     * Compile a "JSON contains" statement into SQL.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @return string
+     * @throws \RuntimeException
+     */
+    protected function compileJsonContains($column, $value)
+    {
+        throw new RuntimeException('The database engine in use is not yet supported.');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -53,6 +53,18 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a "JSON contains" statement into SQL.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileJsonContains($column, $value)
+    {
+        return 'json_contains('.$column.', '.$value.')';
+    }
+
+    /**
      * Compile a single union statement.
      *
      * @param  array  $union

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -65,6 +65,20 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a "JSON contains" statement into SQL.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileJsonContains($column, $value)
+    {
+        $column = str_replace('->>', '->', $column);
+
+        return '('.$column.')::jsonb @> '.$value;
+    }
+
+    /**
      * Compile the lock into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query


### PR DESCRIPTION
This is a re-submit of #24258 to discuss your comment about better tests:

> Asserting the SQL query matches what you expect seems pointless to test. Test that it actually does something useful / correct.

 I assume that you mean integration tests? As far as I see, we don't support these for MySQL/PostgreSQL.
I agree that only testing the generated SQL isn't ideal, but I don't know how to improve it (of course, I tested the code with real databases).

For the future: Is a re-submit your preferred way to ask about a closed PR?