### PR TITLE
[5.6] Fix for HasManyThrough returning incorrect results with cursor(…

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -426,6 +426,16 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Get a generator for the given query.
+     *
+     * @return \Generator
+     */
+    public function cursor()
+    {
+        return $this->prepareQueryBuilder()->cursor();
+    }
+
+    /**
      * Execute a callback over each item while chunking.
      *
      * @param  callable  $callback

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -199,6 +199,27 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         });
     }
 
+    public function testCursorReturnsCorrectModels()
+    {
+        $this->seedData();
+        $this->seedDataExtended();
+        $country = HasManyThroughTestCountry::find(2);
+
+        $posts = $country->posts()->cursor();
+
+        foreach ($posts as $post) {
+            $this->assertEquals([
+                'id',
+                'user_id',
+                'title',
+                'body',
+                'email',
+                'created_at',
+                'updated_at',
+                'country_id', ], array_keys($post->getAttributes()));
+        }
+    }
+
     public function testEachReturnsCorrectModels()
     {
         $this->seedData();


### PR DESCRIPTION
Laravel Version: 5.6.29
PHP Version: 7.1.3 (MacOS 10.13.6)


## Description:
**Summary:** 
This is pull request addresses the issues reported on #22144. Using the cursor() method on a HasManyThrough relation object returns incorrect results. This is due to to the fact that Eloquent QueryBuilder attempts to hydrate the the related model with intermediate model attributes.

> When looping through a belongsToMany association using cursor(), the models aren't correctly hydrated: they get filled with values of the pivot table. If the pivot table have columns with the same name as columns in the related model table, pivot values are used to hydrate the related model.

This is a similar issue to  #24096 where the problem is  issue is a resulted because the intermediate model id is inserted on the query instead of the related model.


## Proposed fix
`cursor()` method was  added to `HasManyThrough` class to correct the selection of columns before they operate. This would contain the behaviour change to `HasManyThrough` without affecting any other behaviours.  Hence, there are no breaking changes introduced.

### Tests
Added and extra test  to `DatabaseEloquentHasManyThroughIntegrationTest` to test `cursor()` . The test asserts that the correct columns are defined. 


