### PR TITLE
Allow to set absolute parameter in signedRoutes

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -301,9 +301,10 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  string  $name
      * @param  array  $parameters
      * @param  \DateTimeInterface|int  $expiration
+     * @param  bool  $absolute
      * @return string
      */
-    public function signedRoute($name, $parameters = [], $expiration = null)
+    public function signedRoute($name, $parameters = [], $expiration = null, $absolute = true)
     {
         $parameters = $this->formatParameters($parameters);
 
@@ -317,7 +318,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         return $this->route($name, $parameters + [
             'signature' => hash_hmac('sha256', $this->route($name, $parameters), $key),
-        ]);
+        ], $absolute);
     }
 
     /**
@@ -326,11 +327,12 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  string  $name
      * @param  \DateTimeInterface|int  $expiration
      * @param  array  $parameters
+     * @param  bool  $absolute
      * @return string
      */
-    public function temporarySignedRoute($name, $expiration, $parameters = [])
+    public function temporarySignedRoute($name, $expiration, $parameters = [], $absolute = true)
     {
-        return $this->signedRoute($name, $parameters, $expiration);
+        return $this->signedRoute($name, $parameters, $expiration, $absolute);
     }
 
     /**


### PR DESCRIPTION
This PR add the `$absolute` parameter that is already defined in the `src/Illuminate/Routing/UrlGenerator.php@route` method for the signed routes.

Basically, in my case I need only the path with the query params (because I will override the host), so the only way to do that is with `str_replace` or something like `parse_url($url, PHP_URL_PATH) . parse_url($url, PHP_URL_QUERY);` not a big deal, but will be cleaner if we can use the parameter that already exists for the route.