### PR TITLE
[5.6] Add method to test Json is missing validation errors for given keys

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -623,6 +623,33 @@ class TestResponse
     }
 
     /**
+     * Assert that the response has no JSON validation errors for the given keys.
+     *
+     * @param  string|array  $keys
+     * @return $this
+     */
+    public function assertJsonMissingValidationErrors($keys)
+    {
+        $json = $this->json();
+
+        if (! array_key_exists('errors', $json)) {
+            PHPUnit::assertArrayNotHasKey('errors', $json);
+            return $this;
+        }
+
+        $errors = $json['errors'];
+
+        foreach (Arr::wrap($keys) as $key) {
+            PHPUnit::assertFalse(
+                isset($errors[$key]),
+                "Found a validation error in the response for key: '{$key}'"
+            );
+        }
+
+        return $this;
+    }
+
+    /**
      * Validate and return the decoded response JSON.
      *
      * @param  string|null  $key
@@ -808,6 +835,37 @@ class TestResponse
                 PHPUnit::assertTrue($errors->has($value), "Session missing error: $value");
             } else {
                 PHPUnit::assertContains($value, $errors->get($key, $format));
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the session does not have the given errors.
+     *
+     * @param  string|array  $keys
+     * @param  mixed  $format
+     * @param  string  $errorBag
+     * @return $this
+     */
+    public function assertSessionMissingErrors($keys = [], $format = null, $errorBag = 'default')
+    {
+        if (!$this->session()->has('errors')) {
+             PhpUnit::assertEmpty($this->session()->has('errors'));
+             
+             return $this;
+        }
+
+        $keys = (array) $keys;
+
+        $errors = $this->session()->get('errors')->getBag($errorBag);
+
+        foreach ($keys as $key => $value) {
+            if (is_int($key)) {
+                PHPUnit::assertFalse($errors->has($value), "Session has error: $value");
+            } else {
+                PHPUnit::assertNotContains($value, $errors->get($key, $format));
             }
         }
 

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use Exception;
 use JsonSerializable;
 use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
@@ -214,6 +215,42 @@ class FoundationTestResponseTest extends TestCase
         // Without structure
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
         $response->assertJsonCount(4);
+    }
+
+    public function testAssertJsonMissingValidationErrors()
+    {
+         $baseResponse = tap(new Response, function ($response) {
+            $response->setContent(json_encode(['errors' => [
+                    'foo' => [],
+                    'bar' => ['one', 'two'],
+                ]]
+            ));
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        try {
+            $response->assertJsonMissingValidationErrors('foo');
+            $this->fail('No exception was thrown');
+        }
+        catch (Exception $e) {
+        }
+
+        try {
+            $response->assertJsonMissingValidationErrors('bar');
+            $this->fail('No exception was thrown');
+        }
+        catch (Exception $e) {
+        }
+
+        $response->assertJsonMissingValidationErrors('baz');
+
+        $baseResponse = tap(new Response, function ($response) {
+            $response->setContent(json_encode(['foo' => 'bar']));
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertJsonMissingValidationErrors('foo');
     }
 
     public function testMacroable()


### PR DESCRIPTION
Additional helper method, opposite of `assertJsonValidationErrors()`