### PR TITLE
[5.6] Standardize the console commands help output

### DIFF
--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -123,7 +123,7 @@ class ClearCommand extends Command
     protected function getArguments()
     {
         return [
-            ['store', InputArgument::OPTIONAL, 'The name of the store you would like to clear.'],
+            ['store', InputArgument::OPTIONAL, 'The name of the store you would like to clear'],
         ];
     }
 
@@ -135,7 +135,7 @@ class ClearCommand extends Command
     protected function getOptions()
     {
         return [
-            ['tags', null, InputOption::VALUE_OPTIONAL, 'The cache tags you would like to clear.', null],
+            ['tags', null, InputOption::VALUE_OPTIONAL, 'The cache tags you would like to clear', null],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -98,17 +98,17 @@ class FreshCommand extends Command
     protected function getOptions()
     {
         return [
-            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
 
-            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
 
-            ['path', null, InputOption::VALUE_OPTIONAL, 'The path to the migrations files to be executed.'],
+            ['path', null, InputOption::VALUE_OPTIONAL, 'The path to the migrations files to be executed'],
 
-            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths.'],
+            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
 
-            ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
+            ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run'],
 
-            ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder.'],
+            ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/InstallCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/InstallCommand.php
@@ -64,7 +64,7 @@ class InstallCommand extends Command
     protected function getOptions()
     {
         return [
-            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -14,13 +14,13 @@ class MigrateCommand extends BaseCommand
      *
      * @var string
      */
-    protected $signature = 'migrate {--database= : The database connection to use.}
-                {--force : Force the operation to run when in production.}
-                {--path= : The path to the migrations files to be executed.}
-                {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths.}
-                {--pretend : Dump the SQL queries that would be run.}
-                {--seed : Indicates if the seed task should be re-run.}
-                {--step : Force the migrations to be run so they can be rolled back individually.}';
+    protected $signature = 'migrate {--database= : The database connection to use}
+                {--force : Force the operation to run when in production}
+                {--path= : The path to the migrations files to be executed}
+                {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
+                {--pretend : Dump the SQL queries that would be run}
+                {--seed : Indicates if the seed task should be re-run}
+                {--step : Force the migrations to be run so they can be rolled back individually}';
 
     /**
      * The console command description.

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -13,11 +13,11 @@ class MigrateMakeCommand extends BaseCommand
      *
      * @var string
      */
-    protected $signature = 'make:migration {name : The name of the migration.}
-        {--create= : The table to be created.}
-        {--table= : The table to migrate.}
-        {--path= : The location where the migration file should be created.}
-        {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths.}';
+    protected $signature = 'make:migration {name : The name of the migration}
+        {--create= : The table to be created}
+        {--table= : The table to migrate}
+        {--path= : The location where the migration file should be created}
+        {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}';
 
     /**
      * The console command description.

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -138,19 +138,19 @@ class RefreshCommand extends Command
     protected function getOptions()
     {
         return [
-            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
 
-            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
 
-            ['path', null, InputOption::VALUE_OPTIONAL, 'The path to the migrations files to be executed.'],
+            ['path', null, InputOption::VALUE_OPTIONAL, 'The path to the migrations files to be executed'],
 
-            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths.'],
+            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
 
-            ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
+            ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run'],
 
-            ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder.'],
+            ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder'],
 
-            ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted & re-run.'],
+            ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted & re-run'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -84,15 +84,15 @@ class ResetCommand extends BaseCommand
     protected function getOptions()
     {
         return [
-            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
 
-            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
 
-            ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to be executed.'],
+            ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to be executed'],
 
-            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths.'],
+            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
 
-            ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
+            ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -80,17 +80,17 @@ class RollbackCommand extends BaseCommand
     protected function getOptions()
     {
         return [
-            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
 
-            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
 
-            ['path', null, InputOption::VALUE_OPTIONAL, 'The path to the migrations files to be executed.'],
+            ['path', null, InputOption::VALUE_OPTIONAL, 'The path to the migrations files to be executed'],
 
-            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths.'],
+            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
 
-            ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
+            ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run'],
 
-            ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted.'],
+            ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -103,11 +103,11 @@ class StatusCommand extends BaseCommand
     protected function getOptions()
     {
         return [
-            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
 
-            ['path', null, InputOption::VALUE_OPTIONAL, 'The path to the migrations files to use.'],
+            ['path', null, InputOption::VALUE_OPTIONAL, 'The path to the migrations files to use'],
 
-            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths.'],
+            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -100,7 +100,7 @@ class SeedCommand extends Command
 
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed'],
 
-            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -290,7 +290,7 @@ class AppNameCommand extends Command
     protected function getArguments()
     {
         return [
-            ['name', InputArgument::REQUIRED, 'The desired namespace.'],
+            ['name', InputArgument::REQUIRED, 'The desired namespace'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -72,7 +72,7 @@ class ConsoleMakeCommand extends GeneratorCommand
     protected function getArguments()
     {
         return [
-            ['name', InputArgument::REQUIRED, 'The name of the command.'],
+            ['name', InputArgument::REQUIRED, 'The name of the command'],
         ];
     }
 
@@ -84,7 +84,7 @@ class ConsoleMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['command', null, InputOption::VALUE_OPTIONAL, 'The terminal command that should be assigned.', 'command:name'],
+            ['command', null, InputOption::VALUE_OPTIONAL, 'The terminal command that should be assigned', 'command:name'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -14,9 +14,9 @@ class DownCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'down {--message= : The message for the maintenance mode. }
-                                 {--retry= : The number of seconds after which the request may be retried.}
-                                 {--allow=* : IP or networks allowed to access the application while in maintenance mode.}';
+    protected $signature = 'down {--message= : The message for the maintenance mode}
+                                 {--retry= : The number of seconds after which the request may be retried}
+                                 {--allow=* : IP or networks allowed to access the application while in maintenance mode}';
 
     /**
      * The console command description.

--- a/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
@@ -76,9 +76,9 @@ class ExceptionMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['render', null, InputOption::VALUE_NONE, 'Create the exception with an empty render method.'],
+            ['render', null, InputOption::VALUE_NONE, 'Create the exception with an empty render method'],
 
-            ['report', null, InputOption::VALUE_NONE, 'Create the exception with an empty report method.'],
+            ['report', null, InputOption::VALUE_NONE, 'Create the exception with an empty report method'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/JobMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMakeCommand.php
@@ -59,7 +59,7 @@ class JobMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['sync', null, InputOption::VALUE_NONE, 'Indicates that job should be synchronous.'],
+            ['sync', null, InputOption::VALUE_NONE, 'Indicates that job should be synchronous'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -104,9 +104,9 @@ class ListenerMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['event', 'e', InputOption::VALUE_OPTIONAL, 'The event class being listened for.'],
+            ['event', 'e', InputOption::VALUE_OPTIONAL, 'The event class being listened for'],
 
-            ['queued', null, InputOption::VALUE_NONE, 'Indicates the event listener should be queued.'],
+            ['queued', null, InputOption::VALUE_NONE, 'Indicates the event listener should be queued'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -108,9 +108,9 @@ class MailMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the mailable already exists.'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the mailable already exists'],
 
-            ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the mailable.'],
+            ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the mailable'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -146,13 +146,13 @@ class ModelMakeCommand extends GeneratorCommand
 
             ['factory', 'f', InputOption::VALUE_NONE, 'Create a new factory for the model'],
 
-            ['force', null, InputOption::VALUE_NONE, 'Create the class even if the model already exists.'],
+            ['force', null, InputOption::VALUE_NONE, 'Create the class even if the model already exists'],
 
-            ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model.'],
+            ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model'],
 
-            ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model.'],
+            ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
 
-            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller.'],
+            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -108,9 +108,9 @@ class NotificationMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the notification already exists.'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the notification already exists'],
 
-            ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the notification.'],
+            ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the notification'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -136,7 +136,7 @@ class PolicyMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the policy applies to.'],
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the policy applies to'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
@@ -85,7 +85,7 @@ class ResourceMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['collection', 'c', InputOption::VALUE_NONE, 'Create a resource collection.'],
+            ['collection', 'c', InputOption::VALUE_NONE, 'Create a resource collection'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -178,15 +178,15 @@ class RouteListCommand extends Command
     protected function getOptions()
     {
         return [
-            ['method', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by method.'],
+            ['method', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by method'],
 
-            ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name.'],
+            ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name'],
 
-            ['path', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by path.'],
+            ['path', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by path'],
 
-            ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes.'],
+            ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
 
-            ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (host, method, uri, name, action, middleware) to sort by.', 'uri'],
+            ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (host, method, uri, name, action, middleware) to sort by', 'uri'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -84,9 +84,9 @@ class ServeCommand extends Command
     protected function getOptions()
     {
         return [
-            ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', '127.0.0.1'],
+            ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on', '127.0.0.1'],
 
-            ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on.', 8000],
+            ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on', 8000],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -38,10 +38,10 @@ class VendorPublishCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'vendor:publish {--force : Overwrite any existing files.}
-                    {--all : Publish assets for all service providers without prompt.}
-                    {--provider= : The service provider that has assets you want to publish.}
-                    {--tag=* : One or many tags that have assets you want to publish.}';
+    protected $signature = 'vendor:publish {--force : Overwrite any existing files}
+                    {--all : Publish assets for all service providers without prompt}
+                    {--provider= : The service provider that has assets you want to publish}
+                    {--tag=* : One or many tags that have assets you want to publish}';
 
     /**
      * The console command description.

--- a/src/Illuminate/Queue/Console/ForgetFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ForgetFailedCommand.php
@@ -11,7 +11,7 @@ class ForgetFailedCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:forget {id : The ID of the failed job.}';
+    protected $signature = 'queue:forget {id : The ID of the failed job}';
 
     /**
      * The console command description.

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -12,7 +12,7 @@ class RetryCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:retry {id* : The ID of the failed job or "all" to retry all jobs.}';
+    protected $signature = 'queue:retry {id* : The ID of the failed job or "all" to retry all jobs}';
 
     /**
      * The console command description.

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -172,13 +172,13 @@ class ControllerMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model.'],
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model'],
 
-            ['resource', 'r', InputOption::VALUE_NONE, 'Generate a resource controller class.'],
+            ['resource', 'r', InputOption::VALUE_NONE, 'Generate a resource controller class'],
 
-            ['parent', 'p', InputOption::VALUE_OPTIONAL, 'Generate a nested resource controller class.'],
+            ['parent', 'p', InputOption::VALUE_OPTIONAL, 'Generate a nested resource controller class'],
 
-            ['api', null, InputOption::VALUE_NONE, 'Exclude the create and edit methods from the controller.'],
+            ['api', null, InputOption::VALUE_NONE, 'Exclude the create and edit methods from the controller'],
         ];
     }
 }


### PR DESCRIPTION
Remove the period at the end of the options and arguments of console
commands that have it. Now all commands use the same format.
