### PR TITLE
[5.6] add missing docblock for InvalidArgumentException

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -51,6 +51,8 @@ abstract class Manager
      *
      * @param  string  $driver
      * @return mixed
+     *
+     * @throws \InvalidArgumentException
      */
     public function driver($driver = null)
     {


### PR DESCRIPTION
Add missing docblock for \InvalidArgumentException