### PR TITLE
[5.7] Remove \Illuminate\Support\Carbon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "erusev/parsedown": "^1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "^1.12",
-        "nesbot/carbon": "^1.26.3",
+        "nesbot/carbon": "^1.32",
         "psr/container": "^1.0",
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^3.7",

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Auth\Notifications;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Notifications\Notification;

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Auth\Passwords;
 
 use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -19,7 +19,7 @@
         "illuminate/http": "5.7.*",
         "illuminate/queue": "5.7.*",
         "illuminate/support": "5.7.*",
-        "nesbot/carbon": "^1.26.3"
+        "nesbot/carbon": "^1.32"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -18,7 +18,8 @@
         "illuminate/contracts": "5.7.*",
         "illuminate/http": "5.7.*",
         "illuminate/queue": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/support": "5.7.*",
+        "nesbot/carbon": "^1.26.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -6,7 +6,7 @@ use Closure;
 use ArrayAccess;
 use DateTimeInterface;
 use BadMethodCallException;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Cache\Events\KeyWritten;

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": "^7.1.3",
         "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/support": "5.7.*",
+        "nesbot/carbon": "^1.26.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.1.3",
         "illuminate/contracts": "5.7.*",
         "illuminate/support": "5.7.*",
-        "nesbot/carbon": "^1.26.3"
+        "nesbot/carbon": "^1.32"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -5,7 +5,7 @@ namespace Illuminate\Console\Scheduling;
 use Closure;
 use Cron\CronExpression;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Contracts\Mail\Mailer;
 use Symfony\Component\Process\Process;
@@ -687,7 +687,7 @@ class Event
      * @param  \DateTime|string  $currentTime
      * @param  int  $nth
      * @param  bool  $allowCurrentDate
