### PR TITLE
[5.7] Allow to customize amount of links on each side in paginator

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -42,6 +42,13 @@ abstract class AbstractPaginator implements Htmlable
     protected $path = '/';
 
     /**
+     * The number of links to display on each side of current page link.
+     *
+     * @var int
+     */
+    protected $onEachSide = 3;
+
+    /**
      * The query parameters to add to all URLs.
      *
      * @var array
@@ -338,6 +345,40 @@ abstract class AbstractPaginator implements Htmlable
     public function setPageName($name)
     {
         $this->pageName = $name;
+
+        return $this;
+    }
+
+    /**
+     * Set the number of links to display on each side of current page link
+     *
+     * @param int $amount
+     * @return this
+     */
+    public function linksOnEachSide($amount)
+    {
+        return $this->setOnEachSide($amount);
+    }
+
+    /**
+     * Get the number of links to display on each side of current page link
+     *
+     * @return int
+     */
+    public function getOnEachSide()
+    {
+        return $this->onEachSide;
+    }
+
+    /**
+     * Set the number of links to display on each side of current page link
+     *
+     * @param int $amount
+     * @return $this
+     */
+    public function setOnEachSide($amount)
+    {
+        $this->onEachSide = $amount;
 
         return $this;
     }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -350,7 +350,7 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
-     * Set the number of links to display on each side of current page link
+     * Set the number of links to display on each side of current page link.
      *
      * @param int $amount
      * @return this
@@ -361,7 +361,7 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
-     * Get the number of links to display on each side of current page link
+     * Get the number of links to display on each side of current page link.
      *
      * @return int
      */
@@ -371,7 +371,7 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
-     * Set the number of links to display on each side of current page link
+     * Set the number of links to display on each side of current page link.
      *
      * @param int $amount
      * @return $this

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -100,7 +100,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      */
     protected function elements()
     {
-        $window = UrlWindow::make($this, $this->onEachSide);
+        $window = UrlWindow::make($this);
 
         return array_filter([
             $window['first'],

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -100,7 +100,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      */
     protected function elements()
     {
-        $window = UrlWindow::make($this);
+        $window = UrlWindow::make($this, $this->onEachSide);
 
         return array_filter([
             $window['first'],

--- a/src/Illuminate/Pagination/UrlWindow.php
+++ b/src/Illuminate/Pagination/UrlWindow.php
@@ -28,22 +28,22 @@ class UrlWindow
      * Create a new URL window instance.
      *
      * @param  \Illuminate\Contracts\Pagination\LengthAwarePaginator  $paginator
-     * @param  int  $onEachSide
      * @return array
      */
-    public static function make(PaginatorContract $paginator, $onEachSide = 3)
+    public static function make(PaginatorContract $paginator)
     {
-        return (new static($paginator))->get($onEachSide);
+        return (new static($paginator))->get();
     }
 
     /**
      * Get the window of URLs to be shown.
      *
-     * @param  int  $onEachSide
      * @return array
      */
-    public function get($onEachSide = 3)
+    public function get()
     {
+        $onEachSide = $this->paginator->getOnEachSide();
+
         if ($this->paginator->lastPage() < ($onEachSide * 2) + 6) {
             return $this->getSmallSlider();
         }

--- a/tests/Pagination/UrlWindowTest.php
+++ b/tests/Pagination/UrlWindowTest.php
@@ -49,4 +49,23 @@ class UrlWindowTest extends TestCase
 
         $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => null, 'last' => $last], $window->get());
     }
+
+    public function testCustomUrlRangeForAWindowOfLinks()
+    {
+        $array = [];
+        for ($i = 1; $i <= 13; $i++) {
+            $array[$i] = 'item'.$i;
+        }
+
+        $p = new LengthAwarePaginator($array, count($array), 1, 8);
+        $p->linksOnEachSide(1);
+        $window = new UrlWindow($p);
+
+        $slider = [];
+        for ($i = 7; $i <= 9; $i++) {
+            $slider[$i] = '/?page='.$i;
+        }
+
+        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => $slider, 'last' => [12 => '/?page=12', 13 => '/?page=13']], $window->get());
+    }
 }


### PR DESCRIPTION
This PR allows to determine amount of links on the each side of the current page link. Thanks to this custom pagination view is not needed.
```php
User::paginate(2)->linksOnEachSide(5);
```