### PR TITLE
[5.6] Required If Rule based on a clousure or boolean value

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -75,7 +75,7 @@ class Rule
     }
 
     /**
-     * Create a new Closure based required validation rule.
+     * Get a required_if constraint builder instance.
      *
      * @param  \Closure  $callback
      * @return \Illuminate\Validation\Rules\RequiredIf

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -73,4 +73,15 @@ class Rule
     {
         return new Rules\Unique($table, $column);
     }
+
+    /**
+     * Create a new Closure based required validation rule.
+     *
+     * @param  \Closure  $callback
+     * @return \Illuminate\Validation\Rules\RequiredIf
+     */
+    public static function requiredIf($callback)
+    {
+        return new Rules\RequiredIf($callback);
+    }
 }

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -14,14 +14,14 @@ class RequiredIf
     /**
      * The condition that validates the attribute.
      *
-     * @var boolean|\Closure
+     * @var bool|\Closure
      */
     public $condition;
 
     /**
      * Create a new Closure based required validation rule.
      *
-     * @param  boolean|\Closure  $condition
+     * @param  bool|\Closure  $condition
      * @return void
      */
     public function __construct($condition)

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+
+class RequiredIf
+{
+    /**
+     * The callback that validates the attribute.
+     *
+     * @var \Closure
+     */
+    public $callback;
+
+    /**
+     * Create a new Closure based required validation rule.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function __construct($callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->callback->__invoke() ? 'required' : '';
+    }
+}

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -7,21 +7,26 @@ use Closure;
 class RequiredIf
 {
     /**
-     * The callback that validates the attribute.
-     *
-     * @var \Closure
+     * The name of the rule.
      */
-    public $callback;
+    protected $rule = 'required';
+
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var boolean|\Closure
+     */
+    public $condition;
 
     /**
      * Create a new Closure based required validation rule.
      *
-     * @param  \Closure  $callback
+     * @param  boolean|\Closure  $condition
      * @return void
      */
-    public function __construct($callback)
+    public function __construct($condition)
     {
-        $this->callback = $callback;
+        $this->condition = $condition;
     }
 
     /**
@@ -31,6 +36,10 @@ class RequiredIf
      */
     public function __toString()
     {
-        return $this->callback->__invoke() ? 'required' : '';
+        if ($this->condition instanceof Closure) {
+            return $this->condition->__invoke() ? $this->rule : '';
+        }
+
+        return $this->condition ? $this->rule : '';
     }
 }

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -19,7 +19,7 @@ class RequiredIf
     public $condition;
 
     /**
-     * Create a new Closure based required validation rule.
+     * Create a new required validation rule based on a condition.
      *
      * @param  bool|\Closure  $condition
      * @return void

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Validation;
 
-use Illuminate\Validation\Rule;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Validation\Rules\RequiredIf;
 

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -22,7 +22,6 @@ class ValidationRequiredIfTest extends TestCase
 
         $this->assertEquals('', (string) $rule);
 
-
         $rule = new RequiredIf(true);
 
         $this->assertEquals('required', (string) $rule);

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -21,5 +21,14 @@ class ValidationRequiredIfTest extends TestCase
         });
 
         $this->assertEquals('', (string) $rule);
+
+
+        $rule = new RequiredIf(true);
+
+        $this->assertEquals('required', (string) $rule);
+
+        $rule = new RequiredIf(false);
+
+        $this->assertEquals('', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Validation\Rule;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Rules\RequiredIf;
+
+class ValidationRequiredIfTest extends TestCase
+{
+    public function testItClousureReturnsFormatsAStringVersionOfTheRule()
+    {
+        $rule = new RequiredIf(function () {
+            return true;
+        });
+
+        $this->assertEquals('required', (string) $rule);
+
+        $rule = new RequiredIf(function () {
+            return false;
+        });
+
+        $this->assertEquals('', (string) $rule);
+    }
+}


### PR DESCRIPTION
This PR will allow me to create a `required` rule-based in a user closure or a boolean value, the same behavior could be achieved with a custom closure but I think this provides a cleaner way to add some custom condition to require a value

Examples:

```
$this->validate($request->all(), [
   'role_id' => Rule::requiredIf(function () use ($request) {
   		return $request->user()->is_admin
   		   && $some_other_complicated_condition; 
    })
})
```

```
$this->validate($request->all(), [
   'role_id' => Rule::requiredIf($request->user()->is_admin)
})
```

