### PR TITLE
[5.6] Enforce response consistency.

### DIFF
--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -12,7 +12,7 @@ trait HandlesAuthorization
      */
     protected function allow($message = null)
     {
-        return new Response($message);
+        return response()->make($message);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -7,9 +7,7 @@ use Throwable;
 use Whoops\Run as Whoops;
 use Illuminate\Support\Arr;
 use Psr\Log\LoggerInterface;
-use Illuminate\Http\Response;
 use Illuminate\Routing\Router;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ViewErrorBag;
@@ -410,7 +408,7 @@ class Handler implements ExceptionHandlerContract
                 $response->getTargetUrl(), $response->getStatusCode(), $response->headers->all()
             );
         } else {
-            $response = new Response(
+            $response = response()->make(
                 $response->getContent(), $response->getStatusCode(), $response->headers->all()
             );
         }
@@ -427,7 +425,7 @@ class Handler implements ExceptionHandlerContract
      */
     protected function prepareJsonResponse($request, Exception $e)
     {
-        return new JsonResponse(
+        return response()->json(
             $this->convertExceptionToArray($e),
             $this->isHttpException($e) ? $e->getStatusCode() : 500,
             $this->isHttpException($e) ? $e->getHeaders() : [],

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -3,8 +3,6 @@
 namespace Illuminate\Routing;
 
 use Illuminate\Support\Str;
-use Illuminate\Http\Response;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -52,7 +50,7 @@ class ResponseFactory implements FactoryContract
      */
     public function make($content = '', $status = 200, array $headers = [])
     {
-        return new Response($content, $status, $headers);
+        return response()->make($content, $status, $headers);
     }
 
     /**
@@ -80,7 +78,7 @@ class ResponseFactory implements FactoryContract
      */
     public function json($data = [], $status = 200, array $headers = [], $options = 0)
     {
-        return new JsonResponse($data, $status, $headers, $options);
+        return response()->json($data, $status, $headers, $options);
     }
 
     /**

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -7,7 +7,6 @@ use ArrayIterator;
 use IteratorAggregate;
 use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
@@ -235,7 +234,7 @@ class RouteCollection implements Countable, IteratorAggregate
     {
         if ($request->method() == 'OPTIONS') {
             return (new Route('OPTIONS', $request->path(), function () use ($methods) {
-                return new Response('', 200, ['Allow' => implode(',', $methods)]);
+                return response()->make('', 200, ['Allow' => implode(',', $methods)]);
             }))->bind($request);
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -8,7 +8,6 @@ use JsonSerializable;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
@@ -721,16 +720,16 @@ class Router implements RegistrarContract, BindingRegistrar
         if ($response instanceof PsrResponseInterface) {
             $response = (new HttpFoundationFactory)->createResponse($response);
         } elseif ($response instanceof Model && $response->wasRecentlyCreated) {
-            $response = new JsonResponse($response, 201);
+            $response = response()->json($response, 201);
         } elseif (! $response instanceof SymfonyResponse &&
                    ($response instanceof Arrayable ||
                     $response instanceof Jsonable ||
                     $response instanceof ArrayObject ||
                     $response instanceof JsonSerializable ||
                     is_array($response))) {
-            $response = new JsonResponse($response);
+            $response = response()->json($response);
         } elseif (! $response instanceof SymfonyResponse) {
-            $response = new Response($response);
+            $response = response()->make($response);
         }
 
         if ($response->getStatusCode() === Response::HTTP_NOT_MODIFIED) {


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Most of the HTML and JSON response returned use the `response()` helper.
This PR ensures all of them do.