### PR TITLE
[5.6] Fix FormRequest class authorization validation priority

### DIFF
--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -16,11 +16,13 @@ trait ValidatesWhenResolvedTrait
     {
         $this->prepareForValidation();
 
-        $instance = $this->getValidatorInstance();
-
         if (! $this->passesAuthorization()) {
             $this->failedAuthorization();
-        } elseif (! $instance->passes()) {
+        }
+
+        $instance = $this->getValidatorInstance();
+
+        if (! $instance->passes()) {
             $this->failedValidation($instance);
         }
     }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -176,11 +176,6 @@ class FoundationTestFormRequestStub extends FormRequest
 
 class FoundationTestFormRequestForbiddenStub extends FormRequest
 {
-    public function rules()
-    {
-        return ['name' => 'required'];
-    }
-
     public function authorize()
     {
         return false;


### PR DESCRIPTION
This pull request fixes an issue where the validation rules were being triggered **before** the **_authorization_**, which was leading to issues on some tests i have, where i was not passing some values (on purpose), and the rules were relying on them, however, for that particular test case, i was testing the authorization **only** and not determining if the provided data was valid. 

So now the validation rules only gets triggered if the `authorize()` passes, which seems the proper way.

> **Note:** I couldn't figure out a good way to add a unit test, but removing the `rules` from the stub class was failing prior to this change and now passes. If anyone has an idea to have a way to test it, let me know and i update the pull request.

Thanks!