### PR TITLE
[5.6] Handle unquoted JSON selector for MYSQL

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -309,8 +309,8 @@ class MySqlGrammar extends Grammar
 
         $field = $this->wrapSegments(explode('.', array_shift($path)));
 
-        return sprintf('%s' . $delimiter . '\'$.%s\'', $field, collect($path)->map(function ($part) {
-            return '"' . $part . '"';
+        return sprintf('%s'.$delimiter.'\'$.%s\'', $field, collect($path)->map(function ($part) {
+            return '"'.$part.'"';
         })->implode('.'));
     }
 }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -301,7 +301,7 @@ class MySqlGrammar extends Grammar
      */
     protected function wrapJsonSelector($value)
     {
-        $delimiter = str_contains($value,'->>')
+        $delimiter = str_contains($value, '->>')
             ? '->>'
             : '->';
 
@@ -309,8 +309,8 @@ class MySqlGrammar extends Grammar
 
         $field = $this->wrapSegments(explode('.', array_shift($path)));
 
-        return sprintf('%s'.$delimiter.'\'$.%s\'', $field, collect($path)->map(function ($part) {
-            return '"'.$part.'"';
+        return sprintf('%s' . $delimiter . '\'$.%s\'', $field, collect($path)->map(function ($part) {
+            return '"' . $part . '"';
         })->implode('.'));
     }
 }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -305,7 +305,7 @@ class MySqlGrammar extends Grammar
 
         $field = $this->wrapSegments(explode('.', array_shift($path)));
 
-        return sprintf('%s->\'$.%s\'', $field, collect($path)->map(function ($part) {
+        return sprintf('%s->>\'$.%s\'', $field, collect($path)->map(function ($part) {
             return '"'.$part.'"';
         })->implode('.'));
     }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -301,11 +301,15 @@ class MySqlGrammar extends Grammar
      */
     protected function wrapJsonSelector($value)
     {
-        $path = explode('->', $value);
+        $delimiter = str_contains($value,'->>')
+            ? '->>'
+            : '->';
+
+        $path = explode($delimiter, $value);
 
         $field = $this->wrapSegments(explode('.', array_shift($path)));
 
-        return sprintf('%s->>\'$.%s\'', $field, collect($path)->map(function ($part) {
+        return sprintf('%s'.$delimiter.'\'$.%s\'', $field, collect($path)->map(function ($part) {
             return '"'.$part.'"';
         })->implode('.'));
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2022,7 +2022,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('items->available', '=', true)->where('items->active', '=', false)->where('items->number_available', '=', 0);
         $this->assertEquals('select * from `users` where `items`->\'$."available"\' = true and `items`->\'$."active"\' = false and `items`->\'$."number_available"\' = ?', $builder->toSql());
     }
-    
+
     public function testMySqlWrappingJsonWithoutQuote()
     {
         $builder = $this->getMySqlBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2022,6 +2022,15 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('items->available', '=', true)->where('items->active', '=', false)->where('items->number_available', '=', 0);
         $this->assertEquals('select * from `users` where `items`->\'$."available"\' = true and `items`->\'$."active"\' = false and `items`->\'$."number_available"\' = ?', $builder->toSql());
     }
+    
+    public function testMySqlWrappingJsonWithoutQuote()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->where('items->>sku', '=', 'foo-bar');
+        $this->assertEquals('select * from `users` where `items`->>\'$."sku"\' = ?', $builder->toSql());
+        $this->assertCount(1, $builder->getRawBindings()['where']);
+        $this->assertEquals('foo-bar', $builder->getRawBindings()['where'][0]);
+    }
 
     public function testMySqlWrappingJson()
     {


### PR DESCRIPTION
I propose the wrapper to handle unquoted output (using `->>` : [reference](https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#operator_json-inline-path) )
The unquoted result is easier to digest later on.

**Originally**  `PaymentMethod::select(['id', 'settings->>name'])->get();` would output
```
#attributes: array:2 [▼
    "id" => "1"
    "`settings`->'$.">name"'" => null
]
```

**Now**`PaymentMethod::select(['id', 'settings->>name'])->get();` will output
```
#attributes: array:2 [▼
    "id" => "1"
    "`settings`->>'$."name"'" => "Bank transfer"
]
```
