### PR TITLE
[5.7] unneccessary to override return statement

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -42,9 +42,7 @@ class Response extends BaseResponse
             $content = $content->render();
         }
 
-        parent::setContent($content);
-
-        return $this;
+        return parent::setContent($content);
     }
 
     /**


### PR DESCRIPTION
After setting the content of the response, SymfonyResponse::setContent() directly returns "$this", so we needn't to raise one more return statement in LaravelResponse::setContent().

I checked the symfony 3.0 at least. This behavior of version 4.1 is the same.
```php
// Symfony\Component\HttpFoundation\Response::setContent().
public function setContent($content)
{
    if (null !== $content && !\is_string($content) && !is_numeric($content) && !\is_callable(array($content, '__toString'))) {
        throw new \UnexpectedValueException(sprintf('The Response content must be a string or object implementing __toString(), "%s" given.', \gettype($content)));
    }
    $this->content = (string) $content;
    return $this;
}
```
