### PR TITLE
[5.6] Add `onceBasic` method to PhpDoc in Auth Facade

### DIFF
--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -18,6 +18,11 @@ namespace Illuminate\Support\Facades;
  * @method static bool onceUsingId(mixed $id)
  * @method static bool viaRemember()
  * @method static void logout()
+ * @method static \Symfony\Component\HttpFoundation\Response|null onceBasic(string $field = 'email',array $extraConditions = [])
+ * @method static null|bool logoutOtherDevices(string $password, string $attribute = 'password')
+ * @method static \Illuminate\Contracts\Auth\UserProvider|null createUserProvider(string $provider = null)
+ * @method static \Illuminate\Auth\AuthManager extend(string $driver, \Closure $callback)
+ * @method static \Illuminate\Auth\AuthManager provider(string $name, \Closure $callback)
  *
  * @see \Illuminate\Auth\AuthManager
  * @see \Illuminate\Contracts\Auth\Factory


### PR DESCRIPTION
 - This method used in documentation https://laravel.com/docs/5.6/authentication

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
