### PR TITLE
[5.6] Use rootNamespace() in 'make' commands extending GeneratorCommand

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -129,7 +129,7 @@ abstract class GeneratorCommand extends Command
     {
         $name = Str::replaceFirst($this->rootNamespace(), '', $name);
 
-        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
+        return $this->rootPath().'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**
@@ -221,6 +221,16 @@ abstract class GeneratorCommand extends Command
     protected function rootNamespace()
     {
         return $this->laravel->getNamespace();
+    }
+
+    /**
+     * Get the root path for the class.
+     *
+     * @return string
+     */
+    protected function rootPath()
+    {
+        return $this->laravel['path'];
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -40,11 +40,11 @@ class ListenerMakeCommand extends GeneratorCommand
         $event = $this->option('event');
 
         if (! Str::startsWith($event, [
-            $this->laravel->getNamespace(),
+            $this->rootNamespace(),
             'Illuminate',
             '\\',
         ])) {
-            $event = $this->laravel->getNamespace().'Events\\'.$event;
+            $event = $this->rootNamespace().'Events\\'.$event;
         }
 
         $stub = str_replace(

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -67,7 +67,7 @@ class ObserverMakeCommand extends GeneratorCommand
     {
         $model = str_replace('/', '\\', $model);
 
-        $namespaceModel = $this->laravel->getNamespace().$model;
+        $namespaceModel = $this->rootNamespace().$model;
 
         if (Str::startsWith($model, '\\')) {
             $stub = str_replace('NamespacedDummyModel', trim($model, '\\'), $stub);

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -76,7 +76,7 @@ class PolicyMakeCommand extends GeneratorCommand
     {
         $model = str_replace('/', '\\', $model);
 
-        $namespaceModel = $this->laravel->getNamespace().$model;
+        $namespaceModel = $this->rootNamespace().$model;
 
         if (Str::startsWith($model, '\\')) {
             $stub = str_replace('NamespacedDummyModel', trim($model, '\\'), $stub);

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -159,7 +159,7 @@ class ControllerMakeCommand extends GeneratorCommand
 
         $model = trim(str_replace('/', '\\', $model), '\\');
 
-        if (! Str::startsWith($model, $rootNamespace = $this->laravel->getNamespace())) {
+        if (! Str::startsWith($model, $rootNamespace = $this->rootNamespace())) {
             $model = $rootNamespace.$model;
         }
 


### PR DESCRIPTION
I stumbled on this when I was extending the `make:{class}` artisan commands to accept another option to allow classes to be created outside of the `/app` directory/namespace. It's only a minor thing, but I found instances in the commands listed below where they used `$this->laravel->getNamespace()` instead of `$this->rootNamespace()` (both of which are identical so no breaking changes):

- \Illuminate\Foundation\Console\ListenerMakeCommand
- \Illuminate\Foundation\Console\ObserverMakeCommand
- \Illuminate\Foundation\Console\PolicyMakeCommand
- \Illuminate\Routing\Console\ControllerMakeCommand

While I was at it, I took the liberty of adding a `rootPath()` method to the base GeneratorCommand, so instead of using `$this->laravel['path']` inside `GeneratorCommand::getPath()` it uses rootPath instead (just makes it easier to extend). Again, it behaves identically and no other commands have a rootPath method, so doesn't affect anything else.