### PR TITLE
[5.6] Save empty array to database

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,15 +2,15 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use LogicException;
 use DateTimeInterface;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\JsonEncodingException;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Str;
+use LogicException;
 
 trait HasAttributes
 {
@@ -677,11 +677,9 @@ trait HasAttributes
      */
     protected function asJson($value)
     {
-        if ($value === []) {
-            return '{}';
-        }
-
-        return json_encode($value);
+        $value = json_encode($value);
+        
+        return $value === '[]' ? '{}' : $value;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,15 +2,15 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use DateTimeInterface;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\JsonEncodingException;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Support\Str;
 use LogicException;
+use DateTimeInterface;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Support\Carbon;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Database\Eloquent\JsonEncodingException;
 
 trait HasAttributes
 {
@@ -678,7 +678,7 @@ trait HasAttributes
     protected function asJson($value)
     {
         $value = json_encode($value);
-        
+
         return $value === '[]' ? '{}' : $value;
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,15 +2,15 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use LogicException;
 use DateTimeInterface;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\JsonEncodingException;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Str;
+use LogicException;
 
 trait HasAttributes
 {
@@ -677,6 +677,10 @@ trait HasAttributes
      */
     protected function asJson($value)
     {
+        if ($value === []) {
+            return '{}';
+        }
+        
         return json_encode($value);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,15 +2,15 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use DateTimeInterface;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\JsonEncodingException;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Support\Str;
 use LogicException;
+use DateTimeInterface;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Support\Carbon;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Database\Eloquent\JsonEncodingException;
 
 trait HasAttributes
 {
@@ -680,7 +680,7 @@ trait HasAttributes
         if ($value === []) {
             return '{}';
         }
-        
+
         return json_encode($value);
     }
 

--- a/tests/Database/DatabaseEloquentArrayCastTest.php
+++ b/tests/Database/DatabaseEloquentArrayCastTest.php
@@ -2,27 +2,27 @@
 
 namespace Illuminate\Tests\Database;
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
-use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentArrayCastTest extends TestCase
 {
     public function setUp()
     {
         $db = new DB;
-        
+
         $db->addConnection([
             'driver' => 'sqlite',
             'database' => ':memory:',
         ]);
-        
+
         $db->bootEloquent();
         $db->setAsGlobal();
-        
+
         $this->createSchema();
     }
-    
+
     /**
      * Setup the database schema.
      *
@@ -36,7 +36,7 @@ class DatabaseEloquentArrayCastTest extends TestCase
             $table->timestamps();
         });
     }
-    
+
     /**
      * Tear down the database schema.
      *
@@ -46,7 +46,7 @@ class DatabaseEloquentArrayCastTest extends TestCase
     {
         $this->schema()->drop('json_table');
     }
-    
+
     /**
      * Tests...
      */
@@ -54,16 +54,16 @@ class DatabaseEloquentArrayCastTest extends TestCase
     {
         /** @var TableWithJsonAttribute $model */
         $model = TableWithJsonAttribute::create([
-            'json_attributes' => ['key1'=>'value1',],
+            'json_attributes' => ['key1'=>'value1'],
         ]);
         $this->assertEquals('{"key1":"value1"}', $model->getOriginal('json_attributes'));
-        
+
         $model = TableWithJsonAttribute::create([
             'json_attributes' => [],
         ]);
         $this->assertEquals('{}', $model->getOriginal('json_attributes'));
     }
-    
+
     /**
      * Get a database connection instance.
      *
@@ -73,7 +73,7 @@ class DatabaseEloquentArrayCastTest extends TestCase
     {
         return Eloquent::getConnectionResolver()->connection();
     }
-    
+
     /**
      * Get a schema builder instance.
      *
@@ -94,12 +94,12 @@ class TableWithJsonAttribute extends Eloquent
      * @var string
      */
     protected $table = 'json_table';
-    
+
     /**
      * @var array
      */
     protected $guarded = [];
-    
+
     /**
      * @var array
      */

--- a/tests/Database/DatabaseEloquentArrayCastTest.php
+++ b/tests/Database/DatabaseEloquentArrayCastTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentArrayCastTest extends TestCase
+{
+    public function setUp()
+    {
+        $db = new DB;
+        
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        
+        $db->bootEloquent();
+        $db->setAsGlobal();
+        
+        $this->createSchema();
+    }
+    
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('json_table', function ($table) {
+            $table->increments('id');
+            $table->string('json_attributes');
+            $table->timestamps();
+        });
+    }
+    
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        $this->schema()->drop('json_table');
+    }
+    
+    /**
+     * Tests...
+     */
+    public function testSavingJsonAttributesAsArrayToDatabase()
+    {
+        /** @var TableWithJsonAttribute $model */
+        $model = TableWithJsonAttribute::create([
+            'json_attributes' => ['key1'=>'value1',],
+        ]);
+        $this->assertEquals('{"key1":"value1"}', $model->getOriginal('json_attributes'));
+        
+        $model = TableWithJsonAttribute::create([
+            'json_attributes' => [],
+        ]);
+        $this->assertEquals('{}', $model->getOriginal('json_attributes'));
+    }
+    
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+    
+    /**
+     * Get a schema builder instance.
+     *
+     * @return Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class TableWithJsonAttribute extends Eloquent
+{
+    /**
+     * @var string
+     */
+    protected $table = 'json_table';
+    
+    /**
+     * @var array
+     */
+    protected $guarded = [];
+    
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'json_attributes'=>'array',
+    ];
+}


### PR DESCRIPTION
### PR as a bug reporting.

---------------

When I have the table with json_attribites column, then I should do attribute casting to the array.

But we have the problem with empty array saving to the database. It is saved as a `[]` instead of the `{}`

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
