### PR TITLE
[5.7] Add array_keys_exists helper method

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -362,6 +362,26 @@ class Arr
     }
 
     /**
+     * Determines if keys of the provided array exist in another array.
+     *
+     * @param  array  $needed
+     * @param  array  $provided
+     * @return bool
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function keysExists(array $needed, array $provided)
+    {
+        if (static::isAssoc($needed) && static::isAssoc($provided)) {
+            return $needed === array_intersect_key($needed, $provided);
+        }
+
+        throw new InvalidArgumentException(
+            'Arrays passed should be associative arrays'
+        );
+    }
+
+    /**
      * Get a subset of the items from the given array.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -172,6 +172,20 @@ if (! function_exists('array_has')) {
     }
 }
 
+if (! function_exists('array_keys_exits')) {
+    /**
+     * Determines if keys of the provided array exist in another array.
+     *
+     * @param  array  $needed
+     * @param  array  $provided
+     * @return bool
+     */
+    function array_keys_exits($needed, $provided)
+    {
+        return Arr::keysExists($needed, $provided);
+    }
+}
+
 if (! function_exists('array_last')) {
     /**
      * Return the last element in an array passing a given truth test.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -172,7 +172,7 @@ if (! function_exists('array_has')) {
     }
 }
 
-if (! function_exists('array_keys_exits')) {
+if (! function_exists('array_keys_exists')) {
     /**
      * Determines if keys of the provided array exist in another array.
      *
@@ -180,7 +180,7 @@ if (! function_exists('array_keys_exits')) {
      * @param  array  $provided
      * @return bool
      */
-    function array_keys_exits($needed, $provided)
+    function array_keys_exists($needed, $provided)
     {
         return Arr::keysExists($needed, $provided);
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -331,6 +331,19 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::isAssoc(['a', 'b']));
     }
 
+    public function testKeysExists()
+    {
+        $neededOnModel = ['api_key' => '', 'secret' => ''];
+        $providedInRequest = ['api_key' => 'somerandomkey', 'secret' => 'somesecret'];
+
+        $this->assertTrue(Arr::keysExists($neededOnModel, $providedInRequest));
+
+        $neededOnModel = ['api_key' => '', 'secret' => ''];
+        $providedInRequest = ['api_key' => 'somerandomkey'];
+
+        $this->assertFalse(Arr::keysExists($neededOnModel, $providedInRequest));
+    }
+
     public function testOnly()
     {
         $array = ['name' => 'Desk', 'price' => 100, 'orders' => 10];


### PR DESCRIPTION
- PHP's `array_key_exists` method doesn't check for multiple keys.
- This helper method tends to fill that void.
- Have added the tests and will send a PR for the docs if this gets merged.
----
### Update: A practical use case
- While creating an app like Forge, you would have a table/list of 'Services' (with context to Forge, services could be DO, linode, etc.)
- Chances are these services have different set of required API credentials. One requires an API key as well as a secret key, while another just requires the API key.
- So you would like to defines the `allowed_keys` for every service, preferably in a json column 
- Example data:

| id | name | allowed_keys |
| ----|-------- | ------------- |
| 1 | DO  | {"api_key": "", "service": ""} |

- So while validating the request inputs received, the proposed `array_keys_exists` could be really helpful. 

----
Open to all suggestions 🙂 