### PR TITLE
[5.7] Modify MSSQL driver order

### DIFF
--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -43,13 +43,15 @@ class SqlServerConnector extends Connector implements ConnectorInterface
         // First we will create the basic DSN setup as well as the port if it is in
         // in the configuration options. This will give us the basic DSN we will
         // need to establish the PDO connections and return them back for use.
-        if (in_array('dblib', $this->getAvailableDrivers())) {
-            return $this->getDblibDsn($config);
-        } elseif ($this->prefersOdbc($config)) {
+        if ($this->prefersOdbc($config)) {
             return $this->getOdbcDsn($config);
         }
 
-        return $this->getSqlSrvDsn($config);
+        if (in_array('sqlsrv', $this->getAvailableDrivers())) {
+            return $this->getSqlSrvDsn($config);
+        } else {
+            return $this->getDblibDsn($config);
+        }
     }
 
     /**


### PR DESCRIPTION
Before this PR dblib was always used for connecting to MSSQL if it was installed on the server, no matter if the user chose via config to prefer ODBC or if sqlserver was also installed. Dblib is deprecated, both by Microsoft and PHP itself ([http://php.net/manual/en/ref.pdo-dblib.php](http://php.net/manual/en/ref.pdo-dblib.php))

>  This extension is not available anymore on Windows with PHP 5.3 or later.
On Windows, you should use SqlSrv, an alternative driver for MS SQL is available from Microsoft.
If it is not possible to use SqlSrv, you can use the PDO_ODBC driver to connect to Microsoft SQL Server and Sybase databases, as the native Windows DB-LIB is ancient, thread un-safe and no longer supported by Microsoft. 

The state after this PR:

1. check if the user prefers ODBC, if yes then use that
2. check for `sqlsrv`, if it's available use that
3. if ODBC was not used, and `sqlsrv` is unavailable then and only then use dblib

Fixes https://github.com/laravel/framework/issues/25133