### PR TITLE
[5.7] making addFailure public

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -584,8 +584,12 @@ class Validator implements ValidatorContract
      * @param  array   $parameters
      * @return void
      */
-    protected function addFailure($attribute, $rule, $parameters)
+    public function addFailure($attribute, $rule, $parameters = [])
     {
+        if (! $this->messages) {
+            $this->passes();
+        }
+
         $this->messages->add($attribute, $this->makeReplacements(
             $this->getMessage($attribute, $rule), $attribute, $rule, $parameters
         ));

--- a/tests/Validation/ValidationAddFailureTest.php
+++ b/tests/Validation/ValidationAddFailureTest.php
@@ -28,7 +28,7 @@ class ValidationAddFailureTest extends TestCase
      * @param string $class name of the class
      * @param string $method name of the method
      * @throws ReflectionException if $class or $method don't exist
-     * @throws PHPUnit_Framework_ExpectationFailedException if the method isn't public
+     * @throws PHPUnit_Framework_ExpectationFailedException if the method is not public
      */
     public function assertPublicMethod($class, $method)
     {

--- a/tests/Validation/ValidationAddFailureTest.php
+++ b/tests/Validation/ValidationAddFailureTest.php
@@ -12,13 +12,13 @@ class ValidationAddFailureTest extends TestCase
      *
      * @return Validator
      */
-    public function makeValidator(): Validator
+    public function makeValidator()
     {
         $mainTest = new ValidationValidatorTest();
         $trans = $mainTest->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => ['bar' => ['baz' => '']]], ['foo.bar.baz' => 'sometimes|required']);
+        $validator = new Validator($trans, ['foo' => ['bar' => ['baz' => '']]], ['foo.bar.baz' => 'sometimes|required']);
 
-        return $v;
+        return $validator;
     }
 
     public function testAddFailureExists()

--- a/tests/Validation/ValidationAddFailureTest.php
+++ b/tests/Validation/ValidationAddFailureTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Validator;
+use Illuminate\Tests\Validation\ValidationValidatorTest;
+use ReflectionMethod;
+
+class ValidationAddFailureTest extends TestCase
+{
+    /**
+     * Making Validator using ValidationValidatorTest
+     * 
+     * @return Validator
+     */
+    public function makeValidator(): Validator
+    {
+        $mainTest = new ValidationValidatorTest();
+        $trans    = $mainTest->getIlluminateArrayTranslator();
+        $v        = new Validator($trans, ['foo' => ['bar' => ['baz' => '']]], ['foo.bar.baz' => 'sometimes|required']);
+
+        return $v;
+    }
+
+    /**
+     * Assert that a method has public access.
+     *
+     * @param string $class name of the class
+     * @param string $method name of the method
+     * @throws ReflectionException if $class or $method don't exist
+     * @throws PHPUnit_Framework_ExpectationFailedException if the method isn't public
+     */
+    public function assertPublicMethod($class, $method)
+    {
+        $reflector = new ReflectionMethod($class, $method);
+        self::assertTrue($reflector->isPublic(), 'method is not public');
+    }
+
+    public function testAddFailureExistsAndVisibile()
+    {
+        $validator   = $this->makeValidator();
+        $method_name = 'addFailure';
+        $this->assertTrue(method_exists($validator, $method_name));
+        $this->assertTrue(is_callable(array($validator, $method_name)));
+        $this->assertPublicMethod($validator, $method_name);
+    }
+
+    public function testAddFailureIsFunctional()
+    {
+        $attribute = 'Eugene';
+        $validator = $this->makeValidator();
+        $validator->addFailure($attribute, 'not_in');
+        $messages = json_decode($validator->messages());
+        $this->assertSame($messages->{"foo.bar.baz"}[0], "validation.required", 'initial data in messages is lost');
+        $this->assertSame($messages->{$attribute}[0], "validation.not_in", 'new data in messages was not added');
+    }
+
+
+}

--- a/tests/Validation/ValidationAddFailureTest.php
+++ b/tests/Validation/ValidationAddFailureTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Validation;
 
-use ReflectionMethod;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Validation\Validator;
 
@@ -22,27 +21,12 @@ class ValidationAddFailureTest extends TestCase
         return $v;
     }
 
