### PR TITLE
[5.6] improve DocBlock (orWhere always return $this)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -232,10 +232,10 @@ class Builder
     /**
      * Add an "or where" clause to the query.
      *
-     * @param  \Closure|array|string  $column
+     * @param  string|array|\Closure  $column
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return \Illuminate\Database\Eloquent\Builder|static
+     * @return $this
      */
     public function orWhere($column, $operator = null, $value = null)
     {


### PR DESCRIPTION
 - **where()** method returns **$this**, **orWhere()** method calls **where()** and return what **where()** return
that is the reason why **orWhere()** should have the same docblock return param as **where()** which is **$this**

also 

 - dockblock $column param is unified for **where()** and **orWhere()**

