### PR TITLE
[5.5] fix report helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -667,19 +667,18 @@ if (! function_exists('redirect')) {
 
 if (! function_exists('report')) {
     /**
-     * Report an exception.
+     * Report a Throwable implementation.
      *
-     * @param  \Exception  $exception
+     * @param  \Throwable  $e
      * @return void
      */
-    function report($exception)
+    function report($e)
     {
-        if ($exception instanceof Throwable &&
-            ! $exception instanceof Exception) {
-            $exception = new FatalThrowableError($exception);
+        if (! $e instanceof Exception) {
+            $e = new FatalThrowableError($e);
         }
 
-        app(ExceptionHandler::class)->report($exception);
+        app(ExceptionHandler::class)->report($e);
     }
 }
 


### PR DESCRIPTION
I has 2 changes in this pull request for the **report** helper.
1. Fix the doc @param.
Let's the way the helper is used (see function rescue below), it should receives a **Throwable** implementation instead of just Exception instance.
```php
function rescue(callable $callback, $rescue = null)
{
    try {
        return $callback();
    } catch (Throwable $e) {
        report($e);

        return value($rescue);
    }
}
```

2. Remove unnecessary comparison "$exception instanceof Throwable"
There are two reasons to do this.
    + The report helper should only receive a **Throwable** implementation, isn't it?
    + If you pass invalid parameter, the FatalThrowableError will check it for you. [FatalThrowableError.php](https://github.com/symfony/symfony/blob/97cee3a157cf480a9204fa45816e5d76db32df72/src/Symfony/Component/Debug/Exception/FatalThrowableError.php)
```php
public function __construct(\Throwable $e)
{
    $this->originalClassName = \get_class($e);
    if ($e instanceof \ParseError) {
        $severity = E_PARSE;
    } elseif ($e instanceof \TypeError) {
        $severity = E_RECOVERABLE_ERROR;
    } else {
        $severity = E_ERROR;
    }
    \ErrorException::__construct(
        $e->getMessage(),
        $e->getCode(),
        $severity,
        $e->getFile(),
        $e->getLine(),
        $e->getPrevious()
    );
    $this->setTrace($e->getTrace());
}
```

Anyway, the interface **\Throwable** that has been used since php v7 that contains both Error and Exception. I suggest using parameter or variable "$e" for the the context that may throw a **Throwable** implementation because I think "$e" means "$exception" or "$error".