### PR TITLE
[5.7] Logger facade: write to channel(s) - add methods docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -15,6 +15,9 @@ use Psr\Log\LoggerInterface;
  * @method static void debug(string $message, array $context = [])
  * @method static void log($level, string $message, array $context = [])
  *
+ * @method static self channel(string $channel)
+ * @method static self stack(array $channels)
+ *
  * @see \Illuminate\Log\Logger
  */
 class Log extends Facade


### PR DESCRIPTION
No features break - Dockblock only, useful for Logger facade methods usage - Log::channel(), Log::stack()