### PR TITLE
[5.7] Convert throwBadMethodCallException to a static method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1341,7 +1341,7 @@ class Builder
         }
 
         if (! isset(static::$macros[$method])) {
-            $this->throwBadMethodCallException($method);
+            static::throwBadMethodCallException($method);
         }
 
         if (static::$macros[$method] instanceof Closure) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2813,6 +2813,6 @@ class Builder
             return $this->dynamicWhere($method, $parameters);
         }
 
-        $this->throwBadMethodCallException($method);
+        static::throwBadMethodCallException($method);
     }
 }

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -231,6 +231,6 @@ class RedirectResponse extends BaseRedirectResponse
             return $this->with(Str::snake(substr($method, 4)), $parameters[0]);
         }
 
-        $this->throwBadMethodCallException($method);
+        static::throwBadMethodCallException($method);
     }
 }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -808,6 +808,6 @@ class Mailable implements MailableContract, Renderable
             return $this->with(Str::camel(substr($method, 4)), $parameters[0]);
         }
 
-        $this->throwBadMethodCallException($method);
+        static::throwBadMethodCallException($method);
     }
 }

--- a/src/Illuminate/Support/Traits/ForwardsCalls.php
+++ b/src/Illuminate/Support/Traits/ForwardsCalls.php
@@ -33,19 +33,19 @@ trait ForwardsCalls
                 throw $e;
             }
 
-            $this->throwBadMethodCallException($method);
+            static::throwBadMethodCallException($method);
         }
     }
 
     /**
-     * Create a bad method call exception for the given method.
+     * Throw a bad method call exception for the given method.
      *
      * @param  string  $method
      * @return void
      *
      * @throws \BadMethodCallException
      */
-    protected function throwBadMethodCallException($method)
+    protected static function throwBadMethodCallException($method)
     {
         throw new BadMethodCallException(sprintf(
             'Call to undefined method %s::%s()', static::class, $method

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -408,6 +408,15 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder->bam(), $builder->getQuery());
     }
 
+    /**
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Call to undefined method Illuminate\Database\Eloquent\Builder::missingMacro()
+     */
+    public function testMissingStaticMacrosThrowsProperException()
+    {
+        Builder::missingMacro();
+    }
+
     public function testGetModelsProperlyHydratesModels()
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[get]', [$this->getMockQueryBuilder()]);

--- a/tests/Support/ForwardsCallsTest.php
+++ b/tests/Support/ForwardsCallsTest.php
@@ -60,7 +60,7 @@ class ForwardsCallsOne
 
     public function throwTestException($method)
     {
-        $this->throwBadMethodCallException($method);
+        static::throwBadMethodCallException($method);
     }
 }
 


### PR DESCRIPTION
...so that it can be called from a `__callStatic` static method.