### PR TITLE
[5.7] fix #23804: attachFromStorageDisk not compatible with the queue

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -118,6 +118,13 @@ class Mailable implements MailableContract, Renderable
      */
     public $rawAttachments = [];
 
+	/**
+	 * The attachments coming from storage disk
+	 *
+	 * @var array
+	 */
+    public $diskAttachments = [];
+
     /**
      * The callbacks for the message.
      *
@@ -343,6 +350,15 @@ class Mailable implements MailableContract, Renderable
             $message->attachData(
                 $attachment['data'], $attachment['name'], $attachment['options']
             );
+        }
+
+        foreach ($this->diskAttachments as $attachment) {
+	        $storage = Container::getInstance()->make(FilesystemFactory::class)->disk($attachment['disk']);
+
+	        return $message->attachData(
+		        $storage->get($attachment['path']), $attachment['name'] ?? basename($attachment['path']),
+		        array_merge(['mime' => $storage->mimeType($attachment['path'])], $attachment['options'])
+	        );
         }
 
         return $this;
@@ -725,12 +741,10 @@ class Mailable implements MailableContract, Renderable
      */
     public function attachFromStorageDisk($disk, $path, $name = null, array $options = [])
     {
-        $storage = Container::getInstance()->make(FilesystemFactory::class)->disk($disk);
+    	$name = $name ?? basename($path);
+	    $this->diskAttachments[] = compact('disk', 'path', 'name', 'options');
 
-        return $this->attachData(
-            $storage->get($path), $name ?? basename($path),
-            array_merge(['mime' => $storage->mimeType($path)], $options)
-        );
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -118,11 +118,11 @@ class Mailable implements MailableContract, Renderable
      */
     public $rawAttachments = [];
 
-	/**
-	 * The attachments coming from storage disk
-	 *
-	 * @var array
-	 */
+    /**
+     * The attachments coming from storage disk.
+     *
+     * @var array
+     */
     public $diskAttachments = [];
 
     /**
@@ -353,12 +353,12 @@ class Mailable implements MailableContract, Renderable
         }
 
         foreach ($this->diskAttachments as $attachment) {
-	        $storage = Container::getInstance()->make(FilesystemFactory::class)->disk($attachment['disk']);
+            $storage = Container::getInstance()->make(FilesystemFactory::class)->disk($attachment['disk']);
 
-	        return $message->attachData(
-		        $storage->get($attachment['path']), $attachment['name'] ?? basename($attachment['path']),
-		        array_merge(['mime' => $storage->mimeType($attachment['path'])], $attachment['options'])
-	        );
+            return $message->attachData(
+                $storage->get($attachment['path']), $attachment['name'] ?? basename($attachment['path']),
+                array_merge(['mime' => $storage->mimeType($attachment['path'])], $attachment['options'])
+            );
         }
 
         return $this;
@@ -741,8 +741,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function attachFromStorageDisk($disk, $path, $name = null, array $options = [])
     {
-    	$name = $name ?? basename($path);
-	    $this->diskAttachments[] = compact('disk', 'path', 'name', 'options');
+        $name = $name ?? basename($path);
+        $this->diskAttachments[] = compact('disk', 'path', 'name', 'options');
 
         return $this;
     }

--- a/tests/Mail/MailMailableDataTest.php
+++ b/tests/Mail/MailMailableDataTest.php
@@ -11,13 +11,13 @@ class MailMailableDataTest extends TestCase
     {
         $testData = ['first_name' => 'James'];
 
-        $mailable = new MailableQueableStub;
+        $mailable = new MailableStub;
         $mailable->build(function ($m) use ($testData) {
             $m->view('view', $testData);
         });
         $this->assertSame($testData, $mailable->buildViewData());
 
-        $mailable = new MailableQueableStub;
+        $mailable = new MailableStub;
         $mailable->build(function ($m) use ($testData) {
             $m->view('view', $testData)
               ->text('text-view');

--- a/tests/Mail/MailMailableDataTest.php
+++ b/tests/Mail/MailMailableDataTest.php
@@ -11,13 +11,13 @@ class MailMailableDataTest extends TestCase
     {
         $testData = ['first_name' => 'James'];
 
-        $mailable = new MailableStub;
+        $mailable = new MailableQueableStub;
         $mailable->build(function ($m) use ($testData) {
             $m->view('view', $testData);
         });
         $this->assertSame($testData, $mailable->buildViewData());
 
-        $mailable = new MailableStub;
+        $mailable = new MailableQueableStub;
         $mailable->build(function ($m) use ($testData) {
             $m->view('view', $testData)
               ->text('text-view');

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Illuminate\Tests\Mail;
+
+use Illuminate\Container\Container;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemManager;
+use Illuminate\Mail\SendQueuedMailable;
+use Illuminate\Support\Testing\Fakes\QueueFake;
+use Mockery as m;
+use Illuminate\Mail\Mailable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Application;
+use PHPUnit\Framework\TestCase;
+
+class MailableQueuedTest extends TestCase
+{
+	public function tearDown()
+	{
+		m::close();
+	}
+
+	public function testQueuedMailableSent()
+	{
+		$queueFake = new QueueFake(new Application);
+		$mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')
+			->setConstructorArgs($this->getMocks())
+			->setMethods(['createMessage', 'to'])
+			->getMock();
+		$mailer->setQueue($queueFake);
+		$mailable = new MailableQueableStub();
+		$queueFake->assertNothingPushed();
+		$mailer->send($mailable);
+		$queueFake->assertPushedOn(null, SendQueuedMailable::class);
+	}
+
+	public function testQueuedMailableWithAttachmentSent()
+	{
+		$queueFake = new QueueFake(new Application);
+		$mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')
+			->setConstructorArgs($this->getMocks())
+			->setMethods(['createMessage'])
+			->getMock();
+		$mailer->setQueue($queueFake);
+		$mailable = new MailableQueableStub();
+		$attachmentOption = ['mime' => 'image/jpeg', 'as' => 'bar.jpg'];
+		$mailable->attach('foo.jpg', $attachmentOption);
+		$this->assertTrue(is_array($mailable->attachments));
+		$this->assertCount(1, $mailable->attachments);
+		$this->assertEquals($mailable->attachments[0]['options'], $attachmentOption);
+		$queueFake->assertNothingPushed();
+		$mailer->send($mailable);
+		$queueFake->assertPushedOn(null, SendQueuedMailable::class);
+	}
+
+	public function testQueuedMailableWithAttachmentFromDiskSent()
+	{
+		$app = new Application;
+		$container = Container::getInstance();
+		$disk = $this->getMockBuilder(Filesystem::class)
+			->getMock();
+		$filesystemFactory = $this->getMockBuilder(FilesystemManager::class)
+			->setConstructorArgs([$app])
+			->getMock();
+		$container->singleton('filesystem', function () use ($filesystemFactory) {
+			return $filesystemFactory;
+		});
+		$queueFake = new QueueFake($app);
+		$mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')
+			->setConstructorArgs($this->getMocks())
+			->setMethods(['createMessage'])
+			->getMock();
+		$mailer->setQueue($queueFake);
+		$mailable = new MailableQueableStub();
+		$attachmentOption = ['mime' => 'image/jpeg', 'as' => 'bar.jpg'];
+
+		$mailable->attachFromStorage('/', 'foo.jpg', $attachmentOption);
+
+		$this->assertTrue(is_array($mailable->diskAttachments));
+		$this->assertCount(1, $mailable->diskAttachments);
+		$this->assertEquals($mailable->diskAttachments[0]['options'], $attachmentOption);
+
+		$queueFake->assertNothingPushed();
+		$mailer->send($mailable);
+		$queueFake->assertPushedOn(null, SendQueuedMailable::class);
+	}
+
+	protected function getMocks()
+	{
+		return [m::mock('Illuminate\Contracts\View\Factory'), m::mock('Swift_Mailer')];
+	}
+}
+
+class MailableQueableStub extends Mailable implements ShouldQueue
+{
+	use Queueable;
+
+	public function build(): self
+	{
+		$this
+			->subject('lorem ipsum')
+			->html('foo bar baz')
+			->to('foo@example.tld');
+		return $this;
+	}
+}

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -2,106 +2,107 @@
 
 namespace Illuminate\Tests\Mail;
 
+use Mockery as m;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Filesystem\FilesystemManager;
-use Illuminate\Mail\SendQueuedMailable;
-use Illuminate\Support\Testing\Fakes\QueueFake;
-use Mockery as m;
-use Illuminate\Mail\Mailable;
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Application;
-use PHPUnit\Framework\TestCase;
+use Illuminate\Mail\SendQueuedMailable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Filesystem\FilesystemManager;
+use Illuminate\Support\Testing\Fakes\QueueFake;
 
 class MailableQueuedTest extends TestCase
 {
-	public function tearDown()
-	{
-		m::close();
-	}
+    public function tearDown()
+    {
+        m::close();
+    }
 
-	public function testQueuedMailableSent()
-	{
-		$queueFake = new QueueFake(new Application);
-		$mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')
-			->setConstructorArgs($this->getMocks())
-			->setMethods(['createMessage', 'to'])
-			->getMock();
-		$mailer->setQueue($queueFake);
-		$mailable = new MailableQueableStub();
-		$queueFake->assertNothingPushed();
-		$mailer->send($mailable);
-		$queueFake->assertPushedOn(null, SendQueuedMailable::class);
-	}
+    public function testQueuedMailableSent()
+    {
+        $queueFake = new QueueFake(new Application);
+        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')
+            ->setConstructorArgs($this->getMocks())
+            ->setMethods(['createMessage', 'to'])
+            ->getMock();
+        $mailer->setQueue($queueFake);
+        $mailable = new MailableQueableStub();
+        $queueFake->assertNothingPushed();
+        $mailer->send($mailable);
+        $queueFake->assertPushedOn(null, SendQueuedMailable::class);
+    }
 
-	public function testQueuedMailableWithAttachmentSent()
-	{
-		$queueFake = new QueueFake(new Application);
-		$mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')
-			->setConstructorArgs($this->getMocks())
-			->setMethods(['createMessage'])
-			->getMock();
-		$mailer->setQueue($queueFake);
-		$mailable = new MailableQueableStub();
-		$attachmentOption = ['mime' => 'image/jpeg', 'as' => 'bar.jpg'];
-		$mailable->attach('foo.jpg', $attachmentOption);
-		$this->assertTrue(is_array($mailable->attachments));
-		$this->assertCount(1, $mailable->attachments);
-		$this->assertEquals($mailable->attachments[0]['options'], $attachmentOption);
-		$queueFake->assertNothingPushed();
-		$mailer->send($mailable);
-		$queueFake->assertPushedOn(null, SendQueuedMailable::class);
-	}
+    public function testQueuedMailableWithAttachmentSent()
+    {
+        $queueFake = new QueueFake(new Application);
+        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')
+            ->setConstructorArgs($this->getMocks())
+            ->setMethods(['createMessage'])
+            ->getMock();
+        $mailer->setQueue($queueFake);
+        $mailable = new MailableQueableStub();
+        $attachmentOption = ['mime' => 'image/jpeg', 'as' => 'bar.jpg'];
+        $mailable->attach('foo.jpg', $attachmentOption);
+        $this->assertTrue(is_array($mailable->attachments));
+        $this->assertCount(1, $mailable->attachments);
+        $this->assertEquals($mailable->attachments[0]['options'], $attachmentOption);
+        $queueFake->assertNothingPushed();
+        $mailer->send($mailable);
+        $queueFake->assertPushedOn(null, SendQueuedMailable::class);
+    }
 
-	public function testQueuedMailableWithAttachmentFromDiskSent()
-	{
-		$app = new Application;
-		$container = Container::getInstance();
-		$disk = $this->getMockBuilder(Filesystem::class)
-			->getMock();
-		$filesystemFactory = $this->getMockBuilder(FilesystemManager::class)
-			->setConstructorArgs([$app])
-			->getMock();
-		$container->singleton('filesystem', function () use ($filesystemFactory) {
-			return $filesystemFactory;
-		});
-		$queueFake = new QueueFake($app);
-		$mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')
-			->setConstructorArgs($this->getMocks())
-			->setMethods(['createMessage'])
-			->getMock();
-		$mailer->setQueue($queueFake);
-		$mailable = new MailableQueableStub();
-		$attachmentOption = ['mime' => 'image/jpeg', 'as' => 'bar.jpg'];
+    public function testQueuedMailableWithAttachmentFromDiskSent()
+    {
+        $app = new Application;
+        $container = Container::getInstance();
+        $disk = $this->getMockBuilder(Filesystem::class)
+            ->getMock();
+        $filesystemFactory = $this->getMockBuilder(FilesystemManager::class)
+            ->setConstructorArgs([$app])
+            ->getMock();
+        $container->singleton('filesystem', function () use ($filesystemFactory) {
+            return $filesystemFactory;
+        });
+        $queueFake = new QueueFake($app);
+        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')
+            ->setConstructorArgs($this->getMocks())
+            ->setMethods(['createMessage'])
+            ->getMock();
+        $mailer->setQueue($queueFake);
+        $mailable = new MailableQueableStub();
+        $attachmentOption = ['mime' => 'image/jpeg', 'as' => 'bar.jpg'];
 
-		$mailable->attachFromStorage('/', 'foo.jpg', $attachmentOption);
+        $mailable->attachFromStorage('/', 'foo.jpg', $attachmentOption);
 
-		$this->assertTrue(is_array($mailable->diskAttachments));
-		$this->assertCount(1, $mailable->diskAttachments);
-		$this->assertEquals($mailable->diskAttachments[0]['options'], $attachmentOption);
+        $this->assertTrue(is_array($mailable->diskAttachments));
+        $this->assertCount(1, $mailable->diskAttachments);
+        $this->assertEquals($mailable->diskAttachments[0]['options'], $attachmentOption);
 
-		$queueFake->assertNothingPushed();
-		$mailer->send($mailable);
-		$queueFake->assertPushedOn(null, SendQueuedMailable::class);
-	}
+        $queueFake->assertNothingPushed();
+        $mailer->send($mailable);
+        $queueFake->assertPushedOn(null, SendQueuedMailable::class);
+    }
 
-	protected function getMocks()
-	{
-		return [m::mock('Illuminate\Contracts\View\Factory'), m::mock('Swift_Mailer')];
-	}
+    protected function getMocks()
+    {
+        return [m::mock('Illuminate\Contracts\View\Factory'), m::mock('Swift_Mailer')];
+    }
 }
 
 class MailableQueableStub extends Mailable implements ShouldQueue
 {
-	use Queueable;
+    use Queueable;
 
-	public function build(): self
-	{
-		$this
-			->subject('lorem ipsum')
-			->html('foo bar baz')
-			->to('foo@example.tld');
-		return $this;
-	}
+    public function build(): self
+    {
+        $this
+            ->subject('lorem ipsum')
+            ->html('foo bar baz')
+            ->to('foo@example.tld');
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Hello,
fix the issue #23804 that create error when mail are queued with attachFromStorageDisk.

So now it will add the information in an array of data, then loop on it when we really send the message.

I add some unit test, hoping to get the error in my unit test, but failed to success in it (I didn't succeed to create the error in the unit test). But the unit test are there so let's keep them ;).