### PR TITLE
[5.7] matchesType should be called statically

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -78,7 +78,7 @@ trait InteractsWithContentTypes
             }
 
             foreach ($types as $type) {
-                if ($this->matchesType($accept, $type) || $accept === strtok($type, '/').'/*') {
+                if (self::matchesType($accept, $type) || $accept === strtok($type, '/').'/*') {
                     return true;
                 }
             }
@@ -111,7 +111,7 @@ trait InteractsWithContentTypes
                     $type = $mimeType;
                 }
 
-                if ($this->matchesType($type, $accept) || $accept === strtok($type, '/').'/*') {
+                if (self::matchesType($type, $accept) || $accept === strtok($type, '/').'/*') {
                     return $contentType;
                 }
             }


### PR DESCRIPTION
The method "matchesType" is defined as a static method, so it should be called statically instead of using "$this->matchesType()".

Please visit [InteractsWithContentTypes](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php)  for more details.