### PR TITLE
Output schedule task run time just like queue job

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -79,7 +79,7 @@ class ScheduleRunCommand extends Command
         }
 
         if (! $this->eventsRan) {
-            $this->info('No scheduled commands are ready to run.');
+            $this->info($this->runAt().'No scheduled commands are ready to run.');
         }
     }
 
@@ -94,7 +94,7 @@ class ScheduleRunCommand extends Command
         if ($this->schedule->serverShouldRun($event, $this->startedAt)) {
             $this->runEvent($event);
         } else {
-            $this->line('<info>Skipping command (has already run on another server):</info> '.$event->getSummaryForDisplay());
+            $this->line('<info>'.$this->runAt().'Skipping command (has already run on another server):</info> '.$event->getSummaryForDisplay());
         }
     }
 
@@ -106,10 +106,20 @@ class ScheduleRunCommand extends Command
      */
     protected function runEvent($event)
     {
-        $this->line('<info>Running scheduled command:</info> '.$event->getSummaryForDisplay());
+        $this->line('<info>'.$this->runAt().'Running scheduled command:</info> '.$event->getSummaryForDisplay());
 
         $event->run($this->laravel);
 
         $this->eventsRan = true;
+    }
+
+    /**
+     * Return string format for current date time
+     *
+     * @return string
+     */
+    private function runAt(): string
+    {
+        return '['.Carbon::now()->format('Y-m-d H:i:s').']';
     }
 }


### PR DESCRIPTION
The current output of `schedule:run` is like

```
Running scheduled command: '/usr/bin/php7.1' 'artisan' task1-name > '/dev/null' 2>&1
No scheduled commands are ready to run.
No scheduled commands are ready to run.
No scheduled commands are ready to run.
No scheduled commands are ready to run.
Running scheduled command: '/usr/bin/php7.1' 'artisan' task2-name > '/dev/null' 2>&1
No scheduled commands are ready to run.
No scheduled commands are ready to run.
```

We don't know the exact time of task running.

This PR adds a DateTime string at the beginning of the output:

```
[2018-08-19 23:00:00]Running scheduled command: '/usr/bin/php7.1' 'artisan' task2-name > '/dev/null' 2>&1
[2018-08-19 23:01:00]No scheduled commands are ready to run.
[2018-08-19 23:02:00]No scheduled commands are ready to run.
```

like what queue worker does.

So that we can know that task2 was triggered at 2018-08-19 23:00:00, it makes debugging schedule-related problems easier.