-    /**
-     * Assert that a method has public access.
-     *
-     * @param string $class name of the class
-     * @param string $method name of the method
-     * @throws ReflectionException if $class or $method don't exist
-     * @throws PHPUnit_Framework_ExpectationFailedException if the method is not public
-     */
-    public function assertPublicMethod($class, $method)
-    {
-        $reflector = new ReflectionMethod($class, $method);
-        self::assertTrue($reflector->isPublic(), 'method is not public');
-    }
-
-    public function testAddFailureExistsAndVisibile()
+    public function testAddFailureExists()
     {
         $validator = $this->makeValidator();
         $method_name = 'addFailure';
         $this->assertTrue(method_exists($validator, $method_name));
         $this->assertTrue(is_callable([$validator, $method_name]));
-        $this->assertPublicMethod($validator, $method_name);
     }
 
     public function testAddFailureIsFunctional()

--- a/tests/Validation/ValidationAddFailureTest.php
+++ b/tests/Validation/ValidationAddFailureTest.php
@@ -2,23 +2,22 @@
 
 namespace Illuminate\Tests\Validation;
 
+use ReflectionMethod;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Validation\Validator;
-use Illuminate\Tests\Validation\ValidationValidatorTest;
-use ReflectionMethod;
 
 class ValidationAddFailureTest extends TestCase
 {
     /**
-     * Making Validator using ValidationValidatorTest
-     * 
+     * Making Validator using ValidationValidatorTest.
+     *
      * @return Validator
      */
     public function makeValidator(): Validator
     {
         $mainTest = new ValidationValidatorTest();
-        $trans    = $mainTest->getIlluminateArrayTranslator();
-        $v        = new Validator($trans, ['foo' => ['bar' => ['baz' => '']]], ['foo.bar.baz' => 'sometimes|required']);
+        $trans = $mainTest->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => ['bar' => ['baz' => '']]], ['foo.bar.baz' => 'sometimes|required']);
 
         return $v;
     }
@@ -39,10 +38,10 @@ class ValidationAddFailureTest extends TestCase
 
     public function testAddFailureExistsAndVisibile()
     {
-        $validator   = $this->makeValidator();
+        $validator = $this->makeValidator();
         $method_name = 'addFailure';
         $this->assertTrue(method_exists($validator, $method_name));
-        $this->assertTrue(is_callable(array($validator, $method_name)));
+        $this->assertTrue(is_callable([$validator, $method_name]));
         $this->assertPublicMethod($validator, $method_name);
     }
 
@@ -52,9 +51,7 @@ class ValidationAddFailureTest extends TestCase
         $validator = $this->makeValidator();
         $validator->addFailure($attribute, 'not_in');
         $messages = json_decode($validator->messages());
-        $this->assertSame($messages->{"foo.bar.baz"}[0], "validation.required", 'initial data in messages is lost');
-        $this->assertSame($messages->{$attribute}[0], "validation.not_in", 'new data in messages was not added');
+        $this->assertSame($messages->{'foo.bar.baz'}[0], 'validation.required', 'initial data in messages is lost');
+        $this->assertSame($messages->{$attribute}[0], 'validation.not_in', 'new data in messages was not added');
     }
-
-
 }


### PR DESCRIPTION
Based on [this stackoverflow question](https://stackoverflow.com/questions/51663977/laravel-custom-validation-failure-with-a-nice-message), this [issue](https://github.com/laravel/framework/issues/25068) and improved in accordance with [this pr improvement request](https://github.com/laravel/framework/pull/25058)

We need a way to GENERATE error messages based on  `\resources\lang\en\validation.php` configuration.

This functionality is sitting in addFailure function. But this function is protected.

So instead of doing:

     $validator->addFailure('my_number', 'not_in', []);

Laravel users may to do:

    $validator->errors()->add('my_number', __('validation.not_in', ['attribute' => __('validation.attributes.my_number')]));

1) But it is not the same because it will ignore `custom` section of validation.php.
2) Some rules has more parameters, not only `attribute`.

So it is quite complex to reproduce `addFailure` functionality using `errors()->add(...` mechanics.

My pull request is  merely making addFailure public.

