### PR TITLE
[5.6] Add JPEG support to FileFactory::image()

### DIFF
--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Http\Testing;
 
+use Illuminate\Support\Str;
+
 class FileFactory
 {
     /**
@@ -28,7 +30,9 @@ class FileFactory
      */
     public function image($name, $width = 10, $height = 10)
     {
-        return new File($name, $this->generateImage($width, $height));
+        $type = Str::endsWith($name, ['.jpg', '.jpeg']) ? 'jpeg' : 'png';
+
+        return new File($name, $this->generateImage($width, $height, $type));
     }
 
     /**
@@ -38,12 +42,21 @@ class FileFactory
      * @param  int  $height
      * @return resource
      */
-    protected function generateImage($width, $height)
+    protected function generateImage($width, $height, $type)
     {
-        return tap(tmpfile(), function ($temp) use ($width, $height) {
+        return tap(tmpfile(), function ($temp) use ($width, $height, $type) {
             ob_start();
 
-            imagepng(imagecreatetruecolor($width, $height));
+            $image = imagecreatetruecolor($width, $height);
+
+            switch ($type) {
+                case 'jpeg':
+                    imagejpeg($image);
+                    break;
+                case 'png':
+                    imagepng($image);
+                    break;
+            }
 
             fwrite($temp, ob_get_clean());
         });

--- a/tests/Http/HttpTestingFileFactoryTest.php
+++ b/tests/Http/HttpTestingFileFactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Tests\Http;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Http\Testing\FileFactory;
+
+class HttpTestingFileFactoryTest extends TestCase
+{
+    public function testImagePng()
+    {
+        $image = (new FileFactory)->image('test.png', 15, 20);
+
+        $info = getimagesize($image->getRealPath());
+
+        $this->assertSame('image/png', $info['mime']);
+        $this->assertSame(15, $info[0]);
+        $this->assertSame(20, $info[1]);
+    }
+
+    public function testImageJpeg()
+    {
+        $image = (new FileFactory)->image('test.jpeg', 15, 20);
+
+        $info = getimagesize($image->getRealPath());
+
+        $this->assertSame('image/jpeg', $info['mime']);
+        $this->assertSame(15, $info[0]);
+        $this->assertSame(20, $info[1]);
+    }
+}


### PR DESCRIPTION
Currently, when generating dummy images for testing, `FileFactory::image()` always creates a PNG:

```php
UploadedFile::fake()->image('avatar.png') // Creates PNG file.
UploadedFile::fake()->image('avatar.jpg') // Also creates PNG file.
```

This PR checks the file extension and creates JPEG images when the filename ends with `.jpeg` or `.jpg`.

The tests use `getimagesize()` instead of `$image->getMimeType()`. `getMimeType()` derives the mime type from the filename, while `getimagesize()` examines the actual file.