### PR TITLE
[5.8] move eloquent exceptions to exceptions folder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -11,6 +11,8 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Exceptions\RelationNotFoundException;
 
 /**
  * @mixin \Illuminate\Database\Query\Builder
@@ -348,7 +350,7 @@ class Builder
      * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      */
     public function findOrFail($id, $columns = ['*'])
     {
@@ -437,7 +439,7 @@ class Builder
      * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|static
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      */
     public function firstOrFail($columns = ['*'])
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Database\Eloquent\JsonEncodingException;
+use Illuminate\Database\Eloquent\Exceptions\JsonEncodingException;
 
 trait HasAttributes
 {

--- a/src/Illuminate/Database/Eloquent/Exceptions/JsonEncodingException.php
+++ b/src/Illuminate/Database/Eloquent/Exceptions/JsonEncodingException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Database\Eloquent;
+namespace Illuminate\Database\Eloquent\Exceptions;
 
 use RuntimeException;
 

--- a/src/Illuminate/Database/Eloquent/Exceptions/MassAssignmentException.php
+++ b/src/Illuminate/Database/Eloquent/Exceptions/MassAssignmentException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Database\Eloquent;
+namespace Illuminate\Database\Eloquent\Exceptions;
 
 use RuntimeException;
 

--- a/src/Illuminate/Database/Eloquent/Exceptions/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/Exceptions/ModelNotFoundException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Database\Eloquent;
+namespace Illuminate\Database\Eloquent\Exceptions;
 
 use RuntimeException;
 use Illuminate\Support\Arr;

--- a/src/Illuminate/Database/Eloquent/Exceptions/RelationNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/Exceptions/RelationNotFoundException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Database\Eloquent;
+namespace Illuminate\Database\Eloquent\Exceptions;
 
 use RuntimeException;
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -15,6 +15,8 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\Eloquent\Exceptions\JsonEncodingException;
+use Illuminate\Database\Eloquent\Exceptions\MassAssignmentException;
 
 abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
@@ -307,7 +309,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  array  $attributes
      * @return $this
      *
-     * @throws \Illuminate\Database\Eloquent\MassAssignmentException
+     * @throws \Illuminate\Database\Eloquent\Exceptions\MassAssignmentException
      */
     public function fill(array $attributes)
     {
@@ -1075,7 +1077,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  int  $options
      * @return string
      *
-     * @throws \Illuminate\Database\Eloquent\JsonEncodingException
+     * @throws \Illuminate\Database\Eloquent\Exceptions\JsonEncodingException
      */
     public function toJson($options = 0)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException;
 
 class BelongsToMany extends Relation
 {
@@ -500,7 +500,7 @@ class BelongsToMany extends Relation
      * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      */
     public function findOrFail($id, $columns = ['*'])
     {
@@ -536,7 +536,7 @@ class BelongsToMany extends Relation
      * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|static
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      */
     public function firstOrFail($columns = ['*'])
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException;
 
 class HasManyThrough extends Relation
 {
@@ -263,7 +263,7 @@ class HasManyThrough extends Relation
      * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|static
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      */
     public function firstOrFail($columns = ['*'])
     {
@@ -317,7 +317,7 @@ class HasManyThrough extends Relation
      * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      */
     public function findOrFail($id, $columns = ['*'])
     {

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -22,7 +22,7 @@ use Illuminate\Validation\ValidationException;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Symfony\Component\Debug\Exception\FlattenException;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -6,7 +6,7 @@ use Exception;
 use ReflectionClass;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Bus\Dispatcher;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException;
 
 class CallQueuedHandler
 {

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -4,7 +4,7 @@ namespace Illuminate\Routing;
 
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Routing\UrlRoutable;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException;
 
 class ImplicitRouteBinding
 {

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -4,7 +4,7 @@ namespace Illuminate\Routing;
 
 use Closure;
 use Illuminate\Support\Str;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException;
 
 class RouteBinding
 {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -913,7 +913,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  \Closure|null  $callback
      * @return void
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      */
     public function model($key, $class, Closure $callback = null)
     {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -60,7 +60,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedException \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      */
     public function testFindOrFailMethodThrowsModelNotFoundException()
     {
@@ -72,7 +72,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedException \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      */
     public function testFindOrFailMethodWithManyThrowsModelNotFoundException()
     {
@@ -84,7 +84,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedException \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      */
     public function testFirstOrFailMethodThrowsModelNotFoundException()
     {
@@ -490,7 +490,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Database\Eloquent\RelationNotFoundException
+     * @expectedException \Illuminate\Database\Eloquent\Exceptions\RelationNotFoundException
      */
     public function testGetRelationThrowsException()
     {

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -119,7 +119,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedException \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].
      */
     public function testFirstOrFailThrowsAnException()
@@ -131,7 +131,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedException \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].
      */
     public function testFindOrFailThrowsAnException()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -438,7 +438,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedException \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1
      */
     public function testFindOrFailWithSingleIdThrowsModelNotFoundException()
@@ -447,7 +447,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedException \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1, 2
      */
     public function testFindOrFailWithMultipleIdsThrowsModelNotFoundException()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -938,7 +938,7 @@ class DatabaseEloquentModelTest extends TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Database\Eloquent\MassAssignmentException
+     * @expectedException \Illuminate\Database\Eloquent\Exceptions\MassAssignmentException
      * @expectedExceptionMessage name
      */
     public function testGlobalGuarded()
@@ -1598,7 +1598,7 @@ class DatabaseEloquentModelTest extends TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Database\Eloquent\JsonEncodingException
+     * @expectedException \Illuminate\Database\Eloquent\Exceptions\JsonEncodingException
      * @expectedExceptionMessage Unable to encode attribute [objectAttribute] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.
      */
     public function testModelAttributeCastingFailsOnUnencodableData()

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -251,7 +251,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     /**
      * @test
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedException \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      */
     public function firstOrFail_method()
     {
@@ -278,7 +278,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     /**
      * @test
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedException \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      */
     public function findOrFail_method()
     {

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -105,6 +105,6 @@ class CallQueuedHandlerExceptionThrower
 
     public function __wakeup()
     {
-        throw new \Illuminate\Database\Eloquent\ModelNotFoundException('Foo');
+        throw new \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException('Foo');
     }
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -777,7 +777,7 @@ class RoutingRouteTest extends TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedException \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      * @expectedExceptionMessage No query results for model [Illuminate\Tests\Routing\RouteModelBindingNullStub].
      */
     public function testModelBindingWithNullReturn()
@@ -1406,7 +1406,7 @@ class RoutingRouteTest extends TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedException \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException
      */
     public function testImplicitBindingsWithOptionalParameterWithNonExistingKeyInUri()
     {
@@ -1793,7 +1793,7 @@ class RoutingTestNonExistingUserModel extends RoutingTestUserModel
 
     public function firstOrFail()
     {
-        throw new \Illuminate\Database\Eloquent\ModelNotFoundException;
+        throw new \Illuminate\Database\Eloquent\Exceptions\ModelNotFoundException;
     }
 }
 


### PR DESCRIPTION
- Just a better way to organize exception classes inside **Illuminate\Database\Eloquent**
on same way like **Illuminate\Http\Exceptions**.

- This is PR into master branch because it is not backward compatible for 5.6