### PR TITLE
[5.6] Added eloquent builder debugger

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent;
 
 use Closure;
 use BadMethodCallException;
+use Illuminate\Database\Query\BuilderDebugger;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Pagination\Paginator;
@@ -1233,6 +1234,14 @@ class Builder
     public function qualifyColumn($column)
     {
         return $this->model->qualifyColumn($column);
+    }
+
+    /**
+     * @return BuilderDebugger
+     */
+    public function debugger(): BuilderDebugger
+    {
+        return new BuilderDebugger($this);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -4,11 +4,11 @@ namespace Illuminate\Database\Eloquent;
 
 use Closure;
 use BadMethodCallException;
-use Illuminate\Database\Query\BuilderDebugger;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Query\BuilderDebugger;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2723,6 +2723,14 @@ class Builder
     }
 
     /**
+     * @return BuilderDebugger
+     */
+    public function debugger(): BuilderDebugger
+    {
+        return new BuilderDebugger($this);
+    }
+
+    /**
      * Get the database connection instance.
      *
      * @return \Illuminate\Database\ConnectionInterface

--- a/src/Illuminate/Database/Query/BuilderDebugger.php
+++ b/src/Illuminate/Database/Query/BuilderDebugger.php
@@ -32,7 +32,6 @@ class BuilderDebugger
         $pattern = '/\:\w+|\?/';
 
         foreach ($bindings as $index => $binding) {
-
             $replace = is_numeric($binding)
                 ? $binding
                 : sprintf("'%s'", str_replace("'", "\'", $binding));

--- a/src/Illuminate/Database/Query/BuilderDebugger.php
+++ b/src/Illuminate/Database/Query/BuilderDebugger.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Illuminate\Database\Query;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+
+class BuilderDebugger
+{
+    /**
+     * @var Builder|EloquentBuilder
+     */
+    private $builder;
+
+    /**
+     * BuilderDebugger constructor.
+     * @param Builder|EloquentBuilder $builder
+     */
+    public function __construct($builder)
+    {
+        $this->builder = $builder;
+    }
+
+    /**
+     * Get compiled sql as string.
+     *
+     * @return string
+     */
+    public function getRawSql(): string
+    {
+        $bindings = $this->builder->getBindings();
+        $sql = $this->builder->toSql();
+        $pattern = '/\:\w+|\?/';
+
+        foreach ($bindings as $index => $binding) {
+
+            $replace = is_numeric($binding)
+                ? $binding
+                : sprintf("'%s'", str_replace("'", "\'", $binding));
+
+            $sql = preg_replace($pattern, $replace, $sql, 1);
+        }
+
+        return (string) $sql;
+    }
+
+    /**
+     * Die with dumping compiled sql.
+     */
+    public function rawSql(): void
+    {
+        dd($this->getRawSql());
+    }
+
+    /**
+     * Dump compiled sql and return builder instance.
+     *
+     * @return Builder|EloquentBuilder
+     */
+    public function dumpRawSql()
+    {
+        dump($this->getRawSql());
+
+        return $this->builder;
+    }
+
+    /**
+     * Dump and die with count of results.
+     *
+     * @param string $columns
+     */
+    public function count(string $columns = '*'): void
+    {
+        dd($this->builder->count($columns));
+    }
+
+    /**
+     * Dump count of elements and return builder instance.
+     *
+     * @param string $columns
+     * @return EloquentBuilder|Builder
+     */
+    public function dumpCount(string $columns = '*')
+    {
+        dump($this->builder->count($columns));
+
+        return $this->builder;
+    }
+
+    /**
+     * Dump and die with the result of callback for builder instance.
+     *
+     * @param callable $callback
+     */
+    public function withCallback(callable $callback): void
+    {
+        dd($callback($this->builder));
+    }
+
+    /**
+     * Dump callback result for builder and return builder instance.
+     *
+     * @param callable $callback
+     * @return EloquentBuilder|Builder
+     */
+    public function dumpWithCallback(callable $callback)
+    {
+        dump($callback($this->builder));
+
+        return $this->builder;
+    }
+
+    /**
+     * Dump and die with clean sql.
+     */
+    public function toSql(): void
+    {
+        dd($this->builder->toSql());
+    }
+
+    /**
+     * Dump clean sql and return builder instance.
+     *
+     * @return EloquentBuilder|Builder
+     */
+    public function dumpSql()
+    {
+        dump($this->builder->toSql());
+
+        return $this->builder;
+    }
+
+    /**
+     * Dump and die query bindings.
+     */
+    public function bindings(): void
+    {
+        dd($this->builder->getBindings());
+    }
+
+    /**
+     * Dump query bindings and return builder instance.
+     *
+     * @return EloquentBuilder|Builder
+     */
+    public function dumpBindings()
+    {
+        dump($this->builder->getBindings());
+
+        return $this->builder;
+    }
+
+    /**
+     * Dump and die with builder instance.
+     */
+    public function instance(): void
+    {
+        dd($this->builder);
+    }
+
+    /**
+     * Dump builder instance and return it.
+     *
+     * @return EloquentBuilder|Builder
+     */
+    public function dumpInstance()
+    {
+        dump($this->builder);
+
+        return $this->builder;
+    }
+}

