### PR TITLE
[5.6] Database Testing - Add option to seed the database to RefreshDatabase trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -52,11 +52,11 @@ trait RefreshDatabase
         if (! RefreshDatabaseState::$migrated) {
             $options = [];
 
-            if( $this->shouldDropViews()       ) {
+            if ($this->shouldDropViews()) {
                 $options['--drop-views'] = true;
             }
 
-            if( $this->shouldSeedWithRefresh() ) {
+            if ($this->shouldSeedWithRefresh()) {
                 $options['--seed'] = true;
             }
 

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -50,9 +50,17 @@ trait RefreshDatabase
     protected function refreshTestDatabase()
     {
         if (! RefreshDatabaseState::$migrated) {
-            $this->artisan('migrate:fresh', $this->shouldDropViews() ? [
-                '--drop-views' => true,
-            ] : []);
+            $options = [];
+
+            if( $this->shouldDropViews()       ) {
+                $options['--drop-views'] = true;
+            }
+
+            if( $this->shouldSeedWithRefresh() ) {
+                $options['--seed'] = true;
+            }
+
+            $this->artisan('migrate:fresh', $options);
 
             $this->app[Kernel::class]->setArtisan(null);
 
@@ -113,5 +121,16 @@ trait RefreshDatabase
     {
         return property_exists($this, 'dropViews')
                             ? $this->dropViews : false;
+    }
+
+    /**
+     * Determine if the database should be seeded when refreshing the database.
+     *
+     * @return bool
+     */
+    protected function shouldSeedWithRefresh()
+    {
+        return property_exists($this, 'seedWithRefresh')
+                            ? $this->seedWithRefresh : false;
     }
 }


### PR DESCRIPTION
This PR adds the ability to optionally seed that database as part of the database refresh in unit testing.

There have been two previous attempts by other authors at this that were not accepted:

* laravel/framework#24278 (implementation via new trait)
* laravel/framework#22471 (implementation via new trait and state)

I suspect both of these attempts over-reached / were over-complicated.

My implementation piggy-backs on the exact same functionality as the drop views option in the existing RefreshDatabase trait.

To have your database seeded in a unit test, just use the trait and define a property:

```php
<?php

namespace Tests\Unit;

use Tests\TestCase;
use Illuminate\Foundation\Testing\RefreshDatabase;

class ExampleTest extends TestCase
{
    use RefreshDatabase;

    private $seedWithRefresh = true;
```

The slightly long / over-descriptive property name `$seedWithRefresh` was chosen to avoid clashes with something a developer may reasonably use.

Given this is the third attempt at this and the fact that this is a fairly frequently asked question around Laravel database testing, I hope this simple PR can be accepted.

It has been tested and confirmed as working on my own code.

The option to chose what to seed the database with in production vs development vs test environments can be made in `database/seeds/DatabaseSeeder.php` as per usual.

I am happy to open a parallel pull request against the document if desired? There is currently no documentation on the drop views option (although that is probably a rarely used option).

This PR is submitted under the terms of the MIT license and in full acceptance of it. Suggested documentation diff:

```
diff database-testing.md database-testing-mine.md
75a76,87
> When refreshing your database, you may also want to seed it. You can do this when using the `RefreshDatabase` trait by adding the following property and setting it to true in your test class:
>
>     private $seedWithRefresh = true
>
> You can control what to seed the database with by checking the environment in `database/seeds/DatabaseSeeder.php`:
>
>     if( app()->environment('testing') ) {
>         // load testing seeders
>     } else {
>         // load production / other seeders
>     }
>
```
