### PR TITLE
[5.6] Locate vendor directory instead hard-coding it in PackageManifest.php

### DIFF
--- a/tests/Foundation/FoundationPackageManifestTest.php
+++ b/tests/Foundation/FoundationPackageManifestTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\PackageManifest;
@@ -11,9 +12,24 @@ class FoundationPackageManifestTest extends TestCase
     public function testAssetLoading()
     {
         @unlink(__DIR__.'/fixtures/packages.php');
-        $manifest = new PackageManifest(new Filesystem, __DIR__.'/fixtures', __DIR__.'/fixtures/packages.php');
+        $manifest = new PackageManifest(
+            new Filesystem,
+            __DIR__.'/fixtures',
+            __DIR__.'/fixtures/packages.php',
+            __DIR__.'/fixtures/vendor'
+        );
         $this->assertEquals(['foo', 'bar', 'baz'], $manifest->providers());
         $this->assertEquals(['Foo' => 'Foo\\Facade'], $manifest->aliases());
         unlink(__DIR__.'/fixtures/packages.php');
+    }
+
+    public function testVendorPath()
+    {
+        $manifest = new PackageManifest(
+            new Filesystem,
+            __DIR__.'/fixtures',
+            __DIR__.'/fixtures/packages.php'
+        );
+        $this->assertTrue(Str::endsWith($manifest->vendorPath, DIRECTORY_SEPARATOR.'vendor'));
     }
 }


### PR DESCRIPTION
This PR includes a change to locate the vendor directory instead of hardcoding it.
Though I'm not sure if it's the cleanest way to do it...

This is necessary in case the vendor directory isn't inside the laravel app directory.
In my case, I have a custom directory structure where the composer file is outside the laravel app directory.

It looks something like this:
```
- /laravel-app
--- /app
--- /bootstrap
--- artisan
--- ...
- /other-project
- /vendor
- composer.json
- composer.lock
```

When I run `package:discover` in /laravel-app it doesn't work, because it's looking for `/laravel-app/vendor` and can't find it.