### PR TITLE
[5.6] Passing parameters to Grouped Middleware(s) on Routes middleware setup

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -677,24 +677,23 @@ class Router implements RegistrarContract, BindingRegistrar
     {
         $middleware = collect($route->gatherMiddleware())->map(function ($name) {
             // try to see if the name contains any middleware parameters
-            if (is_string($name) && strpos($name, ':') !== FALSE) {
+            if (is_string($name) && strpos($name, ':') !== false) {
                 list($main_name, $args) = explode(':', $name);
                 // check to see if the `$main_name` is part of the middleware groups only
                 if (array_key_exists($main_name, $this->middlewareGroups)) {
-                    $group =  $this->middlewareGroups[$main_name];
+                    $groups = $this->middlewareGroups[$main_name];
                     // distribute the middleware parameters to all
                     // individual middlewares that make up the group
-                    foreach ($group as $key => $middleware) {
-                        if (!isset($this->middlewareGroups[$middleware])) {
-                            $group[$key] = "{$middleware}:{$args}";
+                    foreach ($groups as $key => $middleware) {
+                        if (! isset($this->middlewareGroups[$middleware])) {
+                            $groups[$key] = "{$middleware}:{$args}";
                         }
                     }
                     // overwrite major group middleware array with modified one
-                    $this->middlewareGroups[$main_name] = $group;
+                    $this->middlewareGroups[$main_name] = $groups;
                     $name = $main_name;
                 }
             }
-            
             return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);
         })->flatten();
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -694,7 +694,7 @@ class Router implements RegistrarContract, BindingRegistrar
                     $name = $main_name;
                 }
             }
-            
+
             return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);
         })->flatten();
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -682,14 +682,11 @@ class Router implements RegistrarContract, BindingRegistrar
                 // check to see if the `$main_name` is part of the middleware groups only
                 if(array_key_exists($main_name, $this->middlewareGroups)){
                     $group =  $this->middlewareGroups[$main_name];
-                    /* 
-                        loop to:
-                        distribute the middleware parameters/arguments to 
-                        all individual middlewares that make up the group
-                    */
+
                     foreach($group as $key => $middleware){
                         $group[$key] = "{$middleware}:{$args}";
                     }
+
                     $this->middlewareGroups[$main_name] = $group;
                     $name = $main_name;
                 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -677,7 +677,7 @@ class Router implements RegistrarContract, BindingRegistrar
     {
         $middleware = collect($route->gatherMiddleware())->map(function ($name) {
             // try to see if the name contains any middleware parameters
-            if(strpos($name, ':') !== FALSE){
+            if(is_string($name) && strpos($name, ':') !== FALSE){
                 list($main_name, $args) = explode(':', $name);
                 // check to see if the `$main_name` is part of the middleware groups only
                 if(array_key_exists($main_name, $this->middlewareGroups)){

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -694,6 +694,7 @@ class Router implements RegistrarContract, BindingRegistrar
                     $name = $main_name;
                 }
             }
+            
             return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);
         })->flatten();
 


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Okay, so i work for @synergixe and we had some problem reference by issue #24668  and we had to use a workaround (please see workaround code in issue referenced) which my company posted on that issue. This is a pull request that makes it easier to do the below and have all group middlewares receive the same parameters automatically.

```php
     /* example middleware */
     namespace App\Cors;

     use \Barryvdh\Cors\HandleCors;

    class OpsCors extends HandleCors {

    }

```

```php
        /* app/Http/Kernel.php */

            protected $middlewareGroups =  [
                   'security' => [
                         \App\Http\Middleware\LogStuff::class,
                         \App\Cors\OpsCors::class
                   ]
           ];
```

```php
      /* routes/web.php */

     Route::middleware(['security:web'])->group(function(){
             Route::get('/model/{model_test}/', function(App\ModelTest $model_test){
                   return $model_test->getAttributes();
             });
     });
``` 
This will make the life of an average Laravel developer a lot easier going forward. Thanks 