### PR TITLE
Remove redundant compile action code

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -143,10 +143,6 @@ class RouteRegistrar
      */
     protected function registerRoute($method, $uri, $action = null)
     {
-        if (! is_array($action)) {
-            $action = array_merge($this->attributes, $action ? ['uses' => $action] : []);
-        }
-
         return $this->router->{$method}($uri, $this->compileAction($action));
     }
 


### PR DESCRIPTION
The compileAction() method below does the same thing as the removed code.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
