### PR TITLE
[5.7] fix console getDefaultInputDefinition() docblock

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -259,7 +259,7 @@ class Application extends SymfonyApplication implements ApplicationContract
     }
 
     /**
-     * Get the default input definitions for the applications.
+     * Get the default input definition for the application.
      *
      * This is used to add the --env option to every available command.
      *


### PR DESCRIPTION
- I am not an English native speaker but I feel a bit "strangely" with the console getDefaultInputDefinition() doc-block.

- Firstly, the concept "input definitions"  is associated with InputDefinition class, it should be "input definition", shouldn't it? I also refer to Symfony's documentation.

```php
/**
 * Gets the default input definition.
 *
 * @return InputDefinition An InputDefinition instance
 */
protected function getDefaultInputDefinition() {}
```
- Secondly, this method provides the default input definition for a specified application that it belongs to.

Instead of using 'Get the default input definitions for the applications' (plural), I think the description 'Get the default input definition for the application' (singular) is more suitable.

Anyway, this is optional. Just close it if it isn't important!

Thank you,


