### PR TITLE
[5.6] Fix bug when programmatically calling artisan commands which ask for user input.

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -185,7 +185,10 @@ class Application extends SymfonyApplication implements ApplicationContract
 
         $this->setCatchExceptions(false);
 
-        $result = $this->run(new ArrayInput($parameters), $this->lastOutput);
+        $input = new ArrayInput($parameters);
+        $input->setInteractive(false);
+
+        $result = $this->run($input, $this->lastOutput);
 
         $this->setCatchExceptions(true);
 


### PR DESCRIPTION
I saw a tweet by Caleb on Twitter the other day which mentions how you can use the command interface API to make seeders that accept user input: https://twitter.com/calebporzio/status/1028012082522988544 (for reference)

Taking a deeper dive into the feature, I discovered a potential problem where calling the artisan command programmatically when you call the methods asking for user input, it will cause Laravel to "hang" inside this method call. This seems to be because when you call the command, by default it seems to assume that the input (terminal) is interactive, even when calling the command from inside Laravel. Sure enough, when I ran `php artisan tinker` and called the `db:seed` method (through `Artisan::call`), this did cause tinker to seemingly "hang" on this method call.

After applying this patch to the Application.php file, everything appears to be working fine - commands will still ask for input, but when programmatically calling them from inside Laravel they will act much like when you call them from a terminal without an interactable interface (like inside a Docker container), which is much nicer.

I don't see how this will break any backwards compatibility with Laravel so I have requested a merge into the `5.6` branch. Please feel free to correct me if I am wrong.