### PR TITLE
[5.7] Fix #24914 die with unsuccessful return code

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -29,7 +29,8 @@ class LoadEnvironmentVariables
         } catch (InvalidPathException $e) {
             //
         } catch (InvalidFileException $e) {
-            die('The environment file is invalid: '.$e->getMessage());
+            echo 'The environment file is invalid: '.$e->getMessage();
+            die(1);
         }
     }
 


### PR DESCRIPTION
fixes #24914

This is a change to untested code, and I don't know how you'd test it, but at least this won't return a successful return code on failure to parse .env file.

Honestly, I think this should be backported to 5.5 because it really is a bug fix, but opening it here under guidance of @tillkruss https://github.com/laravel/framework/issues/24914#issuecomment-410273392