### PR TITLE
[5.7] Optional logging of request information for Session DB driver

### DIFF
--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -44,6 +44,13 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
     protected $container;
 
     /**
+     * Which request information should be logged.
+     *
+     * @var array
+     */
+    protected $logging;
+
+    /**
      * The existence state of the session.
      *
      * @var bool
@@ -59,10 +66,11 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
      * @param  \Illuminate\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(ConnectionInterface $connection, $table, $minutes, Container $container = null)
+    public function __construct(ConnectionInterface $connection, $table, $minutes, Container $container = null, array $logging = [])
     {
         $this->table = $table;
         $this->minutes = $minutes;
+        $this->logging = $logging;
         $this->container = $container;
         $this->connection = $connection;
     }
@@ -238,6 +246,10 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
      */
     protected function ipAddress()
     {
+        if (! Arr::get($this->logging, 'ip_address', true)) {
+            return null;
+        }
+
         return $this->container->make('request')->ip();
     }
 
@@ -248,6 +260,10 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
      */
     protected function userAgent()
     {
+        if (! Arr::get($this->logging, 'user_agent', true)) {
+            return null;
+        }
+
         return substr((string) $this->container->make('request')->header('User-Agent'), 0, 500);
     }
 

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -74,8 +74,10 @@ class SessionManager extends Manager
 
         $lifetime = $this->app['config']['session.lifetime'];
 
+        $logging = $this->app['config']['session.logging'] ?: [];
+
         return $this->buildSession(new DatabaseSessionHandler(
-            $this->getDatabaseConnection(), $table, $lifetime, $this->app
+            $this->getDatabaseConnection(), $table, $lifetime, $this->app, $logging
         ));
     }
 


### PR DESCRIPTION
With this PR you can choose which information should be logged by DB session driver.

This can be useful to avoid storing personal data for privacy reasons.

In config/session.php (will follow another PR to laravel/laravel if this is accepted):

```php
// ...

/*
|--------------------------------------------------------------------------
| Session Database Logging
|--------------------------------------------------------------------------
|
| When using the "database" session driver, you may specify which
| request information should be logged.
|
*/

'logging' => [
    'ip_address' => env('SESSION_LOG_IP_ADDRESS', true),
    'user_agent' => env('SESSION_LOG_USER_AGENT', true),
],

// ...
```

IP Address and User Agent are logged by default to avoid breaking changes.

Inspired by @barryvdh suggestion in https://github.com/laravel/ideas/issues/1245