### PR TITLE
[5.7] Custom Validator confirmed name attribute part

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -354,11 +354,14 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed   $value
+     * @param  array   $parameters
      * @return bool
      */
-    public function validateConfirmed($attribute, $value)
+    protected function validateConfirmed($attribute, $value, $parameters = [])
     {
-        return $this->validateSame($attribute, $value, [$attribute.'_confirmation']);
+        $custom = ! empty($parameters[0]) ? '_'.$parameters[0] : '_confirmation';
+
+        return $this->validateSame($attribute, $value, [$attribute.$custom]);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1016,6 +1016,22 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateConfirmedCustom()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['password' => 'foo'], ['password' => 'Confirmed:custom']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['password' => 'foo', 'password_custom' => 'bar'], ['password' => 'Confirmed:custom']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['password' => 'foo', 'password_custom' => 'foo'], ['password' => 'Confirmed:custom']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['password' => '1e2', 'password_custom' => '100'], ['password' => 'Confirmed:custom']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateSame()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
By default confirmed Validator (for example 'password' => 'confirmed') will search name attribute with _confirmation part in it (in our example it will search 'password_confirmation' name attribute). I would like to offer little change in Validator behavior by adding optional parameter, which will replace '_confirmation' part if parameter is specified. Now, we can use any word (confirm, check, match and so on) as a part of name attribute. For example we will use 'custom' in our form:

&lt;input name="password" type="text" /&gt;
&lt;input name="password_custom" type="text" /&gt;

and in our controller validation:

$this->validate($request, [
&nbsp;&nbsp;&nbsp;&nbsp;'password' => 'required|confirmed:custom',
]);

This change will give more flexibility and possibility to hide framework fingerprints if 'confirmed' id used.