### PR TITLE
[5.7] Add Arr::stack() method.

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -462,6 +462,29 @@ class Arr
     }
 
     /**
+     * Add a value to an existing key.
+     *
+     * @param  array  $array
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public static function push(&$array, $key, $value)
+    {
+        if ($key === null || trim($key) === '') {
+            return $array = [];
+        }
+
+        $previous = static::get($array, $key, []);
+        $previous = is_array($previous) ? $previous : [];
+        $previous[] = $value;
+
+        static::set($array, $key, $previous);
+
+        return $array;
+    }
+
+    /**
      * Get one or a specified number of random values from an array.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use Exception;
 use ArrayAccess;
 use InvalidArgumentException;
 use Illuminate\Support\Traits\Macroable;
@@ -468,7 +469,8 @@ class Arr
      * @param  string  $key
      * @param  mixed  $value
      * @return mixed
-     * @throws \InvalidArgumentException
+     *
+     * @throws \Exception
      */
     public static function stack(&$array, $key, $value)
     {
@@ -479,7 +481,7 @@ class Arr
         $previous = static::get($array, $key, []);
 
         if (is_array($previous) === false) {
-            throw new InvalidArgumentException;
+            throw new Exception;
         }
 
         $previous[] = $value;

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -472,7 +472,7 @@ class Arr
     public static function push(&$array, $key, $value)
     {
         if ($key === null || trim($key) === '') {
-            return $array = [];
+            return $array;
         }
 
         $previous = static::get($array, $key, []);

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -468,6 +468,7 @@ class Arr
      * @param  string  $key
      * @param  mixed  $value
      * @return mixed
+     * @throws \InvalidArgumentException
      */
     public static function stack(&$array, $key, $value)
     {
@@ -476,7 +477,11 @@ class Arr
         }
 
         $previous = static::get($array, $key, []);
-        $previous = is_array($previous) ? $previous : [];
+
+        if (is_array($previous) === false) {
+            throw new InvalidArgumentException;
+        }
+
         $previous[] = $value;
 
         static::set($array, $key, $previous);

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -469,7 +469,7 @@ class Arr
      * @param  mixed  $value
      * @return mixed
      */
-    public static function push(&$array, $key, $value)
+    public static function stack(&$array, $key, $value)
     {
         if ($key === null || trim($key) === '') {
             return $array;

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -486,9 +486,7 @@ class Arr
 
         $previous[] = $value;
 
-        static::set($array, $key, $previous);
-
-        return $array;
+        return static::set($array, $key, $previous);
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -304,6 +304,23 @@ if (! function_exists('array_sort_recursive')) {
     }
 }
 
+if (! function_exists('array_stack')) {
+    /**
+     * Add a value to an existing key.
+     *
+     * @param  array  $array
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return array
+     *
+     * @throws \Exception
+     */
+    function array_stack($array, $key, $value)
+    {
+        return Arr::stack($array, $key, $value);
+    }
+}
+
 if (! function_exists('array_where')) {
     /**
      * Filter the array using the given callback.

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -419,6 +419,32 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']], $array);
     }
 
+    public function testPush()
+    {
+        $array = ['key' => [['xxx' => 'yyy']]];
+        Arr::push($array, null, ['foo' => 'bar']);
+        $this->assertSame([], $array);
+        Arr::push($array, '', ['foo' => 'bar']);
+        $this->assertSame([], $array);
+
+        $array = [];
+        Arr::push($array, 'key', ['foo' => 'bar']);
+        $this->assertSame('bar', Arr::get($array, 'key.0.foo'));
+
+        $array = ['key' => []];
+        Arr::push($array, 'key', ['foo' => 'bar']);
+        $this->assertSame('bar', Arr::get($array, 'key.0.foo'));
+
+        $array = ['key' => [['xxx' => 'yyy']]];
+        Arr::push($array, 'key', ['foo' => 'bar']);
+        $this->assertSame('yyy', Arr::get($array, 'key.0.xxx'));
+        $this->assertSame('bar', Arr::get($array, 'key.1.foo'));
+
+        $array = ['key' => true];
+        Arr::push($array, 'key', ['foo' => 'bar']);
+        $this->assertSame('bar', Arr::get($array, 'key.0.foo'));
+    }
+
     public function testRandom()
     {
         $random = Arr::random(['foo', 'bar', 'baz']);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -437,10 +437,15 @@ class SupportArrTest extends TestCase
         Arr::stack($array, 'key', ['foo' => 'bar']);
         $this->assertSame('yyy', Arr::get($array, 'key.0.xxx'));
         $this->assertSame('bar', Arr::get($array, 'key.1.foo'));
+    }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testStackThrowsAnException()
+    {
         $array = ['key' => true];
         Arr::stack($array, 'key', ['foo' => 'bar']);
-        $this->assertSame('bar', Arr::get($array, 'key.0.foo'));
     }
 
     public function testRandom()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -422,10 +422,8 @@ class SupportArrTest extends TestCase
     public function testPush()
     {
         $array = ['key' => [['xxx' => 'yyy']]];
-        Arr::push($array, null, ['foo' => 'bar']);
-        $this->assertSame([], $array);
-        Arr::push($array, '', ['foo' => 'bar']);
-        $this->assertSame([], $array);
+        $this->assertSame($array, Arr::push($array, null, ['foo' => 'bar']));
+        $this->assertSame($array, Arr::push($array, '', ['foo' => 'bar']));
 
         $array = [];
         Arr::push($array, 'key', ['foo' => 'bar']);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -440,7 +440,7 @@ class SupportArrTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException \Exception
      */
     public function testStackThrowsAnException()
     {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -419,27 +419,27 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']], $array);
     }
 
-    public function testPush()
+    public function testStack()
     {
         $array = ['key' => [['xxx' => 'yyy']]];
-        $this->assertSame($array, Arr::push($array, null, ['foo' => 'bar']));
-        $this->assertSame($array, Arr::push($array, '', ['foo' => 'bar']));
+        $this->assertSame($array, Arr::stack($array, null, ['foo' => 'bar']));
+        $this->assertSame($array, Arr::stack($array, '', ['foo' => 'bar']));
 
         $array = [];
-        Arr::push($array, 'key', ['foo' => 'bar']);
+        Arr::stack($array, 'key', ['foo' => 'bar']);
         $this->assertSame('bar', Arr::get($array, 'key.0.foo'));
 
         $array = ['key' => []];
-        Arr::push($array, 'key', ['foo' => 'bar']);
+        Arr::stack($array, 'key', ['foo' => 'bar']);
         $this->assertSame('bar', Arr::get($array, 'key.0.foo'));
 
         $array = ['key' => [['xxx' => 'yyy']]];
-        Arr::push($array, 'key', ['foo' => 'bar']);
+        Arr::stack($array, 'key', ['foo' => 'bar']);
         $this->assertSame('yyy', Arr::get($array, 'key.0.xxx'));
         $this->assertSame('bar', Arr::get($array, 'key.1.foo'));
 
         $array = ['key' => true];
-        Arr::push($array, 'key', ['foo' => 'bar']);
+        Arr::stack($array, 'key', ['foo' => 'bar']);
         $this->assertSame('bar', Arr::get($array, 'key.0.foo'));
     }
 


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR introduce a `\Illuminate\Support\Arr::stack()` method (in lack of a better name).

This method give the ability to push a value onto an array using dot notation.

This PR targets `5.7` on purpose, as some developer might already have a `stack` macro.