### PR TITLE
[5.6] Add methods in docblock to URL Facade

### DIFF
--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -12,6 +12,8 @@ namespace Illuminate\Support\Facades;
  * @method static string route(string $name, $parameters = [], bool $absolute = true)
  * @method static string action(string $action, $parameters = [], bool $absolute = true)
  * @method static \Illuminate\Contracts\Routing\UrlGenerator setRootControllerNamespace(string $rootNamespace)
+ * @method static string signedRoute(string $name, array $parameters = [], \DateTimeInterface|int $expiration = null)
+ * @method static string temporarySignedRoute(string $name, \DateTimeInterface|int $expiration, array $parameters = [])
  *
  * @see \Illuminate\Routing\UrlGenerator
  */

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -4,6 +4,8 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static string current()
+ * @method static string full()
+ * @method static string previous($fallback = false)
  * @method static string to(string $path, $extra = [], bool $secure = null)
  * @method static string secure(string $path, array $parameters = [])
  * @method static string asset(string $path, bool $secure = null)

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -14,6 +14,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Contracts\Routing\UrlGenerator setRootControllerNamespace(string $rootNamespace)
  * @method static string signedRoute(string $name, array $parameters = [], \DateTimeInterface|int $expiration = null)
  * @method static string temporarySignedRoute(string $name, \DateTimeInterface|int $expiration, array $parameters = [])
+ * @method static string hasValidSignature(\Illuminate\Http\Request $request)
  *
  * @see \Illuminate\Routing\UrlGenerator
  */

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -15,6 +15,7 @@ namespace Illuminate\Support\Facades;
  * @method static string signedRoute(string $name, array $parameters = [], \DateTimeInterface|int $expiration = null)
  * @method static string temporarySignedRoute(string $name, \DateTimeInterface|int $expiration, array $parameters = [])
  * @method static string hasValidSignature(\Illuminate\Http\Request $request)
+ * @method static void defaults(array $defaults)
  *
  * @see \Illuminate\Routing\UrlGenerator
  */


### PR DESCRIPTION
 - https://laravel.com/docs/5.6/urls in the documentation we have sentence `Each of these methods may also be accessed via the URL facade:

It is about 
```PHP
// Get the current URL without the query string...
echo url()->current();

// Get the current URL including the query string...
echo url()->full();

// Get the full URL for the previous request...
echo url()->previous();
```
`

----

Methods `temporarySignedRoute` and `signedRoute`  and `hasValidSignature` / `defaults` also used in documentation with URL Facade.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
