### PR TITLE
[5.6] Add missing phpredis connection parameters to PhpRedisConnector.

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -92,8 +92,45 @@ class PhpRedisConnector
      */
     protected function establishConnection($client, array $config)
     {
-        $client->{($config['persistent'] ?? false) === true ? 'pconnect' : 'connect'}(
-            $config['host'], $config['port'], Arr::get($config, 'timeout', 0)
+        if($config['persistent'] ?? false) {
+            $this->establishPersistentConnection($client, $config);
+        } else {
+            $this->establishRegularConnection($client, $config);
+        }
+    }
+
+    /**
+     * Establish a persistent connection with the Redis host.
+     *
+     * @param  \Redis  $client
+     * @param  array  $config
+     * @return void
+     */
+    protected function establishPersistentConnection($client, array $config)
+    {
+        $client->pconnect(
+            $config['host'],
+            $config['port'],
+            Arr::get($config, 'timeout', 0.0),
+            Arr::get($config, 'persistent_id', NULL)
+        );
+    }
+
+    /**
+     * Establish a regular connection with the Redis host.
+     *
+     * @param  \Redis  $client
+     * @param  array  $config
+     * @return void
+     */
+    protected function establishRegularConnection($client, array $config)
+    {
+        $client->connect(
+            $config['host'],
+            $config['port'],
+            Arr::get($config, 'timeout', 0.0),
+            Arr::get($config, 'reserved', NULL),
+            Arr::get($config, 'retry_interval', 0)
         );
     }
 

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -92,7 +92,7 @@ class PhpRedisConnector
      */
     protected function establishConnection($client, array $config)
     {
-        if($config['persistent'] ?? false) {
+        if ($config['persistent'] ?? false) {
             $this->establishPersistentConnection($client, $config);
         } else {
             $this->establishRegularConnection($client, $config);
@@ -112,7 +112,7 @@ class PhpRedisConnector
             $config['host'],
             $config['port'],
             Arr::get($config, 'timeout', 0.0),
-            Arr::get($config, 'persistent_id', NULL)
+            Arr::get($config, 'persistent_id', null)
         );
     }
 
@@ -129,7 +129,7 @@ class PhpRedisConnector
             $config['host'],
             $config['port'],
             Arr::get($config, 'timeout', 0.0),
-            Arr::get($config, 'reserved', NULL),
+            Arr::get($config, 'reserved', null),
             Arr::get($config, 'retry_interval', 0)
         );
     }

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -573,6 +573,17 @@ class RedisConnectionTest extends TestCase
         }
     }
 
+    /**
+     * @test
+     */
+    public function it_persists_connection()
+    {
+        $this->assertEquals(
+            'laravel',
+            $this->connections()['persistent']->getPersistentID()
+        );
+    }
+
     public function connections()
     {
         $connections = [
@@ -595,7 +606,21 @@ class RedisConnectionTest extends TestCase
                 ],
             ]);
 
+            $persistentPhpRedis = new RedisManager('phpredis', [
+                'cluster' => false,
+                'default' => [
+                    'host' => $host,
+                    'port' => $port,
+                    'database' => 6,
+                    'options' => ['prefix' => 'laravel:'],
+                    'timeout' => 0.5,
+                    'persistent' => true,
+                    'persistent_id' => 'laravel'
+                ],
+            ]);
+
             $connections[] = $prefixedPhpredis->connection();
+            $connections['persistent'] = $persistentPhpRedis->connection();
         }
 
         return $connections;

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -578,6 +578,10 @@ class RedisConnectionTest extends TestCase
      */
     public function it_persists_connection()
     {
+        if (PHP_ZTS) {
+            $this->markTestSkipped('PhpRedis does not support persistent connections with PHP_ZTS enabled.');
+        }
+
         $this->assertEquals(
             'laravel',
             $this->connections()['persistent']->getPersistentID()

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -615,7 +615,7 @@ class RedisConnectionTest extends TestCase
                     'options' => ['prefix' => 'laravel:'],
                     'timeout' => 0.5,
                     'persistent' => true,
-                    'persistent_id' => 'laravel'
+                    'persistent_id' => 'laravel',
                 ],
             ]);
 


### PR DESCRIPTION
At the moment, not all of the connection options are supported for phpredis. Namely, the `persistent_id` parameter for `pconnect` and the `reserved` and `retry_interval` parameters for `connect` are missing.

The `persistent_id` parameter is particularly useful, since multiple connections will use the previous state of the connection, including any options passed via `setOption` and `select` operations. Configuring multiple connections with different `persistent_id` values isolates these.

This PR adds support for the 3 missing parameters in their respective cases via config options.

This doesn't break any backwards compatibility. The order of the parameters has not changed and the additional parameters are added with the defaults from phpredis code. Any previous connections to Redis will remain the same, unless the new parameters are configured.

Note: I suspect Travis is running an old version of Redis, which doesn't support persistent connections. Should this be upgraded or the added `it_persists_connection` test be removed?

References:
* [phpredis pconnect, popen](https://github.com/phpredis/phpredis#pconnect-popen)
* [phpredis connect, open](https://github.com/phpredis/phpredis#connect-open)
