### PR TITLE
[5.6] Allow contains helper function to do case insensitive check

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -99,10 +99,20 @@ class Str
      *
      * @param  string  $haystack
      * @param  string|array  $needles
+     * @param  bool  $caseSensitive
      * @return bool
      */
-    public static function contains($haystack, $needles)
+    public static function contains($haystack, $needles, $caseSensitive = true)
     {
+        // Normalise case if the check is case insensitive
+        if ($caseSensitive === false) {
+            $haystack = strtolower($haystack);
+
+            $needles = collect($needles)->map(function ($item) {
+                return strtolower($item);
+            })->toArray();
+        }
+
         foreach ((array) $needles as $needle) {
             if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
                 return true;

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -844,11 +844,12 @@ if (! function_exists('str_contains')) {
      *
      * @param  string  $haystack
      * @param  string|array  $needles
+     * @param  bool  $caseSensitive
      * @return bool
      */
-    function str_contains($haystack, $needles)
+    function str_contains($haystack, $needles, $caseSensitive = true)
     {
-        return Str::contains($haystack, $needles);
+        return Str::contains($haystack, $needles, $caseSensitive);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -281,6 +281,11 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(Str::contains('taylor', 'xxx'));
         $this->assertFalse(Str::contains('taylor', ['xxx']));
         $this->assertTrue(Str::contains('taylor', ['xxx', 'taylor']));
+
+        $this->assertFalse(Str::contains('taylor', ['xxx', 'TAYLOR']));
+        $this->assertFalse(Str::contains('taylor', 'TAYLOR'));
+        $this->assertTrue(Str::contains('taylor', ['xxx', 'TAYLOR'], false));
+        $this->assertTrue(Str::contains('taylor', 'TAYLOR', false));
     }
 
     public function testStrFinish()


### PR DESCRIPTION
Allow Str::contains helper function to do case insensitive check. This change is fully backwards compatible with the original functionality, it's just an extra parameter to switch to a case insensitive check.
