### PR TITLE
[5.6] Create "allFilled" to InteractsWithInput

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -197,6 +197,23 @@ trait InteractsWithInput
     }
 
     /**
+     * Get all the entries and files for the request,
+     * which are with values filled, the values need to be boolean,
+     * numeric, strings or non-empty.
+     *
+     * @param array|mixed $keys
+     * @return array
+     */
+    public function allFilled($keys = null)
+    {
+        return collect($this->all($keys))
+            ->filter(function ($value) {
+                return is_bool($value) || is_numeric($value) || is_string($value) || ! empty($value);
+            })
+            ->toArray();
+    }
+
+    /**
      * Retrieve an input item from the request.
      *
      * @param  string|null  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -583,6 +583,12 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(['foo' => 'fooValue', 'qux' => false, 'quux' => true, 'fb' => 0, 'ax' => ''], $request->allFilled());
     }
 
+    public function testAllFilledInputIgnoreKeysNotFilled()
+    {
+        $request = Request::create('/', 'POST', ['foo' => 'fooValue', 'baz' => 'bazValue']);
+        $this->assertEquals(['foo' => 'fooValue'], $request->allFilled(['foo', 'bar']));
+    }
+
     public function testInputWithEmptyFilename()
     {
         $invalidFiles = [

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -577,6 +577,12 @@ class HttpRequestTest extends TestCase
         $this->assertEquals([1 => 'A', 2 => 'B', 3 => 'C'], $request2->all());
     }
 
+    public function testAllFilledInput()
+    {
+        $request = Request::create('/', 'POST', ['foo' => 'fooValue', 'baz' => null, 'qux' => false, 'quux' => true, 'fb' => 0, 'ax' => '']);
+        $this->assertEquals(['foo' => 'fooValue', 'qux' => false, 'quux' => true, 'fb' => 0, 'ax' => ''], $request->allFilled());
+    }
+
     public function testInputWithEmptyFilename()
     {
         $invalidFiles = [


### PR DESCRIPTION
In some cases it is necessary to get only the fields of the request that have values, because if we use **all** it will return all the fields, but if we pass a key that does not exist it returns **empty**, in this case, it may be necessary to need only if there is values.

I've created the **allFilled** method that will only bring values that are boolean, numeric, strings and not empty.