### PR TITLE
[5.7] cleanup in Foundation namespace

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -217,7 +217,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function afterLoadingEnvironment(Closure $callback)
     {
-        return $this->afterBootstrapping(
+        $this->afterBootstrapping(
             LoadEnvironmentVariables::class, $callback
         );
     }

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -36,7 +36,9 @@ class KeyGenerateCommand extends Command
         $key = $this->generateRandomKey();
 
         if ($this->option('show')) {
-            return $this->line('<comment>'.$key.'</comment>');
+            $this->line('<comment>'.$key.'</comment>');
+
+            return;
         }
 
         // Next, we will replace the application key in the environment file so it is

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -55,7 +55,9 @@ class RouteCacheCommand extends Command
         $routes = $this->getFreshApplicationRoutes();
 
         if (count($routes) === 0) {
-            return $this->error("Your application doesn't have any routes.");
+            $this->error("Your application doesn't have any routes.");
+
+            return;
         }
 
         foreach ($routes as $route) {

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -69,7 +69,9 @@ class RouteListCommand extends Command
     public function handle()
     {
         if (count($this->routes) === 0) {
-            return $this->error("Your application doesn't have any routes.");
+            $this->error("Your application doesn't have any routes.");
+
+            return;
         }
 
         $this->displayRoutes($this->getRoutes());

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -28,7 +28,9 @@ class StorageLinkCommand extends Command
     public function handle()
     {
         if (file_exists(public_path('storage'))) {
-            return $this->error('The "public/storage" directory already exists.');
+            $this->error('The "public/storage" directory already exists.');
+
+            return;
         }
 
         $this->laravel->make('files')->link(

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -185,9 +185,15 @@ class VendorPublishCommand extends Command
     protected function publishItem($from, $to)
     {
         if ($this->files->isFile($from)) {
-            return $this->publishFile($from, $to);
-        } elseif ($this->files->isDirectory($from)) {
-            return $this->publishDirectory($from, $to);
+            $this->publishFile($from, $to);
+
+            return;
+        }
+
+        if ($this->files->isDirectory($from)) {
+            $this->publishDirectory($from, $to);
+
+            return;
         }
 
         $this->error("Can't locate path: <{$from}>");

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -778,7 +778,7 @@ class TestResponse
     protected function ensureResponseHasView()
     {
         if (! isset($this->original) || ! $this->original instanceof View) {
-            return PHPUnit::fail('The response is not a view.');
+            PHPUnit::fail('The response is not a view.');
         }
 
         return $this;


### PR DESCRIPTION
This is part of a few PRs that touch mainly docblocks and return calls. 
The changes were split into separate PRs covering different namespaces of the framework to make it easy for you to review them.

what's been done
 - don't return anything where `void` is expected - it helps in two ways:
    * in static analysis
    * going forward, they would trigger PHP errors if we decide, or consumers are using strict `() : void` return types:
        ```php
        function first() : void {}
        function another() : void { return first(); } // ERROR
        ```
        that said, there are **no functional (nor BC breaking) changes**
 - cleanup in docblocks and other minor updates