### PR TITLE
[5.6] Fix ConnectionInterface methods

### DIFF
--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -27,18 +27,20 @@ interface ConnectionInterface
      *
      * @param  string  $query
      * @param  array   $bindings
+     * @param  bool  $useReadPdo
      * @return mixed
      */
-    public function selectOne($query, $bindings = []);
+    public function selectOne($query, $bindings = [], $useReadPdo = true);
 
     /**
      * Run a select statement against the database.
      *
      * @param  string  $query
      * @param  array   $bindings
+     * @param  bool  $useReadPdo
      * @return array
      */
-    public function select($query, $bindings = []);
+    public function select($query, $bindings = [], $useReadPdo = true);
 
     /**
      * Run an insert statement against the database.


### PR DESCRIPTION
Declaration of Illuminate\Database\Connection class methods must be compatible with Illuminate\Database\ConnectionInterface

Does not require any change in the tests.
Doesn't break any existing feature.
