### PR TITLE
[5.6] Join once and replace join

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -446,14 +446,8 @@ class Builder
      * @param  bool    $where
      * @return $this
      */
-    public function joinOnceWithReplace(
-        $table,
-        $first,
-        $operator = null,
-        $second = null,
-        $type = 'inner',
-        $where = false
-    ) {
+    public function replaceJoin($table, $first, $operator = null, $second = null, $type = 'inner', $where = false)
+    {
         foreach ($this->joins as $index => $join) {
             if ($join->table === $table) {
                 // This table was joined already, so remove previous join

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -91,7 +91,7 @@ class Builder
     /**
      * The table joins for the query.
      *
-     * @var array
+     * @var array|JoinClause[]
      */
     public $joins;
 
@@ -406,6 +406,62 @@ class Builder
         }
 
         return $this;
+    }
+
+    /**
+     * Add a join clause to the query only once for one table.
+     * If table was joined already - ignore current one, use only previous join clause.
+     *
+     * @param  string  $table
+     * @param  string|callable  $first
+     * @param  string|null  $operator
+     * @param  string|null  $second
+     * @param  string  $type
+     * @param  bool    $where
+     * @return $this
+     */
+    public function joinOnce($table, $first, $operator = null, $second = null, $type = 'inner', $where = false)
+    {
+        foreach ($this->joins as $join) {
+            if ($join->table === $table) {
+                // This table was joined already, nothing to join
+                // Return builder instance without any changes.
+
+                return $this;
+            }
+        }
+
+        return $this->join($table, $first, $operator, $second, $type, $where);
+    }
+
+    /**
+     * Add a join clause to the query only once for one table.
+     * If table was joined already - remove previous join and use current one.
+     *
+     * @param  string  $table
+     * @param  string|callable  $first
+     * @param  string|null  $operator
+     * @param  string|null  $second
+     * @param  string  $type
+     * @param  bool    $where
+     * @return $this
+     */
+    public function joinOnceWithReplace(
+        $table,
+        $first,
+        $operator = null,
+        $second = null,
+        $type = 'inner',
+        $where = false
+    ) {
+        foreach ($this->joins as $index => $join) {
+            if ($join->table === $table) {
+                // This table was joined already, so remove previous join
+                unset($this->joins[$index]);
+            }
+        }
+
+        return $this->join($table, $first, $operator, $second, $type, $where);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -780,13 +780,13 @@ class DatabaseQueryBuilderTest extends TestCase
         );
     }
 
-    public function testJoinOnceWithReplace()
+    public function testReplaceJoin()
     {
         $builder = $this->getBuilder();
         $builder->select('*')
             ->from('users')
             ->join('profiles', 'profiles.user_id', '=', 'users.id') // this join will be removed
-            ->joinOnceWithReplace('profiles', function (JoinClause $join) {
+            ->replaceJoin('profiles', function (JoinClause $join) {
                 $join
                     ->on('profiles.user_id', '=', 'users.id')
                     ->where('users.status', 'active');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Database\Query\JoinClause;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\JoinClause;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Query\Expression as Raw;
 use Illuminate\Pagination\AbstractPaginator as Paginator;
@@ -757,10 +757,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    /**
-     *
-     * @group current
-     */
     public function testJoinOnce()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Added two methods to builder:

`joinOnce` - applies join only once for one table, other joins for this table will be ignored.
`replaceJoin` - applies current join for table and remove all previous joins for this table.