### PR TITLE
[5.7] Add guard to authentication events

### DIFF
--- a/src/Illuminate/Auth/Events/Attempting.php
+++ b/src/Illuminate/Auth/Events/Attempting.php
@@ -21,7 +21,7 @@ class Attempting
     /**
      * The guard this attempt is made to.
      *
-     * @var string
+     * @var \Illuminate\Contracts\Auth\StatefulGuard
      */
     public $guard;
 
@@ -30,7 +30,7 @@ class Attempting
      *
      * @param  array  $credentials
      * @param  bool  $remember
-     * @param  string  $guard
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return void
      */
     public function __construct($credentials, $remember, $guard)

--- a/src/Illuminate/Auth/Events/Attempting.php
+++ b/src/Illuminate/Auth/Events/Attempting.php
@@ -19,15 +19,24 @@ class Attempting
     public $remember;
 
     /**
+     * The guard this attempt is made to.
+     *
+     * @var string
+     */
+    public $guard;
+
+    /**
      * Create a new event instance.
      *
      * @param  array  $credentials
      * @param  bool  $remember
+     * @param  string  $guard
      * @return void
      */
-    public function __construct($credentials, $remember)
+    public function __construct($credentials, $remember, $guard)
     {
         $this->remember = $remember;
         $this->credentials = $credentials;
+        $this->guard = $guard;
     }
 }

--- a/src/Illuminate/Auth/Events/Authenticated.php
+++ b/src/Illuminate/Auth/Events/Authenticated.php
@@ -18,7 +18,7 @@ class Authenticated
     /**
      * The guard the user is authenticating to.
      *
-     * @var string
+     * @var \Illuminate\Contracts\Auth\StatefulGuard
      */
     public $guard;
 
@@ -26,7 +26,7 @@ class Authenticated
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @param  string  $guard
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return void
      */
     public function __construct($user, $guard)

--- a/src/Illuminate/Auth/Events/Authenticated.php
+++ b/src/Illuminate/Auth/Events/Authenticated.php
@@ -16,13 +16,22 @@ class Authenticated
     public $user;
 
     /**
+     * The guard the user is authenticating to.
+     *
+     * @var string
+     */
+    public $guard;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  string  $guard
      * @return void
      */
-    public function __construct($user)
+    public function __construct($user, $guard)
     {
         $this->user = $user;
+        $this->guard = $guard;
     }
 }

--- a/src/Illuminate/Auth/Events/Failed.php
+++ b/src/Illuminate/Auth/Events/Failed.php
@@ -21,7 +21,7 @@ class Failed
     /**
      * The guard the user failed to authenticated to.
      *
-     * @var string
+     * @var \Illuminate\Contracts\Auth\StatefulGuard
      */
     public $guard;
 
@@ -30,7 +30,7 @@ class Failed
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @param  array  $credentials
-     * @param  string  $guard
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return void
      */
     public function __construct($user, $credentials, $guard)

--- a/src/Illuminate/Auth/Events/Failed.php
+++ b/src/Illuminate/Auth/Events/Failed.php
@@ -19,15 +19,24 @@ class Failed
     public $credentials;
 
     /**
+     * The guard the user failed to authenticated to.
+     *
+     * @var string
+     */
+    public $guard;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @param  array  $credentials
+     * @param  string  $guard
      * @return void
      */
-    public function __construct($user, $credentials)
+    public function __construct($user, $credentials, $guard)
     {
         $this->user = $user;
         $this->credentials = $credentials;
+        $this->guard = $guard;
     }
 }

--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -23,15 +23,24 @@ class Login
     public $remember;
 
     /**
+     * The guard the user authenticated to.
+     *
+     * @var string
+     */
+    public $guard;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  bool  $remember
+     * @param  string  $guard
      * @return void
      */
-    public function __construct($user, $remember)
+    public function __construct($user, $remember, $guard)
     {
         $this->user = $user;
         $this->remember = $remember;
+        $this->guard = $guard;
     }
 }

--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -25,7 +25,7 @@ class Login
     /**
      * The guard the user authenticated to.
      *
-     * @var string
+     * @var \Illuminate\Contracts\Auth\StatefulGuard
      */
     public $guard;
 
