### PR TITLE
[5.6] Revert assertPlainCookie() adding $unserialize argument

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -206,12 +206,11 @@ class TestResponse
      *
      * @param  string  $cookieName
      * @param  mixed  $value
-     * @param  bool  $unserialize
      * @return $this
      */
-    public function assertPlainCookie($cookieName, $value = null, $unserialize = false)
+    public function assertPlainCookie($cookieName, $value = null)
     {
-        $this->assertCookie($cookieName, $value, false, $unserialize);
+        $this->assertCookie($cookieName, $value, false);
 
         return $this;
     }


### PR DESCRIPTION
Because I'm an idiot.

This change is not required since `Encrypter@decrypt()` is never called through this assertion.