### PR TITLE
[5.7] Tuple notation for UrlGenerator actions

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -392,7 +392,7 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Get the URL to a controller action.
      *
-     * @param  string  $action
+     * @param  string|array  $action
      * @param  mixed   $parameters
      * @param  bool    $absolute
      * @return string
@@ -411,11 +411,15 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Format the given controller action.
      *
-     * @param  string  $action
+     * @param  string|array  $action
      * @return string
      */
     protected function formatAction($action)
     {
+        if (is_array($action)) {
+            $action = implode('@', $action);
+        }
+
         if ($this->rootNamespace && ! (strpos($action, '\\') === 0)) {
             return $this->rootNamespace.'\\'.$action;
         } else {

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -244,6 +244,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('/foo/bar/taylor/breeze/otwell?fly=wall', $url->route('bar', ['taylor', 'otwell', 'fly' => 'wall'], false));
         $this->assertEquals('https://www.foo.com/foo/baz', $url->route('baz'));
         $this->assertEquals('http://www.foo.com/foo/bam', $url->action('foo@bar'));
+        $this->assertEquals('http://www.foo.com/foo/bam', $url->action(['foo', 'bar']));
         $this->assertEquals('http://www.foo.com/foo/invoke', $url->action('InvokableActionStub'));
         $this->assertEquals('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['wall', 'woz', 'boom' => 'otwell', 'baz' => 'taylor']));
         $this->assertEquals('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['taylor', 'otwell', 'wall', 'woz']));


### PR DESCRIPTION
This PR allows you to use a tuple notation for generating action urls. This is especially useful when importing a controller class.

```php
action([FooController::class, 'bar']);
```

I think it'd make sense to do this in the router too, but that's a but trickier because we'd need to detect if it's an associative array (for `['uses' => '...']`) first.