### PR TITLE
[5.7] Fix add select

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -250,7 +250,7 @@ class Builder
      */
     public function selectRaw($expression, array $bindings = [])
     {
-        $this->addSelect(new Expression($expression));
+        $this->addSelect(new Expression($expression), false);
 
         if ($bindings) {
             $this->addBinding($bindings, 'select');
@@ -332,11 +332,16 @@ class Builder
      * Add a new select column to the query.
      *
      * @param  array|mixed  $column
+     * @param bool $withWildcard
      * @return $this
      */
-    public function addSelect($column)
+    public function addSelect($column, $withWildcard = true)
     {
         $column = is_array($column) ? $column : func_get_args();
+
+        if (is_null($this->columns) && $withWildcard) {
+            $this->columns = array_merge((array) $this->columns, ['*']);
+        }
 
         $this->columns = array_merge((array) $this->columns, $column);
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -250,7 +250,7 @@ class Builder
      */
     public function selectRaw($expression, array $bindings = [])
     {
-        $this->addSelect(new Expression($expression), false);
+        $this->addSelectWithoutWildcard(new Expression($expression));
 
         if ($bindings) {
             $this->addBinding($bindings, 'select');
@@ -329,19 +329,34 @@ class Builder
     }
 
     /**
-     * Add a new select column to the query.
+     * Add a new select column to the query. Includes the
+     * wildcard '*' to select every column by default
      *
      * @param  array|mixed  $column
-     * @param bool $withWildcard
      * @return $this
      */
-    public function addSelect($column, $withWildcard = true)
+    public function addSelect($column)
     {
         $column = is_array($column) ? $column : func_get_args();
 
-        if (is_null($this->columns) && $withWildcard) {
+        if (is_null($this->columns)) {
             $this->columns = array_merge((array) $this->columns, ['*']);
         }
+
+        $this->columns = array_merge((array) $this->columns, $column);
+
+        return $this;
+    }
+
+    /**
+     * Add a new select column to the query.
+     *
+     * @param  array|mixed  $column
+     * @return $this
+     */
+    public function addSelectWithoutWildcard($column)
+    {
+        $column = is_array($column) ? $column : func_get_args();
 
         $this->columns = array_merge((array) $this->columns, $column);
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -330,7 +330,7 @@ class Builder
 
     /**
      * Add a new select column to the query. Includes the
-     * wildcard '*' to select every column by default
+     * wildcard '*' to select every column by default.
      *
      * @param  array|mixed  $column
      * @return $this

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -85,6 +85,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select "foo", "bar", "baz", "boom" from "users"', $builder->toSql());
     }
 
+    public function testAddingSelectsToDefaultQuery()
+    {
+        $builder = $this->getBuilder();
+        $builder->addSelect('bar')->addSelect(['baz', 'boom'])->from('users');
+        $this->assertEquals('select *, "bar", "baz", "boom" from "users"', $builder->toSql());
+    }
+
     public function testBasicSelectWithPrefix()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
I discovered an issue, which is a little weird: The method 'addSelect' of the query builder suspects, that this ADDS another custom column to the ones that are already in the Select query (which is usually '*'). So, when I call the following:

```
Model::addSelect('...')
Model::select('*')->addSelect('...')
```

Those two queries should be the same, shouldn't they? Right now, when I put this in a query scope, I always have to select the '*' first to be sure it's not overwritten - which is odd ;)

There are still some problems with the HasManyThrough relation. Hope you manage to fix this.

Thanks!