### PR TITLE
[5.6] Support raw expressions in whereRowValues()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1415,7 +1415,7 @@ class Builder
 
         $this->wheres[] = compact('type', 'columns', 'operator', 'values', 'boolean');
 
-        $this->addBinding($values);
+        $this->addBinding($this->cleanBindings($values));
 
         return $this;
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2636,6 +2636,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->where('company_id', 1)->orWhereRowValues(['last_update', 'order_number'], '<', [1, 2]);
         $this->assertEquals('select * from "orders" where "company_id" = ? or (last_update, order_number) < (?, ?)', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('orders')->whereRowValues(['last_update', 'order_number'], '<', [1, new Raw('2')]);
+        $this->assertEquals('select * from "orders" where (last_update, order_number) < (?, 2)', $builder->toSql());
+        $this->assertEquals([1], $builder->getBindings());
     }
 
     public function testWhereRowValuesArityMismatch()


### PR DESCRIPTION
`whereRowValues()` falsely adds raw expressions to the bindings:

```php
$builder = DB::table('table')->whereRowValues(['column'], '=', [DB::raw('value')]);

dd($builder->getBindings());
// expected: []
// actual:   [Expression {}]
```
