### PR TITLE
[5.6] Add `getDoctrineDriver` method to `\Illuminate\Database\Connection`

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -221,6 +221,16 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Get the doctrine driver.
+     *
+     * @return \Doctrine\DBAL\Driver
+     */
+    protected function getDoctrineDriver()
+    {
+        //
+    }
+
+    /**
      * Set the query post processor to the default implementation.
      *
      * @return void


### PR DESCRIPTION
Add `getDoctrineDriver` method to `\Illuminate\Database\Connection`

----------------

 - since in
 ```PHP
     /**
      * Get the Doctrine DBAL schema manager for the connection.
      *
      * @return \Doctrine\DBAL\Schema\AbstractSchemaManager
      */
     public function getDoctrineSchemaManager()
     {
         return $this->getDoctrineDriver()->getSchemaManager($this->getDoctrineConnection());
     }
 ```
 
 Method `getDefaultSchemaGrammar` has the same realization now in Connection.
 
 ```PHP
     /**
      * Get the default schema grammar instance.
      *
      * @return \Illuminate\Database\Schema\Grammars\Grammar
      */
     protected function getDefaultSchemaGrammar()
     {
         //
     }
 ```
 in `\Illuminate\Database\Connection` used a `getDoctrineDriver` method.
 Also... Could we add `abstract` to `Connection` class for 5.7?