### PR TITLE
Load additional env files for current env and current local environment

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -24,8 +24,24 @@ class LoadEnvironmentVariables
 
         $this->checkForSpecificEnvironmentFile($app);
 
+        if ($app->environmentFile() !== '.env') {
+            $this->load($app, '.local'); // .env.[APP_ENV].local
+            $this->load($app); // .env.[APP_ENV]
+        }
+
+        $this->setEnvironmentFilePath($app, '.env');
+
+        $this->load($app, '.local'); // .env.local file
+        $this->load($app); // .env
+    }
+
+    /**
+     * Load the current .env file, optionally with suffix.
+     */
+    protected function load(Application $app, $suffix = '')
+    {
         try {
-            (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
+            (new Dotenv($app->environmentPath(), $app->environmentFile() . $suffix))->load();
         } catch (InvalidPathException $e) {
             //
         } catch (InvalidFileException $e) {


### PR DESCRIPTION
This is modelled after the env configuration from Vue CLI - https://github.com/vuejs/vue-cli/blob/dev/docs/guide/mode-and-env.md

You can specify env variables by placing the following files in your project root:

``` bash
.env                # loaded in all cases
.env.local          # loaded in all cases, ignored by git
.env.[env]          # only loaded in specified mode
.env.[env].local    # only loaded in specified mode, ignored by git
```

**Benefits to end users**
* It allows default values for ENV configuration (without hunting through config/*.php files)
* It allows easy overriding of env vars in local environments

**Reasons it does not break any existing features**
* It doesn't really add anything so won't break anything
* There might be a small performance hit which can be alleviated with `config:cache`

**How it makes building web applications easier**
* By having the .env committed to version control, required vars can't be forgotten which can happen with .env.example
* Having the same .env approach between Laravel and Vue would be beneficial