### PR TITLE
[5.6] Bugfix: concurrent write of bootstrap/cache/packages.php

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -97,6 +97,8 @@ class PackageManifest
             $this->build();
         }
 
+        $this->files->get($this->manifestPath, true);
+
         return $this->manifest = file_exists($this->manifestPath) ?
             $this->files->getRequire($this->manifestPath) : [];
     }
@@ -166,7 +168,8 @@ class PackageManifest
         }
 
         $this->files->put(
-            $this->manifestPath, '<?php return '.var_export($manifest, true).';'
+            $this->manifestPath, '<?php return '.var_export($manifest, true).';',
+            true
         );
     }
 }


### PR DESCRIPTION
When there is no bootstrap/cache/*.php, the php process will attemp to
build bootstrap/cache/packages.php, bootstrap/cache/services.php and
etc. If there are two or more php process doing the same thing, it is
possible for one of the process to read a *dirty*
bootstrap/cache/packages.php (not yet finish writing by another
process).

The solution add write and read lock to prevent read an *dirty*
packages.php and write a wrong services.php file.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
