### PR TITLE
[5.6] Adds ability to change 'password' field for login and also storing them

### DIFF
--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -38,7 +38,17 @@ trait Authenticatable
      */
     public function getAuthPassword()
     {
-        return $this->password;
+        return $this[$this->getAuthPasswordField()];
+    }
+
+    /**
+     * Get the password field for the user.
+     *
+     * @return string
+     */
+    public function getAuthPasswordField()
+    {
+        return 'password';
     }
 
     /**

--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -38,7 +38,7 @@ trait Authenticatable
      */
     public function getAuthPassword()
     {
-        return $this[$this->getAuthPasswordField()];
+        return $this->{$this->getAuthPasswordField()};
     }
 
     /**

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -102,19 +102,21 @@ class EloquentUserProvider implements UserProvider
      */
     public function retrieveByCredentials(array $credentials)
     {
+        $model = $this->createModel();
+
         if (empty($credentials) ||
            (count($credentials) === 1 &&
-            array_key_exists('password', $credentials))) {
+            array_key_exists($model->getAuthPasswordField(), $credentials))) {
             return;
         }
 
         // First we will add each credential element to the query as a where clause.
         // Then we can execute the query and, if we found a user, return it in a
         // Eloquent User "model" that will be utilized by the Guard instances.
-        $query = $this->createModel()->newQuery();
+        $query = $model->newQuery();
 
         foreach ($credentials as $key => $value) {
-            if (Str::contains($key, 'password')) {
+            if (Str::contains($key, $this->getAuthPasswordField())) {
                 continue;
             }
 
@@ -137,7 +139,7 @@ class EloquentUserProvider implements UserProvider
      */
     public function validateCredentials(UserContract $user, array $credentials)
     {
-        $plain = $credentials['password'];
+        $plain = $credentials[$user->getAuthPasswordField()];
 
         return $this->hasher->check($plain, $user->getAuthPassword());
     }

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -116,7 +116,7 @@ class EloquentUserProvider implements UserProvider
         $query = $model->newQuery();
 
         foreach ($credentials as $key => $value) {
-            if (Str::contains($key, $this->getAuthPasswordField())) {
+            if (Str::contains($key, $model->getAuthPasswordField())) {
                 continue;
             }
 

--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -1,3 +1,4 @@
+
 <?php
 
 namespace Illuminate\Foundation\Auth;
@@ -63,7 +64,7 @@ trait AuthenticatesUsers
     {
         $this->validate($request, [
             $this->username() => 'required|string',
-            'password' => 'required|string',
+            $this->password() => 'required|string',
         ]);
     }
 
@@ -88,7 +89,7 @@ trait AuthenticatesUsers
      */
     protected function credentials(Request $request)
     {
-        return $request->only($this->username(), 'password');
+        return $request->only($this->username(), $this->password());
     }
 
     /**
@@ -142,6 +143,16 @@ trait AuthenticatesUsers
     public function username()
     {
         return 'email';
+    }
+
+    /**
+     * Get the login password to be used by the controller.
+     *
+     * @return string
+     */
+    public function password()
+    {
+        return 'password';
     }
 
     /**


### PR DESCRIPTION
This PR adds the function `password()` to `AuthenticatesUsers` trait, so as user can change the password field in their application login system.

Additionally, it adds `getAuthPasswordField()` method to `Authenticatable` trait. So, any authenticatable model can override this method to change the password's field name.

Also, I didn't find any way to make just a 
single function somewhere which can be utilized in both the traits. Hence, this PR can be approved.

USE CASE:
It is possible that someone uses any other field name than 'password' for their passwords. I have used 'secrets' for my passwords field. Just thought this also should be customizable.

Any feedback is appreciated.