### PR TITLE
[5.6] Remove `.` in last word of route name

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -626,7 +626,11 @@ class Route
      */
     public function getName()
     {
-        return $this->action['as'] ?? null;
+        return isset($this->action['as'])
+            ? Str::endsWith($this->action['as'], '.')
+                ? substr($this->action['as'], 0 , -1)
+                : $this->action['as']
+            : null;
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -628,7 +628,7 @@ class Route
     {
         return isset($this->action['as'])
             ? Str::endsWith($this->action['as'], '.')
-                ? substr($this->action['as'], 0 , -1)
+                ? substr($this->action['as'], 0, -1)
                 : $this->action['as']
             : null;
     }


### PR DESCRIPTION
## When generate route with this example.
```
Route::group([
    'as' => 'the.',
    'prefix' => 'the',
], function () {
    Route::get('/', function () {});
    Route::get('/route', function () {})->name('route');
});
```
## Before
```
+--------+----------+-----------+-----------+---------+------------+
| Domain | Method   | URI       | Name      | Action  | Middleware |
+--------+----------+-----------+-----------+---------+------------+
|        | GET|HEAD | the       | the.      | Closure | web        |
|        | GET|HEAD | the/route | the.route | Closure | web        |
+--------+----------+-----------+-----------+---------+------------+
```

## After
```
+--------+----------+-----------+-----------+---------+------------+
| Domain | Method   | URI       | Name      | Action  | Middleware |
+--------+----------+-----------+-----------+---------+------------+
|        | GET|HEAD | the       | the       | Closure | web        |
|        | GET|HEAD | the/route | the.route | Closure | web        |
+--------+----------+-----------+-----------+---------+------------+
```

They should not contains `.` in last of route name.