### PR TITLE
[5.7] Adds active_host Validation Rule

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -26,7 +26,7 @@ class RedirectResponse extends BaseRedirectResponse
     protected $request;
 
     /**
-     * The session store implementation.
+     * The session store instance.
      *
      * @var \Illuminate\Session\Store
      */
@@ -192,7 +192,7 @@ class RedirectResponse extends BaseRedirectResponse
     }
 
     /**
-     * Get the session store implementation.
+     * Get the session store instance.
      *
      * @return \Illuminate\Session\Store|null
      */
@@ -202,7 +202,7 @@ class RedirectResponse extends BaseRedirectResponse
     }
 
     /**
-     * Set the session store implementation.
+     * Set the session store instance.
      *
      * @param  \Illuminate\Session\Store  $session
      * @return void

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -37,6 +37,26 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is an active Host
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateActiveHost($attribute, $value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        try {
+            return count(dns_get_record($value, DNS_A | DNS_AAAA)) > 0;
+        } catch (Exception $e) {
+            return false;
+        }
+    }
+
+    /**
      * Validate that an attribute is an active URL.
      *
      * @param  string  $attribute
@@ -49,12 +69,8 @@ trait ValidatesAttributes
             return false;
         }
 
-        if ($url = parse_url($value, PHP_URL_HOST)) {
-            try {
-                return count(dns_get_record($url, DNS_A | DNS_AAAA)) > 0;
-            } catch (Exception $e) {
-                return false;
-            }
+        if ($host = parse_url($value, PHP_URL_HOST)) {
+            return $this->validateActiveHost($attribute, $host);
         }
 
         return false;

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -37,7 +37,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate that an attribute is an active Host
+     * Validate that an attribute is an active Host.
      *
      * @param  string  $attribute
      * @param  mixed   $value

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2105,6 +2105,22 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateActiveHost()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'active_host']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => ['fdsfs', 'fdsfds']], ['x' => 'active_host']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'google.com'], ['x' => 'active_host']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'www.google.com'], ['x' => 'active_host']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateImage()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This breaks apart the `active_url` validation rule so you can perform validation against simple hostnames as well. Currently, the `active_url` requires the value to be a url before extracting the hostname and performing the validation.