### PR TITLE
[5.6] Add hint to mail fake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -35,11 +35,11 @@ class MailFake implements Mailer
         if (is_numeric($callback)) {
             return $this->assertSentTimes($mailable, $callback);
         }
-        
+
         $message = "The expected [{$mailable}] mailable was not sent.";
-        
+
         if (count($this->queuedMailables) > 0) {
-            $message.= " Did you mean to use assertQueued() instead?";
+            $message .= ' Did you mean to use assertQueued() instead?';
         }
 
         PHPUnit::assertTrue(

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -35,10 +35,16 @@ class MailFake implements Mailer
         if (is_numeric($callback)) {
             return $this->assertSentTimes($mailable, $callback);
         }
+        
+        $message = "The expected [{$mailable}] mailable was not sent.";
+        
+        if (count($this->queuedMailables) > 0) {
+            $message.= " Did you mean to use assertQueued() instead?";
+        }
 
         PHPUnit::assertTrue(
             $this->sent($mailable, $callback)->count() > 0,
-            "The expected [{$mailable}] mailable was not sent."
+            $message
         );
     }
 


### PR DESCRIPTION
In Laravel, you have to use different assertions in tests depending on if you’re queuing a mailable, or immediately sending one.

The head of development at the company I work for has just spent some time trying to test a mailable was sent that he was actually queuing. I’ve made the mistake myself in the past. I’m sure countless other developers have too.

Given that developers of all skill levels get bit by this, I’m proposing to amend the error message in `assertSent()` to append “Did you mean to use assertQueued() instead?” if there is one or more queued mailables. This should hopefully save a few developer headaches in the future!