### PR TITLE
[5.6] Add missing docblock for RuntimeException

### DIFF
--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -47,6 +47,8 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      * @param  string  $value
      * @param  array  $options
      * @return string
+     *
+     * @throws \RuntimeException
      */
     public function make($value, array $options = [])
     {


### PR DESCRIPTION
This PR adds a missing docblock for RuntimeException