### PR TITLE
[5.6] Fire event when logger is resolved

### DIFF
--- a/src/Illuminate/Log/Events/LoggerResolved.php
+++ b/src/Illuminate/Log/Events/LoggerResolved.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Log\Events;
+
+use Psr\Log\LoggerInterface;
+
+class LoggerResolved
+{
+    /**
+     * Logger.
+     *
+     * @var \Psr\Log\LoggerInterface
+     */
+    public $logger;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \Psr\Log\LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+}

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Log;
 
 use Closure;
-use Illuminate\Log\Events\LoggerResolved;
 use Throwable;
 use Illuminate\Support\Str;
 use Psr\Log\LoggerInterface;
@@ -16,6 +15,7 @@ use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Handler\RotatingFileHandler;
 use Monolog\Handler\SlackWebhookHandler;
+use Illuminate\Log\Events\LoggerResolved;
 
 class LogManager implements LoggerInterface
 {
@@ -189,7 +189,7 @@ class LogManager implements LoggerInterface
         $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
 
         if (method_exists($this, $driverMethod)) {
-            return tap($this->{$driverMethod}($config), function($logger) {
+            return tap($this->{$driverMethod}($config), function ($logger) {
                 $this->app['events']->dispatch(new LoggerResolved($logger));
             });
         }

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Log;
 
 use Closure;
+use Illuminate\Log\Events\LoggerResolved;
 use Throwable;
 use Illuminate\Support\Str;
 use Psr\Log\LoggerInterface;
@@ -188,7 +189,9 @@ class LogManager implements LoggerInterface
         $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
 
         if (method_exists($this, $driverMethod)) {
-            return $this->{$driverMethod}($config);
+            return tap($this->{$driverMethod}($config), function($logger) {
+                $this->app['events']->dispatch(new LoggerResolved($logger));
+            });
         }
 
         throw new InvalidArgumentException("Driver [{$config['driver']}] is not supported.");


### PR DESCRIPTION
This will allow to easily attach additional data to logger creating LoggerResolved event listener. For example I often attach request url or artisan command and so on to get more information to track the potential problem.
