### PR TITLE
[5.6] add assertOk() response assertion

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -65,6 +65,21 @@ class TestResponse
     }
 
     /**
+     * Assert that the response has an OK status code.
+     *
+     * @return $this
+     */
+    public function assertOk()
+    {
+        PHPUnit::assertTrue(
+            $this->isOk(),
+            'Response status code [' . $this->getStatusCode() . '] is not an OK status code.'
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has a not found status code.
      *
      * @return $this


### PR DESCRIPTION
This PR adds one more method to response testing:

- assertOk()

I was asserting frequently by the _200_ status code, but with this method (just like `assertNotFound()` and `assertForbidden()`) it would be more verbose and straightforward.
