### PR TITLE
[5.7] Add Blade::helper(...) directive

### DIFF
--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -185,4 +185,56 @@ class BladeCustomTest extends AbstractBladeTestCase
         $expected = '<?php echo $__env->make(\'app.includes.foreach\', [], array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testCustomNamedHelpers()
+    {
+        $this->assertCount(0, $this->compiler->getCustomDirectives());
+        $this->compiler->helper('uppercase', 'strtoupper');
+        $this->assertCount(1, $this->compiler->getCustomDirectives());
+
+        $string = '@uppercase("Hello world.")';
+        $expected = '<?php echo strtoupper("Hello world."); ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testCustomUnnamedHelpers()
+    {
+        $this->assertCount(0, $this->compiler->getCustomDirectives());
+        $this->compiler->helper('join');
+        $this->assertCount(1, $this->compiler->getCustomDirectives());
+
+        $string = '@join("|", ["Hello", "world"])';
+        $expected = '<?php echo join("|", ["Hello", "world"]); ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testCustomHelpersWithoutEcho()
+    {
+        $this->assertCount(0, $this->compiler->getCustomDirectives());
+        $this->compiler->helper('join', null, false);
+        $this->assertCount(1, $this->compiler->getCustomDirectives());
+
+        $string = '@join("|", ["Hello", "world"])';
+        $expected = '<?php join("|", ["Hello", "world"]); ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testCustomHelperCallbacks()
+    {
+        $this->assertCount(0, $this->compiler->getCustomDirectives());
+        $this->compiler->helper('example', function($a, $b, $c = 'give', $d = 'you') {
+            return "$a $b $c $d up";
+        });
+        $this->assertCount(1, $this->compiler->getCustomDirectives());
+
+        $string = '@example("Never", "gonna")';
+        $expected = '<?php echo \Illuminate\Support\Facades\Blade::getHelper(\'example\', "Never", "gonna"); ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        echo $expected;
+    }
 }


### PR DESCRIPTION
**tl;dr makes it easier to work with custom Blade directives**

---

When creating new custom Blade directives using the `Blade::directive(...)` method, it seems to be rare that people actually parse the contents of the expression itself within the directive, opting instead to pass the entire expression as arguments to a helper function or method on another class.

```php
Blade::directive('uppercase', function($expression) {
    return "<?php echo strtoupper($expression); ?>";
});
```

Since from what I've seen, this seems to be the most common use case, I wanted to help make these functions that little bit easier to define without the boilerplate of returning the string or having to consider what an expression may be when creating a directive.

To help with this, this PR introduces a `helper` method on the `BladeCompiler` class. This method accepts two arguments; the first is the name of the directive, and the second is the function that the directive should call.

```php
// Define the helper directive
Blade::helper('uppercase', 'strtoupper');

// Use it in a view
@uppercase('Hello world.')

// Get the compiled result
<?php echo strtoupper('Hello world.'); ?>

// See what's echoed
"HELLO WORLD."
```

If no second argument is supplied, the directive name will attempt to call a function of the same name.

```php
// Define the helper directive
Blade::helper('join');

// Use it in a view
@join('|', ['Hello', 'world'])

// Get the compiled result
<?php echo join('|', ['Hello', 'world']); ?>

// See what's echoed
"Hello|world"
```

The second argument can also take a callback. The advantage of a callback here over the `Blade::directive(...)` method is that the closure defined can have specific parameters defined instead of just the raw expression passed through. This has several good things that solve a [previous idea](https://github.com/laravel/ideas/issues/1104) I brought up:

- Type hint the arguments for the callback
- Manipulate and use the individual arguments when the directive is called, instead of the raw expression as a string
- Define a directive without having to only use it as a proxy to a helper function or class in another part of the application

```php
// Define the helper directive
Blade::helper('example', function($a, $b, $c = 'give', $d = 'you') {
    return "$a $b $c $d up";
});

// Use it in a view
@example('Never', 'gonna')

// Get the compiled result
<?php echo \Illuminate\Support\Facades\Blade::getHelper('example', 'Never', 'gonna'); ?>

// See what's echoed
"Never gonna give you up"
```

By default, all of the helper directives will echo out their contents to the view when used. This can be disabled by passing `false` as the third argument.

```php
// Define the helper directive
Blade::helper('log', null, false);

// Use it in a view
@log('View loaded...')

// Get the compiled result
<?php log('View loaded...'); ?>

// Nothing is echoed
```