### PR TITLE
[5.6] Fix validation of wildcard rules with slashes

### DIFF
--- a/src/Illuminate/Validation/ValidationData.php
+++ b/src/Illuminate/Validation/ValidationData.php
@@ -55,7 +55,7 @@ class ValidationData
     {
         $keys = [];
 
-        $pattern = str_replace('\*', '[^\.]+', preg_quote($attribute));
+        $pattern = str_replace('\*', '[^\.]+', preg_quote($attribute, '/'));
 
         foreach ($data as $key => $value) {
             if ((bool) preg_match('/^'.$pattern.'/', $key, $matches)) {

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -124,7 +124,7 @@ class ValidationRuleParser
      */
     protected function explodeWildcardRules($results, $attribute, $rules)
     {
-        $pattern = str_replace('\*', '[^\.]*', preg_quote($attribute));
+        $pattern = str_replace('\*', '[^\.]*', preg_quote($attribute, '/'));
 
         $data = ValidationData::initializeAndGatherData($attribute, $this->data);
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4005,6 +4005,17 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['first' => 'john', 'preferred' => 'john'], $data);
     }
 
+    public function testValidationKeysWithSlashes()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['foo/' => 'bar'], ['foo/' => 'required']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo/' => ['bar']], ['foo/.*' => 'required']);
+        $this->assertTrue($v->passes());
+    }
+
     protected function getTranslator()
     {
         return m::mock('Illuminate\Contracts\Translation\Translator');


### PR DESCRIPTION
#16309 fixed the validation of "normal" rules with slashes.

This is still an issue with wildcard rules:

```php
$validator = Validator::make(['foo/' => ['bar']], ['foo/.*' => 'required']);
$validator->passes();
```

This throws an exception:
> preg_match(): Unknown modifier '\\'

Fixes #25146.