### PR TITLE
[5.6] Fix BelongsToMany with custom $relatedKey

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -796,7 +796,7 @@ class BelongsToMany extends Relation
     {
         $model->save(['touch' => false]);
 
-        $this->attach($model->getKey(), $pivotAttributes, $touch);
+        $this->attach($model, $pivotAttributes, $touch);
 
         return $model;
     }
@@ -836,7 +836,7 @@ class BelongsToMany extends Relation
         // accomplish this which will insert the record and any more attributes.
         $instance->save(['touch' => false]);
 
-        $this->attach($instance->getKey(), $joining, $touch);
+        $this->attach($instance, $joining, $touch);
 
         return $instance;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -474,11 +474,11 @@ trait InteractsWithPivotTable
     protected function parseIds($value)
     {
         if ($value instanceof Model) {
-            return [$value->getKey()];
+            return [$value->{$this->relatedKey}];
         }
 
         if ($value instanceof Collection) {
-            return $value->modelKeys();
+            return $value->pluck($this->relatedKey)->all();
         }
 
         if ($value instanceof BaseCollection) {
@@ -496,7 +496,7 @@ trait InteractsWithPivotTable
      */
     protected function parseId($value)
     {
-        return $value instanceof Model ? $value->getKey() : $value;
+        return $value instanceof Model ? $value->{$this->relatedKey} : $value;
     }
 
     /**


### PR DESCRIPTION
`BelongsToMany` relationships always use the model's primary key instead of the `$relatedKey` when inserting/updating/deleting pivot entries:

```php
class User extends Model {
    public function roles() {
        return $this->belongsToMany(Role::class, null, null, 'role_slug', null, 'slug');
    }
}

$user = User::first();
$user->roles()->save(new Role($attributes));
$user->roles()->create($attributes);
$user->roles()->attach(Role::get());
$user->roles()->detach(Role::first());
$user->roles()->updateExistingPivot(Role::first(), $attributes);
```

All these queries use the primary key (`$role->id`) instead of the `$relatedKey` (`$role->slug`).

We can fix `save()` and `create()` by passing the whole `$instance` to `attach()`, it will get the key from `parseIds()`.

Fixes #25209.