### PR TITLE
[5.7] Remove broken code

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -602,13 +602,6 @@ class Builder
             return $this->whereNested($column, $boolean);
         }
 
-        // If the given operator is not found in the list of valid operators we will
-        // assume that the developer is just short-cutting the '=' operators and
-        // we will set the operators to '=' and set the values appropriately.
-        if ($this->invalidOperator($operator)) {
-            list($value, $operator) = [$operator, '='];
-        }
-
         // If the value is a Closure, it means the developer is performing an entire
         // sub-select within the query and we will need to compile the sub-select
         // within the where clause to get the appropriate query record results.


### PR DESCRIPTION
The removed code is supposed to handle invalid operators:

````php
DB::table('users')->where('foo', '', 'bar')->get();
// expected: select * from `users` where `foo` = 'bar'
// actual:   select * from `users` where `foo` = ''
````

Since it doesn't work and won't get fixed (#24624), it should be removed.