### PR TITLE
[5.6] Remove return statement in a void method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -217,7 +217,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function afterLoadingEnvironment(Closure $callback)
     {
-        return $this->afterBootstrapping(
+        $this->afterBootstrapping(
             LoadEnvironmentVariables::class, $callback
         );
     }


### PR DESCRIPTION
Signature implies afterLoadingEnvironment() is a void method, and it calls afterBoostrapping() which is also a void method, so there's no value to return.