### PR TITLE
[5.6] Changed PhpDoc in Cookie/Middleware/EncryptCookies:handle

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -52,7 +52,7 @@ class EncryptCookies
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
-     * @return mixed
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function handle($request, Closure $next)
     {


### PR DESCRIPTION
Changed return type in PhpDoc `Cookie/Middleware/EncryptCookies:handle` to `\Symfony\Component\HttpFoundation\Response`, since $this->encrypt always return `\Symfony\Component\HttpFoundation\Response`

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
