### PR TITLE
[5.7] Make MailFake implement MailQueue interface

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -4,10 +4,11 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\Mailable;
+use Illuminate\Contracts\Mail\MailQueue;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class MailFake implements Mailer
+class MailFake implements Mailer, MailQueue
 {
     /**
      * All of the mailables that have been sent.
@@ -302,6 +303,19 @@ class MailFake implements Mailer
         }
 
         $this->queuedMailables[] = $view;
+    }
+
+    /**
+     * Queue a new e-mail message for sending after (n) seconds.
+     *
+     * @param  \DateTimeInterface|\DateInterval|int  $delay
+     * @param  string|array|\Illuminate\Contracts\Mail\Mailable  $view
+     * @param  string  $queue
+     * @return mixed
+     */
+    public function later($delay, $view, $queue = null)
+    {
+        $this->queue($view, $queue);
     }
 
     /**


### PR DESCRIPTION
I don't like to depend on concrete classes in my code and before this PR if I typehinted the MailQueue interface in my code everything would work with the exception of my test when using ```Mail::fake()``` as the fake didn't implement that contract and the test would fail with the message 

> Argument X passed to SomeClass::someMethod() must implement interface Illuminate\Contracts\Mail\MailQueue, instance of Illuminate\Support\Testing\Fakes\MailFake given

As the MailFake already implements the "queue" method which is the "main" method of this contract there is no reason why it shouldn't implement the (entire) contract as there is just one tiny method from the contract that it didn't have.
