### PR TITLE
[5.7] Abstracting out PostgreSQL attribute casting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -685,7 +685,7 @@ trait HasAttributes
     }
 
     /**
-     * Decode the given float using postgreSql constants
+     * Decode the given float using postgreSql constants.
      *
      * @param  mixed  $value
      * @return mixed

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -478,7 +478,7 @@ trait HasAttributes
             case 'real':
             case 'float':
             case 'double':
-                return $this->fromFloat($value);
+                return (float) $value;
             case 'string':
                 return (string) $value;
             case 'bool':
@@ -684,17 +684,6 @@ trait HasAttributes
         return json_encode($value);
     }
 
-    /**
-     * Decode the given float.
-     *
-     * @param  mixed  $value
-     * @return mixed
-     */
-    public function fromFloat($value)
-    {
-        return (float) $value;
-    }
-    
     /**
      * Decode the given float using postgreSql constants
      *

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -498,6 +498,10 @@ trait HasAttributes
                 return $this->asDateTime($value);
             case 'timestamp':
                 return $this->asTimestamp($value);
+            case 'PostgreSQL_real':
+            case 'PostgreSQL_float':
+            case 'PostgreSQL_double':
+                return $this->postgreSqlfromFloat($value);
             default:
                 return $value;
         }
@@ -687,6 +691,17 @@ trait HasAttributes
      * @return mixed
      */
     public function fromFloat($value)
+    {
+        return (float) $value;
+    }
+    
+    /**
+     * Decode the given float using postgreSql constants
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public function postgreSqlfromFloat($value)
     {
         switch ((string) $value) {
             case 'Infinity':

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -685,7 +685,7 @@ trait HasAttributes
     }
 
     /**
-     * Decode the given float using postgreSql constants.
+     * Decode the given float value using postgreSql constants.
      *
      * @param  mixed  $value
      * @return mixed

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -498,9 +498,9 @@ trait HasAttributes
                 return $this->asDateTime($value);
             case 'timestamp':
                 return $this->asTimestamp($value);
-            case 'PostgreSQL_real':
-            case 'PostgreSQL_float':
-            case 'PostgreSQL_double':
+            case 'postgresql_real':
+            case 'postgresql_float':
+            case 'postgresql_double':
                 return $this->postgreSqlfromFloat($value);
             default:
                 return $value;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1617,26 +1617,26 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelCastingStub;
 
-        $model->floatAttribute = 0;
-        $this->assertSame(0.0, $model->floatAttribute);
+        $model->postgreSqlfloatAttribute = 0;
+        $this->assertSame(0.0, $model->postgreSqlfloatAttribute);
 
-        $model->floatAttribute = 'Infinity';
-        $this->assertSame(INF, $model->floatAttribute);
+        $model->postgreSqlfloatAttribute = 'Infinity';
+        $this->assertSame(INF, $model->postgreSqlfloatAttribute);
 
-        $model->floatAttribute = INF;
-        $this->assertSame(INF, $model->floatAttribute);
+        $model->postgreSqlfloatAttribute = INF;
+        $this->assertSame(INF, $model->postgreSqlfloatAttribute);
 
-        $model->floatAttribute = '-Infinity';
-        $this->assertSame(-INF, $model->floatAttribute);
+        $model->postgreSqlfloatAttribute = '-Infinity';
+        $this->assertSame(-INF, $model->postgreSqlfloatAttribute);
 
-        $model->floatAttribute = -INF;
-        $this->assertSame(-INF, $model->floatAttribute);
+        $model->postgreSqlfloatAttribute = -INF;
+        $this->assertSame(-INF, $model->postgreSqlfloatAttribute);
 
-        $model->floatAttribute = 'NaN';
+        $model->postgreSqlfloatAttribute = 'NaN';
         $this->assertNan($model->floatAttribute);
 
-        $model->floatAttribute = NAN;
-        $this->assertNan($model->floatAttribute);
+        $model->postgreSqlfloatAttribute = NAN;
+        $this->assertNan($model->postgreSqlfloatAttribute);
     }
 
     public function testUpdatingNonExistentModelFails()
@@ -2121,6 +2121,7 @@ class EloquentModelCastingStub extends Model
         'dateAttribute' => 'date',
         'datetimeAttribute' => 'datetime',
         'timestampAttribute' => 'timestamp',
+        'postgreSqlfloatAttribute' => 'postgresql_float',
     ];
 
     public function jsonAttributeValue()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1633,7 +1633,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame(-INF, $model->postgreSqlfloatAttribute);
 
         $model->postgreSqlfloatAttribute = 'NaN';
-        $this->assertNan($model->floatAttribute);
+        $this->assertNan($model->postgreSqlfloatAttribute);
 
         $model->postgreSqlfloatAttribute = NAN;
         $this->assertNan($model->postgreSqlfloatAttribute);


### PR DESCRIPTION
Based on #24936 followed with issue #25224 and quick fix #25251 and a recommendation to create a PR made by taylorotwell  [here](https://github.com/laravel/framework/pull/25251#issuecomment-414090792)

Introducing new database types casting attributes `postgresql_real`, `postgresql_float`, `postgresql_double`

Benefit to end users

1.  avoid breaking changes in release 5.7
2. It is a narrow use case - only for PostgreSQL, other DBMS may have another `constant names`.
3. the developer will `explicitly` request the type casting with `Infinity` and `NaN` support, ONLY when they need it.
4. There might be a little speed benefit that comes from less string comparisons and a  float to string casting.