### PR TITLE
[5.6] Define routes that are accessible while in maintenance mode

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -14,9 +14,10 @@ class DownCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'down {--message= : The message for the maintenance mode. }
+    protected $signature = 'down {--message= : The message for the maintenance mode.}
                                  {--retry= : The number of seconds after which the request may be retried.}
-                                 {--allow=* : IP or networks allowed to access the application while in maintenance mode.}';
+                                 {--allow=* : IP or networks allowed to access the application while in maintenance mode.}
+                                 {--except=* : Names of routes that shall be accessible while in maintenance mode.}';
 
     /**
      * The console command description.
@@ -52,6 +53,7 @@ class DownCommand extends Command
             'message' => $this->option('message'),
             'retry' => $this->getRetryTime(),
             'allowed' => $this->option('allow'),
+            'except' => $this->option('except'),
         ];
     }
 

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -17,7 +17,7 @@ class DownCommand extends Command
     protected $signature = 'down {--message= : The message for the maintenance mode.}
                                  {--retry= : The number of seconds after which the request may be retried.}
                                  {--allow=* : IP or networks allowed to access the application while in maintenance mode.}
-                                 {--except=* : Names of routes that shall be accessible while in maintenance mode.}';
+                                 {--except=* : Request URIs that shall be accessible while in maintenance mode.}';
 
     /**
      * The console command description.

--- a/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
+++ b/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
@@ -45,6 +45,10 @@ class CheckForMaintenanceMode
                 return $next($request);
             }
 
+            if (isset($data['except']) && in_array($request->getRequestUri(), (array) $data['except'])) {
+                return $next($request);
+            }
+
             throw new MaintenanceModeException($data['time'], $data['retry'], $data['message']);
         }
 


### PR DESCRIPTION
This pull request adds a **minor** feature to the `artisan down` command and the *CheckForMaintenanceMode* middleware. The user is able to define routes that shall be excluded from maintenance mode which is especially useful when the developer wants to continue to serve e.g. static pages with useful or even required information.

**Possible Use Case**
Example: To comply with EU-law the service provider of a commercial website is required to make sure that every visitor is able to see who is running the website (Legal information page). To prevent legal actions from competitors they may want to show those (static) pages even when the application is in maintenance mode.

**Usage**
`php artisan down --except=/legal --except=/privacy`  

This will result in maintenance mode for the whole application but requests to the routes `/legal` and `/privacy` won't be filtered out by the maintenance middleware.

**Breaking Changes**
**None!** It's an optional parameter for the `artisan down` command that does not affect the usage of the other commands in any way. Also the specific check in the middleware is only run when the `$data['except']` field is set.

**Further discussion**
see: https://github.com/laravel/ideas/issues/1242