### PR TITLE
[5.6] Set the controller name on the action array when callable array syntax is used

### DIFF
--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -31,6 +31,10 @@ class RouteAction
         if (is_callable($action)) {
             if (is_array($action)) {
                 $action = $action[0].'@'.$action[1];
+                return [
+                    'uses' => $action,
+                    'controller' => $action
+                ];
             }
 
             return ['uses' => $action];

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1307,6 +1307,8 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(0, $_SERVER['route.test.controller.middleware.parameters.one']);
         $this->assertEquals(['foo', 'bar'], $_SERVER['route.test.controller.middleware.parameters.two']);
         $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
+        $action = $router->getRoutes()->getRoutes()[0]->getAction()['controller'];
+        $this->assertEquals('Illuminate\Tests\Routing\RouteTestControllerStub@index', $action);
     }
 
     public function testCallableControllerRouting()


### PR DESCRIPTION
Because it is a real controller action route instead of a Closure and so the getActionName method will return the controller name
