### PR TITLE
[5.8] Cast model null attribute always to array

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -487,6 +487,7 @@ trait HasAttributes
             case 'object':
                 return $this->fromJson($value, true);
             case 'array':
+                return $this->fromJsonToArray($value);
             case 'json':
                 return $this->fromJson($value);
             case 'collection':
@@ -698,6 +699,17 @@ trait HasAttributes
             default:
                 return (float) $value;
         }
+    }
+
+    /**
+     * Decode the given JSON into array
+     * @param string $value
+     * @return array
+     */
+    protected function fromJsonToArray($value)
+    {
+        $json = $this->fromJson($value);
+        return !is_array($json) ? [] : $json;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -702,14 +702,14 @@ trait HasAttributes
     }
 
     /**
-     * Decode the given JSON into array
+     * Decode the given JSON into array.
      * @param string $value
      * @return array
      */
     protected function fromJsonToArray($value)
     {
         $json = $this->fromJson($value);
-        return !is_array($json) ? [] : $json;
+        return ! is_array($json) ? [] : $json;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -709,6 +709,7 @@ trait HasAttributes
     protected function fromJsonToArray($value)
     {
         $json = $this->fromJson($value);
+
         return ! is_array($json) ? [] : $json;
     }
 


### PR DESCRIPTION
In current behavior if null presents in attribute value and $casts set to array, it returns null, but should return always array. 