### PR TITLE
[5.7] Fix muttator is setting a JSON array when the attribute should be casted to object

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -617,7 +617,7 @@ trait HasAttributes
 
         $this->attributes[$key] = $this->asJson($this->getArrayAttributeWithValue(
             $path, $key, $value
-        ));
+        ), $this->hasCast($key) && $this->getCastType($key) === 'object');
 
         return $this;
     }
@@ -658,7 +658,7 @@ trait HasAttributes
      */
     protected function castAttributeAsJson($key, $value)
     {
-        $value = $this->asJson($value);
+        $value = $this->asJson($value, $this->hasCast($key) && $this->getCastType($key) === 'object');
 
         if ($value === false) {
             throw JsonEncodingException::forAttribute(
@@ -673,11 +673,16 @@ trait HasAttributes
      * Encode the given value as JSON.
      *
      * @param  mixed  $value
+     * @param  bool  $asObject
      * @return string
      */
-    protected function asJson($value)
+    protected function asJson($value, $asObject = false)
     {
-        return json_encode($value);
+        if ($asObject && is_array($value) && ! $value) {
+            return '{}';
+        } else {
+            return json_encode($value);
+        }
     }
 
     /**


### PR DESCRIPTION
When an attribute casted as 'object' is set with an empty array, it should be casted to an empty object.

`class Example extends Model
{
protected $casts = [
        'test' => 'object'
    ];
}
`

If we set _test_ attribute as an array, it is not casted as an object, like this:

`$example->test = [];`
`=> App\Models\Example {
     id: 1,
     example: "[]"
   }
`

This attribute should be like this:

`=> App\Models\Example {
     id: 1,
     example: "{}"
   }
`