### PR TITLE
[5.7] Only register devCommands on non production environment

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -170,9 +170,15 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->registerCommands(array_merge(
-            $this->commands, $this->devCommands
-        ));
+        if ($this->app->environment('production')) {
+            $commands = $this->commands;
+        } else {
+            $commands = array_merge(
+                $this->commands, $this->devCommands
+            )
+        }
+
+        $this->registerCommands($commands);
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -175,7 +175,7 @@ class ArtisanServiceProvider extends ServiceProvider
         } else {
             $commands = array_merge(
                 $this->commands, $this->devCommands
-            )
+            );
         }
 
         $this->registerCommands($commands);


### PR DESCRIPTION
To clean up the registered Artisan commands on production, this PR updates the ArtisanServiceProvider to only register `$commands` on the `production` environment, i.e. not `$devCommands`.