### PR TITLE
[5.7] Support special float values on PostgreSQL

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -478,7 +478,7 @@ trait HasAttributes
             case 'real':
             case 'float':
             case 'double':
-                return (float) $value;
+                return $this->fromFloat($value);
             case 'string':
                 return (string) $value;
             case 'bool':
@@ -690,6 +690,26 @@ trait HasAttributes
     public function fromJson($value, $asObject = false)
     {
         return json_decode($value, ! $asObject);
+    }
+
+    /**
+     * Cast the given float value.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public function fromFloat($value)
+    {
+        switch ($value) {
+            case 'Infinity':
+                return INF;
+            case '-Infinity':
+                return -INF;
+            case 'NaN':
+                return NAN;
+            default:
+                return (float) $value;
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1613,6 +1613,29 @@ class DatabaseEloquentModelTest extends TestCase
         $model->getAttributes();
     }
 
+    public function testModelAttributeCastingWithSpecialFloatValues()
+    {
+        $model = new EloquentModelCastingStub;
+
+        $model->floatAttribute = 'Infinity';
+        $this->assertEquals(INF, $model->floatAttribute);
+
+        $model->floatAttribute = INF;
+        $this->assertEquals(INF, $model->floatAttribute);
+
+        $model->floatAttribute = '-Infinity';
+        $this->assertEquals(-INF, $model->floatAttribute);
+
+        $model->floatAttribute = -INF;
+        $this->assertEquals(-INF, $model->floatAttribute);
+
+        $model->floatAttribute = 'NaN';
+        $this->assertNan($model->floatAttribute);
+
+        $model->floatAttribute = NAN;
+        $this->assertNan($model->floatAttribute);
+    }
+
     public function testUpdatingNonExistentModelFails()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
PostgreSQL [supports](https://www.postgresql.org/docs/current/static/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL) the special float values `Infinity`, `-Infinity` and `NaN`.
Eloquent's attribute casting doesn't:

```php
class Test extends Model {
    protected $casts = [
        'value' => 'float'
    ];
}

$test = Test::create(['value' => INF])->fresh();

dd($test->value);
// expected: INF
// actual:   0.0
```

Fixes #24933.
