### PR TITLE
[5.6] Add extra parameters passing to factories definition

### DIFF
--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -97,6 +97,12 @@ class EloquentFactoryBuilderTest extends TestCase
 
         $factory->state(FactoryBuildableServer::class, 'inline', ['status' => 'inline']);
 
+        $factory->state(FactoryBuildableUser::class, 'complex', function (Generator $faker, array $attributes, string $namePrefix = '') {
+            return [
+                'name' => $namePrefix.$faker->name,
+            ];
+        });
+
         $app->singleton(Factory::class, function ($app) use ($factory) {
             return $factory;
         });
@@ -282,6 +288,17 @@ class EloquentFactoryBuilderTest extends TestCase
 
         $this->assertNotNull($user->profile);
         $this->assertNotNull($user->servers->where('status', 'callable')->first());
+    }
+
+    /** @test */
+    public function making_models_with_passing_extra_params()
+    {
+        $prefix = bin2hex(random_bytes(2));
+        $users = factory(FactoryBuildableUser::class, 2)->states('complex')->make([], $prefix);
+
+        $users->each(function (FactoryBuildableUser $user) use ($prefix) {
+            $this->assertEquals(0, strpos($user->name, $prefix));
+        });
     }
 }
 


### PR DESCRIPTION
Sometimes we need to do some computation or implement complex logic into our factories.
Several examples:
1) U need to compute complex value that will be when used when creating models instances. This allows to pre-compute it and pass to factory.
2) U have polymorphic relations and want to create morphedBy models [files, for example]. And u know, what every morphTo files model has some method / computable attribute / relation/ etc what u need to execute and set to file instance. So instead of fetching morphedBy model instance from object_id and object_type on each file factory call, u can pass object instance itself.

Benefits:
1) Perfomance [pre-computation]
2) Flexibility, convenience

It's fully backward-compatible with old calls