-     * @return \Illuminate\Support\Carbon
+     * @return \Carbon\Carbon
      */
     public function nextRunDate($currentTime = 'now', $nth = 0, $allowCurrentDate = false)
     {

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Console\Scheduling;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 
 trait ManagesFrequencies
 {

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Console\Scheduling;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Console\Command;
 
 class ScheduleRunCommand extends Command
@@ -31,7 +31,7 @@ class ScheduleRunCommand extends Command
     /**
      * The 24 hour timestamp this scheduler command started running.
      *
-     * @var \Illuminate\Support\Carbon;
+     * @var \Carbon\Carbon;
      */
     protected $startedAt;
 

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -17,6 +17,7 @@
         "php": "^7.1.3",
         "illuminate/contracts": "5.7.*",
         "illuminate/support": "5.7.*",
+        "nesbot/carbon": "^1.26.3",
         "symfony/console": "^4.1"
     },
     "autoload": {

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.1.3",
         "illuminate/contracts": "5.7.*",
         "illuminate/support": "5.7.*",
-        "nesbot/carbon": "^1.26.3",
+        "nesbot/carbon": "^1.32",
         "symfony/console": "^4.1"
     },
     "autoload": {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -6,7 +6,7 @@ use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
@@ -696,7 +696,7 @@ trait HasAttributes
      * Return a timestamp as DateTime object with time set to 00:00:00.
      *
      * @param  mixed  $value
-     * @return \Illuminate\Support\Carbon
+     * @return \Carbon\Carbon
      */
     protected function asDate($value)
     {
@@ -707,7 +707,7 @@ trait HasAttributes
      * Return a timestamp as DateTime object.
      *
      * @param  mixed  $value
-     * @return \Illuminate\Support\Carbon
+     * @return \Carbon\Carbon
      */
     protected function asDateTime($value)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 
 trait HasTimestamps
 {
@@ -77,7 +77,7 @@ trait HasTimestamps
     /**
      * Get a fresh timestamp for the model.
      *
-     * @return \Illuminate\Support\Carbon
+     * @return \Carbon\Carbon
      */
     public function freshTimestamp()
     {

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -19,7 +19,7 @@
         "illuminate/container": "5.7.*",
         "illuminate/contracts": "5.7.*",
         "illuminate/support": "5.7.*",
-        "nesbot/carbon": "^1.26.3"
+        "nesbot/carbon": "^1.32"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -18,7 +18,8 @@
         "php": "^7.1.3",
         "illuminate/container": "5.7.*",
         "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/support": "5.7.*",
+        "nesbot/carbon": "^1.26.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -6,7 +6,7 @@ use RuntimeException;
 use Illuminate\Http\File;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use League\Flysystem\AdapterInterface;

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.1.3",
         "illuminate/contracts": "5.7.*",
         "illuminate/support": "5.7.*",
-        "nesbot/carbon": "^1.26.3",
+        "nesbot/carbon": "^1.32",
         "symfony/finder": "^4.1"
     },
     "autoload": {

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -17,6 +17,7 @@
         "php": "^7.1.3",
         "illuminate/contracts": "5.7.*",
         "illuminate/support": "5.7.*",
+        "nesbot/carbon": "^1.26.3",
         "symfony/finder": "^4.1"
     },
     "autoload": {

--- a/src/Illuminate/Foundation/Http/Exceptions/MaintenanceModeException.php
+++ b/src/Illuminate/Foundation/Http/Exceptions/MaintenanceModeException.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Foundation\Http\Exceptions;
 
 use Exception;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 class MaintenanceModeException extends ServiceUnavailableHttpException
@@ -11,7 +11,7 @@ class MaintenanceModeException extends ServiceUnavailableHttpException
     /**
      * When the application was put in maintenance mode.
      *
-     * @var \Illuminate\Support\Carbon
+     * @var \Carbon\Carbon
      */
     public $wentDownAt;
 
@@ -25,7 +25,7 @@ class MaintenanceModeException extends ServiceUnavailableHttpException
     /**
      * When the application should next be available.
      *
-     * @var \Illuminate\Support\Carbon
+     * @var \Carbon\Carbon
      */
     public $willBeAvailableAt;
 

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Foundation\Testing;
 
 use Mockery;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Console\Application as Artisan;

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -5,7 +5,7 @@ namespace Illuminate\Foundation\Testing;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Support\HtmlString;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher;
@@ -617,7 +617,7 @@ if (! function_exists('now')) {
      * Create a new Carbon instance for the current time.
      *
      * @param  \DateTimeZone|string|null $tz
-     * @return \Illuminate\Support\Carbon
+     * @return \Carbon\Carbon
      */
     function now($tz = null)
     {
@@ -880,7 +880,7 @@ if (! function_exists('today')) {
      * Create a new Carbon instance for the current date.
      *
      * @param  \DateTimeZone|string|null $tz
-     * @return \Illuminate\Support\Carbon
+     * @return \Carbon\Carbon
      */
     function today($tz = null)
     {

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Queue\Console;
 
 use Illuminate\Queue\Worker;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\WorkerOptions;

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Queue;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Database\Connection;
 use Illuminate\Queue\Jobs\DatabaseJob;
 use Illuminate\Queue\Jobs\DatabaseJobRecord;

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Queue\Failed;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Database\ConnectionResolverInterface;
 
 class DatabaseFailedJobProvider implements FailedJobProviderInterface

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -4,7 +4,7 @@ namespace Illuminate\Queue;
 
 use Exception;
 use Throwable;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\DetectsLostConnections;
 use Illuminate\Contracts\Debug\ExceptionHandler;

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -21,6 +21,7 @@
         "illuminate/database": "5.7.*",
         "illuminate/filesystem": "5.7.*",
         "illuminate/support": "5.7.*",
+        "nesbot/carbon": "^1.26.3",
         "symfony/debug": "^4.1",
         "symfony/process": "^4.1"
     },

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -21,7 +21,7 @@
         "illuminate/database": "5.7.*",
         "illuminate/filesystem": "5.7.*",
         "illuminate/support": "5.7.*",
-        "nesbot/carbon": "^1.26.3",
+        "nesbot/carbon": "^1.32",
         "symfony/debug": "^4.1",
         "symfony/process": "^4.1"
     },

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use InvalidArgumentException;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Contracts\Routing\UrlRoutable;

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -21,7 +21,7 @@
         "illuminate/pipeline": "5.7.*",
         "illuminate/session": "5.7.*",
         "illuminate/support": "5.7.*",
-        "nesbot/carbon": "^1.26.3",
+        "nesbot/carbon": "^1.32",
         "symfony/debug": "^4.1",
         "symfony/http-foundation": "^4.1",
         "symfony/http-kernel": "^4.1",

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -21,6 +21,7 @@
         "illuminate/pipeline": "5.7.*",
         "illuminate/session": "5.7.*",
         "illuminate/support": "5.7.*",
+        "nesbot/carbon": "^1.26.3",
         "symfony/debug": "^4.1",
         "symfony/http-foundation": "^4.1",
         "symfony/http-kernel": "^4.1",

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -4,7 +4,7 @@ namespace Illuminate\Session;
 
 use Illuminate\Support\Arr;
 use SessionHandlerInterface;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\InteractsWithTime;

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Session;
 
 use SessionHandlerInterface;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Symfony\Component\Finder\Finder;
 use Illuminate\Filesystem\Filesystem;
 

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -4,7 +4,7 @@ namespace Illuminate\Session\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Session\SessionManager;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Session\CookieSessionHandler;

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -18,6 +18,7 @@
         "illuminate/contracts": "5.7.*",
         "illuminate/filesystem": "5.7.*",
         "illuminate/support": "5.7.*",
+        "nesbot/carbon": "^1.26.3",
         "symfony/finder": "^4.1",
         "symfony/http-foundation": "^4.1"
     },

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -18,7 +18,7 @@
         "illuminate/contracts": "5.7.*",
         "illuminate/filesystem": "5.7.*",
         "illuminate/support": "5.7.*",
-        "nesbot/carbon": "^1.26.3",
+        "nesbot/carbon": "^1.32",
         "symfony/finder": "^4.1",
         "symfony/http-foundation": "^4.1"
     },

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Illuminate\Support;
-
-use Carbon\Carbon as BaseCarbon;
-
-class Carbon extends BaseCarbon
-{
-}

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -17,8 +17,7 @@
         "php": "^7.1.3",
         "ext-mbstring": "*",
         "doctrine/inflector": "^1.1",
-        "illuminate/contracts": "5.7.*",
-        "nesbot/carbon": "^1.24.1"
+        "illuminate/contracts": "5.7.*"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -11,7 +11,7 @@ use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Validation\ValidationData;

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -19,6 +19,7 @@
         "illuminate/contracts": "5.7.*",
         "illuminate/support": "5.7.*",
         "illuminate/translation": "5.7.*",
+        "nesbot/carbon": "^1.26.3",
         "symfony/http-foundation": "^4.1"
     },
     "autoload": {

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "5.7.*",
         "illuminate/support": "5.7.*",
         "illuminate/translation": "5.7.*",
-        "nesbot/carbon": "^1.26.3",
+        "nesbot/carbon": "^1.32",
         "symfony/http-foundation": "^4.1"
     },
     "autoload": {

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Auth;
 
 use Mockery as m;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\Passwords\DatabaseTokenRepository;
 

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Cache;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Cache\FileStore;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Cache;
 
+use Carbon\Carbon;
 use Memcached;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\MemcachedStore;
@@ -63,12 +64,12 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        \Carbon\Carbon::setTestNow($now = \Carbon\Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $memcache = $this->getMockBuilder('Memcached')->setMethods(['set'])->getMock();
         $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo($now->timestamp + 60));
         $store = new MemcachedStore($memcache);
         $store->put('foo', 'bar', 1);
-        \Carbon\Carbon::setTestNow();
+        Carbon::setTestNow();
     }
 
     public function testIncrementMethodProperlyCallsMemcache()

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -63,12 +63,12 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        \Illuminate\Support\Carbon::setTestNow($now = \Illuminate\Support\Carbon::now());
+        \Carbon\Carbon::setTestNow($now = \Carbon\Carbon::now());
         $memcache = $this->getMockBuilder('Memcached')->setMethods(['set'])->getMock();
         $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo($now->timestamp + 60));
         $store = new MemcachedStore($memcache);
         $store->put('foo', 'bar', 1);
-        \Illuminate\Support\Carbon::setTestNow();
+        \Carbon\Carbon::setTestNow();
     }
 
     public function testIncrementMethodProperlyCallsMemcache()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -6,7 +6,7 @@ use DateTime;
 use DateInterval;
 use Mockery as m;
 use DateTimeImmutable;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 
 class CacheRepositoryTest extends TestCase

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Console;
 
 use Mockery as m;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Console\Scheduling\Event;
 

--- a/tests/Console/Scheduling/CacheSchedulingMutexTest.php
+++ b/tests/Console/Scheduling/CacheSchedulingMutexTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Console\Scheduling;
 
 use Mockery as m;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\CacheEventMutex;

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use Exception;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
@@ -605,8 +605,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testAggregatedValuesOfDatetimeField()
     {
-        EloquentTestUser::create(['id' => 1, 'email' => 'test1@test.test', 'created_at' => '2016-08-10 09:21:00', 'updated_at' => \Illuminate\Support\Carbon::now()]);
-        EloquentTestUser::create(['id' => 2, 'email' => 'test2@test.test', 'created_at' => '2016-08-01 12:00:00', 'updated_at' => \Illuminate\Support\Carbon::now()]);
+        EloquentTestUser::create(['id' => 1, 'email' => 'test1@test.test', 'created_at' => '2016-08-10 09:21:00', 'updated_at' => \Carbon\Carbon::now()]);
+        EloquentTestUser::create(['id' => 2, 'email' => 'test2@test.test', 'created_at' => '2016-08-01 12:00:00', 'updated_at' => \Carbon\Carbon::now()]);
 
         $this->assertEquals('2016-08-10 09:21:00', EloquentTestUser::max('created_at'));
         $this->assertEquals('2016-08-01 12:00:00', EloquentTestUser::min('created_at'));
@@ -1129,8 +1129,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testFreshMethodOnModel()
     {
-        $now = \Illuminate\Support\Carbon::now();
-        \Illuminate\Support\Carbon::setTestNow($now);
+        $now = \Carbon\Carbon::now();
+        \Carbon\Carbon::setTestNow($now);
 
         $storedUser1 = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         $storedUser1->newQuery()->update(['email' => 'dev@mathieutu.ovh', 'name' => 'Mathieu TUDISCO']);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -605,8 +605,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testAggregatedValuesOfDatetimeField()
     {
-        EloquentTestUser::create(['id' => 1, 'email' => 'test1@test.test', 'created_at' => '2016-08-10 09:21:00', 'updated_at' => \Carbon\Carbon::now()]);
-        EloquentTestUser::create(['id' => 2, 'email' => 'test2@test.test', 'created_at' => '2016-08-01 12:00:00', 'updated_at' => \Carbon\Carbon::now()]);
+        EloquentTestUser::create(['id' => 1, 'email' => 'test1@test.test', 'created_at' => '2016-08-10 09:21:00', 'updated_at' => Carbon::now()]);
+        EloquentTestUser::create(['id' => 2, 'email' => 'test2@test.test', 'created_at' => '2016-08-01 12:00:00', 'updated_at' => Carbon::now()]);
 
         $this->assertEquals('2016-08-10 09:21:00', EloquentTestUser::max('created_at'));
         $this->assertEquals('2016-08-01 12:00:00', EloquentTestUser::min('created_at'));
@@ -1129,8 +1129,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testFreshMethodOnModel()
     {
-        $now = \Carbon\Carbon::now();
-        \Carbon\Carbon::setTestNow($now);
+        $now = Carbon::now();
+        Carbon::setTestNow($now);
 
         $storedUser1 = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         $storedUser1->newQuery()->update(['email' => 'dev@mathieutu.ovh', 'name' => 'Mathieu TUDISCO']);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -9,7 +9,7 @@ use Mockery as m;
 use ReflectionClass;
 use DateTimeImmutable;
 use DateTimeInterface;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
@@ -35,7 +35,7 @@ class DatabaseEloquentModelTest extends TestCase
         Carbon::setTestNow(null);
 
         \Illuminate\Database\Eloquent\Model::unsetEventDispatcher();
-        \Illuminate\Support\Carbon::resetToStringFormat();
+        \Carbon\Carbon::resetToStringFormat();
     }
 
     public function testAttributeManipulation()
@@ -355,8 +355,8 @@ class DatabaseEloquentModelTest extends TestCase
             'updated_at' => '2012-12-05',
         ]);
 
-        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->created_at);
-        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->updated_at);
+        $this->assertInstanceOf(\Carbon\Carbon::class, $model->created_at);
+        $this->assertInstanceOf(\Carbon\Carbon::class, $model->updated_at);
     }
 
     public function testTimestampsAreReturnedAsObjectsFromPlainDatesAndTimestamps()
