### PR TITLE
[5.6] Fixed sorting of signed url parameters

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -311,6 +311,8 @@ class UrlGenerator implements UrlGeneratorContract
             $parameters = $parameters + ['expires' => $this->availableAt($expiration)];
         }
 
+        ksort($parameters);
+
         $key = call_user_func($this->keyResolver);
 
         return $this->route($name, $parameters + [


### PR DESCRIPTION
When using the redirect after login feature `redirect()->intended()` and the intended url is a signed route, a nice little sorting within the intended query string builder gets in the way of the correct hashing check of the signed route signature parameter. This little change fixes that.