### PR TITLE
[5.6] Allow to disable and enable again timestamps for model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -123,4 +123,28 @@ trait HasTimestamps
     {
         return static::UPDATED_AT;
     }
+
+    /**
+     * Disable timestamps for the model.
+     *
+     * @return $this
+     */
+    public function disableTimestamps()
+    {
+        $this->timestamps = false;
+
+        return $this;
+    }
+
+    /**
+     * Enable timestamps for the model.
+     *
+     * @return $this
+     */
+    public function enableTimestamps()
+    {
+        $this->timestamps = true;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
When model has timestamps, sometimes for internal (not caused by user) updates it's useful to not update timestamps. 

 Now when we want to update single field we have to do it like this:

```
$model = Model::find($id);
$model->timestamps = false;
$model->update(['attribute' => $value]);
```

If approved after this update it would be possible to do it in single line:

```
Model::find($id)->disableTimestamps()->update(['attribute' => $value]);
```

Additional `enableTimestamps` has been also added to re-enable timestamps when needed.