### PR TITLE
[5.5] Remove undefined variable from compact

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1240,7 +1240,7 @@ class Builder
     {
         $type = $not ? 'NotExists' : 'Exists';
 
-        $this->wheres[] = compact('type', 'operator', 'query', 'boolean');
+        $this->wheres[] = compact('type', 'query', 'boolean');
 
         $this->addBinding($query->getBindings(), 'where');
 


### PR DESCRIPTION
Backport of e17be60 to fix `whereHas()` on PHP 7.3.

Fixes #25192.
