### PR TITLE
[5.5] Two Azure SQL Server "connection lost" messages (#24566)

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -32,6 +32,8 @@ trait DetectsLostConnections
             'child connection forced to terminate due to client_idle_limit',
             'query_wait_timeout',
             'reset by peer',
+            'Physical connection is not usable',
+            'TCP Provider: Error code 0x68',
         ]);
     }
 }


### PR DESCRIPTION
Merging pull request #24566 into 5.5 LTS. 

> Using SQL Server database laravel doesn't handle dropped connections in workers so we end up with
> `ERROR: SQLSTATE[08S02]: [Microsoft][ODBC Driver 13 for SQL Server]SMux Provider: Physical connection is not usable [xFFFFFFFF].`