### PR TITLE
[5.6] Integration test for `apiResources` and `apiResource`

### DIFF
--- a/tests/Integration/Routing/Fixtures/ApiResourceTaskController.php
+++ b/tests/Integration/Routing/Fixtures/ApiResourceTaskController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing\Fixtures;
+
+use Illuminate\Routing\Controller;
+
+class ApiResourceTaskController extends Controller
+{
+    public function index()
+    {
+        return 'I`m index tasks';
+    }
+
+    public function store()
+    {
+        return 'I`m store tasks';
+    }
+
+    public function show()
+    {
+        return 'I`m show tasks';
+    }
+
+    public function update()
+    {
+        return 'I`m update tasks';
+    }
+
+    public function destroy()
+    {
+        return 'I`m destroy tasks';
+    }
+}

--- a/tests/Integration/Routing/Fixtures/ApiResourceTestController.php
+++ b/tests/Integration/Routing/Fixtures/ApiResourceTestController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing\Fixtures;
+
+use Illuminate\Routing\Controller;
+
+class ApiResourceTestController extends Controller
+{
+    public function index()
+    {
+        return 'I`m index';
+    }
+
+    public function store()
+    {
+        return 'I`m store';
+    }
+
+    public function show()
+    {
+        return 'I`m show';
+    }
+
+    public function update()
+    {
+        return 'I`m update';
+    }
+
+    public function destroy()
+    {
+        return 'I`m destroy';
+    }
+}

--- a/tests/Integration/Routing/RouteApiResourceTest.php
+++ b/tests/Integration/Routing/RouteApiResourceTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Tests\Integration\Routing\Fixtures\ApiResourceTaskController;
+use Illuminate\Tests\Integration\Routing\Fixtures\ApiResourceTestController;
+
+/**
+ * @group integration
+ */
+class RouteApiResourceTest extends TestCase
+{
+    public function test_api_resource()
+    {
+        Route::apiResource('tests', ApiResourceTestController::class);
+
+        $response = $this->get('/tests');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m index', $response->getContent());
+
+        $response = $this->post('/tests');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m store', $response->getContent());
+
+        $response = $this->get('/tests/1');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m show', $response->getContent());
+
+        $response = $this->put('/tests/1');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m update', $response->getContent());
+        $response = $this->patch('/tests/1');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m update', $response->getContent());
+
+        $response = $this->delete('/tests/1');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m destroy', $response->getContent());
+    }
+
+    public function test_api_resource_with_only()
+    {
+        Route::apiResource('tests', ApiResourceTestController::class)->only(['index', 'store']);
+
+        $response = $this->get('/tests');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m index', $response->getContent());
+
+        $response = $this->post('/tests');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m store', $response->getContent());
+
+        $this->assertEquals(404, $this->get('/tests/1')->getStatusCode());
+        $this->assertEquals(404, $this->put('/tests/1')->getStatusCode());
+        $this->assertEquals(404, $this->patch('/tests/1')->getStatusCode());
+        $this->assertEquals(404, $this->delete('/tests/1')->getStatusCode());
+    }
+
+    public function test_api_resources()
+    {
+        Route::apiResources([
+            'tests' => ApiResourceTestController::class,
+            'tasks' => ApiResourceTaskController::class,
+        ]);
+
+        $response = $this->get('/tests');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m index', $response->getContent());
+
+        $response = $this->post('/tests');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m store', $response->getContent());
+
+        $response = $this->get('/tests/1');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m show', $response->getContent());
+
+        $response = $this->put('/tests/1');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m update', $response->getContent());
+        $response = $this->patch('/tests/1');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m update', $response->getContent());
+
+        $response = $this->delete('/tests/1');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m destroy', $response->getContent());
+
+        /////////////////////
+        $response = $this->get('/tasks');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m index tasks', $response->getContent());
+
+        $response = $this->post('/tasks');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m store tasks', $response->getContent());
+
+        $response = $this->get('/tasks/1');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m show tasks', $response->getContent());
+
+        $response = $this->put('/tasks/1');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m update tasks', $response->getContent());
+        $response = $this->patch('/tasks/1');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m update tasks', $response->getContent());
+
+        $response = $this->delete('/tasks/1');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m destroy tasks', $response->getContent());
+    }
+}


### PR DESCRIPTION
 - I cannot found the integration tests for `apiResource` and `apiResources` methods
 - In `idea` project we have the issue for customizing the `apiResources` https://github.com/laravel/ideas/issues/1202. I think this test will be useful for Laravel.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
