### PR TITLE
[5.6] Retrieve the validated data of multidimensional input

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -174,8 +174,8 @@ class FormRequest extends Request implements ValidatesWhenResolved
     {
         $rules = $this->container->call([$this, 'rules']);
 
-        return $this->only(collect($rules)->keys()->map(function ($rule) {
-            return explode('.', $rule)[0];
+        return $this->only(collect(array_dot($this->all()))->keys()->filter(function ($attribute) use ($rules) {
+            return in_array(preg_replace('/\.[0-9]+\./', '.*.', $attribute), array_keys($rules)) ;
         })->unique()->toArray());
     }
 

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -175,7 +175,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
         $rules = $this->container->call([$this, 'rules']);
 
         return $this->only(collect(array_dot($this->all()))->keys()->filter(function ($attribute) use ($rules) {
-            return in_array(preg_replace('/\.[0-9]+\./', '.*.', $attribute), array_keys($rules)) ;
+            return in_array(preg_replace('/\.[0-9]+\./', '.*.', $attribute), array_keys($rules));
         })->unique()->toArray());
     }
 


### PR DESCRIPTION
## The problem:
The `validated()` method is used to retrieve no more than the data that passed the validation when using a form request. For now it filters only the first level. It means if your request data is structured on two (or more) levels and some unwanted data is present in a sub level, then it will still be present even if the validated method was used.

### Example

The rules for the request
```
[
    'main_address.city' => 'required',
    'other_addresses.*.city' => 'required',
    'password' => 'required',
    'username' => 'required'
]
```

Request input data
```
[
    'foo' => 'bar',
    'main_address' => [
        'city' => 'specified',
        'country' => 'specified'
    ],
    'other_addresses' => [
        [
            'city' => 'specified'
        ],
        [
            'baz' => 'qux',
            'city' => 'specified'
        ]
    ],
    'password' => 'specified',
    'username' => 'specified'
]
```

The `validated()` method's result
```
[
    'main_address' => [
        'city' => 'specified',
        'country' => 'specified',
    ],
    'other_addresses' => [
        [
            'city' => 'specified'
        ],
        [
            'baz' => 'qux',
            'city' => 'specified'
        ]
    ],   
    'username' => 'specified',
    'password' => 'specified'
]
```
The attributes `foo` and `email_address` that weren’t validated are not present anymore. Yet the attributes `main_address.country` and `other_addresses.1.baz` are still present.

## The solution
This pull request makes sure the `validated()` method returns no more than the validated data even if the request input data is structured on multiple levels

### Example
Given the rules and the input data above, the  `validated()` method's result is now
```
[
    'main_address' => [
        'city' => 'specified'
    ],
    'other_addresses' => [
        [
            'city' => 'specified'
        ],
        [
            'city' => 'specified'
        ]
    ],   
    'username' => 'specified',
    'password' => 'specified'
]
```
