### PR TITLE
[5.6] Make Router::addRoute() public

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -425,7 +425,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  \Closure|array|string|null  $action
      * @return \Illuminate\Routing\Route
      */
-    protected function addRoute($methods, $uri, $action)
+    public function addRoute($methods, $uri, $action)
     {
         return $this->routes->add($this->createRoute($methods, $uri, $action));
     }


### PR DESCRIPTION
I'm developing a package that provides a different mechanism for defining routes. It would be much easier for the package to call `addRoute()` directly instead of the individual human-friendly get/post/etc. methods. I don't want to extend the router in order to reduce conflicts with customized apps or other packages.

Currently I am creating a macro and calling `$this->addRoute()` within the closure.

I am unsure if this would be considered a BC-affecting change, specifically if it affects anyone who is already extending the router and this method in particular. If there is a reason for keeping it protected that I am unaware of, I'd love to hear it.