### PR TITLE
[5.6] Add ability to determine if the current user is ALREADY authenticated without triggering side effects

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -41,6 +41,16 @@ trait GuardHelpers
     }
 
     /**
+     * Determine if the current user is already authenticated without triggering side effects.
+     *
+     * @return bool
+     */
+    public function alreadyAuthenticated()
+    {
+        return ! is_null($this->user);
+    }
+
+    /**
      * Determine if the current user is authenticated.
      *
      * @return bool

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -41,11 +41,11 @@ trait GuardHelpers
     }
 
     /**
-     * Determine if the current user is already authenticated without triggering side effects.
+     * Determine if the guard has the current user without triggering side effects.
      *
      * @return bool
      */
-    public function alreadyAuthenticated()
+    public function hasUser()
     {
         return ! is_null($this->user);
     }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -178,20 +178,20 @@ class AuthGuardTest extends TestCase
         $guard->authenticate();
     }
 
-    public function testAlreadyAuthenticatedReturnsFalseWhenUserIsNotNull()
+    public function testHasUserReturnsFalseWhenUserIsNotNull()
     {
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $guard = $this->getGuard()->setUser($user);
 
-        $this->assertTrue($guard->alreadyAuthenticated());
+        $this->assertTrue($guard->hasUser());
     }
 
-    public function testAlreadyAuthenticatedReturnsFalseWhenUserIsNull()
+    public function testHasUserReturnsFalseWhenUserIsNull()
     {
         $guard = $this->getGuard();
         $guard->getSession()->shouldNotReceive('get');
 
-        $this->assertFalse($guard->alreadyAuthenticated());
+        $this->assertFalse($guard->hasUser());
     }
 
     public function testIsAuthedReturnsTrueWhenUserIsNotNull()

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -178,6 +178,22 @@ class AuthGuardTest extends TestCase
         $guard->authenticate();
     }
 
+    public function testAlreadyAuthenticatedReturnsFalseWhenUserIsNotNull()
+    {
+        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $guard = $this->getGuard()->setUser($user);
+
+        $this->assertTrue($guard->alreadyAuthenticated());
+    }
+
+    public function testAlreadyAuthenticatedReturnsFalseWhenUserIsNull()
+    {
+        $guard = $this->getGuard();
+        $guard->getSession()->shouldNotReceive('get');
+
+        $this->assertFalse($guard->alreadyAuthenticated());
+    }
+
     public function testIsAuthedReturnsTrueWhenUserIsNotNull()
     {
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');


### PR DESCRIPTION
- `Auth::check()` internally calls `Auth::user()`. It may trigger side effects.<br>(e.g. accessing database or making an HTTP request for external Web API)
- `Auth::guard()->user` is protected.

We currently do not have an ability to determine if `Auth::guard()->user` is already set without using reflection. This PR adds `Auth::alreadyAuthenticated()` which returns boolean value.

It will be useful in models or custom relations.

### Example

```php
class Post extends Model
{
    protected $visible = ['id', 'title', 'body', 'created_at', 'likes', 'liked'];
    protected $with = ['likeByCurrentUser'];
    protected $appends = ['liked'];

    public function likes()
    {
        return $this->hasMany(Like::class);
    }

    public function likeByCurrentUser()
    {
        return $this->hasOne(Like::class)->where('user_id', Auth::alreadyAuthenticated() ? Auth::id() : null);
    }

    public function getLikedAttribute()
    {
        return Auth::alreadyAuthenticated() ? ! is_null($this->likeByCurrentUser) : null;
    }
}
```