### PR TITLE
[5.6] JSON Assertion Refactor

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Testing;
 
 use Closure;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Traits\Macroable;
@@ -541,7 +540,7 @@ class TestResponse
     }
 
     /**
-     * Walks through leaf nodes of a multi-dimensional array
+     * Walks through leaf nodes of a multi-dimensional array.
      * @param array $data
      * @return \RecursiveIteratorIterator
      */

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -232,6 +232,35 @@ class FoundationTestResponseTest extends TestCase
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
         $response->assertJsonMissing(['id' => 2]);
+
+        try {
+            $response->assertJsonMissing(['id' => 20]);
+            $this->fail('No exception was thrown');
+        } catch (Exception $e) {
+        }
+    }
+
+
+    public function testAssertJsonMissingExact()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
+
+        $response->assertJsonMissingExact(['id' => 2]);
+
+        try {
+            $response->assertJsonMissingExact(['id' => 20]);
+            $this->fail('No exception was thrown');
+        } catch (Exception $e) {
+        }
+
+        try {
+            $response->assertJsonMissingExact(['id' => 20, 'foo' => 'bar']);
+            $this->fail('No exception was thrown');
+        } catch (Exception $e) {
+        }
+
+        // This is missing because bar has changed to baz
+        $response->assertJsonMissingExact(['id' => 20, 'foo' => 'baz']);
     }
 
     public function testAssertJsonMissingValidationErrors()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -182,7 +182,7 @@ class FoundationTestResponseTest extends TestCase
         try {
             $response->assertJsonFragment(['id' => 1]);
             $this->fail('Asserting id => 1, existing in JsonSerializableSingleResourceWithIntegersStub should fail');
-        } catch (\PHPUnit\Framework\ExpectationFailedException $e) {
+        } catch (\PHPUnit\Framework\AssertionFailedError $e) {
         }
     }
 
@@ -239,7 +239,6 @@ class FoundationTestResponseTest extends TestCase
         } catch (Exception $e) {
         }
     }
-
 
     public function testAssertJsonMissingExact()
     {


### PR DESCRIPTION
This PR implements the long term refactor suggested in my previous PR: https://github.com/laravel/framework/pull/24852

The previous implementation to assert than values are present or missing from a JSON response involved JSON encoding the search values and response value and then performing comparisons on the encoded string. e.g. 
```php
PHPUnit::assertTrue(Str::contains('"id": 3,', '{"id": 30, "name": "John"}');
```

This PR retains the existing functionality, removes the hacky string comparisons, recursively walks through all the leaf nodes of data and checks if the values are equal.

I also added some tests around `assertJsonMissingExact()` as there were none.