### PR TITLE
[5.7] Add dynamic SELECT clauses for aggregate functions

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -260,6 +260,26 @@ class Builder
     }
 
     /**
+     * Add a dynamic "select" clause to the query.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return $this
+     */
+    public function dynamicSelect($method, array $parameters)
+    {
+        $function = Str::snake(substr($method, 6));
+
+        $column = $this->grammar->wrap($parameters[0]);
+
+        $as = isset($parameters[1]) ? ' as '.$this->grammar->wrap($parameters[1]) : '';
+
+        $expression = $function.'('.$column.')'.$as;
+
+        return $this->addSelect(new Expression($expression));
+    }
+
+    /**
      * Makes "from" fetch from a subquery.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
@@ -1496,7 +1516,7 @@ class Builder
      * Handles dynamic "where" clauses to the query.
      *
      * @param  string  $method
-     * @param  string  $parameters
+     * @param  array  $parameters
      * @return $this
      */
     public function dynamicWhere($method, $parameters)
@@ -2807,6 +2827,10 @@ class Builder
     {
         if (static::hasMacro($method)) {
             return $this->macroCall($method, $parameters);
+        }
+
+        if (Str::startsWith($method, 'select')) {
+            return $this->dynamicSelect($method, $parameters);
         }
 
         if (Str::startsWith($method, 'where')) {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2777,6 +2777,17 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['1520652582'], $builder->getBindings());
     }
 
+    public function testDynamicSelect()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('user_id')->selectCount('*')->from('purchases')->groupBy('user_id');
+        $this->assertEquals('select `user_id`, count(*) from `purchases` group by `user_id`', $builder->toSql());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('user_id')->selectVarSamp('purchases.amount', 'var')->from('purchases')->groupBy('user_id');
+        $this->assertEquals('select `user_id`, var_samp(`purchases`.`amount`) as `var` from `purchases` group by `user_id`', $builder->toSql());
+    }
+
     protected function getBuilder()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\Grammar;


### PR DESCRIPTION
This PR proposes dynamic SELECT clauses for aggregate functions to reduce the usage of raw expressions:

````php
DB::table('purchases')->select('user_id')->selectCount('*')->groupBy('user_id');
// select "user_id", count(*) from "purchases" group by "user_id"

DB::table('purchases')->select('user_id')->selectSum('amount', 'total')->groupBy('user_id');
// select "user_id", sum("amount") as "total" from "purchases" group by "user_id"
````

As the second parameter, you can optionally specify a column alias.

This feature is similar to the dynamic WHERE clauses: `->whereMyColumn('value')`

The discoverability is not ideal. We could add `@method` annotations for the most common functions:

````php
/**
 * @method $this selectAvg(string $column, string|null $as = null)
 * @method $this selectCount(string $column, string|null $as = null)
 * @method $this selectMax(string $column, string|null $as = null)
 * @method $this selectMin(string $column, string|null $as = null)
 * @method $this selectSum(string $column, string|null $as = null)
 */
class Builder
{
````