### PR TITLE
Missing Terminate method in  Illuminate\Contracts\Foundation\Application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,14 @@ cache:
 services:
   - memcached
   - redis-server
+  - mysql
 
 before_install:
   - phpenv config-rm xdebug.ini || true
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - printf "\n" | pecl install -f redis
   - travis_retry composer self-update
+  - mysql -e 'CREATE DATABASE forge;'
 
 install:
   - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest; fi

--- a/CHANGELOG-5.6.md
+++ b/CHANGELOG-5.6.md
@@ -1,6 +1,20 @@
 # Release Notes for 5.6.x
 
-## v5.6.25 (pre-release)
+## v5.6.26 (2018-06-20)
+
+### Added
+- Added two Azure SQL server connection lost messages ([#24566](https://github.com/laravel/framework/pull/24566))
+- Allowed passing of recipient name in Mail notifications ([#24606](https://github.com/laravel/framework/pull/24606))
+- Started passing table name to the post migration create hooks ([#24621](https://github.com/laravel/framework/pull/24621))
+- Allowed array/collections in Auth::attempt method ([#24620](https://github.com/laravel/framework/pull/24620))
+
+### Changed
+- Prevent calling the bootable trait boot method multiple times ([#24556](https://github.com/laravel/framework/pull/24556))
+- Make chunkById() work for non-incrementing/non-integer ids as well ([#24563](https://github.com/laravel/framework/pull/24563))
+- Make ResetPassword Notification translatable ([#24534](https://github.com/laravel/framework/pull/24534))
+
+
+## v5.6.25 (2018-06-12)
 
 ### Added
 - Added whereJsonContains() to SQL Server ([#24448](https://github.com/laravel/framework/pull/24448))

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -166,6 +166,8 @@ class Application extends SymfonyApplication implements ApplicationContract
      * @param  array  $parameters
      * @param  \Symfony\Component\Console\Output\OutputInterface|null  $outputBuffer
      * @return int
+     *
+     * @throws \Symfony\Component\Console\Exception\CommandNotFoundException
      */
     public function call($command, array $parameters = [], $outputBuffer = null)
     {

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -481,6 +481,16 @@ class Migrator
     }
 
     /**
+     * Get the default connection name.
+     *
+     * @return string
+     */
+    public function getConnection()
+    {
+        return $this->connection;
+    }
+
+    /**
      * Set the default connection name.
      *
      * @param  string  $name
@@ -495,16 +505,6 @@ class Migrator
         $this->repository->setSource($name);
 
         $this->connection = $name;
-    }
-
-    /**
-     * Get the default connection name.
-     *
-     * @return string
-     */
-    public function getConnection()
-    {
-        return $this->connection;
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -498,6 +498,16 @@ class Migrator
     }
 
     /**
+     * Get the default connection name.
+     *
+     * @return string
+     */
+    public function getConnection()
+    {
+        return $this->connection;
+    }
+
+    /**
      * Resolve the database connection instance.
      *
      * @param  string  $connection

--- a/src/Illuminate/Foundation/Console/ViewClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewClearCommand.php
@@ -46,6 +46,8 @@ class ViewClearCommand extends Command
      * Execute the console command.
      *
      * @return void
+     *
+     * @throws \RuntimeException
      */
     public function handle()
     {

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -141,7 +141,7 @@ trait ConditionallyLoadsAttributes
         }
 
         if (! $this->resource->relationLoaded($relationship)) {
-            return $default;
+            return value($default);
         }
 
         if (func_num_args() === 1) {

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -373,6 +373,43 @@ class AuthAccessGateTest extends TestCase
 
         $this->assertFalse($gate->check(['edit', 'update'], new AccessGateTestDummy));
     }
+
+    /**
+     * @dataProvider hasAbilitiesTestDataProvider
+     *
+     * @param array $abilitiesToSet
+     * @param array|string $abilitiesToCheck
+     * @param bool $expectedHasValue
+     */
+    public function test_has_abilities($abilitiesToSet, $abilitiesToCheck, $expectedHasValue)
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->resource('test', AccessGateTestResource::class, $abilitiesToSet);
+
+        $this->assertEquals($expectedHasValue, $gate->has($abilitiesToCheck));
+    }
+
+    public function hasAbilitiesTestDataProvider()
+    {
+        $abilities = ['foo' => 'foo', 'bar' => 'bar'];
+        $noAbilities = [];
+
+        return [
+            [$abilities, ['test.foo', 'test.bar'], true],
+            [$abilities, ['test.bar', 'test.foo'], true],
+            [$abilities, ['test.bar', 'test.foo', 'test.baz'], false],
+            [$abilities, ['test.bar'], true],
+            [$abilities, ['baz'], false],
+            [$abilities, [''], false],
+            [$abilities, [], true],
+            [$abilities, 'test.bar', true],
+            [$abilities, 'test.foo', true],
+            [$abilities, '', false],
+            [$noAbilities, '', false],
+            [$noAbilities, [], true],
+        ];
+    }
 }
 
 class AccessGateTestClass

--- a/tests/Integration/Database/Mysql/MysqlDatabaseTestCase.php
+++ b/tests/Integration/Database/Mysql/MysqlDatabaseTestCase.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Mysql;
+
+use Orchestra\Testbench\TestCase;
+
+class MysqlDatabaseTestCase extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'mysql',
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'username' => 'root',
+            'password' => '',
+            'database' => 'forge',
+            'prefix' => '',
+        ]);
+    }
+}

--- a/tests/Integration/Database/Mysql/MysqlEloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/Mysql/MysqlEloquentCollectionFreshTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Mysql;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @group integration
+ */
+class MysqlEloquentCollectionFreshTest extends MysqlDatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+        });
+    }
+
+    protected function tearDown()
+    {
+        Schema::drop('users');
+
+        parent::tearDown();
+    }
+
+    public function test_eloquent_collection_fresh()
+    {
+        User::insert([
+            ['email' => 'laravel@framework.com'],
+            ['email' => 'laravel@laravel.com'],
+        ]);
+
+        $collection = User::all();
+
+        User::whereKey($collection->pluck('id')->toArray())->delete();
+
+        $this->assertEmpty($collection->fresh()->filter());
+    }
+}
+
+class User extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/Integration/Http/Fixtures/AuthorResourceWithOptionalRelationship.php
+++ b/tests/Integration/Http/Fixtures/AuthorResourceWithOptionalRelationship.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+class AuthorResourceWithOptionalRelationship extends PostResource
+{
+    public function toArray($request)
+    {
+        return [
+            'name' => $this->name,
+            'posts_count' => $this->whenLoaded('posts', function () {
+                return $this->posts->count().' posts';
+            }, function () {
+                return 'not loaded';
+            }),
+            'latest_post_title' => $this->whenLoaded('posts', function () {
+                return optional($this->posts->first())->title ?: 'no posts yet';
+            }, 'not loaded'),
+        ];
+    }
+}

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalData.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalData.php
@@ -15,6 +15,10 @@ class PostResourceWithOptionalData extends JsonResource
             'third' => $this->when(true, function () {
                 return 'value';
             }),
+            'fourth' => $this->when(false, 'value', 'default'),
+            'fifth' => $this->when(false, 'value', function () {
+                return 'default';
+            }),
         ];
     }
 }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -20,6 +20,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\EmptyPostCollectionResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalData;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationship;
+use Illuminate\Tests\Integration\Http\Fixtures\AuthorResourceWithOptionalRelationship;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalPivotRelationship;
 
 /**
@@ -88,6 +89,8 @@ class ResourceTest extends TestCase
                 'id' => 5,
                 'second' => 'value',
                 'third' => 'value',
+                'fourth' => 'default',
+                'fifth' => 'default',
             ],
         ]);
     }
@@ -188,6 +191,29 @@ class ResourceTest extends TestCase
                 'id' => 5,
                 'author' => null,
                 'author_name' => null,
+            ],
+        ]);
+    }
+
+    public function test_resources_may_have_optional_relationships_with_default_values()
+    {
+        Route::get('/', function () {
+            return new AuthorResourceWithOptionalRelationship(new Author([
+                'name' => 'jrrmartin',
+            ]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'name' => 'jrrmartin',
+                'posts_count' => 'not loaded',
+                'latest_post_title' => 'not loaded',
             ],
         ]);
     }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -878,6 +878,19 @@ class SupportHelpersTest extends TestCase
         }));
     }
 
+    public function testTransformDefaultWhenBlank()
+    {
+        $this->assertEquals('baz', transform(null, function () {
+            return 'bar';
+        }, 'baz'));
+
+        $this->assertEquals('baz', transform('', function () {
+            return 'bar';
+        }, function () {
+            return 'baz';
+        }));
+    }
+
     public function testWith()
     {
         $this->assertEquals(10, with(10));


### PR DESCRIPTION
As we noticed with @joanlopez 
In the `__constructor` method of the class `Illuminate\Foundation\Console\Kernel` we inject an `\Illuminate\Contracts\Foundation\Application`. 
Then in the line `149`, we call the `$this->app->terminate()` but this is not defined in the interface. So, if someone need to change this implementation and forget to implement the `terminate()` method, this would crash. 

Thanks ;) 

