### PR TITLE
[5.7] No need to import DateTime

### DIFF
--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Auth;
 
-use DateTime;
-
 trait MustVerifyEmail
 {
     /**
@@ -23,7 +21,7 @@ trait MustVerifyEmail
      */
     public function markEmailAsVerified()
     {
-        $this->forceFill(['email_verified_at' => new DateTime])->save();
+        $this->forceFill(['email_verified_at' => $this->freshTimestamp()])->save();
     }
 
     /**


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

No need to import `DateTime` in `\Illuminate\Auth\MustVerifyEmail`