### PR TITLE
Artisan route list extends

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -161,9 +161,11 @@ class RouteListCommand extends Command
      */
     protected function filterRoute(array $route)
     {
-        if (($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
-             $this->option('path') && ! Str::contains($route['uri'], $this->option('path')) ||
-             $this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) {
+        if ($this->option('filter') && ! Str::contains(implode(' ', $route), $this->option('filter')) ||
+            $this->option('name') && ! Str::contains($route['name'], $this->option('name')) ||
+            $this->option('action') && ! Str::contains($route['action'], $this->option('action')) ||
+            $this->option('path') && ! Str::contains($route['uri'], $this->option('path')) ||
+            $this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) {
             return;
         }
 
@@ -178,11 +180,15 @@ class RouteListCommand extends Command
     protected function getOptions()
     {
         return [
+            ['filter', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by word in any column.'],
+
             ['method', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by method.'],
+
+            ['path', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by path.'],
 
             ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name.'],
 
-            ['path', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by path.'],
+
 
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes.'],
 


### PR DESCRIPTION
This pull request extends artisan route:list with two options:
--filter[=FILTER] Filter the routes by word in any column.
--action[=ACTION] Filter the routes by action.