### PR TITLE
[5.6] Updates render method phpdocs return type

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -162,7 +162,7 @@ class Handler implements ExceptionHandlerContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception  $e
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Symfony\Component\HttpFoundation\Response|\Illuminate\Http\Response
      */
     public function render($request, Exception $e)
     {


### PR DESCRIPTION
**Motivation**: I am currently developing [Larastan](https://github.com/nunomaduro/larastan). And the only error triggered by the tool in a fresh new laravel project is:

`Method App\Exceptions\Handler::render() should return Illuminate\Http\Response but returns Symfony\Component\HttpFoundation\Response.`

This PR addresses the modification of the `@return` phpdoc of the method `render` on the class `Illuminate\Foundation\Exceptions\Handler`.

I can always ignore the warning on the tool itself if this PR doesn't get merged.