### PR TITLE
[5.7] Services can be injected in migrations

### DIFF
--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -57,7 +57,7 @@ class MigrationServiceProvider extends ServiceProvider
         $this->app->singleton('migrator', function ($app) {
             $repository = $app['migration.repository'];
 
-            return new Migrator($repository, $app['db'], $app['files']);
+            return new Migrator($app, $repository, $app['db'], $app['files']);
         });
     }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 class Migrator
@@ -54,17 +55,27 @@ class Migrator
     protected $output;
 
     /**
+     * The IoC container instance.
+     *
+     * @var \Illuminate\Container\Container
+     */
+    protected $container;
+
+    /**
      * Create a new migrator instance.
      *
-     * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
-     * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
-     * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
+     * @param  \Illuminate\Contracts\Container\Container $container
+     * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface $repository
+     * @param  \Illuminate\Database\ConnectionResolverInterface $resolver
+     * @param  \Illuminate\Filesystem\Filesystem $files
      */
-    public function __construct(MigrationRepositoryInterface $repository,
-                                Resolver $resolver,
-                                Filesystem $files)
-    {
+    public function __construct(
+        Container $container,
+        MigrationRepositoryInterface $repository,
+        Resolver $resolver,
+        Filesystem $files
+    ) {
+        $this->container = $container;
         $this->files = $files;
         $this->resolver = $resolver;
         $this->repository = $repository;
@@ -357,7 +368,7 @@ class Migrator
 
         $callback = function () use ($migration, $method) {
             if (method_exists($migration, $method)) {
-                $migration->{$method}();
+                $this->container->call([$migration, $method]);
             }
         };
 

--- a/tests/Database/migrations/three/2018_07_31_000000_create_test_table.php
+++ b/tests/Database/migrations/three/2018_07_31_000000_create_test_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Schema\Builder;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTestTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @param  Builder $builder
+     * @param  DatabaseManager $databaseManager
+     * @return void
+     */
+    public function up(Builder $builder, DatabaseManager $databaseManager)
+    {
+        $builder->create('test', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        $databaseManager->table('test')->insert(['name' => 'PirateKing']);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @param  Builder $builder
+     * @return void
+     */
+    public function down(Builder $builder)
+    {
+        $builder->dropIfExists('test');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.7
| Bug fix?      | no
| New feature?  | yes
| BC break(s)?    | yes
| Test(s) added?   | yes
| Tests pass?   | yes

Currently we can type-hint our services in for example the `boot` method of a service provider, the `rules` and `authorize` methods of a `FormRequest`, in the `handle` method of jobs, Artisan commands etc. but the same doesn't apply to the migration `up` and `down` methods. This is not only inconsistent, but it also means that we have no other choice but to use facades or the global `app()` helper to get our services from the container. There is no reason why we couldn't get our services in the same way we get them in the methods mentioned above so this PR aims to correct that and in doing so it makes the usage of the Laravel migration system even better / more developer-friendly.

The only breaking change is that the `Migrator` now has to take a new parameter in its constructor (the container instance). I also added a test to cover this functionality.
