### PR TITLE
[5.6] Move saveMany test

### DIFF
--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -16,6 +16,21 @@ class DatabaseEloquentHasManyTest extends TestCase
         m::close();
     }
 
+    public function testSaveManyMethod()
+    {
+        $relation = $this->getRelation();
+
+        $mockModel = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['save'])->getMock();
+        $mockModel->expects($this->once())->method('save');
+
+        $mockModel2 = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['save'])->getMock();
+        $mockModel2->expects($this->once())->method('save');
+
+        $result = $relation->saveMany([$mockModel, $mockModel2]);
+
+        $this->assertEquals([$mockModel, $mockModel2], $result);
+    }
+
     public function testMakeMethodDoesNotSaveNewModel()
     {
         $relation = $this->getRelation();

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -213,21 +213,6 @@ class EloquentFactoryBuilderTest extends TestCase
     /**
      * @test
      */
-    public function creating_models_with_relationships()
-    {
-        factory(FactoryBuildableUser::class, 2)
-            ->create()
-            ->each(function ($user) {
-                $user->servers()->saveMany(factory(FactoryBuildableServer::class, 2)->make());
-            })
-            ->each(function ($user) {
-                $this->assertCount(2, $user->servers);
-            });
-    }
-
-    /**
-     * @test
-     */
     public function creating_models_on_custom_connection()
     {
         $user = factory(FactoryBuildableUser::class)


### PR DESCRIPTION
I believe this test doesn't need to exist because the essence of this test seens to be that a collection can be looped over using `each`, and relationships can be saved using the model, which doesn't have anything to do with the factory that the test class is concerned with. Since these tests exist elsewhere in the test suite, I suggest removing this test.

Well, actually, I assumed these tests already exist elsewhere in the test suite, but I discovered that this test in `EloquentFactoryBuilderTest` is the only test covering `HasOneOrMany::saveMany`, so I added a test for `saveMany` where I found a better home for it.