### PR TITLE
bugifx: Eloquent\Collection mapWithKeys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -238,6 +238,24 @@ class Collection extends BaseCollection implements QueueableCollection
             return ! $item instanceof Model;
         }) ? $result->toBase() : $result;
     }
+    
+    
+    /**
+     * Run an associative map over each of the items.
+     *
+     * The callback should return an associative array with a single key/value pair.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function mapWithKeys(callable $callback)
+    {
+        $result = parent::mapWithKeys($callback);
+
+        return $result->contains(function ($item) {
+            return ! $item instanceof Model;
+        }) ? $result->toBase() : $result;
+    }
 
     /**
      * Reload a fresh model instance from the database for all the entities.

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -238,8 +238,7 @@ class Collection extends BaseCollection implements QueueableCollection
             return ! $item instanceof Model;
         }) ? $result->toBase() : $result;
     }
-    
-    
+
     /**
      * Run an associative map over each of the items.
      *

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -245,7 +245,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * The callback should return an associative array with a single key/value pair.
      *
      * @param  callable  $callback
-     * @return static
+     * @return \Illuminate\Support\Collection|static
      */
     public function mapWithKeys(callable $callback)
     {

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -226,6 +226,33 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(BaseCollection::class, get_class($c));
     }
 
+    public function testMapWithKeys()
+    {
+        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock('Illuminate\Database\Eloquent\Model');
+
+        $c = new Collection([$one, $two]);
+
+        $cAfterMap = $c->mapWithKeys(function ($item, $position) {
+            return [$position => $item];
+        });
+
+        $this->assertEquals($c->all(), $cAfterMap->all());
+        $this->assertInstanceOf(Collection::class, $cAfterMap);
+    }
+
+    public function testMappingWithKeysToNonModelsReturnsABaseCollection()
+    {
+        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock('Illuminate\Database\Eloquent\Model');
+
+        $c = (new Collection([$one, $two]))->map(function ($item, $position) {
+            return [$position => 'not-a-model'];
+        });
+
+        $this->assertEquals(BaseCollection::class, get_class($c));
+    }
+
     public function testCollectionDiffsWithGivenCollection()
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');


### PR DESCRIPTION
Replicate the same behaviour as `map`. Since `mapWithKeys` should not return an Eloquent Collection but a Support Collection since it's no longer a model.

I was experiencing this error after modifying an Eloquent Collection with `mapWithKeys` and using the result in a `Job`. The error was thrown on `SerializesModels` `__sleep` method.
