### PR TITLE
[5.6] Create 'format' method to collection

### DIFF
--- a/src/Illuminate/Contracts/Support/Formatter.php
+++ b/src/Illuminate/Contracts/Support/Formatter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+interface Formatter
+{
+    /**
+     * Format the data.
+     *
+     * @return mixed
+     */
+    public function format();
+}

--- a/src/Illuminate/Contracts/Support/FormatterWithKeys.php
+++ b/src/Illuminate/Contracts/Support/FormatterWithKeys.php
@@ -4,5 +4,4 @@ namespace Illuminate\Contracts\Support;
 
 interface FormatterWithKeys extends Formatter
 {
-
 }

--- a/src/Illuminate/Contracts/Support/FormatterWithKeys.php
+++ b/src/Illuminate/Contracts/Support/FormatterWithKeys.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+interface FormatterWithKeys extends Formatter
+{
+
+}

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Support;
 
-use Illuminate\Contracts\Support\FormatterWithKeys;
 use stdClass;
 use Countable;
 use Exception;
@@ -17,6 +16,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Formatter;
+use Illuminate\Contracts\Support\FormatterWithKeys;
 
 /**
  * @property-read HigherOrderCollectionProxy $average
@@ -491,7 +491,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $formatter = new $class($value, $key);
 
             if (! $formatter instanceof Formatter) {
-                throw new \Exception("The given class to format the data is not instance of Formatter");
+                throw new \Exception('The given class to format the data is not instance of Formatter');
             }
 
             $valueFormatted = $formatter->format();

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use Illuminate\Contracts\Support\FormatterWithKeys;
 use stdClass;
 use Countable;
 use Exception;
@@ -15,6 +16,7 @@ use Illuminate\Support\Debug\Dumper;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Formatter;
 
 /**
  * @property-read HigherOrderCollectionProxy $average
@@ -472,6 +474,40 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         return new static(array_filter($this->items));
+    }
+
+    /**
+     * Apply the format in formatter given class.
+     *
+     * @param $class
+     * @return Collection
+     * @throws Exception
+     */
+    public function format($class)
+    {
+        $result = [];
+
+        foreach ($this->items as $key => $value) {
+            $formatter = new $class($value, $key);
+
+            if (! $formatter instanceof Formatter) {
+                throw new \Exception("The given class to format the data is not instance of Formatter");
+            }
+
+            $valueFormatted = $formatter->format();
+
+            if (! $formatter instanceof FormatterWithKeys) {
+                $result[$key] = $valueFormatted;
+
+                continue;
+            }
+
+            foreach ($valueFormatted as $mapKey => $mapValue) {
+                $result[$mapKey] = $mapValue;
+            }
+        }
+
+        return new static($result);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -491,7 +491,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $formatter = new $class($value, $key);
 
             if (! $formatter instanceof Formatter) {
-                throw new \Exception('The given class to format the data is not instance of Formatter');
+                throw new \Exception('The given class to format the data is not instance of Illuminate\Contracts\Support\Formatter');
             }
 
             $valueFormatted = $formatter->format();

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -12,6 +12,8 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Formatter;
+use Illuminate\Contracts\Support\FormatterWithKeys;
 
 class SupportCollectionTest extends TestCase
 {
@@ -980,6 +982,32 @@ class SupportCollectionTest extends TestCase
     {
         $data = new Collection(['name' => 'taylor', 'framework' => 'laravel']);
         $this->assertEquals(['taylor' => 'name', 'laravel' => 'framework'], $data->flip()->toArray());
+    }
+
+    public function testFormat()
+    {
+        $valueOne = "felipe";
+        $valueTwo = "marcos";
+
+        $data = new Collection([$valueOne, $valueTwo]);
+
+        $this->assertEquals([strrev($valueOne), strrev($valueTwo)], $data->format(TestCollectionFormatValues::class)->toArray());
+    }
+
+    public function testFormatWithKeys()
+    {
+        $data = new Collection([
+            ['name' => 'Blastoise', 'type' => 'Water', 'idx' => 9],
+            ['name' => 'Charmander', 'type' => 'Fire', 'idx' => 4],
+            ['name' => 'Dragonair', 'type' => 'Dragon', 'idx' => 148],
+        ]);
+
+        $data = $data->format(TestCollectionFormatValuesWithKeys::class);
+
+        $this->assertEquals(
+            ['Blastoise' => 'Water', 'Charmander' => 'Fire', 'Dragonair' => 'Dragon'],
+            $data->all()
+        );
     }
 
     public function testChunk()
@@ -2783,4 +2811,64 @@ class TestCollectionMapIntoObject
 class TestCollectionSubclass extends Collection
 {
     //
+}
+
+class TestCollectionFormatValues implements Formatter
+{
+    /**
+     * @var string Value to be formatted.
+     */
+    protected $value;
+
+    /**
+     * TestCollectionFormatValues constructor.
+     *
+     * @param $value
+     * @param $key
+     */
+    public function __construct($value, $key)
+    {
+        $this->value = $value;
+    }
+
+
+    /**
+     * Format the data.
+     *
+     * @return mixed
+     */
+    public function format()
+    {
+        return strrev($this->value);
+    }
+}
+
+class TestCollectionFormatValuesWithKeys implements FormatterWithKeys
+{
+    /**
+     * @var string Value to be formatted.
+     */
+    protected $value;
+
+    /**
+     * TestCollectionFormatValues constructor.
+     *
+     * @param $value
+     * @param $key
+     */
+    public function __construct($value, $key)
+    {
+        $this->value = $value;
+    }
+
+
+    /**
+     * Format the data.
+     *
+     * @return mixed
+     */
+    public function format()
+    {
+        return [$this->value['name'] => $this->value['type']];
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -986,8 +986,8 @@ class SupportCollectionTest extends TestCase
 
     public function testFormat()
     {
-        $valueOne = "felipe";
-        $valueTwo = "marcos";
+        $valueOne = 'felipe';
+        $valueTwo = 'marcos';
 
         $data = new Collection([$valueOne, $valueTwo]);
 
@@ -2831,7 +2831,6 @@ class TestCollectionFormatValues implements Formatter
         $this->value = $value;
     }
 
-
     /**
      * Format the data.
      *
@@ -2860,7 +2859,6 @@ class TestCollectionFormatValuesWithKeys implements FormatterWithKeys
     {
         $this->value = $value;
     }
-
 
     /**
      * Format the data.


### PR DESCRIPTION
I recently had to implement some classes that did data formatting, so I was using the `map` or `mapWithKeys` method, but I had to test the interface in all cases, so I thought I'd create a method that already do the formatting and also test the interface if it is not correct.

Now to format the data, just create a class that implements the interface `Formatter`, in this class when it is instantiated, it will be passed as parameter the value and key of the item.

In addition, if we need to format the data with the key as well, simply formatter class implement the `FormatterWithKeys` class, which has the same behavior as the `mapWithKeys` method.

The biggest advantage of this is to remove the business rule from giant callbacks and ensure that the data will be formatted by a class that is a Formatter