### PR TITLE
[5.6] Fix JSON queries with table names on SQL Server

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Query\Grammars;
 
 use RuntimeException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Database\Grammar as BaseGrammar;
@@ -36,6 +37,58 @@ class Grammar extends BaseGrammar
         'unions',
         'lock',
     ];
+
+    /**
+     * Wrap a value in keyword identifiers.
+     *
+     * @param  \Illuminate\Database\Query\Expression|string  $value
+     * @param  bool    $prefixAlias
+     * @return string
+     */
+    public function wrap($value, $prefixAlias = false)
+    {
+        if ($this->isExpression($value)) {
+            return $this->getValue($value);
+        }
+
+        // If the value being wrapped has a column alias we will need to separate out
+        // the pieces so we can wrap each of the segments of the expression on its
+        // own, and then join these both back together using the "as" connector.
+        if (strpos(strtolower($value), ' as ') !== false) {
+            return $this->wrapAliasedValue($value, $prefixAlias);
+        }
+
+        // If the given value is a JSON selector we will wrap it differently than a
+        // traditional value. We will need to split this path and wrap each part
+        // wrapped, etc. Otherwise, we will simply wrap the value as a string.
+        if ($this->isJsonSelector($value)) {
+            return $this->wrapJsonSelector($value);
+        }
+
+        return $this->wrapSegments(explode('.', $value));
+    }
+
+    /**
+     * Wrap the given JSON selector.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function wrapJsonSelector($value)
+    {
+        throw new RuntimeException('This database engine does not support JSON operations.');
+    }
+
+    /**
+     * Determine if the given string is a JSON selector.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    protected function isJsonSelector($value)
+    {
+        return Str::contains($value, '->');
+    }
 
     /**
      * Compile a select query into SQL.
@@ -506,7 +559,7 @@ class Grammar extends BaseGrammar
         $not = $where['not'] ? 'not ' : '';
 
         return $not.$this->compileJsonContains(
-            $this->wrap($where['column']), $this->parameter($where['value'])
+            $where['column'], $this->parameter($where['value'])
         );
     }
 

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Illuminate\Database\Query\Builder;
 
 class PostgresGrammar extends Grammar
@@ -73,7 +72,7 @@ class PostgresGrammar extends Grammar
      */
     protected function compileJsonContains($column, $value)
     {
-        $column = str_replace('->>', '->', $column);
+        $column = str_replace('->>', '->', $this->wrap($column));
 
         return '('.$column.')::jsonb @> '.$value;
     }
