### PR TITLE
Arabic Numbers Middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/ArabicNumbers.php
+++ b/src/Illuminate/Foundation/Http/Middleware/ArabicNumbers.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Middleware;
+
+class ArabicNumbers extends TransformsRequest
+{
+    /**
+     * The attributes that should not be trimmed.
+     *
+     * @var array
+     */
+    protected $except = [
+        //
+    ];
+
+    /**
+     * Transform the given value.
+     *
+     * @param  string $key
+     * @param  mixed $value
+     * @return mixed
+     */
+    protected function transform($key, $value)
+    {
+        if (in_array($key, $this->except, true)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $eastern = ['٠', '١', '٢', '٣', '٤', '٥', '٦', '٧', '٨', '٩'];
+            $western = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+
+            return str_replace($eastern, $western, $value);
+        }
+
+        return $value;
+    }
+}

--- a/tests/Foundation/Http/Middleware/ArabicNumbersTest.php
+++ b/tests/Foundation/Http/Middleware/ArabicNumbersTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Http\Middleware\ArabicNumbers;
+
+class ArabicNumbersTest extends TestCase
+{
+    public function testArabicNumbers(): void
+    {
+        $middleware = new ArabicNumbers;
+        $request = new Request(
+            [
+                'name' => 'Mostafa',
+                'age' => '٢٧',
+                'cell_number' => '١٢٣٤٥٦',
+            ]
+        );
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals('Mostafa', $request->get('name'));
+            $this->assertEquals(27, $request->get('age'));
+            $this->assertEquals('123456', $request->get('cell_number'));
+        });
+    }
+
+    public function testAjaxArabicNumbers(): void
+    {
+        $middleware = new ArabicNumbers;
+        $request = new Request([
+                'name' => 'Mostafa',
+                'age' => '٢٧',
+                'cell_number' => '١٢٣٤٥٦',
+                'CONTENT_TYPE' => '/json',
+            ]
+        );
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals('Mostafa', $request->get('name'));
+            $this->assertEquals('27', $request->get('age'));
+            $this->assertEquals('123456', $request->get('cell_number'));
+        });
+    }
+}


### PR DESCRIPTION
convert Arabic numerals (٠	١	٢	٣	٤	٥	٦	٧	٨	٩) from any user input to a numeric value.
The problem often happens with Arabic inputs from Apple Devices (iPhone, iPad, Mac's ...etc).