### PR TITLE
[5.5] Fix muttator is setting a JSON array when the attribute should be casted to object

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -584,7 +584,7 @@ trait HasAttributes
 
         $this->attributes[$key] = $this->asJson($this->getArrayAttributeWithValue(
             $path, $key, $value
-        ));
+        ), $this->getCastType($key) === 'object');
 
         return $this;
     }
@@ -625,7 +625,7 @@ trait HasAttributes
      */
     protected function castAttributeAsJson($key, $value)
     {
-        $value = $this->asJson($value);
+        $value = $this->asJson($value, $this->getCastType($key) === 'object');
 
         if ($value === false) {
             throw JsonEncodingException::forAttribute(
@@ -640,11 +640,16 @@ trait HasAttributes
      * Encode the given value as JSON.
      *
      * @param  mixed  $value
+     * @param  bool  $asObject
      * @return string
      */
-    protected function asJson($value)
+    protected function asJson($value, $asObject = false)
     {
-        return json_encode($value);
+        if ($asObject && is_array($value) && !$value) {
+            return '{}';
+        } else {
+            return json_encode($value);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -584,7 +584,7 @@ trait HasAttributes
 
         $this->attributes[$key] = $this->asJson($this->getArrayAttributeWithValue(
             $path, $key, $value
-        ), $this->getCastType($key) === 'object');
+        ), $this->hasCast($key) && $this->getCastType($key) === 'object');
 
         return $this;
     }
@@ -625,7 +625,7 @@ trait HasAttributes
      */
     protected function castAttributeAsJson($key, $value)
     {
-        $value = $this->asJson($value, $this->getCastType($key) === 'object');
+        $value = $this->asJson($value, $this->hasCast($key) && $this->getCastType($key) === 'object');
 
         if ($value === false) {
             throw JsonEncodingException::forAttribute(
@@ -645,7 +645,7 @@ trait HasAttributes
      */
     protected function asJson($value, $asObject = false)
     {
-        if ($asObject && is_array($value) && !$value) {
+        if ($asObject && is_array($value) && ! $value) {
             return '{}';
         } else {
             return json_encode($value);


### PR DESCRIPTION
When an attribute casted as 'object' is set with an empty array, it should be casted to an empty object.

`class Example extends Model
{
protected $casts = [
        'test' => 'object'
    ];
}
`

If we set _test_ attribute as an array, it is not casted as an object, like this:

`$example->test = [];`
`=> App\Models\Example {#1001
     id: 1,
     example: "[]"
   }
`

This attribute should be like this:

``=> App\Models\Example {#1001
     id: 1,
     example: "{}"
   }
``