### PR TITLE
[5.6] Add `get` method to PhpDoc in Lang facade:

### DIFF
--- a/src/Illuminate/Support/Facades/Lang.php
+++ b/src/Illuminate/Support/Facades/Lang.php
@@ -7,6 +7,7 @@ namespace Illuminate\Support\Facades;
  * @method static string transChoice(string $key, int | array | \Countable $number, array $replace = [], string $locale = null)
  * @method static string getLocale()
  * @method static void setLocale(string $locale)
+ * @method static string|array|null get(string $key, array $replace = [], string $locale = null, bool $fallback = true)
  *
  * @see \Illuminate\Translation\Translator
  */


### PR DESCRIPTION
 - this method used in Framework in
  `Foundation/Auth/ThrottlesLogins.php` class

  ```PHP
      /**
       * Redirect the user after determining they are locked out.
       *
       * @param  \Illuminate\Http\Request  $request
       * @return void
       * @throws \Illuminate\Validation\ValidationException
       */
      protected function sendLockoutResponse(Request $request)
      {
          $seconds = $this->limiter()->availableIn(
              $this->throttleKey($request)
          );

          throw ValidationException::withMessages([
              $this->username() => [Lang::get('auth.throttle', ['seconds' => $seconds])],
          ])->status(429);
      }
  ```

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
