### PR TITLE
[5.6] Use value() helper in whenLoaded()

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -141,7 +141,7 @@ trait ConditionallyLoadsAttributes
         }
 
         if (! $this->resource->relationLoaded($relationship)) {
-            return $default;
+            return value($default);
         }
 
         if (func_num_args() === 1) {

--- a/tests/Integration/Http/Fixtures/AuthorResourceWithOptionalRelationship.php
+++ b/tests/Integration/Http/Fixtures/AuthorResourceWithOptionalRelationship.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+class AuthorResourceWithOptionalRelationship extends PostResource
+{
+    public function toArray($request)
+    {
+        return [
+            'name' => $this->name,
+            'posts_count' => $this->whenLoaded('posts', function () {
+                return $this->posts->count().' posts';
+            }, function () {
+                return 'not loaded';
+            }),
+            'latest_post_title' => $this->whenLoaded('posts', function () {
+                return optional($this->posts->first())->title ?: 'no posts yet';
+            }, 'not loaded'),
+        ];
+    }
+}

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalData.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalData.php
@@ -15,6 +15,10 @@ class PostResourceWithOptionalData extends JsonResource
             'third' => $this->when(true, function () {
                 return 'value';
             }),
+            'fourth' => $this->when(false, 'value', 'default'),
+            'fifth' => $this->when(false, 'value', function () {
+                return 'default';
+            }),
         ];
     }
 }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -20,6 +20,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\EmptyPostCollectionResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalData;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationship;
+use Illuminate\Tests\Integration\Http\Fixtures\AuthorResourceWithOptionalRelationship;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalPivotRelationship;
 
 /**
@@ -88,6 +89,8 @@ class ResourceTest extends TestCase
                 'id' => 5,
                 'second' => 'value',
                 'third' => 'value',
+                'fourth' => 'default',
+                'fifth' => 'default',
             ],
         ]);
     }
@@ -188,6 +191,29 @@ class ResourceTest extends TestCase
                 'id' => 5,
                 'author' => null,
                 'author_name' => null,
+            ],
+        ]);
+    }
+
+    public function test_resources_may_have_optional_relationships_with_default_values()
+    {
+        Route::get('/', function () {
+            return new AuthorResourceWithOptionalRelationship(new Author([
+                'name' => 'jrrmartin',
+            ]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'name' => 'jrrmartin',
+                'posts_count' => 'not loaded',
+                'latest_post_title' => 'not loaded',
             ],
         ]);
     }


### PR DESCRIPTION
When using a resource it can be useful to pass a `Closure` as the `$default` value so it is only evaluated if needed. 

Currently the `ConditionallyLoadsAttributes` attributes already uses `value($default)` when returning the `$default` value in the `->when()` method, but in the other methods it was missing.

My use case:

```php
// in a Resource
    public function toArray( $request )
    {
        return [
            'id'          => $this->resource->id,
            'name'        => $this->resource->name,
            'description' => $this->resource->description,
            'users_count' => $this->whenLoaded('users',
                function () {return $this->resource->users->count();},
                function () {return $this->resource->users()->count();} // not possible today
            )
        ];
    }
```
