### PR TITLE
[5.6] Revert "Fix ConnectionInterface methods"

### DIFF
--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -27,20 +27,18 @@ interface ConnectionInterface
      *
      * @param  string  $query
      * @param  array   $bindings
-     * @param  bool  $useReadPdo
      * @return mixed
      */
-    public function selectOne($query, $bindings = [], $useReadPdo = true);
+    public function selectOne($query, $bindings = []);
 
     /**
      * Run a select statement against the database.
      *
      * @param  string  $query
      * @param  array   $bindings
-     * @param  bool  $useReadPdo
      * @return array
      */
-    public function select($query, $bindings = [], $useReadPdo = true);
+    public function select($query, $bindings = []);
 
     /**
      * Run an insert statement against the database.


### PR DESCRIPTION
Reverts laravel/framework#25092; changing the signature of an interface is a breaking change that should be done on 5.7