### PR TITLE
Localize responses

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -63,6 +63,6 @@ class Authenticate
             }
         }
 
-        throw new AuthenticationException('Unauthenticated.', $guards);
+        throw new AuthenticationException(__('auth.responses.Unauthenticated'), $guards);
     }
 }


### PR DESCRIPTION
Will propose another file change  to `/resources/lang/en/auth.php`. See here: https://github.com/laravel/laravel/compare/master...dmcbrn:patch-1

---details---

When creating an API I'm getting untranslated responses. This PR (in combination with the one mentioned above) will extract the 'Unauthenticated' text to language files making it easy to translate it.


<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
