### PR TITLE
[5.7] Change Log FacadeAccessor to 'log'.

### DIFF
--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -29,6 +29,6 @@ class Log extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'log;
+        return 'log';
     }
 }

--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Support\Facades;
 
-use Psr\Log\LoggerInterface;
-
 /**
  * @method static void emergency(string $message, array $context = [])
  * @method static void alert(string $message, array $context = [])
@@ -31,6 +29,6 @@ class Log extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return LoggerInterface::class;
+        return 'log;
     }
 }


### PR DESCRIPTION
As asked in https://github.com/laravel/framework/pull/24906#issuecomment-406661637:

>Hi, 
>This PR change the Log Facade Accessor from the complete `LoggerInterface` to the `log` alias. 
>
>This is more consistent with the other Facades which almost all return the alias as facade accessor, with the `logger` helper, and moreover, **this will allow easier testing**.
>
>In fact, for the example:
>
>I'm taking over a project without any test, and adding them. In all the project the helper `logger` is used. I can't use the `Log::shouldReceive('warning')` way to mock, because it will mock only the `\Psr\Log\LoggerInterface`.
>
>`app(\Psr\Log\LoggerInterface::class)` will return the mock but not `app('log')`, `logger()`, `logs()`, `app(\Illuminate\Log\LogManager::class)`, etc.
>
>
>This PR fixes that.
>
>Thanks and see you soon in Amsterdam,
>Matt'.
