### PR TITLE
[5.6] Improvements

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -227,7 +227,7 @@ class FileStore implements Store
     {
         $time = $this->availableAt((int) ($minutes * 60));
 
-        return $minutes === 0 || $time > 9999999999 ? 9999999999 : (int) $time;
+        return $minutes === 0 || $time > 9999999999 ? 9999999999 : $time;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -532,7 +532,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function incrementOrDecrementAttributeValue($column, $amount, $extra, $method)
     {
-        $this->{$column} = $this->{$column} + ($method == 'increment' ? $amount : $amount * -1);
+        $this->{$column} += ($method == 'increment' ? $amount : $amount * -1);
 
         $this->forceFill($extra);
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -507,7 +507,7 @@ trait InteractsWithPivotTable
      */
     protected function castKeys(array $keys)
     {
-        return (array) array_map(function ($v) {
+        return array_map(function ($v) {
             return $this->castKey($v);
         }, $keys);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -216,7 +216,7 @@ class Pivot extends Model
      */
     public function getCreatedAtColumn()
     {
-        return ($this->pivotParent)
+        return $this->pivotParent
                         ? $this->pivotParent->getCreatedAtColumn()
                         : parent::getCreatedAtColumn();
     }
@@ -228,7 +228,7 @@ class Pivot extends Model
      */
     public function getUpdatedAtColumn()
     {
-        return ($this->pivotParent)
+        return $this->pivotParent
                         ? $this->pivotParent->getUpdatedAtColumn()
                         : parent::getUpdatedAtColumn();
     }

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -58,7 +58,7 @@ abstract class Grammar
         // If the value being wrapped has a column alias we will need to separate out
         // the pieces so we can wrap each of the segments of the expression on its
         // own, and then join these both back together using the "as" connector.
-        if (strpos(strtolower($value), ' as ') !== false) {
+        if (stripos($value, ' as ') !== false) {
             return $this->wrapAliasedValue($value, $prefixAlias);
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2057,7 +2057,7 @@ class Builder
     protected function withoutSelectAliases(array $columns)
     {
         return array_map(function ($column) {
-            return is_string($column) && ($aliasPosition = strpos(strtolower($column), ' as ')) !== false
+            return is_string($column) && ($aliasPosition = stripos($column, ' as ')) !== false
                     ? substr($column, 0, $aliasPosition) : $column;
         }, $columns);
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -905,7 +905,7 @@ class Grammar extends BaseGrammar
         // If the value being wrapped has a column alias we will need to separate out
         // the pieces so we can wrap each of the segments of the expression on its
         // own, and then join these both back together using the "as" connector.
-        if (strpos(strtolower($value), ' as ') !== false) {
+        if (stripos($value, ' as ') !== false) {
             return $this->wrapAliasedValue($value, $prefixAlias);
         }
 

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -276,7 +276,7 @@ class MySqlGrammar extends Grammar
     {
         $joins = ' '.$this->compileJoins($query, $query->joins);
 
-        $alias = strpos(strtolower($table), ' as ') !== false
+        $alias = stripos($table, ' as ') !== false
                 ? explode(' as ', $table)[1] : $table;
 
         return trim("delete {$alias} from {$table}{$joins} {$where}");

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -298,7 +298,7 @@ class SqlServerGrammar extends Grammar
     {
         $joins = ' '.$this->compileJoins($query, $query->joins);
 
-        $alias = strpos(strtolower($table), ' as ') !== false
+        $alias = stripos($table, ' as ') !== false
                 ? explode(' as ', $table)[1] : $table;
 
         return trim("delete {$alias} from {$table}{$joins} {$where}");
@@ -364,7 +364,7 @@ class SqlServerGrammar extends Grammar
     {
         $table = $alias = $this->wrapTable($table);
 
-        if (strpos(strtolower($table), '] as [') !== false) {
+        if (stripos($table, '] as [') !== false) {
             $alias = '['.explode('] as [', $table)[1];
         }
 

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -198,9 +198,7 @@ class Kernel implements KernelContract
     {
         $paths = array_unique(Arr::wrap($paths));
 
-        $paths = array_filter($paths, function ($path) {
-            return is_dir($path);
-        });
+        $paths = array_filter($paths, 'is_dir');
 
         if (empty($paths)) {
             return;

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -212,7 +212,7 @@ class Mailable implements MailableContract, Renderable
         if (isset($this->html)) {
             return array_filter([
                 'html' => new HtmlString($this->html),
-                'text' => isset($this->textView) ? $this->textView : null,
+                'text' => $this->textView ?? null,
             ]);
         }
 

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -186,7 +186,7 @@ class MailChannel
 
         return collect($recipients)->mapWithKeys(function ($recipient, $email) {
             return is_numeric($email)
-                    ? [(is_string($recipient) ? $recipient : $recipient->email)]
+                    ? [is_string($recipient) ? $recipient : $recipient->email]
                     : [$email => $recipient];
         })->all();
     }

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -81,7 +81,7 @@ class ListFailedCommand extends Command
     {
         $payload = json_decode($payload, true);
 
-        if ($payload && (! isset($payload['data']['command']))) {
+        if ($payload && ! isset($payload['data']['command'])) {
             return $payload['job'] ?? null;
         } elseif ($payload && isset($payload['data']['command'])) {
             return $this->matchJobName($payload);

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -308,7 +308,7 @@ class UrlGenerator implements UrlGeneratorContract
         $parameters = $this->formatParameters($parameters);
 
         if ($expiration) {
-            $parameters = $parameters + ['expires' => $this->availableAt($expiration)];
+            $parameters += ['expires' => $this->availableAt($expiration)];
         }
 
         ksort($parameters);

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1057,7 +1057,7 @@ if (! function_exists('throw_if')) {
     function throw_if($condition, $exception, ...$parameters)
     {
         if ($condition) {
-            throw (is_string($exception) ? new $exception(...$parameters) : $exception);
+            throw is_string($exception) ? new $exception(...$parameters) : $exception;
         }
 
         return $condition;
@@ -1077,7 +1077,7 @@ if (! function_exists('throw_unless')) {
     function throw_unless($condition, $exception, ...$parameters)
     {
         if (! $condition) {
-            throw (is_string($exception) ? new $exception(...$parameters) : $exception);
+            throw is_string($exception) ? new $exception(...$parameters) : $exception;
         }
 
         return $condition;

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -369,7 +369,7 @@ trait ReplacesAttributes
      */
     protected function replaceBefore($message, $attribute, $rule, $parameters)
     {
-        if (! (strtotime($parameters[0]))) {
+        if (! strtotime($parameters[0])) {
             return str_replace(':date', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -211,7 +211,7 @@ trait ValidatesAttributes
             $secondDate = $this->getDateTimeWithOptionalFormat($format, $this->getValue($second));
         }
 
-        return ($firstDate && $secondDate) && ($this->compare($firstDate, $secondDate, $operator));
+        return ($firstDate && $secondDate) && $this->compare($firstDate, $secondDate, $operator);
     }
 
     /**
@@ -611,7 +611,7 @@ trait ValidatesAttributes
         // that the columns being "verified" shares the given attribute's name.
         $column = $this->getQueryColumn($parameters, $attribute);
 
-        $expected = (is_array($value)) ? count($value) : 1;
+        $expected = is_array($value) ? count($value) : 1;
 
         return $this->getExistCount(
             $connection, $table, $column, $value, $parameters

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -658,7 +658,7 @@ class ResourceTest extends TestCase
                     'Mohamed',
                     $this->mergeWhen(false, ['Adam', 'Matt']),
                     'Jeffrey',
-                    $this->mergeWhen(false, (['Abigail', 'Lydia'])),
+                    $this->mergeWhen(false, ['Abigail', 'Lydia']),
                 ]);
             }
         };

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -72,7 +72,7 @@ class ConcurrentLimiterTest extends TestCase
     {
         $store = [];
 
-        $lock = (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 1, 1));
+        $lock = new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 1, 1);
 
         $lock->block(2, function () use (&$store) {
             $store[] = 1;
@@ -102,7 +102,7 @@ class ConcurrentLimiterTest extends TestCase
     {
         $store = [];
 
-        $lock = (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 1, 2));
+        $lock = new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 1, 2);
 
         $lock->block(2, function () use (&$store) {
             $store[] = 1;
@@ -130,7 +130,7 @@ class ConcurrentLimiterTest extends TestCase
     {
         $store = [];
 
-        $lock = (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 1, 10));
+        $lock = new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 1, 10);
 
         $lock->block(2, function () use (&$store) {
             $store[] = 1;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -145,7 +145,7 @@ class SupportCollectionTest extends TestCase
 
     public function testCollectionShuffleWithSeed()
     {
-        $collection = new Collection((range(0, 100, 10)));
+        $collection = new Collection(range(0, 100, 10));
 
         $firstRandom = $collection->shuffle(1234);
         $secondRandom = $collection->shuffle(1234);

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -120,7 +120,7 @@ class FluentArrayIteratorStub implements IteratorAggregate
 
     public function __construct(array $items = [])
     {
-        $this->items = (array) $items;
+        $this->items = $items;
     }
 
     public function getIterator()


### PR DESCRIPTION
Together with PHPStorm and https://github.com/kalessil/phpinspectionsea, here are some improvements that we can make to Laravel, such as unnecessaries parentheses, casts; plus equal operator usage; stripos instead of strpos + strtolower, etc