### PR TITLE
[5.6] Add notnull option to Eloquent casting type collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -576,6 +576,10 @@ trait HasAttributes
             $value = $this->castAttributeAsJson($key, $value);
         }
 
+        if ($this->isNotNullCollectionCast($key) && is_null($value)) {
+            $value = collect();
+        }
+
         // If this attribute contains a JSON ->, we'll set the proper value in the
         // attribute's underlying array. This takes care of properly nesting an
         // attribute in the array's value in the case of deeply nested items.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -576,7 +576,7 @@ trait HasAttributes
             $value = $this->castAttributeAsJson($key, $value);
         }
 
-        if ($this->isNotNullCollectionCast($key) && is_null($value)) {
+        if ($this->isNotNullCollectionCastable($key) && is_null($value)) {
             $value = collect();
         }
 
@@ -905,6 +905,17 @@ trait HasAttributes
     protected function isJsonCastable($key)
     {
         return $this->hasCast($key, ['array', 'json', 'object', 'collection']);
+    }
+
+    /**
+     * Determine whether a value is Not Null Collection castable for inbound manipulation.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isNotNullCollectionCastable($key)
+    {
+        return $this->hasCast($key, ['notnull_collection']);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -193,6 +193,10 @@ trait HasAttributes
             if ($attributes[$key] && $this->isCustomDateTimeCast($value)) {
                 $attributes[$key] = $attributes[$key]->format(explode(':', $value, 2)[1]);
             }
+
+            if (is_null($attributes[$key]) && $this->isNotNullCollectionCast($value)) {
+                $attributes[$key] = collect();
+            }
         }
 
         return $attributes;
@@ -490,6 +494,7 @@ trait HasAttributes
             case 'json':
                 return $this->fromJson($value);
             case 'collection':
+            case 'notnull_collection':
                 return new BaseCollection($this->fromJson($value));
             case 'date':
                 return $this->asDate($value);
@@ -514,6 +519,9 @@ trait HasAttributes
         if ($this->isCustomDateTimeCast($this->getCasts()[$key])) {
             return 'custom_datetime';
         }
+        if ($this->isNotNullCollectionCast($this->getCasts()[$key])) {
+            return 'notnull_collection';
+        }
 
         return trim(strtolower($this->getCasts()[$key]));
     }
@@ -528,6 +536,17 @@ trait HasAttributes
     {
         return strncmp($cast, 'date:', 5) === 0 ||
                strncmp($cast, 'datetime:', 9) === 0;
+    }
+
+    /**
+     * Determine if the cast type is a not null collection cast.
+     *
+     * @param  string  $cast
+     * @return bool
+     */
+    protected function isNotNullCollectionCast($cast)
+    {
+        return $cast === 'collection:notnull';
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1754,7 +1754,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->notnullCollectionAttribute->isEmpty());
 
         $array = $model->toArray();
-        $this->assertEqual([], $array['notnullCollectionAttribute']);
+        $this->assertEquals([], $array['notnullCollectionAttribute']);
     }
 }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1752,9 +1752,6 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertInstanceOf(\Illuminate\Support\Collection::class, $model->notnullCollectionAttribute);
         $this->assertTrue($model->notnullCollectionAttribute->isEmpty());
-
-        $array = $model->toArray();
-        $this->assertEquals([], $array['notnullCollectionAttribute']);
     }
 }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1549,6 +1549,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->dateAttribute = null;
         $model->datetimeAttribute = null;
         $model->timestampAttribute = null;
+        $model->collectionAttribute = null;
 
         $attributes = $model->getAttributes();
 
@@ -1563,6 +1564,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($attributes['dateAttribute']);
         $this->assertNull($attributes['datetimeAttribute']);
         $this->assertNull($attributes['timestampAttribute']);
+        $this->assertNull($attributes['collectionAttribute']);
 
         $this->assertNull($model->intAttribute);
         $this->assertNull($model->floatAttribute);
@@ -1575,6 +1577,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($model->dateAttribute);
         $this->assertNull($model->datetimeAttribute);
         $this->assertNull($model->timestampAttribute);
+        $this->assertNull($model->collectionAttribute);
 
         $array = $model->toArray();
 
@@ -1589,6 +1592,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($array['dateAttribute']);
         $this->assertNull($array['datetimeAttribute']);
         $this->assertNull($array['timestampAttribute']);
+        $this->assertNull($array['collectionAttribute']);
     }
 
     /**
@@ -1734,6 +1738,23 @@ class DatabaseEloquentModelTest extends TestCase
         $resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection'));
         $model->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
         $model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
+    }
+
+    public function testModelAttributeCastingToNotnullCollectionNeverPreservesNull()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->notnullCollectionAttribute = null;
+
+        $attributes = $model->getAttributes();
+
+        $this->assertInstanceOf(\Illuminate\Support\Collection::class, $attributes['notnullCollectionAttribute']);
+        $this->assertTrue($attributes['notnullCollectionAttribute']->isEmpty());
+
+        $this->assertInstanceOf(\Illuminate\Support\Collection::class, $model->notnullCollectionAttribute);
+        $this->assertTrue($model->notnullCollectionAttribute->isEmpty());
+
+        $array = $model->toArray();
+        $this->assertEqual([], $array['notnullCollectionAttribute']);
     }
 }
 
@@ -2048,6 +2069,8 @@ class EloquentModelCastingStub extends Model
         'dateAttribute' => 'date',
         'datetimeAttribute' => 'datetime',
         'timestampAttribute' => 'timestamp',
+        'collectionAttribute' => 'collection',
+        'notnullCollectionAttribute' => 'collection:notnull',
     ];
 
     public function jsonAttributeValue()


### PR DESCRIPTION
Based on Issue laravel/ideas#460
Keeps default collection casting behavior, and adds option to make collection never preserve null

## Benefits
This PR will help artisans to treat collection casting better (Main purpose is to utilize `->isEmpty()` method on casted attribute).

When we specify a casting like this:
```
// Meta Model Class

protected $casts = [
    'keywords' => 'collection',
];
```
For if statement, i prefer to do something like `@if ($meta->keywords->isEmpty())` than `@if (is_null($meta->keywords))`.

This PR will avoid us to add more checks like is_null($this->keywords). And it's view-friendly when you do something like this {{ $meta->keywords->implode(', ') }}.

## Affect
This PR will make Model to return an empty Collection object instead of null when using `collection:notnull` cast type
```
// Meta Model Class

protected $casts = [
    'keywords' => 'collection:notnull',
];
```
`@if ($meta->keywords->isEmpty())`


## Test
Added `testModelAttributeCastingToNotnullCollectionNeverPreservesNull()` and also added test of default behavior (preserving null)