### PR TITLE
[5.8] fix RedirectResponse session param document

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -26,7 +26,7 @@ class RedirectResponse extends BaseRedirectResponse
     protected $request;
 
     /**
-     * The session store implementation.
+     * The session store instance.
      *
      * @var \Illuminate\Session\Store
      */
@@ -192,7 +192,7 @@ class RedirectResponse extends BaseRedirectResponse
     }
 
     /**
-     * Get the session store implementation.
+     * Get the session store instance.
      *
      * @return \Illuminate\Session\Store|null
      */
@@ -202,7 +202,7 @@ class RedirectResponse extends BaseRedirectResponse
     }
 
     /**
-     * Set the session store implementation.
+     * Set the session store instance.
      *
      * @param  \Illuminate\Session\Store  $session
      * @return void


### PR DESCRIPTION
The [Illuminate\Session\Store](https://github.com/laravel/framework/blob/master/src/Illuminate/Session/Store.php) is a class, not an interface. Thus, the property "$session" of RedirectResponse that is type-hint with Illuminate\Session\Store should be exactly an instance of Illuminate\Session\Store class.


