### PR TITLE
[5.6] Improve unit test error message when assertion fails

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -56,6 +56,8 @@ class TestResponse
      */
     public function assertSuccessful()
     {
+        $this->assertNoException();
+
         PHPUnit::assertTrue(
             $this->isSuccessful(),
             'Response status code ['.$this->getStatusCode().'] is not a successful status code.'
@@ -377,6 +379,24 @@ class TestResponse
     }
 
     /**
+     * Assert that the response has an Exception. You may specify a specific Exception class.
+     *
+     * @param null $exception_name
+     * @return $this
+     */
+    public function assertSeeException($exception_name = null)
+    {
+        $actual = $this->headers->get('x-laravel-exception');
+        if ($exception_name === null) {
+            PHPUnit::assertTrue(strlen($actual) > 0, 'Expected to see an exception but did not');
+        } else {
+            PHPUnit::assertSame($exception_name, $actual, 'Did not see expected exception: '.$exception_name.'. Instead saw '.$actual);
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the given string is not contained within the response.
      *
      * @param  string  $value
@@ -400,6 +420,33 @@ class TestResponse
         PHPUnit::assertNotContains((string) $value, strip_tags($this->getContent()));
 
         return $this;
+    }
+
+    /**
+     * Assert the requested page did not have an uncaught exception
+     * Alias of `assertNoException`.
+     *
+     * @return this
+     */
+    public function assertDontSeeException()
+    {
+        $exception = $this->headers->get('x-laravel-exception');
+        if ($exception !== null) {
+            PHPUnit::fail('Laravel exception: '.$this->headers->get('x-laravel-exception').' : '.$this->headers->get('x-laravel-exception-msg'));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert the requested page did not have an uncaught exception
+     * Alias of `assertDontSeeException`.
+     *
+     * @return $this
+     */
+    public function assertNoException()
+    {
+        return $this->assertDontSeeException();
     }
 
     /**

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -107,6 +107,17 @@ class FoundationTestResponseTest extends TestCase
         }
     }
 
+    public function testAssertSeeException()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->setExceptionHeader(new \Exception('foo'));
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertSeeException(\Exception::class);
+    }
+
     public function testAssertHeader()
     {
         $baseResponse = tap(new Response, function ($response) {

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -196,6 +196,21 @@ class HttpResponseTest extends TestCase
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');
     }
+
+    public function testSetExceptionHeader()
+    {
+        $response = new \Illuminate\Http\Response('');
+
+        $response->setExceptionHeader(new \Exception('foo'));
+
+        $this->assertSame($response->headers->get('x-laravel-exception'), \Exception::class);
+        $this->assertSame($response->headers->get('x-laravel-exception-msg'), 'foo');
+
+        $response->withException(new \Illuminate\Validation\UnauthorizedException('bar'));
+
+        $this->assertSame($response->headers->get('x-laravel-exception'), \Illuminate\Validation\UnauthorizedException::class);
+        $this->assertSame($response->headers->get('x-laravel-exception-msg'), 'bar');
+    }
 }
 
 class ArrayableStub implements Arrayable


### PR DESCRIPTION
(This PR started as #24707 and has been revised based on community feedback)

On many projects it's not possible to use `$this->withoutExceptionHandling()` -- I work in the financial sector and we often need to test how unhandled exceptions are dealt with by the system. Additionally, I find  `$this->withoutExceptionHandling()` to be unnecessarily verbose and can be confusing to new devs. With all of these factors in mind, this PR aims to make TDD easier for those that can't (or don't want to) use  `$this->withoutExceptionHandling()` -- also improving the debugging experience out of the box for those that use `$response->assertSuccessful()`

**When an unhandled exception occurs, instead of just causing your assertions to fail, the Exception information is printed to the console, similar to what you get with exception handling disabled -- except you don't have to disable it**

Example 1:
```
$this->withoutExceptionHandling();
$this->json('POST', ...)->assertSuccessful();
$this->withExceptionHandling();
```

Now becomes:
```
$this->json('POST', ...)->assertSuccessful();
```

Example 2:

```
$this->withoutExceptionHandling();
$this->json('POST', ...)->assertStatus(200);
$this->withExceptionHandling();
```
Now becomes:
```
$this->json('POST', ...)->assertNoException()->assertStatus(200);
```

Similar to how `$this->post(...)->assertSessionHasErrors()` is able to check for certain errors, this would be a more similar approach that can check for **any uncaught exceptions**.  