### PR TITLE
[5.7] Remove aria-label on form tags

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/login.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/login.stub
@@ -8,7 +8,7 @@
                 <div class="card-header">{{ __('Login') }}</div>
 
                 <div class="card-body">
-                    <form method="POST" action="{{ route('login') }}" aria-label="{{ __('Login') }}">
+                    <form method="POST" action="{{ route('login') }}">
                         @csrf
 
                         <div class="form-group row">

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/email.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/email.stub
@@ -14,7 +14,7 @@
                         </div>
                     @endif
 
-                    <form method="POST" action="{{ route('password.email') }}" aria-label="{{ __('Reset Password') }}">
+                    <form method="POST" action="{{ route('password.email') }}">
                         @csrf
 
                         <div class="form-group row">

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
@@ -8,7 +8,7 @@
                 <div class="card-header">{{ __('Reset Password') }}</div>
 
                 <div class="card-body">
-                    <form method="POST" action="{{ route('password.update') }}" aria-label="{{ __('Reset Password') }}">
+                    <form method="POST" action="{{ route('password.update') }}">
                         @csrf
 
                         <input type="hidden" name="token" value="{{ $token }}">

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/register.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/register.stub
@@ -8,7 +8,7 @@
                 <div class="card-header">{{ __('Register') }}</div>
 
                 <div class="card-body">
-                    <form method="POST" action="{{ route('register') }}" aria-label="{{ __('Register') }}">
+                    <form method="POST" action="{{ route('register') }}">
                         @csrf
 
                         <div class="form-group row">


### PR DESCRIPTION
This is just a follow-up to #24530 - I think the rest of the stuff in that PR is great, but this removes the `aria-label` from the form tags.

I'm still relatively new to implementing WAI-ARIA tags, but I can't find any documentation that refers to putting a label on the `form` tag.  [The recommendations around `aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) refer to using it on elements where their text content doesn't describe their purpose.

This doesn't appear necessary on the `form` element, where a form tag isn't interacted with directly. In addition, I wasn't able to get VoiceOver on my Mac to speak or navigate to the label on the form so I don't think it serves a purpose at all.