### PR TITLE
[5.6] Fix Filesystem download non-ASCII fielname (#2703) (#2305)

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -123,7 +123,8 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     {
         $response = new StreamedResponse;
 
-        $disposition = $response->headers->makeDisposition($disposition, $name ?? basename($path));
+        $filenameFallback = Str::ascii(basename($path));
+        $disposition = $response->headers->makeDisposition($disposition, $name ?? $filenameFallback, $filenameFallback);
 
         $response->headers->replace($headers + [
             'Content-Type' => $this->mimeType($path),

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -45,7 +45,7 @@ class FilesystemAdapterTest extends TestCase
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $files = new FilesystemAdapter($this->filesystem);
-        $response = $files->download('file.txt', 'hello.txt');
+        $response = $files->download('file.txt', '中文.txt');
         $this->assertInstanceOf(StreamedResponse::class, $response);
         // $this->assertEquals('attachment; filename="hello.txt"', $response->headers->get('content-disposition'));
     }


### PR DESCRIPTION
Fixed #2703 #2305

```php
// Will be throw InvalidArgumentException: The filename fallback must only contain ASCII characters.
Storage::disk('public')->download('file.txt', 'non-ascii_中文.txt');
```

This PR also fixed 5.5, 5.7 branch.