### PR TITLE
[5.6] Update queue worker memory usage to use the "real" amount of memory used

### DIFF
--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -222,7 +222,7 @@ class Listener
      */
     public function memoryExceeded($memoryLimit)
     {
-        return (memory_get_usage() / 1024 / 1024) >= $memoryLimit;
+        return (memory_get_usage(true) / 1024 / 1024) >= $memoryLimit;
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -541,7 +541,7 @@ class Worker
      */
     public function memoryExceeded($memoryLimit)
     {
-        return (memory_get_usage() / 1024 / 1024) >= $memoryLimit;
+        return (memory_get_usage(true) / 1024 / 1024) >= $memoryLimit;
     }
 
     /**


### PR DESCRIPTION
This update makes a small change to the queue worker memory calculation logic to use the "real usage" calculation, which will include memory that may be allocated outside of the application scripts being processed by the queue, but still being allocated to the PHP thread overall.

The reason for this change is to allow the worker daemon to more accurately calculate the amount of memory allocated to it, improving the "memory" worker's logic to restart the queue worker when it reaches a memory limit defined by the user.

We encountered an issue whereby queue workers were exceeding 800mb of allocated RSS memory to a worker thread, despite having a memory limit in place of 32mb. This was due to a large portion of the memory not being allocated within the bounds of the script, but more so in the system memory (our queues workers process a large number of external HTTP calls, which appear to have a significant amount of memory allocated outside of the value calculated by `get_memory_usage(false)`

Changing the calculation to use `get_memory_usage(true)` is now resulting in the queues restarting around the 120mb allocated memory mark (with a worker limit of 32mb).

Note: Due to the nature of PHP and memory allocation, the number would still be lower than the overall memory that is actually consumed by the worker thread, but this change should result in the calculation being much more closer to the real value, especially when the memory is allocated outside of the script, but still within the php worker thread — all while still maintaining using the internal PHP method call for `get_memory_usage()`.

Example references...
https://github.com/laravel/framework/issues/16783#issuecomment-269476161