### PR TITLE
[5.7] rename parameter of Daily Driver logger from days to max_files

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -261,7 +261,7 @@ class LogManager implements LoggerInterface
     {
         return new Monolog($this->parseChannel($config), [
             $this->prepareHandler(new RotatingFileHandler(
-                $config['path'], $config['days'] ?? 7, $this->level($config),
+                $config['path'], $config['max_files'] ?? 0, $this->level($config),
                 $config['bubble'] ?? true, $config['permission'] ?? null, $config['locking'] ?? false
             )),
         ]);


### PR DESCRIPTION
It will be more clear to rename parameter 'days' of Daily Driver logger to 'max_files' because it show how many files will keep on disk.
Also changed the default value for 'max_files' from 7 to 0 ( '0' value mean unlimited files)

Related to https://github.com/laravel/laravel/pull/4684