### PR TITLE
Fix container handling unresolvable optional dependencies and parameters.

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -905,6 +905,8 @@ class Container implements ArrayAccess, ContainerContract
         // the value of the dependency, similarly to how we do this with scalars.
         catch (BindingResolutionException $e) {
             if ($parameter->isOptional()) {
+                array_pop($this->with);
+
                 return $parameter->getDefaultValue();
             }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -619,6 +619,8 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string  $abstract
      * @param  array  $parameters
      * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function resolve($abstract, $parameters = [])
     {
@@ -642,10 +644,15 @@ class Container implements ArrayAccess, ContainerContract
         // We're ready to instantiate an instance of the concrete type registered for
         // the binding. This will instantiate the types, as well as resolve any of
         // its "nested" dependencies recursively until all have gotten resolved.
-        if ($this->isBuildable($concrete, $abstract)) {
-            $object = $this->build($concrete);
-        } else {
-            $object = $this->make($concrete);
+        try {
+            if ($this->isBuildable($concrete, $abstract)) {
+                $object = $this->build($concrete);
+            } else {
+                $object = $this->make($concrete);
+            }
+        } catch (BindingResolutionException $e) {
+            array_pop($this->with);
+            throw $e;
         }
 
         // If we defined any extenders for this type, we'll need to spin through them
@@ -805,6 +812,8 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  array  $dependencies
      * @return array
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function resolveDependencies(array $dependencies)
     {
@@ -905,8 +914,6 @@ class Container implements ArrayAccess, ContainerContract
         // the value of the dependency, similarly to how we do this with scalars.
         catch (BindingResolutionException $e) {
             if ($parameter->isOptional()) {
-                array_pop($this->with);
-
                 return $parameter->getDefaultValue();
             }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1048,6 +1048,13 @@ class ContainerTest extends TestCase
         $container = new Container;
         $container->get('Taylor');
     }
+
+    public function testContainerHandlesUnresolvableOptionalDependencies()
+    {
+        $container = new Container;
+
+        $this->assertInstanceOf(C::class, $container->make(C::class, ['argument' => 'foo']));
+    }
 }
 
 class ContainerConcreteStub
@@ -1210,5 +1217,26 @@ class ContainerTestContextInjectInstantiations implements IContainerContractStub
     public function __construct()
     {
         static::$instantiations++;
+    }
+}
+
+class A
+{
+    public function __construct($unresolvable)
+    {
+    }
+}
+
+class B
+{
+    public function __construct(A $a = null)
+    {
+    }
+}
+
+class C
+{
+    public function __construct(B $b, $argument)
+    {
     }
 }


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Ignoring whether optional dependencies are a good idea, the error reported without this fix is: 
```
Illuminate\Contracts\Container\BindingResolutionException:
Unresolvable dependency resolving [Parameter #1 [ <required> $argument ]]
in class Illuminate\Tests\Container\C
```

`A, B, C` are just to illustrate the bug. I will try to come up with better class names/or use the existing classes.