### PR TITLE
[5.7] Mailer render append text-only view to html view if both defined in Mailable

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -191,7 +191,7 @@ class Mailer implements MailerContract, MailQueueContract
      *
      * @param  string|array  $view
      * @param  array  $data
-     * @return string|array
+     * @return string
      */
     public function render($view, array $data = [])
     {
@@ -204,13 +204,13 @@ class Mailer implements MailerContract, MailQueueContract
 
 
         //if there is only one view type (html or text) setted return the rendered view
-        if(!$plain)
+        if(! $plain)
             return $this->renderView($view,$data);
-        if(!$view)
+        if(! $view)
             return $this->renderView($plain,$data);
 
-        //otherwise return both rendere views
-        return [$this->renderView($view,$data),$this->renderView($plain,$data)];
+        //otherwise return both rendered views
+        return $this->renderView($view, $data) . $this->renderView($plain, $data);
     }
 
     /**

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Mail;
 
+
 use Swift_Mailer;
 use InvalidArgumentException;
 use Illuminate\Support\HtmlString;
@@ -190,7 +191,7 @@ class Mailer implements MailerContract, MailQueueContract
      *
      * @param  string|array  $view
      * @param  array  $data
-     * @return string
+     * @return string|array
      */
     public function render($view, array $data = [])
     {
@@ -201,7 +202,15 @@ class Mailer implements MailerContract, MailQueueContract
 
         $data['message'] = $this->createMessage();
 
-        return $this->renderView($view ?: $plain, $data);
+
+        //if there is only one view type (html or text) setted return the rendered view
+        if(!$plain)
+            return $this->renderView($view,$data);
+        if(!$view)
+            return $this->renderView($plain,$data);
+
+        //otherwise return both rendere views
+        return [$this->renderView($view,$data),$this->renderView($plain,$data)];
     }
 
     /**

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -43,7 +43,7 @@ class MailMailerTest extends TestCase
         $this->assertEquals($renderedTextView, $rendered);
     }
 
-    public function testMailerRenderAnArrayWhenCalledWithBothHtmlAndTextViews()
+    public function testMailerRenderHtmlAndTextViewsWhenBothAreDefined()
     {
         $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')
             ->setMethods(['createMessage', 'renderView', 'parseView'])
@@ -62,7 +62,7 @@ class MailMailerTest extends TestCase
 
         $rendered = $mailer->render('html,text', []);
 
-        $this->assertEquals([$renderedHtmlView, $renderedTextView], $rendered);
+        $this->assertEquals($renderedHtmlView . $renderedTextView, $rendered);
     }
 
     public function testMailerSendSendsMessageWithProperViewContent()

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -2,16 +2,67 @@
 
 namespace Illuminate\Tests\Mail;
 
-use Mockery as m;
 use Illuminate\Mail\Mailer;
-use PHPUnit\Framework\TestCase;
 use Illuminate\Support\HtmlString;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
 class MailMailerTest extends TestCase
 {
     public function tearDown()
     {
         m::close();
+    }
+
+
+    public function testMailerRenderAStringWhenCalledWithHtmlView()
+    {
+        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage', 'renderView', 'parseView'])->setConstructorArgs($this->getMocks())->getMock();
+        $message = m::mock('Swift_Mime_SimpleMessage');
+        $renderedHtmlView = '<p>view</p>';
+        $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
+        $mailer->expects($this->once())->method('parseView')->will($this->returnValue(['view', null, null]));
+        $mailer->expects($this->once())->method('renderView')->with('view')->will($this->returnValue($renderedHtmlView));
+
+        $rendered = $mailer->render('view', []);
+
+        $this->assertEquals($renderedHtmlView, $rendered);
+    }
+
+    public function testMailerRenderAStringWhenCalledWithTextView()
+    {
+        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage', 'renderView', 'parseView'])->setConstructorArgs($this->getMocks())->getMock();
+        $message = m::mock('Swift_Mime_SimpleMessage');
+        $renderedTextView = 'view';
+        $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
+        $mailer->expects($this->once())->method('parseView')->will($this->returnValue([null, 'text', null]));
+        $mailer->expects($this->once())->method('renderView')->with('text')->will($this->returnValue($renderedTextView));
+
+        $rendered = $mailer->render('view', []);
+
+        $this->assertEquals($renderedTextView, $rendered);
+    }
+
+    public function testMailerRenderAnArrayWhenCalledWithBothHtmlAndTextViews()
+    {
+        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')
+            ->setMethods(['createMessage', 'renderView', 'parseView'])
+            ->setConstructorArgs($this->getMocks())->getMock();
+
+        $message = m::mock('Swift_Mime_SimpleMessage');
+        $renderedHtmlView = '<p>view</p>';
+        $renderedTextView = 'view';
+        $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
+        $mailer->expects($this->once())->method('parseView')->will($this->returnValue(['view', 'text', null]));
+        $mailer->expects($this->exactly(2))->method('renderView')->will($this->returnValueMap(
+            [
+                ['view', ['message' => $message], $renderedHtmlView],
+                ['text', ['message' => $message], $renderedTextView]
+            ]));
+
+        $rendered = $mailer->render('html,text', []);
+
+        $this->assertEquals([$renderedHtmlView, $renderedTextView], $rendered);
     }
 
     public function testMailerSendSendsMessageWithProperViewContent()


### PR DESCRIPTION
When the Mailer renders a Mailable with both html and text-only views defined, now appends the text view instead of render only html view.

This is useful when you have 2 different views for html and text-only and you want to test / render the Mailable in the browser.


### Actual behavior:
If a Mailable is built with both html and text views:

```php
public function build() 
{
        return $this->view('views.html_view'))->text('views.text_only_view');
}
```
then when the render method is called returns only the html view:

```php
//only html view
$rendered = $mailable->render();
```

### Proposed behavior

If both html and text are defined then the method append the text view to the html view


### Test coverage

There was no tests covering the render method, so i added a few cases

### Breaking change? 

Yes, for example if there are test with assertions on the rendered view

