### PR TITLE
[5.6] Make chunkById() work for non-incrementing/non-integer ids as well

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -622,7 +622,7 @@ class Builder
 
         $alias = is_null($alias) ? $column : $alias;
 
-        $lastId = 0;
+        $lastId = null;
 
         do {
             $clone = clone $this;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1805,7 +1805,7 @@ class Builder
      * Constrain the query to the next "page" of results after a given ID.
      *
      * @param  int  $perPage
-     * @param  int  $lastId
+     * @param  int|null  $lastId
      * @param  string  $column
      * @return \Illuminate\Database\Query\Builder|static
      */
@@ -1813,8 +1813,11 @@ class Builder
     {
         $this->orders = $this->removeExistingOrdersFor($column);
 
-        return $this->where($column, '>', $lastId)
-                    ->orderBy($column, 'asc')
+        if ($lastId !== null) {
+            $this->where($column, '>', $lastId);
+        }
+
+        return $this->orderBy($column, 'asc')
                     ->take($perPage);
     }
 
@@ -2088,7 +2091,7 @@ class Builder
     {
         $alias = $alias ?: $column;
 
-        $lastId = 0;
+        $lastId = null;
 
         do {
             $clone = clone $this;

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -366,6 +366,25 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertFalse($model->wasRecentlyCreated);
     }
 
+    public function testChunkByIdWithNonIncrementingKey()
+    {
+        EloquentTestNonIncrementingSecond::create(['name' => ' First']);
+        EloquentTestNonIncrementingSecond::create(['name' => ' Second']);
+        EloquentTestNonIncrementingSecond::create(['name' => ' Third']);
+
+        $i = 0;
+        EloquentTestNonIncrementingSecond::query()->chunkById(2, function (Collection $users) use (&$i) {
+            if (! $i) {
+                $this->assertEquals(' First', $users[0]->name);
+                $this->assertEquals(' Second', $users[1]->name);
+            } else {
+                $this->assertEquals(' Third', $users[0]->name);
+            }
+            $i++;
+        }, 'name');
+        $this->assertEquals(2, $i);
+    }
+
     public function testPluck()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
@@ -1305,6 +1324,11 @@ class EloquentTestNonIncrementing extends Eloquent
     protected $guarded = [];
     public $incrementing = false;
     public $timestamps = false;
+}
+
+class EloquentTestNonIncrementingSecond extends EloquentTestNonIncrementing
+{
+    protected $connection = 'second_connection';
 }
 
 class EloquentTestUserWithGlobalScope extends EloquentTestUser


### PR DESCRIPTION
Currently, chunkById() adds a redundant (wrong) condition to the where clause in the first loop: `id > 0`. The reason this condition is wrong is because it does not work if the type of key (id) is not a positive integer. A related issue exists in laravel-mongodb package. See https://github.com/jenssegers/laravel-mongodb/issues/1538.
