### PR TITLE
[5.6] Allowing passing arrays to JsonResource

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -110,7 +110,9 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function toArray($request)
     {
-        return $this->resource->toArray();
+        return is_array($this->resource)
+            ? $this->resource
+            : $this->resource->toArray();
     }
 
     /**

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -6,6 +6,7 @@ use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Http\Resources\MergeValue;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Tests\Integration\Http\Fixtures\Post;
 use Illuminate\Tests\Integration\Http\Fixtures\Author;
 use Illuminate\Http\Resources\ConditionallyLoadsAttributes;
@@ -703,5 +704,25 @@ class ResourceTest extends TestCase
                 'Fourth',
             ],
         ], $results);
+    }
+
+    public function test_the_resource_can_be_an_array()
+    {
+        Route::get('/', function () {
+            return new JsonResource([
+                'user@example.com' => 'John',
+                'admin@example.com' => 'Hank',
+            ]);
+        });
+
+        $this->withoutExceptionHandling()
+            ->get('/', ['Accept' => 'application/json'])
+            ->assertStatus(200)
+            ->assertJson([
+                'data' => [
+                    'user@example.com' => 'John',
+                    'admin@example.com' => 'Hank',
+                ],
+            ]);
     }
 }


### PR DESCRIPTION
It can be useful to use the `JsonResource` class for one-off api routes instead of having to create a new resource class. This already works for collections, but it won't work with arrays. This PR adds the ability to pass an array to `JsonResource::make()`.

example:
```php
public function index()
{
    $array = $this->getData();

    return JsonResource::make($array);    
}
```
