### PR TITLE
[5.7] Remove duplicated tests of HttpRequestTest

### DIFF
--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -92,9 +92,6 @@ class HttpRequestTest extends TestCase
     {
         $request = Request::create($path, 'GET');
         $this->assertEquals($expected, $request->segments());
-
-        $request = Request::create('foo/bar', 'GET');
-        $this->assertEquals(['foo', 'bar'], $request->segments());
     }
 
     public function segmentsProvider()


### PR DESCRIPTION
In the HttpRequestTest class, the testSegmentsMethod method is called in a loop that is provided data by segmentsProvider method.

There is a fixed-case that is included in testSegmentsMethod. Well, it is called a lot of times depends on the number of items that are defined in segmentsProvider.
- Given input: $path is 'foo/bar'
- Expected output: $request->segments() equals to ['foo', 'bar']

On the other hand, this fixed-case is also defined. Let's take a look at segmentsProvider method, it is exactly ['foo/bar', ['foo', 'bar']].

```php
public function segmentsProvider()
{
    return [
        ['', []],
        ['foo/bar', ['foo', 'bar']],
        ['foo/bar//baz', ['foo', 'bar', 'baz']],
        ['foo/0/bar', ['foo', '0', 'bar']],
    ];
}
```

So, in this pull request, I remove the "wasted" tests.