### PR TITLE
Fix bug in \Illuminate\Database\Query\Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -512,7 +512,7 @@ class Builder
         // assume that the developer is just short-cutting the '=' operators and
         // we will set the operators to '=' and set the values appropriately.
         if ($this->invalidOperator($operator)) {
-            list($value, $operator) = [$operator, '='];
+            list($value, $operator) = [$value, '='];
         }
 
         // If the value is a Closure, it means the developer is performing an entire

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -510,9 +510,9 @@ class Builder
 
         // If the given operator is not found in the list of valid operators we will
         // assume that the developer is just short-cutting the '=' operators and
-        // we will set the operators to '=' and set the values appropriately.
-        if ($this->invalidOperator($operator)) {
-            list($value, $operator) = [$value, '='];
+        // we will set the operators to '='.
+        if (func_num_args() === 3 && $this->invalidOperator($operator)) {
+            $operator = '=';
         }
 
         // If the value is a Closure, it means the developer is performing an entire

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1881,6 +1881,22 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" where "foo" is not null', $builder->toSql());
     }
 
+    public function testProvidingEmptyStringAsOperatorBuildsCorrectly()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('foo', '', 'bar');
+        $this->assertEquals('select * from "users" where "foo" = ?', $builder->toSql());
+        $this->assertEquals(['bar'], $builder->getBindings());
+    }
+
+    public function testProvidingInvalidOperatorBuildsCorrectly()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('foo', 'invalid', 'bar');
+        $this->assertEquals('select * from "users" where "foo" = ?', $builder->toSql());
+        $this->assertEquals(['bar'], $builder->getBindings());
+    }
+
     public function testDynamicWhere()
     {
         $method = 'whereFooBarAndBazOrQux';


### PR DESCRIPTION
Fixes a bug in the query builder where, when an empty or invalid
operator was provided, the value was swapped with the operator itself.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
