### PR TITLE
[5.7] Support methods with underscores and numbers in the ForwardsCalls trait

### DIFF
--- a/src/Illuminate/Support/Traits/ForwardsCalls.php
+++ b/src/Illuminate/Support/Traits/ForwardsCalls.php
@@ -22,7 +22,7 @@ trait ForwardsCalls
         try {
             return $object->{$method}(...$parameters);
         } catch (Error | BadMethodCallException $e) {
-            $pattern = '~^Call to undefined method (?P<class>[^:]+)::(?P<method>[a-zA-Z]+)\(\)$~';
+            $pattern = '~^Call to undefined method (?P<class>[^:]+)::(?P<method>[^\(]+)\(\)$~';
 
             if (! preg_match($pattern, $e->getMessage(), $matches)) {
                 throw $e;

--- a/tests/Support/ForwardsCallsTest.php
+++ b/tests/Support/ForwardsCallsTest.php
@@ -31,6 +31,15 @@ class ForwardsCallsTest extends TestCase
     }
 
     /**
+     * @expectedException  \BadMethodCallException
+     * @expectedExceptionMessage  Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::this1_shouldWork_too()
+     */
+    public function testMissingAlphanumericForwardedCallThrowsCorrectError()
+    {
+        (new ForwardsCallsOne)->this1_shouldWork_too('foo', 'bar');
+    }
+
+    /**
      * @expectedException  \Error
      * @expectedExceptionMessage  Call to undefined method Illuminate\Tests\Support\ForwardsCallsBase::missingMethod()
      */


### PR DESCRIPTION
As pointed out by @garygreen in #25163, the current regex does not support method names with numbers or underscores.

This PR catches those too.