### PR TITLE
[5.6] Abstract some methods in Argon & Bcrypt hashers.

### DIFF
--- a/src/Illuminate/Hashing/AbstractHasher.php
+++ b/src/Illuminate/Hashing/AbstractHasher.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Hashing;
+
+abstract class AbstractHasher
+{
+    /**
+     * Get information about the given hashed value.
+     *
+     * @param  string $hashedValue
+     * @return array
+     */
+    public function info($hashedValue)
+    {
+        return password_get_info($hashedValue);
+    }
+
+    /**
+     * Check the given plain value against a hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array  $options
+     * @return bool
+     */
+    public function check($value, $hashedValue, array $options = [])
+    {
+        if (strlen($hashedValue) === 0) {
+            return false;
+        }
+
+        return password_verify($value, $hashedValue);
+    }
+}

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -5,7 +5,7 @@ namespace Illuminate\Hashing;
 use RuntimeException;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 
-class ArgonHasher implements HasherContract
+class ArgonHasher extends AbstractHasher implements HasherContract
 {
     /**
      * The default memory cost factor.
@@ -42,17 +42,6 @@ class ArgonHasher implements HasherContract
     }
 
     /**
-     * Get information about the given hashed value.
-     *
-     * @param  string  $hashedValue
-     * @return array
-     */
-    public function info($hashedValue)
-    {
-        return password_get_info($hashedValue);
-    }
-
-    /**
      * Hash the given value.
      *
      * @param  string  $value
@@ -72,23 +61,6 @@ class ArgonHasher implements HasherContract
         }
 
         return $hash;
-    }
-
-    /**
-     * Check the given plain value against a hash.
-     *
-     * @param  string  $value
-     * @param  string  $hashedValue
-     * @param  array  $options
-     * @return bool
-     */
-    public function check($value, $hashedValue, array $options = [])
-    {
-        if (strlen($hashedValue) === 0) {
-            return false;
-        }
-
-        return password_verify($value, $hashedValue);
     }
 
     /**

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -5,7 +5,7 @@ namespace Illuminate\Hashing;
 use RuntimeException;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 
-class BcryptHasher implements HasherContract
+class BcryptHasher extends AbstractHasher implements HasherContract
 {
     /**
      * The default cost factor.
@@ -23,17 +23,6 @@ class BcryptHasher implements HasherContract
     public function __construct(array $options = [])
     {
         $this->rounds = $options['rounds'] ?? $this->rounds;
-    }
-
-    /**
-     * Get information about the given hashed value.
-     *
-     * @param  string  $hashedValue
-     * @return array
-     */
-    public function info($hashedValue)
-    {
-        return password_get_info($hashedValue);
     }
 
     /**
@@ -56,23 +45,6 @@ class BcryptHasher implements HasherContract
         }
 
         return $hash;
-    }
-
-    /**
-     * Check the given plain value against a hash.
-     *
-     * @param  string  $value
-     * @param  string  $hashedValue
-     * @param  array   $options
-     * @return bool
-     */
-    public function check($value, $hashedValue, array $options = [])
-    {
-        if (strlen($hashedValue) === 0) {
-            return false;
-        }
-
-        return password_verify($value, $hashedValue);
     }
 
     /**


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

`info` and `check` are exactly the same for both `Argon` & `Bcrypt`; they can be safely extracted.