### PR TITLE
[5.7] Let the user set custom namespaces in a generator.php config file.

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -113,7 +113,7 @@ abstract class GeneratorCommand extends Command
     }
 
     /**
-     * Return the namespace for this type, if any.
+     * Returns the namespace for this type, if overridden.
      *
      * @return mixed
      */

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Console;
 use Illuminate\Support\Str;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
+use Illuminate\Contracts\Config\Repository as Config;
 
 abstract class GeneratorCommand extends Command
 {
@@ -23,16 +24,26 @@ abstract class GeneratorCommand extends Command
     protected $type;
 
     /**
+     * The config.
+     *
+     * @var \Illuminate\Contracts\Config\Repository|null
+     */
+    protected $config;
+
+    /**
      * Create a new controller creator command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @param  \Illuminate\Contracts\Config\Repository|null  $config
      * @return void
      */
-    public function __construct(Filesystem $files)
+    public function __construct(Filesystem $files, Config $config = null)
     {
         parent::__construct();
 
         $this->files = $files;
+
+        $this->config = $config;
     }
 
     /**
@@ -92,9 +103,25 @@ abstract class GeneratorCommand extends Command
 
         $name = str_replace('/', '\\', $name);
 
-        return $this->qualifyClass(
-            $this->getDefaultNamespace(trim($rootNamespace, '\\')).'\\'.$name
-        );
+        if ($namespace = $this->getConfigNamespace()) {
+            $defaultNamespace = trim($namespace, '\\');
+        } else {
+            $defaultNamespace = $this->getDefaultNamespace(trim($rootNamespace, '\\'));
+        }
+
+        return $this->qualifyClass($defaultNamespace.'\\'.$name);
+    }
+
+    /**
+     * Return the namespace for this type, if any.
+     *
+     * @return mixed
+     */
+    protected function getConfigNamespace()
+    {
+        if ($this->config !== null) {
+            return (string) $this->config->get('generator.'.$this->type);
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -260,7 +260,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerChannelMakeCommand()
     {
         $this->app->singleton('command.channel.make', function ($app) {
-            return new ChannelMakeCommand($app['files']);
+            return new ChannelMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -320,7 +320,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerConsoleMakeCommand()
     {
         $this->app->singleton('command.console.make', function ($app) {
-            return new ConsoleMakeCommand($app['files']);
+            return new ConsoleMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -332,7 +332,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerControllerMakeCommand()
     {
         $this->app->singleton('command.controller.make', function ($app) {
-            return new ControllerMakeCommand($app['files']);
+            return new ControllerMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -356,7 +356,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerEventMakeCommand()
     {
         $this->app->singleton('command.event.make', function ($app) {
-            return new EventMakeCommand($app['files']);
+            return new EventMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -368,7 +368,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerExceptionMakeCommand()
     {
         $this->app->singleton('command.exception.make', function ($app) {
-            return new ExceptionMakeCommand($app['files']);
+            return new ExceptionMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -380,7 +380,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerFactoryMakeCommand()
     {
         $this->app->singleton('command.factory.make', function ($app) {
-            return new FactoryMakeCommand($app['files']);
+            return new FactoryMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -416,7 +416,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerJobMakeCommand()
     {
         $this->app->singleton('command.job.make', function ($app) {
-            return new JobMakeCommand($app['files']);
+            return new JobMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -440,7 +440,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerListenerMakeCommand()
     {
         $this->app->singleton('command.listener.make', function ($app) {
-            return new ListenerMakeCommand($app['files']);
+            return new ListenerMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -452,7 +452,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerMailMakeCommand()
     {
         $this->app->singleton('command.mail.make', function ($app) {
-            return new MailMakeCommand($app['files']);
+            return new MailMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -464,7 +464,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerMiddlewareMakeCommand()
     {
         $this->app->singleton('command.middleware.make', function ($app) {
-            return new MiddlewareMakeCommand($app['files']);
+            return new MiddlewareMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -579,7 +579,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerModelMakeCommand()
     {
         $this->app->singleton('command.model.make', function ($app) {
-            return new ModelMakeCommand($app['files']);
+            return new ModelMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -591,7 +591,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerNotificationMakeCommand()
     {
         $this->app->singleton('command.notification.make', function ($app) {
-            return new NotificationMakeCommand($app['files']);
+            return new NotificationMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -627,7 +627,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerObserverMakeCommand()
     {
         $this->app->singleton('command.observer.make', function ($app) {
-            return new ObserverMakeCommand($app['files']);
+            return new ObserverMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -663,7 +663,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerPolicyMakeCommand()
     {
         $this->app->singleton('command.policy.make', function ($app) {
-            return new PolicyMakeCommand($app['files']);
+            return new PolicyMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -687,7 +687,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerProviderMakeCommand()
     {
         $this->app->singleton('command.provider.make', function ($app) {
-            return new ProviderMakeCommand($app['files']);
+            return new ProviderMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -807,7 +807,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerRequestMakeCommand()
     {
         $this->app->singleton('command.request.make', function ($app) {
-            return new RequestMakeCommand($app['files']);
+            return new RequestMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -819,7 +819,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerResourceMakeCommand()
     {
         $this->app->singleton('command.resource.make', function ($app) {
-            return new ResourceMakeCommand($app['files']);
+            return new ResourceMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -831,7 +831,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerRuleMakeCommand()
     {
         $this->app->singleton('command.rule.make', function ($app) {
-            return new RuleMakeCommand($app['files']);
+            return new RuleMakeCommand($app['files'], $app['config']);
         });
     }
 
@@ -959,7 +959,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerTestMakeCommand()
     {
         $this->app->singleton('command.test.make', function ($app) {
-            return new TestMakeCommand($app['files']);
+            return new TestMakeCommand($app['files'], $app['config']);
         });
     }
 


### PR DESCRIPTION
Even if Laravel comes with sensible defaults, the developer sometimes want to have a different structure for a project.

For instance, putting models either in `\App` either in `\App\Models` has been a long discussed topic.

This PR enables the user to override paths for each generated files types in a custom generator.php config file.
If nothing is set, the generator commands will use their defaults.

This works with everything but the migrations files.

---

This PR is related to https://github.com/laravel/laravel/pull/4680