### PR TITLE
[5.6] Allow defining resource routes with class notation. 

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -76,6 +76,10 @@ class ResourceRegistrar
             $this->parameters = $options['parameters'];
         }
 
+        if (class_exists($controller)) {
+            $controller = '\\'.$controller;
+        }
+
         // If the resource name contains a slash, we will assume the developer wishes to
         // register these resource routes with a prefix so we will set that up out of
         // the box so they don't have to mess with it. Otherwise, we will continue.

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -131,7 +131,8 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('https://foo.com/?a=b', $request->fullUrl());
 
         $request = Request::create('https://foo.com?a=b', 'GET');
-        $this->assertEquals('https://foo.com/?a=b&coupon=foo', $request->fullUrlWithQuery(['coupon' => 'foo']));
+        $amp = ini_get('arg_separator.output');
+        $this->assertEquals('https://foo.com/?a=b'.$amp.'coupon=foo', $request->fullUrlWithQuery(['coupon' => 'foo']));
 
         $request = Request::create('https://foo.com?a=b', 'GET');
         $this->assertEquals('https://foo.com/?a=c', $request->fullUrlWithQuery(['a' => 'c']));

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -219,6 +219,15 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('resource-middleware');
     }
 
+    public function testCanRegisterResourceWithClassNotation()
+    {
+        $this->router->middleware('resource-middleware')
+                     ->resource('users', RouteRegistrarControllerStub::class);
+
+        $this->seeResponse('deleted', Request::create('users/1', 'DELETE'));
+        $this->seeMiddleware('resource-middleware');
+    }
+
     public function testCanAccessRegisteredResourceRoutesAsRouteCollection()
     {
         $resource = $this->router->middleware('resource-middleware')

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1119,6 +1119,30 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foo/{foo}/modifier', $routes->getByName('foo.edit')->uri());
     }
 
+    public function testResourceRoutingWithClassNotation()
+    {
+        $router = $this->getRouter();
+
+        $router->resource('foo', RouteRegistrarControllerStub::class);
+        $router->resource('bar', 'RouteRegistrarControllerStub');
+
+        $router->group(['namespace' => 'App'], function ($router) {
+            $router->group(['namespace' => 'Http'], function ($router) {
+                $router->resource('nsfoo', RouteRegistrarControllerStub::class);
+                $router->resource('nsbar', 'RouteRegistrarControllerStub');
+            });
+        });
+        $routes = $router->getRoutes()->getRoutes();
+        $fooAction = $routes[0]->getAction();
+        $barAction = $routes[7]->getAction();
+        $nsfooAction = $routes[14]->getAction();
+        $nsbarAction = $routes[21]->getAction();
+        $this->assertEquals('\Illuminate\Tests\Routing\RouteRegistrarControllerStub@index', $fooAction['controller']);
+        $this->assertEquals('RouteRegistrarControllerStub@index', $barAction['controller']);
+        $this->assertEquals('\Illuminate\Tests\Routing\RouteRegistrarControllerStub@index', $nsfooAction['controller']);
+        $this->assertEquals('App\Http\RouteRegistrarControllerStub@index', $nsbarAction['controller']);
+    }
+
     public function testResourceRoutingParameters()
     {
         ResourceRegistrar::singularParameters();


### PR DESCRIPTION
Allows defining resource routes as:
```
use \Foo\BarController;
Route::resource('bar', BarController::class);
```
or fully qualified
`Route::resource('bar', \Foo\BarController::class);`

This makes it easier to understand which controller is used. Especially when in nested groups with defined group namespaces. Can make use of auto-complete in IDE when writing routes.


Includes fix for `HttpRequestTest::testFullUrlMethod` which is dependent on php.ini setting