### PR TITLE
[5.7] cleanup in Queue namespace

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -64,7 +64,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * @param  string  $job
      * @param  mixed   $data
      * @param  string  $queue
-     * @return mixed
+     * @return int
      */
     public function push($job, $data = '', $queue = null)
     {
@@ -77,7 +77,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * @param  string  $payload
      * @param  string  $queue
      * @param  array   $options
-     * @return mixed
+     * @return int
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
@@ -93,7 +93,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * @param  string  $job
      * @param  mixed   $data
      * @param  string  $queue
-     * @return mixed
+     * @return int
      */
     public function later($delay, $job, $data = '', $queue = null)
     {

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -42,7 +42,9 @@ class CallQueuedHandler
                 $job, unserialize($data['command'])
             );
         } catch (ModelNotFoundException $e) {
-            return $this->handleModelNotFound($job, $e);
+            $this->handleModelNotFound($job, $e);
+
+            return;
         }
 
         $this->dispatcher->dispatchNow(
@@ -127,7 +129,7 @@ class CallQueuedHandler
             return $job->delete();
         }
 
-        return FailingJob::handle(
+        FailingJob::handle(
             $job->getConnectionName(), $job, $e
         );
     }

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -35,11 +35,11 @@ class ListFailedCommand extends Command
      */
     public function handle()
     {
-        if (count($jobs = $this->getFailedJobs()) == 0) {
-            return $this->info('No failed jobs!');
+        if (count($jobs = $this->getFailedJobs()) === 0) {
+            $this->info('No failed jobs!');
+        } else {
+            $this->displayFailedJobs($jobs);
         }
-
-        $this->displayFailedJobs($jobs);
     }
 
     /**

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -149,11 +149,17 @@ class WorkCommand extends Command
     {
         switch ($status) {
             case 'starting':
-                return $this->writeStatus($job, 'Processing', 'comment');
+                $this->writeStatus($job, 'Processing', 'comment');
+
+                return;
             case 'success':
-                return $this->writeStatus($job, 'Processed', 'info');
+                $this->writeStatus($job, 'Processed', 'info');
+
+                return;
             case 'failed':
-                return $this->writeStatus($job, 'Failed', 'error');
+                $this->writeStatus($job, 'Failed', 'error');
+
+                return;
         }
     }
 

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -74,7 +74,7 @@ class DatabaseQueue extends Queue implements QueueContract
      * @param  string  $job
      * @param  mixed   $data
      * @param  string  $queue
-     * @return mixed
+     * @return int
      */
     public function push($job, $data = '', $queue = null)
     {
@@ -87,7 +87,7 @@ class DatabaseQueue extends Queue implements QueueContract
      * @param  string  $payload
      * @param  string  $queue
      * @param  array   $options
-     * @return mixed
+     * @return int
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
@@ -101,7 +101,7 @@ class DatabaseQueue extends Queue implements QueueContract
      * @param  string  $job
      * @param  mixed   $data
      * @param  string  $queue
-     * @return void
+     * @return int
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
@@ -135,7 +135,7 @@ class DatabaseQueue extends Queue implements QueueContract
      * @param  string  $queue
      * @param  \Illuminate\Queue\Jobs\DatabaseJobRecord  $job
      * @param  int  $delay
-     * @return mixed
+     * @return int
      */
     public function release($queue, $job, $delay)
     {
@@ -149,7 +149,7 @@ class DatabaseQueue extends Queue implements QueueContract
      * @param  string  $payload
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  int  $attempts
-     * @return mixed
+     * @return int
      */
     protected function pushToDatabase($queue, $payload, $delay = 0, $attempts = 0)
     {

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -23,7 +23,7 @@ class NullQueue extends Queue implements QueueContract
      * @param  string  $job
      * @param  mixed   $data
      * @param  string  $queue
-     * @return mixed
+     * @return void
      */
     public function push($job, $data = '', $queue = null)
     {
@@ -36,7 +36,7 @@ class NullQueue extends Queue implements QueueContract
      * @param  string  $payload
      * @param  string  $queue
      * @param  array   $options
-     * @return mixed
+     * @return void
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
@@ -50,7 +50,7 @@ class NullQueue extends Queue implements QueueContract
      * @param  string  $job
      * @param  mixed   $data
      * @param  string  $queue
-     * @return mixed
+     * @return void
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
@@ -61,7 +61,7 @@ class NullQueue extends Queue implements QueueContract
      * Pop the next job off of the queue.
      *
      * @param  string  $queue
-     * @return \Illuminate\Contracts\Queue\Job|null
+     * @return void
      */
     public function pop($queue = null)
     {

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -184,7 +184,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function extend($driver, Closure $resolver)
     {
-        return $this->addConnector($driver, $resolver);
+        $this->addConnector($driver, $resolver);
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -68,7 +68,7 @@ class SqsQueue extends Queue implements QueueContract
      * @param  string  $job
      * @param  mixed   $data
      * @param  string  $queue
-     * @return mixed
+     * @return string
      */
     public function push($job, $data = '', $queue = null)
     {
@@ -81,7 +81,7 @@ class SqsQueue extends Queue implements QueueContract
      * @param  string  $payload
      * @param  string  $queue
      * @param  array   $options
-     * @return mixed
+     * @return string
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
@@ -97,7 +97,7 @@ class SqsQueue extends Queue implements QueueContract
      * @param  string  $job
      * @param  mixed   $data
      * @param  string  $queue
-     * @return mixed
+     * @return string
      */
     public function later($delay, $job, $data = '', $queue = null)
     {

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -28,7 +28,7 @@ class SyncQueue extends Queue implements QueueContract
      * @param  string  $job
      * @param  mixed   $data
      * @param  string  $queue
-     * @return mixed
+     * @return int
      *
      * @throws \Exception|\Throwable
      */
@@ -127,7 +127,7 @@ class SyncQueue extends Queue implements QueueContract
      * @param  string  $payload
      * @param  string  $queue
      * @param  array   $options
-     * @return mixed
+     * @return void
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
@@ -141,7 +141,9 @@ class SyncQueue extends Queue implements QueueContract
      * @param  string  $job
      * @param  mixed   $data
      * @param  string  $queue
-     * @return mixed
+     * @return int
+     *
+     * @throws \Exception|\Throwable
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
@@ -152,7 +154,7 @@ class SyncQueue extends Queue implements QueueContract
      * Pop the next job off of the queue.
      *
      * @param  string  $queue
-     * @return \Illuminate\Contracts\Queue\Job|null
+     * @return void
      */
     public function pop($queue = null)
     {

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -225,11 +225,11 @@ class Worker
         // If we're able to pull a job off of the stack, we will process it and then return
         // from this method. If there is no job on the queue, we will "sleep" the worker
         // for the specified number of seconds, then keep processing jobs after sleep.
-        if ($job) {
-            return $this->runJob($job, $connectionName, $options);
+        if (! $job) {
+            $this->sleep($options->sleep);
         }
 
-        $this->sleep($options->sleep);
+        $this->runJob($job, $connectionName, $options);
     }
 
     /**
@@ -269,7 +269,7 @@ class Worker
     protected function runJob($job, $connectionName, WorkerOptions $options)
     {
         try {
-            return $this->process($connectionName, $job, $options);
+            $this->process($connectionName, $job, $options);
         } catch (Exception $e) {
             $this->exceptions->report($e);
 
@@ -432,7 +432,7 @@ class Worker
      */
     protected function failJob($connectionName, $job, $e)
     {
-        return FailingJob::handle($connectionName, $job, $e);
+        FailingJob::handle($connectionName, $job, $e);
     }
 
     /**


### PR DESCRIPTION
This is part of a few PRs that touch mainly docblocks and return calls. 
The changes were split into separate PRs covering different namespaces of the framework to make it easy for you to review them.

what's been done
 - don't return anything where `void` is expected - it helps in two ways:
    * in static analysis
    * going forward, they would trigger PHP errors if we decide, or consumers are using strict `() : void` return types:
        ```php
        function first() : void {}
        function another() : void { return first(); } // ERROR
        ```
        that said, there are **no functional (nor BC breaking) changes**
 - cleanup in docblocks and other minor updates