### PR TITLE
Add a property of table name to the migration stubs

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/create.stub
@@ -7,13 +7,20 @@ use Illuminate\Database\Migrations\Migration;
 class DummyClass extends Migration
 {
     /**
+     * The name for the table.
+     *
+     * @var string
+     */
+    protected $tableName = 'DummyTable';
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::create('DummyTable', function (Blueprint $table) {
+        Schema::create($this->tableName, function (Blueprint $table) {
             $table->increments('id');
             $table->timestamps();
         });
@@ -26,6 +33,6 @@ class DummyClass extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('DummyTable');
+        Schema::dropIfExists($this->tableName);
     }
 }

--- a/src/Illuminate/Database/Migrations/stubs/update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/update.stub
@@ -7,13 +7,20 @@ use Illuminate\Database\Migrations\Migration;
 class DummyClass extends Migration
 {
     /**
+     * The name for the table.
+     *
+     * @var string
+     */
+    protected $tableName = 'DummyTable';
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::table('DummyTable', function (Blueprint $table) {
+        Schema::table($this->tableName, function (Blueprint $table) {
             //
         });
     }
@@ -25,7 +32,7 @@ class DummyClass extends Migration
      */
     public function down()
     {
-        Schema::table('DummyTable', function (Blueprint $table) {
+        Schema::table($this->tableName, function (Blueprint $table) {
             //
         });
     }


### PR DESCRIPTION
In the early days of the project, more is the rename table, instead of writing a new migration file.
I think most developers do this, this will make it easier for us to develop.

I have tested the code, it can working.

Forgive my poor English.