### PR TITLE
[5.6] remove unnecessary foreach from is() method

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -184,13 +184,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function is(...$patterns)
     {
-        foreach ($patterns as $pattern) {
-            if (Str::is($pattern, $this->decodedPath())) {
-                return true;
-            }
-        }
-
-        return false;
+        return Str::is($patterns, $this->decodedPath());
     }
 
     /**


### PR DESCRIPTION
Str::is() method is already contains foreach, request is() method no need to foreach again.