### PR TITLE
[5.6] Fix multiple notification recipients

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -186,7 +186,7 @@ class MailChannel
 
         return collect($recipients)->mapWithKeys(function ($recipient, $email) {
             return is_numeric($email)
-                    ? [(is_string($recipient) ? $recipient : $recipient->email)]
+                    ? [$email => (is_string($recipient) ? $recipient : $recipient->email)]
                     : [$email => $recipient];
         })->all();
     }

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -143,7 +143,7 @@ class SendingMailNotificationsTest extends TestCase
 
         $user->notify($notification);
     }
-    
+
     public function test_mail_is_sent_with_subject()
     {
         $notification = new TestMailNotificationWithSubject;

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -121,7 +121,7 @@ class SendingMailNotificationsTest extends TestCase
             Mockery::on(function ($closure) {
                 $message = Mockery::mock(\Illuminate\Mail\Message::class);
 
-                $message->shouldReceive('to')->once()->with(['taylor@laravel.com' => 'Taylor Otwell', 'foo_taylor@laravel.com']);
+                $message->shouldReceive('to')->once()->with(['taylor@laravel.com' => 'Taylor Otwell', 'foo_taylor@laravel.com', 'bar_taylor@laravel.com']);
 
                 $message->shouldReceive('cc')->once()->with('cc@deepblue.com', 'cc');
 
@@ -201,6 +201,7 @@ class NotifiableUserWithNamedAddress extends NotifiableUser
         return [
             $this->email => $this->name,
             'foo_'.$this->email,
+            'bar_'.$this->email,
         ];
     }
 }


### PR DESCRIPTION
PR #24606 unfortunately broke on-demand notifications addressed to multiple recipients.
This fixes Issue  #24729 and #24956