### PR TITLE
[5.6] Make auth()->user() return mixed

### DIFF
--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -21,7 +21,7 @@ interface Guard
     /**
      * Get the currently authenticated user.
      *
-     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null|mixed
      */
     public function user();
 


### PR DESCRIPTION
When using `auth()->user()->update()` or any eloquent builder functions, editors like PHPStorm are unable to resolve the methods correctly.

This will bring `auth()->user()` in line with `request()->user()`
