### PR TITLE
[5.6] Update sub-query functions on query builder to accept EloquentBuilder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -319,7 +319,7 @@ class Builder
      */
     protected function parseSub($query)
     {
-        if ($query instanceof self) {
+        if ($query instanceof self || $query instanceof EloquentBuilder) {
             return [$query->toSql(), $query->getBindings()];
         } elseif (is_string($query)) {
             return [$query, []];

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Query\Expression as Raw;
 use Illuminate\Pagination\AbstractPaginator as Paginator;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class DatabaseQueryBuilderTest extends TestCase
 {
@@ -1369,6 +1370,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->joinSub(function ($q) {
             $q->from('contacts');
         }, 'sub', 'users.id', '=', 'sub.id');
+        $this->assertEquals('select * from "users" inner join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $eloquentBuilder = new EloquentBuilder($this->getBuilder()->from('contacts'));
+        $builder->from('users')->joinSub($eloquentBuilder, 'sub', 'users.id', '=', 'sub.id');
         $this->assertEquals('select * from "users" inner join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
 
         $builder = $this->getBuilder();


### PR DESCRIPTION
This closes https://github.com/laravel/framework/issues/24594.

This PR updates the `parseSub` function on `QueryBuilder` to operate on instances of `EloquentBuilder` as well. The issue linked above has details on use case, but tl;dr is that sometimes we use the `EloquentBuilder` to build queries and that should not prevent the use of the sub-query functions.

Definitely open to changing how we check for objects that respond to `toSql` and `getBindings` but I couldn't find an interface or parent class that both `Query\Builder` and `Eloquent\Builder` implemented.