### PR TITLE
[5.7] Email Verification (Framework)

### DIFF
--- a/src/Illuminate/Auth/Console/AuthMakeCommand.php
+++ b/src/Illuminate/Auth/Console/AuthMakeCommand.php
@@ -33,6 +33,7 @@ class AuthMakeCommand extends Command
     protected $views = [
         'auth/login.stub' => 'auth/login.blade.php',
         'auth/register.stub' => 'auth/register.blade.php',
+        'auth/verify.stub' => 'auth/verify.blade.php',
         'auth/passwords/email.stub' => 'auth/passwords/email.blade.php',
         'auth/passwords/reset.stub' => 'auth/passwords/reset.blade.php',
         'layouts/app.stub' => 'layouts/app.blade.php',

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/verify.blade.php
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/verify.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">Email Verification</div>
+
+                <div class="card-body">
+                    Please verify your email address.
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/verify.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/verify.stub
@@ -8,6 +8,12 @@
                 <div class="card-header">Verify Your Email Address</div>
 
                 <div class="card-body">
+                    @if (session('resent'))
+                        <div class="alert alert-success" role="alert">
+                            A fresh verification link has been sent to your email address.
+                        </div>
+                    @endif
+
                     Before proceeding, please check your email for a verification link.
                     If you did not receive the email, <a href="{{ route('verification.resend') }}">click here to request another</a>.
                 </div>

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/verify.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/verify.stub
@@ -5,10 +5,11 @@
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="card">
-                <div class="card-header">Email Verification</div>
+                <div class="card-header">Verify Your Email Address</div>
 
                 <div class="card-body">
-                    Please verify your email address.
+                    Before proceeding, please check your email for a verification link.
+                    If you did not receive the email, <a href="{{ route('verification.resend') }}">click here to request another</a>.
                 </div>
             </div>
         </div>

--- a/src/Illuminate/Auth/Listeners/SendEmailVerificationNotification.php
+++ b/src/Illuminate/Auth/Listeners/SendEmailVerificationNotification.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Auth\Listeners;
+
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+
+class SendEmailVerificationNotification
+{
+    /**
+     * Handle the event.
+     *
+     * @param  \Illuminate\Auth\Events\Registered  $event
+     * @return void
+     */
+    public function handle(Registered $event)
+    {
+        if ($event->user instanceof MustVerifyEmail) {
+            $event->user->sendEmailVerificationNotification();
+        }
+    }
+}

--- a/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
+++ b/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Auth\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+
+class EnsureEmailIsVerified
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return \Illuminate\Http\Response
+     */
+    public function handle($request, Closure $next)
+    {
+        if (! $request->user() ||
+            ($request->user() instanceof MustVerifyEmail &&
+            ! $request->user()->hasVerifiedEmail())) {
+            return Redirect::route('verification.notice');
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Auth;
 
+use DateTime;
+
 trait MustVerifyEmail
 {
     /**
@@ -11,7 +13,7 @@ trait MustVerifyEmail
      */
     public function hasVerifiedEmail()
     {
-        return (bool) $this->email_verified;
+        return ! is_null($this->email_verified_at);
     }
 
     /**
@@ -21,7 +23,7 @@ trait MustVerifyEmail
      */
     public function markEmailAsVerified()
     {
-        $this->forceFill(['email_verified' => true])->save();
+        $this->forceFill(['email_verified_at' => new DateTime])->save();
     }
 
     /**

--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Auth;
+
+trait MustVerifyEmail
+{
+    /**
+     * Determine if the user has verified their email address.
+     *
+     * @return bool
+     */
+    public function hasVerifiedEmail()
+    {
+        return (bool) $this->email_verified;
+    }
+
+    /**
+     * Mark the given user's email as verified.
+     *
+     * @return void
+     */
+    public function markEmailAsVerified()
+    {
+        $this->forceFill(['email_verified' => true])->save();
+    }
+
+    /**
+     * Send the email verification notification.
+     *
+     * @return void
+     */
+    public function sendEmailVerificationNotification()
+    {
+        $this->notify(new Notifications\VerifyEmail);
+    }
+}

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Illuminate\Auth\Notifications;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class VerifyEmail extends Notification
+{
+    /**
+     * The callback that should be used to build the mail message.
+     *
+     * @var \Closure|null
+     */
+    public static $toMailCallback;
+
+    /**
+     * Get the notification's channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array|string
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Build the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        if (static::$toMailCallback) {
+            return call_user_func(static::$toMailCallback, $notifiable);
+        }
+
+        return (new MailMessage)
+            ->subject(Lang::getFromJson('Verify Email Address'))
+            ->line(Lang::getFromJson('Please click the button below to verify your email address.'))
+            ->action(
+                Lang::getFromJson('Verify Email Address'),
+                $this->verificationUrl($notifiable)
+            )
+            ->line(Lang::getFromJson('If you did not create an account, no further action is required.'));
+    }
+
+    /**
+     * Get the verification URL for the given notifiable.
+     *
+     * @param  mixed  $notifiable
+     * @return string
+     */
+    protected function verificationUrl($notifiable)
+    {
+        return URL::temporarySignedRoute(
+            'verification.verify', Carbon::now()->addMinutes(60), ['id' => $notifiable->getKey()]
+        );
+    }
+
+    /**
+     * Set a callback that should be used when building the notification mail message.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function toMailUsing($callback)
+    {
+        static::$toMailCallback = $callback;
+    }
+}

--- a/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Contracts\Auth;
+
+interface MustVerifyEmail
+{
+    /**
+     * Determine if the user has verified their email address.
+     *
+     * @return bool
+     */
+    public function hasVerifiedEmail();
+
+    /**
+     * Mark the given user's email as verified.
+     *
+     * @return void
+     */
+    public function markEmailAsVerified();
+
+    /**
+     * Send the email verification notification.
+     *
+     * @return void
+     */
+    public function sendEmailVerificationNotification();
+}

--- a/src/Illuminate/Foundation/Auth/User.php
+++ b/src/Illuminate/Foundation/Auth/User.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Auth\Authenticatable;
+use Illuminate\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Foundation\Auth\Access\Authorizable;
@@ -15,5 +16,5 @@ class User extends Model implements
     AuthorizableContract,
     CanResetPasswordContract
 {
-    use Authenticatable, Authorizable, CanResetPassword;
+    use Authenticatable, Authorizable, CanResetPassword, MustVerifyEmail;
 }

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -46,6 +46,6 @@ trait VerifiesEmails
     {
         $request->user()->sendEmailVerificationNotification();
 
-        return back();
+        return back()->with('resent', true);
     }
 }

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Foundation\Auth;
+
+use Illuminate\Http\Request;
+
+trait VerifiesEmails
+{
+    use RedirectsUsers;
+
+    /**
+     * Show the email verification notice.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Request $request)
+    {
+        return $request->user()->hasVerifiedEmail()
+                        ? redirect($this->redirectPath())
+                        : view('auth.verify');
+    }
+
+    /**
+     * Mark the authenticated user's email address as verified.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function verify(Request $request)
+    {
+        if ($request->route('id') == $request->user()->getKey()) {
+            $request->user()->markEmailAsVerified();
+        }
+
+        return redirect($this->redirectPath());
+    }
+}

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -35,4 +35,17 @@ trait VerifiesEmails
 
         return redirect($this->redirectPath());
     }
+
+    /**
+     * Resend the email verification notification.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function resend(Request $request)
+    {
+        $request->user()->sendEmailVerificationNotification();
+
+        return back();
+    }
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1124,9 +1124,10 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Register the typical authentication routes for an application.
      *
+     * @param  array  $options
      * @return void
      */
-    public function auth()
+    public function auth(array $options = [])
     {
         // Authentication Routes...
         $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
@@ -1142,6 +1143,23 @@ class Router implements RegistrarContract, BindingRegistrar
         $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
         $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
         $this->post('password/reset', 'Auth\ResetPasswordController@reset');
+
+        // Email Verification Routes...
+        if ($options['verify'] ?? false) {
+            $this->emailVerification();
+        }
+    }
+
+    /**
+     * Register the typical email verification routes for an application.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    public function emailVerification()
+    {
+        $this->get('email/verify', 'Auth\VerificationController@show')->name('verification.notice');
+        $this->get('email/verify/{id}', 'Auth\VerificationController@verify')->name('verification.verify');
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1160,6 +1160,7 @@ class Router implements RegistrarContract, BindingRegistrar
     {
         $this->get('email/verify', 'Auth\VerificationController@show')->name('verification.notice');
         $this->get('email/verify/{id}', 'Auth\VerificationController@verify')->name('verification.verify');
+        $this->get('email/resend', 'Auth\VerificationController@resend')->name('verification.resend');
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1153,7 +1153,6 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Register the typical email verification routes for an application.
      *
-     * @param  array  $options
      * @return void
      */
     public function emailVerification()

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -44,10 +44,11 @@ class Auth extends Facade
     /**
      * Register the typical authentication routes for an application.
      *
+     * @param  array  $options
      * @return void
      */
-    public static function routes()
+    public static function routes(array $options = [])
     {
-        static::$app->make('router')->auth();
+        static::$app->make('router')->auth($options);
     }
 }


### PR DESCRIPTION
This PR adds optional email verification to the typical "make:auth" setup. To utilize this, the end-user must only do "make:auth" and then add `implements MustVerifyEmail` to their `User` model. Everything should be automatic from there.

This uses temporary signed URLs to avoid creating another "token" table, etc.

Corresponding application skeleton PR will be incoming to add necessary controller, as well as middleware registration.