### PR TITLE
[5.6] Move ramsey/uuid dependency to illuminate/support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "nesbot/carbon": "1.25.*",
         "psr/container": "~1.0",
         "psr/simple-cache": "^1.0",
-        "ramsey/uuid": "^3.7",
         "swiftmailer/swiftmailer": "~6.0",
         "symfony/console": "~4.0",
         "symfony/debug": "~4.0",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -18,7 +18,8 @@
         "ext-mbstring": "*",
         "doctrine/inflector": "~1.1",
         "illuminate/contracts": "5.6.*",
-        "nesbot/carbon": "^1.24.1"
+        "nesbot/carbon": "^1.24.1",
+        "ramsey/uuid": "^3.7"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"


### PR DESCRIPTION
If you only install `illuminate/support`, `Str::uuid()` doesn't work because the `ramsey/uuid` package is required by `laravel/framework/composer.json`.

This PR moves the dependency to `illuminate/support/composer.json`.

Fixes #24380.