### PR TITLE
[5.6] [fix] support tags as variadic params in Repository::tags

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -419,7 +419,7 @@ class Repository implements CacheContract, ArrayAccess
             throw new BadMethodCallException('This cache store does not support tagging.');
         }
 
-        $cache = $this->store->tags($names);
+        $cache = $this->store->tags(is_array($names) ? $names : func_get_args());
 
         if (! is_null($this->events)) {
             $cache->setEventDispatcher($this->events);

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -228,6 +228,17 @@ class CacheRepositoryTest extends TestCase
         $repo->deleteMultiple(['a-key', 'a-second-key']);
     }
 
+    public function testAllTagsArePassedToTaggableStore()
+    {
+        $store = m::mock('Illuminate\Cache\ArrayStore');
+        $repo = new \Illuminate\Cache\Repository($store);
+
+        $taggedCache = m::mock();
+        $taggedCache->shouldReceive('setDefaultCacheTime');
+        $store->shouldReceive('tags')->once()->with(['foo', 'bar', 'baz'])->andReturn($taggedCache);
+        $repo->tags('foo', 'bar', 'baz');
+    }
+
     protected function getRepository()
     {
         $dispatcher = new \Illuminate\Events\Dispatcher(m::mock('Illuminate\Container\Container'));


### PR DESCRIPTION
`TaggableStore::tags` accepts tags as array or variadic params, but the `Repository::tags` does not, which makes this happen:

```php
Cache::tags(['foo', 'bar', 'baz']) // works fine:
$this->store->tags(['foo', 'bar', 'baz'])

// but

Cache::tags('foo', 'bar', 'baz') // will pass only first param to the TaggableStore:
$this->store->tags('foo') // wrong!
```

This PR fixes the bug.