### PR TITLE
[5.7] When scheduling a job, respect the already set queue

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -97,7 +97,7 @@ class Schedule
             $job = is_string($job) ? resolve($job) : $job;
 
             if ($job instanceof ShouldQueue) {
-                $queue = $queue || $job->queue;
+                $queue = $queue !== null ? $queue : $job->queue;
 
                 dispatch($job)->onConnection($connection)->onQueue($queue);
             } else {

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -97,9 +97,9 @@ class Schedule
             $job = is_string($job) ? resolve($job) : $job;
 
             if ($job instanceof ShouldQueue) {
-                $job->queue === null || $queue !== null ?
-                    dispatch($job)->onConnection($connection)->onQueue($queue) :
-                    dispatch($job)->onConnection($connection);
+                $queue = $queue || $job->queue;
+
+                dispatch($job)->onConnection($connection)->onQueue($queue);
             } else {
                 dispatch_now($job);
             }

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -97,7 +97,9 @@ class Schedule
             $job = is_string($job) ? resolve($job) : $job;
 
             if ($job instanceof ShouldQueue) {
-                dispatch($job)->onConnection($connection)->onQueue($queue);
+                $job->queue === null || $queue !== null ?
+                    dispatch($job)->onConnection($connection)->onQueue($queue) :
+                    dispatch($job)->onConnection($connection);
             } else {
                 dispatch_now($job);
             }

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Tests\Console\Scheduling;
+
+use Illuminate\Support\Facades\Queue;
+use Mockery as m;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Container\Container;
+use PHPUnit\Framework\TestCase;
+
+class ScheduleTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $container = Container::getInstance();
+
+        $container->instance('Illuminate\Console\Scheduling\EventMutex', m::mock('Illuminate\Console\Scheduling\CacheEventMutex'));
+
+        $container->instance('Illuminate\Console\Scheduling\SchedulingMutex', m::mock('Illuminate\Console\Scheduling\CacheSchedulingMutex'));
+    }
+
+    public function testJob()
+    {
+        Queue::fake();
+
+        $scheduler = new Schedule();
+
+        // Create a new job.
+        $scheduler->job(JobWithDefaultQueue::class)->everyMinute();
+        $scheduler->job(JobWithoutDefaultQueue::class)->everyMinute();
+
+        // Need to fire the event, but because it's async/queued, I have no idea how to mock/fire this.
+
+        Queue::assertPushedOn('test-queue', JobWithDefaultQueue::class);
+        Queue::assertPushedOn('default', JobWithoutDefaultQueue::class);
+    }
+}
+
+class JobWithDefaultQueue implements \Illuminate\Contracts\Queue\ShouldQueue
+{
+    use \Illuminate\Bus\Queueable,
+        \Illuminate\Queue\InteractsWithQueue;
+
+    public function __construct()
+    {
+        $this->onQueue('test-queue');
+    }
+}
+
+class JobWithoutDefaultQueue implements \Illuminate\Contracts\Queue\ShouldQueue
+{
+    use \Illuminate\Bus\Queueable,
+        \Illuminate\Queue\InteractsWithQueue;
+}

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Console\Scheduling;
 
-use Illuminate\Support\Facades\Queue;
 use Mockery as m;
-use Illuminate\Console\Scheduling\Schedule;
-use Illuminate\Container\Container;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Console\Scheduling\Schedule;
 
 class ScheduleTest extends TestCase
 {


### PR DESCRIPTION
## Problem description
When creating a job, we sometimes want to define in which queue the job should run.
Sometimes that's something that we want to define in the job itself.

When creating a job, we often specify which queue it should be stored at in the constructor:
```php
// MyCustomJob-class

public function __construct()
{
    $this->onQueue('my-custom-queue');
}
```

But when scheduling this job, we need to specify a queue in which the job should run.
```php
// Will add the job to the 'default'-queue.
$schedule->job(MyCustomJob::class)->everyMinute();

// Will add the job to the 'my-custom-queue'-queue.
$schedule->job(MyCustomJob::class, 'my-custom-queue')->everyMinute();
```

This results in having to specify the queue multiple times instead of just once.

## Proposed solution
It would be a good solution to respect the already defined queue on the custom job class.
Using the example above, it'll result in a solution something like this:
```php
// MyCustomJob-class

public function __construct()
{
    $this->onQueue('my-custom-queue');
}
```

```php
// Will add the job to the 'my-custom-queue'-queue.
$schedule->job(MyCustomJob::class)->everyMinute();

// Will add the job to the 'my-other-queue'-queue.
$schedule->job(MyCustomJob::class, 'my-other-queue')->everyMinute();

// Will still add the job to the 'default'-queue.
$schedule->job(MyCustomJob::class, 'default')->everyMinute();
```