@@ -300,28 +299,6 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Wrap a single string in keyword identifiers.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    protected function wrapValue($value)
-    {
-        if ($value === '*') {
-            return $value;
-        }
-
-        // If the given value is a JSON selector we will wrap it differently than a
-        // traditional value. We will need to split this path and wrap each part
-        // wrapped, etc. Otherwise, we will simply wrap the value as a string.
-        if (Str::contains($value, '->')) {
-            return $this->wrapJsonSelector($value);
-        }
-
-        return '"'.str_replace('"', '""', $value).'"';
-    }
-
-    /**
      * Wrap the given JSON selector.
      *
      * @param  string  $value
@@ -331,7 +308,7 @@ class PostgresGrammar extends Grammar
     {
         $path = explode('->', $value);
 
-        $field = $this->wrapValue(array_shift($path));
+        $field = $this->wrapSegments(explode('.', array_shift($path)));
 
         $wrappedPath = $this->wrapJsonPathAttributes($path);
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Illuminate\Database\Query\Builder;
 
 class SqlServerGrammar extends Grammar
@@ -113,11 +112,13 @@ class SqlServerGrammar extends Grammar
      */
     protected function compileJsonContains($column, $value)
     {
-        $from = $column[0] == '['
-                ? 'openjson('.$column.')'
-                : substr_replace($column, 'openjson', 0, strlen('json_value'));
+        $parts = explode('->', $column, 2);
 
-        return $value.' in (select [value] from '.$from.')';
+        $field = $this->wrap($parts[0]);
+
+        $path = count($parts) > 1 ? ', '.$this->wrapJsonPath($parts[1]) : '';
+
+        return $value.' in (select [value] from openjson('.$field.$path.'))';
     }
 
     /**
@@ -439,18 +440,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function wrapValue($value)
     {
-        if ($value === '*') {
-            return $value;
-        }
-
-        // If the given value is a JSON selector we will wrap it differently than a
-        // traditional value. We will need to split this path and wrap each part
-        // wrapped, etc. Otherwise, we will simply wrap the value as a string.
-        if (Str::contains($value, '->')) {
-            return $this->wrapJsonSelector($value);
-        }
-
-        return '['.str_replace(']', ']]', $value).']';
+        return $value === '*' ? $value : '['.str_replace(']', ']]', $value).']';
     }
 
     /**
@@ -461,13 +451,22 @@ class SqlServerGrammar extends Grammar
      */
     protected function wrapJsonSelector($value)
     {
-        $path = explode('->', $value);
+        $parts = explode('->', $value, 2);
 
-        $field = $this->wrapValue(array_shift($path));
+        $field = $this->wrapSegments(explode('.', array_shift($parts)));
 
-        return sprintf('json_value(%s, \'$.%s\')', $field, collect($path)->map(function ($part) {
-            return '"'.$part.'"';
-        })->implode('.'));
+        return 'json_value('.$field.', '.$this->wrapJsonPath($parts[0]).')';
+    }
+
+    /**
+     * Wrap the given JSON path.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function wrapJsonPath($value)
+    {
+        return '\'$."'.str_replace('->', '"."', $value).'"\'';
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2024,8 +2024,8 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from `users` where items->\'$."price"\' = 1', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
-        $builder->select('items->price')->from('users')->where('items->price', '=', 1)->orderBy('items->price');
-        $this->assertEquals('select `items`->\'$."price"\' from `users` where `items`->\'$."price"\' = ? order by `items`->\'$."price"\' asc', $builder->toSql());
+        $builder->select('items->price')->from('users')->where('users.items->price', '=', 1)->orderBy('items->price');
+        $this->assertEquals('select `items`->\'$."price"\' from `users` where `users`.`items`->\'$."price"\' = ? order by `items`->\'$."price"\' asc', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
@@ -2039,8 +2039,8 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testPostgresWrappingJson()
     {
         $builder = $this->getPostgresBuilder();
-        $builder->select('items->price')->from('users')->where('items->price', '=', 1)->orderBy('items->price');
-        $this->assertEquals('select "items"->>\'price\' from "users" where "items"->>\'price\' = ? order by "items"->>\'price\' asc', $builder->toSql());
+        $builder->select('items->price')->from('users')->where('users.items->price', '=', 1)->orderBy('items->price');
+        $this->assertEquals('select "items"->>\'price\' from "users" where "users"."items"->>\'price\' = ? order by "items"->>\'price\' asc', $builder->toSql());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
@@ -2054,8 +2054,8 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testSqlServerWrappingJson()
     {
         $builder = $this->getSqlServerBuilder();
-        $builder->select('items->price')->from('users')->where('items->price', '=', 1)->orderBy('items->price');
-        $this->assertEquals('select json_value([items], \'$."price"\') from [users] where json_value([items], \'$."price"\') = ? order by json_value([items], \'$."price"\') asc', $builder->toSql());
+        $builder->select('items->price')->from('users')->where('users.items->price', '=', 1)->orderBy('items->price');
+        $this->assertEquals('select json_value([items], \'$."price"\') from [users] where json_value([users].[items], \'$."price"\') = ? order by json_value([items], \'$."price"\') asc', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
@@ -2640,8 +2640,8 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['["en"]'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
-        $builder->select('*')->from('users')->whereJsonContains('options->languages', ['en']);
-        $this->assertEquals('select * from `users` where json_contains(`options`->\'$."languages"\', ?)', $builder->toSql());
+        $builder->select('*')->from('users')->whereJsonContains('users.options->languages', ['en']);
+        $this->assertEquals('select * from `users` where json_contains(`users`.`options`->\'$."languages"\', ?)', $builder->toSql());
         $this->assertEquals(['["en"]'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
@@ -2658,8 +2658,8 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['["en"]'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
-        $builder->select('*')->from('users')->whereJsonContains('options->languages', ['en']);
-        $this->assertEquals('select * from "users" where ("options"->\'languages\')::jsonb @> ?', $builder->toSql());
+        $builder->select('*')->from('users')->whereJsonContains('users.options->languages', ['en']);
+        $this->assertEquals('select * from "users" where ("users"."options"->\'languages\')::jsonb @> ?', $builder->toSql());
         $this->assertEquals(['["en"]'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
@@ -2685,8 +2685,8 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['true'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
-        $builder->select('*')->from('users')->whereJsonContains('options->languages', 'en');
-        $this->assertEquals('select * from [users] where ? in (select [value] from openjson([options], \'$."languages"\'))', $builder->toSql());
+        $builder->select('*')->from('users')->whereJsonContains('users.options->languages', 'en');
+        $this->assertEquals('select * from [users] where ? in (select [value] from openjson([users].[options], \'$."languages"\'))', $builder->toSql());
         $this->assertEquals(['en'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();


### PR DESCRIPTION
JSON queries on SQL Server don't yet support columns with table names:

```php
DB::table('users')->where('users.options->language', 'en')->get();
DB::table('users')->whereJsonContains('users.options->languages', 'en')->get();
```

Table names have been broken because JSON queries work differently on SQL Server: While MySQL and PostgreSQL use the arrow operator (`column->path`), SQL Server uses JSON functions.
This led to incorrect SQL: `where [users].json_value([options], '$."language"') = ?`.

Unfortunately, the fix requires some refactoring. We have to move the use of `wrapJsonSelector()` from `wrapValue()` up to `wrap()`. We could integrate it into `Database\Grammar::wrap()`, but I think that it rather belongs into `Database\Query\Grammars\Grammar` since it doesn't concern `Schema` grammars.

I also used the opportunity to improve the SQL Server grammar by extracting `wrapJsonPath()`. It's a better solution than replacing the names of JSON functions in SQL strings.

I added table name tests for all databases.

The PR is also a preparation for supporting JSON queries on MariaDB (https://github.com/laravel/ideas/issues/811):
When replacing MySQL's arrow operator with the equivalent `JSON_EXTRACT()`, we would have run into the same wrapping problems.