### PR TITLE
[5.6] Fix validating arrays returns unexpected values

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -306,11 +306,10 @@ class Validator implements ValidatorContract
             throw new ValidationException($this);
         }
 
-        $data = collect($this->getData());
-
-        return $data->only(collect($this->getRules())->keys()->map(function ($rule) {
-            return explode('.', $rule)[0];
-        })->unique())->toArray();
+        return array_reduce( array_keys($this->getRules()), function($data, $key) {
+            array_set($data, $key, array_get($this->getData(), $key));
+            return $data;
+        }, [] );
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4003,6 +4003,15 @@ class ValidationValidatorTest extends TestCase
         $data = $v->validate();
 
         $this->assertEquals(['first' => 'john', 'preferred' => 'john'], $data);
+
+        // Test array validation...
+        $data = (new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['name' => ['first' => 'john', 'last' => 'doe']],
+            ['name.first' => 'required']
+        ))->validate();
+
+        $this->assertEquals(['name' => ['first' => 'john']], $data);
     }
 
     protected function getTranslator()


### PR DESCRIPTION
While working on something I noticed the $request->validate() method returns unexpected values when validating arrays.

To demonstrate, the data was an array
```
[ 'name' => [ 'first' => 'john', 'last' => 'doe' ] ]
```

In my controller I was validating it as follows
```
$data = $request->validate([
	'name.first' => 'required',
]);
```

So I was expecting to get an array as follows:
```
[ 'name' => [ 'first' => 'john' ] ]
```

But it didn't work, it returned the array as is
```
[ 'name' => [ 'first' => 'john', 'last' => 'doe' ] ]
```

This PR solves this issue.