### PR TITLE
[5.6] Fix MorphTo lazy eager loading

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -543,7 +543,7 @@ class Builder
         // and error prone. We don't want constraints because we add eager ones.
         $relation = Relation::noConstraints(function () use ($name) {
             try {
-                return $this->getModel()->{$name}();
+                return $this->getModel()->newInstance()->$name();
             } catch (BadMethodCallException $e) {
                 throw RelationNotFoundException::make($this->getModel(), $name);
             }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -460,7 +460,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->setModel($this->getMockModel());
-        $builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock('stdClass'));
+        $builder->getModel()->shouldReceive('newInstance->orders')->once()->andReturn($relation = m::mock('stdClass'));
         $relationQuery = m::mock('stdClass');
         $relation->shouldReceive('getQuery')->andReturn($relationQuery);
         $relationQuery->shouldReceive('with')->once()->with(['lines' => null, 'lines.details' => null]);
@@ -473,8 +473,8 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->setModel($this->getMockModel());
-        $builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock('stdClass'));
-        $builder->getModel()->shouldReceive('ordersGroups')->once()->andReturn($groupsRelation = m::mock('stdClass'));
+        $builder->getModel()->shouldReceive('newInstance->orders')->once()->andReturn($relation = m::mock('stdClass'));
+        $builder->getModel()->shouldReceive('newInstance->ordersGroups')->once()->andReturn($groupsRelation = m::mock('stdClass'));
 
         $relationQuery = m::mock('stdClass');
         $relation->shouldReceive('getQuery')->andReturn($relationQuery);

--- a/tests/Integration/Database/EloquentMorphToLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphToLazyEagerLoadingTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphToLazyEagerLoadingTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphToLazyEagerLoadingTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('post_id');
+            $table->unsignedInteger('user_id');
+        });
+
+        Schema::create('videos', function (Blueprint $table) {
+            $table->increments('video_id');
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('commentable_type');
+            $table->integer('commentable_id');
+        });
+
+        $user = User::create();
+
+        $post = tap((new Post)->user()->associate($user))->save();
+
+        $video = Video::create();
+
+        (new Comment)->commentable()->associate($post)->save();
+        (new Comment)->commentable()->associate($video)->save();
+    }
+
+    public function test_lazy_eager_loading()
+    {
+        $comments = Comment::all();
+
+        \DB::enableQueryLog();
+
+        $comments->load('commentable');
+
+        $this->assertCount(3, \DB::getQueryLog());
+        $this->assertTrue($comments[0]->relationLoaded('commentable'));
+        $this->assertTrue($comments[0]->commentable->relationLoaded('user'));
+        $this->assertTrue($comments[1]->relationLoaded('commentable'));
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Post extends Model
+{
+    public $timestamps = false;
+    protected $primaryKey = 'post_id';
+    protected $with = ['user'];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}
+
+class User extends Model
+{
+    public $timestamps = false;
+}
+
+class Video extends Model
+{
+    public $timestamps = false;
+    protected $primaryKey = 'video_id';
+}


### PR DESCRIPTION
`Collection::load()` uses the first model to get the relationships for lazy eager loading. This can cause problems on `MorphTo` relationships when the related models differ in certain aspects:

### Example 1: Different relationships in `$with` (#16604)

```php
class Comment extends Model {
    public function commentable() {
        return $this->morphTo();
    }
}

class Post extends Model {
    protected $with = ['user'];

    public function user() {
        return $this->belongsTo(User::class);
    }
}

class Video extends Model {}

$post = Post::create(['user_id' => 1]);
$video = Video::create();
(new Comment)->commentable()->associate($post)->save();
(new Comment)->commentable()->associate($video)->save();

Comment::all()->load('commentable');
```

This fails because Eloquent tries to load the `user` relationship on `$video` (as specified in `$post`). 

### Example 2: Different primary keys (#24654)

```php
class Comment extends Model {
    public function commentable() {
        return $this->morphTo();
    }
}

class Post extends Model {
    protected $primaryKey = 'post_id';
}

class Video extends Model {
    protected $primaryKey = 'video_id';
}

$post = Post::create();
$video = Video::create();
(new Comment)->commentable()->associate($post)->save();
(new Comment)->commentable()->associate($video)->save();

Comment::all()->load('commentable');
```

This fails because Eloquent tries to access the `videos.post_id` column (as specified in `$post`). 

---

All this is caused by `HasRelationships::morphTo()` only calling `morphEagerTo()` on eager loading: On *lazy* eager loading, `morphInstanceTo()` is used.

We can fix the problem by always using a fresh model instance when getting the relationship in `Builder::getRelation()`.  This mimics eager loading where the query builder is initialized with a fresh instance. 

The new integration test combines different primary keys and the usage of `$with`.

Fixes #16604 and fixes #24654.