### PR TITLE
[5.6] Test transform() helper $default argument

### DIFF
--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -878,6 +878,19 @@ class SupportHelpersTest extends TestCase
         }));
     }
 
+    public function testTransformDefaultWhenBlank()
+    {
+        $this->assertEquals('baz', transform(null, function () {
+            return 'bar';
+        }, 'baz'));
+
+        $this->assertEquals('baz', transform('', function () {
+            return 'bar';
+        }, function () {
+            return 'baz';
+        }));
+    }
+
     public function testWith()
     {
         $this->assertEquals(10, with(10));


### PR DESCRIPTION
Show that the `transform()` global helper function accepts callables as its `$default` argument.