### PR TITLE
[5.6] remove deprected warning caused by symfony http foundation.

### DIFF
--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -99,7 +99,7 @@ class UploadedFile extends SymfonyUploadedFile
             $file->getPathname(),
             $file->getClientOriginalName(),
             $file->getClientMimeType(),
-            $file->getClientSize(),
+            $file->getSize(),
             $file->getError(),
             $test
         );


### PR DESCRIPTION
[`Symfony\Component\HttpFoundation\File\UploadedFile::getClientSize`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/File/UploadedFile.php#L161) has been deprecated since Symfony 4.1. Use `getSize()` instead.