### PR TITLE
[5.6] Let Exception Handler do the reporting

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -182,9 +182,7 @@ class ConnectionFactory
                 try {
                     return $this->createConnector($config)->connect($config);
                 } catch (PDOException $e) {
-                    if (count($hosts) - 1 === $key && $this->container->bound(ExceptionHandler::class)) {
-                        $this->container->make(ExceptionHandler::class)->report($e);
-                    }
+                    continue;
                 }
             }
 

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -11,7 +11,6 @@ use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SqlServerConnection;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Contracts\Debug\ExceptionHandler;
 
 class ConnectionFactory
 {

--- a/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
+++ b/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Auth\ApiAuthenticationWithEloquentTest;
 
-use Illuminate\Database\QueryException;
-use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Database\QueryException;
 
 class ApiAuthenticationWithEloquentTest extends TestCase
 {
@@ -48,5 +48,4 @@ class ApiAuthenticationWithEloquentTest extends TestCase
 
 class User extends \Illuminate\Foundation\Auth\User
 {
-
 }

--- a/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
+++ b/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
@@ -40,7 +40,7 @@ class ApiAuthenticationWithEloquentTest extends TestCase
 
         $this->expectException(QueryException::class);
 
-        $this->expectExceptionMessage('SQLSTATE[HY000] [2002] Connection refused (SQL: select * from `users` where `api_token` = whatever limit 1)');
+        $this->expectExceptionMessage("SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: YES) (SQL: select * from `users` where `api_token` = whatever limit 1)");
 
         $this->withoutExceptionHandling()->get('/auth', ['Authorization' => 'Bearer whatever']);
     }

--- a/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
+++ b/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Auth\ApiAuthenticationWithEloquentTest;
+
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class ApiAuthenticationWithEloquentTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        // Auth configuration
+        $app['config']->set('auth.defaults.guard', 'api');
+        $app['config']->set('auth.providers.users.model', User::class);
+
+        // Database configuration
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'mysql',
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'username' => 'root',
+            'password' => 'invalid-credentials',
+            'database' => 'forge',
+            'prefix' => '',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function authentication_via_api_with_eloquent_using_wrong_database_credentials_should_not_cause_infinite_loop()
+    {
+        Route::get('/auth', function () {
+            return 'success';
+        })->middleware('auth:api');
+
+        $this->expectException(QueryException::class);
+
+        $this->expectExceptionMessage('SQLSTATE[HY000] [2002] Connection refused (SQL: select * from `users` where `api_token` = whatever limit 1)');
+
+        $this->withoutExceptionHandling()->get('/auth', ['Authorization' => 'Bearer whatever']);
+    }
+}
+
+class User extends \Illuminate\Foundation\Auth\User
+{
+
+}

--- a/tests/Integration/Database/EloquentRelationshipsTest.php
+++ b/tests/Integration/Database/EloquentRelationshipsTest.php
@@ -22,7 +22,6 @@ class EloquentRelationshipsTest extends TestCase
 {
     /**
      * @test
-     * @group f
      */
     public function standard_relationships()
     {
@@ -41,7 +40,6 @@ class EloquentRelationshipsTest extends TestCase
 
     /**
      * @test
-     * @group f
      */
     public function overridden_relationships()
     {


### PR DESCRIPTION
When using the API Guard on `auth.php`, Laravel will try to authenticate the user through the Authorization Header.
The User Provider can be Eloquent, in which case it will require a valid database connection.

The problem happens when the database connection configuration is wrong (username, password, database, etc) and the Auth Provider tries to reach for the database to authenticate the User.
Since the database is wrong, an exception will be thrown. However, the Handler will try to load the `Context` from the Auth Guard as stated here: https://github.com/laravel/framework/blob/5.6/src/Illuminate/Foundation/Exceptions/Handler.php#L151-L153. 

The Auth Guard will try to reach for the Database to load the User, which again will throw an exception, which will try to load the Context, which will go to the Database until PHP Max Allowed Memory gets exhausted.

This pull request changes the ConnectionFactory to just rely on the default Exception Handler instead of trying to force-log an exception itself, thus avoiding an infinite loop.