### PR TITLE
[5.6] Add ramsey/uuid suggestion to illuminate/support

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -38,6 +38,7 @@
     },
     "suggest": {
         "illuminate/filesystem": "Required to use the composer class (5.6.*).",
+        "ramsey/uuid": "Required to use Str::uuid() (^3.7).",
         "symfony/process": "Required to use the composer class (~4.0).",
         "symfony/var-dumper": "Required to use the dd function (~4.0)."
     },


### PR DESCRIPTION
If you install `illuminate/support` separately, `Str::uuid()` doesn't work because the `ramsey/uuid` package is only required by `laravel/framework/composer.json`.

Fixes #24380.