### PR TITLE
[5.6] Add whereJsonContains() to SQL Server

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1449,7 +1449,7 @@ class Builder
         $this->wheres[] = compact('type', 'column', 'value', 'boolean', 'not');
 
         if (! $value instanceof Expression) {
-            $this->addBinding(json_encode($value));
+            $this->addBinding($this->grammar->prepareBindingForJsonContains($value));
         }
 
         return $this;

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -524,6 +524,17 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Prepare the binding for a "JSON contains" statement.
+     *
+     * @param  mixed  $binding
+     * @return string
+     */
+    public function prepareBindingForJsonContains($binding)
+    {
+        return json_encode($binding);
+    }
+
+    /**
      * Compile the "group by" portions of the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -105,6 +105,33 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile a "JSON contains" statement into SQL.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileJsonContains($column, $value)
+    {
+        $from = $column[0] == '[' ?
+            'openjson('.$column.')' :
+            substr_replace($column, 'openjson', 0, strlen('json_value'));
+
+        return $value.' in (select [value] from '.$from.')';
+    }
+
+    /**
+     * Prepare the binding for a "JSON contains" statement.
+     *
+     * @param  mixed  $binding
+     * @return string
+     */
+    public function prepareBindingForJsonContains($binding)
+    {
+        return is_bool($binding) ? json_encode($binding) : $binding;
+    }
+
+    /**
      * Create a full ANSI offset clause for the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query


### PR DESCRIPTION
Adds `Builder::whereJsonContains()` (#24330) to SQL Server 2016+ using [`OPENJSON()`](https://docs.microsoft.com/en-us/sql/t-sql/functions/openjson-transact-sql?view=sql-server-2017).

While MySQL and PostgreSQL expect the binding as a JSON string, SQL Server requires the raw value.
This is why we need a separate `prepareBindingForJsonContains()` method.

`compileJsonContains()` has to differentiate between columns without and with a path (`column->path`).
In the first case, we have to wrap the column in `OPENJSON()`. In the second case, we have to replace `JSON_VALUE()` (coming from `wrapJsonSelector()`) with `OPENJSON()`. I also added tests for path-less columns to MySQL and Postgres.

There are three limitations:
- `NULL` values don't work.
- Boolean values only work as strings. The downside is that this also finds `"true"`/`"false"` strings.
- Arrays don't work: `->whereJsonContains('options->languages', ['de', 'en'])`
In MySQL and PostgreSQL this can be used as the short version of `->whereJsonContains('options->languages', 'de')->whereJsonContains('options->languages', 'en')`.