### PR TITLE
[5.7] Show error view when validation fails on GET requests

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -248,9 +248,17 @@ class Handler implements ExceptionHandlerContract
      */
     protected function invalid($request, ValidationException $exception)
     {
-        return redirect($exception->redirectTo ?? url()->previous())
-                    ->withInput($request->except($this->dontFlash))
-                    ->withErrors($exception->errors(), $exception->errorBag);
+        $url = $exception->redirectTo ?? url()->previous();
+
+        if ($request->isMethod('get') && strtok($url, '?') === url()->current()) {
+            $this->registerErrorViewPaths();
+
+            return response()->view('errors::validation', ['message' => $exception->getMessage()]);
+        }
+
+        return redirect($url)
+            ->withInput($request->except($this->dontFlash))
+            ->withErrors($exception->errors(), $exception->errorBag);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/views/validation.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/validation.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::layout')
+
+@section('title', 'Error')
+
+@section('message', $message)


### PR DESCRIPTION
When using validation on a GET request, the default behaviour causes an infinite redirection loop. This PR checks if the user will be redirected back to the same url, in which case displays an error view instead of causing an infinite redirection loop.