### PR TITLE
[5.6] Fixes @param type on helper response()

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -779,7 +779,7 @@ if (! function_exists('response')) {
     /**
      * Return a new response from the application.
      *
-     * @param  string|array  $content
+     * @param  string|array|null  $content
      * @param  int     $status
      * @param  array   $headers
      * @return \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Routing\ResponseFactory


### PR DESCRIPTION
**Motivation**: I am currently developing [Larastan](https://github.com/nunomaduro/larastan). When the user uses the following code `response(null, 200)` and the first parameter is `null` the tool triggers this error: `Parameter #1 $content of function response expects array|string, null given.`

This PR proposes the modification of the `@param  string|array  $content`  to `@param  string|array|null  $content`.

I can always ignore the warning on the tool itself if this PR doesn't get merged.