### PR TITLE
[5.6] Fix for some urlencoded XSRF header tokens

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -138,7 +138,7 @@ class VerifyCsrfToken
         $token = $request->input('_token') ?: $request->header('X-CSRF-TOKEN');
 
         if (! $token && $header = $request->header('X-XSRF-TOKEN')) {
-            $token = $this->encrypter->decrypt($header);
+            $token = $this->encrypter->decrypt(urldecode($header));
         }
 
         return $token;


### PR DESCRIPTION
Sometimes XSRF header tokens sent from JS frameworks are reaching to Laravel with ending "%3D", and the request is ending up with DecryptException "The payload is invalid.". This will sanitize and get rid of these random errors.