### PR TITLE
[5.7] Sync changes before firing updated event 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -691,9 +691,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         if (count($dirty) > 0) {
             $this->setKeysForSaveQuery($query)->update($dirty);
-            
             $this->syncChanges();
-            
             $this->fireModelEvent('updated', false);
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -691,10 +691,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         if (count($dirty) > 0) {
             $this->setKeysForSaveQuery($query)->update($dirty);
-
-            $this->fireModelEvent('updated', false);
-
+            
             $this->syncChanges();
+            
+            $this->fireModelEvent('updated', false);
         }
 
         return true;


### PR DESCRIPTION
**! Contains breaking change**

## Problem

1. Logic: Since the updated events suggests the model is now saved (which it is). We should be using the `->wasChanged` function instead of the `->isDirty` functions within this function.

2. Unwanted behaviour: In my case I now check if a value is dirty and then save another. But it will create an infinite loop when you save the model, because the dirty values are still there when you update again. Instead of just that second new value.

## Code example

This is my code example which creates an infinite loop, which it wouldn't when using `->wasChanged`.

`HasLocationObserver`

```php
public function updated(HasLocation $model)
    {
        if ($model->needsLocationUpdate()) {
            FetchLatLong::dispatchNow($model);
        }
    }
```

`Model` function ->needsLocationUpdate()

```php
public function needsLocationUpdate(): bool
    {
        return $this->isDirty(['city', 'country_code']);
    }
```

The `FetchLatLong` job sets the spatial point value and saves again. But since the dirty values from the previous update still are set on the model, it will always return `true` on the `->needsLocationUpdate` function