### PR TITLE
[5.6] Wrap columns in whereRowValues()

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -490,9 +490,11 @@ class Grammar extends BaseGrammar
      */
     protected function whereRowValues(Builder $query, $where)
     {
+        $columns = $this->columnize($where['columns']);
+
         $values = $this->parameterize($where['values']);
 
-        return '('.implode(', ', $where['columns']).') '.$where['operator'].' ('.$values.')';
+        return '('.$columns.') '.$where['operator'].' ('.$values.')';
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2631,15 +2631,15 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->whereRowValues(['last_update', 'order_number'], '<', [1, 2]);
-        $this->assertEquals('select * from "orders" where (last_update, order_number) < (?, ?)', $builder->toSql());
+        $this->assertEquals('select * from "orders" where ("last_update", "order_number") < (?, ?)', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->where('company_id', 1)->orWhereRowValues(['last_update', 'order_number'], '<', [1, 2]);
-        $this->assertEquals('select * from "orders" where "company_id" = ? or (last_update, order_number) < (?, ?)', $builder->toSql());
+        $this->assertEquals('select * from "orders" where "company_id" = ? or ("last_update", "order_number") < (?, ?)', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->whereRowValues(['last_update', 'order_number'], '<', [1, new Raw('2')]);
-        $this->assertEquals('select * from "orders" where (last_update, order_number) < (?, 2)', $builder->toSql());
+        $this->assertEquals('select * from "orders" where ("last_update", "order_number") < (?, 2)', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
     }
 


### PR DESCRIPTION
`whereRowValues()` doesn't wrap the columns:

```php
$builder = DB::table('table')->whereRowValues(['column1', 'column2'], '=', ['foo', 'bar']);
dd($builder->toSql());

// expected: select * from "table" where ("column1", "column2") = (?, ?)
// actual:   select * from "table" where (column1, column2) = (?, ?)
```
