### PR TITLE
[5.6] add missing docblock for InvalidArgumentException

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -145,6 +145,8 @@ class Factory implements FactoryContract
      * @param  array   $data
      * @param  array   $mergeData
      * @return \Illuminate\Contracts\View\View
+     *
+     * @throws \InvalidArgumentException
      */
     public function first(array $views, $data = [], $mergeData = [])
     {


### PR DESCRIPTION
This PR just adds a missing docblock for InvalidArgumentException