### PR TITLE
[5.7] Dont try to display message if Output is not set

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -587,6 +587,8 @@ class Migrator
      */
     protected function note($message)
     {
-        $this->output->writeln($message);
+        if ($this->output) {
+            $this->output->writeln($message);
+        }
     }
 }

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -27,7 +27,7 @@ class MigratorTest extends TestCase
 
         $migrator->getRepository()->createRepository();
 
-        $migrator->run([__DIR__ . '/fixtures']);
+        $migrator->run([__DIR__.'/fixtures']);
 
         $this->assertTrue($this->tableExists('members'));
     }
@@ -42,5 +42,4 @@ class MigratorTest extends TestCase
 
         return true;
     }
-
 }

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Migration;
+
+use Orchestra\Testbench\TestCase;
+
+class MigratorTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function dont_display_output_when_output_object_is_not_available()
+    {
+        $migrator = $this->app->make('migrator');
+
+        $migrator->getRepository()->createRepository();
+
+        $migrator->run([__DIR__ . '/fixtures']);
+
+        $this->assertTrue($this->tableExists('members'));
+    }
+
+    private function tableExists($table): bool
+    {
+        try {
+            $this->app->make('db')->select("SELECT COUNT(*) FROM $table");
+        } catch (\PDOException $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/tests/Integration/Migration/fixtures/2014_10_12_000000_create_members_table.php
+++ b/tests/Integration/Migration/fixtures/2014_10_12_000000_create_members_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateMembersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('members', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('members');
+    }
+}

--- a/tests/Integration/Migration/fixtures/2014_10_12_000000_create_members_table.php
+++ b/tests/Integration/Migration/fixtures/2014_10_12_000000_create_members_table.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Illuminate\Tests\Integration\Migration\fixtures;
+
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;


### PR DESCRIPTION
After looking at https://github.com/laravel/framework/pull/24811 I predicted a nasty bug coming my way. #24811 assumes everybody is using the Migrator through the console. However, that's not always the case.
I work with Multi Database Multi Tenant application and we make use of the Migrator outside of Artisan because the client can self-register and that will give them their own database automatically.

This pull request add an integration test that proves the broken state of 5.7 and fixes it by simply doing the output only when it has been explicitly set. Everything else continues to work as expected.

Without this change, the migrator simply does not work without setting an Output, which is a completely useless component when not in the console.

```
1) Illuminate\Tests\Integration\Migration\MigratorTest::dont_display_output_when_output_object_is_not_available
Error: Call to a member function writeln() on null
```