### PR TITLE
[5.6] Return instance of spy when swapping facade for a Mockery spy

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -25,14 +25,18 @@ abstract class Facade
     /**
      * Convert the facade into a Mockery spy.
      *
-     * @return void
+     * @return MockInterface
      */
     public static function spy()
     {
         if (! static::isMock()) {
             $class = static::getMockableClass();
 
-            static::swap($class ? Mockery::spy($class) : Mockery::spy());
+            $spy = $class ? Mockery::spy($class) : Mockery::spy();
+
+            static::swap($spy);
+
+            return $spy;
         }
     }
 

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -39,6 +39,18 @@ class SupportFacadeTest extends TestCase
         $this->assertEquals('baz', $app['foo']->foo('bar'));
     }
 
+    public function testSpyReturnsAMockerySpy()
+    {
+        $app = new ApplicationStub;
+        $app->setAttributes(['foo' => new stdClass]);
+        FacadeStub::setFacadeApplication($app);
+
+        $this->assertInstanceOf(m\MockInterface::class, $spy = FacadeStub::spy());
+
+        FacadeStub::foo();
+        $spy->shouldHaveReceived('foo');
+    }
+
     public function testShouldReceiveCanBeCalledTwice()
     {
         $app = new ApplicationStub;


### PR DESCRIPTION
One of the main benefits of spies is that you can move the assertion to the end of the test method. For example, instead of 

```
$mock->shouldReceive('foo')->once()
//act on something
``` 

after the 'act' step in your test, you can do 

```
// act on something
$spy->shouldHaveRecieved('foo')->once()
```

Right now, if I want to get an instance of the spy I have to do
```$spy = Facade::getFacadeRoot()```
so that I can use the spy in my assertions at the end of the test, which isn't as nice as it could be. This PR simply returns the spy after creating it. 