@@ -368,15 +368,15 @@ class DatabaseEloquentModelTest extends TestCase
             'updated_at' => $this->currentTime(),
         ]);
 
-        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->created_at);
-        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->updated_at);
+        $this->assertInstanceOf(\Carbon\Carbon::class, $model->created_at);
+        $this->assertInstanceOf(\Carbon\Carbon::class, $model->updated_at);
     }
 
     public function testTimestampsAreReturnedAsObjectsOnCreate()
     {
         $timestamps = [
-            'created_at' => \Illuminate\Support\Carbon::now(),
-            'updated_at' => \Illuminate\Support\Carbon::now(),
+            'created_at' => \Carbon\Carbon::now(),
+            'updated_at' => \Carbon\Carbon::now(),
         ];
         $model = new EloquentDateModelStub;
         \Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
@@ -384,15 +384,15 @@ class DatabaseEloquentModelTest extends TestCase
         $mockConnection->shouldReceive('getQueryGrammar')->andReturn($mockConnection);
         $mockConnection->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $instance = $model->newInstance($timestamps);
-        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $instance->updated_at);
-        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $instance->created_at);
+        $this->assertInstanceOf(\Carbon\Carbon::class, $instance->updated_at);
+        $this->assertInstanceOf(\Carbon\Carbon::class, $instance->created_at);
     }
 
     public function testDateTimeAttributesReturnNullIfSetToNull()
     {
         $timestamps = [
-            'created_at' => \Illuminate\Support\Carbon::now(),
-            'updated_at' => \Illuminate\Support\Carbon::now(),
+            'created_at' => \Carbon\Carbon::now(),
+            'updated_at' => \Carbon\Carbon::now(),
         ];
         $model = new EloquentDateModelStub;
         \Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
@@ -409,26 +409,26 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentDateModelStub;
         $model->created_at = '2013-05-22 00:00:00';
-        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->created_at);
+        $this->assertInstanceOf(\Carbon\Carbon::class, $model->created_at);
 
         $model = new EloquentDateModelStub;
         $model->created_at = $this->currentTime();
