### PR TITLE
[5.6] Check if configuration cache is valid after saving

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -65,7 +65,7 @@ class ConfigCacheCommand extends Command
             $this->files->delete($configPath);
             throw new LogicException('Unable to cache Laravel configuration.', 0, $e);
         }
-        
+
         $this->info('Configuration cached successfully!');
     }
 


### PR DESCRIPTION
If a configuration is cached with closures, the caching command works correctly, but an error occurs when loading the app next time.

This prevents that, and deletes the config when it's invalid.

To test it, just add a closure in any config value and try to cache it.