### PR TITLE
[5.6] Fix return docblock for response helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -782,7 +782,7 @@ if (! function_exists('response')) {
      * @param  \Illuminate\View\View|string|array|null  $content
      * @param  int     $status
      * @param  array   $headers
-     * @return \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Routing\ResponseFactory
+     * @return \Illuminate\Http\Response|\Illuminate\Contracts\Routing\ResponseFactory
      */
     function response($content = '', $status = 200, array $headers = [])
     {


### PR DESCRIPTION
Running larastan (a static code analyzer) I got this error
> Call to an undefined method Illuminate\Contracts\Routing\ResponseFactory|::header()

on a similar piece of code to this:
```
response('content')->header("my header")
```
After some digging I realized the docblock isn't entirely correct since the helper can only return an instance of `Illuminate\Contracts\Routing\ResponseFactory` when called empty or an instance of `Illuminate\Http\Response` when given some content, hence the fix for the docblock.

Since it's a change on a docblock and not actual code it shouldn't break anything.





