### PR TITLE
[5.6] Rename `setGlobalTo` to `setGlobalToAndRemoveCcAndBcc`

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -236,7 +236,7 @@ class Mailer implements MailerContract, MailQueueContract
         // message. This is primarily useful during local development in which each
         // message should be delivered into a single mail address for inspection.
         if (isset($this->to['address'])) {
-            $this->setGlobalTo($message);
+            $this->setGlobalToAndRemoveCcAndBcc($message);
         }
 
         // Next we will determine if the message should be sent. We give the developer
@@ -347,7 +347,7 @@ class Mailer implements MailerContract, MailQueueContract
      * @param  \Illuminate\Mail\Message  $message
      * @return void
      */
-    protected function setGlobalTo($message)
+    protected function setGlobalToAndRemoveCcAndBcc($message)
     {
         $message->to($this->to['address'], $this->to['name'], true);
         $message->cc(null, null, true);


### PR DESCRIPTION
I spent a bunch of time earlier tonight trying to figure out why the `cc` addressee I was setting in my `Mailable` wasn't receiving a copy of the email I was sending. Turns out the `setGlobalTo` method in the `Mailer` removes the `cc` and `bcc` recipients.

This change may prevent future devs from banging their heads against this.


