### PR TITLE
[5.7] Add exit status to WorkStopping event

### DIFF
--- a/src/Illuminate/Queue/Events/WorkerStopping.php
+++ b/src/Illuminate/Queue/Events/WorkerStopping.php
@@ -4,5 +4,21 @@ namespace Illuminate\Queue\Events;
 
 class WorkerStopping
 {
-    //
+    /**
+     * The exit status.
+     *
+     * @var int
+     */
+    public $status;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  int  $status
+     * @return void
+     */
+    public function __construct($status = 0)
+    {
+        $this->status = $status;
+    }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -552,7 +552,7 @@ class Worker
      */
     public function stop($status = 0)
     {
-        $this->events->dispatch(new Events\WorkerStopping);
+        $this->events->dispatch(new Events\WorkerStopping($status));
 
         exit($status);
     }
@@ -565,7 +565,7 @@ class Worker
      */
     public function kill($status = 0)
     {
-        $this->events->dispatch(new Events\WorkerStopping);
+        $this->events->dispatch(new Events\WorkerStopping($status));
 
         if (extension_loaded('posix')) {
             posix_kill(getmypid(), SIGKILL);


### PR DESCRIPTION
Add exit status to WorkStopping event, uses for logging the work exit status in WorkStopping event.