### PR TITLE
[5.6] Mysql integration test sample

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,14 @@ cache:
 services:
   - memcached
   - redis-server
+  - mysql
 
 before_install:
   - phpenv config-rm xdebug.ini || true
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - printf "\n" | pecl install -f redis
   - travis_retry composer self-update
+  - mysql -e 'CREATE DATABASE forge;'
 
 install:
   - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest; fi

--- a/tests/Integration/Database/Mysql/MysqlDatabaseTestCase.php
+++ b/tests/Integration/Database/Mysql/MysqlDatabaseTestCase.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Mysql;
+
+use Orchestra\Testbench\TestCase;
+
+class MysqlDatabaseTestCase extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'mysql',
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'username' => 'root',
+            'password' => '',
+            'database' => 'forge',
+            'prefix' => '',
+        ]);
+    }
+}

--- a/tests/Integration/Database/Mysql/MysqlEloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/Mysql/MysqlEloquentCollectionFreshTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Mysql;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @group integration
+ */
+class MysqlEloquentCollectionFreshTest extends MysqlDatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+        });
+    }
+
+    protected function tearDown()
+    {
+        Schema::drop('users');
+
+        parent::tearDown();
+    }
+
+    public function test_eloquent_collection_fresh()
+    {
+        User::insert([
+            ['email' => 'laravel@framework.com'],
+            ['email' => 'laravel@laravel.com'],
+        ]);
+
+        $collection = User::all();
+
+        User::whereKey($collection->pluck('id')->toArray())->delete();
+
+        $this->assertEmpty($collection->fresh()->filter());
+    }
+}
+
+class User extends Model
+{
+    protected $guarded = [];
+}
+

--- a/tests/Integration/Database/Mysql/MysqlEloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/Mysql/MysqlEloquentCollectionFreshTest.php
@@ -46,4 +46,3 @@ class User extends Model
 {
     protected $guarded = [];
 }
-


### PR DESCRIPTION
For the last few weeks there has been some Pull Requests related to database JSON columns (MySQL, Postgres and SQL Server). JSON columns are getting popular specially because database vendors are providing some built-in features on it. Usually those Pull Requests (such as https://github.com/laravel/framework/pull/24670) comes with a comment about SQLite either not supporting it or integration tests only working with SQLite.

This pull request attempts to bring MySQL integration tests as a starting-point for future integration tests that requires something different than SQLite.

Since this is just a Test Sample, I copied a simple test case from `EloquentCollectionFreshTest`. In a way, this Pull Request adds no value on it's own, but it does set the base for future contributors to be able to easily write test cases for Mysql.