### PR TITLE
Simplify GuardHelpers@{check, guest} a bit

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -57,7 +57,7 @@ trait GuardHelpers
      */
     public function check()
     {
-        return ! is_null($this->user());
+        return ! $this->guest();
     }
 
     /**
@@ -67,7 +67,7 @@ trait GuardHelpers
      */
     public function guest()
     {
-        return ! $this->check();
+        return is_null($this->user());
     }
 
     /**


### PR DESCRIPTION
It seems to be simpler without double negation
 
