### PR TITLE
add --step option to migrate:fresh command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -51,6 +51,7 @@ class FreshCommand extends Command
             '--database' => $database,
             '--path' => $this->input->getOption('path'),
             '--realpath' => $this->input->getOption('realpath'),
+            '--step' => $this->input->getOption('step'),
             '--force' => true,
         ]);
 
@@ -131,6 +132,8 @@ class FreshCommand extends Command
             ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
 
             ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder.'],
+            
+            ['step', null, InputOption::VALUE_NONE, 'Force the migrations to be run so they can be rolled back individually.'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -132,7 +132,7 @@ class FreshCommand extends Command
             ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
 
             ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder.'],
-            
+
             ['step', null, InputOption::VALUE_NONE, 'Force the migrations to be run so they can be rolled back individually.'],
         ];
     }


### PR DESCRIPTION
This PR adds the --step option to the `migrate:fresh` command and passes it to the `migrate` command.

I tried to run `migrate:fresh --seed --step`, and then test if i could individually run back the migrations. But trying that throws a `The "--step" option does not exist.` error.
