### PR TITLE
[5.6] Add refreshUser method to Auth so that user can be reloaded explicitly

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -153,6 +153,16 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
+     * Reload the authenticated user.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function refreshUser()
+    {
+        return $this->user = $this->provider->retrieveById($this->id());
+    }
+
+    /**
      * Pull a user from the repository by its "remember me" cookie token.
      *
      * @param  \Illuminate\Auth\Recaller  $recaller

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -204,6 +204,19 @@ class AuthGuardTest extends TestCase
         $this->assertSame($user, $mock->user());
     }
 
+    public function testRefreshUserMethodReloadsUser()
+    {
+        $mock = $this->getGuard();
+        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $updatedUser = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+
+        $mock->setUser($user);
+        $user->shouldReceive('getAuthIdentifier')->once();
+        $mock->getProvider()->shouldReceive('retrieveById')->once()->andReturn($updatedUser);
+
+        $this->assertSame($updatedUser, $mock->refreshUser());
+    }
+
     public function testNullIsReturnedForUserIfNoUserFound()
     {
         $mock = $this->getGuard();


### PR DESCRIPTION
The `user()` method in `SessionGuard` caches the user to avoid fetching data for each call, however, if the authenticated user has been updated indirectly (not through the auth user reference), the `Auth()->user()` won't get the updated user info. 

Adding `refreshUser()` method allow reloading the authenticated user explicitly, thus the subsequent calls of `Auth()->user()` can get the latest user info. 

Not like `setUser()`, `refreshUser()` won't fire authenticated event.


