### PR TITLE
[5.6] Add phpdoc with $factory type hint in factory stub

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -2,6 +2,9 @@
 
 use Faker\Generator as Faker;
 
+/**
+ * @var Illuminate\Database\Eloquent\Factory $factory
+ */
 $factory->define(DummyModel::class, function (Faker $faker) {
     return [
         //


### PR DESCRIPTION
It would be pretty convenient to have `$factory` typehinted in generated factories so that the IDE knows how to handle that `$factory` var.

Ps. It's obviously not breaking any existing feature. Also I guess it would be pointless to test it.