### PR TITLE
[5.6] Fix session file check and removed unnecessary call

### DIFF
--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -66,9 +66,9 @@ class FileSessionHandler implements SessionHandlerInterface
      */
     public function read($sessionId)
     {
-        if ($this->files->exists($path = $this->path.'/'.$sessionId)) {
-            if (filemtime($path) >= Carbon::now()->subMinutes($this->minutes)->getTimestamp()) {
-                return $this->files->get($path, true);
+        if ($this->files->isFile($path = $this->path.'/'.$sessionId)) {
+            if ($this->files->lastModified($path) >= Carbon::now()->subMinutes($this->minutes)->getTimestamp()) {
+                return $this->files->sharedGet($path);
             }
         }
 


### PR DESCRIPTION
The original code was calling the ```$this->files->exists()``` method, this is not correct (runs ```file_exists()``` function which will return true on a directory or a file. Replaced it with the ```$this->files->isFile()``` method.

Also changed the ```filemtime()``` call to ```$this->files->lastModified($path)``` method which calls ```filemtime()``` in the end, so this is more a cleaner way.

Finally changed the ```$this->files->get()``` call to ```$this->files->sharedGet()``` because it was already calling this method within the ```$this->files->get()``` function.
The ```$this->files->get()``` method would also do a ```isFile()``` check, so by directly calling ```$this->files->sharedGet()``` the extra check is skipped.