### PR TITLE
[5.7] Make httpOnly CSRF cookie optional

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -35,7 +35,7 @@ class VerifyCsrfToken
     protected $except = [];
 
     /**
-     * If you're client-side scripts need the XSRF-TOKEN cookie, enable this setting.
+     * If your client-side scripts need the XSRF-TOKEN cookie, enable this setting.
      *
      * @var bool
      */

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -35,6 +35,13 @@ class VerifyCsrfToken
     protected $except = [];
 
     /**
+     * If you're client-side scripts need the XSRF-TOKEN cookie, enable this setting.
+     *
+     * @var bool
+     */
+    protected $addHttpCookie = false;
+
+    /**
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Foundation\Application  $app
@@ -64,7 +71,13 @@ class VerifyCsrfToken
             $this->inExceptArray($request) ||
             $this->tokensMatch($request)
         ) {
-            return $this->addCookieToResponse($request, $next($request));
+            $response = $next($request);
+
+            if ($this->addHttpCookie) {
+                $this->addCookieToResponse($request, $response);
+            }
+
+            return $response;
         }
 
         throw new TokenMismatchException;


### PR DESCRIPTION
This httpOnly Cookie is added by default, to enable automatic passing of the CSRF token to frameworks like Angular. But this is not the case for many other Http libraries (eg. for jQuery and Axios, Laravel just sets the headers directly).

While this cookie does not have any security implications (that I'm aware of), I've had multiple security audits flag this as an issue. While they may be (and probably indeed are) incorrect, it can be difficult to explain, especially if you don't actually use libraries that require this.

This adds a flag to toggle the cookie more easily. It should be accompanied by adding the same property to the laravel/laravel framework and/or a note in the docs.
This is breaking, so it warrants an upgrade guide notice. But we could also change the default to `true` to avoid the break.

See also https://github.com/laravel/ideas/issues/873