### PR TITLE
[5.6] Allow callable array syntax in route definition

### DIFF
--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -32,7 +32,7 @@ class RouteAction
 
             if (\is_array($action)) {
                 [$class, $method] = $action;
-                $action = $class . '@' . $method;
+                $action = $class.'@'.$method;
             }
 
             return ['uses' => $action];

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -29,7 +29,6 @@ class RouteAction
         // as the "uses" property, because there is nothing else we need to do when
         // it is available. Otherwise we will need to find it in the action list.
         if (is_callable($action)) {
-
             if (\is_array($action)) {
                 [$class, $method] = $action;
                 $action = $class.'@'.$method;

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -29,6 +29,12 @@ class RouteAction
         // as the "uses" property, because there is nothing else we need to do when
         // it is available. Otherwise we will need to find it in the action list.
         if (is_callable($action)) {
+
+            if (\is_array($action)) {
+                [$class, $method] = $action;
+                $action = $class . '@' . $method;
+            }
+
             return ['uses' => $action];
         }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1289,6 +1289,26 @@ class RoutingRouteTest extends TestCase
         $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
     }
 
+    public function testControllerRoutingArrayCallable()
+    {
+        unset(
+            $_SERVER['route.test.controller.middleware'], $_SERVER['route.test.controller.except.middleware'],
+            $_SERVER['route.test.controller.middleware.class'],
+            $_SERVER['route.test.controller.middleware.parameters.one'], $_SERVER['route.test.controller.middleware.parameters.two']
+        );
+
+        $router = $this->getRouter();
+
+        $router->get('foo/bar', [RouteTestControllerStub::class, 'index']);
+
+        $this->assertEquals('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertTrue($_SERVER['route.test.controller.middleware']);
+        $this->assertEquals(\Illuminate\Http\Response::class, $_SERVER['route.test.controller.middleware.class']);
+        $this->assertEquals(0, $_SERVER['route.test.controller.middleware.parameters.one']);
+        $this->assertEquals(['foo', 'bar'], $_SERVER['route.test.controller.middleware.parameters.two']);
+        $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
+    }
+
     public function testCallableControllerRouting()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
This PR will allow defining route actions as arrays

`Route::get('smth', [SomeController::class, 'methodName']);`

This has no direct benefit code-wise, but enables better navigation in IDE-s.

`is_callable` validates that specified class and method exist and only `is_array` check is needed.