### PR TITLE
[5.6] Fix typo in the observer stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/observer.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.stub
@@ -7,7 +7,7 @@ use NamespacedDummyModel;
 class DummyClass
 {
     /**
-     * Handle to the DocDummyModel "created" event.
+     * Handle the DocDummyModel "created" event.
      *
      * @param  \NamespacedDummyModel  $dummyModel
      * @return void


### PR DESCRIPTION
Noticed that the observer stub has an unnecessary `to` in a docblock. 

The other docblocks are unaffected.