### PR TITLE
[5.6] Allow array/collections in Auth::attempt method

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Auth;
 
 use Illuminate\Support\Str;
-use Illuminate\Support\Collection;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
@@ -115,11 +115,7 @@ class DatabaseUserProvider implements UserProvider
                 continue;
             }
 
-            if ($value instanceof Arrayable || $value instanceof Collection) {
-                $value = $value->toArray();
-            }
-
-            if (is_array($value)) {
+            if (is_array($value) || $value instanceof Arrayable) {
                 $query->whereIn($key, $value);
             } else {
                 $query->where($key, $value);

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Auth;
 
 use Illuminate\Support\Str;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -110,7 +110,17 @@ class DatabaseUserProvider implements UserProvider
         $query = $this->conn->table($this->table);
 
         foreach ($credentials as $key => $value) {
-            if (! Str::contains($key, 'password')) {
+            if (Str::contains($key, 'password')) {
+                continue;
+            }
+
+            if($value instanceof Arrayable || $value instanceof Collection) {
+                $value = $value->toArray();
+            }
+
+            if ( is_array($value) ) {
+                $query->whereIn($key, $value);
+            } else {
                 $query->where($key, $value);
             }
         }

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -114,11 +114,11 @@ class DatabaseUserProvider implements UserProvider
                 continue;
             }
 
-            if($value instanceof Arrayable || $value instanceof Collection) {
+            if ($value instanceof Arrayable || $value instanceof Collection) {
                 $value = $value->toArray();
             }
 
-            if ( is_array($value) ) {
+            if (is_array($value)) {
                 $query->whereIn($key, $value);
             } else {
                 $query->where($key, $value);

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Auth;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Auth;
 
 use Illuminate\Support\Str;
-use Illuminate\Support\Collection;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
@@ -118,11 +118,7 @@ class EloquentUserProvider implements UserProvider
                 continue;
             }
 
-            if ($value instanceof Arrayable || $value instanceof Collection) {
-                $value = $value->toArray();
-            }
-
-            if (is_array($value)) {
+            if (is_array($value) || $value instanceof Arrayable) {
                 $query->whereIn($key, $value);
             } else {
                 $query->where($key, $value);

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -117,11 +117,11 @@ class EloquentUserProvider implements UserProvider
                 continue;
             }
 
-            if($value instanceof Arrayable || $value instanceof Collection) {
+            if ($value instanceof Arrayable || $value instanceof Collection) {
                 $value = $value->toArray();
             }
 
-            if ( is_array($value) ) {
+            if (is_array($value)) {
                 $query->whereIn($key, $value);
             } else {
                 $query->where($key, $value);

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -113,7 +113,17 @@ class EloquentUserProvider implements UserProvider
         $query = $this->createModel()->newQuery();
 
         foreach ($credentials as $key => $value) {
-            if (! Str::contains($key, 'password')) {
+            if (Str::contains($key, 'password')) {
+                continue;
+            }
+
+            if($value instanceof Arrayable || $value instanceof Collection) {
+                $value = $value->toArray();
+            }
+
+            if ( is_array($value) ) {
+                $query->whereIn($key, $value);
+            } else {
                 $query->where($key, $value);
             }
         }

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Auth;
 
 use Illuminate\Support\Str;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
 

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Auth;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -66,6 +66,18 @@ class AuthGuardTest extends TestCase
         $guard->basic('email', ['active' => 1]);
     }
 
+    public function testBasicWithExtraArrayConditions()
+    {
+        list($session, $provider, $request, $cookie) = $this->getMocks();
+        $guard = m::mock('Illuminate\Auth\SessionGuard[check,attempt]', ['default', $provider, $session]);
+        $guard->shouldReceive('check')->once()->andReturn(false);
+        $guard->shouldReceive('attempt')->once()->with(['email' => 'foo@bar.com', 'password' => 'secret', 'active' => 1, 'type' => [1, 2, 3]])->andReturn(true);
+        $request = \Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
+        $guard->setRequest($request);
+
+        $guard->basic('email', ['active' => 1, 'type' => [1, 2, 3]]);
+    }
+
     public function testAttemptCallsRetrieveByCredentials()
     {
         $guard = $this->getGuard();


### PR DESCRIPTION
Currently Auth::attempt allows to pass in additional conditions, however, it won't allow passing in arrays as conditions.

Current behavior

```
Auth::attempt([
                'email' => $request->get('email'),
                'password' => $request->get('password'),
                'user_type' =>[1, 2, 3],
                'active' => 'Y'
          ], $request->get('remember'))
```
Results in the following query:

```
select * from `user` where `email` = 'xxx' and `user_type` = '1' and `active` = 'Y' limit 1
```

With this PR the above code will generate the following query instead:

```
select * from `user` where `email` = 'xxx' and `user_type` in ('1', '2', '3') and `active` = 'Y' limit 1
```

This supports both arrays and collections so the following is exactly the same as the example above

```
Auth::attempt([
                'email' => $request->get('email'),
                'password' => $request->get('password'),
                'user_type' => collect([1, 2, 3]),
                'active' => 'Y'
          ], $request->get('remember'))
```

I hope i added the test correctly. All tests seem to pass with this change.

Based on the Contributing guide i added this to the current release since it's a minor change and has no backwards compatibility breaks.

Thank You.