### PR TITLE
[5.6] Adding a missing test case for Gate::has() method

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -373,6 +373,43 @@ class AuthAccessGateTest extends TestCase
 
         $this->assertFalse($gate->check(['edit', 'update'], new AccessGateTestDummy));
     }
+
+    /**
+     * @dataProvider hasAbilitiesTestDataProvider
+     *
+     * @param array $abilitiesToSet
+     * @param array|string $abilitiesToCheck
+     * @param bool $expectedHasValue
+     */
+    public function test_has_abilities($abilitiesToSet, $abilitiesToCheck, $expectedHasValue)
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->resource('test', AccessGateTestResource::class, $abilitiesToSet);
+
+        $this->assertEquals($expectedHasValue, $gate->has($abilitiesToCheck));
+    }
+
+    public function hasAbilitiesTestDataProvider()
+    {
+        $abilities = ['foo' => 'foo', 'bar' => 'bar'];
+        $noAbilities = [];
+
+        return [
+            [$abilities, ['test.foo', 'test.bar'], true],
+            [$abilities, ['test.bar', 'test.foo'], true],
+            [$abilities, ['test.bar', 'test.foo', 'test.baz'], false],
+            [$abilities, ['test.bar'], true],
+            [$abilities, ['baz'], false],
+            [$abilities, [''], false],
+            [$abilities, [], true],
+            [$abilities, 'test.bar', true],
+            [$abilities, 'test.foo', true],
+            [$abilities, '', false],
+            [$noAbilities, '', false],
+            [$noAbilities, [], true],
+        ];
+    }
 }
 
 class AccessGateTestClass


### PR DESCRIPTION
I was not able to find any test case for `Gate::has()` so decided to add one. 

While working on the test I found that calling `Gate::has()` with an empty array as an argument (`$gate->has([])`) always returns true. I haven't changed this behavior and the test case reflects that. If it is something that we don't want to happen, I can fix the `Gate::has()` method in a separate PR.