### PR TITLE
[5.8] Bumped Laravel version to 5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
         "league/flysystem-cached-adapter": "^1.0",
         "mockery/mockery": "^1.0",
         "moontoast/math": "^1.1",
-        "orchestra/testbench-core": "3.7.*",
+        "orchestra/testbench-core": "3.8.*",
         "pda/pheanstalk": "^3.0",
         "phpunit/phpunit": "^7.0",
         "predis/predis": "^1.1.1",

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/http": "5.7.*",
-        "illuminate/queue": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/contracts": "5.8.*",
+        "illuminate/http": "5.8.*",
+        "illuminate/queue": "5.8.*",
+        "illuminate/support": "5.8.*"
     },
     "autoload": {
         "psr-4": {
@@ -27,13 +27,13 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "suggest": {
-        "illuminate/console": "Required to use the auth:clear-resets command (5.7.*).",
-        "illuminate/queue": "Required to fire login / logout events (5.7.*).",
-        "illuminate/session": "Required to use the session based guard (5.7.*)."
+        "illuminate/console": "Required to use the auth:clear-resets command (5.8.*).",
+        "illuminate/queue": "Required to fire login / logout events (5.8.*).",
+        "illuminate/session": "Required to use the session based guard (5.8.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -16,10 +16,10 @@
     "require": {
         "php": "^7.1.3",
         "psr/log": "^1.0",
-        "illuminate/bus": "5.7.*",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/queue": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/bus": "5.8.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/queue": "5.8.*",
+        "illuminate/support": "5.8.*"
     },
     "autoload": {
         "psr-4": {
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "suggest": {

--- a/src/Illuminate/Bus/composer.json
+++ b/src/Illuminate/Bus/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/pipeline": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/contracts": "5.8.*",
+        "illuminate/pipeline": "5.8.*",
+        "illuminate/support": "5.8.*"
     },
     "autoload": {
         "psr-4": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,13 +25,13 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "suggest": {
-        "illuminate/database": "Required to use the database cache driver (5.7.*).",
-        "illuminate/filesystem": "Required to use the file cache driver (5.7.*).",
-        "illuminate/redis": "Required to use the redis cache driver (5.7.*)."
+        "illuminate/database": "Required to use the database cache driver (5.8.*).",
+        "illuminate/filesystem": "Required to use the file cache driver (5.8.*).",
+        "illuminate/redis": "Required to use the redis cache driver (5.8.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Config/composer.json
+++ b/src/Illuminate/Config/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*",
         "symfony/console": "^4.1"
     },
     "autoload": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "suggest": {

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
+        "illuminate/contracts": "5.8.*",
         "psr/container": "^1.0"
     },
     "autoload": {
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Contracts/composer.json
+++ b/src/Illuminate/Contracts/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*",
         "symfony/http-foundation": "^4.1",
         "symfony/http-kernel": "^4.1"
     },
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -16,9 +16,9 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/container": "5.7.*",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/container": "5.8.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*"
     },
     "autoload": {
         "psr-4": {
@@ -27,16 +27,16 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "suggest": {
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (^1.4).",
-        "illuminate/console": "Required to use the database commands (5.7.*).",
-        "illuminate/events": "Required to use the observers with Eloquent (5.7.*).",
-        "illuminate/filesystem": "Required to use the migrations (5.7.*).",
-        "illuminate/pagination": "Required to paginate the result set (5.7.*)."
+        "illuminate/console": "Required to use the database commands (5.8.*).",
+        "illuminate/events": "Required to use the observers with Eloquent (5.8.*).",
+        "illuminate/filesystem": "Required to use the migrations (5.8.*).",
+        "illuminate/pagination": "Required to paginate the result set (5.8.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -17,8 +17,8 @@
         "php": "^7.1.3",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/container": "5.7.*",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/container": "5.8.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*"
     },
     "autoload": {
         "psr-4": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*",
         "symfony/finder": "^4.1"
     },
     "autoload": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "suggest": {

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -29,7 +29,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.7-dev';
+    const VERSION = '5.8-dev';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/session": "5.7.*",
-        "illuminate/support": "5.7.*",
+        "illuminate/session": "5.8.*",
+        "illuminate/support": "5.8.*",
         "symfony/http-foundation": "^4.1",
         "symfony/http-kernel": "^4.1"
     },
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*",
         "monolog/monolog": "^1.11"
     },
     "autoload": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -16,9 +16,9 @@
     "require": {
         "php": "^7.1.3",
         "erusev/parsedown": "^1.7",
-        "illuminate/container": "5.7.*",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*",
+        "illuminate/container": "5.8.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*",
         "psr/log": "^1.0",
         "swiftmailer/swiftmailer": "^6.0",
         "tijsverkoyen/css-to-inline-styles": "^2.2.1"
@@ -30,7 +30,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "suggest": {

--- a/src/Illuminate/Notifications/composer.json
+++ b/src/Illuminate/Notifications/composer.json
@@ -15,14 +15,14 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/broadcasting": "5.7.*",
-        "illuminate/bus": "5.7.*",
-        "illuminate/container": "5.7.*",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/filesystem": "5.7.*",
-        "illuminate/mail": "5.7.*",
-        "illuminate/queue": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/broadcasting": "5.8.*",
+        "illuminate/bus": "5.8.*",
+        "illuminate/container": "5.8.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/filesystem": "5.8.*",
+        "illuminate/mail": "5.8.*",
+        "illuminate/queue": "5.8.*",
+        "illuminate/support": "5.8.*"
     },
     "autoload": {
         "psr-4": {
@@ -31,12 +31,12 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "suggest": {
         "guzzlehttp/guzzle": "Required to use the Slack transport (^6.0)",
-        "illuminate/database": "Required to use the database transport (5.7.*).",
+        "illuminate/database": "Required to use the database transport (5.8.*).",
         "nexmo/client": "Required to use the Nexmo transport (^1.0)."
     },
     "config": {

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Pipeline/composer.json
+++ b/src/Illuminate/Pipeline/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -15,12 +15,12 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/console": "5.7.*",
-        "illuminate/container": "5.7.*",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/database": "5.7.*",
-        "illuminate/filesystem": "5.7.*",
-        "illuminate/support": "5.7.*",
+        "illuminate/console": "5.8.*",
+        "illuminate/container": "5.8.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/database": "5.8.*",
+        "illuminate/filesystem": "5.8.*",
+        "illuminate/support": "5.8.*",
         "symfony/debug": "^4.1",
         "symfony/process": "^4.1"
     },
@@ -31,14 +31,14 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "suggest": {
         "ext-pcntl": "Required to use all features of the queue worker.",
         "ext-posix": "Required to use all features of the queue worker.",
         "aws/aws-sdk-php": "Required to use the SQS queue driver (^3.0).",
-        "illuminate/redis": "Required to use the Redis queue driver (5.7.*).",
+        "illuminate/redis": "Required to use the Redis queue driver (5.8.*).",
         "pda/pheanstalk": "Required to use the Beanstalk queue driver (^3.0)."
     },
     "config": {

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*",
         "predis/predis": "^1.0"
     },
     "autoload": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -15,12 +15,12 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/container": "5.7.*",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/http": "5.7.*",
-        "illuminate/pipeline": "5.7.*",
-        "illuminate/session": "5.7.*",
-        "illuminate/support": "5.7.*",
+        "illuminate/container": "5.8.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/http": "5.8.*",
+        "illuminate/pipeline": "5.8.*",
+        "illuminate/session": "5.8.*",
+        "illuminate/support": "5.8.*",
         "symfony/debug": "^4.1",
         "symfony/http-foundation": "^4.1",
         "symfony/http-kernel": "^4.1",
@@ -33,11 +33,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "suggest": {
-        "illuminate/console": "Required to use the make commands (5.7.*).",
+        "illuminate/console": "Required to use the make commands (5.8.*).",
         "symfony/psr-http-message-bridge": "Required to psr7 bridging features (^1.0)."
     },
     "config": {

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/filesystem": "5.7.*",
-        "illuminate/support": "5.7.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/filesystem": "5.8.*",
+        "illuminate/support": "5.8.*",
         "symfony/finder": "^4.1",
         "symfony/http-foundation": "^4.1"
     },
@@ -28,11 +28,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "suggest": {
-        "illuminate/console": "Required to use the session:table command (5.7.*)."
+        "illuminate/console": "Required to use the session:table command (5.8.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.1.3",
         "ext-mbstring": "*",
         "doctrine/inflector": "^1.1",
-        "illuminate/contracts": "5.7.*",
+        "illuminate/contracts": "5.8.*",
         "nesbot/carbon": "^1.24.1"
     },
     "conflict": {
@@ -33,11 +33,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "suggest": {
-        "illuminate/filesystem": "Required to use the composer class (5.7.*).",
+        "illuminate/filesystem": "Required to use the composer class (5.8.*).",
         "ramsey/uuid": "Required to use Str::uuid() (^3.7).",
         "symfony/process": "Required to use the composer class (^4.1).",
         "symfony/var-dumper": "Required to use the dd function (^4.1)."

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/filesystem": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/contracts": "5.8.*",
+        "illuminate/filesystem": "5.8.*",
+        "illuminate/support": "5.8.*"
     },
     "autoload": {
         "psr-4": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/container": "5.7.*",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*",
-        "illuminate/translation": "5.7.*",
+        "illuminate/container": "5.8.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/support": "5.8.*",
+        "illuminate/translation": "5.8.*",
         "symfony/http-foundation": "^4.1"
     },
     "autoload": {
@@ -28,11 +28,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "suggest": {
-        "illuminate/database": "Required to use the database presence verifier (5.7.*)."
+        "illuminate/database": "Required to use the database presence verifier (5.8.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -15,11 +15,11 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/container": "5.7.*",
-        "illuminate/contracts": "5.7.*",
-        "illuminate/events": "5.7.*",
-        "illuminate/filesystem": "5.7.*",
-        "illuminate/support": "5.7.*",
+        "illuminate/container": "5.8.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/events": "5.8.*",
+        "illuminate/filesystem": "5.8.*",
+        "illuminate/support": "5.8.*",
         "symfony/debug": "^4.1"
     },
     "autoload": {
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.7-dev"
+            "dev-master": "5.8-dev"
         }
     },
     "config": {

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -47,7 +47,7 @@ class ConsoleApplicationTest extends TestCase
 
     protected function getMockConsole(array $methods)
     {
-        $app = m::mock('Illuminate\Contracts\Foundation\Application', ['version' => '5.7']);
+        $app = m::mock('Illuminate\Contracts\Foundation\Application', ['version' => '5.8']);
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher', ['dispatch' => null]);
 
         return $this->getMockBuilder('Illuminate\Console\Application')->setMethods($methods)->setConstructorArgs([

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -123,7 +123,7 @@ class MailableStub extends Mailable
 {
     public $framework = 'Laravel';
 
-    protected $version = '5.7';
+    protected $version = '5.8';
 
     /**
      * Build the message.
@@ -141,7 +141,7 @@ class QueueableMailableStub extends Mailable implements ShouldQueue
 {
     public $framework = 'Laravel';
 
-    protected $version = '5.7';
+    protected $version = '5.8';
 
     /**
      * Build the message.


### PR DESCRIPTION
This PR **only** bumps the versions on master to 5.8, since we now have a 5.7 branch that targets 5.7.x.

What this PR **does not** do is:

1. Bump the minimum symfony version (can be done later - probably `^4.1` -> `^4.2`);
2. Alter the minimum required version of PHP (can be discussed later - probably `^7.1.3` -> `^7.2` or `^7.2.7` (7.2.7 is the version Ubuntu 18.04 LTS seemed to give me when I installed php with apt)).