### PR TITLE
[5.6] Revert breaking change introduced by #24852

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -549,13 +549,7 @@ class TestResponse
      */
     protected function jsonSearchStrings($key, $value)
     {
-        $needle = substr(json_encode([$key => $value]), 1, -1);
-
-        return [
-            $needle.']',
-            $needle.'}',
-            $needle.',',
-        ];
+        return substr(json_encode([$key => $value]), 1, -1);
     }
 
     /**

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -167,6 +167,8 @@ class FoundationTestResponseTest extends TestCase
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
+        $response->assertJsonFragment(['barfoo']);
+
         $response->assertJsonFragment(['foo' => 'bar']);
 
         $response->assertJsonFragment(['foobar_foo' => 'foo']);

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -174,16 +174,6 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonFragment(['foobar' => ['foobar_foo' => 'foo', 'foobar_bar' => 'bar']]);
 
         $response->assertJsonFragment(['foo' => 'bar 0', 'bar' => ['foo' => 'bar 0', 'bar' => 'foo 0']]);
-
-        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub()));
-
-        $response->assertJsonFragment(['id' => 10]);
-
-        try {
-            $response->assertJsonFragment(['id' => 1]);
-            $this->fail('Asserting id => 1, existsing in JsonSerializableSingleResourceWithIntegersStub should fail');
-        } catch (\PHPUnit\Framework\ExpectationFailedException $e) {
-        }
     }
 
     public function testAssertJsonStructure()
@@ -225,13 +215,6 @@ class FoundationTestResponseTest extends TestCase
         // Without structure
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
         $response->assertJsonCount(4);
-    }
-
-    public function testAssertJsonMissing()
-    {
-        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
-
-        $response->assertJsonMissing(['id' => 2]);
     }
 
     public function testAssertJsonMissingValidationErrors()


### PR DESCRIPTION
This PR reverts the breaking change introduced by #24852.

Today after updating to Laravel 5.6.28, a bunch of tests started failing in our application because of the linked Pull Request. Our use case is the following: 

```
        $this->get('/driver-value?date=[]')
            ->assertStatus(422)
            ->assertSeeText('The given data was invalid')
            ->assertJsonFragment(['date.from'])
            ->assertJsonFragment(['date.to'])
            ->assertJsonFragment(['date.type']);
```

This is particularly good because we don't really care about the error message that was provided to the user, but rather if the field validation is present within the response.

This worked fine, but #24852 broke it.

I also added a test to make sure this does not break again.

I can try to work on a PR to fix the original issue sometime this week.

Unfortunately, I could not just revert commit from GitHub because the button is not available.