### PR TITLE
[5.7] tiny cleanup in Cache ns

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -4,8 +4,9 @@ namespace Illuminate\Cache;
 
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Contracts\Cache\LockTimeoutException;
+use Illuminate\Contracts\Cache\Lock as LockContract;
 
-abstract class Lock
+abstract class Lock implements LockContract
 {
     use InteractsWithTime;
 
@@ -42,6 +43,13 @@ abstract class Lock
      * @return bool
      */
     abstract public function acquire();
+
+    /**
+     * Release the lock.
+     *
+     * @return void
+     */
+    abstract public function release();
 
     /**
      * Attempt to acquire the lock.

--- a/src/Illuminate/Cache/MemcachedLock.php
+++ b/src/Illuminate/Cache/MemcachedLock.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Cache;
 
-use Illuminate\Contracts\Cache\Lock as LockContract;
-
-class MemcachedLock extends Lock implements LockContract
+class MemcachedLock extends Lock
 {
     /**
      * The Memcached instance.

--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Cache;
 
-use Illuminate\Contracts\Cache\Lock as LockContract;
-
-class RedisLock extends Lock implements LockContract
+class RedisLock extends Lock
 {
     /**
      * The Redis factory implementation.

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -188,7 +188,9 @@ class Repository implements CacheContract, ArrayAccess
     public function put($key, $value, $minutes = null)
     {
         if (is_array($key)) {
-            return $this->putMany($key, $value);
+            $this->putMany($key, $value);
+
+            return;
         }
 
         if (! is_null($minutes = $this->getMinutes($minutes))) {


### PR DESCRIPTION
This PR cleans a bit the Cache namespace in that:

1. `Repository` - don't return anything when `void` is expected return value (helps static analysis and in case somebody has strict `() : void` return value in place
2. `abstract Lock` - currently the abstraction is split in 2, ie. `Lock` class depends on `release` method, which is defined in the `Lock` interface, but this interface is implemented by redis/memcached locks.The PR moves abstraction & interface to one place to simplify things.

It doesn't change any behavior and is not BC breaking internally.
It might be BC breaking if somebody is using `Lock` abstract class on their own without `interface Lock` but it would break on that missing `release` method anyway.