### PR TITLE
[5.6] Make email subcopy-text translatable via json

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -52,8 +52,7 @@
 @isset($actionText)
 @component('mail::subcopy')
 @lang(
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
-    'into your web browser: [:actionURL](:actionURL)',
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser: [:actionURL](:actionURL)",
     [
         'actionText' => $actionText,
         'actionURL' => $actionUrl


### PR DESCRIPTION
This makes the subcopy text translatable via JSON-Localization
