### PR TITLE
[5.7] Missing use statement in VerifyCsrfToken

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -71,7 +71,7 @@ class VerifyCsrfToken
             $this->inExceptArray($request) ||
             $this->tokensMatch($request)
         ) {
-            return tap($next($request), function ($response) {
+            return tap($next($request), function ($response) use ($request) {
                 if ($this->addHttpCookie) {
                     $this->addCookieToResponse($request, $response);
                 }


### PR DESCRIPTION
Look like there's been a small [refactoring](https://github.com/laravel/framework/commit/669ad7180773cb45dcc59b7629e70f583409fa6c#diff-09745b260205ab889479555249ecc663R74) in VerifyCsrfToken...
