### PR TITLE
[5.6] Allow the outside world to access the name of the default connection in Migrator

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -498,6 +498,16 @@ class Migrator
     }
 
     /**
+     * Get the default connection name.
+     *
+     * @return string
+     */
+    public function getConnection()
+    {
+        return $this->connection;
+    }
+
+    /**
      * Resolve the database connection instance.
      *
      * @param  string  $connection


### PR DESCRIPTION
Sometimes, when porting legacy apps to Laravel, it's necessary to have several connections (legacy code).
When going to reverse engineering the current tables into new migrations there's some logic necessary to 'fork' the connection and accessing the Migrator connection name simplifies things a lot.

It's not like a huge change and the surface API doesn't increase much.