-        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->created_at);
+        $this->assertInstanceOf(\Carbon\Carbon::class, $model->created_at);
 
         $model = new EloquentDateModelStub;
         $model->created_at = 0;
-        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->created_at);
+        $this->assertInstanceOf(\Carbon\Carbon::class, $model->created_at);
 
         $model = new EloquentDateModelStub;
         $model->created_at = '2012-01-01';
-        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->created_at);
+        $this->assertInstanceOf(\Carbon\Carbon::class, $model->created_at);
     }
 
     public function testFromDateTime()
     {
         $model = new EloquentModelStub;
 
-        $value = \Illuminate\Support\Carbon::parse('2015-04-17 22:59:01');
+        $value = \Carbon\Carbon::parse('2015-04-17 22:59:01');
         $this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
 
         $value = new DateTime('2015-04-17 22:59:01');
@@ -1504,8 +1504,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $model->arrayAttribute);
         $this->assertEquals(['foo' => 'bar'], $model->jsonAttribute);
         $this->assertEquals('{"foo":"bar"}', $model->jsonAttributeValue());
-        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->dateAttribute);
-        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->datetimeAttribute);
+        $this->assertInstanceOf(\Carbon\Carbon::class, $model->dateAttribute);
+        $this->assertInstanceOf(\Carbon\Carbon::class, $model->datetimeAttribute);
         $this->assertEquals('1969-07-20', $model->dateAttribute->toDateString());
         $this->assertEquals('1969-07-20 22:56:00', $model->datetimeAttribute->toDateTimeString());
         $this->assertEquals(-14173440, $model->timestampAttribute);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -35,7 +35,7 @@ class DatabaseEloquentModelTest extends TestCase
         Carbon::setTestNow(null);
 
         \Illuminate\Database\Eloquent\Model::unsetEventDispatcher();
