### PR TITLE
[5.6] Add TestResponse@assertSeeEscaped for allowing the testing of escaped strings

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -339,6 +339,17 @@ class TestResponse
     }
 
     /**
+     * Escape a given string and assert that is contained within the response text.
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertSeeEscaped($value)
+    {
+        return $this->assertSee(e($value));
+    }
+
+    /**
      * Assert that the given strings are contained in order within the response.
      *
      * @param  array  $values

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -81,6 +81,19 @@ class FoundationTestResponseTest extends TestCase
         $response->assertSeeText('foobar');
     }
 
+    public function testAssertSeeEscaped()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->setContent(\Mockery::mock(View::class, [
+                'render' => 'Ahmed Kh&#039;aled',
+            ]));
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertSeeEscaped('Ahmed Kh\'aled');
+    }
+
     public function testAssertSeeTextInOrder()
     {
         $baseResponse = tap(new Response, function ($response) {


### PR DESCRIPTION
Given that we have a html response like the following:
```
<b>Ahmed Kh&#039;aled</b>
```
The browser will render it as
**Ahmed Kh'aled**

There is no way for asserting this string in the response, I have tried `assertSee` and `assertSeeText` with no sucess, so I have created a method that do the following:
1. Escape the given string
2. Assert that the html response contains the escaped string

Example:
```php
$user = factory(\App\User::class)->create(['name' => "Ahmed Kh'aled"]);

$response = $this->get(route('users.index'));
$response->assertSeeEscaped($user->name);

```
