### PR TITLE
[5.6] Refactor PhpRedis connector

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -94,14 +94,19 @@ class PhpRedisConnector
     {
         $persistent = $config['persistent'] ?? false;
 
-        $client->{($persistent ? 'pconnect' : 'connect')}(
+        $parameters = [
             $config['host'],
             $config['port'],
             Arr::get($config, 'timeout', 0.0),
             $persistent ? Arr::get($config, 'persistent_id', null) : null,
             Arr::get($config, 'retry_interval', 0),
-            Arr::get($config, 'read_timeout', 0.0)
-        );
+        ];
+
+        if (version_compare(phpversion('redis'), '3.1.3', '>=')) {
+            $parameters[] = Arr::get($config, 'read_timeout', 0.0);
+        }
+
+        $client->{($persistent ? 'pconnect' : 'connect')}(...$parameters);
     }
 
     /**

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -92,44 +92,13 @@ class PhpRedisConnector
      */
     protected function establishConnection($client, array $config)
     {
-        ($config['persistent'] ?? false)
-                ? $this->establishPersistentConnection($client, $config)
-                : $this->establishTemporaryConnection($client, $config);
-    }
+        $persistent = $config['persistent'] ?? false;
 
-    /**
-     * Establish a persistent connection with the Redis host.
-     *
-     * @param  \Redis  $client
-     * @param  array  $config
-     * @return void
-     */
-    protected function establishPersistentConnection($client, array $config)
-    {
-        $client->pconnect(
+        $client->{($persistent ? 'pconnect' : 'connect')}(
             $config['host'],
             $config['port'],
             Arr::get($config, 'timeout', 0.0),
-            Arr::get($config, 'persistent_id', null),
-            Arr::get($config, 'retry_interval', null),
-            Arr::get($config, 'read_timeout', null)
-        );
-    }
-
-    /**
-     * Establish a regular connection with the Redis host.
-     *
-     * @param  \Redis  $client
-     * @param  array  $config
-     * @return void
-     */
-    protected function establishTemporaryConnection($client, array $config)
-    {
-        $client->connect(
-            $config['host'],
-            $config['port'],
-            Arr::get($config, 'timeout', 0.0),
-            null,
+            $persistent ? Arr::get($config, 'persistent_id', null) : null,
             Arr::get($config, 'retry_interval', 0),
             Arr::get($config, 'read_timeout', 0.0)
         );

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -94,7 +94,7 @@ class PhpRedisConnector
     {
         ($config['persistent'] ?? false)
                 ? $this->establishPersistentConnection($client, $config)
-                : $this->establishRegularConnection($client, $config);
+                : $this->establishTemporaryConnection($client, $config);
     }
 
     /**
@@ -110,7 +110,9 @@ class PhpRedisConnector
             $config['host'],
             $config['port'],
             Arr::get($config, 'timeout', 0.0),
-            Arr::get($config, 'persistent_id', null)
+            Arr::get($config, 'persistent_id', null),
+            Arr::get($config, 'retry_interval', null),
+            Arr::get($config, 'read_timeout', null)
         );
     }
 
@@ -121,14 +123,15 @@ class PhpRedisConnector
      * @param  array  $config
      * @return void
      */
-    protected function establishRegularConnection($client, array $config)
+    protected function establishTemporaryConnection($client, array $config)
     {
         $client->connect(
             $config['host'],
             $config['port'],
             Arr::get($config, 'timeout', 0.0),
-            Arr::get($config, 'reserved', null),
-            Arr::get($config, 'retry_interval', 0)
+            null,
+            Arr::get($config, 'retry_interval', 0),
+            Arr::get($config, 'read_timeout', 0.0)
         );
     }
 


### PR DESCRIPTION
This PR is an addition to #24678 thanks to @dzuelke's suggestions in https://github.com/laravel/framework/pull/24678#issuecomment-402582340 and #24748.

- #24678 introduced a non-existent `reserved` option. It's just a reference in the docs.
- Add the `retry_interval` option to persistent connections.
- If PhpRedis is `>=3.1.3` add the `read_timeout` option to connections so the authentication and database selection steps are also subject to the read timeout.
- Merge `connect()` and `pconnect()` calls, since both just pass through their arguments to `redis_connect()`.

Fixes #24748.