### PR TITLE
[5.7] Fix SRP compliance in MailgunTransport

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -23,7 +23,7 @@ class MailgunTransport extends Transport
     protected $key;
 
     /**
-     * The Mailgun domain.
+     * The Mailgun email domain.
      *
      * @var string
      */
@@ -34,7 +34,7 @@ class MailgunTransport extends Transport
      *
      * @var string
      */
-    protected $url;
+    protected $endpoint;
 
     /**
      * Create a new Mailgun transport instance.
@@ -44,10 +44,12 @@ class MailgunTransport extends Transport
      * @param  string  $domain
      * @return void
      */
-    public function __construct(ClientInterface $client, $key, $domain)
+    public function __construct(ClientInterface $client, $key, $domain, $endpoint = null)
     {
         $this->key = $key;
         $this->client = $client;
+        $this->endpoint = $endpoint ?? 'api.mailgun.net';
+
         $this->setDomain($domain);
     }
 
@@ -62,7 +64,10 @@ class MailgunTransport extends Transport
 
         $message->setBcc([]);
 
-        $this->client->post($this->url, $this->payload($message, $to));
+        $this->client->post(
+            "https://{$this->endpoint}/v3/{$this->domain}/messages.mime",
+            $this->payload($message, $to)
+        );
 
         $this->sendPerformed($message);
 
@@ -162,12 +167,6 @@ class MailgunTransport extends Transport
      */
     public function setDomain($domain)
     {
-        $url = ! Str::startsWith($domain, ['http://', 'https://'])
-                        ? 'https://api.mailgun.net/v3/'.$domain
-                        : $domain;
-
-        $this->url = $url.'/messages.mime';
-
         return $this->domain = $domain;
     }
 }

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -118,7 +118,9 @@ class TransportManager extends Manager
 
         return new MailgunTransport(
             $this->guzzle($config),
-            $config['secret'], $config['domain']
+            $config['secret'],
+            $config['domain'],
+            $config['endpoint'] ?? null
         );
     }
 


### PR DESCRIPTION
The `MailgunTransport::setDomain()` method does not comply with the single responsibility pattern and we can't have that.

Joking aside, I didn't really like how #24994 looked and 8544966 just makes it messier IMO.

This PR does:
- Pass optional `endpoint` config parameter to `MailgunTransport`
- Remove `$url` property and construct it on the fly in `send()` method, instead of in `setDomain()`


