### PR TITLE
[5.6] Modify sortKeys and sortKeysDesc to match sort

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1505,7 +1505,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  bool  $descending
      * @return static
      */
-    public function sortKeys($options = SORT_REGULAR, $descending = false)
+    public function sortByKeys($options = SORT_REGULAR, $descending = false)
     {
         $items = $this->items;
 
@@ -1520,7 +1520,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  int $options
      * @return static
      */
-    public function sortKeysDesc($options = SORT_REGULAR)
+    public function sortByKeysDesc($options = SORT_REGULAR)
     {
         return $this->sortKeys($options, true);
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1539,7 +1539,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function sortByKeysDesc($options = SORT_REGULAR)
     {
-        return $this->sortKeys($options, true);
+        return $this->sortByKeys($options, true);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1499,6 +1499,23 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Sort through each item by keys with a callback.
+     *
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public function sortKeys(callable $callback = null)
+    {
+        $items = $this->items;
+
+        $callback
+            ? uksort($items, $callback)
+            : ksort($items);
+
+        return new static($items);
+    }
+
+    /**
      * Sort the collection keys.
      *
      * @param  int  $options

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -949,18 +949,18 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => 'dayle', 0 => 'taylor'], $data->all());
     }
 
-    public function testSortKeys()
+    public function testSortByKeys()
     {
         $data = new Collection(['b' => 'dayle', 'a' => 'taylor']);
 
-        $this->assertEquals(['a' => 'taylor', 'b' => 'dayle'], $data->sortKeys()->all());
+        $this->assertEquals(['a' => 'taylor', 'b' => 'dayle'], $data->sortByKeys()->all());
     }
 
-    public function testSortKeysDesc()
+    public function testSortByKeysDesc()
     {
         $data = new Collection(['a' => 'taylor', 'b' => 'dayle']);
 
-        $this->assertEquals(['b' => 'dayle', 'a' => 'taylor'], $data->sortKeys()->all());
+        $this->assertEquals(['b' => 'dayle', 'a' => 'taylor'], $data->sortByKeys()->all());
     }
 
     public function testReverse()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -952,7 +952,7 @@ class SupportCollectionTest extends TestCase
     public function testSortKeys()
     {
         $data = new Collection(['b' => 'dayle', 'a' => 'taylor']);
-        $data = $data->sortKeys(function($a, $b) {
+        $data = $data->sortKeys(function ($a, $b) {
             return strcasecmp($a, $b);
         });
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -949,6 +949,16 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => 'dayle', 0 => 'taylor'], $data->all());
     }
 
+    public function testSortKeys()
+    {
+        $data = new Collection(['b' => 'dayle', 'a' => 'taylor']);
+        $data = $data->sortKeys(function($a, $b) {
+            return strcasecmp($a, $b);
+        });
+
+        $this->assertEquals(['a' => 'taylor', 'b' => 'dayle'], $data->all());
+    }
+
     public function testSortByKeys()
     {
         $data = new Collection(['b' => 'dayle', 'a' => 'taylor']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -957,6 +957,9 @@ class SupportCollectionTest extends TestCase
         });
 
         $this->assertEquals(['a' => 'taylor', 'b' => 'dayle'], $data->all());
+
+        $data = new Collection(['b' => 'dayle', 'a' => 'taylor']);
+        $this->assertEquals(['a' => 'taylor', 'b' => 'dayle'], $data->sortKeys()->all());
     }
 
     public function testSortByKeys()


### PR DESCRIPTION
In https://github.com/laravel/framework/commit/41da426e96d8624e5ed44a9a9daa6cdf0eaf5d06, `sortKeys` and `sortKeysDesc` has been introduced.

This PR change the name of those methods to match `sortBy` and `sortByDesc` by renaming `sortKeys` and `sortKeysDesc` to `sortByKeys` and `sortByKeysDesc`. 

This PR also add a new `sortKeys` which takes a nullable callback as parameters and use [uksort](https://secure.php.net/manual/en/function.uksort.php) if the callback is set.

```php
$data = collect(['b' => 'dayle', 'a' => 'taylor'])
        ->sortKeys(function($a, $b) {
            return strcasecmp($a, $b);
        });
```