### PR TITLE
[5.7] add Store to CacheFacade class doc block

### DIFF
--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Contracts\Cache\Repository  store(string|null $name = null)
+ * @method static \Illuminate\Contracts\Cache\Repository store(string|null $name = null)
  * @method static bool has(string $key)
  * @method static mixed get(string $key, mixed $default = null)
  * @method static mixed pull(string $key, mixed $default = null)
@@ -20,6 +20,7 @@ namespace Illuminate\Support\Facades;
  *
  * @see \Illuminate\Cache\CacheManager
  * @see \Illuminate\Cache\Repository
+ * @see \Illuminate\Contracts\Cache\Store
  */
 class Cache extends Facade
 {


### PR DESCRIPTION
I see the Illuminate\Cache\CacheManager class dynamically calling methods of Illuminate\Contracts\Cache\Store implementation. The current [laravel document](https://laravel.com/docs/5.6/cache) also describes how to use Store's methods such as forever, increment, decrement,...

Therefore, I think it's helpful to add the Illuminate\Contracts\Cache\Store interface to CacheFacade class doc block that helps developers quickly to checkout available methods without visiting online documentation.

This is CacheManager::__call() for details.

```
/**
 * Dynamically call the default driver instance.
 *
 * @param  string  $method
 * @param  array   $parameters
 * @return mixed
*/
public function __call($method, $parameters)
{
    return $this->store()->$method(...$parameters);
}
```

Thanks for reviewing!