### PR TITLE
[5.6] Make Auth/Recaller handle serialized and unserialized cookies

### DIFF
--- a/src/Illuminate/Auth/Recaller.php
+++ b/src/Illuminate/Auth/Recaller.php
@@ -21,7 +21,7 @@ class Recaller
      */
     public function __construct($recaller)
     {
-        $this->recaller = @unserialize($recaller) ?: $recaller;
+        $this->recaller = @unserialize($recaller, false) ?: $recaller;
     }
 
     /**

--- a/src/Illuminate/Auth/Recaller.php
+++ b/src/Illuminate/Auth/Recaller.php
@@ -81,6 +81,10 @@ class Recaller
      */
     protected function hasAllSegments()
     {
+        if (@unserialize($this->recaller)) {
+            return false;
+        }
+
         $segments = explode('|', $this->recaller);
 
         return count($segments) == 3 && trim($segments[0]) !== '' && trim($segments[1]) !== '';

--- a/src/Illuminate/Auth/Recaller.php
+++ b/src/Illuminate/Auth/Recaller.php
@@ -21,7 +21,7 @@ class Recaller
      */
     public function __construct($recaller)
     {
-        $this->recaller = $recaller;
+        $this->recaller = @unserialize($recaller) ?: $recaller;
     }
 
     /**
@@ -81,10 +81,6 @@ class Recaller
      */
     protected function hasAllSegments()
     {
-        if (@unserialize($this->recaller)) {
-            return false;
-        }
-
         $segments = explode('|', $this->recaller);
 
         return count($segments) == 3 && trim($segments[0]) !== '' && trim($segments[1]) !== '';


### PR DESCRIPTION
Deals with situations like this: https://github.com/laravel/framework/issues/25160

pgsql is strict about the types so it'll return a sql error instead of empty results like in MySQL.