### PR TITLE
[5.7] Feature: Add Initialization Events to Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -153,8 +153,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->syncOriginal();
 
         $this->fill($attributes);
-
-        $this->fireModelEvent('initialized', false);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -148,9 +148,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $this->bootIfNotBooted();
 
+        $this->fireModelEvent('initializing', false);
+
         $this->syncOriginal();
 
         $this->fill($attributes);
+
+        $this->fireModelEvent('initialized', false);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -37,7 +37,6 @@ class DatabaseEloquentModelTest extends TestCase
         \Illuminate\Database\Eloquent\Model::unsetEventDispatcher();
         \Illuminate\Support\Carbon::resetToStringFormat();
 
-
         EloquentModelStub::unboot();
     }
 
@@ -479,10 +478,10 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->exists);
 
         $events->shouldReceive('fire')->once()->withArgs(function ($message, $model = null) {
-            return ($message === 'eloquent.initializing: '.get_class($model) && $model instanceof Model);
+            return $message === 'eloquent.initializing: '.get_class($model) && $model instanceof Model;
         });
         $events->shouldReceive('fire')->once()->withArgs(function ($message, $model = null) {
-            return ($message === 'eloquent.initialized: '.get_class($model) && $model instanceof Model);
+            return $message === 'eloquent.initialized: '.get_class($model) && $model instanceof Model;
         });
 
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -480,9 +480,6 @@ class DatabaseEloquentModelTest extends TestCase
         $events->shouldReceive('fire')->once()->withArgs(function ($message, $model = null) {
             return $message === 'eloquent.initializing: '.get_class($model) && $model instanceof Model;
         });
-        $events->shouldReceive('fire')->once()->withArgs(function ($message, $model = null) {
-            return $message === 'eloquent.initialized: '.get_class($model) && $model instanceof Model;
-        });
 
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -1263,7 +1260,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelObserversCanBeAttachedToModels()
     {
         EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $events->shouldReceive('fire')->times(6);
+        $events->shouldReceive('fire')->times(4);
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
         $events->shouldReceive('forget');
@@ -1274,7 +1271,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelObserversCanBeAttachedToModelsWithString()
     {
         EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $events->shouldReceive('fire')->times(6);
+        $events->shouldReceive('fire')->times(4);
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
         $events->shouldReceive('forget');
@@ -1285,7 +1282,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelObserversCanBeAttachedToModelsThroughAnArray()
     {
         EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $events->shouldReceive('fire')->times(6);
+        $events->shouldReceive('fire')->times(4);
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
         $events->shouldReceive('forget');
@@ -1296,7 +1293,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelObserversCanBeAttachedToModelsThroughCallingObserveMethodOnlyOnce()
     {
         EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $events->shouldReceive('fire')->times(6);
+        $events->shouldReceive('fire')->times(4);
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -36,6 +36,9 @@ class DatabaseEloquentModelTest extends TestCase
 
         \Illuminate\Database\Eloquent\Model::unsetEventDispatcher();
         \Illuminate\Support\Carbon::resetToStringFormat();
+
+
+        EloquentModelStub::unboot();
     }
 
     public function testAttributeManipulation()
@@ -474,6 +477,13 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->save());
         $this->assertEquals(1, $model->id);
         $this->assertTrue($model->exists);
+
+        $events->shouldReceive('fire')->once()->withArgs(function ($message, $model = null) {
+            return ($message === 'eloquent.initializing: '.get_class($model) && $model instanceof Model);
+        });
+        $events->shouldReceive('fire')->once()->withArgs(function ($message, $model = null) {
+            return ($message === 'eloquent.initialized: '.get_class($model) && $model instanceof Model);
+        });
 
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -1254,6 +1264,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelObserversCanBeAttachedToModels()
     {
         EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $events->shouldReceive('fire')->times(6);
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
         $events->shouldReceive('forget');
@@ -1264,6 +1275,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelObserversCanBeAttachedToModelsWithString()
     {
         EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $events->shouldReceive('fire')->times(6);
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
         $events->shouldReceive('forget');
@@ -1274,6 +1286,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelObserversCanBeAttachedToModelsThroughAnArray()
     {
         EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $events->shouldReceive('fire')->times(6);
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
         $events->shouldReceive('forget');
@@ -1284,6 +1297,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelObserversCanBeAttachedToModelsThroughCallingObserveMethodOnlyOnce()
     {
         EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $events->shouldReceive('fire')->times(6);
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
 
@@ -1850,6 +1864,11 @@ class EloquentModelStub extends Model
     public function scopeFramework(Builder $builder, $framework, $version)
     {
         $this->scopesCalled['framework'] = [$framework, $version];
+    }
+
+    public static function unboot()
+    {
+        unset(static::$booted[static::class]);
     }
 }
 


### PR DESCRIPTION
There are a couple of areas in eloquent that still make it difficult to write extensions that can handle complex attributes.  (By "complex attributes", I mean non-natively-known attribute types that can be expressed as objects until serialization, like how datetime objects are handled). Take for example there were an attribute of type `Coordinate`, and one wishes to be able to achieve the following workflow:

```php
class Coordinate {} // assume exists as a 3rd party value object
class Place extends Model { uses 3rdParty/HasGeoTrait; ...} // assume this kind of model

$place = Place::find(1234);
$place->coordinate->setLatLong(30.01, -90.10);

// or

$place = new Place;
$place->coordinate->setLatLong(30.01, -90.10);
```

While the former can be setup by a 3rd party trait by hooking into the `retrieved` eloquent event, the latter cannot because there is no event fired early enough to setup an attribute with a value object for the `coordinate`. (To fully understand the example, `saving` would serialize the value object to be put into the database and `saved` would restore the value object to further interaction.)

Thus, I am proposing that the base eloquent model introduce 2 new events that will fire at construction time: `initializing` (pre fill()) and `initialized` (post fill()).

This will give 3rd party traits the opportunity to do some initialization on eloquent models whether they were retrieved or newly instantiated (thus they will not have to instruct consumers to override the constructor.)

(Separately, could this be a 5.6 feature? If so I can rebase against that branch.)