### PR TITLE
[5.6] adds the loginRoute method to simplify overriding

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -484,7 +484,7 @@ class Handler implements ExceptionHandlerContract
      *
      * @return string
      */
-    protected function loginRoute(): string
+    protected function loginRoute()
     {
         return route('login');
     }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -217,7 +217,7 @@ class Handler implements ExceptionHandlerContract
     {
         return $request->expectsJson()
                     ? response()->json(['message' => $exception->getMessage()], 401)
-                    : redirect()->guest(route('login'));
+                    : redirect()->guest($this->loginRoute());
     }
 
     /**
@@ -477,5 +477,15 @@ class Handler implements ExceptionHandlerContract
     protected function isHttpException(Exception $e)
     {
         return $e instanceof HttpException;
+    }
+
+    /**
+     * Returns the route that a user should be redirected to if they aren't authenticated.
+     *
+     * @return string
+     */
+    protected function loginRoute(): string
+    {
+        return route('login');
     }
 }


### PR DESCRIPTION
As overriding the login route is a common task, and the bolierplate override for the `unauthenticated` method has been removed from the `App\Exceptions\Handler` class, this simplifies defining a bespoke route.

See this [SO question](https://stackoverflow.com/questions/45340855/laravel-5-5-change-unauthenticated-login-redirect-url) - at 13k views at the time of posting.