### PR TITLE
[5.6] Do not show full path views for exceptions, but only from base_path.

### DIFF
--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -4,6 +4,7 @@ namespace Illuminate\View\Engines;
 
 use Exception;
 use ErrorException;
+use Illuminate\Support\Str;
 use Illuminate\View\Compilers\CompilerInterface;
 
 class CompilerEngine extends PhpEngine

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -87,7 +87,7 @@ class CompilerEngine extends PhpEngine
      */
     protected function getMessage(Exception $e)
     {
-        return $e->getMessage().' (View: '.realpath(last($this->lastCompiled)).')';
+        return $e->getMessage().' (View: '.Str::replaceFirst(base_path(), '', last($this->lastCompiled)).')';
     }
 
     /**


### PR DESCRIPTION
As mentioned in #25215, i don't understand why we are using a full path for throwing exceptions in views, as this will conflict with most issue/exception trackers. It will create multiple issues if you are using deployment like for example Envoyer og similar deployment procedures, where each deployment get a unique directory with a timestamp or an unique id.