### PR TITLE
[5.7] Add SecuresRequest middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/EnsureRequestIsSecure.php
+++ b/src/Illuminate/Foundation/Http/Middleware/EnsureRequestIsSecure.php
@@ -4,7 +4,7 @@ namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
 
-class SecuresRequest
+class EnsureRequestIsSecure
 {
     /**
      * Handle an incoming request.

--- a/src/Illuminate/Foundation/Http/Middleware/EnsureRequestIsSecure.php
+++ b/src/Illuminate/Foundation/Http/Middleware/EnsureRequestIsSecure.php
@@ -15,7 +15,7 @@ class EnsureRequestIsSecure
      */
     public function handle($request, Closure $next)
     {
-        if (! $request->secure() && config('app.https')) {
+        if (config('app.https') && !$request->secure()) {
             return redirect()->secure($request->getRequestUri(), 301);
         }
 

--- a/src/Illuminate/Foundation/Http/Middleware/EnsureRequestIsSecure.php
+++ b/src/Illuminate/Foundation/Http/Middleware/EnsureRequestIsSecure.php
@@ -15,7 +15,7 @@ class EnsureRequestIsSecure
      */
     public function handle($request, Closure $next)
     {
-        if (config('app.https') && !$request->secure()) {
+        if (config('app.https') && ! $request->secure()) {
             return redirect()->secure($request->getRequestUri(), 301);
         }
 

--- a/src/Illuminate/Foundation/Http/Middleware/SecuresRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/SecuresRequest.php
@@ -16,7 +16,7 @@ class SecuresRequest
     public function handle($request, Closure $next)
     {
         if (! $request->secure() && config('app.https')) {
-            return redirect()->secure($request->path(), 301);
+            return redirect()->secure($request->getRequestUri(), 301);
         }
 
         return $next($request);

--- a/src/Illuminate/Foundation/Http/Middleware/SecuresRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/SecuresRequest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
+
 class SecuresRequest
 {
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/SecuresRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/SecuresRequest.php
@@ -15,7 +15,7 @@ class SecuresRequest
      */
     public function handle($request, Closure $next)
     {
-        if ( ! $request->secure() && config('app.https')) {
+        if (! $request->secure() && config('app.https')) {
             return redirect()->secure($request->path(), 301);
         }
 

--- a/src/Illuminate/Foundation/Http/Middleware/SecuresRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/SecuresRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Middleware;
+
+use Closure;
+class SecuresRequest
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if ( ! $request->secure() && config('app.https')) {
+            return redirect()->secure($request->path(), 301);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
This adds middleware to the core of Laravel that will allow users to forcefully redirect their apps to HTTPS. Especially now with things like Let's Encrypt most apps these days are going to be secured whether it be on Forge, Heroku or something else. It's important that HTTP connections be permanently redirected to HTTPS so that search engines don't see duplicate content.

This will make it easy for developers to easily opt-in to this redirect without having to think about it. If approved I can go add the boilerplate to the `laravel/laravel` repo - adding the new `https` key to the configuration and placing the middleware in the Http stack after `TrustProxies`.

I understand that some people will say "this should be handled at the server level" - and yes, that's probably going to be faster. But it requires going to look up Apache or Nginx configuration and having to think about it per server environment. This is a really simple way to get the HTTPS redirect out of the box.

```php
/*
|--------------------------------------------------------------------------
| Force HTTPS
|--------------------------------------------------------------------------
|
| If an unsecured request is received by your app it can redirect
| back to the same resource over HTTPS. This prevents you from
| serving duplicate content over HTTP and HTTPS schemes.
|
*/

'https' => env('APP_HTTPS', false),
```

Obviously still need to work out the three character spacing on the description there, but that's the gist. I imagine it would go under the `url` key in `config/app.php`.