### PR TITLE
[5.6] Remove unused import

### DIFF
--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -5,7 +5,6 @@ namespace Illuminate\Foundation\Providers;
 use Illuminate\Routing\Redirector;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Http\FormRequest;
-use Symfony\Component\HttpFoundation\Request;
 use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 
 class FormRequestServiceProvider extends ServiceProvider


### PR DESCRIPTION
It seems import is not necessary since this commit: https://github.com/laravel/framework/commit/b0c2459d7e55519d1c61927ab526e489a3a52eaf