### PR TITLE
[5.7] Feature: Eloquent Trait Initializers

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -211,11 +211,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         }
     }
 
+    /**
+     * Initialize any initializable traits on the model.
+     *
+     * @return void
+     */
     protected function initializeTraits()
     {
-        $class = static::class;
-
-        foreach (static::$traitInitializers[$class] as $method) {
+        foreach (static::$traitInitializers[static::class] as $method) {
             $this->{$method}();
         }
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -118,7 +118,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected static $booted = [];
 
     /**
-     * The array of trait initializers that will be called on each new instance
+     * The array of trait initializers that will be called on each new instance.
      *
      * @var array
      */

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1367,6 +1367,12 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue(EloquentModelBootingTestStub::isBooted());
     }
 
+    public function testModelsTraitIsInitialized()
+    {
+        $model = new EloquentModelStubWithTrait;
+        $this->assertTrue($model->fooBarIsInitialized);
+    }
+
     public function testAppendingOfAttributes()
     {
         $model = new EloquentModelAppendsStub;
@@ -1851,6 +1857,21 @@ class EloquentModelStub extends Model
     {
         $this->scopesCalled['framework'] = [$framework, $version];
     }
+}
+
+trait FooBarTrait
+{
+    public $fooBarIsInitialized = false;
+
+    public function initializeFooBarTrait()
+    {
+        $this->fooBarIsInitialized = true;
+    }
+}
+
+class EloquentModelStubWithTrait extends EloquentModelStub
+{
+    use FooBarTrait;
 }
 
 class EloquentModelCamelStub extends EloquentModelStub


### PR DESCRIPTION
(This is an alternative to #24445.)

Essentially, this introduces the opportunity for traits to call an initialization method whenever an eloquent model is new'd up without the impact of using the `Dispatcher`.  There is 0 performance impact on default models and existing usages.  The performance impact for 1000 objects returned from the database that use a trait that has an initializer is a mere `2ms`, near 0%.

To use this feature, an Eloquent trait will implement a method named `initialize<TraitName>` (this is the same pattern used for static method of booting a model.

The use case for this feature is that there are a couple of areas in eloquent that still make it difficult to write extensions that can handle complex attributes.  (By "complex attributes", I mean non-natively-known attribute types that can be expressed as objects until serialization, like how datetime objects are handled). Take for example there were an attribute of type `Coordinate`, and one wishes to be able to achieve the following workflow:

```php
class Coordinate {} // assume exists as a 3rd party value object
trait HasGeoTrait { // assume exists as a 3rd party Eloquent trait
  public function initializeHasGeoTrait() {
    // this will be called on $this for every new object.
  }
}
class Place extends Model { uses 3rdParty/HasGeoTrait; ...} // assume this kind of model

$place = Place::find(1234);
$place->coordinate->setLatLong(30.01, -90.10);

// or

$place = new Place;
$place->coordinate->setLatLong(30.01, -90.10);
```

(Separately, could this be a 5.6 feature? If so I can rebase against that branch.)