### PR TITLE
Updates \Illuminate\Http\Request::fullUrlIs to have one single level of indentation

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -212,15 +212,18 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function fullUrlIs(...$patterns)
     {
-        $url = $this->fullUrl();
+        $matchingPatterns = array_filter($patterns, [$this, 'isPatternMatchingCurrentUrl']);
 
-        foreach ($patterns as $pattern) {
-            if (Str::is($pattern, $url)) {
-                return true;
-            }
-        }
+        return count($matchingPatterns) > 0;
+    }
 
-        return false;
+    /**
+     * @param string $pattern
+     * @return bool
+     */
+    private function isPatternMatchingCurrentUrl($pattern)
+    {
+        return Str::is($pattern, $this->fullUrl());
     }
 
     /**


### PR DESCRIPTION
Code developed while introducing to students object calisthenics exercise no 1, to have one single line of indentation per method.

It should not break the project as it refactors a small piece of code that is covered by tests.

As a benefit it makes the code explicit about what it is doing.

There's a downside, though: it loops the entire `$patterns` collection instead of getting an early return.

Feel free to accept or drop, just felt like wouldn't hurt to reuse my example as a small contribution to this project.

Cheers 🍻