### PR TITLE
[5.6] Use input method to allow compatibility with Lumen and PusherBroadcaster

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -84,7 +84,7 @@ class PusherBroadcaster extends Broadcaster
      */
     protected function decodePusherResponse($request, $response)
     {
-        if (! $request->callback) {
+        if (! $request->input('callback', false)) {
             return json_decode($response, true);
         }
 


### PR DESCRIPTION
When using Lumen, the route resolver as called in `\Illuminate\Http\Request::route` will generally return an array and not a `\Illuminate\Routing\Route` object. This presents a  problem whenever the `__get` magic method on the `Request` object is called.

In `\Illuminate\Broadcasting\Broadcasters\PusherBroadcaster::decodePusherResponse`, the first conditional uses that magic method to check if a callback is present. This change was introduced in https://github.com/laravel/framework/pull/24018 and is the root cause of [this issue](https://github.com/laravel/lumen-framework/issues/763).

To resolve this issue, we should use the `input` method to check for a callback rather than the current style. The change introduced here does just that and will fix https://github.com/laravel/lumen-framework/issues/763.
