### PR TITLE
Confirm before replacing HomeController in make:auth 

### DIFF
--- a/src/Illuminate/Auth/Console/AuthMakeCommand.php
+++ b/src/Illuminate/Auth/Console/AuthMakeCommand.php
@@ -50,11 +50,20 @@ class AuthMakeCommand extends Command
 
         $this->exportViews();
 
-        if (! $this->option('views')) {
-            file_put_contents(
-                app_path('Http/Controllers/HomeController.php'),
-                $this->compileControllerStub()
-            );
+        if (!$this->option('views')) {
+            if (file_exists(app_path('Http/Controllers/HomeController.php')) && !$this->option('force')) {
+                if ($this->confirm('The [HomeController.php] controller already exists. Do you want to replace it?')) {
+                    file_put_contents(
+                        app_path('Http/Controllers/HomeController.php'),
+                        $this->compileControllerStub()
+                    );
+                }
+            } else {
+                file_put_contents(
+                    app_path('Http/Controllers/HomeController.php'),
+                    $this->compileControllerStub()
+                );
+            }
 
             file_put_contents(
                 base_path('routes/web.php'),


### PR DESCRIPTION
### Change
Confirm before overwriting `HomeController.php` class, when `php artisan make:auth` is executed. 

### Output

```bash
$ php artisan make:auth
....
The [HomeController.php] controller already exists. Do you want to replace it? (yes/no) [no]:
>
```
That's it!
