### PR TITLE
[5.6] Optimize method calls with `stripos()`

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -58,7 +58,7 @@ abstract class Grammar
         // If the value being wrapped has a column alias we will need to separate out
         // the pieces so we can wrap each of the segments of the expression on its
         // own, and then join these both back together using the "as" connector.
-        if (strpos(strtolower($value), ' as ') !== false) {
+        if (stripos($value, ' as ') !== false) {
             return $this->wrapAliasedValue($value, $prefixAlias);
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2057,7 +2057,7 @@ class Builder
     protected function withoutSelectAliases(array $columns)
     {
         return array_map(function ($column) {
-            return is_string($column) && ($aliasPosition = strpos(strtolower($column), ' as ')) !== false
+            return is_string($column) && ($aliasPosition = stripos($column, ' as ')) !== false
                     ? substr($column, 0, $aliasPosition) : $column;
         }, $columns);
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -905,7 +905,7 @@ class Grammar extends BaseGrammar
         // If the value being wrapped has a column alias we will need to separate out
         // the pieces so we can wrap each of the segments of the expression on its
         // own, and then join these both back together using the "as" connector.
-        if (strpos(strtolower($value), ' as ') !== false) {
+        if (stripos($value, ' as ') !== false) {
             return $this->wrapAliasedValue($value, $prefixAlias);
         }
 

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -276,7 +276,7 @@ class MySqlGrammar extends Grammar
     {
         $joins = ' '.$this->compileJoins($query, $query->joins);
 
-        $alias = strpos(strtolower($table), ' as ') !== false
+        $alias = stripos($table, ' as ') !== false
                 ? explode(' as ', $table)[1] : $table;
 
         return trim("delete {$alias} from {$table}{$joins} {$where}");

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -298,7 +298,7 @@ class SqlServerGrammar extends Grammar
     {
         $joins = ' '.$this->compileJoins($query, $query->joins);
 
-        $alias = strpos(strtolower($table), ' as ') !== false
+        $alias = stripos($table, ' as ') !== false
                 ? explode(' as ', $table)[1] : $table;
 
         return trim("delete {$alias} from {$table}{$joins} {$where}");
@@ -364,7 +364,7 @@ class SqlServerGrammar extends Grammar
     {
         $table = $alias = $this->wrapTable($table);
 
-        if (strpos(strtolower($table), '] as [') !== false) {
+        if (stripos($table, '] as [') !== false) {
             $alias = '['.explode('] as [', $table)[1];
         }
 


### PR DESCRIPTION
this is a breakout of #24758 , and only includes the `strpos(strtolower(` --> `stripos(` changes.

`stripos` is the case insensitive version of `strpos`, which removes the need to lowercase the string first.

Switching from 2 method calls to 1 method call improves performance. The following 2 scripts were profiled with Blackfire.io

```php
foreach(range(1, 1000) as $_) {
    var_dump(strpos(strtolower('Test String'), 'test string') !== false);
}
```

```php
foreach(range(1, 1000) as $_) {
    var_dump(stripos('Test String', 'test string') !== false);
}
```

The timing gains and losses for the `strpos` and `stripos` basically cancelled each other other, but removing the `strtolower` call was a straight gain.

![screen shot 2018-07-09 at 10 58 24 am](https://user-images.githubusercontent.com/5232313/42461954-7a9f4b70-8367-11e8-8620-68f7264bc006.png)

![screen shot 2018-07-09 at 10 58 11 am](https://user-images.githubusercontent.com/5232313/42461961-80887106-8367-11e8-9d63-bd93fa055fdc.png)

![screen shot 2018-07-09 at 10 57 49 am](https://user-images.githubusercontent.com/5232313/42461966-83dbe298-8367-11e8-99e0-1084f6807945.png)
