### PR TITLE
Making addFailure function - public

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -589,7 +589,7 @@ class Validator implements ValidatorContract
         if (! $this->messages) {
             $this->passes();
         }
-        
+
         $this->messages->add($attribute, $this->makeReplacements(
             $this->getMessage($attribute, $rule), $attribute, $rule, $parameters
         ));

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -584,7 +584,7 @@ class Validator implements ValidatorContract
      * @param  array   $parameters
      * @return void
      */
-    public function addFailure($attribute, $rule, $parameters)
+    public function addFailure($attribute, $rule, $parameters = [])
     {
         if (! $this->messages) {
             $this->passes();

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -584,8 +584,12 @@ class Validator implements ValidatorContract
      * @param  array   $parameters
      * @return void
      */
-    protected function addFailure($attribute, $rule, $parameters)
+    public function addFailure($attribute, $rule, $parameters)
     {
+        if (! $this->messages) {
+            $this->passes();
+        }
+        
         $this->messages->add($attribute, $this->makeReplacements(
             $this->getMessage($attribute, $rule), $attribute, $rule, $parameters
         ));

--- a/tests/Validation/ValidationAddFailureTest.php
+++ b/tests/Validation/ValidationAddFailureTest.php
@@ -11,7 +11,6 @@ use ReflectionMethod;
 
 class ValidationAddFailureTest extends TestCase
 {
-
     /**
      * Making Validator using ValidationValidatorTest
      * 
@@ -25,7 +24,6 @@ class ValidationAddFailureTest extends TestCase
 
         return $v;
     }
-
 
     /**
      * Assert that a method has public access.
@@ -41,7 +39,6 @@ class ValidationAddFailureTest extends TestCase
         self::assertTrue($reflector->isPublic(), 'method is not public');
     }
 
-
     public function testAddFailureExistsAndVisibile()
     {
         $validator   = $this->makeValidator();
@@ -51,13 +48,11 @@ class ValidationAddFailureTest extends TestCase
         $this->assertPublicMethod($validator, $method_name);
     }
 
-
     public function testAddFailureIsFunctional()
     {
         $attribute = 'Eugene';
         $validator = $this->makeValidator();
         $validator->addFailure($attribute, 'not_in');
-        echo $validator->messages();
         $messages = json_decode($validator->messages());
         $this->assertSame($messages->{"foo.bar.baz"}[0], "validation.required", 'initial data in messages is lost');
         $this->assertSame($messages->{$attribute}[0], "validation.not_in", 'new data in messages was not added');

--- a/tests/Validation/ValidationAddFailureTest.php
+++ b/tests/Validation/ValidationAddFailureTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+//use Illuminate\Validation\Rule;
+use PHPUnit\Framework\TestCase;
+//use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Validator;
+use Illuminate\Tests\Validation\ValidationValidatorTest;
+use ReflectionMethod;
+
+class ValidationAddFailureTest extends TestCase
+{
+
+    /**
+     * Making Validator using ValidationValidatorTest
+     * 
+     * @return Validator
+     */
+    public function makeValidator(): Validator
+    {
+        $mainTest = new ValidationValidatorTest();
+        $trans    = $mainTest->getIlluminateArrayTranslator();
+        $v        = new Validator($trans, ['foo' => ['bar' => ['baz' => '']]], ['foo.bar.baz' => 'sometimes|required']);
+
+        return $v;
+    }
+
+
+    /**
+     * Assert that a method has public access.
+     *
+     * @param string $class name of the class
+     * @param string $method name of the method
+     * @throws ReflectionException if $class or $method don't exist
+     * @throws PHPUnit_Framework_ExpectationFailedException if the method isn't public
+     */
+    public function assertPublicMethod($class, $method)
+    {
+        $reflector = new ReflectionMethod($class, $method);
+        self::assertTrue($reflector->isPublic(), 'method is not public');
+    }
+
+
+    public function testAddFailureExistsAndVisibile()
+    {
+        $validator   = $this->makeValidator();
+        $method_name = 'addFailure';
+        $this->assertTrue(method_exists($validator, $method_name));
+        $this->assertTrue(is_callable(array($validator, $method_name)));
+        $this->assertPublicMethod($validator, $method_name);
+    }
+
+
+    public function testAddFailureIsFunctional()
+    {
+        $attribute = 'Eugene';
+        $validator = $this->makeValidator();
+        $validator->addFailure($attribute, 'not_in');
+        echo $validator->messages();
+        $messages = json_decode($validator->messages());
+        $this->assertSame($messages->{"foo.bar.baz"}[0], "validation.required", 'initial data in messages is lost');
+        $this->assertSame($messages->{$attribute}[0], "validation.not_in", 'new data in messages was not added');
+    }
+
+
+}


### PR DESCRIPTION
1) Making addFailure function - public and setting up defaults for the last parameter.
2) Making test cases around it

This gives users an option to use existing functionality to generate and add new error message. The existing functionality takes care of translation and ":attribute" naming. It also simplifies the use of `\resources\lang\en\validation.php` file as a single source of truth for an error messages.

