### PR TITLE
[5.7] Make Route::redirect() default to 302

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -236,7 +236,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  int  $status
      * @return \Illuminate\Routing\Route
      */
-    public function redirect($uri, $destination, $status = 301)
+    public function redirect($uri, $destination, $status = 302)
     {
         return $this->any($uri, '\Illuminate\Routing\RedirectController')
                 ->defaults('destination', $destination)

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1484,11 +1484,24 @@ class RoutingRouteTest extends TestCase
         $router->get('contact_us', function () {
             throw new \Exception('Route should not be reachable.');
         });
-        $router->redirect('contact_us', 'contact', 302);
+        $router->redirect('contact_us', 'contact');
 
         $response = $router->dispatch(Request::create('contact_us', 'GET'));
         $this->assertTrue($response->isRedirect('contact'));
         $this->assertEquals(302, $response->getStatusCode());
+    }
+
+    public function testRouteRedirectWithCustomStatus()
+    {
+        $router = $this->getRouter();
+        $router->get('contact_us', function () {
+            throw new \Exception('Route should not be reachable.');
+        });
+        $router->redirect('contact_us', 'contact', 301);
+
+        $response = $router->dispatch(Request::create('contact_us', 'GET'));
+        $this->assertTrue($response->isRedirect('contact'));
+        $this->assertEquals(301, $response->getStatusCode());
     }
 
     protected function getRouter()


### PR DESCRIPTION
`Route::redirect()` currently defaults to a 301 permanent redirect, which is almost never what you want.

I got terribly bitten by this when I wanted to temporarily redirect my users from the homepage to a different page, only to later realize that _I now have no way to re-enable the homepage for all my previous visitors_ :cry: 

With this PR, `Route::redirect()` will default to a 302 temporary redirect, which also matches the default for the regular `back()` and `redirect()->to(...)` methods.

Of course, you may still pass in a different status code if you need that.