### PR TITLE
[5.6] Allow passing of recipient name in Mail notifications

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -184,8 +184,12 @@ class MailChannel
             $recipients = [$recipients];
         }
 
-        return collect($recipients)->map(function ($recipient) {
-            return is_string($recipient) ? $recipient : $recipient->email;
+        return collect($recipients)->mapWithKeys(function ($recipient, $email) {
+            if (! is_numeric($email)) {
+                return [$email => $recipient];
+            }
+
+            return [(is_string($recipient) ? $recipient : $recipient->email)];
         })->all();
     }
 

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -198,10 +198,10 @@ class NotifiableUserWithNamedAddress extends NotifiableUser
 {
     public function routeNotificationForMail($notification)
     {
-    	return [
-    		$this->email => $this->name,
-    		'foo_'.$this->email,
-    	];
+        return [
+            $this->email => $this->name,
+            'foo_'.$this->email,
+        ];
     }
 }
 

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -59,6 +59,7 @@ class SendingMailNotificationsTest extends TestCase
         Schema::create('users', function ($table) {
             $table->increments('id');
             $table->string('email');
+            $table->string('name')->nullable();
         });
     }
 
@@ -80,6 +81,47 @@ class SendingMailNotificationsTest extends TestCase
                 $message = Mockery::mock(\Illuminate\Mail\Message::class);
 
                 $message->shouldReceive('to')->once()->with(['taylor@laravel.com']);
+
+                $message->shouldReceive('cc')->once()->with('cc@deepblue.com', 'cc');
+
+                $message->shouldReceive('bcc')->once()->with('bcc@deepblue.com', 'bcc');
+
+                $message->shouldReceive('from')->once()->with('jack@deepblue.com', 'Jacques Mayol');
+
+                $message->shouldReceive('replyTo')->once()->with('jack@deepblue.com', 'Jacques Mayol');
+
+                $message->shouldReceive('subject')->once()->with('Test Mail Notification');
+
+                $message->shouldReceive('setPriority')->once()->with(1);
+
+                $closure($message);
+
+                return true;
+            })
+        );
+
+        $user->notify($notification);
+    }
+
+    public function test_mail_is_sent_to_named_address()
+    {
+        $notification = new TestMailNotification;
+
+        $user = NotifiableUserWithNamedAddress::forceCreate([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        $this->markdown->shouldReceive('render')->once()->andReturn('htmlContent');
+        $this->markdown->shouldReceive('renderText')->once()->andReturn('textContent');
+
+        $this->mailer->shouldReceive('send')->once()->with(
+            ['html' => 'htmlContent', 'text' => 'textContent'],
+            $notification->toMail($user)->toArray(),
+            Mockery::on(function ($closure) {
+                $message = Mockery::mock(\Illuminate\Mail\Message::class);
+
+                $message->shouldReceive('to')->once()->with(['taylor@laravel.com' => 'Taylor Otwell', 'foo_taylor@laravel.com']);
 
                 $message->shouldReceive('cc')->once()->with('cc@deepblue.com', 'cc');
 
@@ -150,6 +192,17 @@ class NotifiableUser extends Model
 
     public $table = 'users';
     public $timestamps = false;
+}
+
+class NotifiableUserWithNamedAddress extends NotifiableUser
+{
+    public function routeNotificationForMail($notification)
+    {
+    	return [
+    		$this->email => $this->name,
+    		'foo_'.$this->email,
+    	];
+    }
 }
 
 class TestMailNotification extends Notification


### PR DESCRIPTION
`MailChannel` only passes an email address to the Mailer when sending mail notifications. It's a common situation to also know the notifiable's name and hence it seems appropriate to include this as the recipient's name in order to gain trust:

```
hello@example.org
   vs
John Doe <hello@example.org>
```
 This rather small fix allows mail notifications to include the recipient name by using common syntax in the `routeNotificationForMail()` method:

```php
/**
 * Route notifications for the Mail channel.
 *
 * @param  \Illuminate\Notifications\Notification  $notification
 * @return string
 */
public function routeNotificationForMail($notification)
{
    return [
        $this->email => $this->name,
    ];
}
```

Multiple addresses remain supported, with or without a set name:
```php
/**
 * Route notifications for the Mail channel.
 *
 * @param  \Illuminate\Notifications\Notification  $notification
 * @return string
 */
public function routeNotificationForMail($notification)
{
    return [
        $this->email => $this->name,
        $this->email_2,
        $this->email_3 => $this->otherName,
    ];
}
```