### PR TITLE
[5.6] Add ramsey/uuid dependency to illuminate/support

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -18,7 +18,8 @@
         "ext-mbstring": "*",
         "doctrine/inflector": "~1.1",
         "illuminate/contracts": "5.6.*",
-        "nesbot/carbon": "^1.24.1"
+        "nesbot/carbon": "^1.24.1",
+        "ramsey/uuid": "^3.7"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"


### PR DESCRIPTION
If you install `illuminate/support` separately, `Str::uuid()` doesn't work because the `ramsey/uuid` package is only required by `laravel/framework/composer.json`.

Fixes #24380.
