### PR TITLE
[5.7] Allow overriding Eloquent model array attribute casting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -649,14 +649,14 @@ trait HasAttributes
     }
 
     /**
-     * Alias for fromJson
+     * Alias for fromJson.
      *
      * @param  string  $value
      * @return mixed
      */
     public function fromArray($value)
     {
-        return $this->fromJson($value, false);
+        return $this->fromJson($value);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -649,7 +649,7 @@ trait HasAttributes
     }
 
     /**
-     * Alias for fromJson.
+     * Convert an attribute to an array.
      *
      * @param  string  $value
      * @return mixed

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -649,7 +649,7 @@ trait HasAttributes
     }
 
     /**
-     * Convert an attribute to an array.
+     * Convert the given value for an array attribute.
      *
      * @param  string  $value
      * @return mixed

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -481,6 +481,7 @@ trait HasAttributes
             case 'object':
                 return $this->fromJson($value, true);
             case 'array':
+                return $this->fromArray($value);
             case 'json':
                 return $this->fromJson($value);
             case 'collection':
@@ -645,6 +646,17 @@ trait HasAttributes
     protected function asJson($value)
     {
         return json_encode($value);
+    }
+
+    /**
+     * Alias for fromJson
+     *
+     * @param  string  $value
+     * @return mixed
+     */
+    public function fromArray($value)
+    {
+        return $this->fromJson($value, false);
     }
 
     /**


### PR DESCRIPTION
The use case is that libraries exist to extend Eloquent for use with other database drivers, such as MongoDB and ElasticSearch. Some of these (in particular MongoDB) have native support for storing arrays without them needing to be encoded as JSON.

Currently, using a MongoDB driver I can't cast an array attribute as such in a model as it results in an error:

```
ErrorException: json_decode() expects parameter 1 to be string, array given
```

I could overload the fromJson method in the MongoDB Eloquent library, but that doesn't seem entirely right. I don't think a method called fromJson should need to check whether the value is already an array.

This would allow Eloquent drivers for database with native array support to override the `fromArray` method to return the value as it is rather than attempting to decode from json.

Admittedly, it isn't actually necessary to use a case at all if the database driver natively supports arrays. But this change makes it easier for the database driver to be changed without changing the casts attribute of the model.