### PR TITLE
[5.6] Allow to specify options in the `apiResources`.

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Closure;
 use ArrayObject;
+use LogicException;
 use JsonSerializable;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
@@ -314,8 +315,29 @@ class Router implements RegistrarContract, BindingRegistrar
     public function apiResources(array $resources)
     {
         foreach ($resources as $name => $controller) {
-            $this->apiResource($name, $controller);
+            if (! is_array($controller)) {
+                $this->apiResource($name, $controller);
+            } else {
+                $this->apiResourceWithOptions($name, $controller);
+            }
         }
+    }
+
+    /**
+     * Register a resource with parameters from apiResources.
+     *
+     * @param  string  $name
+     * @param  array  $options
+     * @return void
+     * @throws \LogicException
+     */
+    protected function apiResourceWithOptions($name, array $options)
+    {
+        if (! isset($options['use'])) {
+            throw new LogicException('"use" is required');
+        }
+
+        $this->apiResource($name, $options['use'], $options);
     }
 
     /**

--- a/tests/Integration/Routing/RouteApiResourceTest.php
+++ b/tests/Integration/Routing/RouteApiResourceTest.php
@@ -112,4 +112,36 @@ class RouteApiResourceTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('I`m destroy tasks', $response->getContent());
     }
+
+    public function test_api_resources_with_parameters()
+    {
+        Route::apiResources([
+            'tests' => ['use' => ApiResourceTestController::class, 'only' => ['index', 'store']],
+            'tasks' => ['use' => ApiResourceTaskController::class, 'only' => ['index']],
+        ]);
+
+        $response = $this->get('/tests');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m index', $response->getContent());
+
+        $response = $this->post('/tests');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m store', $response->getContent());
+
+        $this->assertEquals(404, $this->get('/tests/1')->getStatusCode());
+        $this->assertEquals(404, $this->put('/tests/1')->getStatusCode());
+        $this->assertEquals(404, $this->patch('/tests/1')->getStatusCode());
+        $this->assertEquals(404, $this->delete('/tests/1')->getStatusCode());
+
+        /////////////////////
+        $response = $this->get('/tasks');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('I`m index tasks', $response->getContent());
+
+        $this->assertEquals(405, $this->post('/tasks')->getStatusCode());
+        $this->assertEquals(404, $this->get('/tasks/1')->getStatusCode());
+        $this->assertEquals(404, $this->put('/tasks/1')->getStatusCode());
+        $this->assertEquals(404, $this->patch('/tasks/1')->getStatusCode());
+        $this->assertEquals(404, $this->delete('/tasks/1')->getStatusCode());
+    }
 }


### PR DESCRIPTION
So, now we can specify the resources witch will be added from `apiResources` method.

```PHP
      Route::apiResources([
            'tests' => ['use' => ApiResourceTestController::class, 'only' => ['index', 'store']],
            'tasks' => ['use' => ApiResourceTaskController::class, 'only' => ['index',]],
        ]);
```

--------------

Issue in the idea https://github.com/laravel/ideas/issues/1202

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
