### PR TITLE
[5.6] revert #24872

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -184,7 +184,13 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function is(...$patterns)
     {
-        return Str::is($patterns, $this->decodedPath());
+        foreach ($patterns as $pattern) {
+            if (Str::is($pattern, $this->decodedPath())) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
#24872 causes a BC break when the user passes an array to the function.

```php
$request->is(['pathA', 'pathB']);
```

This code worked on previous versions, but not after the change due to the fact the method uses the splat operator which wraps the input array in an additional array.

While I agree it should not be used this way in the future, and should be changed in 5.7, I believe it is a BC break for 5.6.  If this is accepted, I will make the PR to 5.7.