### PR TITLE
[5.7] Correct segmentProvider in HttpRequestTest

### DIFF
--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -79,9 +79,9 @@ class HttpRequestTest extends TestCase
     {
         return [
             ['', 1, 'default'],
-            ['foo/bar//baz', '1', 'foo'],
-            ['foo/bar//baz', '2', 'bar'],
-            ['foo/bar//baz', '3', 'baz'],
+            ['foo/bar//baz', 1, 'foo'],
+            ['foo/bar//baz', 2, 'bar'],
+            ['foo/bar//baz', 3, 'baz'],
         ];
     }
 


### PR DESCRIPTION
The Illuminate\Http\Request::segment() method expects the first parameter $index to be an integer.

```php
/**
 * Get a segment from the URI (1 based index).
 *
 * @param  int  $index
 * @param  string|null  $default
 * @return string|null
 */
public function segment($index, $default = null)
{
    return Arr::get($this->segments(), $index - 1, $default);
}
```

But the HttpRequestTest::segmentProvider() provides some indexes that are string. Let's take a look at the HttpRequestTest::testSegmentMethod() and HttpRequestTest::segmentProvider().

```php
/**
 * @dataProvider segmentProvider
 */
public function testSegmentMethod($path, $segment, $expected)
{
    $request = Request::create($path, 'GET');
    $this->assertEquals($expected, $request->segment($segment, 'default'));
}

public function segmentProvider()
{
    return [
        ['', 1, 'default'],
        ['foo/bar//baz', '1', 'foo'],
        ['foo/bar//baz', '2', 'bar'],
        ['foo/bar//baz', '3', 'baz'],
    ];
}
```

In this pull request, I just correct HttpRequestTest::segmentProvider() that should provide exact integeres ($index) for HttpRequestTest::testSegmentMethod()