### PR TITLE
[5.6] Changed incorrect PhpDoc in `\Illuminate\Mail\Mailer::sendSwiftMessage`

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -456,7 +456,7 @@ class Mailer implements MailerContract, MailQueueContract
      * Send a Swift Message instance.
      *
      * @param  \Swift_Message  $message
-     * @return void
+     * @return int
      */
     protected function sendSwiftMessage($message)
     {


### PR DESCRIPTION
….

 - ```PHP
        /**
         * Send a Swift Message instance.
         *
         * @param  \Swift_Message  $message
         * @return int
         */
        protected function sendSwiftMessage($message)
        {
            try {
                return $this->swift->send($message, $this->failedRecipients);
            } finally {
                $this->forceReconnection();
            }
        }
   ```
   It returned the int.

--------------

71949085771880ef76dfc10e43a9551efebedec9
It is a hash of commit, where return was added to the method, but PhpDoc was not changed


<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
