### PR TITLE
Fix soft-delete does not sync original.

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -77,6 +77,8 @@ trait SoftDeletes
         }
 
         $query->update($columns);
+
+        $this->syncOriginal();
     }
 
     /**


### PR DESCRIPTION
Currently when we are soft-deleting model original is not synced. This causes an issue when model is deleted and restored without getting fresh data from database it actually stays deleted.

Here is an example of this happening in artisan:
```php
>>> $model = App\Models\MyModel::find("HAKXFY")
=> App\Models\MyModel {#684
     id: "HAKXFY",
     created_at: "2018-05-31 15:56:13",
     updated_at: "2018-05-31 15:56:13",
     deleted_at: null,
   }
>>> $model->delete()
=> true
>>> App\Models\MyModel::find("HAKXFY")
=> null
//model is still dirty
>>> $model->getDirty();
=> [
     "updated_at" => "2018-05-31 15:58:12",
     "deleted_at" => "2018-05-31 15:58:12",
   ]
>>> $model->restore();
=> true
//Model is clean now
>>> $model->getDirty();
=> []
//While model instance thinks he's restored
>>> $model
=> App\Models\MyModel {#684
     id: "HAKXFY",
     created_at: "2018-05-31 15:56:13",
     updated_at: "2018-05-31 15:58:12",
     deleted_at: null,
   }
// Actual results from DB are different
>>> App\Models\MyModel::find("HAKXFY")
=> null
>>> App\Models\MyModel::withTrashed()->find("HAKXFY")
=> App\Models\MyModel {#689
     id: "HAKXFY",
     created_at: "2018-05-31 15:56:13",
     updated_at: "2018-05-31 15:58:12",
     deleted_at: "2018-05-31 15:58:12",
   }
```

