### PR TITLE
Added @mix and @asset blade directives

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -19,6 +19,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesJson,
         Concerns\CompilesLayouts,
         Concerns\CompilesLoops,
+        Concerns\CompilesMix,
         Concerns\CompilesRawPhp,
         Concerns\CompilesStacks,
         Concerns\CompilesTranslations;

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -7,7 +7,8 @@ use Illuminate\Support\Str;
 
 class BladeCompiler extends Compiler implements CompilerInterface
 {
-    use Concerns\CompilesAuthorizations,
+    use Concerns\CompilesAsset,
+        Concerns\CompilesAuthorizations,
         Concerns\CompilesComments,
         Concerns\CompilesComponents,
         Concerns\CompilesConditionals,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesAsset.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesAsset.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesAsset
+{
+    /**
+     * Generate an asset path for the application.
+     *
+     * @param  string  $path
+     * @param  bool    $secure
+     * @return string
+     */
+    protected function compileAsset($arguments)
+    {
+        return "<?php echo asset$arguments; ?>";
+    }
+}

--- a/src/Illuminate/View/Compilers/Concerns/CompilesAsset.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesAsset.php
@@ -7,8 +7,7 @@ trait CompilesAsset
     /**
      * Generate an asset path for the application.
      *
-     * @param  string  $path
-     * @param  bool    $secure
+     * @param  string  $arguments
      * @return string
      */
     protected function compileAsset($arguments)

--- a/src/Illuminate/View/Compilers/Concerns/CompilesMix.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesMix.php
@@ -7,11 +7,8 @@ trait CompilesMix
     /**
      * Get the path to a versioned Mix file.
      *
-     * @param  string  $path
-     * @param  string  $manifestDirectory
-     * @return \Illuminate\Support\HtmlString|string
-     *
-     * @throws \Exception
+     * @param  string  $arguments
+     * @return string
      */
     protected function compileMix($arguments)
     {

--- a/src/Illuminate/View/Compilers/Concerns/CompilesMix.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesMix.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesMix
+{
+    /**
+     * Get the path to a versioned Mix file.
+     *
+     * @param  string  $path
+     * @param  string  $manifestDirectory
+     * @return \Illuminate\Support\HtmlString|string
+     *
+     * @throws \Exception
+     */
+    protected function compileMix($arguments)
+    {
+        return "<?php echo mix$arguments; ?>";
+    }
+}

--- a/tests/View/Blade/BladeAssetTest.php
+++ b/tests/View/Blade/BladeAssetTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeAssetTest extends AbstractBladeTestCase
+{
+    public function testAssetsAreCompiled()
+    {
+        $this->assertEquals('<?php echo asset(""); ?>', $this->compiler->compileString('@asset("")'));
+    }
+}

--- a/tests/View/Blade/BladeMixTest.php
+++ b/tests/View/Blade/BladeMixTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeMixTest extends AbstractBladeTestCase
+{
+    public function testMixesAreCompiled()
+    {
+        $this->assertEquals('<?php echo mix("js/app.js"); ?>', $this->compiler->compileString('@mix("js/app.js")'));
+    }
+}


### PR DESCRIPTION
This is a simple PR that provides access to a `@asset()` and `@mix()` blade directive to allow a more short hand access to the helpers, recently many directives such as `@json` `@dump` etc this continues that.

```html
<link href="{{ mix('css/app.css') }}" rel="stylesheet">
<!-- vs -->
<link href="@mix('css/app.css')" rel="stylesheet">

<img src="{{ asset('img/logo.svg') }}" alt="Laravel logo">
<!-- vs -->
<img src="@asset('img/logo.svg')" alt="Laravel logo">
```