### PR TITLE
Added data_increment/decrement and array_increment/decrement

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -277,6 +277,38 @@ if (! function_exists('array_set')) {
     }
 }
 
+if (! function_exists('array_increment')) {
+    /**
+     * Increment an item on an array with a given value using "dot" notation.
+     *
+     * @param  array   $array
+     * @param  string  $key
+     * @param  mixed   $value
+     * @param  mixed   $startValue
+     * @return array
+     */
+    function array_increment(&$array, $key, $value = 1, $startValue = 0)
+    {
+        return Arr::set($array, $key, Arr::get($array, $key, $startValue) + $value);
+    }
+}
+
+if (! function_exists('array_decrement')) {
+    /**
+     * Decrement an item on an array with a given value using "dot" notation.
+     *
+     * @param  array   $array
+     * @param  string  $key
+     * @param  mixed   $value
+     * @param  mixed   $startValue
+     * @return array
+     */
+    function array_decrement(&$array, $key, $value = 1, $startValue = 0)
+    {
+        return Arr::set($array, $key, Arr::get($array, $key, $startValue) - $value);
+    }
+}
+
 if (! function_exists('array_sort')) {
     /**
      * Sort the array by the given callback or attribute name.
@@ -541,6 +573,38 @@ if (! function_exists('data_set')) {
         }
 
         return $target;
+    }
+}
+
+if (! function_exists('data_increment')) {
+    /**
+     * Increment an item on an array or object with a given value using dot notation.
+     *
+     * @param  mixed  $target
+     * @param  string|array  $key
+     * @param  mixed  $value
+     * @param  mixed  $startValue
+     * @return mixed
+     */
+    function data_increment(&$target, $key, $value = 1, $startValue = 0)
+    {
+        return data_set($target, $key, data_get($target, $key, $startValue) + $value);
+    }
+}
+
+if (! function_exists('data_decrement')) {
+    /**
+     * Decrement an item on an array or object with a given value using dot notation.
+     *
+     * @param  mixed  $target
+     * @param  string|array  $key
+     * @param  mixed  $value
+     * @param  mixed  $startValue
+     * @return mixed
+     */
+    function data_decrement(&$target, $key, $value = 1, $startValue = 0)
+    {
+        return data_set($target, $key, data_get($target, $key, $startValue) - $value);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -43,6 +43,24 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(Arr::has($array, 'foo.bar'));
     }
 
+    public function testArrayIncrement()
+    {
+        $array = ['name' => 'taylor', 'age' => 26];
+        $this->assertEquals(['name' => 'taylor', 'age' => 27], array_increment($array, 'age'));
+
+        $array = ['name' => 'taylor', 'age' => 26];
+        $this->assertEquals(['name' => 'taylor', 'age' => 28], array_increment($array, 'age', 2));
+    }
+
+    public function testArrayDecrement()
+    {
+        $array = ['name' => 'taylor', 'age' => 26];
+        $this->assertEquals(['name' => 'taylor', 'age' => 25], array_decrement($array, 'age'));
+
+        $array = ['name' => 'taylor', 'age' => 26];
+        $this->assertEquals(['name' => 'taylor', 'age' => 24], array_decrement($array, 'age', 2));
+    }
+
     public function testArraySet()
     {
         $array = [];
@@ -613,6 +631,24 @@ class SupportHelpersTest extends TestCase
                 ],
             ],
         ], $data);
+    }
+
+    public function testDataIncrement()
+    {
+        $data = ['name' => 'taylor', 'age' => 26];
+        $this->assertEquals(['name' => 'taylor', 'age' => 27], data_increment($data, 'age'));
+
+        $data = ['name' => 'taylor', 'age' => 26];
+        $this->assertEquals(['name' => 'taylor', 'age' => 28], data_increment($data, 'age', 2));
+    }
+
+    public function testDataDecrement()
+    {
+        $array = ['name' => 'taylor', 'age' => 26];
+        $this->assertEquals(['name' => 'taylor', 'age' => 25], data_decrement($array, 'age'));
+
+        $array = ['name' => 'taylor', 'age' => 26];
+        $this->assertEquals(['name' => 'taylor', 'age' => 24], data_decrement($array, 'age', 2));
     }
 
     public function testArraySort()


### PR DESCRIPTION
When incrementing values in an array, one might need to do this:

```
$someArray['things'] = [];
$someArray['other_things'] = [];
 
foreach ($stuff as $key => $value){
    if (!isset($someArray['things'][$key])){
        $someArray['things'][$key] = 0;    
    }
    $someArray['things'][$key]++;
    
    // or incrementing with a value

    if (!isset($someArray['other_things'][$key])){
        $someArray['other_things'][$key] = 0;    
    }
    $someArray['other_things'][$key] += $value;
}
```

With this change, you can write this
```
$someArray['things'] = [];
$someArray['other_things'] = [];
 
foreach ($stuff as $key => $value){
    data_increment($someArray, 'things.'.$key);
    
    // or incrementing with a value

    data_increment($someArray, 'other_things.'.$key, $value);
}
```

I'ts also possible to use a start value. This will be the default value BEFORE incrementing.
```
$data = [];
data_increment($data, 'foo', 1, 100);

// Result:
// $data == ['foo' => 101];
```

I've also added a decrement function for both array_ and data_, which function in the same way.