### PR TITLE
[5.5] Fix type of $path in loadViewsFrom docblock

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -75,7 +75,7 @@ abstract class ServiceProvider
     /**
      * Register a view file namespace.
      *
-     * @param  string  $path
+     * @param  string|array  $path
      * @param  string  $namespace
      * @return void
      */


### PR DESCRIPTION
Because addNamespace can take arrays as its second argument, loadViewsFrom should allow this, too.