### PR TITLE
[5.6] Redirect with input when sending reset links fails

### DIFF
--- a/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
+++ b/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
@@ -70,9 +70,9 @@ trait SendsPasswordResetEmails
      */
     protected function sendResetLinkFailedResponse(Request $request, $response)
     {
-        return back()->withErrors(
-            ['email' => trans($response)]
-        );
+        return back()
+                    ->withInput($request->only('email'))
+                    ->withErrors(['email' => trans($response)]);
     }
 
     /**


### PR DESCRIPTION
When send reset links fails the user was redirected back to the form but the input old email value was not populated.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
