### PR TITLE
[5.7] Throw error with proper message when dispatching dynamic method calls

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -17,7 +18,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
  */
 class Builder
 {
-    use BuildsQueries, Concerns\QueriesRelationships;
+    use BuildsQueries, Concerns\QueriesRelationships, ForwardsCalls;
 
     /**
      * The base query builder instance.
@@ -1317,7 +1318,7 @@ class Builder
             return $this->toBase()->{$method}(...$parameters);
         }
 
-        $this->query->{$method}(...$parameters);
+        $this->forwardCallTo($this->query, $method, $parameters);
 
         return $this;
     }
@@ -1340,9 +1341,7 @@ class Builder
         }
 
         if (! isset(static::$macros[$method])) {
-            throw new BadMethodCallException(sprintf(
-                'Method %s::%s does not exist.', static::class, $method
-            ));
+            $this->throwBadMethodCallException($method);
         }
 
         if (static::$macros[$method] instanceof Closure) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Database\Eloquent\Relations\Pivot;
@@ -24,7 +25,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         Concerns\HasRelationships,
         Concerns\HasTimestamps,
         Concerns\HidesAttributes,
-        Concerns\GuardsAttributes;
+        Concerns\GuardsAttributes,
+        ForwardsCalls;
 
     /**
      * The connection name for the model.
@@ -1598,7 +1600,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $this->$method(...$parameters);
         }
 
-        return $this->newQuery()->$method(...$parameters);
+        return $this->forwardCallTo($this->newQuery(), $method, $parameters);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -9,13 +9,14 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Traits\ForwardsCalls;
 
 /**
  * @mixin \Illuminate\Database\Eloquent\Builder
  */
 abstract class Relation
 {
-    use Macroable {
+    use ForwardsCalls, Macroable {
         __call as macroCall;
     }
 
@@ -366,7 +367,7 @@ abstract class Relation
             return $this->macroCall($method, $parameters);
         }
 
-        $result = $this->query->{$method}(...$parameters);
+        $result = $this->forwardCallTo($this->query, $method, $parameters);
 
         if ($result === $this->query) {
             return $this;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Query;
 
 use Closure;
 use RuntimeException;
-use BadMethodCallException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -13,6 +12,7 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\ConnectionInterface;
+use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
@@ -20,7 +20,7 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class Builder
 {
-    use BuildsQueries, Macroable {
+    use BuildsQueries, ForwardsCalls, Macroable {
         __call as macroCall;
     }
 
@@ -2813,8 +2813,6 @@ class Builder
             return $this->dynamicWhere($method, $parameters);
         }
 
-        throw new BadMethodCallException(sprintf(
-            'Method %s::%s does not exist.', static::class, $method
-        ));
+        $this->throwBadMethodCallException($method);
     }
 }

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Support\Providers;
 
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Contracts\Routing\UrlGenerator;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Contracts\Routing\UrlGenerator;
  */
 class RouteServiceProvider extends ServiceProvider
 {
+    use ForwardsCalls;
+
     /**
      * The controller namespace for the application.
      *
@@ -94,8 +97,8 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array(
-            [$this->app->make(Router::class), $method], $parameters
+        return $this->forwardCallTo(
+            $this->app->make(Router::class), $method, $parameters
         );
     }
 }

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Http;
 
-use BadMethodCallException;
 use Illuminate\Support\Str;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\ViewErrorBag;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Session\Store as SessionStore;
 use Illuminate\Contracts\Support\MessageProvider;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse as BaseRedirectResponse;
 
 class RedirectResponse extends BaseRedirectResponse
 {
-    use ResponseTrait, Macroable {
+    use ForwardsCalls, ResponseTrait, Macroable {
         Macroable::__call as macroCall;
     }
 
@@ -231,8 +231,6 @@ class RedirectResponse extends BaseRedirectResponse
             return $this->with(Str::snake(substr($method, 4)), $parameters[0]);
         }
 
-        throw new BadMethodCallException(sprintf(
-            'Method %s::%s does not exist.', static::class, $method
-        ));
+        $this->throwBadMethodCallException($method);
     }
 }

--- a/src/Illuminate/Http/Resources/DelegatesToResource.php
+++ b/src/Illuminate/Http/Resources/DelegatesToResource.php
@@ -3,9 +3,12 @@
 namespace Illuminate\Http\Resources;
 
 use Exception;
+use Illuminate\Support\Traits\ForwardsCalls;
 
 trait DelegatesToResource
 {
+    use ForwardsCalls;
+
     /**
      * Get the value of the resource's route key.
      *
@@ -125,6 +128,6 @@ trait DelegatesToResource
      */
     public function __call($method, $parameters)
     {
-        return $this->resource->{$method}(...$parameters);
+        return $this->forwardCallTo($this->resource, $method, $parameters);
     }
 }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -4,13 +4,13 @@ namespace Illuminate\Mail;
 
 use ReflectionClass;
 use ReflectionProperty;
-use BadMethodCallException;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Container\Container;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Contracts\Queue\Factory as Queue;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
@@ -18,7 +18,7 @@ use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 
 class Mailable implements MailableContract, Renderable
 {
-    use Localizable;
+    use ForwardsCalls, Localizable;
 
     /**
      * The locale of the message.
@@ -808,8 +808,6 @@ class Mailable implements MailableContract, Renderable
             return $this->with(Str::camel(substr($method, 4)), $parameters[0]);
         }
 
-        throw new BadMethodCallException(sprintf(
-            'Method %s::%s does not exist.', static::class, $method
-        ));
+        $this->throwBadMethodCallException($method);
     }
 }

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -4,12 +4,15 @@ namespace Illuminate\Mail;
 
 use Swift_Image;
 use Swift_Attachment;
+use Illuminate\Support\Traits\ForwardsCalls;
 
 /**
  * @mixin \Swift_Message
  */
 class Message
 {
+    use ForwardsCalls;
+
     /**
      * The Swift Message instance.
      *
@@ -321,8 +324,6 @@ class Message
      */
     public function __call($method, $parameters)
     {
-        $callable = [$this->swift, $method];
-
-        return call_user_func_array($callable, $parameters);
+        return $this->forwardCallTo($this->swift, $method, $parameters);
     }
 }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -7,12 +7,15 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Traits\ForwardsCalls;
 
 /**
  * @mixin \Illuminate\Support\Collection
  */
 abstract class AbstractPaginator implements Htmlable
 {
+    use ForwardsCalls;
+
     /**
      * All of the items being paginated.
      *
@@ -620,7 +623,7 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function __call($method, $parameters)
     {
-        return $this->getCollection()->$method(...$parameters);
+        return $this->forwardCallTo($this->getCollection(), $method, $parameters);
     }
 
     /**

--- a/src/Illuminate/Support/Traits/ForwardsCalls.php
+++ b/src/Illuminate/Support/Traits/ForwardsCalls.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+use Error;
+use BadMethodCallException;
+
+trait ForwardsCalls
+{
+    protected function forwardCallTo($object, $method, $parameters)
+    {
+        try {
+            return $object->{$method}(...$parameters);
+        } catch (Error | BadMethodCallException $e) {
+            $pattern = '~^Call to undefined method (?P<class>[^:]+)::(?P<method>[a-zA-Z]+)\(\)$~';
+
+            if (! preg_match($pattern, $e->getMessage(), $matches)) {
+                throw $e;
+            }
+
+            if ($matches['class'] != get_class($object) || $matches['method'] != $method) {
+                throw $e;
+            }
+
+            $this->throwBadMethodCallException($method);
+        }
+    }
+
+    protected function throwBadMethodCallException($method)
+    {
+        throw new BadMethodCallException(sprintf(
+            'Call to undefined method %s::%s()', static::class, $method
+        ));
+    }
+}

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -121,7 +121,7 @@ class HttpRedirectResponseTest extends TestCase
 
     /**
      * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method Illuminate\Http\RedirectResponse::doesNotExist does not exist.
+     * @expectedExceptionMessage Call to undefined method Illuminate\Http\RedirectResponse::doesNotExist()
      */
     public function testMagicCallException()
     {

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -189,7 +189,7 @@ class HttpResponseTest extends TestCase
 
     /**
      * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method Illuminate\Http\RedirectResponse::doesNotExist does not exist.
+     * @expectedExceptionMessage Call to undefined method Illuminate\Http\RedirectResponse::doesNotExist()
      */
     public function testMagicCallException()
     {

--- a/tests/Support/ForwardsCallsTest.php
+++ b/tests/Support/ForwardsCallsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Traits\ForwardsCalls;
+
+class ForwardsCallsTest extends TestCase
+{
+    public function testForwardsCalls()
+    {
+        $results = (new ForwardsCallsOne)->forwardedTwo('foo', 'bar');
+
+        $this->assertEquals(['foo', 'bar'], $results);
+    }
+
+    public function testNestedForwardCalls()
+    {
+        $results = (new ForwardsCallsOne)->forwardedBase('foo', 'bar');
+
+        $this->assertEquals(['foo', 'bar'], $results);
+    }
+
+    /**
+     * @expectedException  \BadMethodCallException
+     * @expectedExceptionMessage  Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::missingMethod()
+     */
+    public function testMissingForwardedCallThrowsCorrectError()
+    {
+        (new ForwardsCallsOne)->missingMethod('foo', 'bar');
+    }
+
+    /**
+     * @expectedException  \Error
+     * @expectedExceptionMessage  Call to undefined method Illuminate\Tests\Support\ForwardsCallsBase::missingMethod()
+     */
+    public function testNonForwardedErrorIsNotTamperedWith()
+    {
+        (new ForwardsCallsOne)->baseError('foo', 'bar');
+    }
+
+    /**
+     * @expectedException  \BadMethodCallException
+     * @expectedExceptionMessage  Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::test()
+     */
+    public function testThrowBadMethodCallException()
+    {
+        (new ForwardsCallsOne)->throwTestException('test');
+    }
+}
+
+class ForwardsCallsOne
+{
+    use ForwardsCalls;
+
+    public function __call($method, $parameters)
+    {
+        return $this->forwardCallTo(new ForwardsCallsTwo, $method, $parameters);
+    }
+
+    public function throwTestException($method)
+    {
+        $this->throwBadMethodCallException($method);
+    }
+}
+
+class ForwardsCallsTwo
+{
+    use ForwardsCalls;
+
+    public function __call($method, $parameters)
+    {
+        return $this->forwardCallTo(new ForwardsCallsBase, $method, $parameters);
+    }
+
+    public function forwardedTwo(...$parameters)
+    {
+        return $parameters;
+    }
+}
+
+class ForwardsCallsBase
+{
+    public function forwardedBase(...$parameters)
+    {
+        return $parameters;
+    }
+
+    public function baseError()
+    {
+        return $this->missingMethod();
+    }
+}


### PR DESCRIPTION
### Intro

Laravel has _a lot_ of dynamic method calls, such as in Eloquent's `Model` class:

https://github.com/laravel/framework/blob/a1c2f82c2d38842a0296070b99d997be6d985ae3/src/Illuminate/Database/Eloquent/Model.php#L1564-L1571

This is how calling `User::where(...)` works, because the call to the `where` method is dynamically dispatched to the query builder.

### Problem

If you call a method on the model that doesn't exists, for example `User::missingMethod()`, you get an error saying that the method doesn't exist _on the query builder_ class:

```
BadMethodCallException: Call to undefined method Illuminate\Database\Query\Builder::missingMethod()
```

This message is quite cryptic, since the user hasn't called _any_ method on the query builder. This is especially confusing to newcomers, who don't even know about the builder and/or dynamic dispatch.

## Solution

This PR adds [a new `ForwardsCalls` trait](https://github.com/JosephSilber/framework/commit/525f780709026979e08ba5cfe0da91a6853075d8) to the `Support` module, which is able to intelligently catch and parse these errors. It'll convert the error to a new error with the message you would expect:

```
BadMethodCallException: Call to undefined method App\User::missingMethod()
```

I hooked up many of the framework's dynamic calls to this trait. After we merge this, I'm sure there are more places throughout the framework that we can use this.