### PR TITLE
[5.7] cleanup in Support namespace

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -24,13 +24,13 @@ class BusFake implements Dispatcher
     public function assertDispatched($command, $callback = null)
     {
         if (is_numeric($callback)) {
-            return $this->assertDispatchedTimes($command, $callback);
+            $this->assertDispatchedTimes($command, $callback);
+        } else {
+            PHPUnit::assertTrue(
+                $this->dispatched($command, $callback)->count() > 0,
+                "The expected [{$command}] job was not dispatched."
+            );
         }
-
-        PHPUnit::assertTrue(
-            $this->dispatched($command, $callback)->count() > 0,
-            "The expected [{$command}] job was not dispatched."
-        );
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -53,13 +53,13 @@ class EventFake implements Dispatcher
     public function assertDispatched($event, $callback = null)
     {
         if (is_int($callback)) {
-            return $this->assertDispatchedTimes($event, $callback);
+            $this->assertDispatchedTimes($event, $callback);
+        } else {
+            PHPUnit::assertTrue(
+                $this->dispatched($event, $callback)->count() > 0,
+                "The expected [{$event}] event was not dispatched."
+            );
         }
-
-        PHPUnit::assertTrue(
-            $this->dispatched($event, $callback)->count() > 0,
-            "The expected [{$event}] event was not dispatched."
-        );
     }
 
     /**
@@ -188,11 +188,11 @@ class EventFake implements Dispatcher
      * @param  string|object  $event
      * @param  mixed  $payload
      * @param  bool  $halt
-     * @return array|null
+     * @return void
      */
     public function fire($event, $payload = [], $halt = false)
     {
-        return $this->dispatch($event, $payload, $halt);
+        $this->dispatch($event, $payload, $halt);
     }
 
     /**
@@ -201,7 +201,7 @@ class EventFake implements Dispatcher
      * @param  string|object  $event
      * @param  mixed  $payload
      * @param  bool  $halt
-     * @return array|null
+     * @return void
      */
     public function dispatch($event, $payload = [], $halt = false)
     {
@@ -255,6 +255,6 @@ class EventFake implements Dispatcher
      */
     public function until($event, $payload = [])
     {
-        return $this->dispatch($event, $payload, true);
+        $this->dispatch($event, $payload, true);
     }
 }

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -33,13 +33,13 @@ class MailFake implements Mailer
     public function assertSent($mailable, $callback = null)
     {
         if (is_numeric($callback)) {
-            return $this->assertSentTimes($mailable, $callback);
+            $this->assertSentTimes($mailable, $callback);
+        } else {
+            PHPUnit::assertTrue(
+                $this->sent($mailable, $callback)->count() > 0,
+                "The expected [{$mailable}] mailable was not sent."
+            );
         }
-
-        PHPUnit::assertTrue(
-            $this->sent($mailable, $callback)->count() > 0,
-            "The expected [{$mailable}] mailable was not sent."
-        );
     }
 
     /**
@@ -92,13 +92,13 @@ class MailFake implements Mailer
     public function assertQueued($mailable, $callback = null)
     {
         if (is_numeric($callback)) {
-            return $this->assertQueuedTimes($mailable, $callback);
+            $this->assertQueuedTimes($mailable, $callback);
+        } else {
+            PHPUnit::assertTrue(
+                $this->queued($mailable, $callback)->count() > 0,
+                "The expected [{$mailable}] mailable was not queued."
+            );
         }
-
-        PHPUnit::assertTrue(
-            $this->queued($mailable, $callback)->count() > 0,
-            "The expected [{$mailable}] mailable was not queued."
-        );
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -36,13 +36,13 @@ class NotificationFake implements NotificationFactory, NotificationDispatcher
         }
 
         if (is_numeric($callback)) {
-            return $this->assertSentToTimes($notifiable, $notification, $callback);
+            $this->assertSentToTimes($notifiable, $notification, $callback);
+        } else {
+            PHPUnit::assertTrue(
+                $this->sent($notifiable, $notification, $callback)->count() > 0,
+                "The expected [{$notification}] notification was not sent."
+            );
         }
-
-        PHPUnit::assertTrue(
-            $this->sent($notifiable, $notification, $callback)->count() > 0,
-            "The expected [{$notification}] notification was not sent."
-        );
     }
 
     /**
@@ -178,7 +178,7 @@ class NotificationFake implements NotificationFactory, NotificationDispatcher
      */
     public function send($notifiables, $notification)
     {
-        return $this->sendNow($notifiables, $notification);
+        $this->sendNow($notifiables, $notification);
     }
 
     /**
@@ -211,7 +211,7 @@ class NotificationFake implements NotificationFactory, NotificationDispatcher
      * Get a channel instance by name.
      *
      * @param  string|null  $name
-     * @return mixed
+     * @return void
      */
     public function channel($name = null)
     {

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -25,13 +25,13 @@ class QueueFake extends QueueManager implements Queue
     public function assertPushed($job, $callback = null)
     {
         if (is_numeric($callback)) {
-            return $this->assertPushedTimes($job, $callback);
+            $this->assertPushedTimes($job, $callback);
+        } else {
+            PHPUnit::assertTrue(
+                $this->pushed($job, $callback)->count() > 0,
+                "The expected [{$job}] job was not pushed."
+            );
         }
-
-        PHPUnit::assertTrue(
-            $this->pushed($job, $callback)->count() > 0,
-            "The expected [{$job}] job was not pushed."
-        );
     }
 
     /**
@@ -59,7 +59,7 @@ class QueueFake extends QueueManager implements Queue
      */
     public function assertPushedOn($queue, $job, $callback = null)
     {
-        return $this->assertPushed($job, function ($job, $pushedQueue) use ($callback, $queue) {
+        $this->assertPushed($job, function ($job, $pushedQueue) use ($callback, $queue) {
             if ($pushedQueue !== $queue) {
                 return false;
             }
@@ -146,10 +146,10 @@ class QueueFake extends QueueManager implements Queue
      */
     protected function isChainOfObjects($chain)
     {
-        return collect($chain)->count() == collect($chain)
-                    ->filter(function ($job) {
+        return collect($chain)
+                    ->reject(function ($job) {
                         return is_object($job);
-                    })->count();
+                    })->isEmpty();
     }
 
     /**
@@ -207,7 +207,7 @@ class QueueFake extends QueueManager implements Queue
      */
     public function hasPushed($job)
     {
-        return isset($this->jobs[$job]) && ! empty($this->jobs[$job]);
+        return ! empty($this->jobs[$job]);
     }
 
     /**
@@ -238,7 +238,7 @@ class QueueFake extends QueueManager implements Queue
      * @param  string  $job
      * @param  mixed   $data
      * @param  string  $queue
-     * @return mixed
+     * @return void
      */
     public function push($job, $data = '', $queue = null)
     {
@@ -254,7 +254,7 @@ class QueueFake extends QueueManager implements Queue
      * @param  string  $payload
      * @param  string  $queue
      * @param  array   $options
-     * @return mixed
+     * @return void
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
@@ -268,11 +268,11 @@ class QueueFake extends QueueManager implements Queue
      * @param  string  $job
      * @param  mixed   $data
      * @param  string  $queue
-     * @return mixed
+     * @return void
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
-        return $this->push($job, $data, $queue);
+        $this->push($job, $data, $queue);
     }
 
     /**
@@ -281,11 +281,11 @@ class QueueFake extends QueueManager implements Queue
      * @param  string  $queue
      * @param  string  $job
      * @param  mixed   $data
-     * @return mixed
+     * @return void
      */
     public function pushOn($queue, $job, $data = '')
     {
-        return $this->push($job, $data, $queue);
+        $this->push($job, $data, $queue);
     }
 
     /**
@@ -295,18 +295,18 @@ class QueueFake extends QueueManager implements Queue
      * @param  \DateTime|int  $delay
      * @param  string  $job
      * @param  mixed   $data
-     * @return mixed
+     * @return void
      */
     public function laterOn($queue, $delay, $job, $data = '')
     {
-        return $this->push($job, $data, $queue);
+        $this->push($job, $data, $queue);
     }
 
     /**
      * Pop the next job off of the queue.
      *
      * @param  string  $queue
-     * @return \Illuminate\Contracts\Queue\Job|null
+     * @return void
      */
     public function pop($queue = null)
     {
@@ -319,7 +319,7 @@ class QueueFake extends QueueManager implements Queue
      * @param  array $jobs
      * @param  mixed $data
      * @param  string $queue
-     * @return mixed
+     * @return void
      */
     public function bulk($jobs, $data = '', $queue = null)
     {
@@ -331,7 +331,7 @@ class QueueFake extends QueueManager implements Queue
     /**
      * Get the connection name for the queue.
      *
-     * @return string
+     * @return void
      */
     public function getConnectionName()
     {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -139,7 +139,7 @@ if (! function_exists('array_forget')) {
      */
     function array_forget(&$array, $keys)
     {
-        return Arr::forget($array, $keys);
+        Arr::forget($array, $keys);
     }
 }
 


### PR DESCRIPTION
This is part of a few PRs that touch mainly docblocks and return calls. 
The changes were split into separate PRs covering different namespaces of the framework to make it easy for you to review them.

what's been done
 - don't return anything where `void` is expected - it helps in two ways:
    * in static analysis
    * going forward, they would trigger PHP errors if we decide, or consumers are using strict `() : void` return types:
        ```php
        function first() : void {}
        function another() : void { return first(); } // ERROR
        ```
        that said, there are **no functional (nor BC breaking) changes**
 - cleanup in docblocks and other minor updates