### PR TITLE
[5.6] Remove invalid attribute setting

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="true"
 >
     <testsuites>


### PR DESCRIPTION
The attribute `syntaxCheck` has not had an effect in years. It was removed long ago.

By removing this attribute, PHPUnit _stops_ complaining like so:

```
  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 15:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Test results may not be as expected.
```