### PR TITLE
[5.6] No need to pass unused $app as an argument.

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -207,7 +207,7 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerAuthMakeCommand()
     {
-        $this->app->singleton('command.auth.make', function ($app) {
+        $this->app->singleton('command.auth.make', function () {
             return new AuthMakeCommand;
         });
     }
@@ -622,7 +622,7 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerPackageDiscoverCommand()
     {
-        $this->app->singleton('command.package.discover', function ($app) {
+        $this->app->singleton('command.package.discover', function () {
             return new PackageDiscoverCommand;
         });
     }
@@ -966,7 +966,7 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerViewCacheCommand()
     {
-        $this->app->singleton('command.view.cache', function ($app) {
+        $this->app->singleton('command.view.cache', function () {
             return new ViewCacheCommand;
         });
     }


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

No need to pass unused `$app` as an argument.