### PR TITLE
[5.7] Fix float casting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -688,7 +688,7 @@ trait HasAttributes
      */
     public function fromFloat($value)
     {
-        switch ($value) {
+        switch ((string) $value) {
             case 'Infinity':
                 return INF;
             case '-Infinity':

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1617,6 +1617,9 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelCastingStub;
 
+        $model->floatAttribute = 0;
+        $this->assertEquals(0, $model->floatAttribute);
+
         $model->floatAttribute = 'Infinity';
         $this->assertEquals(INF, $model->floatAttribute);
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1618,19 +1618,19 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelCastingStub;
 
         $model->floatAttribute = 0;
-        $this->assertEquals(0, $model->floatAttribute);
+        $this->assertSame(0.0, $model->floatAttribute);
 
         $model->floatAttribute = 'Infinity';
-        $this->assertEquals(INF, $model->floatAttribute);
+        $this->assertSame(INF, $model->floatAttribute);
 
         $model->floatAttribute = INF;
-        $this->assertEquals(INF, $model->floatAttribute);
+        $this->assertSame(INF, $model->floatAttribute);
 
         $model->floatAttribute = '-Infinity';
-        $this->assertEquals(-INF, $model->floatAttribute);
+        $this->assertSame(-INF, $model->floatAttribute);
 
         $model->floatAttribute = -INF;
-        $this->assertEquals(-INF, $model->floatAttribute);
+        $this->assertSame(-INF, $model->floatAttribute);
 
         $model->floatAttribute = 'NaN';
         $this->assertNan($model->floatAttribute);


### PR DESCRIPTION
The float casting introduced in #24936 doesn't work with `0`. A loose comparison between `0` and any string returns `true` in PHP:

```php
dd(0 == 'Infinity'); // true
```

Explicitly converting the value to a string fixes it.

Fixes #25224.