### PR TITLE
[5.6] Allow comparing attributes both numeric but of different types

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -846,6 +846,10 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) > $parameters[0];
         }
 
+        if (is_numeric($value) && is_numeric($comparedToValue)) {
+            return $value > $comparedToValue;
+        }
+
         $this->requireSameType($value, $comparedToValue);
 
         return $this->getSize($attribute, $value) > $this->getSize($attribute, $comparedToValue);
@@ -869,6 +873,10 @@ trait ValidatesAttributes
 
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) < $parameters[0];
+        }
+
+        if (is_numeric($value) && is_numeric($comparedToValue)) {
+            return $value < $comparedToValue;
         }
 
         $this->requireSameType($value, $comparedToValue);
@@ -896,6 +904,10 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) >= $parameters[0];
         }
 
+        if (is_numeric($value) && is_numeric($comparedToValue)) {
+            return $value >= $comparedToValue;
+        }
+
         $this->requireSameType($value, $comparedToValue);
 
         return $this->getSize($attribute, $value) >= $this->getSize($attribute, $comparedToValue);
@@ -919,6 +931,10 @@ trait ValidatesAttributes
 
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) <= $parameters[0];
+        }
+
+        if (is_numeric($value) && is_numeric($comparedToValue)) {
+            return $value <= $comparedToValue;
         }
 
         $this->requireSameType($value, $comparedToValue);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1066,6 +1066,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'numeric|gt:rhs']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['lhs' => 15.0, 'rhs' => 10], ['lhs' => 'numeric|gt:rhs']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => '15', 'rhs' => 10], ['lhs' => 'numeric|gt:rhs']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->passes());
 
@@ -1081,12 +1087,24 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gt:10']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => 15.0], ['lhs' => 'numeric|gt:10']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => '15'], ['lhs' => 'numeric|gt:10']);
+        $this->assertTrue($v->passes());
     }
 
     public function testLessThan()
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['lhs' => 15, 'rhs' => 10], ['lhs' => 'numeric|lt:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => 15.0, 'rhs' => 10], ['lhs' => 'numeric|lt:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => '15', 'rhs' => 10], ['lhs' => 'numeric|lt:rhs']);
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'lt:rhs']);
@@ -1104,12 +1122,24 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lt:10']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => 15.0], ['lhs' => 'numeric|lt:10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => '15'], ['lhs' => 'numeric|lt:10']);
+        $this->assertTrue($v->fails());
     }
 
     public function testGreaterThanOrEqual()
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['lhs' => 15, 'rhs' => 15], ['lhs' => 'numeric|gte:rhs']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => 15.0, 'rhs' => 15], ['lhs' => 'numeric|gte:rhs']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => '15', 'rhs' => 15], ['lhs' => 'numeric|gte:rhs']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'gte:rhs']);
@@ -1127,12 +1157,24 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gte:15']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => 15.0], ['lhs' => 'numeric|gte:15']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => '15'], ['lhs' => 'numeric|gte:15']);
+        $this->assertTrue($v->passes());
     }
 
     public function testLessThanOrEqual()
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['lhs' => 15, 'rhs' => 15], ['lhs' => 'numeric|lte:rhs']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => 15.0, 'rhs' => 15], ['lhs' => 'numeric|lte:rhs']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => '15', 'rhs' => 15], ['lhs' => 'numeric|lte:rhs']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'lte:rhs']);
@@ -1149,6 +1191,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lte:10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => 15.0], ['lhs' => 'numeric|lte:10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => '15'], ['lhs' => 'numeric|lte:10']);
         $this->assertTrue($v->fails());
     }
 


### PR DESCRIPTION
Fixing #24650.

Previously, you could validate "numericly" values when comparing with a directly-supplied number.

Now, you can do the same when the parameter is an attribute name.