### PR TITLE
[5.6] Add JSON SELECT queries to SQL Server

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Database\Query\Builder;
 
 class SqlServerGrammar extends Grammar
@@ -411,7 +412,35 @@ class SqlServerGrammar extends Grammar
      */
     protected function wrapValue($value)
     {
-        return $value === '*' ? $value : '['.str_replace(']', ']]', $value).']';
+        if ($value === '*') {
+            return $value;
+        }
+
+        // If the given value is a JSON selector we will wrap it differently than a
+        // traditional value. We will need to split this path and wrap each part
+        // wrapped, etc. Otherwise, we will simply wrap the value as a string.
+        if (Str::contains($value, '->')) {
+            return $this->wrapJsonSelector($value);
+        }
+
+        return '['.str_replace(']', ']]', $value).']';
+    }
+
+    /**
+     * Wrap the given JSON selector.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function wrapJsonSelector($value)
+    {
+        $path = explode('->', $value);
+
+        $field = $this->wrapValue(array_shift($path));
+
+        return sprintf('json_value(%s, \'$.%s\')', $field, collect($path)->map(function ($part) {
+            return '"'.$part.'"';
+        })->implode('.'));
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2046,6 +2046,21 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" where "items"->\'price\'->>\'in_usd\' = ? and "items"->>\'age\' = ?', $builder->toSql());
     }
 
+    public function testSqlServerWrappingJson()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('items->price')->from('users')->where('items->price', '=', 1)->orderBy('items->price');
+        $this->assertEquals('select json_value([items], \'$."price"\') from [users] where json_value([items], \'$."price"\') = ? order by json_value([items], \'$."price"\') asc', $builder->toSql());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
+        $this->assertEquals('select * from [users] where json_value([items], \'$."price"."in_usd"\') = ?', $builder->toSql());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1)->where('items->age', '=', 2);
+        $this->assertEquals('select * from [users] where json_value([items], \'$."price"."in_usd"\') = ? and json_value([items], \'$."age"\') = ?', $builder->toSql());
+    }
+
     public function testSQLiteOrderBy()
     {
         $builder = $this->getSQLiteBuilder();


### PR DESCRIPTION
Adds JSON `SELECT` queries to SQL Server 2016+:

    DB::table('users')->select('items->price')->where('items->price', 1)->orderBy('items->price');

I found two limitations:

- In comparisons, Boolean values only work as strings: `where('foo->bool', 'true')`
The downside is that this also selects `"true"` strings (PostgreSQL has the same problem).
- Extracting arrays and objects doesn't work: `select('foo->array') // returns null`
The reason is that SQL Server uses different functions for scalar values (`JSON_VALUE()`) and arrays/objects (`JSON_QUERY()`).
MySQL and PostgreSQL return arrays and objects as JSON strings.