### PR TITLE
[5.6] Output error message when vendor:publish cannot copy a file

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -208,6 +208,8 @@ class VendorPublishCommand extends Command
             $this->files->copy($from, $to);
 
             $this->status($from, $to, 'File');
+        } else {
+            $this->status($from, $to, 'File', false);
         }
     }
 
@@ -262,14 +264,20 @@ class VendorPublishCommand extends Command
      * @param  string  $from
      * @param  string  $to
      * @param  string  $type
+     * @param  bool    $status
      * @return void
      */
-    protected function status($from, $to, $type)
+    protected function status($from, $to, $type, $status = true)
     {
         $from = str_replace(base_path(), '', realpath($from));
 
         $to = str_replace(base_path(), '', realpath($to));
 
-        $this->line('<info>Copied '.$type.'</info> <comment>['.$from.']</comment> <info>To</info> <comment>['.$to.']</comment>');
+        if ($status) {
+            $this->line('<info>Copied '.$type.'</info> <comment>['.$from.']</comment> <info>To</info> <comment>['.$to.']</comment>');
+        } else {
+            $this->line('<error>Could Not Copy '.$type.'</error> <comment>['.$from.']</comment> <info>To</info> <comment>['.$to.']</comment> as this '.lcfirst($type).' already exists');
+            $this->line('Run this command again with --force option to overwrite all files.');
+        }
     }
 }


### PR DESCRIPTION
When you run `vendor:publish` if it cannot copy a file because it already exists it silently fails. 
Because of this if you rerun `vendor:publish` and it says "Publishing complete." it isn't unreasonable to assume it has overwritten the files when it actually hasn't. I think it would be good to put in a warning that files were left and some context as well as a tip to use the `--force` if you want to overwrite those files.

Not sure I like the bold red error message but green and orange at the beginning of the lines didn't seem bold enough.

Before:
<img width="563" alt="screen shot 2018-06-07 at 18 41 12" src="https://user-images.githubusercontent.com/9828591/41116557-8c2e5078-6a82-11e8-9312-8097ceab8fed.png">

After:
<img width="949" alt="screen shot 2018-06-07 at 18 40 32" src="https://user-images.githubusercontent.com/9828591/41116559-8efa72e6-6a82-11e8-9fe4-b615d5f69382.png">