-        \Carbon\Carbon::resetToStringFormat();
+        Carbon::resetToStringFormat();
     }
 
     public function testAttributeManipulation()
@@ -355,8 +355,8 @@ class DatabaseEloquentModelTest extends TestCase
             'updated_at' => '2012-12-05',
         ]);
 
-        $this->assertInstanceOf(\Carbon\Carbon::class, $model->created_at);
-        $this->assertInstanceOf(\Carbon\Carbon::class, $model->updated_at);
+        $this->assertInstanceOf(Carbon::class, $model->created_at);
+        $this->assertInstanceOf(Carbon::class, $model->updated_at);
     }
 
     public function testTimestampsAreReturnedAsObjectsFromPlainDatesAndTimestamps()
@@ -368,15 +368,15 @@ class DatabaseEloquentModelTest extends TestCase
             'updated_at' => $this->currentTime(),
         ]);
 
-        $this->assertInstanceOf(\Carbon\Carbon::class, $model->created_at);
-        $this->assertInstanceOf(\Carbon\Carbon::class, $model->updated_at);
+        $this->assertInstanceOf(Carbon::class, $model->created_at);
+        $this->assertInstanceOf(Carbon::class, $model->updated_at);
     }
 
     public function testTimestampsAreReturnedAsObjectsOnCreate()
     {
         $timestamps = [
-            'created_at' => \Carbon\Carbon::now(),
-            'updated_at' => \Carbon\Carbon::now(),
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
         ];
         $model = new EloquentDateModelStub;
         \Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
@@ -384,15 +384,15 @@ class DatabaseEloquentModelTest extends TestCase
         $mockConnection->shouldReceive('getQueryGrammar')->andReturn($mockConnection);
         $mockConnection->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $instance = $model->newInstance($timestamps);
-        $this->assertInstanceOf(\Carbon\Carbon::class, $instance->updated_at);
-        $this->assertInstanceOf(\Carbon\Carbon::class, $instance->created_at);
+        $this->assertInstanceOf(Carbon::class, $instance->updated_at);
+        $this->assertInstanceOf(Carbon::class, $instance->created_at);
     }
 
     public function testDateTimeAttributesReturnNullIfSetToNull()
     {
         $timestamps = [
-            'created_at' => \Carbon\Carbon::now(),
-            'updated_at' => \Carbon\Carbon::now(),
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
         ];
         $model = new EloquentDateModelStub;
         \Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
@@ -409,26 +409,26 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentDateModelStub;
         $model->created_at = '2013-05-22 00:00:00';
-        $this->assertInstanceOf(\Carbon\Carbon::class, $model->created_at);
+        $this->assertInstanceOf(Carbon::class, $model->created_at);
 
         $model = new EloquentDateModelStub;
         $model->created_at = $this->currentTime();
-        $this->assertInstanceOf(\Carbon\Carbon::class, $model->created_at);
+        $this->assertInstanceOf(Carbon::class, $model->created_at);
 
         $model = new EloquentDateModelStub;
         $model->created_at = 0;
-        $this->assertInstanceOf(\Carbon\Carbon::class, $model->created_at);
+        $this->assertInstanceOf(Carbon::class, $model->created_at);
 
         $model = new EloquentDateModelStub;
         $model->created_at = '2012-01-01';
-        $this->assertInstanceOf(\Carbon\Carbon::class, $model->created_at);
+        $this->assertInstanceOf(Carbon::class, $model->created_at);
     }
 
     public function testFromDateTime()
     {
         $model = new EloquentModelStub;
 
-        $value = \Carbon\Carbon::parse('2015-04-17 22:59:01');
+        $value = Carbon::parse('2015-04-17 22:59:01');
         $this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
 
         $value = new DateTime('2015-04-17 22:59:01');
@@ -1504,8 +1504,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $model->arrayAttribute);
         $this->assertEquals(['foo' => 'bar'], $model->jsonAttribute);
         $this->assertEquals('{"foo":"bar"}', $model->jsonAttributeValue());