@@ -34,7 +34,7 @@ class Login
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  bool  $remember
-     * @param  string  $guard
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return void
      */
     public function __construct($user, $remember, $guard)

--- a/src/Illuminate/Auth/Events/Logout.php
+++ b/src/Illuminate/Auth/Events/Logout.php
@@ -16,13 +16,22 @@ class Logout
     public $user;
 
     /**
+     * The guard to which the user was authenticated.
+     *
+     * @var string
+     */
+    public $guard;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  string  $guard
      * @return void
      */
-    public function __construct($user)
+    public function __construct($user, $guard)
     {
         $this->user = $user;
+        $this->guard = $guard;
     }
 }

--- a/src/Illuminate/Auth/Events/Logout.php
+++ b/src/Illuminate/Auth/Events/Logout.php
@@ -18,7 +18,7 @@ class Logout
     /**
      * The guard to which the user was authenticated.
      *
-     * @var string
+     * @var \Illuminate\Contracts\Auth\StatefulGuard
      */
     public $guard;
 
@@ -26,7 +26,7 @@ class Logout
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @param  string  $guard
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return void
      */
     public function __construct($user, $guard)

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -493,7 +493,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         }
 
         if (isset($this->events)) {
-            $this->events->dispatch(new Events\Logout($user, $this->name));
+            $this->events->dispatch(new Events\Logout($user, $this));
         }
 
         // Once we have fired the logout event we will clear the users out of memory
@@ -576,7 +576,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Events\Attempting(
-                $credentials, $remember, $this->name
+                $credentials, $remember, $this
             ));
         }
     }
@@ -592,7 +592,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Events\Login(
-                $user, $remember, $this->name
+                $user, $remember, $this
             ));
         }
     }
@@ -607,7 +607,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Events\Authenticated(
-                $user, $this->name
+                $user, $this
             ));
         }
     }
@@ -623,7 +623,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Events\Failed(
-                $user, $credentials, $this->name
+                $user, $credentials, $this
             ));
         }
     }
@@ -645,7 +645,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function getName()
     {
-        return 'login_'.$this->name.'_'.sha1(static::class);
+        return 'login_'.$this->getGuardName().'_'.sha1(static::class);
     }
 
     /**
@@ -655,7 +655,17 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function getRecallerName()
     {
-        return 'remember_'.$this->name.'_'.sha1(static::class);
+        return 'remember_'.$this->getGuardName().'_'.sha1(static::class);
+    }
+
+    /**
+     * Get the name of the guard, corresponding to name in authentication configuration.
+     *
+     * @return string
+     */
+    public function getGuardName()
+    {
+        return $this->name;
     }
 
     /**

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -493,7 +493,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         }
 
         if (isset($this->events)) {
-            $this->events->dispatch(new Events\Logout($user));
+            $this->events->dispatch(new Events\Logout($user, $this->name));
         }
 
         // Once we have fired the logout event we will clear the users out of memory
@@ -576,7 +576,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Events\Attempting(
-                $credentials, $remember
+                $credentials, $remember, $this->name
             ));
         }
     }
@@ -591,7 +591,9 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected function fireLoginEvent($user, $remember = false)
     {
         if (isset($this->events)) {
-            $this->events->dispatch(new Events\Login($user, $remember));
+            $this->events->dispatch(new Events\Login(
+                $user, $remember, $this->name
+            ));
         }
     }
 
@@ -604,7 +606,9 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected function fireAuthenticatedEvent($user)
     {
         if (isset($this->events)) {
-            $this->events->dispatch(new Events\Authenticated($user));
+            $this->events->dispatch(new Events\Authenticated(
+                $user, $this->name
+            ));
         }
     }
 
@@ -618,7 +622,9 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected function fireFailedEvent($user, array $credentials)
     {
         if (isset($this->events)) {
-            $this->events->dispatch(new Events\Failed($user, $credentials));
+            $this->events->dispatch(new Events\Failed(
+                $user, $credentials, $this->name
+            ));
         }
     }
 


### PR DESCRIPTION
I'm running into a situation where I need to fire some actions after logout, but only for a particular guard.

Currently there's no straightforward way to determine which guard was responsible for firing one of the authentication events.