### PR TITLE
[5.6] Fix pivot table migration name generation from the make:model command

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -83,7 +83,7 @@ class ModelMakeCommand extends GeneratorCommand
     protected function createMigration()
     {
         $table = Str::plural(Str::snake(class_basename($this->argument('name'))));
-        
+
         if ($this->option('pivot')) {
             $table = Str::singular($table);
         }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -83,6 +83,10 @@ class ModelMakeCommand extends GeneratorCommand
     protected function createMigration()
     {
         $table = Str::plural(Str::snake(class_basename($this->argument('name'))));
+        
+        if ($this->option('pivot')) {
+            $table = Str::singular($table);
+        }
 
         $this->call('make:migration', [
             'name' => "create_{$table}_table",


### PR DESCRIPTION
- Currently, when using the `-p` flag with the `make:model` command the convention of singular name is not followed. This PR aims to fix that.
- Before this PR, doing `php artisan make:model CompanyUser -p` used to generate the migration with the table name `company_users` whereas it should do `company_user`.
- I couldn't find the related tests, so if someone can point me to the right direction I will add the test for this case :) 
