### PR TITLE
[5.7] Flatten preset asset directories

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/Bootstrap.php
+++ b/src/Illuminate/Foundation/Console/Presets/Bootstrap.php
@@ -38,7 +38,7 @@ class Bootstrap extends Preset
      */
     protected static function updateSass()
     {
-        copy(__DIR__.'/bootstrap-stubs/_variables.scss', resource_path('assets/sass/_variables.scss'));
-        copy(__DIR__.'/bootstrap-stubs/app.scss', resource_path('assets/sass/app.scss'));
+        copy(__DIR__.'/bootstrap-stubs/_variables.scss', resource_path('sass/_variables.scss'));
+        copy(__DIR__.'/bootstrap-stubs/app.scss', resource_path('sass/app.scss'));
     }
 }

--- a/src/Illuminate/Foundation/Console/Presets/None.php
+++ b/src/Illuminate/Foundation/Console/Presets/None.php
@@ -17,8 +17,8 @@ class None extends Preset
         static::updateBootstrapping();
 
         tap(new Filesystem, function ($filesystem) {
-            $filesystem->deleteDirectory(resource_path('assets/js/components'));
-            $filesystem->delete(resource_path('assets/sass/_variables.scss'));
+            $filesystem->deleteDirectory(resource_path('js/components'));
+            $filesystem->delete(resource_path('sass/_variables.scss'));
             $filesystem->deleteDirectory(base_path('node_modules'));
             $filesystem->deleteDirectory(public_path('css'));
             $filesystem->deleteDirectory(public_path('js'));
@@ -53,7 +53,7 @@ class None extends Preset
      */
     protected static function updateBootstrapping()
     {
-        file_put_contents(resource_path('assets/sass/app.scss'), ''.PHP_EOL);
-        copy(__DIR__.'/none-stubs/app.js', resource_path('assets/js/app.js'));
+        file_put_contents(resource_path('sass/app.scss'), ''.PHP_EOL);
+        copy(__DIR__.'/none-stubs/app.js', resource_path('js/app.js'));
     }
 }

--- a/src/Illuminate/Foundation/Console/Presets/Preset.php
+++ b/src/Illuminate/Foundation/Console/Presets/Preset.php
@@ -15,7 +15,7 @@ class Preset
     {
         $filesystem = new Filesystem;
 
-        if (! $filesystem->isDirectory($directory = resource_path('assets/js/components'))) {
+        if (! $filesystem->isDirectory($directory = resource_path('js/components'))) {
             $filesystem->makeDirectory($directory, 0755, true);
         }
     }

--- a/src/Illuminate/Foundation/Console/Presets/React.php
+++ b/src/Illuminate/Foundation/Console/Presets/React.php
@@ -55,12 +55,12 @@ class React extends Preset
     protected static function updateComponent()
     {
         (new Filesystem)->delete(
-            resource_path('assets/js/components/ExampleComponent.vue')
+            resource_path('js/components/ExampleComponent.vue')
         );
 
         copy(
             __DIR__.'/react-stubs/Example.js',
-            resource_path('assets/js/components/Example.js')
+            resource_path('js/components/Example.js')
         );
     }
 
@@ -71,6 +71,6 @@ class React extends Preset
      */
     protected static function updateBootstrapping()
     {
-        copy(__DIR__.'/react-stubs/app.js', resource_path('assets/js/app.js'));
+        copy(__DIR__.'/react-stubs/app.js', resource_path('js/app.js'));
     }
 }

--- a/src/Illuminate/Foundation/Console/Presets/Vue.php
+++ b/src/Illuminate/Foundation/Console/Presets/Vue.php
@@ -55,12 +55,12 @@ class Vue extends Preset
     protected static function updateComponent()
     {
         (new Filesystem)->delete(
-            resource_path('assets/js/components/Example.js')
+            resource_path('js/components/Example.js')
         );
 
         copy(
             __DIR__.'/vue-stubs/ExampleComponent.vue',
-            resource_path('assets/js/components/ExampleComponent.vue')
+            resource_path('js/components/ExampleComponent.vue')
         );
     }
 
@@ -71,6 +71,6 @@ class Vue extends Preset
      */
     protected static function updateBootstrapping()
     {
-        copy(__DIR__.'/vue-stubs/app.js', resource_path('assets/js/app.js'));
+        copy(__DIR__.'/vue-stubs/app.js', resource_path('js/app.js'));
     }
 }

--- a/src/Illuminate/Foundation/Console/Presets/react-stubs/webpack.mix.js
+++ b/src/Illuminate/Foundation/Console/Presets/react-stubs/webpack.mix.js
@@ -11,5 +11,5 @@ let mix = require('laravel-mix');
  |
  */
 
-mix.react('resources/assets/js/app.js', 'public/js')
-   .sass('resources/assets/sass/app.scss', 'public/css');
+mix.react('resources/js/app.js', 'public/js')
+   .sass('resources/sass/app.scss', 'public/css');

--- a/src/Illuminate/Foundation/Console/Presets/vue-stubs/webpack.mix.js
+++ b/src/Illuminate/Foundation/Console/Presets/vue-stubs/webpack.mix.js
@@ -11,5 +11,5 @@ let mix = require('laravel-mix');
  |
  */
 
-mix.js('resources/assets/js/app.js', 'public/js')
-   .sass('resources/assets/sass/app.scss', 'public/css');
+mix.js('resources/js/app.js', 'public/js')
+   .sass('resources/sass/app.scss', 'public/css');


### PR DESCRIPTION
Laravel 5.7 flattens the `resources/assets` directory, so this PR simply updates all of the presets that publish changes to that directory.

Related: https://github.com/laravel/laravel/commit/ff38d4e1a007c1a7709b5a614da1036adb464b32