### PR TITLE
[5.7] When running tests, refresh the logged in user on each redirect

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -37,6 +37,21 @@ trait InteractsWithAuthentication
     }
 
     /**
+     * Refresh the logged in user, it may have gone stale
+     *
+     * @return $this
+     */
+    public function refreshAuthenticated()
+    {
+        $user = $this->app->make('auth')->guard()->user();
+        if ($user) {
+            $this->app['auth']->guard()->setUser($user->fresh());
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the user is authenticated.
      *
      * @param  string|null  $guard

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -439,6 +439,7 @@ trait MakesHttpRequests
     protected function followRedirects($response)
     {
         while ($response->isRedirect()) {
+            $this->refreshAuthenticated();
             $response = $this->get($response->headers->get('Location'));
         }
 


### PR DESCRIPTION
To mimick real world HTTP redirects, the logged in user should be reloaded on each call.
The included test shows the problem: if the user is updated and a redirect is generated, the test runner would previously have stale data.