### PR TITLE
[5.7] Add new conditional rule for validation

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -84,4 +84,15 @@ class Rule
     {
         return new Rules\Unique($table, $column);
     }
+
+    /**
+     * Get a conditional builder instance.
+     *
+     * @param  \Closure|bool $value
+     * @return \Illuminate\Validation\Rules\Conditional
+     */
+    public static function conditional($value)
+    {
+        return new Rules\Conditional($value);
+    }
 }

--- a/src/Illuminate/Validation/Rules/Conditional.php
+++ b/src/Illuminate/Validation/Rules/Conditional.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+class Conditional
+{
+    /**
+     * @var bool|\Closure
+     */
+    protected $condition;
+
+    /**
+     * @var array
+     */
+    protected $passRules = [];
+
+    /**
+     * @var array
+     */
+    protected $failRules = [];
+
+    /**
+     * Create a new conditional rule instance.
+     *
+     * @param  bool|\Closure  $condition
+     * @return void
+     */
+    public function __construct($condition)
+    {
+        $this->condition = $condition;
+    }
+
+    /**
+     * @param  mixed ...$rules
+     *
+     * @return $this
+     */
+    public function passes(...$rules)
+    {
+        if (is_array($rules[0])) {
+            $rules = $rules[0];
+        }
+
+        $this->passRules = $rules;
+
+        return $this;
+    }
+
+    /**
+     * @param  mixed ...$rules
+     *
+     * @return $this
+     */
+    public function fails(...$rules)
+    {
+        if (is_array($rules[0])) {
+            $rules = $rules[0];
+        }
+
+        $this->failRules = $rules;
+
+        return $this;
+    }
+
+    /**
+     * Get the rules that should be applied.
+     *
+     * @return array
+     */
+    public function getRules()
+    {
+        return value($this->condition) ? $this->passRules : $this->failRules;
+    }
+}

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -5,9 +5,9 @@ namespace Illuminate\Validation;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Illuminate\Validation\Rules\Conditional;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
+use Illuminate\Validation\Rules\Conditional;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
 
 class ValidationRuleParser
@@ -313,7 +313,7 @@ class ValidationRuleParser
         }
 
         foreach ($rules as $key => $rule) {
-            if (!$rule instanceof Conditional) {
+            if (! $rule instanceof Conditional) {
                 continue;
             }
 

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -5,6 +5,7 @@ namespace Illuminate\Validation;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\Conditional;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
@@ -85,6 +86,8 @@ class ValidationRuleParser
     {
         if (is_string($rule)) {
             return explode('|', $rule);
+        } elseif ($this->hasConditionalRule($rule)) {
+            return $this->mergeConditionalRules($rule);
         } elseif (is_object($rule)) {
             return [$this->prepareRule($rule)];
         }
@@ -106,6 +109,7 @@ class ValidationRuleParser
 
         if (! is_object($rule) ||
             $rule instanceof RuleContract ||
+            $rule instanceof Conditional ||
             ($rule instanceof Exists && $rule->queryCallbacks()) ||
             ($rule instanceof Unique && $rule->queryCallbacks())) {
             return $rule;
@@ -273,5 +277,54 @@ class ValidationRuleParser
             default:
                 return $rule;
         }
+    }
+
+    /**
+     * Checks if there are any conditional rules.
+     *
+     * @param  mixed $rules
+     *
+     * @return bool
+     */
+    protected function hasConditionalRule($rules)
+    {
+        if (is_object($rules)) {
+            return $rules instanceof Conditional;
+        }
+
+        return count(
+                Arr::where($rules, function ($rule) {
+                    return $rule instanceof Conditional;
+                })
+            ) > 0;
+    }
+
+    /**
+     * Merge any conditional rules into the set rules.
+     *
+     * @param  $rules
+     *
+     * @return array
+     */
+    protected function mergeConditionalRules($rules)
+    {
+        if (is_object($rules)) {
+            $rules = [$rules];
+        }
+
+        foreach ($rules as $key => $rule) {
+            if (!$rule instanceof Conditional) {
+                continue;
+            }
+
+            $rules = array_merge(
+                $rules,
+                $this->explodeExplicitRule($rule->getRules())
+            );
+
+            unset($rules[$key]);
+        }
+
+        return array_map([$this, 'prepareRule'], array_values($rules));
     }
 }

--- a/tests/Validation/ValidationConditionalRuleTest.php
+++ b/tests/Validation/ValidationConditionalRuleTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Validation\Rules\Conditional;
+use PHPUnit\Framework\TestCase;
+
+class ValidationConditionalRuleTest extends TestCase
+{
+    public function testItReturnsTheCorrectSetOfRules()
+    {
+        $rule = (new Conditional(true))
+            ->passes('required', 'email')
+            ->fails('nullable', 'url');
+
+        $this->assertEquals(['required', 'email'], $rule->getRules());
+
+        $rule = (new Conditional(false))
+            ->passes('required', 'email')
+            ->fails('nullable', 'url');
+
+        $this->assertEquals(['nullable', 'url'], $rule->getRules());
+    }
+
+    public function testItAcceptsCallbacksThatReturnABool()
+    {
+        $callback = function () {
+            return true;
+        };
+
+        $rule = (new Conditional($callback))
+            ->passes(['required', 'email']);
+
+        $this->assertEquals(['required', 'email'], $rule->getRules());
+    }
+}

--- a/tests/Validation/ValidationConditionalRuleTest.php
+++ b/tests/Validation/ValidationConditionalRuleTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Validation;
 
-use Illuminate\Validation\Rules\Conditional;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Rules\Conditional;
 
 class ValidationConditionalRuleTest extends TestCase
 {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3,17 +3,17 @@
 namespace Illuminate\Tests\Validation;
 
 use DateTime;
-use Illuminate\Validation\Rules\Conditional;
-use Illuminate\Validation\Rules\In;
 use Mockery as m;
 use DateTimeImmutable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Validator;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Validation\Rules\Conditional;
 use Symfony\Component\HttpFoundation\File\File;
 use Illuminate\Contracts\Validation\ImplicitRule;
 
@@ -4046,8 +4046,8 @@ class ValidationValidatorTest extends TestCase
                         'required',
                         (new In(['john@example.com'])),
                         (new Conditional(false))->fails('max:40'),
-                    ])
-                ]
+                    ]),
+                ],
             ]);
 
         $this->assertTrue($v->passes());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Validation;
 
 use DateTime;
