### PR TITLE
[5.7] Modifies Route::redirect to use 302 as the default status code instead of a 301

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -236,7 +236,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  int  $status
      * @return \Illuminate\Routing\Route
      */
-    public function redirect($uri, $destination, $status = 301)
+    public function redirect($uri, $destination, $status = 302)
     {
         return $this->any($uri, '\Illuminate\Routing\RedirectController')
                 ->defaults('destination', $destination)


### PR DESCRIPTION
A [301 status](https://httpstatuses.com/301) is a permanent redirect from one location to another, these redirects are cached by browsers, which is the expected behaviour:

>  A 301 response is cacheable by default; i.e., unless otherwise indicated by the method definition or explicit cache controls.

Laravel defaults to using a `301` in the `Route::redirect` method. This is unfortunately quite dangerous: if a developer does not know that a `301` is going to be used, and that it is going to be cached with no expiry, their users will be permanently redirected with no way for the developer to undo the redirect.

Laravel does not default to a `301` anywhere else, for example the [`redirect` helper](https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/helpers.php#L680) defaults to a `302`.

I have performed a [search of GitHub for open source Laravel projects using the `Route::redirect` method](https://github.com/search?q=%22Route%3A%3Aredirect%22+extension%3Aphp+path%3Aroutes&type=Code) and found the following:

1. Many developers are explicitly defining their status code as `301`
2. Some developers are using the `redirect` method within conditionals without specifying a `302`

This indicates to me the following things are true:

1. Developers expect that the default is not `301`
2. Developers who wish to use a `301` are explicitly defining it 
3. Developers are shipping applications that will perform in unintended ways because they do not realise that by default all redirects are permanently cached by their user's browsers

Therefore I propose that the default be changed to a safe `302`. Due to the permanent nature of a `301` it should only be used when explicitly defined by a developer. 

Edit to add: this [Super User post](https://superuser.com/questions/304589/how-can-i-make-chrome-stop-caching-redirects) where people discuss accidentally using 301s and trying to deal with the cached result has over 230,000 views, which indicates that there are a lot of developers uninformed about the result of using a 301.

Thanks!