### PR TITLE
[5.6] Add static|static[] to return hint for findOrFail

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -312,7 +312,7 @@ class Builder
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */


### PR DESCRIPTION
This allows advanced editors like IDEs to better infer the returned result.

Together with https://github.com/barryvdh/laravel-ide-helper this now works (assume ▌is the cursor):
```php
$user = User::findOrFail(123);
$user->na▌// Pressing tab here autocompletes to `name`
```
Also works with collections:
```php
$users = User::findOrFail([123,456]);
foreach ($users as $user) {
    $user->na▌// Pressing tab here autocompletes to `name`
}
```
Previously this only worked with an explicit editor specific type hint, e.g. `/** @var User $user */`.

Furhter,  `static` was added to `firstOrFail()` or `static[]` to `get()` and it beautifully works with IDEs but not so much for `findOrFail`.

It's not perfect due to the polymorphic behaviour of `findOrFail` returning different "kind of things", but it's better then having no autocomplete helper at all.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
