### PR TITLE
[5.7] Use functional mail button class names

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/button.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/button.blade.php
@@ -7,7 +7,7 @@
                         <table border="0" cellpadding="0" cellspacing="0">
                             <tr>
                                 <td>
-                                    <a href="{{ $url }}" class="button button-{{ $type ?? 'primary' }}" target="_blank">{{ $slot }}</a>
+                                    <a href="{{ $url }}" class="button button-{{ $color ?? 'primary' }}" target="_blank">{{ $slot }}</a>
                                 </td>
                             </tr>
                         </table>

--- a/src/Illuminate/Mail/resources/views/html/button.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/button.blade.php
@@ -7,7 +7,7 @@
                         <table border="0" cellpadding="0" cellspacing="0">
                             <tr>
                                 <td>
-                                    <a href="{{ $url }}" class="button button-{{ $color ?? 'blue' }}" target="_blank">{{ $slot }}</a>
+                                    <a href="{{ $url }}" class="button button-{{ $type ?? 'primary' }}" target="_blank">{{ $slot }}</a>
                                 </td>
                             </tr>
                         </table>

--- a/src/Illuminate/Mail/resources/views/html/themes/default.css
+++ b/src/Illuminate/Mail/resources/views/html/themes/default.css
@@ -218,7 +218,7 @@ img {
     -webkit-text-size-adjust: none;
 }
 
-.button-blue {
+.button-primary {
     background-color: #3097D1;
     border-top: 10px solid #3097D1;
     border-right: 18px solid #3097D1;
@@ -226,7 +226,7 @@ img {
     border-left: 18px solid #3097D1;
 }
 
-.button-green {
+.button-success {
     background-color: #2ab27b;
     border-top: 10px solid #2ab27b;
     border-right: 18px solid #2ab27b;
@@ -234,7 +234,7 @@ img {
     border-left: 18px solid #2ab27b;
 }
 
-.button-red {
+.button-danger {
     background-color: #bf5329;
     border-top: 10px solid #bf5329;
     border-right: 18px solid #bf5329;

--- a/src/Illuminate/Mail/resources/views/html/themes/default.css
+++ b/src/Illuminate/Mail/resources/views/html/themes/default.css
@@ -218,6 +218,7 @@ img {
     -webkit-text-size-adjust: none;
 }
 
+.button-blue,
 .button-primary {
     background-color: #3097D1;
     border-top: 10px solid #3097D1;
@@ -226,6 +227,7 @@ img {
     border-left: 18px solid #3097D1;
 }
 
+.button-green,
 .button-success {
     background-color: #2ab27b;
     border-top: 10px solid #2ab27b;
@@ -234,7 +236,8 @@ img {
     border-left: 18px solid #2ab27b;
 }
 
-.button-danger {
+.button-red,
+.button-error {
     background-color: #bf5329;
     border-top: 10px solid #bf5329;
     border-right: 18px solid #bf5329;

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -21,13 +21,11 @@
 <?php
     switch ($level) {
         case 'success':
-            $color = 'green';
-            break;
         case 'error':
-            $color = 'red';
+            $color = $level;
             break;
         default:
-            $color = 'blue';
+            $color = 'primary';
     }
 ?>
 @component('mail::button', ['url' => $actionUrl, 'color' => $color])


### PR DESCRIPTION
This PR replaces color names with functional labels for button classes. 

Today, if your application's primary color is something other than blue, you need to override the `button.blade.php` component if you don't want a `button-blue` class that isn't blue.

I stole Bootstrap's color names for the new button classes. If this gets accepted, I'll send a follow-up documentation PR.