### PR TITLE
[5.7] Add 'allowed_without' validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -70,7 +70,7 @@ trait ValidatesAttributes
      */
     public function ValidateAllowedWithout($attribute, $value, $parameters)
     {
-        return !($this->validateRequired($attribute, $value) === $this->validateRequired($parameters[0], $this->getValue($parameters[0])));
+        return ! ($this->validateRequired($attribute, $value) === $this->validateRequired($parameters[0], $this->getValue($parameters[0])));
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -61,6 +61,19 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is an active URL.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function ValidateAllowedWithout($attribute, $value, $parameters)
+    {
+        return !($this->validateRequired($attribute, $value) === $this->validateRequired($parameters[0], $this->getValue($parameters[0])));
+    }
+
+    /**
      * "Break" on first validation fail.
      *
      * Always returns true, just lets us put "bail" in rules.

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -602,6 +602,20 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->hasRule('bar', 'Required'));
     }
 
+    public function testValidateAllowedWithout()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['phone' => '911'], ['phone' => 'allowed_without:email']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['phone' => '911', 'email' => 'unnecessary@email.com'], ['phone' => 'allowed_without:email']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['phone' => null, 'email' => null], ['phone' => 'allowed_without:email']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateArray()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Example of 2 common problems that led to this PR:

**Problem 1:**

- There are 2 fields: a file input field called `video` and another one `videourl`. User can either upload a video or give a URL of a publicly accessible video file. 
- Needed: The app only needs one of these, not both.

**Problem 2:**

- There are 2 fields: `phone` & `email`. User can either use his phone number or his email id. 
- Needed: Again, the app only needs one of these, not both.

---

- The existing `required_with` rule allows both fields to be passed through validation and `required_without` vice versa.

---

- Example implementation of the `allowed_without` validation rule in a form request class:

```php
public function rules()
{
    return [
        'video' => [
            'allowed_without:videourl',
            'file',
            'mimetypes:video/avi,video/mpeg,video/quicktime,video/mp4'
        ],
        'videourl' => 'allowed_without:video',
    ];
}
```

- I might have missed the existing feature to solve this types of exact problem. Happy to learn and correct myself if that is the case 🙂 
- If there are workarounds, native support would be more helpful since this is a really common scenario to validate :) 
