### PR TITLE
[5.6] Fix inverted fake logic

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -234,7 +234,7 @@ class EventFake implements Dispatcher
                             ? $event($eventName, $payload)
                             : $event === $eventName;
             })
-            ->isEmpty();
+            ->isNotEmpty();
     }
 
     /**

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -78,7 +78,7 @@ class SupportTestingEventFakeTest extends TestCase
     public function testAssertDispatchedWithIgnore()
     {
         $dispatcher = m::mock(Dispatcher::class);
-        $dispatcher->shouldReceive('dispatch')->twice();
+        $dispatcher->shouldReceive('dispatch')->once();
 
         $fake = new EventFake($dispatcher, [
             'Foo',

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -91,9 +91,9 @@ class SupportTestingEventFakeTest extends TestCase
         $fake->dispatch('Bar', ['id' => 1]);
         $fake->dispatch('Baz');
 
-        $fake->assertNotDispatched('Foo');
-        $fake->assertNotDispatched('Bar');
-        $fake->assertDispatched('Baz');
+        $fake->assertDispatched('Foo');
+        $fake->assertDispatched('Bar');
+        $fake->assertNotDispatched('Baz');
     }
 }
 


### PR DESCRIPTION
This pull request fixes a breaking change introduced in #24887. As @aliselcuk describes, the logic to fake events was inverted and is breaking existing code.

This is fixed now and all events passed to `$eventsToFake` will be faked, instead of ignored.

Sorry for my mistake!