### PR TITLE
[5.6] Add joiningTableSegment method to Model.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -425,7 +425,7 @@ trait HasRelationships
         // models using underscores in alphabetical order. The two model names
         // are transformed to snake case from their default CamelCase also.
         if (is_null($table)) {
-            $table = $this->joiningTable($related);
+            $table = $this->joiningTable($related, $instance);
         }
 
         return $this->newBelongsToMany(
@@ -565,14 +565,14 @@ trait HasRelationships
      * @param  string  $related
      * @return string
      */
-    public function joiningTable($related)
+    public function joiningTable($related, $instance = null)
     {
         // The joining table name, by convention, is simply the snake cased models
         // sorted alphabetically and concatenated with an underscore, so we can
         // just sort the models and join them together to get the table name.
         $models = [
-            Str::snake(class_basename($related)),
-            Str::snake(class_basename($this)),
+            $instance ? $instance->joiningTablePortion() : Str::snake(class_basename($related)),
+            $this->joiningTablePortion(),
         ];
 
         // Now that we have the model names in an array we can just sort them and
@@ -581,6 +581,16 @@ trait HasRelationships
         sort($models);
 
         return strtolower(implode('_', $models));
+    }
+
+    /**
+     * Get this model's half of the joining table.
+     *
+     * @return string
+     */
+    public function joiningTablePortion()
+    {
+        return Str::snake(class_basename($this));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -571,8 +571,8 @@ trait HasRelationships
         // sorted alphabetically and concatenated with an underscore, so we can
         // just sort the models and join them together to get the table name.
         $models = [
-            $instance ? $instance->joiningTablePortion() : Str::snake(class_basename($related)),
-            $this->joiningTablePortion(),
+            $instance ? $instance->joiningTableSegment() : Str::snake(class_basename($related)),
+            $this->joiningTableSegment(),
         ];
 
         // Now that we have the model names in an array we can just sort them and
@@ -588,7 +588,7 @@ trait HasRelationships
      *
      * @return string
      */
-    public function joiningTablePortion()
+    public function joiningTableSegment()
     {
         return Str::snake(class_basename($this));
     }


### PR DESCRIPTION
Currently, if I have two models (Podcast, EmailList) that both use the same table ('subscribable'), I have to explicitly provide the table name:
```php
class User extends Model
{
    public function podcasts()
    {
        return $this->belongsToMany(Podcast::class, 'user_subscribable');
    }

    public function emailLists()
    {
        return $this->belongsToMany(EmailList::class, 'user_subscribable');
    }
}
```

With this PR, I could add a new "joiningTableSegment" method to the models like so:
```php
class Podcast extends Model
{
    $table = 'subscribables';

    public function joiningTableSegment()
    {
        return 'subscribable'
    }
}

class EmailList extends Model
{
    $table = 'subscribables';

    public function joiningTableSegment()
    {
        return 'subscribable'
    }
}
```

Then the User model would become:
```php
class User extends Model
{
    public function podcasts()
    {
        return $this->belongsToMany(Podcast::class);
    }

    public function emailLists()
    {
        return $this->belongsToMany(EmailList::class);
    }
}
```

If this example seems obscure, here's some context: Tighten has a Single Table Inheritance package called "Parental" that currently requires users to manually add table names in the case described above. It would make for a much cleaner experience if this ability to override joining table names existed.

https://github.com/tightenco/parental

I'm not in love with the function name or the implementation, so lmk thoughts and I can change it.

Thanks!!!