### PR TITLE
[5.6] Eloquent isolate scopes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -86,6 +86,13 @@ class Builder
     protected $removedScopes = [];
 
     /**
+     * Indicates if scopes would be isolated
+     *
+     * @var bool
+     */
+    protected $isolateScopes = true;
+
+    /**
      * Create a new Eloquent query builder instance.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -954,8 +961,10 @@ class Builder
 
         $result = $scope(...array_values($parameters)) ?? $this;
 
-        if (count((array) $query->wheres) > $originalWhereCount) {
-            $this->addNewWheresWithinGroup($query, $originalWhereCount);
+        if($this->isIsolateScopes()){
+            if (count((array) $query->wheres) > $originalWhereCount) {
+                $this->addNewWheresWithinGroup($query, $originalWhereCount);
+            }
         }
 
         return $result;
@@ -1244,6 +1253,29 @@ class Builder
     public function getMacro($name)
     {
         return Arr::get($this->localMacros, $name);
+    }
+
+    /**
+     * Get the value indicating whether scopes are isolated
+     *
+     * @return bool
+     */
+    public function isIsolateScopes(): bool
+    {
+        return $this->isolateScopes;
+    }
+
+    /**
+     * Set whether scopes will be isolated
+     *
+     * @param  bool  $isolateScopes
+     * @return $this
+     */
+    public function setIsolateScopes(bool $isolateScopes): Builder
+    {
+        $this->isolateScopes = $isolateScopes;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -945,9 +945,9 @@ class Builder
      *
      * @param  callable  $scope
      * @param  array  $parameters
-     * @return mixed
+     * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function callScope(callable $scope, $parameters = [])
+    protected function callScope(callable $scope, $parameters = []) : Builder
     {
         array_unshift($parameters, $this);
 
@@ -957,17 +957,18 @@ class Builder
         // scope so that we can properly group the added scope constraints in the
         // query as their own isolated nested where statement and avoid issues.
         $originalWhereCount = is_null($query->wheres)
-                    ? 0 : count($query->wheres);
+            ? 0 : count($query->wheres);
 
-        $result = $scope(...array_values($parameters)) ?? $this;
+        $builder = $scope(...array_values($parameters)) ?? $this;
 
-        if($this->isIsolateScopes()){
+        // We can oly disable isolating for Local Scopes
+        if($scope instanceof Closure  ||  $builder->isIsolateScopes()){
             if (count((array) $query->wheres) > $originalWhereCount) {
                 $this->addNewWheresWithinGroup($query, $originalWhereCount);
             }
         }
 
-        return $result;
+        return $builder;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -961,7 +961,7 @@ class Builder
 
         $builder = $scope(...array_values($parameters)) ?? $this;
 
-        // We can oly disable isolating for Local Scopes
+        // We can only disable isolating for Local Scopes
         if($scope instanceof Closure  ||  $builder->isIsolateScopes()){
             if (count((array) $query->wheres) > $originalWhereCount) {
                 $this->addNewWheresWithinGroup($query, $originalWhereCount);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -86,7 +86,7 @@ class Builder
     protected $removedScopes = [];
 
     /**
-     * Indicates if scopes would be isolated
+     * Indicates if local scopes will be isolated
      *
      * @var bool
      */
@@ -1257,7 +1257,7 @@ class Builder
     }
 
     /**
-     * Get the value indicating whether scopes are isolated
+     * Get the value indicating whether local scopes are isolated
      *
      * @return bool
      */
@@ -1267,7 +1267,7 @@ class Builder
     }
 
     /**
-     * Set whether scopes will be isolated
+     * Set whether local scopes will be isolated
      *
      * @param  bool  $isolateScopes
      * @return $this


### PR DESCRIPTION
Problem : **Extending eloquent builder**

- If you want to extend eloquent builder you can do that easiest with scopes.
- But problem is that scopes are isolated and query will not bet generated as it would be without scopes

for example I have this query : 

    User::where(function($query){
        $query->where('first_name', 'like', 'a');
        $query->orWhere('first_name', 'like', 'b');
    })->get();

which produces this mysql : 

    select * from `users` where (`first_name` like ? or `first_name` like ?) and `users`.`deleted_at` is null

but when I just move my code to scopes : 

    public function scopeWhereTest($builder, $column, $operator = null, $value = null, $boolean = 'and')
    {
        $builder->where($column, $operator, $value, $boolean);
    }

    public function scopeOrWhereTest($builder, $column, $operator = null, $value = null)
    {
        $builder->orWhere($column, $operator, $value);
    }

and run this : 

    User::where(function($query){
        $query->whereTest('first_name', 'like', 'a');
        $query->orWhereTest('first_name', 'like', 'b');
    })->get();

generated mysql is not the same : 
 
    select * from `users` where (`first_name` like ? or (`first_name` like ?)) and `users`.`deleted_at` is null

for this example it does not matter, but for more complicated it does, see https://github.com/laravel/framework/issues/24996

I know that many laravel packages like this one https://github.com/fico7489/laravel-eloquent-join
want to extend builder and this could really help 


With that option I can do following : 

    public function scopeWhereTest($builder, $column, $operator = null, $value = null, $boolean = 'and')
    {
        $builder->setIsolateScopes(false)
            ->where($column, $operator, $value, $boolean)
            ->setIsolateScopes(true);
    }

    public function scopeOrWhereTest($builder, $column, $operator = null, $value = null)
    {
        $builder->setIsolateScopes(false)
            ->orWhere($column, $operator, $value)
            ->setIsolateScopes(true);
    }
	
And now generated queries are the same for : 

	    User::where(function($query){
        $query->where('first_name', 'like', 'a');
        $query->orWhere('first_name', 'like', 'b');
    })->get();
	
and 
	
    User::where(function($query){
        $query->whereTest('first_name', 'like', 'a');
        $query->orWhereTest('first_name', 'like', 'b');
    })->get();