### PR TITLE
[5.6] Allow callable array syntax in route definition 'uses' keyword

### DIFF
--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -42,6 +42,11 @@ class RouteAction
             $action['uses'] = static::findCallable($action);
         }
 
+        if (\is_array($action['uses']) && \is_callable($action['uses'])) {
+            $action['uses'] = implode('@', $action['uses']);
+            $action['controller'] = $action['uses'];
+        }
+
         if (is_string($action['uses']) && ! Str::contains($action['uses'], '@')) {
             $action['uses'] = static::makeInvokable($action['uses']);
         }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1311,6 +1311,28 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('Illuminate\Tests\Routing\RouteTestControllerStub@index', $action);
     }
 
+    public function testControllerRoutingUsesArrayCallable()
+    {
+        unset(
+            $_SERVER['route.test.controller.middleware'], $_SERVER['route.test.controller.except.middleware'],
+            $_SERVER['route.test.controller.middleware.class'],
+            $_SERVER['route.test.controller.middleware.parameters.one'], $_SERVER['route.test.controller.middleware.parameters.two']
+        );
+
+        $router = $this->getRouter();
+
+        $router->get('foo/bar', ['uses' => [RouteTestControllerStub::class, 'index']]);
+
+        $this->assertEquals('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertTrue($_SERVER['route.test.controller.middleware']);
+        $this->assertEquals(\Illuminate\Http\Response::class, $_SERVER['route.test.controller.middleware.class']);
+        $this->assertEquals(0, $_SERVER['route.test.controller.middleware.parameters.one']);
+        $this->assertEquals(['foo', 'bar'], $_SERVER['route.test.controller.middleware.parameters.two']);
+        $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
+        $action = $router->getRoutes()->getRoutes()[0]->getAction()['controller'];
+        $this->assertEquals('Illuminate\Tests\Routing\RouteTestControllerStub@index', $action);
+    }
+
     public function testCallableControllerRouting()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
Extension of PR #24385,  [comment by @rentalhost](https://github.com/laravel/framework/pull/24385#issuecomment-396682072) requesting array callable syntax for 'uses' keyword in route definition: `\Route::get('x', [ 'uses' => [ A::class, 'b' ] ])`