### PR TITLE
Update Builder.php

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2357,6 +2357,7 @@ class Builder
     public function aggregate($function, $columns = ['*'])
     {
         $results = $this->cloneWithout(['columns'])
+                        ->cloneWithout(['groups'])
                         ->cloneWithoutBindings(['select'])
                         ->setAggregate($function, $columns)
                         ->get($columns);


### PR DESCRIPTION
I have users table that has 5000 rows.
I has some query like this 
```
select users.* from `users` group by `users`.`id` order by `users`.`id` asc
```
(don't ask me why I am grouping this, it's just a little part of a query which I has issue with)
Result:
```
$query = $model->groupBy('id');

$query->count();  //  1
//  because count() didn't remove 'group by', and it's return 
//  $results[0] which is 1 (as another 5000 rows of aggregate column)

$query->get();
//  Collection {
//    #items: array:5000
//  }
```
So with cloneWithout(['groups']), we will remove 'group by' and result of method count() will be correct