### PR TITLE
[5.6] Add Queueable, SerializesModels to all notification events

### DIFF
--- a/src/Illuminate/Notifications/Events/NotificationFailed.php
+++ b/src/Illuminate/Notifications/Events/NotificationFailed.php
@@ -2,8 +2,13 @@
 
 namespace Illuminate\Notifications\Events;
 
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+
 class NotificationFailed
 {
+    use Queueable, SerializesModels;
+
     /**
      * The notifiable entity who received the notification.
      *

--- a/src/Illuminate/Notifications/Events/NotificationSending.php
+++ b/src/Illuminate/Notifications/Events/NotificationSending.php
@@ -2,8 +2,13 @@
 
 namespace Illuminate\Notifications\Events;
 
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+
 class NotificationSending
 {
+    use Queueable, SerializesModels;
+
     /**
      * The notifiable entity who received the notification.
      *

--- a/src/Illuminate/Notifications/Events/NotificationSent.php
+++ b/src/Illuminate/Notifications/Events/NotificationSent.php
@@ -2,8 +2,13 @@
 
 namespace Illuminate\Notifications\Events;
 
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+
 class NotificationSent
 {
+    use Queueable, SerializesModels;
+
     /**
      * The notifiable entity who received the notification.
      *


### PR DESCRIPTION
This PR adds `SerializesModels` (and `Queueable`) to all notification events.

Sometimes the `$notifiable` model in these events have a bunch of extra stuff on it (relationships, etc) added during a flow and all of this data is being unnecessarily added to queued jobs, from the listeners. This can cause issues for queueing systems because the jobs can have huge payloads.

Refs https://github.com/laravel/framework/issues/24350
