### PR TITLE
[5.7] Support index length on MySQL

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -459,11 +459,12 @@ class Blueprint
      * @param  string|array  $columns
      * @param  string  $name
      * @param  string|null  $algorithm
+     * @param  int|array|null  $lengths
      * @return \Illuminate\Support\Fluent
      */
-    public function primary($columns, $name = null, $algorithm = null)
+    public function primary($columns, $name = null, $algorithm = null, $lengths = null)
     {
-        return $this->indexCommand('primary', $columns, $name, $algorithm);
+        return $this->indexCommand('primary', $columns, $name, $algorithm, $lengths);
     }
 
     /**
@@ -472,11 +473,12 @@ class Blueprint
      * @param  string|array  $columns
      * @param  string  $name
      * @param  string|null  $algorithm
+     * @param  int|array|null  $lengths
      * @return \Illuminate\Support\Fluent
      */
-    public function unique($columns, $name = null, $algorithm = null)
+    public function unique($columns, $name = null, $algorithm = null, $lengths = null)
     {
-        return $this->indexCommand('unique', $columns, $name, $algorithm);
+        return $this->indexCommand('unique', $columns, $name, $algorithm, $lengths);
     }
 
     /**
@@ -485,11 +487,12 @@ class Blueprint
      * @param  string|array  $columns
      * @param  string  $name
      * @param  string|null  $algorithm
+     * @param  int|array|null  $lengths
      * @return \Illuminate\Support\Fluent
      */
-    public function index($columns, $name = null, $algorithm = null)
+    public function index($columns, $name = null, $algorithm = null, $lengths = null)
     {
-        return $this->indexCommand('index', $columns, $name, $algorithm);
+        return $this->indexCommand('index', $columns, $name, $algorithm, $lengths);
     }
 
     /**
@@ -1195,11 +1198,14 @@ class Blueprint
      * @param  string|array  $columns
      * @param  string  $index
      * @param  string|null  $algorithm
+     * @param  int|array|null  $lengths
      * @return \Illuminate\Support\Fluent
      */
-    protected function indexCommand($type, $columns, $index, $algorithm = null)
+    protected function indexCommand($type, $columns, $index, $algorithm = null, $lengths = null)
     {
         $columns = (array) $columns;
+
+        $lengths = (array) $lengths;
 
         // If no name was specified for this index, we will create one using a basic
         // convention of the table name, followed by the columns, followed by an
@@ -1207,7 +1213,7 @@ class Blueprint
         $index = $index ?: $this->createIndexName($type, $columns);
 
         return $this->addCommand(
-            $type, compact('index', 'columns', 'algorithm')
+            $type, compact('index', 'columns', 'algorithm', 'lengths')
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -215,12 +215,20 @@ class MySqlGrammar extends Grammar
      */
     protected function compileKey(Blueprint $blueprint, Fluent $command, $type)
     {
+        $columns = [];
+
+        foreach ($command->columns as $i => $column) {
+            $length = isset($command->lengths[$i]) ? '('.$command->lengths[$i].')' : '';
+
+            $columns[] = $this->wrap($column).$length;
+        }
+
         return sprintf('alter table %s add %s %s%s(%s)',
             $this->wrapTable($blueprint),
             $type,
             $this->wrap($command->index),
             $command->algorithm ? ' using '.$command->algorithm : '',
-            $this->columnize($command->columns)
+            implode(', ', $columns)
         );
     }
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -309,6 +309,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add primary key `bar` using hash(`foo`)', $statements[0]);
     }
 
+    public function testAddingPrimaryKeyWithLengths()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->primary('foo', 'bar', null, 50);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add primary key `bar`(`foo`(50))', $statements[0]);
+    }
+
     public function testAddingUniqueKey()
     {
         $blueprint = new Blueprint('users');
@@ -317,6 +327,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table `users` add unique `bar`(`foo`)', $statements[0]);
+    }
+
+    public function testAddingUniqueKeyWithLengths()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->unique('foo', 'bar', null, 50);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add unique `bar`(`foo`(50))', $statements[0]);
     }
 
     public function testAddingIndex()
@@ -337,6 +357,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table `users` add index `baz` using hash(`foo`, `bar`)', $statements[0]);
+    }
+
+    public function testAddingIndexWithLengths()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo', 'bar'], 'baz', null, [50, 100]);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add index `baz`(`foo`(50), `bar`(100))', $statements[0]);
     }
 
     public function testAddingSpatialIndex()


### PR DESCRIPTION
This PR allows MySQL migrations to specify the index length:

```php
Schema::create('table', function(Blueprint $table) {
    $table->string('a');
    $table->string('b');
    $table->text('c');
    $table->primary(['a', 'b'], null, null, [10, 20]);
    $table->index('c', null, null, 50);
});
```

This is especially useful for `TEXT` columns, as they don't allow indexes without a length.

PostgreSQL, SQLite and SQL Server don't support index lengths. There is a [workaround](https://stackoverflow.com/questions/21823949/how-to-add-a-prefix-length-index-in-postgresql) for PostgreSQL, but it only supports non-unique indexes and is cumbersome to use in queries. So I don't think it's worth the effort.

I didn't add exceptions for the other databases because I don't think they are necessary for a such a minor feature.

Resolves #9293.