### PR TITLE
[5.6] LogManager: support configuring a Formatter in the monolog factory

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -336,11 +336,15 @@ class LogManager implements LoggerInterface
             );
         }
 
-        $handlers = [$this->prepareHandler(
-            $this->app->make($config['handler'], $config['with'] ?? [])
-        )];
+        $handler = $this->app->make($config['handler'], $config['with'] ?? []);
 
-        return new Monolog($this->parseChannel($config), $handlers);
+        if (!isset($config['formatter'])) {
+            $this->prepareHandler($handler);
+        } elseif ($config['formatter'] !== 'default') {
+            $handler->setFormatter($this->app->make($config['formatter'], $config['formatter_with'] ?? []));
+        }
+
+        return new Monolog($this->parseChannel($config), [$handler]);
     }
 
     /**

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -338,7 +338,7 @@ class LogManager implements LoggerInterface
 
         $handler = $this->app->make($config['handler'], $config['with'] ?? []);
 
-        if (!isset($config['formatter'])) {
+        if (! isset($config['formatter'])) {
             $this->prepareHandler($handler);
         } elseif ($config['formatter'] !== 'default') {
             $handler->setFormatter($this->app->make($config['formatter'], $config['formatter_with'] ?? []));

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -13,7 +13,6 @@ use Monolog\Handler\NewRelicHandler;
 use Monolog\Handler\LogEntriesHandler;
 use Monolog\Formatter\NormalizerFormatter;
 
-
 class LogManagerTest extends TestCase
 {
     public function testLogManagerCachesLoggerInstances()
@@ -69,7 +68,7 @@ class LogManagerTest extends TestCase
         $logger = $manager->channel('logentries');
         $handlers = $logger->getLogger()->getHandlers();
 
-        $logToken = new \ReflectionProperty(get_class($handlers[0]), 'logToken');
+        $logToken = new ReflectionProperty(get_class($handlers[0]), 'logToken');
         $logToken->setAccessible(true);
 
         $this->assertInstanceOf(LogEntriesHandler::class, $handlers[0]);
@@ -83,7 +82,7 @@ class LogManagerTest extends TestCase
             'driver' => 'monolog',
             'name' => 'nr',
             'handler' => NewRelicHandler::class,
-            'formatter' => 'default'
+            'formatter' => 'default',
         ]);
 
         $manager = new LogManager($this->app);
@@ -101,8 +100,8 @@ class LogManagerTest extends TestCase
             'handler' => NewRelicHandler::class,
             'formatter' => HtmlFormatter::class,
             'formatter_with' => [
-                'dateFormat' => 'Y/m/d--test'
-            ]
+                'dateFormat' => 'Y/m/d--test',
+            ],
         ]);
 
         $logger = $manager->channel('newrelic2');


### PR DESCRIPTION
Fully backwards compatible. This adds the configuration option `formatter` to the log channel configuration. In the majority of use cases, using the normal laravel `LineFormatter` is fine. In a smaller percentage of situations, it is best to default to the Handlers "default formatter". For example, NewRelic prefers the `NormalizeFormatter` (incidentally, `LineFormatter` is giving us problems with the NewRelic handler b/c it does not handle array's well):

https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/NewRelicHandler.php#L199-L202

This PR adds `formatter` support.  If left off, the normal `LineFormatter` provided by laravel is injected. If set to the string `default`, the Handler specific formatter will be used (via the handlers `getDefaultFormatter()` method.  If set to a class name, it will `app->make()` a new Formatter.  Additionally, if there are constructor parameters, they can be configured via `formatter_with` config option (this is honestly a very rare use case).

Example of default:

```php
    'newrelic' => [
        'driver' => 'monolog',
        'handler' => NewRelicHandler::class,
        'formatter' => 'default'
    ]
```

Example with ctor options:

```php
    'newrelic' => [
        'driver' => 'monolog',
        'handler' => NewRelicHandler::class,
        'formatter' => HtmlFormatter::class,
        'formatter_with' => [
            'dateFormat' => 'Y/m/d'
        ]
    ]
```

I will fully document in the manual.