### PR TITLE
[5.6] Fix typo in method name

### DIFF
--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -178,7 +178,7 @@ class AuthGuardTest extends TestCase
         $guard->authenticate();
     }
 
-    public function testHasUserReturnsFalseWhenUserIsNotNull()
+    public function testHasUserReturnsTrueWhenUserIsNotNull()
     {
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $guard = $this->getGuard()->setUser($user);


### PR DESCRIPTION
Changed:
```public function testHasUserReturnsFalseWhenUserIsNotNull()```

To:
```public function testHasUserReturnsTrueWhenUserIsNotNull()```

When the user is **NOT** null, ```hasUser()``` should return true.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
