### PR TITLE
[5.6] Fix eager loading MorphTo relationship with custom name

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
@@ -525,7 +526,9 @@ class Builder
         // using the relationship instance. Then we just return the finished arrays
         // of models which have been eagerly hydrated and are readied for return.
         return $relation->match(
-            $relation->initRelation($models, $name),
+            $relation->initRelation(
+                $models, $relation instanceof MorphTo ? $relation->getRelation() : $name
+            ),
             $relation->getEager(), $name
         );
     }

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -137,6 +137,17 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $this->assertTrue($likes[1]->likeable->relationLoaded('comments'));
     }
 
+    public function testItLoadsRelationshipsWithCustomName()
+    {
+        $this->seedData();
+
+        $like = TestLike::with('likeableWithName')->first();
+
+        $this->assertTrue($like->relationLoaded('likeable_custom'));
+        $this->assertFalse($like->relationLoaded('likeableWithName'));
+        $this->assertEquals(TestComment::first(), $like->likeable_custom);
+    }
+
     /**
      * Helpers...
      */
@@ -241,6 +252,11 @@ class TestLike extends Eloquent
     public function likeable()
     {
         return $this->morphTo();
+    }
+
+    public function likeableWithName()
+    {
+        return $this->morphTo('likeable_custom', 'likeable_type', 'likeable_id');
     }
 }
 


### PR DESCRIPTION
When eager loading a `MorphTo` relationship with a custom name, Eloquent falsely initializes the relationship with the original method name:

```php
class Like extends Model
{
    public function likeable()
    {
        return $this->morphTo('likeable_custom', 'likeable_type', 'likeable_id');
    }
}

$like = Like::with('likeable')->first();
dd($like->getRelations());

// expected
array:1 [▼
  "likeable_custom" => Post {#123 ▶}
]

// actual
array:2 [▼
  "likeable" => null
  "likeable_custom" => Post {#123 ▶}
]
```

Fixes #24787.

---

`BelongsTo` and `BelongsToMany` relationships also allow the user to specify a custom name  (`$relation`/`$relationName`). However, neither of them actually uses the name on eager loading. `BelongsTo` only uses it when calling `associate()`/`dissociate()`.

I assume that's a bug and should also be fixed?