### PR TITLE
[5.7] Allow Gates / Policies To Accept "Guests"

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -26,6 +26,24 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->check('bar'));
     }
 
+    public function test_closures_can_allow_guest_users()
+    {
+        $gate = new Gate(new Container, function () {
+            return null;
+        });
+
+        $gate->define('foo', function (?StdClass $user) {
+            return true;
+        });
+
+        $gate->define('bar', function (StdClass $user) {
+            return false;
+        });
+
+        $this->assertTrue($gate->check('foo'));
+        $this->assertFalse($gate->check('bar'));
+    }
+
     public function test_resource_gates_can_be_defined()
     {
         $gate = $this->getBasicGate();

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -44,6 +44,91 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->check('bar'));
     }
 
+    public function test_policies_can_allow_guests()
+    {
+        unset($_SERVER['__laravel.testBefore']);
+
+        $gate = new Gate(new Container, function () {
+            return null;
+        });
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyThatAllowsGuests::class);
+
+        $this->assertTrue($gate->check('edit', new AccessGateTestDummy));
+        $this->assertFalse($gate->check('update', new AccessGateTestDummy));
+        $this->assertTrue($_SERVER['__laravel.testBefore']);
+
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyThatAllowsGuests::class);
+
+        $this->assertTrue($gate->check('edit', new AccessGateTestDummy));
+        $this->assertTrue($gate->check('update', new AccessGateTestDummy));
+
+        unset($_SERVER['__laravel.testBefore']);
+    }
+
+    public function test_policy_before_not_called_with_guests_if_it_doesnt_allow_them()
+    {
+        $_SERVER['__laravel.testBefore'] = false;
+
+        $gate = new Gate(new Container, function () {
+            return null;
+        });
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithNonGuestBefore::class);
+
+        $this->assertTrue($gate->check('edit', new AccessGateTestDummy));
+        $this->assertFalse($gate->check('update', new AccessGateTestDummy));
+        $this->assertFalse($_SERVER['__laravel.testBefore']);
+
+        unset($_SERVER['__laravel.testBefore']);
+    }
+
+    public function test_before_and_after_callbacks_can_allow_guests()
+    {
+        $_SERVER['__laravel.gateBefore'] = false;
+        $_SERVER['__laravel.gateBefore2'] = false;
+        $_SERVER['__laravel.gateAfter'] = false;
+        $_SERVER['__laravel.gateAfter2'] = false;
+
+        $gate = new Gate(new Container, function () {
+            return null;
+        });
+
+        $gate->before(function (?StdClass $user) {
+            $_SERVER['__laravel.gateBefore'] = true;
+        });
+
+        $gate->after(function (?StdClass $user) {
+            $_SERVER['__laravel.gateAfter'] = true;
+        });
+
+        $gate->before(function (StdClass $user) {
+            $_SERVER['__laravel.gateBefore2'] = true;
+        });
+
+        $gate->after(function (StdClass $user) {
+            $_SERVER['__laravel.gateAfter2'] = true;
+        });
+
+        $gate->define('foo', function ($user = null) {
+            return true;
+        });
+
+        $this->assertTrue($gate->check('foo'));
+
+        $this->assertTrue($_SERVER['__laravel.gateBefore']);
+        $this->assertFalse($_SERVER['__laravel.gateBefore2']);
+        $this->assertTrue($_SERVER['__laravel.gateAfter']);
+        $this->assertFalse($_SERVER['__laravel.gateAfter2']);
+
+        unset($_SERVER['__laravel.gateBefore']);
+        unset($_SERVER['__laravel.gateBefore2']);
+        unset($_SERVER['__laravel.gateAfter']);
+        unset($_SERVER['__laravel.gateAfter2']);
+    }
+
     public function test_resource_gates_can_be_defined()
     {
         $gate = $this->getBasicGate();
@@ -532,6 +617,42 @@ class AccessGateTestPolicyWithNoPermissions
 class AccessGateTestPolicyWithAllPermissions
 {
     public function edit($user, AccessGateTestDummy $dummy)
+    {
+        return true;
+    }
+
+    public function update($user, AccessGateTestDummy $dummy)
+    {
+        return true;
+    }
+}
+
+class AccessGateTestPolicyThatAllowsGuests
+{
+    public function before(?StdClass $user)
+    {
+        $_SERVER['__laravel.testBefore'] = true;
+    }
+
+    public function edit(?StdClass $user, AccessGateTestDummy $dummy)
+    {
+        return true;
+    }
+
+    public function update($user, AccessGateTestDummy $dummy)
+    {
+        return true;
+    }
+}
+
+class AccessGateTestPolicyWithNonGuestBefore
+{
+    public function before(StdClass $user)
+    {
+        $_SERVER['__laravel.testBefore'] = true;
+    }
+
+    public function edit(?StdClass $user, AccessGateTestDummy $dummy)
     {
         return true;
     }


### PR DESCRIPTION
This PR allows gates and policies to allow "guest users" (`null`) to be passed to them instead of automatically returning `false`. They can allow this by marking their user type-hint as optional or providing a `null` default value for the incoming user:

```php
$gate->define('foo', function (?User $user) {
    return true;
});
```

The same convention can be used for policy methods as well as before and after callbacks.