### PR TITLE
[5.7] cleanup in Contracts namespace

### DIFF
--- a/src/Illuminate/Contracts/Pipeline/Pipeline.php
+++ b/src/Illuminate/Contracts/Pipeline/Pipeline.php
@@ -17,7 +17,7 @@ interface Pipeline
     /**
      * Set the stops of the pipeline.
      *
-     * @param  dynamic|array  $stops
+     * @param  array|...mixed  $stops
      * @return $this
      */
     public function through($stops);


### PR DESCRIPTION
This is part of a few PRs that touch mainly docblocks and return calls. 
The changes were split into separate PRs covering different namespaces of the framework to make it easy for you to review them.

what's been done
 - don't return anything where `void` is expected - it helps in two ways:
    * in static analysis
    * going forward, they would trigger PHP errors if we decide, or consumers are using strict `() : void` return types:
        ```php
        function first() : void {}
        function another() : void { return first(); } // ERROR
        ```
        that said, there are **no functional (nor BC breaking) changes**
 - cleanup in docblocks and other minor updates