-        $this->assertInstanceOf(\Carbon\Carbon::class, $model->dateAttribute);
-        $this->assertInstanceOf(\Carbon\Carbon::class, $model->datetimeAttribute);
+        $this->assertInstanceOf(Carbon::class, $model->dateAttribute);
+        $this->assertInstanceOf(Carbon::class, $model->datetimeAttribute);
         $this->assertEquals('1969-07-20', $model->dateAttribute->toDateString());
         $this->assertEquals('1969-07-20 22:56:00', $model->datetimeAttribute->toDateTimeString());
         $this->assertEquals(-14173440, $model->timestampAttribute);

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -47,7 +47,7 @@ class DatabaseEloquentRelationTest extends TestCase
         $relation = new HasOne($builder, $parent, 'foreign_key', 'id');
         $related->shouldReceive('getTable')->andReturn('table');
         $related->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-        $now = \Illuminate\Support\Carbon::now();
+        $now = \Carbon\Carbon::now();
         $related->shouldReceive('freshTimestampString')->andReturn($now);
         $builder->shouldReceive('update')->once()->with(['updated_at' => $now]);
 
@@ -120,7 +120,7 @@ class DatabaseEloquentRelationTest extends TestCase
             $anotherBuilder->shouldReceive('where');
             $anotherBuilder->shouldReceive('withoutGlobalScopes')->andReturnSelf();
             $anotherRelation = new HasOne($anotherBuilder, $anotherParent, 'foreign_key', 'id');
