### PR TITLE
Allow validated data to be retrieved by key.

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -170,13 +170,18 @@ class FormRequest extends Request implements ValidatesWhenResolved
      *
      * @return array
      */
-    public function validated()
+    public function validated($keys = null)
     {
         $rules = $this->container->call([$this, 'rules']);
+        $keys = is_array($keys) ? $keys : func_get_args();
 
-        return $this->only(collect($rules)->keys()->map(function ($rule) {
+        $data = collect($rules)->keys()->map(function ($rule) {
             return explode('.', $rule)[0];
-        })->unique()->toArray());
+        })->unique()->filter(function ($value, $key) use ($keys) {
+            return in_array($value, $keys) ? $value : null;
+        });
+
+        return $this->only($data->toArray());
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -174,13 +174,15 @@ class FormRequest extends Request implements ValidatesWhenResolved
     {
         $rules = $this->container->call([$this, 'rules']);
         $keys = is_array($keys) ? $keys : func_get_args();
-
         $data = collect($rules)->keys()->map(function ($rule) {
             return explode('.', $rule)[0];
-        })->unique()->filter(function ($value, $key) use ($keys) {
-            return in_array($value, $keys) ? $value : null;
-        });
+        })->unique();
 
+        if ($keys) {
+            $data = $data->filter(function ($value, $key) use ($keys) {
+                return in_array($value, $keys) ? $value : null;
+            });
+        }
         return $this->only($data->toArray());
     }
 


### PR DESCRIPTION
We should be able to get the validated data by passing a key or array. 
`$request->validated('name');` or 
`$request->validated('name', 'email');` or 
`$request->validated(['name', 'email']);`

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
