### PR TITLE
[5.6] Add support for raw expressions to whereBetween()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1000,9 +1000,9 @@ class Builder
     {
         $type = 'between';
 
-        $this->wheres[] = compact('column', 'type', 'boolean', 'not');
+        $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');
 
-        $this->addBinding($values, 'where');
+        $this->addBinding($this->cleanBindings($values), 'where');
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -331,7 +331,11 @@ class Grammar extends BaseGrammar
     {
         $between = $where['not'] ? 'not between' : 'between';
 
-        return $this->wrap($where['column']).' '.$between.' ? and ?';
+        $min = $this->parameter(reset($where['values']));
+
+        $max = $this->parameter(end($where['values']));
+
+        return $this->wrap($where['column']).' '.$between.' '.$min.' and '.$max;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -546,6 +546,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereNotBetween('id', [1, 2]);
         $this->assertEquals('select * from "users" where "id" not between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereBetween('id', [new Raw(1), new Raw(2)]);
+        $this->assertEquals('select * from "users" where "id" between 1 and 2', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
     }
 
     public function testBasicOrWheres()


### PR DESCRIPTION
Adds support for raw expressions to `Builder::whereBetween()`:

    DB::table('table')->whereBetween('column', [DB::raw('min_column'), DB::raw('max_column')]);

I chose `reset($values)/end($values)` instead of `$values[0]`/`$values[1]` to handle associative arrays:

    DB::table('table')->whereBetween('column', ['min' => 1, 'max' => 2]);

Fixes #17810.