### PR TITLE
[5.7] Allow setting full Mailgun API URL

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -161,7 +161,7 @@ class MailgunTransport extends Transport
      */
     public function setDomain($domain)
     {
-        $this->url = 'https://api.mailgun.net/v3/'.$domain.'/messages.mime';
+        $this->url = $domain.'/messages.mime';
 
         return $this->domain = $domain;
     }


### PR DESCRIPTION
This PR resolves #24987.

Mailgun recently launched a new EU endpoint which isn't compatible with the current Laravel integration as the URL is forced to begin with `https://api.mailgun.net/v3/`, but now needs to being with `https://api.eu.mailgun.net/v3/`.

This PR would allow setting the full URL for Mailgun's API manually, which ensures any future endpoints they may launch can also be supported.