### PR TITLE
[5.7] Add make:view command

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Console\TableCommand;
 use Illuminate\Auth\Console\AuthMakeCommand;
 use Illuminate\Foundation\Console\UpCommand;
+use Illuminate\View\Console\ViewMakeCommand;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
@@ -163,6 +164,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'Serve' => 'command.serve',
         'TestMake' => 'command.test.make',
         'VendorPublish' => 'command.vendor.publish',
+        'ViewMake' => 'command.view.make',
     ];
 
     /**
@@ -173,7 +175,8 @@ class ArtisanServiceProvider extends ServiceProvider
     public function register()
     {
         $this->registerCommands(array_merge(
-            $this->commands, $this->devCommands
+            $this->commands,
+            $this->devCommands
         ));
     }
 
@@ -1008,6 +1011,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.view.clear', function ($app) {
             return new ViewClearCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerViewMakeCommand()
+    {
+        $this->app->singleton('command.view.make', function ($app) {
+            return new ViewMakeCommand($app['files']);
         });
     }
 

--- a/src/Illuminate/View/Console/ViewMakeCommand.php
+++ b/src/Illuminate/View/Console/ViewMakeCommand.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Illuminate\View\Console;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class ViewMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:view';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new view file';
+
+    /**
+     * Create a new command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @return void
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct($files);
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__ . '/stubs/view.stub';
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        return $this->getViewPath() . '/' . $this->getFileName();
+    }
+
+    /**
+     * Get the views folder path.
+     *
+     * @return string
+     */
+    protected function getViewPath()
+    {
+        if ($path = $this->option('path')) {
+            return $path;
+        }
+
+        return $this->laravel['config']['view.paths'][0];
+    }
+
+    /**
+     * Get the view file path.
+     *
+     * @return string
+     */
+    protected function getFileName()
+    {
+        return $this->getNameInput() . '.blade.php';
+    }
+
+    /**
+     * Replace the view dots syntax with slashes.
+     *
+     * @return string
+     */
+    protected function getNameInput()
+    {
+        return str_replace('.', '/', parent::getNameInput());
+    }
+
+    /**
+     * Build the view file with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $replace = $this->buildViewReplacements([]);
+
+        return str_replace(
+            array_keys($replace),
+            array_values($replace),
+            $this->files->get($this->getStub())
+        );
+    }
+
+    /**
+     * Build the view replacement values.
+     *
+     * @param  array  $replace
+     * @return array
+     */
+    protected function buildViewReplacements(array $replace)
+    {
+        return array_merge($replace, [
+            'ParentView' => $this->option('extends'),
+            'ContentSection' => $this->option('section'),
+        ]);
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['path', 'p', InputOption::VALUE_OPTIONAL, 'Where to store the view file.'],
+            ['extends', 'e', InputOption::VALUE_OPTIONAL, 'The parent view.'],
+            ['section', 's', InputOption::VALUE_OPTIONAL, 'The section of the content.'],
+        ];
+    }
+}

--- a/src/Illuminate/View/Console/ViewMakeCommand.php
+++ b/src/Illuminate/View/Console/ViewMakeCommand.php
@@ -40,7 +40,7 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__ . '/stubs/view.stub';
+        return __DIR__.'/stubs/view.stub';
     }
 
     /**
@@ -51,7 +51,7 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function getPath($name)
     {
-        return $this->getViewPath() . '/' . $this->getFileName();
+        return $this->getViewPath().'/'.$this->getFileName();
     }
 
     /**
@@ -75,7 +75,7 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function getFileName()
     {
-        return $this->getNameInput() . '.blade.php';
+        return $this->getNameInput().'.blade.php';
     }
 
     /**

--- a/src/Illuminate/View/Console/stubs/view.stub
+++ b/src/Illuminate/View/Console/stubs/view.stub
@@ -1,0 +1,5 @@
+@extends('ParentView')
+
+@section('ContentSection')
+
+@endsection


### PR DESCRIPTION
This [PR](https://twitter.com/blackburn1911/status/1030792125045256192) adds the ability to generate a view, set a custom path, the parent view and the content section.

**Examples:**
```bash
php artisan make:view home
php artisan make:view home -p "path-to-views-folder"
php artisan make:view home -e "master" -s "container"
```
**Works also with folder names:**

```bash
php artisan make:view posts.index
```