### PR TITLE
[5.6] Allow closure to determine if event should be faked

### DIFF
--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -74,6 +74,27 @@ class SupportTestingEventFakeTest extends TestCase
             $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\EventStub] event was dispatched.'));
         }
     }
+
+    public function testAssertDispatchedWithIgnore()
+    {
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldReceive('dispatch')->twice();
+
+        $fake = new EventFake($dispatcher, [
+            'Foo',
+            function ($event, $payload) {
+                return $event === 'Bar' && $payload['id'] === 1;
+            }
+        ]);
+
+        $fake->dispatch('Foo');
+        $fake->dispatch('Bar', ['id' => 1]);
+        $fake->dispatch('Baz');
+
+        $fake->assertNotDispatched('Foo');
+        $fake->assertNotDispatched('Bar');
+        $fake->assertDispatched('Baz');
+    }
 }
 
 class EventStub

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -17,7 +17,7 @@ class SupportTestingEventFakeTest extends TestCase
         $this->fake = new EventFake(m::mock(Dispatcher::class));
     }
 
-    public function testAssertDispacthed()
+    public function testAssertDispatched()
     {
         try {
             $this->fake->assertDispatched(EventStub::class);

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -84,7 +84,7 @@ class SupportTestingEventFakeTest extends TestCase
             'Foo',
             function ($event, $payload) {
                 return $event === 'Bar' && $payload['id'] === 1;
-            }
+            },
         ]);
 
         $fake->dispatch('Foo');


### PR DESCRIPTION
This PR adds a way to dynamically determine if an event should be faked or not. Currently we can do this only based on an event name. By also allowing closures we can with one simple closure include or exclude multiple events at once.

```php
// Ignore all 'eloquent.*' events so observers will still work ...
\Event::fake(function($event) {
    return !starts_with($event, 'eloquent.');
})
```

It's even possible to make them more specific and inspect the payload to determine if we should fake the event or dispatch it as normal:
```php
\Event::fake(function($event, $payload) {
    return $event === 'Foo' && $payload->user_id != 1;
})
```

It's still possible to use only event names or a combination of closures and event names:
```php
\Event::fake([
    function($event, $payload) {
        return $event === 'Foo' && $payload->user_id != 1;
    },
    function($event) {
        return !starts_with($event, 'eloquent.');
    },
    EventOne::class,
    EventTwo::class,
])
```