### PR TITLE
[5.6] JSON assertion bugfixes

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -471,7 +471,7 @@ class TestResponse
             PHPUnit::assertTrue(
                 Str::contains($actual, $expected),
                 'Unable to find JSON fragment: '.PHP_EOL.PHP_EOL.
-                "[". json_encode([$key => $value]) ."]".PHP_EOL.PHP_EOL.
+                '['.json_encode([$key => $value]).']'.PHP_EOL.PHP_EOL.
                 'within'.PHP_EOL.PHP_EOL.
                 "[{$actual}]."
             );
@@ -503,7 +503,7 @@ class TestResponse
             PHPUnit::assertFalse(
                 Str::contains($actual, $unexpected),
                 'Found unexpected JSON fragment: '.PHP_EOL.PHP_EOL.
-                "[".json_encode([$key => $value])."]".PHP_EOL.PHP_EOL.
+                '['.json_encode([$key => $value]).']'.PHP_EOL.PHP_EOL.
                 'within'.PHP_EOL.PHP_EOL.
                 "[{$actual}]."
             );
@@ -555,9 +555,9 @@ class TestResponse
         $needle = substr(json_encode([$key => $value]), 1, -1);
 
         return [
-            $needle . ']',
-            $needle . '}',
-            $needle . ',',
+            $needle.']',
+            $needle.'}',
+            $needle.',',
         ];
     }
 

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -466,12 +466,12 @@ class TestResponse
         ));
 
         foreach (Arr::sortRecursive($data) as $key => $value) {
-            $expected = substr(json_encode([$key => $value]), 1, -1);
+            $expected = $this->jsonSearchStrings($key, $value);
 
             PHPUnit::assertTrue(
                 Str::contains($actual, $expected),
                 'Unable to find JSON fragment: '.PHP_EOL.PHP_EOL.
-                "[{$expected}]".PHP_EOL.PHP_EOL.
+                "[". json_encode([$key => $value]) ."]".PHP_EOL.PHP_EOL.
                 'within'.PHP_EOL.PHP_EOL.
                 "[{$actual}]."
             );
@@ -498,12 +498,12 @@ class TestResponse
         ));
 
         foreach (Arr::sortRecursive($data) as $key => $value) {
-            $unexpected = substr(json_encode([$key => $value]), 1, -1);
+            $unexpected = $this->jsonSearchStrings($key, $value);
 
             PHPUnit::assertFalse(
                 Str::contains($actual, $unexpected),
                 'Found unexpected JSON fragment: '.PHP_EOL.PHP_EOL.
-                "[{$unexpected}]".PHP_EOL.PHP_EOL.
+                "[".json_encode([$key => $value])."]".PHP_EOL.PHP_EOL.
                 'within'.PHP_EOL.PHP_EOL.
                 "[{$actual}]."
             );
@@ -525,7 +525,7 @@ class TestResponse
         ));
 
         foreach (Arr::sortRecursive($data) as $key => $value) {
-            $unexpected = substr(json_encode([$key => $value]), 1, -1);
+            $unexpected = $this->jsonSearchStrings($key, $value);
 
             if (! Str::contains($actual, $unexpected)) {
                 return $this;
@@ -538,6 +538,27 @@ class TestResponse
             'within'.PHP_EOL.PHP_EOL.
             "[{$actual}]."
         );
+    }
+
+    /**
+     * TestResponse::assertJsonFragment and TestResponse::assertJsonMissing search for
+     * JSON encoded strings in the Response. This function returns the set of strings to
+     * be searched for in the response, explicitly adding all of the possible characters
+     * which could follow $value in the response.
+     *
+     * @param $key
+     * @param $value
+     * @return array
+     */
+    protected function jsonSearchStrings($key, $value)
+    {
+        $needle = substr(json_encode([$key => $value]), 1, -1);
+
+        return [
+            $needle . ']',
+            $needle . '}',
+            $needle . ',',
+        ];
     }
 
     /**

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -174,6 +174,16 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonFragment(['foobar' => ['foobar_foo' => 'foo', 'foobar_bar' => 'bar']]);
 
         $response->assertJsonFragment(['foo' => 'bar 0', 'bar' => ['foo' => 'bar 0', 'bar' => 'foo 0']]);
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub()));
+
+        $response->assertJsonFragment(['id' => 10]);
+
+        try {
+            $response->assertJsonFragment(['id' => 1]);
+            $this->fail('Asserting id => 1, existsing in JsonSerializableSingleResourceWithIntegersStub should fail');
+        } catch (\PHPUnit\Framework\ExpectationFailedException $e) {
+        }
     }
 
     public function testAssertJsonStructure()
@@ -215,6 +225,13 @@ class FoundationTestResponseTest extends TestCase
         // Without structure
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
         $response->assertJsonCount(4);
+    }
+
+    public function testAssertJsonMissing()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
+
+        $response->assertJsonMissing(['id' => 2]);
     }
 
     public function testAssertJsonMissingValidationErrors()
@@ -327,6 +344,18 @@ class JsonSerializableSingleResourceStub implements JsonSerializable
             ['foo' => 'foo 1', 'bar' => 'bar 1', 'foobar' => 'foobar 1'],
             ['foo' => 'foo 2', 'bar' => 'bar 2', 'foobar' => 'foobar 2'],
             ['foo' => 'foo 3', 'bar' => 'bar 3', 'foobar' => 'foobar 3'],
+        ];
+    }
+}
+
+class JsonSerializableSingleResourceWithIntegersStub implements JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return [
+            ['id' => 10, 'foo' => 'bar'],
+            ['id' => 20, 'foo' => 'bar'],
+            ['id' => 30, 'foo' => 'bar'],
         ];
     }
 }


### PR DESCRIPTION
I've added tests which illustrate the issue I'm having, and this PR adds a fix.

## Bug Description
JSON Request Response:

```
{"id":200,"data":"Lorem Ipsum..."}
```

Running the following would fail:

```
$response->assertJsonMissing(['id' => 20]);
```

The reason this was failing is because the assertion functions search for: `"id":20` which clearly is present in the response.

If instead we search for:

*  `"id":20,`
*  `"id":20}`
*  `"id":20]`

We guarantee that the value we are searching for is present, and not just a portion of the value.

## Long Term
The existing way that the assertion functions operate, i.e. via string comparison isn't ideal, and I'd suggest refactoring it to work recursively walking through the leaves of the array, and then performing value comparisons. Note that this is likely to be less efficient.
