### PR TITLE
[5.6] Passes `token` configuration value to AWS Client

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -220,7 +220,7 @@ class FilesystemManager implements FactoryContract
         $config += ['version' => 'latest'];
 
         if ($config['key'] && $config['secret']) {
-            $config['credentials'] = Arr::only($config, ['key', 'secret']);
+            $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
         }
 
         return $config;

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -19,7 +19,7 @@ class SqsConnector implements ConnectorInterface
         $config = $this->getDefaultConfiguration($config);
 
         if ($config['key'] && $config['secret']) {
-            $config['credentials'] = Arr::only($config, ['key', 'secret']);
+            $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
         }
 
         return new SqsQueue(


### PR DESCRIPTION
The AWS client accepts a `token` configuration value alongside `key` and `secret`. This value is optional in most cases but it is required when accessing AWS in some environments, e.g: Lambda. At present the Laravel S3 storage driver and the Laravel SQS connector cannot be used from within a Lambda function because this value is not passed through.

Via [AwsClient](https://github.com/aws/aws-sdk-php/blob/master/src/AwsClient.php#L58):

```
     * - credentials:
     *   (Aws\Credentials\CredentialsInterface|array|bool|callable) Specifies
     *   the credentials used to sign requests. Provide an
     *   Aws\Credentials\CredentialsInterface object, an associative array of
     *   "key", "secret", and an optional "token" key, `false` to use null
     *   credentials, or a callable credentials provider used to create
     *   credentials or return null. See Aws\Credentials\CredentialProvider for
     *   a list of built-in credentials providers. If no credentials are
     *   provided, the SDK will attempt to load them from the environment.
```

This was already fixed for the for the mail manager in https://github.com/laravel/framework/pull/23766

This PR fixes it for the S3 driver and the SQS connector which are the remaining AWS integrations in `laravel/framework`.