### PR TITLE
[5.7] Make array values to work as expected for retrieveByCredentials method

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -111,7 +111,7 @@ class DatabaseUserProvider implements UserProvider
 
         foreach ($credentials as $key => $value) {
             if (! Str::contains($key, 'password')) {
-                $query->where($key, $value);
+                is_array($value) ? $query->whereIn($key, $value) : $query->where($key, $value);
             }
         }
 

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -114,7 +114,7 @@ class EloquentUserProvider implements UserProvider
 
         foreach ($credentials as $key => $value) {
             if (! Str::contains($key, 'password')) {
-                $query->where($key, $value);
+                is_array($value) ? $query->whereIn($key, $value) : $query->where($key, $value);
             }
         }
 

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -87,10 +87,11 @@ class AuthDatabaseUserProviderTest extends TestCase
         $conn = m::mock('Illuminate\Database\Connection');
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('where')->once()->with('username', 'dayle');
+        $conn->shouldReceive('whereIn')->once()->with('group', ['one', 'two']);
         $conn->shouldReceive('first')->once()->andReturn(['id' => 1, 'name' => 'taylor']);
         $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
-        $user = $provider->retrieveByCredentials(['username' => 'dayle', 'password' => 'foo']);
+        $user = $provider->retrieveByCredentials(['username' => 'dayle', 'password' => 'foo', 'group' => ['one', 'two']]);
 
         $this->assertInstanceOf('Illuminate\Auth\GenericUser', $user);
         $this->assertEquals(1, $user->getAuthIdentifier());

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -78,9 +78,10 @@ class AuthEloquentUserProviderTest extends TestCase
         $mock = m::mock('stdClass');
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('where')->once()->with('username', 'dayle');
+        $mock->shouldReceive('whereIn')->once()->with('group', ['one', 'two']);
         $mock->shouldReceive('first')->once()->andReturn('bar');
         $provider->expects($this->once())->method('createModel')->will($this->returnValue($mock));
-        $user = $provider->retrieveByCredentials(['username' => 'dayle', 'password' => 'foo']);
+        $user = $provider->retrieveByCredentials(['username' => 'dayle', 'password' => 'foo', 'group' => ['one', 'two']]);
 
         $this->assertEquals('bar', $user);
     }


### PR DESCRIPTION
Recently I was implementing own `credentials` method in `ResetPasswordController` and it looked something like this:

```
protected function credentials(Request $request)
{
    return [
        'email' => $request->input('email'),
        'password' => $request->input('password'),
        'token' => $request->input('token'),
        'group' => User::GROUP_OWNER,
        'status' => [User::STATUS_OK, User::STATUS_PENDING],
    ];
} 
```

I was quite surprised by generated query. For `status` column it contained only:

```
AND status = 'ok' 
```

and not

```
AND status IN ('ok', 'pending')
```

The most important thing: no exception was thrown so if I didn't have tests I wouldn't know about the problem. 

In my opinion this is in fact bug fix/improvement, but it can break existing applications, so I think it's better to target 5.7 instead of 5.6 