### PR TITLE
[5.6] Simplify `configureUsingFluentDefinition()` method for the `Command` class

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -130,13 +130,8 @@ class Command extends SymfonyCommand
         // After parsing the signature we will spin through the arguments and options
         // and set them on this command. These will already be changed into proper
         // instances of these "InputArgument" and "InputOption" Symfony classes.
-        foreach ($arguments as $argument) {
-            $this->getDefinition()->addArgument($argument);
-        }
-
-        foreach ($options as $option) {
-            $this->getDefinition()->addOption($option);
-        }
+        $this->getDefinition()->addArguments($argument);
+        $this->getDefinition()->addOptions($option);
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -130,8 +130,8 @@ class Command extends SymfonyCommand
         // After parsing the signature we will spin through the arguments and options
         // and set them on this command. These will already be changed into proper
         // instances of these "InputArgument" and "InputOption" Symfony classes.
-        $this->getDefinition()->addArguments($argument);
-        $this->getDefinition()->addOptions($option);
+        $this->getDefinition()->addArguments($arguments);
+        $this->getDefinition()->addOptions($options);
     }
 
     /**


### PR DESCRIPTION
I like simplifying stuff. This is a really small one. But still needed to keep the code quality at a high level.

I removed the foreach loops because there are 'plural' versions for both methods. Which do the exact same thing: looping over the array and calling the `addArgument()` or `addOption()` method for each item. This doesn't change any functionality. It just removes a few lines of code.
