### PR TITLE
Added terminate method in Application Contract

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -110,4 +110,11 @@ interface Application extends Container
      * @return string
      */
     public function getCachedPackagesPath();
+    
+    /**
+     * Terminate the application.
+     *
+     * @return void
+     */
+    public function terminate();
 }

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -110,7 +110,7 @@ interface Application extends Container
      * @return string
      */
     public function getCachedPackagesPath();
-    
+
     /**
      * Terminate the application.
      *


### PR DESCRIPTION
As we noticed with @joanlopez
In the `__constructor` method of the class `Illuminate\Foundation\Console\Kernel` we inject an `\Illuminate\Contracts\Foundation\Application`.
Then in the line `149`, we call the `$this->app->terminate()` but this is not defined in the interface. So, if someone need to change this implementation and forget to implement the `terminate()` method, this would crash.

Thanks ;)