### PR TITLE
[5.6] Accept EloquentBuilder as argument for sub-query functions

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -319,7 +319,7 @@ class Builder
      */
     protected function parseSub($query)
     {
-        if ($query instanceof self) {
+        if ($query instanceof self || $query instanceof EloquentBuilder) {
             return [$query->toSql(), $query->getBindings()];
         } elseif (is_string($query)) {
             return [$query, []];

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Query\Expression as Raw;
 use Illuminate\Pagination\AbstractPaginator as Paginator;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class DatabaseQueryBuilderTest extends TestCase
 {
@@ -1369,6 +1370,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->joinSub(function ($q) {
             $q->from('contacts');
         }, 'sub', 'users.id', '=', 'sub.id');
+        $this->assertEquals('select * from "users" inner join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $eloquentBuilder = new EloquentBuilder($this->getBuilder()->from('contacts'));
+        $builder->from('users')->joinSub($eloquentBuilder, 'sub', 'users.id', '=', 'sub.id');
         $this->assertEquals('select * from "users" inner join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
 
         $builder = $this->getBuilder();


### PR DESCRIPTION
This closes #24594. Reopening this PR as the [previous one](https://github.com/laravel/framework/pull/24595) was closed without any discussion.

### Code change
Currently, subquery functions like `fromSub` and `joinSub` allows you to pass in a raw SQL query string or a base query builder instance for the subquery. https://github.com/laravel/framework/blob/a8f17c52d2c01289999eba7e5fa893a45b0204e2/src/Illuminate/Database/Query/Builder.php#L320-L329

This PR allows you to pass in an Eloquent Builder instance as well since Eloquent Builders behave similar to the base query builder and will respond to `toSql()` and `getBindings()`. In fact Eloquent Builder just forwards those method calls along to the base query builder.

https://github.com/laravel/framework/blob/a8f17c52d2c01289999eba7e5fa893a45b0204e2/src/Illuminate/Database/Eloquent/Builder.php#L69-L72

https://github.com/laravel/framework/blob/a8f17c52d2c01289999eba7e5fa893a45b0204e2/src/Illuminate/Database/Eloquent/Builder.php#L1282-L1284

This change will not break any existing features because the return values of the public API methods (subquery functions `selectSub`, `fromSub`, and `joinSub`) are unchanged. 

### Benefits
The main benefit of this change is to allow both types of query builders to be accepted as the argument for the subqueries. Since the Eloquent builder produces a specialized query builder, it makes sense from a development standpoint to use them to encapsulate the subquery and not force developers to call `toBase()` on the Eloquent Builder (especially since that's not documented anywhere).