### PR TITLE
[5.6] Skip null/empty values in SeeInOrder

### DIFF
--- a/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php
@@ -43,6 +43,10 @@ class SeeInOrder extends Constraint
         $position = 0;
 
         foreach ($values as $value) {
+            if ($value === null || mb_strlen($value) === 0) {
+                continue;
+            }
+
             $valuePosition = mb_strpos($this->content, $value, $position);
 
             if ($valuePosition === false || $valuePosition < $position) {

--- a/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php
@@ -43,7 +43,7 @@ class SeeInOrder extends Constraint
         $position = 0;
 
         foreach ($values as $value) {
-            if ($value === null || mb_strlen($value) === 0) {
+            if (empty($value)) {
                 continue;
             }
 


### PR DESCRIPTION
Currently passing empty strings to SeeInOrder emits a warning from `mb_strpos()`:

```
PHP Warning:  mb_strpos(): Empty delimiter in vendor/laravel/framework/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php on line 46
```

As demonstrated in `php artisan tinker`:

```php
Psy Shell v0.9.4 (PHP 7.2.6 — cli) by Justin Hileman
>>> use Illuminate\Foundation\Testing\Constraints\SeeInOrder;
>>> $const = new SeeInOrder('test');
=> Illuminate\Foundation\Testing\Constraints\SeeInOrder {#2448}
>>> $const->matches(['']);
PHP Warning:  mb_strpos(): Empty delimiter in vendor/laravel/framework/src/Illuminate/Foundation/Testing/Constraints/SeeInOrder.php on line 46
```

We're currently using `assertSeeInOrder` to verify pages show model values in a form, but it currently fails on null/empty properties as mentioned above.