### PR TITLE
[5.6] PHPDoc to prevent use of Request::get() the most we can

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -310,7 +310,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
-     * Symfony's Request get() method.
+     * Symfony's Request get() method. Do not use.
      *
      * You should not use this method in your Laravel application. This can
      * introduce subtle bugs. Use Laravel's Request input() method instead.

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -310,6 +310,17 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Symfony's Request get() method.
+     *
+     * You should not use this method in your Laravel application. This can
+     * introduce subtle bugs. Use Laravel's Request input() method instead.
+     */
+    public function get(...$args)
+    {
+        return parent::get(...$args);
+    }
+
+    /**
      * Get the JSON payload for the request.
      *
      * @param  string  $key


### PR DESCRIPTION
See #24689 and https://github.com/laravel/ideas/issues/114.