### PR TITLE
[5.6] Except URIs from CheckForMaintenanceMode middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
+++ b/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
@@ -17,6 +17,13 @@ class CheckForMaintenanceMode
     protected $app;
 
     /**
+     * The URIs that should be accessible while maintenance mode is enabled.
+     *
+     * @var array
+     */
+    protected $except = [];
+
+    /**
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -45,9 +52,35 @@ class CheckForMaintenanceMode
                 return $next($request);
             }
 
+            if ($this->inExceptArray($request)) {
+                return $next($request);
+            }
+
             throw new MaintenanceModeException($data['time'], $data['retry'], $data['message']);
         }
 
         return $next($request);
     }
+
+    /**
+     * Determine if the request has a URI that should be accessible in maintenance mode.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function inExceptArray($request)
+    {
+        foreach ($this->except as $except) {
+            if ($except !== '/') {
+                $except = trim($except, '/');
+            }
+
+            if ($request->fullUrlIs($except) || $request->is($except)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
 }


### PR DESCRIPTION
**Feature**
Like in the `VerfiyCsrfToken` middleware you should be able to specify URIs that are excluded from the handling of the `CheckForMaintenanceMode` middleware by adding them to a `$except` array. URIs that are matching are handled by the application even when maintenance mode is currently active.

**Type**
I consider this a minor feature.

**Background & Use Case**
Check the old pull request (https://github.com/laravel/framework/pull/24731) that was designed to extend the `artisan down` command and the original feature proposal (https://github.com/laravel/ideas/issues/1242) for a deeper description of the use case.

**Usage**
Same procedure as in the `VerifyCsrfToken` middleware:

```
<?php

namespace App\Http\Middleware;

use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode as Middleware;

class CheckForMaintenanceMode extends Middleware
{
    /**
     * The URIs that should be excluded from CSRF verification.
     *
     * @var array
     */
    protected $except = [
        '/legal',
        '/privacy',
        '/terms',
        '/even/wildcards/are/okay/*
    ];
}
```

**Breaking Changes**
None. The middleware keeps its usual behavior unless the `$except` array gets redefined in a child middleware that extends the `CheckForMaintenanceMode` middleware.