### PR TITLE
[5.5] Fixes #20616

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 
@@ -408,6 +409,14 @@ trait HasAttributes
 
         if (! $relation instanceof Relation) {
             throw new LogicException(get_class($this).'::'.$method.' must return a relationship instance.');
+        }
+        
+        // If the foreign key is null then the relation is not setted and we don't 
+        // need to perform any query.
+        if ($relation instanceof BelongsTo) {
+            if (is_null($this->{$relation->getForeignKey()})) {
+                return null;
+            }
         }
 
         return tap($relation->getResults(), function ($results) use ($method) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -9,8 +9,8 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 
 trait HasAttributes
@@ -411,7 +411,7 @@ trait HasAttributes
             throw new LogicException(get_class($this).'::'.$method.' must return a relationship instance.');
         }
         
-        // If the foreign key is null then the relation is not setted and we don't 
+        // If the foreign key is null then the relation is not setted and we don't
         // need to perform any query.
         if ($relation instanceof BelongsTo) {
             if (is_null($this->{$relation->getForeignKey()})) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -410,7 +410,7 @@ trait HasAttributes
         if (! $relation instanceof Relation) {
             throw new LogicException(get_class($this).'::'.$method.' must return a relationship instance.');
         }
-        
+
         // If the foreign key is null then the relation is not setted and we don't
         // need to perform any query.
         if ($relation instanceof BelongsTo) {


### PR DESCRIPTION
Fixes a bug that makes Eloquent perform unnecessary queries when a relationship is loaded using the __get magic method and the foreign key is null. In other words, we are performing queries to retrieve a non-existent related model.