### PR TITLE
[5.6] Make ResetPassword Notification translateable

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Notifications;
 
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\MailMessage;
 
@@ -56,9 +57,10 @@ class ResetPassword extends Notification
         }
 
         return (new MailMessage)
-            ->line('You are receiving this email because we received a password reset request for your account.')
-            ->action('Reset Password', url(config('app.url').route('password.reset', $this->token, false)))
-            ->line('If you did not request a password reset, no further action is required.');
+            ->subject(Lang::getFromJson('Reset Password Notification'))
+            ->line(Lang::getFromJson('You are receiving this email because we received a password reset request for your account.'))
+            ->action(Lang::getFromJson('Reset Password'), url(config('app.url').route('password.reset', $this->token, false)))
+            ->line(Lang::getFromJson('If you did not request a password reset, no further action is required.'));
     }
 
     /**


### PR DESCRIPTION
Instead of doing funky stuff like this (https://laracasts.com/discuss/channels/laravel/how-to-language-for-illuminateauthnotificationsresetpasswordphp) it would be so nice to just be able to translate the messages in the password reset mail like everything else, kinda like a no brainer :-)