### PR TITLE
[5.7] Form request improvements

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -89,9 +89,15 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function createDefaultValidator(ValidationFactory $factory)
     {
+        $messages = [];
+
+        if (method_exists($this, 'messages')) {
+            $messages = $this->container->call([$this, 'messages']);
+        }
+
         return $factory->make(
             $this->validationData(), $this->container->call([$this, 'rules']),
-            $this->messages(), $this->attributes()
+            $messages, $this->attributes()
         );
     }
 
@@ -178,16 +184,6 @@ class FormRequest extends Request implements ValidatesWhenResolved
         return $this->only(collect($rules)->keys()->map(function ($rule) {
             return Str::contains($rule, '*') ? explode('.', $rule)[0] : $rule;
         })->unique()->toArray());
-    }
-
-    /**
-     * Get custom messages for validator errors.
-     *
-     * @return array
-     */
-    public function messages()
-    {
-        return [];
     }
 
     /**

--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -22,7 +22,7 @@ trait ValidatesWhenResolvedTrait
 
         $instance = $this->getValidatorInstance();
 
-        if (! $instance->passes()) {
+        if ($instance->fails()) {
             $this->failedValidation($instance);
         }
     }


### PR DESCRIPTION
This PR aims to improve two things regarding form requests.

1. In `ValidatesWhenResolvedTrait` the `passes` method was called on a `\Illuminate\Contracts\Validation\Validator` instance even though the `passes` method doesn't exist on the interface. This was adjusted to call the `fails` method which is present on the interface and thus I avoided making a breaking change (adding the `passes` method to the interface).

2. Unlike the `rules` and `authorize` methods, the `messages` method wasn't called via the container. This was not only inconsistent, but it also meant that I had to write a few more lines than I must now :)

Before this PR:
```php
use Illuminate\Contracts\Translation\Translator;

    public function messages()
    {
        /** @var Translator $translator */
        $translator = $this->container->make(Translator::class);

        return [
            'name.required' => $translator->trans('messages.foobar'),
        ];
    }
```

After this PR:
```php
use Illuminate\Contracts\Translation\Translator;

    public function messages(Translator $translator)
    {
        return [
            'name.required' => $translator->trans('messages.foobar'),
        ];
    }
```

I also added a test that proves that method injecting works with the `messages` method (as well as with  `rules` and `authorize` methods as that wasn't even tested before).