### PR TITLE
[5.7] Don't rollback migrations in DatabaseMigrations as migrate:fresh is used now

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
@@ -18,8 +18,6 @@ trait DatabaseMigrations
         $this->app[Kernel::class]->setArtisan(null);
 
         $this->beforeApplicationDestroyed(function () {
-            $this->artisan('migrate:rollback');
-
             RefreshDatabaseState::$migrated = false;
         });
     }


### PR DESCRIPTION
Since https://github.com/laravel/framework/pull/20090 we are using `migrate:fresh` in trait instead of  `migrate`. Using `migrate:fresh` ensures everything will be wiped out before running migrations, so `migrate:rollback` in many scenarios is not necessary and slows downs tests.

In my case (Dusk tests) difference is 1.9 minutes to 1.3 minutes so it's quite big difference (over 30%).

However this of course change behavior and in some scenarios (I don't have them) could cause problems. The most important thing is that after running tests database is not empty now. For me it's not a problem  but maybe in some cases it could be.