### PR TITLE
[5.6] Improves guessing of the table name when generating a migration

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -91,6 +91,17 @@ class MigrateMakeCommand extends BaseCommand
             }
         }
 
+        // Next, we will attempt to guess the table name if this the migration has
+        // "to", "from", "in" in the name. This will allow us to provide a convenient
+        // way of creating migrations that modify tables in the application.
+        if (! $table) {
+            if (preg_match('/_(to|from|in)_(\w+)_table$/', $name, $matches)) {
+                $table = $matches[2];
+
+                $create = false;
+            }
+        }
+
         // Now we are ready to write the migration out to disk. Once we've written
         // the migration out, we will dump-autoload for the entire framework to
         // make sure that the migrations are registered by the class loaders.


### PR DESCRIPTION
This pull request improves guessing of the table name when generating a migration.

As a result it won't be necessary to specify the table name in such cases because it will be guessed automatically:
`php artisan make:migration add_title_field_to_posts_table`
`php artisan make:migration delete_description_field_from_products_table`
`php artisan make:migration change_type_of_body_field_in_posts_table`