--- a/tests/Database/DatabaseBuilderDebuggerTest.php
+++ b/tests/Database/DatabaseBuilderDebuggerTest.php
@@ -22,7 +22,7 @@ class DatabaseBuilderDebuggerTest extends TestCase
             ->where('users.status', 'active')
             ->where('users.age', '>', 18)
             ->whereRaw('users.locale = :locale', ['locale' => 'en'])
-            ->whereIn('users.group', [1 ,2 , 3, 'string'])
+            ->whereIn('users.group', [1, 2, 3, 'string'])
             ->whereRaw('users.something_else = :binding', ['unnamed_binding_value"with\'quotes']);
 
         $this->assertSame(

--- a/tests/Database/DatabaseBuilderDebuggerTest.php
+++ b/tests/Database/DatabaseBuilderDebuggerTest.php
@@ -2,17 +2,12 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Database\ConnectionInterface;
-use Illuminate\Database\Query\Builder;
-use Illuminate\Database\Query\Grammars\MySqlGrammar;
-use Illuminate\Database\Query\Processors\Processor;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Query\Processors\Processor;
+use Illuminate\Database\Query\Grammars\MySqlGrammar;
 
-/**
- * Class DatabaseBuilderDebuggerTest
- * @package Illuminate\Tests\Database
- *
- */
 class DatabaseBuilderDebuggerTest extends TestCase
 {
     /**
@@ -28,8 +23,7 @@ class DatabaseBuilderDebuggerTest extends TestCase
             ->where('users.age', '>', 18)
             ->whereRaw('users.locale = :locale', ['locale' => 'en'])
             ->whereIn('users.group', [1,2,3, 'string'])
-            ->whereRaw('users.something_else = :binding', ['unnamed_binding_value"with\'quotes'])
-            ;
+            ->whereRaw('users.something_else = :binding', ['unnamed_binding_value"with\'quotes']);
 
         $this->assertSame(
             "select * from `users` where `users`.`status` = 'active' and `users`.`age` > 18 and users.locale = 'en' and `users`.`group` in (1, 2, 3, 'string') and users.something_else = 'unnamed_binding_value\"with\'quotes\'",
@@ -47,6 +41,7 @@ class DatabaseBuilderDebuggerTest extends TestCase
         /** @var Processor $processor */
         $connection = $this->createMock(ConnectionInterface::class);
         $processor = $this->createMock(Processor::class);
+
         return new Builder(
             $connection,
             new MySqlGrammar(),

--- a/tests/Database/DatabaseBuilderDebuggerTest.php
+++ b/tests/Database/DatabaseBuilderDebuggerTest.php
@@ -17,7 +17,6 @@ class DatabaseBuilderDebuggerTest extends TestCase
 {
     /**
      * @throws \ReflectionException
-     * @group current
      */
     public function testGetRawSql()
     {
@@ -33,7 +32,7 @@ class DatabaseBuilderDebuggerTest extends TestCase
             ;
 
         $this->assertSame(
-            "select * from `users` where `users`.`status` = 'active' and `users`.`age` > 18 and users.locale = 'en' and `users`.`group` in (1, 2, 3, 'string') and users.something_else = 'unnamed_binding_value\"with\'quotes'",
+            "select * from `users` where `users`.`status` = 'active' and `users`.`age` > 18 and users.locale = 'en' and `users`.`group` in (1, 2, 3, 'string') and users.something_else = 'unnamed_binding_value\"with\'quotes\'",
             $builder->debugger()->getRawSql()
         );
     }

--- a/tests/Database/DatabaseBuilderDebuggerTest.php
+++ b/tests/Database/DatabaseBuilderDebuggerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Grammars\MySqlGrammar;
+use Illuminate\Database\Query\Processors\Processor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class DatabaseBuilderDebuggerTest
+ * @package Illuminate\Tests\Database
+ *
+ */
+class DatabaseBuilderDebuggerTest extends TestCase
+{
+    /**
+     * @throws \ReflectionException
+     * @group current
+     */
+    public function testGetRawSql()
+    {
+        $builder = $this->getMysqlBuilder();
+
+        return $builder->select('*')
+            ->from('users')
+            ->where('users.status', 'active')
+            ->where('users.age', '>', 18)
+            ->whereRaw('users.locale = :locale', ['locale' => 'en'])
+            ->whereIn('users.group', [1,2,3, 'string'])
+            ->whereRaw('users.something_else = :binding', ['unnamed_binding_value"with\'quotes'])
+            ;
+
+        $this->assertSame(
+            "select * from `users` where `users`.`status` = 'active' and `users`.`age` > 18 and users.locale = 'en' and `users`.`group` in (1, 2, 3, 'string') and users.something_else = 'unnamed_binding_value\"with\'quotes'",
+            $builder->debugger()->getRawSql()
+        );
+    }
+
+    /**
+     * @return Builder
+     * @throws \ReflectionException
+     */
+    private function getMysqlBuilder(): Builder
+    {
+        /** @var ConnectionInterface $connection */
+        /** @var Processor $processor */
+        $connection = $this->createMock(ConnectionInterface::class);
+        $processor = $this->createMock(Processor::class);
+        return new Builder(
+            $connection,
+            new MySqlGrammar(),
+            $processor
+        );
+    }
+}

--- a/tests/Database/DatabaseBuilderDebuggerTest.php
+++ b/tests/Database/DatabaseBuilderDebuggerTest.php
@@ -22,7 +22,7 @@ class DatabaseBuilderDebuggerTest extends TestCase
             ->where('users.status', 'active')
             ->where('users.age', '>', 18)
             ->whereRaw('users.locale = :locale', ['locale' => 'en'])
-            ->whereIn('users.group', [1,2,3, 'string'])
+            ->whereIn('users.group', [1 ,2 , 3, 'string'])
             ->whereRaw('users.something_else = :binding', ['unnamed_binding_value"with\'quotes']);
 
         $this->assertSame(


### PR DESCRIPTION
It can help to debug queries. For example we have a huge query

```php

User::where('status', 'active')
 ->where(...)
 ->orWhere(function ($q) { ... })
 ->join(...)
 ->join(...)
 ->orderBy(...)
 ->groupBy(...)
 ->get();

```

And we can debug full human readable sql query by adding:

```php
  ->debugger()->rawSql()
```
before `->get();`.

We can only dump something from builder, no break execution:

```php
Product::where('price', '<', 200)
 ->debugger()->dumpRawSql()
 ->get();

```

For example we can log custom query:

```php
Product::where('price', '<', 200)
 ->tap(function ($query) {
       logger($query->debugger()->getRawSql());
  })
 ->get();
```

We can dump bindings, amount of elements and anything else using callback:

```php
$users = User::where('age', '>', 18)
 ->debugger()->dumpBindings()
 ->get();
```

```php
User::where('is_admin', true)
 ->debugger()->dumpWithCallback(function(Builder $query) {
  // do something and dump result.
  return $query->getRawBindings();
})
 ->get();
```

Maybe it will be usefull to add `dd` and `dump` methods to builders which dumping raw sql (and exit for dd).

