### PR TITLE
[5.6] Add method to test Json is missing validation errors for given keys

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -622,7 +622,6 @@ class TestResponse
         return $this;
     }
 
-
     /**
      * Assert that the response has no JSON validation errors for the given keys.
      *
@@ -632,7 +631,7 @@ class TestResponse
     public function assertJsonMissingValidationErrors($keys)
     {
         $json = $this->json();
-        
+
         if (! array_key_exists('errors', $json)) {
             PHPUnit::assertArrayNotHasKey('errors', $json);
 

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -622,6 +622,35 @@ class TestResponse
         return $this;
     }
 
+
+    /**
+     * Assert that the response has no JSON validation errors for the given keys.
+     *
+     * @param  string|array  $keys
+     * @return $this
+     */
+    public function assertJsonMissingValidationErrors($keys)
+    {
+        $json = $this->json();
+        
+        if (! array_key_exists('errors', $json)) {
+            PHPUnit::assertArrayNotHasKey('errors', $json);
+
+            return $this;
+        }
+
+        $errors = $json['errors'];
+
+        foreach (Arr::wrap($keys) as $key) {
+            PHPUnit::assertFalse(
+                isset($errors[$key]),
+                "Found a validation error in the response for key: '{$key}'"
+            );
+        }
+
+        return $this;
+    }
+
     /**
      * Validate and return the decoded response JSON.
      *

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -249,7 +249,7 @@ class FoundationTestResponseTest extends TestCase
 
         $response = TestResponse::fromBaseResponse($baseResponse);
         $response->assertJsonMissingValidationErrors('foo');
-    }    
+    }
 
     public function testMacroable()
     {


### PR DESCRIPTION
Additional helper method, opposite of `assertJsonValidationErrors()`