### PR TITLE
[5.6] fix custom blade conditional ignoring 0 as argument

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -396,13 +396,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
         $this->conditions[$name] = $callback;
 
         $this->directive($name, function ($expression) use ($name) {
-            return $expression
+            return $expression !== ''
                     ? "<?php if (\Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"
                     : "<?php if (\Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
         });
 
         $this->directive('else'.$name, function ($expression) use ($name) {
-            return $expression
+            return $expression !== ''
                 ? "<?php elseif (\Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"
                 : "<?php elseif (\Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
         });

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -93,13 +93,15 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testCustomConditionsAccepts0AsArgument()
     {
-        $this->compiler->if('custom', function ($user) {
+        $this->compiler->if('custom', function ($number) {
             return true;
         });
 
         $string = '@custom(0)
+@elsecustom(0)
 @endcustom';
         $expected = '<?php if (\Illuminate\Support\Facades\Blade::check(\'custom\', 0)): ?>
+<?php elseif (\Illuminate\Support\Facades\Blade::check(\'custom\', 0)): ?>
 <?php endif; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -91,6 +91,19 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testCustomConditionsAccepts0AsArgument()
+    {
+        $this->compiler->if('custom', function ($user) {
+            return true;
+        });
+
+        $string = '@custom(0)
+@endcustom';
+        $expected = '<?php if (\Illuminate\Support\Facades\Blade::check(\'custom\', 0)): ?>
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testCustomComponents()
     {
         $this->compiler->component('app.components.alert', 'alert');


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Fixes https://github.com/laravel/framework/issues/24390

Improved the ternary condition so that it will also print `0` as an argument to the check method instead of pretending there were no arguments passed to the conditional. 
This happens because apparently `"0" == false`
Added tests that compiles a custom conditional with `0` as an argument.