### PR TITLE
[5.6] Fix dd() helper colors

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -9,9 +9,11 @@ use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
+use Illuminate\Support\Debug\Dumper;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Log\LogServiceProvider;
 use Illuminate\Support\ServiceProvider;
+use Symfony\Component\VarDumper\VarDumper;
 use Illuminate\Events\EventServiceProvider;
 use Illuminate\Routing\RoutingServiceProvider;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -146,6 +148,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $this->registerBaseServiceProviders();
 
         $this->registerCoreContainerAliases();
+
+        $this->registerVarDumper();
     }
 
     /**
@@ -188,6 +192,16 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $this->register(new LogServiceProvider($this));
 
         $this->register(new RoutingServiceProvider($this));
+    }
+
+    /**
+     * Register Laravel's dumper.
+     *
+     * @return void
+     */
+    protected function registerVarDumper()
+    {
+        VarDumper::setHandler([new Dumper, 'dump']);
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -544,23 +544,6 @@ if (! function_exists('data_set')) {
     }
 }
 
-if (! function_exists('dd')) {
-    /**
-     * Dump the passed variables and end the script.
-     *
-     * @param  mixed  $args
-     * @return void
-     */
-    function dd(...$args)
-    {
-        foreach ($args as $x) {
-            (new Dumper)->dump($x);
-        }
-
-        die(1);
-    }
-}
-
 if (! function_exists('e')) {
     /**
      * Escape HTML special characters in a string.


### PR DESCRIPTION
Symfony added their own `dd()` helper in https://github.com/symfony/symfony/pull/26970, which made Laravel's `dd()` helper useless.

This PR removes our helper function and registers Laravel's `Dumper` as handler for Symfony's function.

I'm not sure where to add this really, the `Application` seems reasonable since it's loaded early on, but maybe there is a better place, @taylorotwell?

Fixes #24913.