### PR TITLE
[5.6] Route prefix "where" attribute available in group function, but not as a function on Route

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -54,7 +54,7 @@ class RouteRegistrar
      * @var array
      */
     protected $allowedAttributes = [
-        'as', 'domain', 'middleware', 'name', 'namespace', 'prefix', 'where'
+        'as', 'domain', 'middleware', 'name', 'namespace', 'prefix', 'where',
     ];
 
     /**

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -53,7 +53,7 @@ class RouteRegistrar
      * @var array
      */
     protected $allowedAttributes = [
-        'as', 'domain', 'middleware', 'name', 'namespace', 'prefix',
+        'as', 'domain', 'middleware', 'name', 'namespace', 'prefix', 'where'
     ];
 
     /**

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -21,6 +21,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\RouteRegistrar name(string $value)
  * @method \Illuminate\Routing\RouteRegistrar namespace(string $value)
  * @method \Illuminate\Routing\RouteRegistrar prefix(string  $prefix)
+ * @method \Illuminate\Routing\RouteRegistrar where(array  $where)
  */
 class RouteRegistrar
 {

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -12,6 +12,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\Route any(string $uri, \Closure|array|string|null $action = null)
  * @method static \Illuminate\Routing\Route match(array|string $methods, string $uri, \Closure|array|string|null $action = null)
  * @method static \Illuminate\Routing\RouteRegistrar prefix(string  $prefix)
+ * @method static \Illuminate\Routing\RouteRegistrar where(array  $where)
  * @method static \Illuminate\Routing\PendingResourceRegistration resource(string $name, string $controller, array $options = [])
  * @method static \Illuminate\Routing\PendingResourceRegistration apiResource(string $name, string $controller, array $options = [])
  * @method static void apiResources(array $resources)

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -170,15 +170,15 @@ class RouteRegistrarTest extends TestCase
 
         $this->assertEquals('api/users', $this->getRoute()->uri());
     }
-    
+
     public function testCanRegisterGroupWithPrefixAndWhere()
     {
         $this->router->prefix('foo/{bar}')->where(['bar' => '[0-9]+'])->group(function ($router) {
-            $router->get('here', function(){
+            $router->get('here', function () {
                 return 'good';
             });
         });
-        
+
         $this->seeResponse('good', Request::create('foo/12345/here', 'GET'));
     }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -170,6 +170,17 @@ class RouteRegistrarTest extends TestCase
 
         $this->assertEquals('api/users', $this->getRoute()->uri());
     }
+    
+    public function testCanRegisterGroupWithPrefixAndWhere()
+    {
+        $this->router->prefix('foo/{bar}')->where(['bar' => '[0-9]+'])->group(function ($router) {
+            $router->get('here', function(){
+                return 'good';
+            });
+        });
+        
+        $this->seeResponse('good', Request::create('foo/12345/here', 'GET'));
+    }
 
     public function testCanRegisterGroupWithNamePrefix()
     {


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When registering routes in web.php you are able to add a prefix with a where constrain like this
Route::group([ 'prefix' => 'foo/{bar}', 'where' => ['bar' => '[0-9a-Z]+'] ], function() {} );
But you were not able to add a where constrain like this
Route::prefix('foo/{bar}')->where(['bar' => '[0-9a-Z]+'])->group( function() {} );
because "Method Illuminate\Routing\RouteRegistrar::where did not exist."

But with this pull request everything should work as expected.

This change will benefit to end users that prefer using nested function calls instead of one call to group(array) with all the parameters.

I believe it won't break because the where attribute already exists but was not added to RouteRegistrar $allowedAttributes array

Issue #25181