### PR TITLE
[5.6] Fix dumping collections into the Laravel Dump Server

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -310,7 +310,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         (new static(func_get_args()))
             ->push($this)
             ->each(function ($item) {
-                (new Dumper)->dump($item);
+                dump($item);
             });
 
         return $this;

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -11,9 +11,9 @@ use ArrayIterator;
 use CachingIterator;
 use JsonSerializable;
 use IteratorAggregate;
-use Illuminate\Support\Debug\Dumper;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
+use Symfony\Component\VarDumper\VarDumper;
 use Illuminate\Contracts\Support\Arrayable;
 
 /**
@@ -310,7 +310,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         (new static(func_get_args()))
             ->push($this)
             ->each(function ($item) {
-                dump($item);
+                VarDumper::dump($item);
             });
 
         return $this;


### PR DESCRIPTION
When running the Laravel Dump Server and dumping a collection it will
not show up into the dump server. When using the dump() helper within
the dump method from the Collection class it will show up.

Laravel Dump Server Package: https://github.com/beyondcode/laravel-dump-server
