### PR TITLE
[5.6] View Factory : no need to use a collection.

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -148,7 +148,7 @@ class Factory implements FactoryContract
      */
     public function first(array $views, $data = [], $mergeData = [])
     {
-        $view = collect($views)->first(function ($view) {
+        $view = Arr::first($views, function ($view) {
             return $this->exists($view);
         });
 


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Using a collection here is costly an useless, as we only need to call `Arr::first()`.