### PR TITLE
[5.7] Let \Illuminate\Support\Carbon support immutable datetimes.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.0",
+        "cakephp/chronos": "^1.1",
         "doctrine/dbal": "^2.6",
         "filp/whoops": "^2.1.4",
         "league/flysystem-cached-adapter": "^1.0",
@@ -112,6 +113,7 @@
         "ext-pcntl": "Required to use all features of the queue worker.",
         "ext-posix": "Required to use all features of the queue worker.",
         "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (^3.0).",
+        "cakephp/chronos": "Required to use immutable datetimes (^1.1).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (^1.4).",
         "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers and the ping methods on schedules (^6.0).",

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -14,9 +14,8 @@ class Carbon extends BaseCarbon
      */
     public function immutable()
     {
-        return MutableDateTime::createFromFormat(
-            'Y-m-d H:i:s',
-            $this->toDateTimeString(),
+        return MutableDateTime::createFromTimestamp(
+            $this->getTimestamp(),
             $this->getTimezone()
         )->toImmutable();
     }

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -3,7 +3,21 @@
 namespace Illuminate\Support;
 
 use Carbon\Carbon as BaseCarbon;
+use Cake\Chronos\MutableDateTime;
 
 class Carbon extends BaseCarbon
 {
+    /**
+     * Return an immutable datetime.
+     *
+     * @return \Cake\Chronos\Chronos
+     */
+    public function immutable()
+    {
+        return MutableDateTime::createFromFormat(
+            'Y-m-d H:i:s',
+            $this->toDateTimeString(),
+            $this->getTimezone()
+        )->toImmutable();
+    }
 }

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -37,6 +37,7 @@
         }
     },
     "suggest": {
+        "cakephp/chronos": "Required to use immutable datetimes (^1.1).",
         "illuminate/filesystem": "Required to use the composer class (5.7.*).",
         "ramsey/uuid": "Required to use Str::uuid() (^3.7).",
         "symfony/process": "Required to use the composer class (^4.1).",

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -122,5 +122,6 @@ class SupportCarbonTest extends TestCase
 
         $this->assertInstanceOf(Chronos::class, $immutable);
         $this->assertSame($this->now->getTimestamp(), $immutable->getTimestamp());
+        $this->assertEquals($this->now->getTimezone(), $immutable->getTimezone());
     }
 }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use DateTime;
 use DateTimeInterface;
+use Cake\Chronos\Chronos;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Carbon\Carbon as BaseCarbon;
@@ -112,5 +113,14 @@ class SupportCarbonTest extends TestCase
         $deserialized = eval($serialized);
 
         $this->assertInstanceOf(Carbon::class, $deserialized);
+    }
+
+    public function testImmutable()
+    {
+        $immutable = $this->now->immutable();
+        $immutable->addYear();
+
+        $this->assertInstanceOf(Chronos::class, $immutable);
+        $this->assertSame($this->now->getTimestamp(), $immutable->getTimestamp());
     }
 }


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Let `\Illuminate\Support\Carbon` support immutable datetimes and return a Chonos instance.

---

This requires `cakephp/chronos` to be installed as set in the suggest section of `composer.json`.