### PR TITLE
[5.7] Type-hint constructor for abstract manager

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Closure;
 use InvalidArgumentException;
+use Illuminate\Contracts\Container\Container;
 
 abstract class Manager
 {
@@ -31,10 +32,10 @@ abstract class Manager
     /**
      * Create a new manager instance.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Container\Container  $app
      * @return void
      */
-    public function __construct($app)
+    public function __construct(Container $app)
     {
         $this->app = $app;
     }

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -6,24 +6,22 @@ use Aws\Ses\SesClient;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
+use Illuminate\Container\Container;
 use Illuminate\Mail\TransportManager;
-use Illuminate\Foundation\Application;
 use Illuminate\Mail\Transport\SesTransport;
 
 class MailSesTransportTest extends TestCase
 {
     public function testGetTransport()
     {
-        /** @var Application $app */
-        $app = [
-            'config' => new Collection([
-                'services.ses' => [
-                    'key'    => 'foo',
-                    'secret' => 'bar',
-                    'region' => 'us-east-1',
-                ],
-            ]),
-        ];
+        $app = new Container;
+        $app->instance('config', new Collection([
+            'services.ses' => [
+                'key'    => 'foo',
+                'secret' => 'bar',
+                'region' => 'us-east-1',
+            ],
+        ]));
 
         $manager = new TransportManager($app);
 


### PR DESCRIPTION
I really love using `Illuminate\Support\Manager` class for a lot of cases but it's a bit annoying to register every manager in a service provider just because it's constructor is not type-hinted and `$app` variable cannot be resolved automatically.