### PR TITLE
[5.7] Unnecessary to check EventDispatcher on Logger constructor

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -36,10 +36,7 @@ class Logger implements LoggerInterface
     public function __construct(LoggerInterface $logger, Dispatcher $dispatcher = null)
     {
         $this->logger = $logger;
-
-        if (isset($dispatcher)) {
-            $this->dispatcher = $dispatcher;
-        }
+        $this->dispatcher = $dispatcher;
     }
 
     /**


### PR DESCRIPTION
The **$dispatcher** property of Logger will be always null unless the developer sets a **Dispatcher** implementation into the constructor or uses setter, so I think we needn't to check whether the **Dispatcher** is set in Logger constructor.
