### PR TITLE
[5.6] Add method to append data to JSON response

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -55,6 +55,19 @@ class JsonResponse extends BaseJsonResponse
     }
 
     /**
+     * Append data to json.
+     *
+     * @param  array  $data
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function appendData($data = [])
+    {
+        return $this->setData(array_merge($this->original, $data));
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function setData($data = [])

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -46,8 +46,8 @@ class HttpJsonResponseTest extends TestCase
         $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar']);
         $newResponse = $response->appendData(['another_foo' => 'new_bar']);
         $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $newResponse);
-        $this->assertEquals('bar', $newResponse->foo);
-        $this->assertEquals('new_bar', $newResponse->another_foo);
+        $this->assertEquals('bar', $newResponse->getData()->foo);
+        $this->assertEquals('new_bar', $newResponse->getData()->another_foo);
     }
 
     public function testGetOriginalContent()

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -41,6 +41,15 @@ class HttpJsonResponseTest extends TestCase
         $this->assertEquals('bar', $data->foo);
     }
 
+    public function testAppendAndRetrieveData()
+    {
+        $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar']);
+        $newResponse = $response->appendData(['another_foo' => 'new_bar']);
+        $this->assertInstanceOf('stdClass', $newResponse);
+        $this->assertEquals('bar', $data->foo);
+        $this->assertEquals('new_bar', $data->another_foo);
+    }
+
     public function testGetOriginalContent()
     {
         $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestArrayableObject);

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -45,7 +45,7 @@ class HttpJsonResponseTest extends TestCase
     {
         $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar']);
         $newResponse = $response->appendData(['another_foo' => 'new_bar']);
-        $this->assertInstanceOf('stdClass', $newResponse);
+        $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $newResponse);
         $this->assertEquals('bar', $data->foo);
         $this->assertEquals('new_bar', $data->another_foo);
     }

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -46,8 +46,8 @@ class HttpJsonResponseTest extends TestCase
         $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar']);
         $newResponse = $response->appendData(['another_foo' => 'new_bar']);
         $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $newResponse);
-        $this->assertEquals('bar', $data->foo);
-        $this->assertEquals('new_bar', $data->another_foo);
+        $this->assertEquals('bar', $newResponse->foo);
+        $this->assertEquals('new_bar', $newResponse->another_foo);
     }
 
     public function testGetOriginalContent()


### PR DESCRIPTION
When building api you may come across occasion that you need to append data to difference json responses from multiple places. This pull request make that easier.

Let's say your application use JWT with short expiration. Every time user send a request to your application you process the request, create response, and attach new JWT to that response so the user won't have to login again too often.

Instead of attaching that JWT at the time you create the response, you can use after middleware to simplify your code. That middleware can be something like

```
class RenewJWT
{
    /**
     * Handle an incoming request.
     *
     * @param  \Illuminate\Http\Request  $request
     * @param  \Closure  $next
     * @return mixed
     */
    public function handle($request, Closure $next)
    {
        $response = $next($request);

        $response->appendData(["jwt" => "New JWT!"]);

        return $response;
    }
}
```

This pull request create the `appendData()` method in `Illuminate\Http\JsonResponse`.