### PR TITLE
[5.6] Remove fresh from description

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -69,7 +69,7 @@ abstract class Facade
     }
 
     /**
-     * Create a fresh mock instance for the given class.
+     * Create a mock instance for the given class.
      *
      * @return \Mockery\MockInterface
      */


### PR DESCRIPTION
the annotation of function createFreshMockInstance is the same as function createMock i think it is wrong createMock just creates a mock
