### PR TITLE
Give die a status code when the env file is not valid

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -27,9 +27,11 @@ class LoadEnvironmentVariables
         try {
             (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
         } catch (InvalidPathException $e) {
-            //
+            echo 'The configured environment file path is invalid: '.$e->getMessage();
+            die(1);
         } catch (InvalidFileException $e) {
-            die('The environment file is invalid: '.$e->getMessage());
+            echo 'The environment file is invalid: '.$e->getMessage();
+            die(1);
         }
     }
 


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
The purpose of this PR is to address the rather rare case when the `.env` file is invalid. This could pop up when one of the lines has a key but no value, and it's followed by a comment. An example line might look like:

```
CUSTOM_VALUE=                # This is a value to be used for tests
```
Having a value like this causes the `die` method to be called and thus kills the app, but since previously there was a string in the place of a status code, it would exit with a `0` status code despite the process actually being killed.

For some CI platforms any application that closes with a `0` status code is considered to be successful. Which means our tests pass even though our tests never actually run.

This PR aims to address this false positive by forcing the `die` method to have a status code that isn't text, thus making the program exit with a non-zero status. 

Personally I feel like there should also be a similar `echo` and `die` in the `InvalidPathException` that is just discarded, but that may not be needed since it was previously ignored.

