### PR TITLE
[5.7] Remove loose comparisons

### DIFF
--- a/src/Illuminate/Auth/Recaller.php
+++ b/src/Illuminate/Auth/Recaller.php
@@ -83,6 +83,6 @@ class Recaller
     {
         $segments = explode('|', $this->recaller);
 
-        return count($segments) == 3 && trim($segments[0]) !== '' && trim($segments[1]) !== '';
+        return count($segments) === 3 && trim($segments[0]) !== '' && trim($segments[1]) !== '';
     }
 }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -163,7 +163,7 @@ class Event
      */
     public function getDefaultOutput()
     {
-        return (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
+        return (DIRECTORY_SEPARATOR === '\\') ? 'NUL' : '/dev/null';
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -165,7 +165,7 @@ trait ManagesFrequencies
         $segments = explode(':', $time);
 
         return $this->spliceIntoPosition(2, (int) $segments[0])
-                    ->spliceIntoPosition(1, count($segments) == 2 ? (int) $segments[1] : '0');
+                    ->spliceIntoPosition(1, count($segments) === 2 ? (int) $segments[1] : '0');
     }
 
     /**

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -49,7 +49,7 @@ class BoundMethod
         // We will assume an @ sign is used to delimit the class name from the method
         // name. We will split on this @ sign and then build a callable array that
         // we can pass right back into the "call" method for dependency binding.
-        $method = count($segments) == 2
+        $method = count($segments) === 2
                         ? $segments[1] : $defaultMethod;
 
         if (is_null($method)) {

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -173,7 +173,7 @@ trait GuardsAttributes
      */
     public function totallyGuarded()
     {
-        return count($this->getFillable()) == 0 && $this->getGuarded() == ['*'];
+        return count($this->getFillable()) === 0 && $this->getGuarded() == ['*'];
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -195,7 +195,7 @@ trait QueriesRelationships
 
             unset($alias);
 
-            if (count($segments) == 3 && Str::lower($segments[1]) == 'as') {
+            if (count($segments) === 3 && Str::lower($segments[1]) == 'as') {
                 list($name, $alias) = [$segments[0], $segments[2]];
             }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1667,7 +1667,7 @@ class Builder
     {
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
             'column' => $column,
-            'direction' => strtolower($direction) == 'asc' ? 'asc' : 'desc',
+            'direction' => strtolower($direction) === 'asc' ? 'asc' : 'desc',
         ];
 
         return $this;

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -204,7 +204,7 @@ class PostgresGrammar extends Grammar
         // strip the leading boolean we will do so when using as the only where.
         $joinWheres = $this->compileUpdateJoinWheres($query);
 
-        if (trim($baseWheres) == '') {
+        if (trim($baseWheres) === '') {
             return 'where '.$this->removeLeadingBoolean($joinWheres);
         }
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1154,7 +1154,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 
         foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path) {
             foreach ((array) $path as $pathChoice) {
-                if (realpath(app_path()) == realpath(base_path().'/'.$pathChoice)) {
+                if (realpath(app_path()) === realpath(base_path().'/'.$pathChoice)) {
                     return $this->namespace = $namespace;
                 }
             }

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -35,7 +35,7 @@ class ListFailedCommand extends Command
      */
     public function handle()
     {
-        if (count($jobs = $this->getFailedJobs()) == 0) {
+        if (count($jobs = $this->getFailedJobs()) === 0) {
             return $this->info('No failed jobs!');
         }
 

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -103,7 +103,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function hmget($key, ...$dictionary)
     {
-        if (count($dictionary) == 1) {
+        if (count($dictionary) === 1) {
             $dictionary = $dictionary[0];
         }
 
@@ -119,7 +119,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function hmset($key, ...$dictionary)
     {
-        if (count($dictionary) == 1) {
+        if (count($dictionary) === 1) {
             $dictionary = $dictionary[0];
         } else {
             $input = collect($dictionary);

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -257,7 +257,7 @@ class RouteUrlGenerator
         // First we will get all of the string parameters that are remaining after we
         // have replaced the route wildcards. We'll then build a query string from
         // these string parameters then use it as a starting point for the rest.
-        if (count($parameters) == 0) {
+        if (count($parameters) === 0) {
             return '';
         }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -558,7 +558,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 return is_string($value) || (is_object($value) && method_exists($value, '__toString'));
             });
 
-            if (count($strings) < 2 && count(array_filter([$retrieved, $value], 'is_object')) == 1) {
+            if (count($strings) < 2 && count(array_filter([$retrieved, $value], 'is_object')) === 1) {
                 return in_array($operator, ['!=', '<>', '!==']);
             }
 

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -26,7 +26,7 @@ class MessageSelector
 
         $pluralIndex = $this->getPluralIndex($locale, $number);
 
-        if (count($segments) == 1 || ! isset($segments[$pluralIndex])) {
+        if (count($segments) === 1 || ! isset($segments[$pluralIndex])) {
             return $segments[0];
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -713,7 +713,7 @@ trait ValidatesAttributes
             $id = $this->getValue($matches[1]);
         }
 
-        if (strtolower($id) == 'null') {
+        if (strtolower($id) === 'null') {
             $id = null;
         }
 
@@ -955,7 +955,7 @@ trait ValidatesAttributes
                 }
             }
 
-            return count(array_diff($value, $parameters)) == 0;
+            return count(array_diff($value, $parameters)) === 0;
         }
 
         return ! is_array($value) && in_array((string) $value, $parameters);
@@ -1655,7 +1655,7 @@ trait ValidatesAttributes
      */
     protected function requireSameType($first, $second)
     {
-        if (gettype($first) != gettype($second)) {
+        if (gettype($first) !== gettype($second)) {
             throw new InvalidArgumentException('The values under comparison must be of the same type');
         }
     }

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -15,25 +15,25 @@ class EventTest extends TestCase
 
     public function testBuildCommand()
     {
-        $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
+        $quote = (DIRECTORY_SEPARATOR === '\\') ? '"' : "'";
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\EventMutex'), 'php -i');
 
-        $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
+        $defaultOutput = (DIRECTORY_SEPARATOR === '\\') ? 'NUL' : '/dev/null';
         $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1", $event->buildCommand());
 
-        $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
+        $quote = (DIRECTORY_SEPARATOR === '\\') ? '"' : "'";
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\EventMutex'), 'php -i');
         $event->runInBackground();
 
-        $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
+        $defaultOutput = (DIRECTORY_SEPARATOR === '\\') ? 'NUL' : '/dev/null';
         $this->assertSame("(php -i > {$quote}{$defaultOutput}{$quote} 2>&1 ; '".PHP_BINARY."' artisan schedule:finish \"framework/schedule-eeb46c93d45e928d62aaf684d727e213b7094822\") > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
     }
 
     public function testBuildCommandSendOutputTo()
     {
-        $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
+        $quote = (DIRECTORY_SEPARATOR === '\\') ? '"' : "'";
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\EventMutex'), 'php -i');
 
@@ -48,7 +48,7 @@ class EventTest extends TestCase
 
     public function testBuildCommandAppendOutput()
     {
-        $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
+        $quote = (DIRECTORY_SEPARATOR === '\\') ? '"' : "'";
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\EventMutex'), 'php -i');
 

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -410,7 +410,7 @@ class FilesystemTest extends TestCase
             }
         }
 
-        while (pcntl_waitpid(0, $status) != -1) {
+        while (pcntl_waitpid(0, $status) !== -1) {
             $status = pcntl_wexitstatus($status);
             $result *= $status;
         }


### PR DESCRIPTION
As suggested in https://github.com/laravel/framework/pull/25251#issuecomment-414090792, we should get rid of loose comparisons in the next version of Laravel.

This PR remove the ones that we know the return from sure:
 - `count`, `pcntl_waitpid`: int
 - `trim`, `strtolower`, `realpath`: string
 - `DIRECTORY_SEPARATOR`: string 