### PR TITLE
[5.6] Move saveMany test

### DIFF
--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -16,6 +16,21 @@ class DatabaseEloquentHasManyTest extends TestCase
         m::close();
     }
 
+    public function testSaveManyMethod()
+    {
+        $relation = $this->getRelation();
+
+        $mockModel = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['save'])->getMock();
+        $mockModel->expects($this->once())->method('save');
+
+        $mockModel2 = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['save'])->getMock();
+        $mockModel2->expects($this->once())->method('save');
+
+        $result = $relation->saveMany([$mockModel, $mockModel2]);
+
+        $this->assertEquals([$mockModel, $mockModel2], $result);
+    }
+
     public function testMakeMethodDoesNotSaveNewModel()
     {
         $relation = $this->getRelation();

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -213,21 +213,6 @@ class EloquentFactoryBuilderTest extends TestCase
     /**
      * @test
      */
-    public function creating_models_with_relationships()
-    {
-        factory(FactoryBuildableUser::class, 2)
-            ->create()
-            ->each(function ($user) {
-                $user->servers()->saveMany(factory(FactoryBuildableServer::class, 2)->make());
-            })
-            ->each(function ($user) {
-                $this->assertCount(2, $user->servers);
-            });
-    }
-
-    /**
-     * @test
-     */
     public function creating_models_on_custom_connection()
     {
         $user = factory(FactoryBuildableUser::class)


### PR DESCRIPTION
Sorry for the opus, I apparently didn't supply enough explanation previously. So here goes:

First of all, I know this may seem like a weird pull request, but having having a clean test suite is just as important as having clean production code. If a developer wants to find out where a test is for a piece of production code they are looking at, it should be easy to find. Additionally, test classes should contain tests that test the thing that the class is purporting to test. If it doesn't, it should be removed or deleted. A pretty framework like Laravel can and should have organized and pretty tests.

Anyway, I was looking at the factory builder and the corresponding tests (tests make good documentation for how something works), and noticed a weird test: `creating_models_with_relationships` inside of `EloquentFactoryBuilderTest.php` which you would think should be testing `EloquentFactoryBuilder` right?

Well on the surface it may look like it's testing `EloquentFactoryBuilder`, because it's using it. But if you look at it a little more closely, you'll notice that it's only interacting with `EloquentFactoryBuilder` in order to get a collection. In other words, the test would still work if you replaced `factory(FactoryBuildableUser::class, 2)` with any collection of models. Thus, the only assertion this test is making against `EloquentFactoryBuilder` is that it returns a collection.

As it turns out, the test `EloquentFactoryBuilder::creating_collection_of_models` is already asserting that very thing: `$this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $instances);`. That makes this test redundant, only as far as `EloquentFactoryBuilder` is concerned.

We can't remove the test yet, because we could still potentially remove code coverage that we're relying on. What else is this code testing? For one, it looks like `Collection::each`. We already have code coverage there which is sufficient. The only other thing it could be testing is `HasOneOrMany::saveMany`. At this point, to see if there's any other tests covering this method, you can simply comment out the contents of `HasOneOrMany::saveMany` and see what tests fail. 

At this point it looks like this is the only test covering that particular piece of production code so we can't remove this test method without adding coverage for `HasOneOrMany::saveMany` somewhere else, preferably not in `EloquentFactoryBuilderTest` because that wouldn't be make for good test suite organization.

So that's why I added a test method in `DatabaseElqouentHasManyTest`