### PR TITLE
[5.6] Add `$this` return hint in docblocks of `BuildsQueries::when` and `BuildsQueries::unless` methods

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -83,7 +83,7 @@ trait BuildsQueries
      * @param  mixed  $value
      * @param  callable  $callback
      * @param  callable  $default
-     * @return mixed
+     * @return mixed|$this
      */
     public function when($value, $callback, $default = null)
     {
@@ -113,7 +113,7 @@ trait BuildsQueries
      * @param  mixed  $value
      * @param  callable  $callback
      * @param  callable  $default
-     * @return mixed
+     * @return mixed|$this
      */
     public function unless($value, $callback, $default = null)
     {


### PR DESCRIPTION
This will allow IDEs like PhpStorm to recognize that whichever class implementing this trait may be returned from these functions, thus not breaking the nice "chain" in Eloquent queries.

I kept the `mixed` there, since you can still return anything truthy from inside the callback, and that would be given back. 