### PR TITLE
[5.7] Make the Gate's "raw" method public

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -303,7 +303,7 @@ class Gate implements GateContract
      * @param  array|mixed  $arguments
      * @return mixed
      */
-    protected function raw($ability, $arguments = [])
+    public function raw($ability, $arguments = [])
     {
         $arguments = Arr::wrap($arguments);
 

--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -94,6 +94,15 @@ interface Gate
     public function authorize($ability, $arguments = []);
 
     /**
+     * Get the raw result from the authorization callback.
+     *
+     * @param  string  $ability
+     * @param  array|mixed  $arguments
+     * @return mixed
+     */
+    public function raw($ability, $arguments = []);
+
+    /**
      * Get a policy instance for a given class.
      *
      * @param  object|string  $class


### PR DESCRIPTION
Especially useful now that `raw` can actually return `null`. Sometimes you may want to know if the check was actually rejected, or it just wasn't granted.