-            $now = \Illuminate\Support\Carbon::now();
+            $now = \Carbon\Carbon::now();
             $anotherRelated->shouldReceive('freshTimestampString')->andReturn($now);
             $anotherBuilder->shouldReceive('update')->once()->with(['updated_at' => $now]);
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use Carbon\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
@@ -47,7 +48,7 @@ class DatabaseEloquentRelationTest extends TestCase
         $relation = new HasOne($builder, $parent, 'foreign_key', 'id');
         $related->shouldReceive('getTable')->andReturn('table');
         $related->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-        $now = \Carbon\Carbon::now();
+        $now = Carbon::now();
         $related->shouldReceive('freshTimestampString')->andReturn($now);
         $builder->shouldReceive('update')->once()->with(['updated_at' => $now]);
 
@@ -120,7 +121,7 @@ class DatabaseEloquentRelationTest extends TestCase
             $anotherBuilder->shouldReceive('where');
             $anotherBuilder->shouldReceive('withoutGlobalScopes')->andReturnSelf();
             $anotherRelation = new HasOne($anotherBuilder, $anotherParent, 'foreign_key', 'id');
-            $now = \Carbon\Carbon::now();
+            $now = Carbon::now();
             $anotherRelated->shouldReceive('freshTimestampString')->andReturn($now);
             $anotherBuilder->shouldReceive('update')->once()->with(['updated_at' => $now]);
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Database\Query\Builder;

--- a/tests/Database/DatabaseEloquentTimestamps.php
+++ b/tests/Database/DatabaseEloquentTimestamps.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use Carbon\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -24,7 +25,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         ]);
         $model->delete();
 
-        $this->assertInstanceOf(\Carbon\Carbon::class, $model->deleted_at);
+        $this->assertInstanceOf(Carbon::class, $model->deleted_at);
     }
 
     public function testRestore()
@@ -90,7 +91,7 @@ class DatabaseSoftDeletingTraitStub
 
     public function freshTimestamp()
     {
-        return \Carbon\Carbon::now();
+        return Carbon::now();
     }
 
     public function fromDateTime()

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -24,7 +24,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         ]);
         $model->delete();
 
-        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->deleted_at);
+        $this->assertInstanceOf(\Carbon\Carbon::class, $model->deleted_at);
     }
 
     public function testRestore()
@@ -90,7 +90,7 @@ class DatabaseSoftDeletingTraitStub
 
     public function freshTimestamp()
     {
-        return \Illuminate\Support\Carbon::now();
+        return \Carbon\Carbon::now();
     }
 
     public function fromDateTime()

--- a/tests/Integration/Cache/CacheLockTest.php
+++ b/tests/Integration/Cache/CacheLockTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Integration\Cache;
 
 use Memcached;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -33,7 +33,7 @@ class EloquentModelTest extends DatabaseTestCase
         ]);
 
         $user->fill([
-            'nullable_date' => $now = \Illuminate\Support\Carbon::now(),
+            'nullable_date' => $now = \Carbon\Carbon::now(),
         ]);
         $this->assertTrue($user->isDirty('nullable_date'));
 

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 
@@ -33,7 +34,7 @@ class EloquentModelTest extends DatabaseTestCase
         ]);
 
         $user->fill([
-            'nullable_date' => $now = \Carbon\Carbon::now(),
+            'nullable_date' => $now = Carbon::now(),
         ]);
         $this->assertTrue($user->isDirty('nullable_date'));
 

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentMorphManyTest;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentTouchParentWithGlobalScopeTest;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Integration\Http;
 
 use Throwable;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Routing\Middleware\ThrottleRequests;

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Integration\Http;
 
 use Throwable;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;

--- a/tests/Integration/Mail/Fixtures/timestamp.blade.php
+++ b/tests/Integration/Mail/Fixtures/timestamp.blade.php
@@ -1,1 +1,1 @@
-{{__('nom')}} {{ Illuminate\Support\Carbon::tomorrow()->diffForHumans() }}
+{{__('nom')}} {{ Carbon\Carbon::tomorrow()->diffForHumans() }}

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\Integration\Mail;
 
 use Mockery;
 use Illuminate\Mail\Mailable;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\View;

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Integration\Routing;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Route;

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Notifications;
 
