### PR TITLE
[5.6] Fix BelongsTo self relation existence query with custom owner key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -274,7 +274,7 @@ class BelongsTo extends Relation
         $query->getModel()->setTable($hash);
 
         return $query->whereColumn(
-            $hash.'.'.$query->getModel()->getKeyName(), '=', $this->getQualifiedForeignKey()
+            $this->getQualifiedForeignKey(), '=', $hash.'.'.$this->ownerKey
         );
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -848,6 +848,15 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertContains('"self_alias_hash"."id" = "self_related_stubs"."parent_id"', $sql);
     }
 
+    public function testSelfHasWithCustomOwnerKey()
+    {
+        $model = new EloquentBuilderTestModelSelfRelatedStub;
+
+        $sql = $model->has('parentBar')->toSql();
+
+        $this->assertRegExp('/"laravel_reserved_\d"\."owner_key"/', $sql);
+    }
+
     public function testDoesntHave()
     {
         $model = new EloquentBuilderTestModelParentStub;
@@ -1096,6 +1105,11 @@ class EloquentBuilderTestModelSelfRelatedStub extends \Illuminate\Database\Eloqu
     public function parentFoo()
     {
         return $this->belongsTo('Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub', 'parent_id', 'id', 'parent');
+    }
+
+    public function parentBar()
+    {
+        return $this->belongsTo('Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub', 'parent_id', 'owner_key', 'parent');
     }
 
     public function childFoo()


### PR DESCRIPTION
`BelongsTo` doesn't use custom owner keys on self relation existence queries. It always uses the model's primary key instead:

```php
public function parent() {
    return $this->belongsTo(self::class, 'parent_id', 'owner_key');
}

User::has('parent')->toSql();
// expected: [...] where "laravel_reserved_0"."owner_key" = "users"."parent_id"
// actual:   [...] where "laravel_reserved_0"."id" = "users"."parent_id"
```

I switched the columns to match the order in `getRelationExistenceQuery()`.

Fixes #24721.