### PR TITLE
[5.6] Make grammars macroable

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -3,9 +3,12 @@
 namespace Illuminate\Database;
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Traits\Macroable;
 
 abstract class Grammar
 {
+    use Macroable;
+
     /**
      * The grammar table prefix.
      *

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -941,6 +941,18 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('drop table `alpha`,`beta`,`gamma`', $statement);
     }
 
+    public function testGrammarsAreMacroable()
+    {
+        // compileReplace macro.
+        $this->getGrammar()::macro('compileReplace', function () {
+            return true;
+        });
+
+        $c = $this->getGrammar()::compileReplace();
+
+        $this->assertTrue($c);
+    }
+
     protected function getConnection()
     {
         return m::mock('Illuminate\Database\Connection');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -799,4 +799,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     {
         return new \Illuminate\Database\Schema\Grammars\PostgresGrammar;
     }
+
+    public function testGrammarsAreMacroable()
+    {
+        // compileReplace macro.
+        $this->getGrammar()::macro('compileReplace', function () {
+            return true;
+        });
+
+        $c = $this->getGrammar()::compileReplace();
+
+        $this->assertTrue($c);
+    }
 }

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -759,6 +759,18 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add column "coordinates" multipolygon not null', $statements[0]);
     }
 
+    public function testGrammarsAreMacroable()
+    {
+        // compileReplace macro.
+        $this->getGrammar()::macro('compileReplace', function () {
+            return true;
+        });
+
+        $c = $this->getGrammar()::compileReplace();
+
+        $this->assertTrue($c);
+    }
+
     protected function getConnection()
     {
         return m::mock('Illuminate\Database\Connection');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -768,6 +768,18 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
+    public function testGrammarsAreMacroable()
+    {
+        // compileReplace macro.
+        $this->getGrammar()::macro('compileReplace', function () {
+            return true;
+        });
+
+        $c = $this->getGrammar()::compileReplace();
+
+        $this->assertTrue($c);
+    }
+
     protected function getConnection()
     {
         return m::mock('Illuminate\Database\Connection');


### PR DESCRIPTION
I have a situation where i need to extend the default grammar in order to add additional compiled queries e.g `replace into` for mysql.

But i don't really want to extend a base queryBuilder sense it can be confusing and tidious to deal with extended classes and when the connection has been resovled and all of that stuff.

I could only find tests for the Schema Grammars not the Query grammars is this by design?

So simply making every Grammar macroable is a better approach to this atleast i think.
