### PR TITLE
[5.6] Update contract to match implementation

### DIFF
--- a/src/Illuminate/View/ViewFinderInterface.php
+++ b/src/Illuminate/View/ViewFinderInterface.php
@@ -50,7 +50,7 @@ interface ViewFinderInterface
      *
      * @param  string  $namespace
      * @param  string|array  $hints
-     * @return $this
+     * @return void
      */
     public function replaceNamespace($namespace, $hints);
 


### PR DESCRIPTION
The `replaceNamespace` method says it returns the current object in the contract docblock but void in the implementation. Updated the contract to match other declarations on the interface.
