### PR TITLE
[5.6] Fix Request::get() to correctly retrieve merged inputs in a JSON request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -330,6 +330,23 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Get an input element from any bag.
+     *
+     * @param  string  $key
+     * @param  mixed|null  $default
+     *
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        if ($this->isJson() && $this->hasJson()) {
+            return data_get($this->getJson()->all(), $key, $default);
+        }
+
+        return parent::get($key, $default);
+    }
+
+    /**
      * Get the input source for the request.
      *
      * @return \Symfony\Component\HttpFoundation\ParameterBag
@@ -536,6 +553,26 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $this->json = $json;
 
         return $this;
+    }
+
+    /**
+     * Get the JSON payload for the request.
+     *
+     * @return null|ParameterBag
+     */
+    public function getJson()
+    {
+        return $this->json;
+    }
+
+    /**
+     * Determine if the request contains JSON payload.
+     *
+     * @return bool
+     */
+    public function hasJson()
+    {
+        return isset($this->json);
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -904,6 +904,16 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(empty($request->undefined), true);
     }
 
+    public function testGetMethodRetrievesMergedParametersInJsonRequest()
+    {
+        $payload = ['name' => 'Taylor'];
+        $request = Request::create('/', 'GET', [], [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($payload));
+        $merge = ['buddy' => 'Dayle'];
+        $request->merge($merge);
+        $this->assertEquals('Taylor', $request->get('name'));
+        $this->assertEquals('Dayle', $request->get('buddy'));
+    }
+
     public function testHttpRequestFlashCallsSessionFlashInputWithInputData()
     {
         $session = m::mock('Illuminate\Session\Store');


### PR DESCRIPTION
Currently in Laravel if you merged an input to an existing request and you try to retrieve it with the different methods on the Request class [get, only, input] they will all work as expected. However if this is a JSON request and you tried to merge an input and retrieve it through the `get()` method, it won't return the merged input, it always fetches the original inputs.

Scenario to produce the problem:

```
$payload = ['name' => 'Taylor'];
$request = Request::create('/', 'GET', [], [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($payload));

$merge = ['age' => 26];
$request->merge($merge);

$request->get('age'); // Output: null
$request->input('age'); //Output: 26
```
