### PR TITLE
[5.6] FilesystemManger return $this, after set a cutom disk

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -318,11 +318,13 @@ class FilesystemManager implements FactoryContract
      *
      * @param  string  $name
      * @param  mixed  $disk
-     * @return void
+     * @return $this
      */
     public function set($name, $disk)
     {
         $this->disks[$name] = $disk;
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Hi, maybe we return $this after set custom disk.

```php 
Storage::set('server_name', $serverArray)
       ->put($fileName, $fileContents);
```