### PR TITLE
[5.7] Collection::where with one parameter

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -524,7 +524,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  mixed  $value
      * @return static
      */
-    public function where($key, $operator, $value = null)
+    public function where($key, $operator = null, $value = null)
     {
         return $this->filter($this->operatorForWhere(...func_get_args()));
     }
@@ -537,8 +537,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  mixed  $value
      * @return \Closure
      */
-    protected function operatorForWhere($key, $operator, $value = null)
+    protected function operatorForWhere($key, $operator = null, $value = null)
     {
+        if (func_num_args() === 1) {
+            $value = true;
+
+            $operator = '=';
+        }
+
         if (func_num_args() === 2) {
             $value = $operator;
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -483,6 +483,12 @@ class SupportCollectionTest extends TestCase
             [['v' => 'hello']],
             $c->where('v', new \Illuminate\Support\HtmlString('hello'))->values()->all()
         );
+
+        $c = new Collection([['v' => 1], ['v' => 2], ['v' => null]]);
+        $this->assertEquals(
+            [['v' => 1], ['v' => 2]],
+            $c->where('v')->values()->all()
+        );
     }
 
     public function testWhereStrict()


### PR DESCRIPTION
This allows you to call `where` with one parameter for truthy values.

For example, `$posts->where('draft')` to retrieve all posts with `['draft' => true]`.