### PR TITLE
[5.6] Support tags and utf-8 string in console alerts

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -507,7 +507,7 @@ class Command extends SymfonyCommand
      */
     public function alert($string)
     {
-        $length = Str::length(strip_tags($string) + 12);
+        $length = Str::length(strip_tags($string)) + 12;
 
         $this->comment(str_repeat('*', $length));
         $this->comment('*     '.$string.'     *');

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
 use Symfony\Component\Console\Helper\Table;
@@ -506,9 +507,11 @@ class Command extends SymfonyCommand
      */
     public function alert($string)
     {
-        $this->comment(str_repeat('*', strlen($string) + 12));
+        $cleanString = strip_tags($string);
+
+        $this->comment(str_repeat('*', Str::length($cleanString) + 12));
         $this->comment('*     '.$string.'     *');
-        $this->comment(str_repeat('*', strlen($string) + 12));
+        $this->comment(str_repeat('*', Str::length($cleanString) + 12));
 
         $this->output->newLine();
     }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -509,9 +509,9 @@ class Command extends SymfonyCommand
     {
         $length = Str::length(strip_tags($string) + 12);
 
-        $this->comment(str_repeat('*', $length);
+        $this->comment(str_repeat('*', $length));
         $this->comment('*     '.$string.'     *');
-        $this->comment(str_repeat('*', $length);
+        $this->comment(str_repeat('*', $length));
 
         $this->output->newLine();
     }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -507,11 +507,11 @@ class Command extends SymfonyCommand
      */
     public function alert($string)
     {
-        $cleanString = strip_tags($string);
+        $length = Str::length(strip_tags($string)) + 12);
 
-        $this->comment(str_repeat('*', Str::length($cleanString) + 12));
+        $this->comment(str_repeat('*', $length);
         $this->comment('*     '.$string.'     *');
-        $this->comment(str_repeat('*', Str::length($cleanString) + 12));
+        $this->comment(str_repeat('*', $length);
 
         $this->output->newLine();
     }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -507,7 +507,7 @@ class Command extends SymfonyCommand
      */
     public function alert($string)
     {
-        $length = Str::length(strip_tags($string)) + 12);
+        $length = Str::length(strip_tags($string) + 12);
 
         $this->comment(str_repeat('*', $length);
         $this->comment('*     '.$string.'     *');


### PR DESCRIPTION
Currently `$this->alert(...)` doesn't support utf-8 because `strlen` used inside.

Before
![before](https://user-images.githubusercontent.com/2151259/40888235-390ea5ca-677e-11e8-8ca5-8f01870cba39.png)

and after
![after](https://user-images.githubusercontent.com/2151259/40888237-3e25089c-677e-11e8-97e0-37cc18aa2326.png)


