### PR TITLE
[5.7] cleanup in Pipeline namespace

### DIFF
--- a/src/Illuminate/Pipeline/Hub.php
+++ b/src/Illuminate/Pipeline/Hub.php
@@ -41,7 +41,7 @@ class Hub implements HubContract
      */
     public function defaults(Closure $callback)
     {
-        return $this->pipeline('default', $callback);
+        $this->pipeline('default', $callback);
     }
 
     /**


### PR DESCRIPTION
This is part of a few PRs that touch mainly docblocks and return calls. 
The changes were split into separate PRs covering different namespaces of the framework to make it easy for you to review them.

what's been done
 - don't return anything where `void` is expected - it helps in two ways:
    * in static analysis
    * going forward, they would trigger PHP errors if we decide, or consumers are using strict `() : void` return types:
        ```php
        function first() : void {}
        function another() : void { return first(); } // ERROR
        ```
        that said, there are **no functional (nor BC breaking) changes**
 - cleanup in docblocks and other minor updates