### PR TITLE
[5.7] Allow guests in authorize middleware

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -5,17 +5,9 @@ namespace Illuminate\Auth\Middleware;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Auth\Access\Gate;
-use Illuminate\Contracts\Auth\Factory as Auth;
 
 class Authorize
 {
-    /**
-     * The authentication factory instance.
-     *
-     * @var \Illuminate\Contracts\Auth\Factory
-     */
-    protected $auth;
-
     /**
      * The gate instance.
      *
@@ -26,13 +18,11 @@ class Authorize
     /**
      * Create a new middleware instance.
      *
-     * @param  \Illuminate\Contracts\Auth\Factory  $auth
      * @param  \Illuminate\Contracts\Auth\Access\Gate  $gate
      * @return void
      */
-    public function __construct(Auth $auth, Gate $gate)
+    public function __construct(Gate $gate)
     {
-        $this->auth = $auth;
         $this->gate = $gate;
     }
 
@@ -50,8 +40,6 @@ class Authorize
      */
     public function handle($request, Closure $next, $ability, ...$models)
     {
-        $this->auth->authenticate();
-
         $this->gate->authorize($ability, $this->getGateArguments($request, $models));
 
         return $next($request);

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -12,7 +12,6 @@ use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Contracts\Routing\Registrar;
-use Illuminate\Contracts\Auth\Factory as Auth;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 
@@ -33,13 +32,6 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->user = new stdClass;
 
         Container::setInstance($this->container = new Container);
-
-        $this->container->singleton(Auth::class, function () {
-            $auth = m::mock(Auth::class);
-            $auth->shouldReceive('authenticate')->once()->andReturn(null);
-
-            return $auth;
-        });
 
         $this->container->singleton(GateContract::class, function () {
             return new Gate($this->container, function () {
@@ -208,7 +200,7 @@ class AuthorizeMiddlewareTest extends TestCase
             $nextParam = $param;
         };
 
-        (new Authorize($this->container->make(Auth::class), $this->gate()))
+        (new Authorize($this->gate()))
             ->handle($request, $next, 'success', $instance);
     }
 


### PR DESCRIPTION
Since the gate now allows guests, [the `can` middleware should also allow guests](https://github.com/laravel/framework/pull/24576#issuecomment-396789787).

If the user wants to return a 401 (or redirect), they should use the `auth` middleware before the `can` middleware.