### PR TITLE
[5.7] Mailables can hook into LocaleUpdated

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -12,7 +12,6 @@ use Illuminate\Container\Container;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\Queue\Factory as Queue;
-use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
@@ -134,9 +133,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function send(MailerContract $mailer)
     {
-        $translator = Container::getInstance()->make(Translator::class);
-
-        $this->withLocale($this->locale, $translator, function () use ($mailer) {
+        $this->withLocale($this->locale, function () use ($mailer) {
             Container::getInstance()->call([$this, 'build']);
 
             $mailer->send($this->buildView(), $this->buildViewData(), function ($message) {

--- a/src/Illuminate/Support/Traits/Localizable.php
+++ b/src/Illuminate/Support/Traits/Localizable.php
@@ -2,30 +2,33 @@
 
 namespace Illuminate\Support\Traits;
 
+use Illuminate\Container\Container;
+
 trait Localizable
 {
     /**
      * Run the callback with the given locale.
      *
-     * @param  string  $locale
-     * @param  \Illuminate\Contracts\Translation\Translator  $translator
-     * @param  \Closure  $callback
+     * @param  string   $locale
+     * @param  \Closure $callback
      * @return bool
      */
-    public function withLocale($locale, $translator, $callback)
+    public function withLocale($locale, $callback)
     {
-        if (! $locale || ! $translator) {
+        if (! $locale) {
             return $callback();
         }
 
-        $original = $translator->getLocale();
+        $app = Container::getInstance();
+
+        $original = $app->getLocale();
 
         try {
-            $translator->setLocale($locale);
+            $app->setLocale($locale);
 
             return $callback();
         } finally {
-            $translator->setLocale($original);
+            $app->setLocale($original);
         }
     }
 }

--- a/tests/Integration/Mail/Fixtures/timestamp.blade.php
+++ b/tests/Integration/Mail/Fixtures/timestamp.blade.php
@@ -1,0 +1,1 @@
+{{__('nom')}} {{ Illuminate\Support\Carbon::tomorrow()->diffForHumans() }}


### PR DESCRIPTION
This makes `send()` of translated `Mailable` (and eventually `Notification`) objects dispatch the event `Illuminate\Foundation\Events\LocaleUpdated` to allow for more complete localization. For example:

* `Carbon`-formatted timestamps
* Currency and money output
* `route()` country/region URI prefixes

Translatable mailable classes were added in 5.6.5 (https://github.com/laravel/framework/pull/23178) to allow translated email subjects and view bodies, but the above localizable content types are left unchanged for queued items.

## Example to localize mailable timestamps

When the default queue worker locale is `'en'`, calling `Mail::to($francophone)->locale('fr')->queue(new Schedule);` would show French formatting for `Carbon` timestamps using this event listener.

```php
\Illuminate\Foundation\Events\LocaleUpdated::class => [
    \App\Listeners\LocalizeApp::class,
],
```

```php
namespace App\Listeners;

use Illuminate\Support\Carbon;
use Illuminate\Foundation\Events\LocaleUpdated;

class LocalizeApp
{
    public function handle(LocaleUpdated $event)
    {
        // Carbon@formatLocalized() / strftime()
        setlocale(LC_TIME, array_get([
            'en' => 'en_CA.UTF-8',
            'fr' => 'fr_CA.UTF-8',
        ], $event->locale, 'en'));

        // Carbon@diffForHumans()
        Carbon::setLocale($event->locale);
    }
}
```

## Flexibility in implementation

I chose the simplest solution (1. below) but this pull request to can be changed one of the following (or another approach entirely.)

1. **Simplest:** Assume by localizing a mailable, the app container instance has `getLocale()` / `setLocale()` methods.

   ```php
   public function withLocale($locale, $callback)
   {
       if (! $locale) {
           return $callback();
       }
   
       $app = Container::getInstance();
   
       // throws exception for custom containers
       // maybe you shouldn't be trying to locale() a mailable
       $original = $app->getLocale();
   ```
2. **Hack:** Check explicitly for Laravel's concrete `Application` container.

   ```php
   public function withLocale($locale, $callback)
   {
       $app = Container::getInstance();
 
       if (! $locale || ! $app instanceof \Illuminate\Foundation\Application) {
           return $callback();
       }
 
       $original = $app->getLocale();
   ```
3. **Custom Container-friendly Contract:** Make Laravel's app container implement a new interface.

   ```php
   interface LocalizedApplication
   {
       public function setLocale($locale);
       public function getLocale();
       public function isLocale($locale);
   }
   ```

   ```php
   class Application
       extends Container
       implements ApplicationContract, HttpKernelInterface, LocalizedApplication
   {
   ```

   ```php
   public function withLocale($locale, $callback)
   {
       $app = Container::getInstance();

       if (! $locale || ! $app instanceof LocalizedApplication) {
           return $callback();
       }

       $original = $app->getLocale();
   ```

This changes the method signature of `Illuminate\Support\Traits\Localizable@withLocale()` so this pull request is proposed for 5.7.