### PR TITLE
[5.7] Wildcard guard for eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -151,8 +151,7 @@ trait GuardsAttributes
             return false;
         }
 
-        return empty($this->getFillable()) &&
-            ! Str::startsWith($key, '_');
+        return empty($this->getFillable());
     }
 
     /**
@@ -163,7 +162,7 @@ trait GuardsAttributes
      */
     public function isGuarded($key)
     {
-        return in_array($key, $this->getGuarded()) || $this->getGuarded() == ['*'];
+        return Str::is($this->getGuarded(), $key);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -912,6 +912,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testUnderscorePropertiesAreNotFilled()
     {
         $model = new EloquentModelStub;
+        $model->guard(['_*']);
         $model->fill(['_method' => 'PUT']);
         $this->assertEquals([], $model->getAttributes());
     }


### PR DESCRIPTION
Currently all model attributes that starts with _ (underscore) are guarded. Other than listing all the fields in fillable, someone can opt-out of this behavior by overriding isFillable(), copy and paste all the code except the last condition: `&& ! Str::startsWith($key, '_')`. This is a bit inconvenient, especially when there is no need to guard at all. 

This PR removes the hard-coded line and let the programmers choose to guard fields using wildcard matching. For example, if they really want to guard `_*` fields here is the solution:

```php
class User extends Model
{
    protected $guarded = ['_*'];
}
```
The reason I am interested is because in MongoDB all documents have a primary key named `_id`. So if I don't want to guard that, I will be in trouble.

I don't know if you are comfortable with this change, because it relaxes a security check from the code. Also, I am aware that my issue has workarounds. **So, if you reject this, please at least document somewhere that `_*` fields are guarded.**
Thanks.