### PR TITLE
[5.6] add tests for TestResponse::assertJsonMissingExact()

### DIFF
--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -240,7 +240,6 @@ class FoundationTestResponseTest extends TestCase
         }
     }
 
-
     public function testAssertJsonMissingExact()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -232,6 +232,35 @@ class FoundationTestResponseTest extends TestCase
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
         $response->assertJsonMissing(['id' => 2]);
+
+        try {
+            $response->assertJsonMissing(['id' => 20]);
+            $this->fail('No exception was thrown');
+        } catch (Exception $e) {
+        }
+    }
+
+
+    public function testAssertJsonMissingExact()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
+
+        $response->assertJsonMissingExact(['id' => 2]);
+
+        try {
+            $response->assertJsonMissingExact(['id' => 20]);
+            $this->fail('No exception was thrown');
+        } catch (Exception $e) {
+        }
+
+        try {
+            $response->assertJsonMissingExact(['id' => 20, 'foo' => 'bar']);
+            $this->fail('No exception was thrown');
+        } catch (Exception $e) {
+        }
+
+        // This is missing because bar has changed to baz
+        $response->assertJsonMissingExact(['id' => 20, 'foo' => 'baz']);
     }
 
     public function testAssertJsonMissingValidationErrors()


### PR DESCRIPTION
Currently this method is completely untested.