### PR TITLE
[5.6] Allow an --ini option when calling `artisan serve`

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -48,12 +48,25 @@ class ServeCommand extends Command
      */
     protected function serverCommand()
     {
-        return sprintf('%s -S %s:%s %s',
-            ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false)),
-            $this->host(),
-            $this->port(),
-            ProcessUtils::escapeArgument(base_path('server.php'))
-        );
+        if (empty($this->ini()))
+        {
+            return sprintf('%s -S %s:%s %s',
+                ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false)),
+                $this->host(),
+                $this->port(),
+                ProcessUtils::escapeArgument(base_path('server.php'))
+            );
+        }
+        else 
+        {
+            return sprintf('%s -c %s -S %s:%s %s',
+                ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false)),
+                $this->ini(),
+                $this->host(),
+                $this->port(),
+                ProcessUtils::escapeArgument(base_path('server.php'))
+            );
+        }
     }
 
     /**
@@ -76,6 +89,16 @@ class ServeCommand extends Command
         return $this->input->getOption('port');
     }
 
+     /**
+     * Get the php.ini file for the command.
+     *
+     * @return string
+     */
+    protected function ini()
+    {
+        return $this->input->getOption('ini');
+    }
+    
     /**
      * Get the console command options.
      *
@@ -87,6 +110,8 @@ class ServeCommand extends Command
             ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', '127.0.0.1'],
 
             ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on.', 8000],
+            
+            ['ini', null, InputOption::VALUE_OPTIONAL, 'The php.ini file to use.', ''],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -48,17 +48,14 @@ class ServeCommand extends Command
      */
     protected function serverCommand()
     {
-        if (empty($this->ini()))
-        {
+        if (empty($this->ini())) {
             return sprintf('%s -S %s:%s %s',
                 ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false)),
                 $this->host(),
                 $this->port(),
                 ProcessUtils::escapeArgument(base_path('server.php'))
             );
-        }
-        else 
-        {
+        } else {
             return sprintf('%s -c %s -S %s:%s %s',
                 ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false)),
                 $this->ini(),
@@ -89,7 +86,7 @@ class ServeCommand extends Command
         return $this->input->getOption('port');
     }
 
-     /**
+    /**
      * Get the php.ini file for the command.
      *
      * @return string
@@ -98,7 +95,7 @@ class ServeCommand extends Command
     {
         return $this->input->getOption('ini');
     }
-    
+
     /**
      * Get the console command options.
      *
@@ -110,7 +107,7 @@ class ServeCommand extends Command
             ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', '127.0.0.1'],
 
             ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on.', 8000],
-            
+
             ['ini', null, InputOption::VALUE_OPTIONAL, 'The php.ini file to use.', ''],
         ];
     }


### PR DESCRIPTION
This allows `artisan serve` to be called using a custom .ini

The primary reason for this is to allow a user to pass a php.ini with xdebug enabled, when they want to debug, rather than have xdebug enabled in their default .ini configuration (since it slows down PHP considerably).
