### PR TITLE
[5.7] Fix console application return docblock

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -287,7 +287,7 @@ class Application extends SymfonyApplication implements ApplicationContract
     /**
      * Get the Laravel application instance.
      *
-     * @return \Illuminate\Contracts\Foundation\Application
+     * @return \Illuminate\Contracts\Container\Container
      */
     public function getLaravel()
     {


### PR DESCRIPTION
The property "$laravel" of the console application is documented as a type (or an implementation) of Illuminate\Contracts\Container\Container. The console constructor also requires an Illuminate\Contracts\Container\Container implementation. But the getLaravel() method is documented as returning Illuminate\Contracts\Foundation\Application type.

- The property:
```php
/**
 * The Laravel application instance.
 *
 * @var \Illuminate\Contracts\Container\Container
 */
protected $laravel;
```

- The constructor:
```php
/**
 * Create a new Artisan console application.
 *
 * @param  \Illuminate\Contracts\Container\Container  $laravel
 * @param  \Illuminate\Contracts\Events\Dispatcher  $events
 * @param  string  $version
 * @return void
 */
public function __construct(Container $laravel, Dispatcher $events, $version)
```
- The getter method:
```php
/**
 * Get the Laravel application instance.
 *
 * @return \Illuminate\Contracts\Foundation\Application
 */
public function getLaravel()
{
    return $this->laravel;
}
```

I guess the reason is a Laravel application is injected in run-time, but the logical action above isn't correct. The application interface extends container interface, so the container is the super-type and the application is the sub-type. A sub-type variable (application) is also the super-type (container) but a super one (container) may not be (application).

I think instead of returning Illuminate\Contracts\Foundation\Application type, the getLaravel() method of console application must be documented as returning Illuminate\Contracts\Console\Container type.

Just close if I misunderstood the Laravel's idea!

Thanks!
