### PR TITLE
[5.6] Fix numeric keys in resources

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -28,7 +28,10 @@ trait ConditionallyLoadsAttributes
             }
 
             if (is_numeric($key) && $value instanceof MergeValue) {
-                return $this->merge($data, $index, $this->filter($value->data), $numericKeys);
+                return $this->merge(
+                    $data, $index, $this->filter($value->data),
+                    array_values($value->data) === $value->data
+                );
             }
 
             if ($value instanceof self && is_null($value->resource)) {
@@ -80,8 +83,7 @@ trait ConditionallyLoadsAttributes
             }
         }
 
-        return ! empty($data) && is_numeric(array_keys($data)[0])
-                        ? array_values($data) : $data;
+        return $numericKeys ? array_values($data) : $data;
     }
 
     /**

--- a/tests/Integration/Http/Fixtures/PostResourceWithNumericKeys.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithNumericKeys.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+class PostResourceWithNumericKeys extends PostResource
+{
+    public function toArray($request)
+    {
+        return [
+            'array' => [1 => 'foo', 2 => 'bar'],
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -17,6 +17,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\ReallyEmptyPostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\SerializablePostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithExtraData;
 use Illuminate\Tests\Integration\Http\Fixtures\EmptyPostCollectionResource;
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithNumericKeys;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalData;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationship;
@@ -524,7 +525,26 @@ class ResourceTest extends TestCase
         });
     }
 
-    public function test_leading_merge__keyed_value_is_merged_correctly()
+    public function test_numeric_keys()
+    {
+        Route::get('/', function () {
+            return new PostResourceWithNumericKeys(new Post());
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'data' => [
+                'array' => [1 => 'foo', 2 => 'bar'],
+            ],
+        ]);
+    }
+
+    public function test_leading_merge_keyed_value_is_merged_correctly()
     {
         $filter = new class {
             use ConditionallyLoadsAttributes;


### PR DESCRIPTION
#23414 fixed an issue with `MergeValue` and an associative array. However, this left the `$numericKeys` parameter in `removeMissingValues()` unused and thereby broke associative arrays with numeric keys:

    $test = new Test(['array' => [1 => 'foo', 2 => 'bar']]);
    return new TestResource($test);

    Expected response: {"data":{"array":{"1":"foo","2":"bar"}}}
    Actual response:   {"data":{"array":["foo","bar"]}}

This PR reverts #23414 and instead fixes the problem in `filter()`: `$numericKeys` has to be determined on the data of `MergeValue`, not on the original `$data`.

Fixes #23595 and fixes #24302.
