### PR TITLE
Fix CacheFileStore Increment Concurrent Writes

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -90,14 +90,14 @@ class FileStore implements Store
     {
         $path = $this->path($key);
 
-        $handle = @fopen($path, "r+");
+        $handle = @fopen($path, 'r+');
         if ($handle === false) {
             return false;
         }
 
         try {
             $locked = flock($handle, LOCK_EX);
-            if (!$locked) {
+            if (! $locked) {
                 return false;
             }
 
@@ -111,7 +111,7 @@ class FileStore implements Store
             $rawValue = unserialize(substr($raw, 10));
             $newValue = ((int) $rawValue) + $value;
 
-            if (!ftruncate($handle, 0) || !rewind($handle)) {
+            if (! ftruncate($handle, 0) || ! rewind($handle)) {
                 return false;
             }
 

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -84,15 +84,48 @@ class FileStore implements Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return int
+     * @return int | boolean
      */
     public function increment($key, $value = 1)
     {
-        $raw = $this->getPayload($key);
+        $path = $this->path($key);
 
-        return tap(((int) $raw['data']) + $value, function ($newValue) use ($key, $raw) {
-            $this->put($key, $newValue, $raw['time'] ?? 0);
-        });
+        $handle = @fopen($path, "r+");
+        if ($handle === false) {
+            return false;
+        }
+
+        try {
+            $locked = flock($handle, LOCK_EX);
+            if (!$locked) {
+                return false;
+            }
+
+            clearstatcache(true, $path);
+            $raw = fread($handle, filesize($path));
+            if ($raw === false) {
+                return false;
+            }
+
+            $rawExp = substr($raw, 0, 10);
+            $rawValue = unserialize(substr($raw, 10));
+            $newValue = ((int) $rawValue) + $value;
+
+            if (!ftruncate($handle, 0) || !rewind($handle)) {
+                return false;
+            }
+
+            if (fwrite($handle, $rawExp.serialize($newValue)) && fflush($handle)) {
+                return $newValue;
+            }
+        } finally {
+            if ($locked) {
+                flock($handle, LOCK_UN);
+            }
+            fclose($handle);
+        }
+
+        return false;
     }
 
     /**
@@ -100,7 +133,7 @@ class FileStore implements Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return int
+     * @return int | boolean
      */
     public function decrement($key, $value = 1)
     {

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -104,10 +104,10 @@ class CacheFileStoreTest extends TestCase
         $initialValue = $expiration.serialize(1);
         $valueAfterIncrement = $expiration.serialize(2);
         $store = new FileStore($files, __DIR__);
-        $files->expects($this->once())->method('get')->will($this->returnValue($initialValue));
+        $files->method('get')->will($this->returnValue($initialValue));
         $hash = sha1('foo');
         $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
-        $files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash), $this->equalTo($valueAfterIncrement));
+        $files->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash), $this->equalTo($valueAfterIncrement));
         $store->increment('foo');
     }
 


### PR DESCRIPTION
Fix #24496 

    Route::get('/init', function () {
        \Illuminate\Support\Facades\Cache::forever('num',0);
    });

    Route::get('/inc', function () {
        \Illuminate\Support\Facades\Cache::increment("num");
    });

    Route::get('/get', function () {
        $num = \Illuminate\Support\Facades\Cache::get("num");
        dd($num);
    });

1. visit http://hostname/init
2. `ab -c10 -n2000 http://hostname/inc/`
3. visit http://hostname/get

You will find that the result is always less than 2000, This pr is solved through a mutex lock.


