### PR TITLE
[5.7] Add missed throws dockblock of FilesystemAdapter

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -370,6 +370,8 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      *
      * @param  string  $path
      * @return string
+     *
+     * @throws \RuntimeException
      */
     public function url($path)
     {
@@ -489,6 +491,8 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      * @param  \DateTimeInterface  $expiration
      * @param  array  $options
      * @return string
+     *
+     * @throws \RuntimeException
      */
     public function temporaryUrl($path, $expiration, array $options = [])
     {


### PR DESCRIPTION
FilesystemAdapter::url() or FilesystemAdapter::temporaryUrl() will throw a RuntimeException if the current used driver does not support to generate (temporary) URLs. In this pull request, I just add the "missed throws dockblock" for them. 