### PR TITLE
[5.6] Add mixins for Auth and session manager classes

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -6,6 +6,9 @@ use Closure;
 use InvalidArgumentException;
 use Illuminate\Contracts\Auth\Factory as FactoryContract;
 
+/**
+ * @mixin \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
+ */
 class AuthManager implements FactoryContract
 {
     use CreatesUserProviders;

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -4,6 +4,9 @@ namespace Illuminate\Session;
 
 use Illuminate\Support\Manager;
 
+/**
+ * @mixin \Illuminate\Session\Store
+ */
 class SessionManager extends Manager
 {
     /**


### PR DESCRIPTION
This PR adds mixin docblocks so that method autocompleting can work in IDEs for the AuthManager and SessionManager classes. The mixin docblocks are already added in other "manager" classes (eg. CacheManager, DatabaseManager etc.) so there is no reason why they shouldn't be added here too.