### PR TITLE
[5.7] throw explicitly in public method

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -770,7 +770,7 @@ class Container implements ArrayAccess, ContainerContract
         // an abstract type such as an Interface of Abstract Class and there is
         // no binding registered for the abstractions so we need to bail out.
         if (! $reflector->isInstantiable()) {
-            return $this->notInstantiable($concrete);
+            throw $this->notInstantiable($concrete);
         }
 
         $this->buildStack[] = $concrete;
@@ -916,9 +916,7 @@ class Container implements ArrayAccess, ContainerContract
      * Throw an exception that the concrete is not instantiable.
      *
      * @param  string  $concrete
-     * @return void
-     *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @return \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function notInstantiable($concrete)
     {
@@ -930,7 +928,7 @@ class Container implements ArrayAccess, ContainerContract
             $message = "Target [$concrete] is not instantiable.";
         }
 
-        throw new BindingResolutionException($message);
+        return new BindingResolutionException($message);
     }
 
     /**


### PR DESCRIPTION
This one is a suggestion to throw explicitly in a public method body rather than calling `return $this->someProtectedMethod()` which in fact throws exception internally. It helps in readability of the code.

No functional or BC breaking change in public interface.
**little chance to be BC breaking** in case where someone is extending & using `protected Container::notInstantiable` method in their implementation. That is because this method does not throw, but rather returns the exception now.

To address that fact 2 replacements should do (sublime style in regex mode): 

![image](https://user-images.githubusercontent.com/6928818/42668530-bfc3da9e-8683-11e8-9fa8-c518cd30b644.png)
![image](https://user-images.githubusercontent.com/6928818/42668537-c6c3586a-8683-11e8-8d43-ebb47b588b14.png)

normal regex can do in one go in greedy mode.