### PR TITLE
[5.6] Two Azure SQL Server "connection lost" messages

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -32,6 +32,8 @@ trait DetectsLostConnections
             'child connection forced to terminate due to client_idle_limit',
             'query_wait_timeout',
             'reset by peer',
+            'Physical connection is not usable',
+            'TCP Provider: Error code 0x68',
         ]);
     }
 }


### PR DESCRIPTION
More Info: https://github.com/laravel/framework/issues/23925 and  https://github.com/illuminate/database/pull/234  

Using SQL Server database laravel doesn't handle dropped connections in workers so we end up with
`ERROR: SQLSTATE[08S02]: [Microsoft][ODBC Driver 13 for SQL Server]SMux Provider: Physical connection is not usable [xFFFFFFFF].`

As @judgej says though, might be worth looking into a solution for non-english errors? But thats for discussion on another issue.