### PR TITLE
[5.6] Add alias for calling with single state

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -118,6 +118,17 @@ class FactoryBuilder
     }
 
     /**
+     * Set the state to be applied to the model.
+     *
+     * @param  string  $state
+     * @return $this
+     */
+    public function state($state)
+    {
+        return $this->states([$state]);
+    }
+
+    /**
      * Set the states to be applied to the model.
      *
      * @param  array|mixed  $states

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -53,7 +53,7 @@ class EloquentFactoryBuilderTest extends TestCase
 
         $factory->afterMakingState(FactoryBuildableUser::class, 'with_callable_server', function (FactoryBuildableUser $user, Generator $faker) {
             $server = factory(FactoryBuildableServer::class)
-                ->states('callable')
+                ->state('callable')
                 ->make(['user_id' => $user->id]);
 
             $user->servers->push($server);
@@ -91,7 +91,7 @@ class EloquentFactoryBuilderTest extends TestCase
 
         $factory->afterCreatingState(FactoryBuildableUser::class, 'with_callable_server', function (FactoryBuildableUser $user, Generator $faker) {
             $server = factory(FactoryBuildableServer::class)
-                ->states('callable')
+                ->state('callable')
                 ->create(['user_id' => $user->id]);
         });
 
@@ -186,11 +186,11 @@ class EloquentFactoryBuilderTest extends TestCase
     /**
      * @test
      */
-    public function creating_models_with_callable_states()
+    public function creating_models_with_callable_state()
     {
         $server = factory(FactoryBuildableServer::class)->create();
 
-        $callableServer = factory(FactoryBuildableServer::class)->states('callable')->create();
+        $callableServer = factory(FactoryBuildableServer::class)->state('callable')->create();
 
         $this->assertEquals('active', $server->status);
         $this->assertEquals(['Storage', 'Data'], $server->tags);
@@ -200,11 +200,11 @@ class EloquentFactoryBuilderTest extends TestCase
     /**
      * @test
      */
-    public function creating_models_with_inline_states()
+    public function creating_models_with_inline_state()
     {
         $server = factory(FactoryBuildableServer::class)->create();
 
-        $inlineServer = factory(FactoryBuildableServer::class)->states('inline')->create();
+        $inlineServer = factory(FactoryBuildableServer::class)->state('inline')->create();
 
         $this->assertEquals('active', $server->status);
         $this->assertEquals('inline', $inlineServer->status);
@@ -249,9 +249,9 @@ class EloquentFactoryBuilderTest extends TestCase
     }
 
     /** @test **/
-    public function creating_models_with_after_callback_states()
+    public function creating_models_with_after_callback_state()
     {
-        $user = factory(FactoryBuildableUser::class)->states('with_callable_server')->create();
+        $user = factory(FactoryBuildableUser::class)->state('with_callable_server')->create();
 
         $this->assertNotNull($user->profile);
         $this->assertNotNull($user->servers->where('status', 'callable')->first());
@@ -276,9 +276,9 @@ class EloquentFactoryBuilderTest extends TestCase
     }
 
     /** @test **/
-    public function making_models_with_after_callback_states()
+    public function making_models_with_after_callback_state()
     {
-        $user = factory(FactoryBuildableUser::class)->states('with_callable_server')->make();
+        $user = factory(FactoryBuildableUser::class)->state('with_callable_server')->make();
 
         $this->assertNotNull($user->profile);
         $this->assertNotNull($user->servers->where('status', 'callable')->first());


### PR DESCRIPTION
Minor - I know - but I find that when I'm using factory states I'm only ever using a single state at a time. I don't think I've ever used multiple states with a factory. I've tried calling just `state()` so many times assuming it would work and then realising it doesn't. Also, it just reads better when you're only dealing with a single argument.

```php
// Still works...
$listing = factory(Listing::class)->states('activated')->create();

// Reads better...
$listing = factory(Listing::class)->state('activated')->create();
```