### PR TITLE
[5.6] Uncaught exception reported via response header

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -377,6 +377,24 @@ class TestResponse
     }
 
     /**
+     * Assert that the response has an Exception. You may specify a specific Exception class.
+     *
+     * @param null $exception_name
+     * @return $this
+     */
+    public function assertSeeException($exception_name = null)
+    {
+        $actual = $this->headers->get('x-laravel-exception');
+        if ($exception_name === null) {
+            PHPUnit::assertTrue(strlen($actual) > 0, 'Expected to see an exception but did not');
+        } else {
+            PHPUnit::assertSame($exception_name, $actual, 'Did not see expected exception: '.$exception_name.'. Instead saw '.$actual);
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the given string is not contained within the response.
      *
      * @param  string  $value
@@ -400,6 +418,33 @@ class TestResponse
         PHPUnit::assertNotContains((string) $value, strip_tags($this->getContent()));
 
         return $this;
+    }
+
+    /**
+     * Assert the requested page did not have an uncaught exception
+     * Alias of `assertNoException`.
+     *
+     * @return this
+     */
+    public function assertDontSeeException()
+    {
+        $exception = $this->headers->get('x-laravel-exception');
+        if ($exception !== null) {
+            PHPUnit::fail('Laravel exception: '.$this->headers->get('x-laravel-exception').' : '.$this->headers->get('x-laravel-exception-msg'));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert the requested page did not have an uncaught exception
+     * Alias of `assertDontSeeException`.
+     *
+     * @return $this
+     */
+    public function assertNoException()
+    {
+        return $this->assertDontSeeException();
     }
 
     /**

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -126,6 +126,39 @@ trait ResponseTrait
     {
         $this->exception = $e;
 
+        // For security, we only want to expose this header in test environments
+        if (app()->runningUnitTests() === true || config('app.debug') === true) {
+            $this->setExceptionHeader($e);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Expose an exception as a header on the response.
+     *
+     * @param \Exception $e
+     * @return $this
+     */
+    public function setExceptionHeader(Exception $e)
+    {
+        $msg = $e->getMessage();
+        if ($e instanceof \Illuminate\Validation\ValidationException) {
+            $msg = $e->getMessage().' : '.$e->validator->errors()->toJson();
+        }
+
+        // Strip newlines from exception messages
+        $msg = preg_replace('/[\r\n]/', ' ', $msg);
+
+        $headers = [
+            'x-laravel-exception' => get_class($e),
+            'x-laravel-exception-msg' => substr($msg, 0, 1024),
+            'x-laravel-exception-line' => $e->getFile().':'.$e->getLine(),
+        ];
+
+        // Add these headers to the response
+        $this->withHeaders($headers);
+
         return $this;
     }
 

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -107,6 +107,17 @@ class FoundationTestResponseTest extends TestCase
         }
     }
 
+    public function testAssertSeeException()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->setExceptionHeader(new \Exception('foo'));
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertSeeException(\Exception::class);
+    }
+
     public function testAssertHeader()
     {
         $baseResponse = tap(new Response, function ($response) {

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -196,6 +196,21 @@ class HttpResponseTest extends TestCase
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');
     }
+
+    public function testSetExceptionHeader()
+    {
+        $response = new \Illuminate\Http\Response('');
+
+        $response->setExceptionHeader(new \Exception('foo'));
+
+        $this->assertSame($response->headers->get('x-laravel-exception'), \Exception::class);
+        $this->assertSame($response->headers->get('x-laravel-exception-msg'), 'foo');
+
+        $response->withException(new \Illuminate\Validation\UnauthorizedException('bar'));
+
+        $this->assertSame($response->headers->get('x-laravel-exception'), \Illuminate\Validation\UnauthorizedException::class);
+        $this->assertSame($response->headers->get('x-laravel-exception-msg'), 'bar');
+    }
 }
 
 class ArrayableStub implements Arrayable


### PR DESCRIPTION
When creating unit/acceptance tests for their sites, many developers resort to a widely used `$this->disableExceptionHandling()` strategy within their tests. I find this approach less than ideal and so my strategy is to instead include the unhandled exception information in the response headers. I've used this approach for several months in over 500 tests and believe it's now stable enough to contribute into the framework.

This will not break existing sites because it simply adds additional headers to the response. I've included new assertions such as  `assertSeeException` that can be used in lieu of `disableExceptionHandling`. 

Test driven development is extremely important and providing this alternative approach for TDD tests will make it easier for many developers (as it has for me).
