### PR TITLE
[5.7] Allow custom monolog driver to be able to use channel name parser (fallback to environment) and parse string level into monolog constant.

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -18,6 +18,8 @@ use Monolog\Handler\SlackWebhookHandler;
 
 class LogManager implements LoggerInterface
 {
+    use LoggerConfiguration;
+
     /**
      * The application instance.
      *
@@ -38,22 +40,6 @@ class LogManager implements LoggerInterface
      * @var array
      */
     protected $customCreators = [];
-
-    /**
-     * The Log levels.
-     *
-     * @var array
-     */
-    protected $levels = [
-        'debug' => Monolog::DEBUG,
-        'info' => Monolog::INFO,
-        'notice' => Monolog::NOTICE,
-        'warning' => Monolog::WARNING,
-        'error' => Monolog::ERROR,
-        'critical' => Monolog::CRITICAL,
-        'alert' => Monolog::ALERT,
-        'emergency' => Monolog::EMERGENCY,
-    ];
 
     /**
      * Create a new Log manager instance.
@@ -386,40 +372,6 @@ class LogManager implements LoggerInterface
         return tap(new LineFormatter(null, null, true, true), function ($formatter) {
             $formatter->includeStacktraces();
         });
-    }
-
-    /**
-     * Extract the log channel from the given configuration.
-     *
-     * @param  array  $config
-     * @return string
-     */
-    protected function parseChannel(array $config)
-    {
-        if (! isset($config['name'])) {
-            return $this->app->bound('env') ? $this->app->environment() : 'production';
-        }
-
-        return $config['name'];
-    }
-
-    /**
-     * Parse the string level into a Monolog constant.
-     *
-     * @param  array  $config
-     * @return int
-     *
-     * @throws \InvalidArgumentException
-     */
-    protected function level(array $config)
-    {
-        $level = $config['level'] ?? 'debug';
-
-        if (isset($this->levels[$level])) {
-            return $this->levels[$level];
-        }
-
-        throw new InvalidArgumentException('Invalid log level.');
     }
 
     /**

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -375,6 +375,16 @@ class LogManager implements LoggerInterface
     }
 
     /**
+     * Get fallback log channel name.
+     *
+     * @return string
+     */
+    protected function getFallbackChannelName()
+    {
+        return $this->app->bound('env') ? $this->app->environment() : 'production';
+    }
+
+    /**
      * Get the log connection configuration.
      *
      * @param  string  $name

--- a/src/Illuminate/Log/LoggerConfiguration.php
+++ b/src/Illuminate/Log/LoggerConfiguration.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Log;
+
+use InvalidArgumentException;
+use Monolog\Logger as Monolog;
+
+trait LoggerConfiguration
+{
+    /**
+     * The Log levels.
+     *
+     * @var array
+     */
+    protected $levels = [
+        'debug' => Monolog::DEBUG,
+        'info' => Monolog::INFO,
+        'notice' => Monolog::NOTICE,
+        'warning' => Monolog::WARNING,
+        'error' => Monolog::ERROR,
+        'critical' => Monolog::CRITICAL,
+        'alert' => Monolog::ALERT,
+        'emergency' => Monolog::EMERGENCY,
+    ];
+
+    /**
+     * Parse the string level into a Monolog constant.
+     *
+     * @param  array  $config
+     * @return int
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function level(array $config)
+    {
+        $level = $config['level'] ?? 'debug';
+
+        if (isset($this->levels[$level])) {
+            return $this->levels[$level];
+        }
+
+        throw new InvalidArgumentException('Invalid log level.');
+    }
+
+    /**
+     * Extract the log channel from the given configuration.
+     *
+     * @param  array  $config
+     * @return string
+     */
+    protected function parseChannel(array $config)
+    {
+        if (! isset($config['name'])) {
+            return $this->app->bound('env') ? $this->app->environment() : 'production';
+        }
+
+        return $config['name'];
+    }
+}

--- a/src/Illuminate/Log/LoggerConfiguration.php
+++ b/src/Illuminate/Log/LoggerConfiguration.php
@@ -51,9 +51,16 @@ trait LoggerConfiguration
     protected function parseChannel(array $config)
     {
         if (! isset($config['name'])) {
-            return $this->app->bound('env') ? $this->app->environment() : 'production';
+            return $this->getFallbackChannelName();
         }
 
         return $config['name'];
     }
+
+    /**
+     * Get fallback log channel name.
+     *
+     * @return string
+     */
+    abstract protected function getFallbackChannelName();
 }


### PR DESCRIPTION
As an example if we use custom channel and we need to specify log level, we need to use Monolog constant instead of e.g: `'warning'`, and we need to manually set the channel name instead of using any name from the configuration just like the predefine channels. 

```php
'channels' => [
    'graylog' => [
        'driver' => 'custom',
        'via' => App\Logging\CreateGraylogLogger::class,
        'host' => 'graylog.yourcompany.com',
        'port' => 5141,
        'level' => Monolog\Logger::WARNING,
    ],
],
```

```php
<?php

namespace App\Logging;

use Gelf\Publisher;
use Gelf\Transport\TcpTransport;
use Monolog\Handler\GelfHandler;
use Monolog\Logger;

class CreateGraylogLogger
{
    /**
     * Create a custom Monolog instance.
     *
     * @param  array  $config
     * @return \Monolog\Logger
     */
    public function __invoke(array $config)
    {
        $publisher = new Publisher(new TcpTransport($config['host'], $config['port']));

        return new Logger('production', [
            new GelfHandler($publisher, $config['level'])
        ]);
    }
}
```


Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>
