### PR TITLE
[5.6] apply realpath option to refresh and fresh commands

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -50,6 +50,7 @@ class FreshCommand extends Command
         $this->call('migrate', [
             '--database' => $database,
             '--path' => $this->input->getOption('path'),
+            '--realpath' => $this->input->getOption('realpath'),
             '--force' => true,
         ]);
 

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -61,6 +61,7 @@ class RefreshCommand extends Command
         $this->call('migrate', [
             '--database' => $database,
             '--path' => $path,
+            '--realpath' => $this->input->getOption('realpath'),
             '--force' => $force,
         ]);
 
@@ -83,6 +84,7 @@ class RefreshCommand extends Command
         $this->call('migrate:rollback', [
             '--database' => $database,
             '--path' => $path,
+            '--realpath' => $this->input->getOption('realpath'),
             '--step' => $step,
             '--force' => $force,
         ]);
@@ -101,6 +103,7 @@ class RefreshCommand extends Command
         $this->call('migrate:reset', [
             '--database' => $database,
             '--path' => $path,
+            '--realpath' => $this->input->getOption('realpath'),
             '--force' => $force,
         ]);
     }

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -35,8 +35,8 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
         $console->shouldReceive('find')->with('migrate:reset')->andReturn($resetCommand);
         $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
 
-        $resetCommand->shouldReceive('run')->with(new InputMatcher("--database --path --force 'migrate:reset'"), m::any());
-        $migrateCommand->shouldReceive('run')->with(new InputMatcher('--database --path --force migrate'), m::any());
+        $resetCommand->shouldReceive('run')->with(new InputMatcher("--database --path --realpath --force 'migrate:reset'"), m::any());
+        $migrateCommand->shouldReceive('run')->with(new InputMatcher('--database --path --realpath --force migrate'), m::any());
 
         $this->runCommand($command);
     }
@@ -57,8 +57,8 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
         $console->shouldReceive('find')->with('migrate:rollback')->andReturn($rollbackCommand);
         $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
 
-        $rollbackCommand->shouldReceive('run')->with(new InputMatcher("--database --path --step=2 --force 'migrate:rollback'"), m::any());
-        $migrateCommand->shouldReceive('run')->with(new InputMatcher('--database --path --force migrate'), m::any());
+        $rollbackCommand->shouldReceive('run')->with(new InputMatcher("--database --path --realpath --step=2 --force 'migrate:rollback'"), m::any());
+        $migrateCommand->shouldReceive('run')->with(new InputMatcher('--database --path --realpath --force migrate'), m::any());
 
         $this->runCommand($command, ['--step' => 2]);
     }

--- a/tests/Integration/Database/RefreshCommandTest.php
+++ b/tests/Integration/Database/RefreshCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Support\Facades\DB;
+
+class RefreshCommandTest extends DatabaseTestCase
+{
+    public function test_refresh_without_realpath()
+    {
+        $this->app->setBasePath(__DIR__);
+
+        $options = [
+            '--path' => 'stubs/',
+        ];
+
+        $this->migrate_refresh_with($options);
+    }
+
+    public function test_refresh_with_realpath()
+    {
+        $options = [
+            '--path' => realpath(__DIR__.'/stubs/'),
+            '--realpath' => true,
+        ];
+
+        $this->migrate_refresh_with($options);
+    }
+
+    private function migrate_refresh_with(array $options)
+    {
+        $this->beforeApplicationDestroyed(function () use ($options) {
+            $this->artisan('migrate:rollback', $options);
+        });
+
+        $this->artisan('migrate:refresh', $options);
+        DB::table('members')->insert(['name' => 'foo', 'email' => 'foo@bar', 'password' => 'secret']);
+        $this->assertEquals(1, DB::table('members')->count());
+
+        $this->artisan('migrate:refresh', $options);
+        $this->assertEquals(0, DB::table('members')->count());
+    }
+}


### PR DESCRIPTION
Currently `--realpath` is ignored for `migrate:refresh` and `migrate:fresh` commands. This PR reads and applies the ignored option.