### PR TITLE
[5.6] Avoid "Undefined offset: 0" in RedisQueue.php

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -162,7 +162,11 @@ class RedisQueue extends Queue implements QueueContract
     {
         $this->migrate($prefixed = $this->getQueue($queue));
 
-        list($job, $reserved) = $this->retrieveNextJob($prefixed);
+        if (empty($nextJob = $this->retrieveNextJob($prefixed))) {
+            return;
+        }
+
+        list($job, $reserved) = $nextJob;
 
         if ($reserved) {
             return new RedisJob(


### PR DESCRIPTION
We're experiencing some network issues with our Redis instance, combined with our quite low read timeout the LUA script executed in `RedisQueue::retrieveNextJob()` return `false`.

This PR simply ensures that `retrieveNextJob()` returned a filled array before continuing.