### PR TITLE
[5.6] Non faked events should be properly dispatched

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -135,7 +135,7 @@ class EventFake implements Dispatcher
      */
     public function listen($events, $listener)
     {
-        //
+        $this->dispatcher->listen($events, $listener);
     }
 
     /**
@@ -146,7 +146,7 @@ class EventFake implements Dispatcher
      */
     public function hasListeners($eventName)
     {
-        //
+        return $this->dispatcher->hasListeners($eventName);
     }
 
     /**
@@ -169,7 +169,7 @@ class EventFake implements Dispatcher
      */
     public function subscribe($subscriber)
     {
-        //
+        $this->dispatcher->subscribe($subscriber);
     }
 
     /**

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Events;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+
+class EventFakeTest extends TestCase
+{
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application   $app
+     *
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        // Database configuration
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'mysql',
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'username' => 'root',
+            'password' => '',
+            'database' => 'forge',
+            'prefix' => '',
+        ]);
+    }
+
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Clean up the testing environment before the next test.
+     *
+     * @return void
+     */
+    protected function tearDown()
+    {
+        Schema::dropIfExists('posts');
+
+        parent::tearDown();
+    }
+
+    public function testNonFakedEventGetsProperlyDispatched()
+    {
+        Event::fake(NonImportantEvent::class);
+        Post::observe([PostObserver::class]);
+
+        $post = new Post();
+        $post->title = 'xyz';
+        $post->save();
+
+        $this->assertSame('xyz-Test', $post->slug);
+
+        Event::assertNotDispatched(NonImportantEvent::class);
+    }
+}
+
+class Post extends Model
+{
+    public $table = 'posts';
+}
+
+class NonImportantEvent
+{
+}
+
+class PostObserver
+{
+    public function saving(Post $post)
+    {
+        $post->slug = sprintf('%s-Test', $post->title);
+    }
+}


### PR DESCRIPTION
Currently the `EventFake` can receive an array of events which should be faked. If you specify exactly which events should be faked, I'd expect that all other events should be properly dispatched and their listeners executed. That's currently not the case  as the `EventFake` `listen` and `subscribe` methods do nothing.

I stumbled upon this problem when I was writing some tests:

```php
Event::fake([FoobarEvent::class]);

$user = factory(User::class)->create();

// rest of the test
```

In this case I have an observer on the User model which creates a "slug" for the model. So when doing User::observe([UserObserver::class]); this gets called

```php
static::$dispatcher->listen("eloquent.{$event}: {$name}", $callback);
```

As the dispatcher is now the `EventFake` instance and the listen method in it does nothing my observer listeners weren't registered. This resulted in a

`Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1364 Field 'slug' doesn't have a default value`

exception when the above test was run which I totally didn't expect since I explicitly told the faker that I want only `FoobarEvent` to be faked.

I fixed this to behave as expected and I also added a test for it.