### PR TITLE
[5.7] Support relationships with JSON foreign keys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -312,7 +312,7 @@ trait HasAttributes
         // If the attribute exists in the attribute array or has a "get" mutator we will
         // get the attribute's value. Otherwise, we will proceed as if the developers
         // are asking for a relationship's value. This covers both types of values.
-        if (array_key_exists($key, $this->attributes) ||
+        if (array_key_exists(explode('->', $key)[0], $this->attributes) ||
             $this->hasGetMutator($key)) {
             return $this->getAttributeValue($key);
         }
@@ -335,6 +335,15 @@ trait HasAttributes
      */
     public function getAttributeValue($key)
     {
+        // If this attribute contains a JSON ->, we'll get the proper value in the
+        // attribute's underlying array. This takes care of properly nesting an
+        // attribute in the array's value in the case of deeply nested items.
+        if (Str::contains($key, '->')) {
+            list($key, $path) = explode('->', $key, 2);
+
+            return Arr::get($this->getAttributeValue($key), str_replace('->', '.', $path));
+        }
+
         $value = $this->getAttributeFromArray($key);
 
         // If the attribute has a get mutator, we will call that then return what

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -203,13 +203,15 @@ class HasManyThrough extends Relation
      */
     protected function buildDictionary(Collection $results)
     {
+        $firstKey = explode('->', $this->firstKey)[0];
+
         $dictionary = [];
 
         // First we will create a dictionary of models keyed by the foreign key of the
         // relationship as this will allow us to quickly access all of the related
         // models without having to do nested looping which will be quite slow.
         foreach ($results as $result) {
-            $dictionary[$result->{$this->firstKey}][] = $result;
+            $dictionary[$result->$firstKey][] = $result;
         }
 
         return $dictionary;
@@ -412,7 +414,9 @@ class HasManyThrough extends Relation
             $columns = [$this->related->getTable().'.*'];
         }
 
-        return array_merge($columns, [$this->getQualifiedFirstKeyName()]);
+        $alias = explode('->', $this->firstKey)[0];
+
+        return array_merge($columns, [$this->getQualifiedFirstKeyName().' as '.$alias]);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -857,6 +857,13 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayNotHasKey('age', $array);
     }
 
+    public function testAccessingJsonAttributes()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->setRawAttributes(['jsonAttribute' => json_encode(['meta' => ['name' => 'foo']])]);
+        $this->assertEquals('foo', $model->{'jsonAttribute->meta->name'});
+    }
+
     public function testFillable()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
Now that we support JSON queries on all databases except SQLite, we can use relationships with JSON foreign keys:

```php
class User extends Model
{
    protected $casts = [
        'options' => 'json'
    ];

    public function locale()
    {
        return $this->belongsTo(Locale::class, 'options->locale_id');
    }
}

class Locale extends Model
{
    public function users()
    {
        return $this->hasMany(User::class, 'options->locale_id');
    }
}
```

We already support the mutation of JSON attributes, so we only need to add the ability to access JSON attributes: `$user->{'options->locale_id'}`

Additionally, `HasManyThrough` requires a column alias for the `firstKey`:
``select `posts`.*, `users`.`options`->'$."country_id"' as `options` ``

The PR is theoretically a breaking change for cases like this:

````php
(new User)->setRawAttributes(['foo->bar' => 123])->{'foo->bar'};
````

Resolves https://github.com/laravel/ideas/issues/1212.

### Tests

Since we only support integration tests on SQLite, I don't think we can really test JSON foreign keys. Of course, I tested them on actual databases. We could test the generated SQL of `HasManyThrough` relationships, but there isn't even a non-integration test file.

### Limitations

This PR supports `BelongsTo`, `HasOne`, `HasMany`, `HasManyThrough`, `MorphTo`, `MorphOne` and `MorphMany`.

Adding JSON foreign keys to `BelongsToMany` and `MorphToMany` would be possible but require more changes. I also don't think that it makes a lot of sense with pivot tables. We could use JSON arrays instead and implement a `User` ↔ `Role` relationship with `users.role_ids`. This would require a new relationship type and use `whereJsonContains()` for the reverse direction.

Due to the strict column comparison, existence queries (`Locale::has('users')`) and `HasManyThrough` relationships don't work on PostgreSQL when using integer keys.

### Referential Integrity

[MySQL 5.7](https://dev.mysql.com/doc/refman/5.7/en/create-table-foreign-keys.html) and [SQL Server 2016](https://docs.microsoft.com/en-us/sql/relational-databases/tables/specify-computed-columns-in-a-table?view=sql-server-2016) support foreign keys on JSON columns with generated/computed columns.

Laravel migrations support this feature on MySQL:

```php
Schema::create('users', function (Blueprint $table) {
    $table->increments('id');
    $table->json('options');
    $table->unsignedInteger('locale_id')->storedAs('`options`->\'$."locale_id"\'');
    $table->foreign('locale_id')->references('id')->on('locales');
});
```

SQL Server requires raw SQL:

```php
Schema::create('users', function (Blueprint $table) {
    $table->increments('id');
    $table->json('options');
});
DB::statement('ALTER TABLE [users] ADD "locale_id" AS CAST(JSON_VALUE([options], \'$."locale_id"\') AS INT) PERSISTED');
Schema::table('users', function (Blueprint $table) {
    $table->foreign('locale_id')->references('id')->on('locales');
});
```