### PR TITLE
[5.6] Updates action/route method phpdocs return type

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -147,7 +147,7 @@ class Redirector
      * Create a new redirect response to a named route.
      *
      * @param  string  $route
-     * @param  array   $parameters
+     * @param  mixed   $parameters
      * @param  int     $status
      * @param  array   $headers
      * @return \Illuminate\Http\RedirectResponse
@@ -161,7 +161,7 @@ class Redirector
      * Create a new redirect response to a controller action.
      *
      * @param  string  $action
-     * @param  array   $parameters
+     * @param  mixed   $parameters
      * @param  int     $status
      * @param  array   $headers
      * @return \Illuminate\Http\RedirectResponse


### PR DESCRIPTION
**Motivation**: I am currently developing [Larastan](https://github.com/nunomaduro/larastan). When the user uses the following code `redirect()->route('thread', $thread->slug())` and the second parameter is a string the tool triggers this error.

`Parameter #2 $parameters of method Illuminate\Routing\Redirector::route() expects array, string given.`

This PR proposes the modification of the `@param array $parameters`  to `@param mixed $parameters` phpdoc of the method `action`/`route` on the class `Illuminate\Routing\Redirector`.

I can always ignore the warning on the tool itself if this PR doesn't get merged.