### PR TITLE
making addFailure function - public in Illuminate/Validation/Validator.php

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -589,7 +589,7 @@ class Validator implements ValidatorContract
         if (! $this->messages) {
             $this->passes();
         }
-        
+
         $this->messages->add($attribute, $this->makeReplacements(
             $this->getMessage($attribute, $rule), $attribute, $rule, $parameters
         ));

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -584,8 +584,12 @@ class Validator implements ValidatorContract
      * @param  array   $parameters
      * @return void
      */
-    protected function addFailure($attribute, $rule, $parameters)
+    public function addFailure($attribute, $rule, $parameters)
     {
+        if (! $this->messages) {
+            $this->passes();
+        }
+        
         $this->messages->add($attribute, $this->makeReplacements(
             $this->getMessage($attribute, $rule), $attribute, $rule, $parameters
         ));


### PR DESCRIPTION
This gives users an option to use existing functionality to generate and add new error message. The existing functionality takes care of translation and ":attribute" naming. It also simplifies the use of `\resources\lang\en\validation.php` file as a single source of truth for an error messages.


