### PR TITLE
[5.5] Fixes #25174

### DIFF
--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -22,7 +22,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Support\Facades\Route name(string $value)
  * @method static \Illuminate\Support\Facades\Route namespace(string $value)
  * @method static \Illuminate\Support\Facades\Route where(array|string $name, string $expression = null)
- * @method static \Illuminate\Routing\Router group(\Closure|string|array $value)
+ * @method static \Illuminate\Routing\Router group(\Closure|string|array $value, \Closure|string $routes)
  * @method static \Illuminate\Support\Facades\Route redirect(string $uri, string $destination, int $status = 301)
  * @method static \Illuminate\Support\Facades\Route view(string $uri, string $view, array $data = [])
  *


### PR DESCRIPTION
incorrect PHPDoc

Class Route -> incorrect PHPDoc, line 25 of 

\Illuminate\Support\Facades\Route.php @  \Illuminate\Routing\Router group (\Closure|string|array $value)

contains incorrect number of parameters (1 instead of 2), which triggers code inspector while using Route::Group(param1, param2)

**Doesn't break anything; Only doc change suggested by issue poster.**