### PR TITLE
[5.7] Don't modify default connection when running Migrations

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -500,7 +500,7 @@ class Migrator
     public function setConnection($name)
     {
         if (! is_null($name)) {
-            $this->resolver->setDefaultConnection($name);
+            $this->connection = $this->resolveConnection($name);
         }
 
         $this->repository->setSource($name);


### PR DESCRIPTION
A pain-point for me with the Migrator process is the fact that I always have to store the default connection, run the migrations and then restore it back, like the following: 

```
        // We need to store the current default connection name in order to
        // restore it back later.
        $defaultConnectionName = config('database.default');

        // When setting a connection in the migrator, Laravel will override the
        // application's default connection with the one provided here.
        $migrator->setConnection($connectionName);

        if (! $migrator->repositoryExists()) {
            $migrator->getRepository()->createRepository();
        }

        $migrationsExecuted = $migrator->run([$migrationPath]);

        // After migrating, we can restore the default connection to it's original
        // value to prevent undesired behavior from components that rely
        // on the default database connection.
        $migrator->setConnection($defaultConnectionName);

        return $migrationsExecuted;
```

If I don't do this, any code that relies on the default connection will fail because the Migrator switches it.

This pull request changes the strategy to resolve the connection instead of override the default connection, allowing us to keep relying on default connection even if we're running migrations on the fly.