### PR TITLE
[5.7] cleanup in Routing namespace

### DIFF
--- a/src/Illuminate/Routing/ControllerMiddlewareOptions.php
+++ b/src/Illuminate/Routing/ControllerMiddlewareOptions.php
@@ -25,7 +25,7 @@ class ControllerMiddlewareOptions
     /**
      * Set the controller methods the middleware should apply to.
      *
-     * @param  array|string|dynamic  $methods
+     * @param  array|...string  $methods
      * @return $this
      */
     public function only($methods)
@@ -38,7 +38,7 @@ class ControllerMiddlewareOptions
     /**
      * Set the controller methods the middleware should exclude.
      *
-     * @param  array|string|dynamic  $methods
+     * @param  array|...string  $methods
      * @return $this
      */
     public function except($methods)

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -59,7 +59,7 @@ class PendingResourceRegistration
     /**
      * Set the methods the controller should apply to.
      *
-     * @param  array|string|dynamic  $methods
+     * @param  array|...string  $methods
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function only($methods)
@@ -72,7 +72,7 @@ class PendingResourceRegistration
     /**
      * Set the methods the controller should exclude.
      *
-     * @param  array|string|dynamic  $methods
+     * @param  array|...string  $methods
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function except($methods)

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -645,7 +645,7 @@ class Route
     /**
      * Determine whether the route's name matches the given patterns.
      *
-     * @param  dynamic  $patterns
+     * @param  ...string  $patterns
      * @return bool
      */
     public function named(...$patterns)

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1062,7 +1062,7 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Alias for the "currentRouteNamed" method.
      *
-     * @param  dynamic  $patterns
+     * @param  ...string  $patterns
      * @return bool
      */
     public function is(...$patterns)
@@ -1073,7 +1073,7 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Determine if the current route matches a pattern.
      *
-     * @param  dynamic  $patterns
+     * @param  ...string  $patterns
      * @return bool
      */
     public function currentRouteNamed(...$patterns)


### PR DESCRIPTION
This is part of a few PRs that touch mainly docblocks and return calls. 
The changes were split into separate PRs covering different namespaces of the framework to make it easy for you to review them.

what's been done
 - don't return anything where `void` is expected - it helps in two ways:
    * in static analysis
    * going forward, they would trigger PHP errors if we decide, or consumers are using strict `() : void` return types:
        ```php
        function first() : void {}
        function another() : void { return first(); } // ERROR
        ```
        that said, there are **no functional (nor BC breaking) changes**
 - cleanup in docblocks and other minor updates