### PR TITLE
Add the onEachSide option to Builder's pagination

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -697,11 +697,12 @@ class Builder
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  int $onEachSide
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      *
      * @throws \InvalidArgumentException
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $onEachSide = 3)
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
@@ -714,6 +715,7 @@ class Builder
         return $this->paginator($results, $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
+            'onEachSide' => $onEachSide
         ]);
     }
 

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -35,7 +35,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      * @param  int  $total
      * @param  int  $perPage
      * @param  int|null  $currentPage
-     * @param  array  $options (path, query, fragment, pageName)
+     * @param  array  $options (path, query, fragment, pageName, onEachSide)
      * @return void
      */
     public function __construct($items, $total, $perPage, $currentPage = null, array $options = [])
@@ -100,7 +100,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      */
     protected function elements()
     {
-        $window = UrlWindow::make($this);
+        $window = UrlWindow::make($this, $this->onEachSide ?: 3);
 
         return array_filter([
             $window['first'],


### PR DESCRIPTION
Add the onEachSide option to Builder's pagination, so you can customize LenghtAwarePaginator paginator's items count.
E.g.: MyItem::paginate(10, ['*'], 'page', null, 1);
                                                ^
It's not really handy, but it's clean and not many people will complain.
The main benefit is that having the default (3) items per page in the paginator may end with too many links in the paginator; that could be a problem in some layouts.

Keeping this argument sequence does not break any existing feature, and I also used 3 as the default onEarchSide parameter like before.

This is a feature request for the maintainers, if they know how to do it better, they're welcome.

