### PR TITLE
[5.6] Allow dependency injection on exception->report call

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -99,7 +99,7 @@ class Handler implements ExceptionHandlerContract
         }
 
         if (method_exists($e, 'report')) {
-            return $e->report();
+            return $this->container->call([$e, 'report']);
         }
 
         try {


### PR DESCRIPTION
Currently using the report method on an exception the implementer has no choice but using Facades or the app()->make service locator. This change makes possible to use dependency injection too.

If the idea is supported I can make the necessary modifications for the render method too.
