### PR TITLE
Added region to Mailgun transport

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -29,7 +29,14 @@ class MailgunTransport extends Transport
     protected $domain;
 
     /**
-     * The Mailgun API end-point.
+     * The Mailgun region.
+     *
+     * @var string
+     */
+    protected $region;
+
+    /**
+     * THe Mailgun API end-point.
      *
      * @var string
      */
@@ -144,6 +151,27 @@ class MailgunTransport extends Transport
     }
 
     /**
+     * Get the region being used.
+     *
+     * @return string
+     */
+    public function getRegion()
+    {
+        return $this->region;
+    }
+
+    /**
+     * Set the region being used.
+     *
+     * @param  string  $region
+     * @return string
+     */
+    public function setRegion($region)
+    {
+        return $this->region = $region;
+    }
+
+    /**
      * Get the domain being used by the transport.
      *
      * @return string
@@ -161,7 +189,8 @@ class MailgunTransport extends Transport
      */
     public function setDomain($domain)
     {
-        $this->url = 'https://api.mailgun.net/v3/'.$domain.'/messages.mime';
+        $region = empty($this->getRegion()) ? '' : str_finish($this->getRegion(), '.');
+        $this->url = 'https://api.'.$region.'mailgun.net/v3/'.$domain.'/messages.mime';
 
         return $this->domain = $domain;
     }


### PR DESCRIPTION
- Laravel Version: 5.6.*
- PHP Version: 7.2

### Description:
Mailgun recently [introduced regions](https://www.mailgun.com/blog/we-have-a-new-region-in-europe-yall) to their service so we need some minor updates to make it work with the [new regions structure](https://documentation.mailgun.com/en/latest/api-intro.html#mailgun-regions).

`config/services.php` would also need an extra parameter region:
```php
'mailgun' => [
    'domain' => env('MAILGUN_DOMAIN'),
    'region' => env('MAILGUN_REGION'),
    'secret' => env('MAILGUN_SECRET'),
],
```

Plus I would write some needed tests after feedback.
See also: https://github.com/mailgun/mailgun-php/issues/471