### PR TITLE
[5.7] Inform user when a `cache:clear` command fails

### DIFF
--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -64,7 +64,9 @@ class ClearCommand extends Command
             'cache:clearing', [$this->argument('store'), $this->tags()]
         );
 
-        $this->cache()->flush();
+        if (! $this->cache()->flush()) {
+            return $this->error('Failed to clear cache. Make sure you have appropriate rights.');
+        }
 
         $this->flushFacades();
 

--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -64,11 +64,13 @@ class ClearCommand extends Command
             'cache:clearing', [$this->argument('store'), $this->tags()]
         );
 
-        if (! $this->cache()->flush()) {
-            return $this->error('Failed to clear cache. Make sure you have appropriate rights.');
-        }
+        $successful = $this->cache()->flush();
 
         $this->flushFacades();
+
+        if (! $successful) {
+            return $this->error('Failed to clear cache. Make sure you have appropriate rights.');
+        }
 
         $this->laravel['events']->fire(
             'cache:cleared', [$this->argument('store'), $this->tags()]


### PR DESCRIPTION
## Reasoning
When a `cache:clear` command fails it does not inform user in any way about what happend, giving indication everything went ok.

Fail can happen if current user has no write permission in the cache folder.

## Impact
It fixes https://github.com/laravel/framework/issues/1179. It also resolves many issues listed [here](https://encrypted.google.com/search?q=cache%3Aclear+not+working+laravel).

This change could be considered a breaking change, but very unlikely it would impact anyone. 

## Changes
I have added an if statement to see, if flushing succeeded or not. It should be safe to do so as the [contract enforces a boolean to be returned](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Contracts/Cache/Store.php#L82).
