### PR TITLE
[5.6] Fix edge case in assertJsonFragment

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -552,6 +552,7 @@ class TestResponse
         $needle = substr(json_encode([$key => $value]), 1, -1);
 
         return [
+            $needle.':',
             $needle.']',
             $needle.'}',
             $needle.',',

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -167,6 +167,8 @@ class FoundationTestResponseTest extends TestCase
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
+        $response->assertJsonFragment(['foobar']);
+
         $response->assertJsonFragment(['foo' => 'bar']);
 
         $response->assertJsonFragment(['foobar_foo' => 'foo']);


### PR DESCRIPTION
Issue: #24978 .

[This commit](https://github.com/laravel/framework/commit/fc3150c514ff6d2b09e5f270ad0c60d3f69edc8f) broke the test in the first place. 

When asserting whether an array is a fragment of a given json, the test had not regarded that just a key can also be a fragment of a json. 