### PR TITLE
[5.7] Call proper validator interface method on a form request

### DIFF
--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -22,7 +22,7 @@ trait ValidatesWhenResolvedTrait
 
         $instance = $this->getValidatorInstance();
 
-        if (! $instance->passes()) {
+        if ($instance->fails()) {
             $this->failedValidation($instance);
         }
     }


### PR DESCRIPTION
As https://github.com/laravel/framework/pull/25152 which contained two changes unfortunately didn't get merged I created this PR which contains only the first change of that PR.

> 1. In `ValidatesWhenResolvedTrait` the `passes` method was called on a `\Illuminate\Contracts\Validation\Validator` instance even though the `passes` method doesn't exist on the interface. This was adjusted to call the `fails` method which is present on the interface and thus I avoided making a breaking change (adding the `passes` method to the interface).