### PR TITLE
[5.7] Recursively resolve Responsable objects

### DIFF
--- a/src/Illuminate/Contracts/Support/Responsable.php
+++ b/src/Illuminate/Contracts/Support/Responsable.php
@@ -8,7 +8,7 @@ interface Responsable
      * Create an HTTP response that represents the object.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\Response|\Illuminate\Contracts\Support\Responsable
      */
     public function toResponse($request);
 }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -170,7 +170,7 @@ class Handler implements ExceptionHandlerContract
         if (method_exists($e, 'render') && $response = $e->render($request)) {
             return Router::toResponse($request, $response);
         } elseif ($e instanceof Responsable) {
-            return $e->toResponse($request);
+            return Router::resolveResponsable($e, $request);
         }
 
         $e = $this->prepareException($e);

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Str;
+use Illuminate\Routing\Router;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\HtmlString;
 use Illuminate\Container\Container;
@@ -38,7 +39,7 @@ if (! function_exists('abort')) {
         if ($code instanceof Response) {
             throw new HttpResponseException($code);
         } elseif ($code instanceof Responsable) {
-            throw new HttpResponseException($code->toResponse(request()));
+            throw new HttpResponseException(Router::resolveResponsable($code), request());
         }
 
         app()->abort($code, $message, $headers);

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -5,8 +5,8 @@ namespace Illuminate\Pipeline;
 use Closure;
 use RuntimeException;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\Pipeline\Pipeline as PipelineContract;
 
 class Pipeline implements PipelineContract
@@ -151,9 +151,7 @@ class Pipeline implements PipelineContract
                                 ? $pipe->{$this->method}(...$parameters)
                                 : $pipe(...$parameters);
 
-                return $response instanceof Responsable
-                            ? $response->toResponse($this->container->make(Request::class))
-                            : $response;
+                return Router::resolveResponsable($response, $this->container->make(Request::class));
             };
         };
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -714,9 +714,7 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public static function toResponse($request, $response)
     {
-        if ($response instanceof Responsable) {
-            $response = $response->toResponse($request);
-        }
+        $response = static::resolveResponsable($response, $request);
 
         if ($response instanceof PsrResponseInterface) {
             $response = (new HttpFoundationFactory)->createResponse($response);
@@ -738,6 +736,15 @@ class Router implements RegistrarContract, BindingRegistrar
         }
 
         return $response->prepare($request);
+    }
+
+    public static function resolveResponsable($response, $request)
+    {
+        while ($response instanceof Responsable) {
+            $response = $response->toResponse($request);
+        }
+
+        return $response;
     }
 
     /**

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -80,6 +80,13 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertSame('{"response":"My custom exception response"}', $response);
     }
 
+    public function testReturnsCustomResponseWhenExceptionImplementsResponsableAndHasNestedResponsableChildren()
+    {
+        $response = $this->handler->render($this->request, new CustomExceptionWithNestedResponsableChild)->getContent();
+
+        $this->assertSame('{"response":"My custom exception response"}', $response);
+    }
+
     public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalseAndExceptionMessageIsMasked()
     {
         $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(false);
@@ -131,5 +138,13 @@ class CustomException extends Exception implements Responsable
     public function toResponse($request)
     {
         return response()->json(['response' => 'My custom exception response']);
+    }
+}
+
+class CustomExceptionWithNestedResponsableChild extends Exception implements Responsable
+{
+    public function toResponse($request)
+    {
+        return new CustomException;
     }
 }

--- a/tests/Integration/Routing/ResponsableTest.php
+++ b/tests/Integration/Routing/ResponsableTest.php
@@ -23,6 +23,19 @@ class ResponsableTest extends TestCase
         $this->assertEquals('Taylor', $response->headers->get('X-Test-Header'));
         $this->assertEquals('hello world', $response->getContent());
     }
+
+    public function test_nested_responsable_objects_are_rendered()
+    {
+        Route::get('/responsable', function () {
+            return new TestResponsableResponseWithNestedChild;
+        });
+
+        $response = $this->get('/responsable');
+
+        $this->assertEquals(201, $response->status());
+        $this->assertEquals('Taylor', $response->headers->get('X-Test-Header'));
+        $this->assertEquals('hello world', $response->getContent());
+    }
 }
 
 class TestResponsableResponse implements Responsable
@@ -30,5 +43,13 @@ class TestResponsableResponse implements Responsable
     public function toResponse($request)
     {
         return response('hello world', 201, ['X-Test-Header' => 'Taylor']);
+    }
+}
+
+class TestResponsableResponseWithNestedChild implements Responsable
+{
+    public function toResponse($request)
+    {
+        return new TestResponsableResponse;
     }
 }

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -67,6 +67,23 @@ class PipelineTest extends TestCase
     {
         $result = (new Pipeline(new \Illuminate\Container\Container))
             ->send('foo')
+            ->through([new PipelineTestPipeResponsableWithNestedChild])
+            ->then(
+                function ($piped) {
+                    return $piped;
+                }
+            );
+
+        $this->assertEquals('bar', $result);
+        $this->assertEquals('foo', $_SERVER['__test.pipe.responsable_with_nested_child']);
+
+        unset($_SERVER['__test.pipe.responsable_with_nested_child']);
+    }
+
+    public function testPipelineUsageWithResponsableObjectsWithNestedChild()
+    {
+        $result = (new Pipeline(new \Illuminate\Container\Container))
+            ->send('foo')
             ->through([new PipelineTestPipeResponsable])
             ->then(
                 function ($piped) {
@@ -186,6 +203,14 @@ class PipeResponsable implements Responsable
     }
 }
 
+class PineResponsableWithNestedChild implements Responsable
+{
+    public function toResponse($request)
+    {
+        return new PipeResponsable;
+    }
+}
+
 class PipelineTestPipeTwo
 {
     public function __invoke($piped, $next)
@@ -203,6 +228,16 @@ class PipelineTestPipeResponsable
         $_SERVER['__test.pipe.responsable'] = $piped;
 
         return new PipeResponsable;
+    }
+}
+
+class PipelineTestPipeResponsableWithNestedChild
+{
+    public function handle($piped, $next)
+    {
+        $_SERVER['__test.pipe.responsable_with_nested_child'] = $piped;
+
+        return new PineResponsableWithNestedChild;
     }
 }
 


### PR DESCRIPTION
This brings the ability to return nested `Responsable` objects from controllers that are then resolved recursively.

I've found this handy if you have a `Responsable` object that determines the preferred return format: `html`, `csv`, `json` etc.  but there is still a bit of logic around creating the specific formats response which you want to wrap up in a dedicated `Responsable` object. You can push logic down into sub classes as needed.

This also allows you to return existing framework `Responsable` objects - like Json Resources. I'm sure this is only scratching the surface of what this could allow for, that being said it is my only "real world" example I can offer at the moment:

```php
class UserController
{
    public function index(Request $request)
    {
        $query = User::query()->latest()->whereState($request->state);

        // our first level response object. nothing new here.
        return new UserIndexResponse($query);
    }
}

class UserIndexResponse implements Responsable
{
    protected $query;

    public function __construct($query)
    {
        $this->query = $query;
    }

    public function toResponse($request)
    {
        if ($this->wantsCsv($request)) {

            // return a custom Responsable object that can handle
            // transforming and exporting to csv...
            return new UserCsvResponse($query->all());
        }

        if ($this->wantsJson($request)) {

            // return a Responsable Resource object built into the
            // framework that will build our json...
            return new UserCollection($query->paginate());
        }

        // return a standard view. nothing special here...
        return view('users.index', ['users' => $this->query->paginate()]);
    }

    // ...
}
```

I'm currently resolving `Responsable` objects in my base `Response` class just in my projects code ([which I wrote some stuff about](https://timacdonald.me/versatile-response-objects-laravel/)) which works perfectly well, and this may be the best way to do this, i.e. not in core, but thought I'd see if there was any interest in this kinda thing.

This resolving would also have to happen in these places, so a public helper method somewhere would probably be the best place for the resolving logic (i.e the while loop).
https://github.com/laravel/framework/blob/3f4bb53dcd176fad6c9de342c1b632c9ed05f75d/src/Illuminate/Pipeline/Pipeline.php#L154
https://github.com/laravel/framework/blob/c14caab76aaffa6be2f227cd558cca096f0ea72f/src/Illuminate/Foundation/Exceptions/Handler.php#L171
https://github.com/laravel/framework/blob/0ca13a53a0e0a4f913d37ec6e24ab128176d9e37/src/Illuminate/Foundation/helpers.php#L40

If this seems like something that is good for the core, I'll finish up this PR so that nested `Responsable`'s are allowed everywhere.

This is a breaking change in that the contract is *adding* a return type. Not sure if multiple return types is a good thing ~ever~ in this instance though...feels wrong, but I dig this ability so 🤷‍♂️