### PR TITLE
[5.7] Don't use deprecated method

### DIFF
--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -99,7 +99,7 @@ class UploadedFile extends SymfonyUploadedFile
             $file->getPathname(),
             $file->getClientOriginalName(),
             $file->getClientMimeType(),
-            $file->getClientSize(),
+            $file->getSize(),
             $file->getError(),
             $test
         );


### PR DESCRIPTION
`getClientSize()` was deprecated in Symfony 4.1