### PR TITLE
[5.6] Prevent calling the bootable trait boot method twice

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -190,9 +190,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $class = static::class;
 
+        $booted = [];
+
         foreach (class_uses_recursive($class) as $trait) {
-            if (method_exists($class, $method = 'boot'.class_basename($trait))) {
+            $method = 'boot'.class_basename($trait);
+
+            if (method_exists($class, $method) && ! in_array($method, $booted)) {
                 forward_static_call([$class, $method]);
+
+                $booted[] = $method;
             }
         }
     }


### PR DESCRIPTION
The User model in Spark for example uses the `Spark\Billable` trait which uses the `Cashier\Billable` trait, in `Model::bootTraits` method `class_uses_recursive` will return the two different Billable traits in the results, so if the Billable trait has a `bootBillable` method it'll be called twice:

One when `model::bootTrairs` found `Spark\Billable` and one when it found `Cashier\Billable`.

This PR prevents calling the trait boot method multiple times by keeping track of what methods were called and prevent calling them again.