### PR TITLE
[5.6] Get rid of useless temporary variables when returning the result of a function

### DIFF
--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -143,13 +143,11 @@ class AuthPasswordBrokerTest extends TestCase
 
     protected function getMocks()
     {
-        $mocks = [
+        return [
             'tokens' => m::mock('Illuminate\Auth\Passwords\TokenRepositoryInterface'),
             'users'  => m::mock('Illuminate\Contracts\Auth\UserProvider'),
             'mailer' => m::mock('Illuminate\Contracts\Mail\Mailer'),
             'view'   => 'resetLinkView',
         ];
-
-        return $mocks;
     }
 }

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -50,10 +50,8 @@ class ConsoleApplicationTest extends TestCase
         $app = m::mock('Illuminate\Contracts\Foundation\Application', ['version' => '5.6']);
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher', ['dispatch' => null]);
 
-        $console = $this->getMockBuilder('Illuminate\Console\Application')->setMethods($methods)->setConstructorArgs([
+        return $this->getMockBuilder('Illuminate\Console\Application')->setMethods($methods)->setConstructorArgs([
             $app, $events, 'test-version',
         ])->getMock();
-
-        return $console;
     }
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -286,9 +286,7 @@ class ContainerTest extends TestCase
             $_SERVER['_test_rebind'] = true;
         });
         $container->bind('foo', function () {
-            $obj = new stdClass;
-
-            return $obj;
+            return new stdClass;
         });
 
         $this->assertFalse($_SERVER['_test_rebind']);

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -155,6 +155,7 @@ class DatabaseEloquentMorphToTest extends TestCase
         $this->related->shouldReceive('getTable')->andReturn('relation');
         $this->builder->shouldReceive('getModel')->andReturn($this->related);
         $parent = $parent ?: new EloquentMorphToModelStub;
+
         return m::mock('Illuminate\Database\Eloquent\Relations\MorphTo[createModelByType]', [$this->builder, $parent, 'foreign_key', 'id', 'morph_type', 'relation']);
     }
 }

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -155,9 +155,7 @@ class DatabaseEloquentMorphToTest extends TestCase
         $this->related->shouldReceive('getTable')->andReturn('relation');
         $this->builder->shouldReceive('getModel')->andReturn($this->related);
         $parent = $parent ?: new EloquentMorphToModelStub;
-        $morphTo = m::mock('Illuminate\Database\Eloquent\Relations\MorphTo[createModelByType]', [$this->builder, $parent, 'foreign_key', 'id', 'morph_type', 'relation']);
-
-        return $morphTo;
+        return m::mock('Illuminate\Database\Eloquent\Relations\MorphTo[createModelByType]', [$this->builder, $parent, 'foreign_key', 'id', 'morph_type', 'relation']);
     }
 }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2830,12 +2830,10 @@ class DatabaseQueryBuilderTest extends TestCase
      */
     protected function getMockQueryBuilder()
     {
-        $builder = m::mock('Illuminate\Database\Query\Builder', [
+        return m::mock('Illuminate\Database\Query\Builder', [
             m::mock('Illuminate\Database\ConnectionInterface'),
             new \Illuminate\Database\Query\Grammars\Grammar,
             m::mock('Illuminate\Database\Query\Processors\Processor'),
         ])->makePartial();
-
-        return $builder;
     }
 }


### PR DESCRIPTION


<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Get rid of useless temporary variables when returning the result of a function
