### PR TITLE
[5.6] Fix call to "setConnection" method that is not present in the "PresenceVerifierInterface"

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1047,7 +1047,9 @@ class Validator implements ValidatorContract
     protected function getPresenceVerifierFor($connection)
     {
         return tap($this->getPresenceVerifier(), function ($verifier) use ($connection) {
-            $verifier->setConnection($connection);
+            if (method_exists($verifier, 'setConnection')) {
+                $verifier->setConnection($connection);
+            }
         });
     }
 

--- a/tests/Validation/ValidationCustomPresenceVerifierTest.php
+++ b/tests/Validation/ValidationCustomPresenceVerifierTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Validator;
+use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Validation\PresenceVerifierInterface;
+
+class ValidationCustomPresenceVerifierTest extends TestCase
+{
+    protected function tearDown()
+    {
+        m::close();
+    }
+
+    public function testSetConnectionShouldNotBeCalledOnCustomPresenceVerifierWithUniqueRule()
+    {
+        $translator = m::mock(Translator::class);
+        $verifier = $this->getPresenceVerifier();
+
+        $validator = new Validator($translator, ['username' => 'foo'], ['username' => 'unique:users']);
+        $validator->setPresenceVerifier($verifier);
+
+        $validator->fails();
+    }
+
+    public function testSetConnectionShouldNotBeCalledOnCustomPresenceVerifierWithExistsRule()
+    {
+        $translator = m::mock(Translator::class);
+        $translator->shouldReceive('trans')->twice();
+        $verifier = $this->getPresenceVerifier();
+
+        $validator = new Validator($translator, ['username' => 'foo'], ['username' => 'exists:users']);
+        $validator->setPresenceVerifier($verifier);
+
+        $validator->fails();
+    }
+
+    protected function getPresenceVerifier()
+    {
+        $verifier = m::mock(PresenceVerifierInterface::class);
+        $verifier
+            ->shouldReceive('getCount')
+            ->once();
+        $verifier
+            ->shouldReceive('setConnection')
+            ->never();
+        return $verifier;
+    }
+}

--- a/tests/Validation/ValidationCustomPresenceVerifierTest.php
+++ b/tests/Validation/ValidationCustomPresenceVerifierTest.php
@@ -47,7 +47,7 @@ class ValidationCustomPresenceVerifierTest extends TestCase
         $verifier
             ->shouldReceive('setConnection')
             ->never();
-        
+
         return $verifier;
     }
 }

--- a/tests/Validation/ValidationCustomPresenceVerifierTest.php
+++ b/tests/Validation/ValidationCustomPresenceVerifierTest.php
@@ -47,6 +47,7 @@ class ValidationCustomPresenceVerifierTest extends TestCase
         $verifier
             ->shouldReceive('setConnection')
             ->never();
+        
         return $verifier;
     }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1648,42 +1648,36 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(0);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:connection.users']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock->shouldReceive('setConnection')->once()->with('connection');
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(0);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,1']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id', [])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,1,id_col']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id_col', [])->andReturn(2);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['users' => [['id' => 1, 'email' => 'foo']]], ['users.*.email' => 'Unique:users,email,[users.*.id]']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', '1', 'id', [])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,NULL,id_col,foo,bar']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', null, 'id_col', ['foo' => 'bar'])->andReturn(2);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
@@ -1696,7 +1690,6 @@ class ValidationValidatorTest extends TestCase
             '*.email' => 'unique:users', '*.type' => 'exists:user_types',
         ]);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock->shouldReceive('setConnection')->twice()->with(null);
         $mock->shouldReceive('getCount')->with('users', 'email', 'foo', null, null, [])->andReturn(0);
         $mock->shouldReceive('getCount')->with('user_types', 'type', 'bar', null, null, [])->andReturn(1);
         $v->setPresenceVerifier($mock);
@@ -1710,7 +1703,6 @@ class ValidationValidatorTest extends TestCase
             '*.type' => (new Exists('user_types'))->where($closure),
         ]);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock->shouldReceive('setConnection')->twice()->with(null);
         $mock->shouldReceive('getCount')->with('users', 'email', 'foo', null, 'id', [$closure])->andReturn(0);
         $mock->shouldReceive('getCount')->with('user_types', 'type', 'bar', null, null, [$closure])->andReturn(1);
         $v->setPresenceVerifier($mock);
@@ -1722,7 +1714,6 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
@@ -1730,28 +1721,24 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users,email,account_id,1,name,taylor']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, ['account_id' => 1, 'name' => 'taylor'])->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users,email_addr']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', null, null, [])->andReturn(false);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => ['foo']], ['email' => 'Exists:users,email_addr']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getMultiCount')->once()->with('users', 'email_addr', ['foo'], [])->andReturn(false);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:connection.users']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock->shouldReceive('setConnection')->once()->with('connection');
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
@@ -1769,7 +1756,6 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['id' => '1'], ['id' => 'Integer|Exists:users,id']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '1', null, null, [])->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());


### PR DESCRIPTION
Before this PR, when I tried to define a custom implementation for the PresenceVerifierInterface in the Validator, I received a "call to undefined method CustomPresenceVerifier::setConnection()" error message, because the interface does not have that method. So I just added an if statement checking if the verifier object has the setConnection method, so that it won't break the existing default implementation (DatabasePresenceVerifier).

Specifically, this method was called when the "unique" and "exists" rules were evaluated. I added a test as well...
