### PR TITLE
[5.6] React Component - Allow multiple renders on the same page

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/react-stubs/Example.js
+++ b/src/Illuminate/Foundation/Console/Presets/react-stubs/Example.js
@@ -21,6 +21,9 @@ export default class Example extends Component {
     }
 }
 
-if (document.getElementById('example')) {
-    ReactDOM.render(<Example />, document.getElementById('example'));
+const reactElements = document.querySelectorAll('.example');
+if (reactElements.length > 0) {
+    reactElements.forEach(element => {
+        ReactDOM.render(<Example />, element);
+    });
 }


### PR DESCRIPTION
Currently, the example React component can only be rendered out once on a page because it uses an id. If you need to render out more than one component (say in a loop), it won't work and will only display one.

This pull request uses classes instead of an id. This will allow multiple components to be rendered.
