### PR TITLE
[5.6] Updating the Pluralizer class to respect the grammar rule

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -64,7 +64,7 @@ class Pluralizer
      */
     public static function plural($value, $count = 2)
     {
-        if ((int) $count === 1 || static::uncountable($value)) {
+        if ((int) abs($count) === 1 || static::uncountable($value)) {
             return $value;
         }
 

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -39,4 +39,11 @@ class SupportPluralizerTest extends TestCase
         $this->assertEquals('IndexFields', Str::plural('IndexField'));
         $this->assertEquals('VertexFields', Str::plural('VertexField'));
     }
+
+    public function testPluralWithNegativeCount() {
+        $this->assertEquals('test', Str::plural('test', 1));
+        $this->assertEquals('tests', Str::plural('test', 2));
+        $this->assertEquals('test', Str::plural('test', -1));
+        $this->assertEquals('tests', Str::plural('test', -2));
+    }
 }


### PR DESCRIPTION
[5.6] When count is -1, word must be in the singular
