### PR TITLE
Remove implicit not null constraint on foriegn key to remove assumption about data

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -68,8 +68,6 @@ abstract class HasOneOrMany extends Relation
     {
         if (static::$constraints) {
             $this->query->where($this->foreignKey, '=', $this->getParentKey());
-
-            $this->query->whereNotNull($this->foreignKey);
         }
     }
 


### PR DESCRIPTION
When creating a HasOne or HasMany relation, Laravel adds a constraint on the query that limits it to returning only results where the foreign key is not null.

Unfortunately, this makes an assumption about the data and implies that a null value for a foreign key will never return related data.

NULL is a valid value, just like the number 5 or the string "hello", and should be treated as such by the framework. There are valid use cases where a foreign key can be null.

In my particular use case, a foreign key is a client_id, and there is a table representing settings for a client. When the client_id is null, it is interpreted by the application as the "default" client (e.g. default settings).

Unfortunately, querying for data related to the client fail because of the NOT NULL constraint.

This pull request removes the constraint, leaving it up to the application to decide what values should return data from the join.