### PR TITLE
[5.6] Dispatch event when translation fails

### DIFF
--- a/src/Illuminate/Translation/Events/TranslationNotFound.php
+++ b/src/Illuminate/Translation/Events/TranslationNotFound.php
@@ -5,21 +5,21 @@ namespace Illuminate\Translation\Events;
 class TranslationNotFound
 {
     /**
-     * The key of the missing translation
+     * The key of the missing translation.
      *
      * @var string
      */
     public $key;
 
     /**
-     * The locale in which the translation was searched
+     * The locale in which the translation was searched.
      *
      * @var string
      */
     public $locale;
 
     /**
-     * The array of replacements passed to the translator
+     * The array of replacements passed to the translator.
      *
      * @var array
      */

--- a/src/Illuminate/Translation/Events/TranslationNotFound.php
+++ b/src/Illuminate/Translation/Events/TranslationNotFound.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Translation\Events;
+
+class TranslationNotFound
+{
+    /**
+     * The key of the missing translation
+     *
+     * @var string
+     */
+    public $key;
+
+    /**
+     * The locale in which the translation was searched
+     *
+     * @var string
+     */
+    public $locale;
+
+    /**
+     * The array of replacements passed to the translator
+     *
+     * @var array
+     */
+    public $replacements;
+
+    /**
+     * Creates the event.
+     *
+     * @param string $key
+     * @param string $locale
+     * @param array $replacements
+     */
+    public function __construct(string $key, string $locale, array $replacements = [])
+    {
+        $this->key = $key;
+        $this->locale = $locale;
+        $this->replacements = $replacements;
+    }
+}

--- a/src/Illuminate/Translation/TranslationServiceProvider.php
+++ b/src/Illuminate/Translation/TranslationServiceProvider.php
@@ -30,7 +30,9 @@ class TranslationServiceProvider extends ServiceProvider
             // configuration so we can easily get both of these values from there.
             $locale = $app['config']['app.locale'];
 
-            $trans = new Translator($loader, $locale);
+            $events = $app['events'];
+
+            $trans = new Translator($loader, $locale, $events);
 
             $trans->setFallback($app['config']['app.fallback_locale']);
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -3,15 +3,15 @@
 namespace Illuminate\Translation;
 
 use Countable;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Support\NamespacedItemResolver;
-use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 use Illuminate\Translation\Events\TranslationNotFound;
+use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 
 class Translator extends NamespacedItemResolver implements TranslatorContract
 {
@@ -25,7 +25,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     protected $loader;
 
     /**
-     * The event dispatcher
+     * The event dispatcher.
      *
      * @var \Illuminate\Events\Dispatcher
      */

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Translation;
 
-use Illuminate\Events\Dispatcher;
-use Illuminate\Translation\Events\TranslationNotFound;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Translation\Events\TranslationNotFound;
 
 class TranslationTranslatorTest extends TestCase
 {


### PR DESCRIPTION
This PR adds an event, dispatched every time the Translator fail to find a translation.

Its definitely a needed feature, it has inspired stevegrunwell/lost-in-translation and other packages like it.