### PR TITLE
[5.6] Pass table name to the post migration create hooks

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -61,7 +61,7 @@ class MigrationCreator
         // Next, we will fire any hooks that are supposed to fire after a migration is
         // created. Once that is done we'll be ready to return the full path to the
         // migration file so it can be used however it's needed by the developer.
-        $this->firePostCreateHooks();
+        $this->firePostCreateHooks($table);
 
         return $path;
     }
@@ -150,12 +150,13 @@ class MigrationCreator
     /**
      * Fire the registered post create hooks.
      *
+     * @param  string  $table
      * @return void
      */
-    protected function firePostCreateHooks()
+    protected function firePostCreateHooks($table)
     {
         foreach ($this->postCreate as $callback) {
-            call_user_func($callback);
+            call_user_func($callback, $table);
         }
     }
 


### PR DESCRIPTION
* Developers can register post migration create hooks via `afterCreate()` currently.
* They are called after creating the migration file.
* Having an ability to receive the name of the table in the callback will be helpful and create more use cases.