### PR TITLE
[5.6] Fix validation of slashes with wildcard rules

### DIFF
--- a/src/Illuminate/Validation/ValidationData.php
+++ b/src/Illuminate/Validation/ValidationData.php
@@ -55,7 +55,7 @@ class ValidationData
     {
         $keys = [];
 
-        $pattern = str_replace('\*', '[^\.]+', preg_quote($attribute));
+        $pattern = str_replace('\*', '[^\.]+', preg_quote($attribute, '/'));
 
         foreach ($data as $key => $value) {
             if ((bool) preg_match('/^'.$pattern.'/', $key, $matches)) {

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -124,7 +124,7 @@ class ValidationRuleParser
      */
     protected function explodeWildcardRules($results, $attribute, $rules)
     {
-        $pattern = str_replace('\*', '[^\.]*', preg_quote($attribute));
+        $pattern = str_replace('\*', '[^\.]*', preg_quote($attribute, '/'));
 
         $data = ValidationData::initializeAndGatherData($attribute, $this->data);
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4005,6 +4005,17 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['first' => 'john', 'preferred' => 'john'], $data);
     }
 
+    public function testValidationWithSlashes()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['foo/' => 'bar'], ['foo/' => 'required']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['bar/' => 'baz']], ['foo.*' => 'sometimes']);
+        $this->assertTrue($v->passes());
+    }
+
     protected function getTranslator()
     {
         return m::mock('Illuminate\Contracts\Translation\Translator');


### PR DESCRIPTION
*This is a modified re-submit of #25156.*

https://github.com/laravel/framework/issues/25146#issuecomment-411658669 describes a case where having a slash in the validation *data* (not in the rules) is enough to cause an exception:

```php
$validator = Validator::make(['foo' => ['bar/' => 'baz']], ['foo.*' => 'sometimes']);
$validator->passes();
```

So a (malicious) user could crash the application by submitting the right data. This might not be a security risk, but certainly is an undesirable behavior.

Fixes #25146.