### PR TITLE
[5.6] Add assertTimesSent method to NotificationFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -98,9 +98,8 @@ class NotificationFake implements NotificationFactory, NotificationDispatcher
     /**
      * Assert the total amount of times a notification was sent.
      *
-     * @param int $expectedCount
-     * @param string $notification
-     *
+     * @param int  $expectedCount
+     * @param string  $notification
      * @return void
      */
     public function assertTimesSent(int $expectedCount, string $notification)

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -96,6 +96,29 @@ class NotificationFake implements NotificationFactory, NotificationDispatcher
     }
 
     /**
+     * Assert the total amount of times a notification was sent.
+     *
+     * @param int $expectedCount
+     * @param string $notification
+     *
+     * @return void
+     */
+    public function assertTimesSent(int $expectedCount, string $notification)
+    {
+        $actualCount = collect($this->notifications)
+            ->flatten(1)
+            ->reduce(function ($count, $sent) use ($notification) {
+                return $count + count($sent[$notification] ?? []);
+            }, 0);
+
+        PHPUnit::assertSame(
+            $expectedCount,
+            $actualCount,
+            "[{$notification}] was not sent as many times as expected."
+        );
+    }
+
+    /**
      * Get all of the notifications matching a truth-test callback.
      *
      * @param  mixed  $notifiable

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -66,6 +66,19 @@ class SupportTestingNotificationFakeTest extends TestCase
         $this->assertNotNull($notification->id);
         $this->assertNotSame($id, $notification->id);
     }
+
+    public function testAssertTimesSent()
+    {
+        $this->fake->assertTimesSent(0, NotificationStub::class);
+
+        $this->fake->send($this->user, new NotificationStub);
+
+        $this->fake->send($this->user, new NotificationStub);
+
+        $this->fake->send(new UserStub, new NotificationStub);
+
+        $this->fake->assertTimesSent(3, NotificationStub::class);
+    }
 }
 
 class NotificationStub extends Notification


### PR DESCRIPTION
This PR adds an `assertTimesSent` method to the `NotificationFake` class. The method asserts the total amount of times a notification was sent (regardless of who it was sent to).

An example usage is testing an email that should be sent to all users:
```
// ... send emails to all users

Notification::assertTimesSent(User::count(), Notification::class);
```