### PR TITLE
[5.6] Add renderers to exceptions

### DIFF
--- a/src/Illuminate/Contracts/Debug/ExceptionRenderer.php
+++ b/src/Illuminate/Contracts/Debug/ExceptionRenderer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Debug;
+
+interface ExceptionRenderer
+{
+    /**
+     * Render the exception response.
+     *
+     * @return mixed
+     */
+    public function render();
+}

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -74,6 +74,11 @@ class Handler implements ExceptionHandlerContract
     ];
 
     /**
+     * Renders to render the exception.
+     */
+    protected $renderers = [];
+
+    /**
      * Create a new exception handler instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
@@ -173,6 +178,15 @@ class Handler implements ExceptionHandlerContract
         }
 
         $e = $this->prepareException($e);
+
+        $renderer = collect($this->renderers)
+            ->first(function($renderer, $toBeRender) use ($e) {
+                return $e instanceof $toBeRender;
+            });
+
+        if ($renderer) {
+            return (new $renderer($request, $e))->render();
+        }
 
         if ($e instanceof HttpResponseException) {
             return $e->getResponse();

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -180,7 +180,7 @@ class Handler implements ExceptionHandlerContract
         $e = $this->prepareException($e);
 
         $renderer = collect($this->renderers)
-            ->first(function($renderer, $toBeRender) use ($e) {
+            ->first(function ($renderer, $toBeRender) use ($e) {
                 return $e instanceof $toBeRender;
             });
 

--- a/src/Illuminate/Foundation/Exceptions/Renderer.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions;
+
+use Illuminate\Contracts\Debug\ExceptionRenderer;
+
+abstract class Renderer implements ExceptionRenderer
+{
+    /**
+     * Request.
+     *
+     * @var
+     */
+    protected $request;
+
+    /**
+     * Exception to be rendered.
+     *
+     * @var \Exception
+     */
+    protected $exception;
+
+    /**
+     * Renderer constructor.
+     *
+     * @param $request
+     * @param \Exception $exception
+     */
+    public function __construct($request, \Exception $exception)
+    {
+        $this->request = $request;
+        $this->exception = $exception;
+    }
+}

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation;
 
 use Exception;
+use Illuminate\Foundation\Exceptions\Renderer;
 use Mockery as m;
 use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
@@ -80,6 +81,15 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertSame('{"response":"My custom exception response"}', $response);
     }
 
+    public function testHandleTheException()
+    {
+        $customHandler = new CustomHandlerToRenderer($this->container);
+
+        $response = $customHandler->render($this->request, new Exception('Exception message'))->getContent();
+
+        $this->assertSame('{"error":true,"custom":true}', $response);
+    }
+
     public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalseAndExceptionMessageIsMasked()
     {
         $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(false);
@@ -131,5 +141,25 @@ class CustomException extends Exception implements Responsable
     public function toResponse($request)
     {
         return response()->json(['response' => 'My custom exception response']);
+    }
+}
+
+class CustomHandlerToRenderer extends Handler
+{
+    protected $renderers = [
+        Exception::class => CustomRenderer::class
+    ];
+}
+
+class CustomRenderer extends Renderer
+{
+    /**
+     * Render the exception response.
+     *
+     * @return mixed
+     */
+    public function render()
+    {
+        return response()->json(['error' => true, 'custom' => true]);
     }
 }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -81,7 +81,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertSame('{"response":"My custom exception response"}', $response);
     }
 
-    public function testHandleTheException()
+    public function testRenderTheExceptionWithRenderer()
     {
         $customHandler = new CustomHandlerToRenderer($this->container);
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Foundation;
 
 use Exception;
-use Illuminate\Foundation\Exceptions\Renderer;
 use Mockery as m;
 use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
@@ -11,6 +10,7 @@ use Illuminate\Container\Container;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Foundation\Exceptions\Handler;
+use Illuminate\Foundation\Exceptions\Renderer;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -147,7 +147,7 @@ class CustomException extends Exception implements Responsable
 class CustomHandlerToRenderer extends Handler
 {
     protected $renderers = [
-        Exception::class => CustomRenderer::class
+        Exception::class => CustomRenderer::class,
     ];
 }
 


### PR DESCRIPTION
In a recent application, I had to handle several exceptions and for this I separated into classes, but at a certain moment of the application the file "Exception/Handler" started to get very large with several "instanceof", so I decided to do it automatically with a "array", worked correctly and I thought it would be an interesting feature for the framework.

In the **Handler** I created an array called **renderers** with expects for an item in which the key is the class to be rendered and the value is the class that will render. When the class is instantiated, the Request and Exception is passed as parameter.

In addition, an interface called **ExceptionRenderer** and an abstract **Renderer** class were also created, in the **Renderer** abstract class in your constructor she receives the Request and Exception and adds them as properties in the class.
