### PR TITLE
[5.7] Optimize Collection::mapWithKeys

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1013,6 +1013,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function mapWithKeys(callable $callback)
     {
+        if ($this->isEmpty()) {
+            return new static([]);
+        }
+
         $values = array_map($callback, $this->items, array_keys($this->items));
 
         return new static(array_replace(...$values));

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1013,13 +1013,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function mapWithKeys(callable $callback)
     {
-        if ($this->isEmpty()) {
-            return new static([]);
-        }
-
         $values = array_map($callback, $this->items, array_keys($this->items));
 
-        return new static(array_replace(...$values));
+        return new static(array_replace([], [], ...$values));
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1016,11 +1016,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $result = [];
 
         foreach ($this->items as $key => $value) {
-            $assoc = $callback($value, $key);
-
-            foreach ($assoc as $mapKey => $mapValue) {
-                $result[$mapKey] = $mapValue;
-            }
+            $result += $callback($value, $key);
         }
 
         return new static($result);

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1013,13 +1013,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function mapWithKeys(callable $callback)
     {
-        $result = [];
+        $values = array_map($callback, $this->items, array_keys($this->items));
 
-        foreach ($this->items as $key => $value) {
-            $result += $callback($value, $key);
-        }
-
-        return new static($result);
+        return new static(array_replace(...$values));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1557,6 +1557,25 @@ class SupportCollectionTest extends TestCase
         );
     }
 
+    public function testMapWithKeysOverwritingKeys()
+    {
+        $data = new Collection([
+            ['id' => 1, 'name' => 'A'],
+            ['id' => 2, 'name' => 'B'],
+            ['id' => 1, 'name' => 'C'],
+        ]);
+        $data = $data->mapWithKeys(function ($item) {
+            return [$item['id'] => $item['name']];
+        });
+        $this->assertSame(
+            [
+                1 => 'C',
+                2 => 'B',
+            ],
+            $data->all()
+        );
+    }
+
     public function testMapInto()
     {
         $data = new Collection([


### PR DESCRIPTION
Benchmark (100,000 iterations):
```
Old method: 4.133s
New method: 3.175s
---
Old method: 3.754s
New method: 2.975s
---
Old method: 3.773s
New method: 3.246s
```

https://gist.github.com/dmitrybubyakin/6bdcc7c0ee7eaffdae699d61017214ee

15-25% faster.