### PR TITLE
[5.6] When apply collection changes in paginator, keep the type

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -62,6 +62,13 @@ abstract class AbstractPaginator implements Htmlable
     protected $pageName = 'page';
 
     /**
+     * Additional Instance Options.
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    /**
      * The current path resolver callback.
      *
      * @var \Closure

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -50,6 +50,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
         $this->currentPage = $this->setCurrentPage($currentPage, $this->pageName);
         $this->items = $items instanceof Collection ? $items : Collection::make($items);
+        $this->options = $options;
     }
 
     /**
@@ -195,5 +196,19 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     public function toJson($options = 0)
     {
         return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Make dynamic calls into the collection.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        $collectionResult = parent::__call($method, $parameters);
+
+        return new static($collectionResult, $this->total, $this->perPage, $this->currentPage, $this->options);
     }
 }

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -39,6 +39,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
         $this->perPage = $perPage;
         $this->currentPage = $this->setCurrentPage($currentPage);
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
+        $this->options = $options;
 
         $this->setItems($items);
     }
@@ -173,5 +174,12 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     public function toJson($options = 0)
     {
         return json_encode($this->jsonSerialize(), $options);
+    }
+
+    public function __call($method, $parameters)
+    {
+        $collectionResult = parent::__call($method, $parameters);
+
+        return new static($collectionResult, $this->perPage, $this->currentPage, $this->options);
     }
 }

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -83,4 +83,22 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEquals('http://website.com/test?foo=1',
                             $this->p->url($this->p->currentPage() - 2));
     }
+
+    public function testLengthAwarePaginatorWhenApplyCollectionChangesStillKeepWithLengthAwarePaginator()
+    {
+        $data = ['marcos', 'felipe'];
+
+        $lengthAwarePaginator = new LengthAwarePaginator($data, 2, 1);
+        $lengthAwarePaginatorTransformed = $lengthAwarePaginator->map(function($value) {
+            return strrev($value);
+        });
+
+        $this->assertInstanceOf(LengthAwarePaginator::class, $lengthAwarePaginatorTransformed);
+
+        foreach ($lengthAwarePaginatorTransformed as $key => $value) {
+            $oldValue = $data[$key];
+
+            $this->assertEquals(strrev($oldValue), $value);
+        }
+    }
 }

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -89,7 +89,7 @@ class LengthAwarePaginatorTest extends TestCase
         $data = ['marcos', 'felipe'];
 
         $lengthAwarePaginator = new LengthAwarePaginator($data, 2, 1);
-        $lengthAwarePaginatorTransformed = $lengthAwarePaginator->map(function($value) {
+        $lengthAwarePaginatorTransformed = $lengthAwarePaginator->map(function ($value) {
             return strrev($value);
         });
 

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -46,4 +46,22 @@ class PaginatorTest extends TestCase
 
         $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
     }
+
+    public function testPaginatorWhenApplyCollectionChangesStillKeepWithPaginator()
+    {
+        $data = ['marcos', 'felipe'];
+
+        $paginator = new Paginator($data, 2, 1);
+        $paginatorTransformed = $paginator->map(function($value) {
+            return strrev($value);
+        });
+
+        $this->assertInstanceOf(Paginator::class, $paginatorTransformed);
+
+        foreach ($paginatorTransformed as $key => $value) {
+            $oldValue = $data[$key];
+
+            $this->assertEquals(strrev($oldValue), $value);
+        }
+    }
 }

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -52,7 +52,7 @@ class PaginatorTest extends TestCase
         $data = ['marcos', 'felipe'];
 
         $paginator = new Paginator($data, 2, 1);
-        $paginatorTransformed = $paginator->map(function($value) {
+        $paginatorTransformed = $paginator->map(function ($value) {
             return strrev($value);
         });
 


### PR DESCRIPTION
I recently needed to apply some changes to a paged result I got, but I realized that by applying these changes the object lost the Paginator type and returned only as a Collection. In my opinion this is a bug, because if we are using a paging object, we want it to always be pagination, otherwise we create another object for this.

This pull request corrects exactly that, after applying a change of collections, it recreates the paging object (for both the _Paginator_ and the _LengthAwarePaginator_).
