### PR TITLE
[5.7] cleanup in Redis namespace

### DIFF
--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -85,7 +85,7 @@ abstract class Connection
      */
     public function subscribe($channels, Closure $callback)
     {
-        return $this->createSubscription($channels, $callback, __FUNCTION__);
+        $this->createSubscription($channels, $callback, __FUNCTION__);
     }
 
     /**
@@ -97,7 +97,7 @@ abstract class Connection
      */
     public function psubscribe($channels, Closure $callback)
     {
-        return $this->createSubscription($channels, $callback, __FUNCTION__);
+        $this->createSubscription($channels, $callback, __FUNCTION__);
     }
 
     /**


### PR DESCRIPTION
This is part of a few PRs that touch mainly docblocks and return calls. 
The changes were split into separate PRs covering different namespaces of the framework to make it easy for you to review them.

what's been done
 - don't return anything where `void` is expected - it helps in two ways:
    * in static analysis
    * going forward, they would trigger PHP errors if we decide, or consumers are using strict `() : void` return types:
        ```php
        function first() : void {}
        function another() : void { return first(); } // ERROR
        ```
        that said, there are **no functional (nor BC breaking) changes**
 - cleanup in docblocks and other minor updates