### PR TITLE
[5.6] Fix assertCookie() now cookies are unserialized by default

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -206,11 +206,12 @@ class TestResponse
      *
      * @param  string  $cookieName
      * @param  mixed  $value
+     * @param  bool  $unserialize
      * @return $this
      */
-    public function assertPlainCookie($cookieName, $value = null)
+    public function assertPlainCookie($cookieName, $value = null, $unserialize = false)
     {
-        $this->assertCookie($cookieName, $value, false);
+        $this->assertCookie($cookieName, $value, false, $unserialize);
 
         return $this;
     }
@@ -221,9 +222,10 @@ class TestResponse
      * @param  string  $cookieName
      * @param  mixed  $value
      * @param  bool  $encrypted
+     * @param  bool  $unserialize
      * @return $this
      */
-    public function assertCookie($cookieName, $value = null, $encrypted = true)
+    public function assertCookie($cookieName, $value = null, $encrypted = true, $unserialize = false)
     {
         PHPUnit::assertNotNull(
             $cookie = $this->getCookie($cookieName),
@@ -237,7 +239,7 @@ class TestResponse
         $cookieValue = $cookie->getValue();
 
         $actual = $encrypted
-            ? app('encrypter')->decrypt($cookieValue) : $cookieValue;
+            ? app('encrypter')->decrypt($cookieValue, $unserialize) : $cookieValue;
 
         PHPUnit::assertEquals(
             $value, $actual,


### PR DESCRIPTION
With the security fix, `EncryptCookies` middleware now has `$serialize = false` out-of-the-box so cookie
tests now fail with `app('encrypter')->decrypt($cookieValue, $unserialize = true)` always called by `assertCookie()`.

This breaks the method signature by adding another optional argument but today's changes also (necessarily) do so `¯\_(ツ)_/¯`.

To avoid changing the method signature in 5.5 & 5.6, an alternate solution is to hardcode `assertCookie()` to false:

```php
app('encrypter')->decrypt($cookieValue, false)
```

And if anyone wishes to keep:

```php
protected static $serialize = true;
```

in their `EncryptCookies` middleware, they must add macros to `TestReponse` with their own assertion methods.