### PR TITLE
[MigrationCreatorPatch-Issue-24907] Reference a variable of the insta…

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -55,6 +55,8 @@ class MigrationCreator
     {
         $this->ensureMigrationDoesntAlreadyExist($name);
 
+        // We are assigning the variable to the instance for backwards compatibility with prior versions
+        // so that it can be used in the firePostCreateHooks
         $this->table = $table;
 
         // First we will get the stub file for the migration, which serves as a type
@@ -70,7 +72,7 @@ class MigrationCreator
         // Next, we will fire any hooks that are supposed to fire after a migration is
         // created. Once that is done we'll be ready to return the full path to the
         // migration file so it can be used however it's needed by the developer.
-        $this->firePostCreateHooks($table);
+        $this->firePostCreateHooks();
 
         return $path;
     }

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -24,6 +24,13 @@ class MigrationCreator
     protected $postCreate = [];
 
     /**
+     * The table.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
      * Create a new migration creator instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
@@ -47,6 +54,8 @@ class MigrationCreator
     public function create($name, $path, $table = null, $create = false)
     {
         $this->ensureMigrationDoesntAlreadyExist($name);
+
+        $this->table = $table;
 
         // First we will get the stub file for the migration, which serves as a type
         // of template for the migration. Once we have those we will populate the
@@ -150,13 +159,12 @@ class MigrationCreator
     /**
      * Fire the registered post create hooks.
      *
-     * @param  string  $table
      * @return void
      */
-    protected function firePostCreateHooks($table)
+    protected function firePostCreateHooks()
     {
         foreach ($this->postCreate as $callback) {
-            call_user_func($callback, $table);
+            call_user_func($callback, $this->table);
         }
     }
 


### PR DESCRIPTION
The purpose of this PR is to make a minor enhancement backwards compatible.

The firePostCreateHooks() is protected and in prior version accepts no arguments. For any applications or libraries using the code, we'll see those fail.

To fix the problem, I'm suggesting we assign the $table name to a property of the instance so that later the class can use that in the `firePostCreateHooks` method.

I was going to write a test, but saw this method which verifies existing functionality is unaffected: `testBasicCreateMethodCallsPostCreateHooks`

Issue Reference: https://github.com/laravel/framework/issues/24907