### PR TITLE
Add the onEachSide option to Builder's pagination

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -731,11 +731,12 @@ class Builder
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  int  $onEachSide
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      *
      * @throws \InvalidArgumentException
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $onEachSide = 3)
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
@@ -748,6 +749,7 @@ class Builder
         return $this->paginator($results, $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
+            'onEachSide' => $onEachSide,
         ]);
     }
 

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -100,7 +100,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      */
     protected function elements()
     {
-        $window = UrlWindow::make($this);
+        $window = UrlWindow::make($this, $this->onEachSide ?: 3);
 
         return array_filter([
             $window['first'],


### PR DESCRIPTION
Add the onEachSide option to Builder's pagination, so you can customize LenghtAwarePaginator paginator's items count.

E.g.: MyItem::paginate(10, ['*'], 'page', null, 1);
                                                                          ^
It's not really handy, but it's clean.
The main benefit is that having the default (3) items per page in the paginator may end with too many links in the paginator; that could be a problem in some layouts.

Keeping this argument sequence does not break any existing feature in the framework, and I also used 3 as the default onEarchSide parameter like before.

However this would be a breaking change since I'm modifying an existing method signature.

This is a feature request for the maintainers, if they know how to do it better, they're welcome.