### PR TITLE
[5.6] Make Mail::assertSentTimes and Mail::assertQueuedTimes public

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -55,7 +55,7 @@ class MailFake implements Mailer
      * @param  int  $times
      * @return void
      */
-    protected function assertSentTimes($mailable, $times = 1)
+    public function assertSentTimes($mailable, $times = 1)
     {
         PHPUnit::assertTrue(
             ($count = $this->sent($mailable)->count()) === $times,
@@ -114,7 +114,7 @@ class MailFake implements Mailer
      * @param  int  $times
      * @return void
      */
-    protected function assertQueuedTimes($mailable, $times = 1)
+    public function assertQueuedTimes($mailable, $times = 1)
     {
         PHPUnit::assertTrue(
             ($count = $this->queued($mailable)->count()) === $times,


### PR DESCRIPTION
Asserting that a specific email was sent or queued is easy using `Mail::assertSent()` or `Mail::assertQueued()`, but asserting how many times an email was sent is difficult because both `Mail::assertSentTimes()` and `Mail::assertQueuedTimes()` are protected. This PR makes both of those methods public.

For example, i'm working on an application that polls rss feeds and then emails you the new items. One of my tests looks like this:
```php
$feedItems = $this->getFeedItems(2);

(new SendNewFeedEntryEmails)->handle(
    new FeedPolled($this->feed, $feedItems)
);

Mail::assertQueued(FeedEntryEmail::class, function (FeedEntryEmail $email) {
    return '2003-06-03 11:39:21' === (string) $email->feedEntry->publishedAt;
});

Mail::assertQueued(FeedEntryEmail::class, function (FeedEntryEmail $email) {
    return '2003-05-30 13:06:42' === (string) $email->feedEntry->publishedAt;
});
```

The problem with this test is that it also passes when i send unexpected FeedEntryEmails. To test that i could add:
```php
Mail::assertNotQueued(FeedEntryEmail::class, function (FeedEntryEmail $email) {
    $publishedAt = (string) $email->feedEntry->publishedAt;

    return $publishedAt !== '2003-06-03 11:39:21' && $publishedAt !== '2003-05-30 13:06:42';
});
```

It would be nicer if i could just do this:
```php
Mail::assertQueuedTimes(FeedEntryEmail::class, 2);
```
