### PR TITLE
Fix relationship management in BelongsToMany.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -195,7 +195,7 @@ class BelongsToMany extends Relation
     protected function addWhereConstraints()
     {
         $this->query->where(
-            $this->getQualifiedForeignPivotKeyName(), '=', $this->parent->{$this->parentKey}
+            $this->getQualifiedForeignPivotKeyName(), '=', $this->parent->attributes[$this->parentKey]
         );
 
         return $this;


### PR DESCRIPTION
I have recently found this issue => the BelongsToMany class directly interferes with the Model-Level of the application.

The problem is, that eloquent is calling the parentKey implicitly and thus forcing the call of getters defined on the model-level.
Example:
- I create a Model, which is bound via belongsToMany to another model (through a pivot table)
- The model has a getter defined for the primary key, which is manipulating the read-value of the primary key (example: the ID is being padded with str_pad)
- The BelongsToMany class is trying to match the padded ID with the non-padded ID which is written to the database
- The BelongsToMany is not retrieving any data because there is no match found for the padded ID's

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
