### PR TITLE
[5.6] Relationship fails with uppercase foreign key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -408,7 +408,7 @@ abstract class HasOneOrMany extends Relation
     {
         $segments = explode('.', $this->getQualifiedForeignKeyName());
 
-        return end($segments);
+        return strtolower(end($segments));
     }
 
     /**


### PR DESCRIPTION
I recently installed `yajra/laravel-oci8`  library for Laravel. 
Please note that all columns are upper case in our database.
My `User` model has a `hasOne` relationship with an `Info` model. 

Doing `User::first()->info`, worked just fined, however, when doing:

```
$test = User::find($id);
$test->load('info');
return $test;
```

The relationship would always return null, same when doing `with('info')`.

Digging into Eloquent, I found out that Laravel was turning the columns into lowercase ones, and within the relationship I had specified the foreign column using upper case characters, causing the `buildDictionary` to fail and not bind the key to the foreign key's value. 

I'm not familiar with any database where you can have duplicate columns names as long as their vary in upper and lower case characters. 

As such, it makes sense to turn the foreign key lower case, so it will match the column, whether or not it is lower or upper case.