+use Carbon\Carbon;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Notifications\Notification;
@@ -179,7 +180,7 @@ class NotificationSlackChannelTestNotification extends Notification
                     ->to('#ghost-talk')
                     ->content('Content')
                     ->attachment(function ($attachment) {
-                        $timestamp = Mockery::mock(\Carbon\Carbon::class);
+                        $timestamp = Mockery::mock(Carbon::class);
                         $timestamp->shouldReceive('getTimestamp')->andReturn(1234567890);
                         $attachment->title('Laravel', 'https://laravel.com')
                                    ->content('Attachment Content')
@@ -206,7 +207,7 @@ class NotificationSlackChannelTestNotificationWithImageIcon extends Notification
                     ->to('#ghost-talk')
                     ->content('Content')
                     ->attachment(function ($attachment) {
-                        $timestamp = Mockery::mock(\Carbon\Carbon::class);
+                        $timestamp = Mockery::mock(Carbon::class);
                         $timestamp->shouldReceive('getTimestamp')->andReturn(1234567890);
                         $attachment->title('Laravel', 'https://laravel.com')
                                    ->content('Attachment Content')

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -179,7 +179,7 @@ class NotificationSlackChannelTestNotification extends Notification
                     ->to('#ghost-talk')
                     ->content('Content')
                     ->attachment(function ($attachment) {
-                        $timestamp = Mockery::mock(\Illuminate\Support\Carbon::class);
+                        $timestamp = Mockery::mock(\Carbon\Carbon::class);
                         $timestamp->shouldReceive('getTimestamp')->andReturn(1234567890);
                         $attachment->title('Laravel', 'https://laravel.com')
                                    ->content('Attachment Content')
@@ -206,7 +206,7 @@ class NotificationSlackChannelTestNotificationWithImageIcon extends Notification
                     ->to('#ghost-talk')
                     ->content('Content')
                     ->attachment(function ($attachment) {
-                        $timestamp = Mockery::mock(\Illuminate\Support\Carbon::class);
+                        $timestamp = Mockery::mock(\Carbon\Carbon::class);
                         $timestamp->shouldReceive('getTimestamp')->andReturn(1234567890);
                         $attachment->title('Laravel', 'https://laravel.com')
                                    ->content('Attachment Content')

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Queue;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Queue\DatabaseQueue;

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -42,7 +42,7 @@ class QueueRedisQueueTest extends TestCase
 
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoRedis()
     {
-        $date = \Illuminate\Support\Carbon::now();
+        $date = \Carbon\Carbon::now();
         $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $queue->expects($this->once())->method('availableAt')->with($date)->will($this->returnValue(2));

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Queue;
 
+use Carbon\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -42,7 +43,7 @@ class QueueRedisQueueTest extends TestCase
 
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoRedis()
     {
-        $date = \Carbon\Carbon::now();
+        $date = Carbon::now();
         $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $queue->expects($this->once())->method('availableAt')->with($date)->will($this->returnValue(2));

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -85,7 +85,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs()
     {
-        $now = \Illuminate\Support\Carbon::now();
+        $now = \Carbon\Carbon::now();
         $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
         $queue->expects($this->once())->method('secondsUntil')->with($now)->will($this->returnValue(5));

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Queue;
 
 use Aws\Result;
+use Carbon\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -85,7 +86,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs()
     {
-        $now = \Carbon\Carbon::now();
+        $now = Carbon::now();
         $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
         $queue->expects($this->once())->method('secondsUntil')->with($now)->will($this->returnValue(5));

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\Queue;
 
 use Mockery;
 use RuntimeException;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Queue\WorkerOptions;

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Queue;
 
 use Mockery as m;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Queue\RedisQueue;
 use Illuminate\Container\Container;

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -5,7 +5,7 @@ namespace Illuminate\Tests\Support;
 use stdClass;
 use ArrayObject;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -4,14 +4,14 @@ namespace Illuminate\Tests\Support;
 
 use DateTime;
 use DateTimeInterface;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Carbon\Carbon as BaseCarbon;
 
 class SupportCarbonTest extends TestCase
 {
     /**
-     * @var \Illuminate\Support\Carbon
+     * @var \Carbon\Carbon
      */
     protected $now;
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6,7 +6,7 @@ use DateTime;
 use Mockery as m;
 use DateTimeImmutable;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Validation\Validator;
 use Illuminate\Validation\Rules\Exists;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,7 +14,7 @@
 
 require __DIR__.'/../vendor/autoload.php';
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Since `nesbot/Carbon` now supports serialization and macros, there is no need to have `\Illuminate\Support\Carbon`.

This PR:
- replaces every use of `\Illuminate\Support\Carbon` by `\Carbon\Carbon`
- remove `src/Illuminate/Support/Carbon.php`
- require `nesbot/carbon` in the `composer.json` files of all the packages that need this package
- import `\Carbon\Carbon` in tests
- update `nesbot/carbon` version