### PR TITLE
[5.6] Make sure to return model after setting mutator value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -585,11 +585,13 @@ trait HasAttributes
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return mixed
+     * @return $this
      */
     protected function setMutatedAttributeValue($key, $value)
     {
-        return $this->{'set'.Str::studly($key).'Attribute'}($value);
+        $this->{'set'.Str::studly($key).'Attribute'}($value);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Using an example from the documentation:

```php
class User extends Model
{
    /**
     * @param  string  $value
     * @return void
     */
    public function setFirstNameAttribute($value)
    {
        $this->attributes['first_name'] = strtolower($value);
    }
}
```

When running the following code

```php
$user->setAttribute('first_name', 'Taylor')->save();
```

We get a PHP Error

```sh
PHP Error: Call to a member function save() on null
```

The documentation suggests that mutator methods should return `void`. 
This PR makes sure that we can chain model methods like `save`, `toArray`, etc. After a call to `setAttribute`.

