### PR TITLE
[5.7] Pop the argument stack when unresolvable optional dependencies are found

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -905,6 +905,8 @@ class Container implements ArrayAccess, ContainerContract
         // the value of the dependency, similarly to how we do this with scalars.
         catch (BindingResolutionException $e) {
             if ($parameter->isOptional()) {
+                array_pop($this->with);
+
                 return $parameter->getDefaultValue();
             }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -619,6 +619,8 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string  $abstract
      * @param  array  $parameters
      * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function resolve($abstract, $parameters = [])
     {
@@ -642,10 +644,15 @@ class Container implements ArrayAccess, ContainerContract
         // We're ready to instantiate an instance of the concrete type registered for
         // the binding. This will instantiate the types, as well as resolve any of
         // its "nested" dependencies recursively until all have gotten resolved.
-        if ($this->isBuildable($concrete, $abstract)) {
-            $object = $this->build($concrete);
-        } else {
-            $object = $this->make($concrete);
+        try {
+            if ($this->isBuildable($concrete, $abstract)) {
+                $object = $this->build($concrete);
+            } else {
+                $object = $this->make($concrete);
+            }
+        } catch (BindingResolutionException $e) {
+            array_pop($this->with);
+            throw $e;
         }
 
         // If we defined any extenders for this type, we'll need to spin through them
@@ -805,6 +812,8 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  array  $dependencies
      * @return array
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function resolveDependencies(array $dependencies)
     {
@@ -905,8 +914,6 @@ class Container implements ArrayAccess, ContainerContract
         // the value of the dependency, similarly to how we do this with scalars.
         catch (BindingResolutionException $e) {
             if ($parameter->isOptional()) {
-                array_pop($this->with);
-
                 return $parameter->getDefaultValue();
             }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1048,6 +1048,13 @@ class ContainerTest extends TestCase
         $container = new Container;
         $container->get('Taylor');
     }
+
+    public function testContainerHandlesUnresolvableOptionalDependencies()
+    {
+        $container = new Container;
+
+        $this->assertInstanceOf(C::class, $container->make(C::class, ['argument' => 'foo']));
+    }
 }
 
 class ContainerConcreteStub
@@ -1210,5 +1217,26 @@ class ContainerTestContextInjectInstantiations implements IContainerContractStub
     public function __construct()
     {
         static::$instantiations++;
+    }
+}
+
+class A
+{
+    public function __construct($unresolvable)
+    {
+    }
+}
+
+class B
+{
+    public function __construct(A $a = null)
+    {
+    }
+}
+
+class C
+{
+    public function __construct(B $b, $argument)
+    {
     }
 }


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The technical explanation is that when an unresolved dependency is found in the container, a `BindingResolutionException` is thrown. Higher up in the code, if that dependency was optional, the default value is returned. But, that exception skips the code where the `with` (argument) stack would normally get popped. So, when the next dependency with arguments gets resolved, it has the wrong entry in the stack, and claims that the argument is missing.

This is a difficult bug to explain, it's easier with an example.

Paraphrasing some real code:
```php
// Somewhere in a test we set this in the conatiner.

app()->bind(ViesSoapClient::class, ViesSoapClientMock::class)

class ViesSoapClient
{
    public function __construct($wsdl) {}
}

class ViesSoapClientMock extends ViesSoapClient
{
    public function __construct() {}
}

class TaxService
{
    private $client;

    // Adding the optional constructor dependency here triggers the error.

    public function __construct(ViesSoapClient $client = null)
    {
        $this->client = $client ?: new ViesSoapClient('https://foo');
    }
}

class CartProcessor
{
    public function __construct(TaxService $t, $argument) {}
}

class CartFactory
{
    private $app;

    public function __construct(Application $app)
    {
        $this->app = $app;
    }

    public function buildCartProcessor()
    {
        // The error appears here. This code hasn't changed.
        // I stared at this for a long time scratching my head.
        // I checked the spelling of `argument`. Finally, looking at my diff
        // I was able to guess what change actually caused the error.

        // Illuminate\Contracts\Container\BindingResolutionException:
        // Unresolvable dependency resolving [Parameter #1 [ <required> $argument ]]
        // in class CartProcessor

        return $this->app->make(CartProcessor::class, ['argument' => 'foo']);
    }
}
```

> What does this change actually do?

This code catches the `BindingResolutionException`, cleans up the stack, and re-throws it.

> I am closing this pull request because it lacks sufficient explanation, tests, or both. It is difficult for us to merge pull requests without these things because the change may introduce breaking changes to the framework.

This code has tests. I admit that they're not great at this point. I would appreciate some discussion as to how to make them acceptable once a consensus has been reached.

As far as I can tell this does not break BC. In most cases, `BindingResolutionException` propagates and this doesn't matter. I'm assuming the current behavior is not desired. If BC wasn't an issue, I would probably remove support for optional dependencies altogether, but that's not an option.

> Feel free to re-submit your change with a thorough explanation of the feature and tests - integration tests are preferred over unit tests. Please include it's benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

This is a bug fix. That's the best explanation I can provide. Integration tests don't really make sense in this case. 
The benefit to end users is that Laravel doesn't tell them that perfectly fine code is broken in an unrelated place.