### PR TITLE
[5.6] Added unsetRelation method to Eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -714,9 +714,7 @@ trait HasRelationships
      */
     public function unsetRelation($relation)
     {
-        if ($this->relationLoaded($relation)) {
-            unset($this->relations[$relation]);
-        }
+        unset($this->relations[$relation]);
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -707,6 +707,21 @@ trait HasRelationships
     }
 
     /**
+     * Unset an existing relation.
+     *
+     * @param  string  $relation
+     * @return $this
+     */
+    public function unsetRelation($relation)
+    {
+        if ($this->relationLoaded($relation)) {
+            unset($this->relations[$relation]);
+        }
+
+        return $this;
+    }
+
+    /**
      * Set the entire relations array on the model.
      *
      * @param  array  $relations

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -25,7 +25,7 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertArrayNotHasKey('foo', $parent->toArray());
     }
 
-    public function testUnsetExistingRelation() 
+    public function testUnsetExistingRelation()
     {
         $parent = new EloquentRelationResetModelStub;
         $relation = new EloquentRelationResetModelStub;

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -25,6 +25,15 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertArrayNotHasKey('foo', $parent->toArray());
     }
 
+    public function testUnsetExistingRelation() 
+    {
+        $parent = new EloquentRelationResetModelStub;
+        $relation = new EloquentRelationResetModelStub;
+        $parent->setRelation('foo', $relation);
+        $parent->unsetRelation('foo');
+        $this->assertFalse($parent->relationLoaded('foo'));
+    }
+
     public function testTouchMethodUpdatesRelatedTimestamps()
     {
         $builder = m::mock(Builder::class);


### PR DESCRIPTION
There are many ways to set and load relationships in Eloquent models. However it becomes tricky for unsetting an already loaded relation.

I do work a lot in packages which interact with Eloquent and relationships with paradigms such as EAV and others where you have to manipulate relationships directly from traits. I think it'll be useful to provide as much methods as possible to manage them.

Right now, the only way I found to unset a relationship from outside the model was:

```php
// Lets assume "user" and "image" relations and we try to remove "user"
$relations = $model->getRelations();
unset($relations['user']);
$model->setRelations($relations);
```

With this PR:

```php
$model->unsetRelation('user');
```