### PR TITLE
[5.6] Fix order in offset queries on SQL Server

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -185,7 +185,7 @@ class SqlServerGrammar extends Grammar
     {
         $constraint = $this->compileRowConstraint($query);
 
-        return "select * from ({$sql}) as temp_table where row_num {$constraint}";
+        return "select * from ({$sql}) as temp_table where row_num {$constraint} order by row_num";
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2096,15 +2096,15 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(10);
-        $this->assertEquals('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num >= 11', $builder->toSql());
+        $this->assertEquals('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num >= 11 order by row_num', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(10)->take(10);
-        $this->assertEquals('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num between 11 and 20', $builder->toSql());
+        $this->assertEquals('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num between 11 and 20 order by row_num', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(10)->take(10)->orderBy('email', 'desc');
-        $this->assertEquals('select * from (select *, row_number() over (order by [email] desc) as row_num from [users]) as temp_table where row_num between 11 and 20', $builder->toSql());
+        $this->assertEquals('select * from (select *, row_number() over (order by [email] desc) as row_num from [users]) as temp_table where row_num between 11 and 20 order by row_num', $builder->toSql());
     }
 
     public function testMySqlSoundsLikeOperator()


### PR DESCRIPTION
When using `offset()`/`skip()`/pagination on SQL Server, Laravel wraps the query in an outer query:

```php
DB::table('users')->offset(10)->latest()->get();
```

```sql
select *
from
  (select *, row_number() over (order by [created_at] desc) as row_num
   from [users]) as temp_table
where row_num >= 11
```

Despite the outer query not having an explicit `ORDER BY` clause, the results are correctly ordered in most cases. #24701 describes a query where the order is incorrect ([thread on MSDN](https://social.msdn.microsoft.com/Forums/en-US/e5dda657-6ad1-44d0-856e-4d535b4df553/rownumber-over-order-by-incorrect-sorting?forum=transactsql)).

This PR adds an `ORDER BY` clause:

```sql
select *
from
  (select *, row_number() over (order by [created_at] desc) as row_num
   from [users]) as temp_table
where row_num >= 11
order by row_num
```

Fixes #24701.