### PR TITLE
[5.6] Use $numericKeys parameter instead of another check

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -80,8 +80,7 @@ trait ConditionallyLoadsAttributes
             }
         }
 
-        return ! empty($data) && is_numeric(array_keys($data)[0])
-                        ? array_values($data) : $data;
+        return ! empty($data) && $numericKeys ? array_values($data) : $data;
     }
 
     /**


### PR DESCRIPTION
@taylorotwell This can be potentially breaking change as it changes they way how verification was made (so in theory result can differ). But I believe this `$numericKeys` parameter was supposed to be used here when you were making changes in https://github.com/laravel/framework/pull/23369 but probably you know better 😄 

Ok, it seems tests are failing now. So maybe we should just remove this parameter completely assuming tests are working as expected?