### PR TITLE
[5.6] Add skipped file message to vendor:publish

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -86,7 +86,7 @@ class VendorPublishCommand extends Command
         if ($this->filesWereSkipped) {
             $this->line('Run command again with --force option to overwrite all files.');
         }
-        
+
         $this->info('Publishing complete.');
     }
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -208,6 +208,11 @@ class VendorPublishCommand extends Command
             $this->files->copy($from, $to);
 
             $this->status($from, $to, 'File');
+        } else {
+            $to = str_replace(base_path(), '', realpath($to));
+
+            $this->comment('Skipping file ['.$to.'] as it already exists');
+            $this->line('Run command again with --force option to overwrite all files.');
         }
     }
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -34,6 +34,13 @@ class VendorPublishCommand extends Command
     protected $tags = [];
 
     /**
+     * Were any files skipped during publishing.
+     *
+     * @var bool
+     */
+    protected $filesWereSkipped = false;
+
+    /**
      * The console command signature.
      *
      * @var string
@@ -76,6 +83,10 @@ class VendorPublishCommand extends Command
             $this->publishTag($tag);
         }
 
+        if ($this->filesWereSkipped) {
+            $this->line('Run command again with --force option to overwrite all files.');
+        }
+        
         $this->info('Publishing complete.');
     }
 
@@ -209,10 +220,11 @@ class VendorPublishCommand extends Command
 
             $this->status($from, $to, 'File');
         } else {
+            $this->filesWereSkipped = true;
+
             $to = str_replace(base_path(), '', realpath($to));
 
             $this->comment('Skipping file ['.$to.'] as it already exists');
-            $this->line('Run command again with --force option to overwrite all files.');
         }
     }
 


### PR DESCRIPTION
Add a skipped file message if files were not copied across during `vendor:publish` so it is obvious they were not overwritten.

Update of https://github.com/laravel/framework/pull/24499

Before:
<img width="563" alt="screen shot 2018-06-07 at 18 41 12" src="https://user-images.githubusercontent.com/9828591/41121327-fad72948-6a8f-11e8-89b0-9073cb62a3d2.png">

After:
<img width="562" alt="screen shot 2018-06-07 at 20 19 20" src="https://user-images.githubusercontent.com/9828591/41121370-14c4950c-6a90-11e8-9104-7645168031bf.png">

