### PR TITLE
[5.6] Fixing docblock

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -495,7 +495,7 @@ trait HasRelationships
     }
 
     /**
-     * Instantiate a new HasManyThrough relationship.
+     * Instantiate a new MorphToMany relationship.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  \Illuminate\Database\Eloquent\Model  $parent


### PR DESCRIPTION
Just a cleanup - there was an incorrect return type in the docblock header part.
