### PR TITLE
[5.6] Added toString method to Optional helper

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use ArrayAccess;
 use ArrayObject;
+use InvalidArgumentException;
 
 class Optional implements ArrayAccess
 {
@@ -127,4 +128,18 @@ class Optional implements ArrayAccess
             return $this->value->{$method}(...$parameters);
         }
     }
+
+	/**
+	 * Get the string value of the underlying object, if it is a string.
+	 *
+	 * @return string
+	 */
+	public function __toString()
+	{
+		if (is_string($this->value)) {
+			return (string) $this->value;
+		}
+
+		throw new InvalidArgumentException('Object of class Illuminate\Support\Optional could not be converted to string');
+	}
 }

--- a/tests/Support/SupportOptionalTest.php
+++ b/tests/Support/SupportOptionalTest.php
@@ -88,4 +88,13 @@ class SupportOptionalTest extends TestCase
 
         $this->assertFalse(isset($optional['item']));
     }
+
+	public function testGetStringNoMethodCall()
+	{
+		$targetArr = 'Hello, world';
+
+		$optional = new Optional($targetArr);
+
+		$this->assertEquals('Hello, world',$optional);
+	}
 }


### PR DESCRIPTION
When calling optional($variable) on a string variable without any appended function call or attribute, it will throw an exception if trying to implicitly __toString it.

Real-world example:

I have a lot of objects where almost all of them have functions that i need to access, but some are just plain strings. Because I'm a really lazy programmer, here is what i did:

`$array = [`
`    'pixel_aspect_ratio' => optional($video->get('pixel_aspect_ratio')),`
`    'video_codec' => optional($video->get('codec'))->getFullName(),`
`]`

`optional($video->get('codec'))->getFullName(),` works just fine because it is a function call.

`optional($video->get('pixel_aspect_ratio'))` doesn't work because `$video->get('pixel_aspect_ratio')` returns a string. I would expect that wrapping a string in the optional helper should just return the string when __toStringing. As it is now, it throws an exception.

First Laravel pull request, so all edits and fixes very welcome..!