### PR TITLE
FIXED PHP version requirement conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-openssl": "*",
         "classpreloader/classpreloader": "~2.0|~3.0",
         "danielstjules/stringy": "~1.8",
-        "doctrine/inflector": "~1.0",
+        "doctrine/inflector": "1.1.*",
         "jeremeamia/superclosure": "~2.0",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",


### PR DESCRIPTION
FIXED PHP version requirement conflict
laravel/framework 5.1 branch requires php 5.5 while doctrine/inflector branch 1.2 requires php 7