+use Illuminate\Validation\Rules\Conditional;
+use Illuminate\Validation\Rules\In;
 use Mockery as m;
 use DateTimeImmutable;
 use Illuminate\Support\Arr;
@@ -4018,6 +4020,55 @@ class ValidationValidatorTest extends TestCase
         $data = $v->validate();
 
         $this->assertEquals(['nested' => ['foo' => 'bar'], 'array' => [1, 2]], $data);
+    }
+
+    public function testItMergesConditionalRulesIntoTheMainRulesArray()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans,
+            [
+                'address' => 'Fakestreet',
+                'users' => [
+                    ['name' => 'John'],
+                    ['name' => 'Jane'],
+                ],
+                'email' => 'john@example.com',
+            ],
+            [
+                'address' => (new Conditional(true))->passes('required'),
+                'users.*.name' => [
+                    'required',
+                    (new Conditional(true))->passes('max:10'),
+                ],
+                'email' => [
+                    (new Conditional(true))->passes([
+                        'required',
+                        (new In(['john@example.com'])),
+                        (new Conditional(false))->fails('max:40'),
+                    ])
+                ]
+            ]);
+
+        $this->assertTrue($v->passes());
+        $this->assertEquals([
+            'address' => [
+                'required',
+            ],
+            'users.0.name' => [
+                'required',
+                'max:10',
+            ],
+            'users.1.name' => [
+                'required',
+                'max:10',
+            ],
+            'email' => [
+                'required',
+                'in:"john@example.com"',
+                'max:40',
+            ],
+        ], $v->getRules());
     }
 
     protected function getTranslator()


### PR DESCRIPTION
This PR adds a new conditional rule that allows conditionally adding rules based on a closure or boolean.

**Example**
```php
$this->validate($data, [
    'user_id' => [
        'numeric',
        Rule::conditional(Auth::user()->isAdmin())->passes(['required', 'numeric'])->fails('nullable'),
    ],
]);
```

This also allows complex nested rules if you want. (These can be nested as far as you need - even with a conditional rule inside a conditional rule)

```php
$this->validate($data, [
    'user_id' => [
        'numeric',
        Rule::conditional(Auth::user()->isAdmin())->passes(new MyCustomRule),
    ],
]);
```

This would also replace some of the usage of `$v->sometimes`.

Sometimes approach:
```php
$v->sometimes('reason', 'required|max:500', function ($input) {
    return $input->games >= 100;
});
```

Conditional Rule approach:
```php
$this->validate($input, [
    'reason' => Rule::conditional($input->games >= 100)->passes('required', 'max:500'),
]);
```

This to me is a much simpler way of doing conditional validation and looks alot cleaner too.