### PR TITLE
[5.6] Issue 24766 : make fopen to be read-only when streaming the file to copy

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -204,7 +204,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      */
     public function putFileAs($path, $file, $name, $options = [])
     {
-        $stream = fopen($file->getRealPath(), 'r+');
+        $stream = fopen($file->getRealPath(), 'r');
 
         // Next, we will format the path of the file and store the file using a stream since
         // they provide better performance than alternatives. Once we write the file this


### PR DESCRIPTION
https://github.com/laravel/framework/issues/24766

The FileSystemAdapter method putFileAs does not work if the origin file is in a read-only folder because it does ask for write access to read the file to copy:

Line 207 : $stream = fopen($file->getRealPath(), 'r+');

Since the code is not trying at all to change the file, i propose to change the second argument as read-only as well by default: 'r'
