### PR TITLE
[5.6] Helper function to check if any of the passed variables is empty

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -17,7 +17,7 @@ if (! function_exists('any_empty')) {
     function any_empty()
     {
         foreach (func_get_args() as $arg) {
-            if (empty($arg) === true) {
+            if (empty($arg)) {
                 return true;
             }
         }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -8,6 +8,24 @@ use Illuminate\Support\Debug\Dumper;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HigherOrderTapProxy;
 
+if (! function_exists('any_empty')) {
+    /**
+     * Check if any of the given variables is empty.
+     *
+     * @return string
+     */
+    function any_empty()
+    {
+        foreach (func_get_args() as $arg) {
+            if (empty($arg) === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
 if (! function_exists('append_config')) {
     /**
      * Assign high numeric IDs to a config item to force appending.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -950,6 +950,18 @@ class SupportHelpersTest extends TestCase
         putenv('foo=(null)');
         $this->assertEquals('', env('foo'));
     }
+
+    public function testAnyEmpty()
+    {
+        $this->assertTrue(any_empty('foo', null, 'bar'));
+        $this->assertTrue(any_empty('foo', '', 'bar'));
+        $this->assertTrue(any_empty('foo', 0, 'bar'));
+        $this->assertTrue(any_empty('foo', false, 'bar'));
+        $this->assertFalse(any_empty('foo', 'null', 'bar'));
+        $this->assertFalse(any_empty('foo', ' ', 'bar'));
+        $this->assertFalse(any_empty('foo', 1, 'bar'));
+        $this->assertFalse(any_empty('foo', true, 'bar'));
+    }
 }
 
 trait SupportTestTraitOne


### PR DESCRIPTION
Added helper function `any_empty` to check if any of the passed variables is empty. It works exactly the same as PHP's `empty($var)` function with the difference being that you can pass as many variables as you want `any_empty($var1, $var2)`. This is a new helper function so doesn't break existing features.