### PR TITLE
Prevent routes with the same name, resolves #25034

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -76,14 +76,7 @@ class ResourceRegistrar
             $this->parameters = $options['parameters'];
         }
 
-        // If the resource name contains a slash, we will assume the developer wishes to
-        // register these resource routes with a prefix so we will set that up out of
-        // the box so they don't have to mess with it. Otherwise, we will continue.
-        if (Str::contains($name, '/')) {
-            $this->prefixedResource($name, $controller, $options);
-
-            return;
-        }
+        $name = str_replace("/",".",$name);
 
         // We need to extract the base resource from the resource name. Nested resources
         // are supported in the framework, but we need to know what name to use for a


### PR DESCRIPTION
If we create two controllers with the same name that one of the is in another folder and we use the resource routing then we have two routes with the same name. Something like this:
```
php artisan make:controller CategoryController
php artisan make:controller Admin/CategoryController
```
```
Route::resource('categories', 'CategoryController');
Route::resource('admin/categories', 'Admin\CategoryController')
```
And I think it's normal to encounter this problem.