### PR TITLE
[5.7] Fix model nullable attribute on array access

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -297,6 +297,44 @@ trait HasAttributes
         return $values;
     }
 
+    public function hasAttribute($key)
+    {
+        if (! $key) {
+            return false;
+        }
+
+        // If the attribute exists in the attribute array or has a "get" mutator we will
+        // get the attribute's value. Otherwise, we will proceed as if the developers
+        // are asking for a relationship's value. This covers both types of values.
+        if (array_key_exists($key, $this->attributes) ||
+            $this->hasGetMutator($key)) {
+            return true;
+        }
+
+        // Here we will determine if the model base class itself contains this given key
+        // since we don't want to treat any of those methods as relationships because
+        // they are all intended as helper methods and none of these are relations.
+        if (method_exists(self::class, $key)) {
+            return false;
+        }
+
+        // If the key already exists in the relationships array, it just means the
+        // relationship has already been loaded, so we'll just return it out of
+        // here because there is no need to query within the relations twice.
+        if ($this->relationLoaded($key)) {
+            return true;
+        }
+
+        // If the "attribute" exists as a method on the model, we will just assume
+        // it is a relationship and will load and return results from the query
+        // and hydrate the relationship's value on the "relationships" array.
+        if (method_exists($this, $key)) {
+            return true;
+        }
+
+        return false;
+    }
+
     /**
      * Get an attribute from the model.
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1434,7 +1434,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function offsetExists($offset)
     {
-        return ! is_null($this->getAttribute($offset));
+        return $this->hasAttribute($offset);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -127,7 +127,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testArrayAccessToAttributes()
     {
-        $model = new EloquentModelStub(['attributes' => 1, 'connection' => 2, 'table' => 3]);
+        $model = new EloquentModelStub(['attributes' => 1, 'connection' => 2, 'table' => 3, 'nullable' => null]);
         unset($model['table']);
 
         $this->assertTrue(isset($model['attributes']));
@@ -137,6 +137,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse(isset($model['table']));
         $this->assertEquals($model['table'], null);
         $this->assertFalse(isset($model['with']));
+        $this->assertTrue(isset($model['nullable']));
+        $this->assertNull($model['nullable']);
     }
 
     public function testOnly()


### PR DESCRIPTION
Hi!

We are recently found an issue on accessing an attribute (null) with twig. It is impossible to get an attribute that is null, since twig checks the ArrayAccess interface and call `offsetExists`.

Simple failing use case:
```php
//  test.twig
{{ model.nullable | default(model.title) }}
```

So, i changed the expacted behaviour to check if the attribute exist.