### PR TITLE
[5.7] Add ability to set retry delay per Job

### DIFF
--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -70,6 +70,13 @@ interface Job
     public function failed($e);
 
     /**
+     * Get the delay for retrying a job.
+     *
+     * @return int
+     */
+    public function retryDelay();
+
+    /**
      * Get the number of times to attempt a job.
      *
      * @return int|null

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -149,4 +149,29 @@ class CallQueuedHandler
             $command->failed($e);
         }
     }
+
+    /**
+     * Call the retryDelay method on the job instance.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  array  $data
+     * @return int
+     */
+    public function retryDelay(Job $job, array $data)
+    {
+        try {
+            $command = $this->setJobInstanceIfNecessary(
+                $job, unserialize($data['command'])
+            );
+        } catch (ModelNotFoundException $e) {
+            $this->handleModelNotFound($job, $e);
+            return 0;
+        }
+
+        if (method_exists($command, 'retryDelay')) {
+            return $command->retryDelay();
+        }
+
+        return 0;
+    }
 }

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -165,6 +165,7 @@ class CallQueuedHandler
             );
         } catch (ModelNotFoundException $e) {
             $this->handleModelNotFound($job, $e);
+
             return 0;
         }
 

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -174,6 +174,24 @@ abstract class Job
     }
 
     /**
+     * Get the delay for retrying a job.
+     *
+     * @return int
+     */
+    public function retryDelay()
+    {
+        $payload = $this->payload();
+
+        list($class, $method) = JobName::parse($payload['job']);
+
+        if (method_exists($this->instance = $this->resolve($class), 'retryDelay')) {
+            return $this->instance->retryDelay($this, $payload['data']);
+        }
+
+        return 0;
+    }
+
+    /**
      * Resolve the given class.
      *
      * @param  string  $class

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -378,16 +378,16 @@ class Worker
     protected function getJobRetryDelay($job)
     {
         try {
-            return $job->retryDelay();
+            if (($retryDelay = $job->retryDelay()) > 0) {
+                return $retryDelay;
+            }
         } catch (Exception $e) {
             $this->exceptions->report($e);
-
-            return 0;
         } catch (Throwable $e) {
             $this->exceptions->report($e = new FatalThrowableError($e));
-
-            return 0;
         }
+
+        return 0;
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -362,7 +362,7 @@ class Worker
             // so it is not lost entirely. This'll let the job be retried at a later time by
             // another listener (or this same one). We will re-throw this exception after.
             if (! $job->isDeleted() && ! $job->isReleased() && ! $job->hasFailed()) {
-                $job->release($options->delay + $this->getJobRetryDelay($job));
+                $job->release($this->getJobRetryDelay($job));
             }
         }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -362,7 +362,7 @@ class Worker
             // so it is not lost entirely. This'll let the job be retried at a later time by
             // another listener (or this same one). We will re-throw this exception after.
             if (! $job->isDeleted() && ! $job->isReleased() && ! $job->hasFailed()) {
-                $job->release($options->delay);
+                $job->release($options->delay + $job->retryDelay());
             }
         }
 

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -80,6 +80,55 @@ class CallQueuedHandlerTest extends TestCase
 
         Event::assertNotDispatched(JobFailed::class);
     }
+
+    public function test_job_with_retry_delay_returns_delay()
+    {
+        CallQueuedHandlerTestJob::$handled = false;
+
+        $instance = new \Illuminate\Queue\CallQueuedHandler(new \Illuminate\Bus\Dispatcher(app()));
+
+        $job = Mockery::mock('Illuminate\Contracts\Queue\Job');
+
+        $retryDelay = $instance->retryDelay($job, [
+            'command' => serialize(new CallQueuedHandlerTestJob),
+        ]);
+
+        $this->assertEquals(CallQueuedHandlerTestJob::$retryDelay, $retryDelay);
+    }
+
+    public function test_job_with_no_retry_delay_returns_default()
+    {
+        CallQueuedHandlerTestJob::$handled = false;
+
+        $instance = new \Illuminate\Queue\CallQueuedHandler(new \Illuminate\Bus\Dispatcher(app()));
+
+        $job = Mockery::mock('Illuminate\Contracts\Queue\Job');
+
+        $retryDelay = $instance->retryDelay($job, [
+            'command' => serialize(new CallQueuedHandlerNoRetryJob),
+        ]);
+
+        $this->assertEquals(0, $retryDelay);
+    }
+
+    public function test_job_when_model_not_found_exception_is_thrown_retry_delay_returns_default()
+    {
+        $instance = new \Illuminate\Queue\CallQueuedHandler(new \Illuminate\Bus\Dispatcher(app()));
+
+        $job = Mockery::mock('Illuminate\Contracts\Queue\Job');
+        $job->shouldReceive('getConnectionName')->andReturn('connection');
+        $job->shouldReceive('resolveName')->andReturn(__CLASS__);
+        $job->shouldReceive('markAsFailed')->once();
+        $job->shouldReceive('isDeleted')->andReturn(false);
+        $job->shouldReceive('delete')->once();
+        $job->shouldReceive('failed')->once();
+
+        $retryDelay = $instance->retryDelay($job, [
+            'command' => serialize(new CallQueuedHandlerExceptionThrower),
+        ]);
+
+        $this->assertEquals(0, $retryDelay);
+    }
 }
 
 class CallQueuedHandlerTestJob
@@ -87,10 +136,26 @@ class CallQueuedHandlerTestJob
     use \Illuminate\Queue\InteractsWithQueue;
 
     public static $handled = false;
+    public static $retryDelay = 10;
 
     public function handle()
     {
         static::$handled = true;
+    }
+
+    public function retryDelay()
+    {
+        return static::$retryDelay;
+    }
+}
+
+class CallQueuedHandlerNoRetryJob
+{
+    use \Illuminate\Queue\InteractsWithQueue;
+
+    public function handle()
+    {
+        //
     }
 }
 

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -56,6 +56,32 @@ class QueueBeanstalkdJobTest extends TestCase
         $job->bury();
     }
 
+    public function testRetryDelayCallsHandlerWithMethodDefined()
+    {
+        $job = $this->getJob();
+        $handler = $this->getMockBuilder('stdClass')->setMethods(['retryDelay'])->getMock();
+
+        $job->getPheanstalkJob()->shouldReceive('getData')->once()->andReturn(json_encode(['job' => 'foo', 'data' => ['data']]));
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler);
+        $handler->expects($this->once())->method('retryDelay')->with($job, ['data'])->willReturn(10);
+
+        $retryDelay = $job->retryDelay();
+
+        $this->assertEquals(10, $retryDelay);
+    }
+
+    public function testRetryDelayDoesNotCallHandlerWithoutMethodDefined()
+    {
+        $job = $this->getJob();
+        $job->getPheanstalkJob()->shouldReceive('getData')->once()->andReturn(json_encode(['job' => 'foo', 'data' => ['data']]));
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('stdClass'));
+        $handler->shouldNotReceive('retryDelay');
+
+        $retryDelay = $job->retryDelay();
+
+        $this->assertEquals(0, $retryDelay);
+    }
+
     protected function getJob()
     {
         return new \Illuminate\Queue\Jobs\BeanstalkdJob(

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -39,6 +39,30 @@ class QueueRedisJobTest extends TestCase
         $job->release(1);
     }
 
+    public function testRetryDelayCallsHandlerWithMethodDefined()
+    {
+        $job = $this->getJob();
+        $handler = $this->getMockBuilder('stdClass')->setMethods(['retryDelay'])->getMock();
+
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler);
+        $handler->expects($this->once())->method('retryDelay')->with($job, ['data'])->willReturn(10);
+
+        $retryDelay = $job->retryDelay();
+
+        $this->assertEquals(10, $retryDelay);
+    }
+
+    public function testRetryDelayDoesNotCallHandlerWithoutMethodDefined()
+    {
+        $job = $this->getJob();
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('stdClass'));
+        $handler->shouldNotReceive('retryDelay');
+
+        $retryDelay = $job->retryDelay();
+
+        $this->assertEquals(0, $retryDelay);
+    }
+
     protected function getJob()
     {
         return new \Illuminate\Queue\Jobs\RedisJob(

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -93,13 +93,12 @@ class QueueWorkerTest extends TestCase
             throw $e;
         });
 
-        $initialDelay = 10;
         $retryDelay = $job->retryDelay();
 
         $worker = $this->getWorker('default', ['queue' => [$job]]);
-        $worker->runNextJob('default', 'queue', $this->workerOptions(['delay' => $initialDelay]));
+        $worker->runNextJob('default', 'queue', $this->workerOptions(['delay' => 10]));
 
-        $this->assertEquals($initialDelay + $retryDelay, $job->releaseAfter);
+        $this->assertEquals($retryDelay, $job->releaseAfter);
         $this->assertFalse($job->deleted);
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
         $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobExceptionOccurred::class))->once();


### PR DESCRIPTION
### Problem
When a queued job fails, the job will retry immediately or with the `$delay` that the job was originally called with. However, there are times when you want a job to retry after a certain time (i.e. jobs dependent on external APIs), but you don't want to dispatch the job with an initial delay.

Some discussion here => https://github.com/laravel/ideas/issues/537 & https://github.com/laravel/ideas/issues/1268

### Solution
This PR allows developers to define a `retryDelay` on the job class to specify a delay between job retries.

Example (retry with constant time):
```php
/**
 * Determine the duration of seconds before a retry attempt
 *
 * @return int
 */
public function retryDelay()
{
    return 10;
}
```

Example (retry with exponential backoff):
```php
<?php namespace App\Jobs;

use Illuminate\Queue\InteractsWithQueue;
use Illuminate\Contracts\Queue\ShouldQueue;

class TestJob implements ShouldQueue
{
    use InteractsWithQueue;

    /**
     * Determine the duration of seconds before a retry attempt
     *
     * @return int
     */
    public function retryDelay()
    {
        return 2 ** $this->attempts();
    }
}
```

## Breaking Change
Prior to 5.7, failed jobs were released back on to the queue with a delay specified by the job's initial delay. For example, if `ProcessPodcast::dispatch($podcast)->delay(10);` failed, it would be released back onto the queue with a delay of 10 seconds.

With the new `retryDelay` function, failed jobs will be released back to the queue with the value specified in the `retryDelay` function and will not account for the initial delay.