### PR TITLE
[5.6] Changed PhpDoc for $app in `QueueManager`

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -15,7 +15,7 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * The application instance.
      *
-     * @var \Illuminate\Foundation\Application
+     * @var \Illuminate\Contracts\Foundation\Application
      */
     protected $app;
 
@@ -36,7 +36,7 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Create a new queue manager instance.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
     public function __construct($app)


### PR DESCRIPTION
Changed PhpDoc for $app in `QueueManager` \Illuminate\Foundation\Application` to `\Illuminate\Contracts\Foundation\Application`, since we should depend on the interfaces not on the realization.

 - We actually have a problem in `Support/Facades/Queue.php` class `fake` method
  ```PHP
      /**
       * Replace the bound instance with a fake.
       *
       * @return void
       */
      public static function fake()
      {
          static::swap(new QueueFake(static::getFacadeApplication()));
      }
  ```
  Since QueueFake expected a `\Illuminate\Foundation\Application`,
  but `static::getFacadeApplication()` returned a `\Illuminate\Contracts\Foundation\Application`

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
