### PR TITLE
[5.6] Bumps nesbot/carbon to 1.29.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "erusev/parsedown": "~1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "~1.12",
-        "nesbot/carbon": "1.25.*",
+        "nesbot/carbon": "1.29.*",
         "psr/container": "~1.0",
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^3.7",


### PR DESCRIPTION
This version introduced new utility CarbonPeriod which is a nice interface for generating date periods into arrays / collectons and plays nicely with current Carbon\Carbon / DateTime objects
