### PR TITLE
[5.7] Mock console output while testing to help making assertions

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -163,7 +163,7 @@ class Command extends SymfonyCommand
     public function run(InputInterface $input, OutputInterface $output)
     {
         return parent::run(
-            $this->input = $input, 
+            $this->input = $input,
             $this->output = $this->laravel->make(OutputStyle::class, ['input' => $input, 'output' => $output])
         );
     }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -163,7 +163,8 @@ class Command extends SymfonyCommand
     public function run(InputInterface $input, OutputInterface $output)
     {
         return parent::run(
-            $this->input = $input, $this->output = new OutputStyle($input, $output)
+            $this->input = $input, 
+            $this->output = $this->laravel->make(OutputStyle::class, ['input' => $input, 'output' => $output])
         );
     }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -9,14 +9,14 @@ trait InteractsWithConsole
 {
     /**
      * The list of expected questions with their answers.
-     * 
+     *
      * @var array
      */
     public $expectedQuestions = [];
 
     /**
      * The list of expected outputs.
-     * 
+     *
      * @var array
      */
     public $expectedOutput = [];

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -3,9 +3,24 @@
 namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\PendingCommand;
 
 trait InteractsWithConsole
 {
+    /**
+     * The list of expected questions with their answers.
+     * 
+     * @var array
+     */
+    public $expectedQuestions = [];
+
+    /**
+     * The list of expected outputs.
+     * 
+     * @var array
+     */
+    public $expectedOutput = [];
+
     /**
      * Call artisan command and return code.
      *
@@ -15,6 +30,16 @@ trait InteractsWithConsole
      */
     public function artisan($command, $parameters = [])
     {
-        return $this->app[Kernel::class]->call($command, $parameters);
+        $this->beforeApplicationDestroyed(function () {
+            if (count($this->expectedQuestions)) {
+                $this->fail('Question "'.array_first($this->expectedQuestions)[0].'" was never asked!');
+            }
+
+            if (count($this->expectedOutput)) {
+                $this->fail('Output "'.array_first($this->expectedOutput).'" was never printed!');
+            }
+        });
+
+        return new PendingCommand($this, $this->app, $command, $parameters);
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
-use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\PendingCommand;
 
 trait InteractsWithConsole

--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing;
 use Mockery;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Console\Kernel;
+use PHPUnit\Framework\TestCase as PHPUnit;
 use Mockery\Exception\BadMethodCallException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -41,15 +42,22 @@ class PendingCommand
     private $parameters;
 
     /**
+     * The expected exit code.
+     *
+     * @var int
+     */
+    private $expectedExitCode;
+
+    /**
      * Create a new pending console command run.
      *
-     * @param  \Illuminate\Foundation\Testing\TestCase  $test
+     * @param  \PHPUnit\Framework\TestCase  $test
      * @param  \Illuminate\Foundation\Application  $app
      * @param  string  $command
      * @param  array  $parameters
      * @return void
      */
-    public function __construct(TestCase $test, $app, $command, $parameters)
+    public function __construct(PHPUnit $test, $app, $command, $parameters)
     {
         $this->test = $test;
         $this->app = $app;
@@ -85,6 +93,19 @@ class PendingCommand
     }
 
     /**
+     * Assert that the response has the given status code.
+     *
+     * @param  int  $status
+     * @return $this
+     */
+    public function assertStatus($status)
+    {
+        $this->expectedExitCode = $status;
+
+        return $this;
+    }
+
+    /**
      * Mock the application's console output.
      *
      * @return void
@@ -92,7 +113,7 @@ class PendingCommand
     private function mockTheConsoleOutput()
     {
         $mock = Mockery::mock(OutputStyle::class.'[askQuestion]', [
-            (new ArrayInput($this->parameters)), $this->createABufferedOutputMock()
+            (new ArrayInput($this->parameters)), $this->createABufferedOutputMock(),
         ]);
 
         foreach ($this->test->expectedQuestions as $i => $question) {
@@ -148,7 +169,7 @@ class PendingCommand
         $this->mockTheConsoleOutput();
 
         try {
-            $this->app[Kernel::class]->call($this->command, $this->parameters);
+            $exitCode = $this->app[Kernel::class]->call($this->command, $this->parameters);
         } catch (NoMatchingExpectationException $e) {
             if ($e->getMethodName() == 'askQuestion') {
                 $this->test->fail('Unexpected question "'.$e->getActualArguments()[0]->getQuestion().'" was asked!');
@@ -157,6 +178,13 @@ class PendingCommand
             if (str_contains($e->getMessage(), 'askQuestion')) {
                 $this->test->fail('An an expected question was asked while running the command.');
             }
+        }
+
+        if ($this->expectedExitCode != null) {
+            $this->test->assertTrue(
+                $exitCode == $this->expectedExitCode,
+                "Expected status code {$this->expectedExitCode} but received {$exitCode}."
+            );
         }
     }
 }

--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Mockery;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Contracts\Console\Kernel;
+use Mockery\Exception\BadMethodCallException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Mockery\Exception\NoMatchingExpectationException;
+
+class PendingCommand
+{
+    /**
+     * The test being run.
+     *
+     * @var \Illuminate\Foundation\Testing\TestCase
+     */
+    public $test;
+
+    /**
+     * The application instance.
+     *
+     * @var \Illuminate\Foundation\Application
+     */
+    private $app;
+
+    /**
+     * The command to run.
+     *
+     * @var string
+     */
+    private $command;
+
+    /**
+     * The parameters to pass to the command.
+     *
+     * @var array
+     */
+    private $parameters;
+
+    /**
+     * Create a new pending console command run.
+     *
+     * @param  \Illuminate\Foundation\Testing\TestCase  $test
+     * @param  \Illuminate\Foundation\Application  $app
+     * @param  string  $command
+     * @param  array  $parameters
+     * @return void
+     */
+    public function __construct(TestCase $test, $app, $command, $parameters)
+    {
+        $this->test = $test;
+        $this->app = $app;
+        $this->command = $command;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * Specify a question that should be asked when the command runs.
+     *
+     * @param  string  $question
+     * @param  string  $answer
+     * @return $this
+     */
+    public function expectsQuestion($question, $answer)
+    {
+        $this->test->expectedQuestions[] = [$question, $answer];
+
+        return $this;
+    }
+
+    /**
+     * Specify an output that should be printed when the command runs.
+     *
+     * @param  string  $output
+     * @return $this
+     */
+    public function expectsOutput($output)
+    {
+        $this->test->expectedOutput[] = $output;
+
+        return $this;
+    }
+
+    /**
+     * Mock the application's console output.
+     *
+     * @return void
+     */
+    private function mockTheConsoleOutput()
+    {
+        $mock = Mockery::mock(OutputStyle::class.'[askQuestion]', [
+            (new ArrayInput($this->parameters)), $this->createABufferedOutputMock()
+        ]);
+
+        foreach ($this->test->expectedQuestions as $i => $question) {
+            $mock->shouldReceive('askQuestion')
+                ->once()
+                ->ordered()
+                ->with(Mockery::on(function ($argument) use ($question) {
+                    return $argument->getQuestion() == $question[0];
+                }))
+                ->andReturnUsing(function () use ($question, $i) {
+                    unset($this->test->expectedQuestions[$i]);
+
+                    return $question[1];
+                });
+        }
+
+        $this->app->bind(OutputStyle::class, function () use ($mock) {
+            return $mock;
+        });
+    }
+
+    /**
+     * Create a mock for the buffered output.
+     *
+     * @return \Mockery\MockInterface
+     */
+    private function createABufferedOutputMock()
+    {
+        $mock = Mockery::mock(BufferedOutput::class.'[doWrite]')
+                ->shouldAllowMockingProtectedMethods()
+                ->shouldIgnoreMissing();
+
+        foreach ($this->test->expectedOutput as $i => $output) {
+            $mock->shouldReceive('doWrite')
+                ->once()
+                ->ordered()
+                ->with($output, Mockery::any())
+                ->andReturnUsing(function () use ($i) {
+                    unset($this->test->expectedOutput[$i]);
+                });
+        }
+
+        return $mock;
+    }
+
+    /**
+     * Handle the object's destruction.
+     *
+     * @return void
+     */
+    public function __destruct()
+    {
+        $this->mockTheConsoleOutput();
+
+        try {
+            $this->app[Kernel::class]->call($this->command, $this->parameters);
+        } catch (NoMatchingExpectationException $e) {
+            if ($e->getMethodName() == 'askQuestion') {
+                $this->test->fail('Unexpected question "'.$e->getActualArguments()[0]->getQuestion().'" was asked!');
+            }
+        } catch (BadMethodCallException $e) {
+            if (str_contains($e->getMessage(), 'askQuestion')) {
+                $this->test->fail('An an expected question was asked while running the command.');
+            }
+        }
+    }
+}

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Mockery;
 use Illuminate\Database\Seeder;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Console\OutputStyle;
 use Illuminate\Container\Container;
 use Illuminate\Database\Console\Seeds\SeedCommand;
 use Illuminate\Database\ConnectionResolverInterface;
@@ -13,6 +14,9 @@ class SeedCommandTest extends TestCase
 {
     public function testHandle()
     {
+        $input = new \Symfony\Component\Console\Input\ArrayInput(['--force' => true, '--database' => 'sqlite']);
+        $output = new \Symfony\Component\Console\Output\NullOutput;
+
         $seeder = Mockery::mock(Seeder::class);
         $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
         $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
@@ -25,12 +29,15 @@ class SeedCommandTest extends TestCase
         $container->shouldReceive('call');
         $container->shouldReceive('environment')->once()->andReturn('testing');
         $container->shouldReceive('make')->with('DatabaseSeeder')->andReturn($seeder);
+        $container->shouldReceive('make')->with('Illuminate\Console\OutputStyle', Mockery::any())->andReturn(
+            new OutputStyle($input, $output)
+        );
 
         $command = new SeedCommand($resolver);
         $command->setLaravel($container);
 
         // call run to set up IO, then fire manually.
-        $command->run(new \Symfony\Component\Console\Input\ArrayInput(['--force' => true, '--database' => 'sqlite']), new \Symfony\Component\Console\Output\NullOutput);
+        $command->run($input, $output);
         $command->handle();
 
         $container->shouldHaveReceived('call')->with([$command, 'handle']);

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -19,18 +19,14 @@ class ConsoleApplicationTest extends TestCase
     {
         $exitCode = $this->artisan('foo:bar', [
             'id' => 1,
-        ]);
-
-        $this->assertEquals($exitCode, 0);
+        ])->assertStatus(0);
     }
 
     public function test_artisan_call_using_command_class()
     {
         $exitCode = $this->artisan(FooCommandStub::class, [
             'id' => 1,
-        ]);
-
-        $this->assertEquals($exitCode, 0);
+        ])->assertStatus(0);
     }
 
     /*


### PR DESCRIPTION
This makes it easier to test interactive artisan commands and also do assertions on the console output.

```php
public function testBasicTest()
{

    $this->artisan('package:install')
        ->expectsQuestion('Please provide a token', 'tokenSecret')
        ->expectsOutput('Token is valid')
        ->expectsQuestion('Please select a release', 'v2.0')
        ->expectsQuestion('Are you sure you want to install v2.0?', 'yes')
        ->expectsOutput('Installing...')
        ->assertStatus(0);
}
```

For a console command like this:

```php
public function handle()
{
    $token = $this->secret('Please provide a token');

    if(...){
        $this->info('Token is valid');
    }

    $release = $this->choice('Please select a release', ['v1.0', 'v2.0']);

    if ($this->confirm('Are you sure you want to install '.release.'?')) {
        $this->info('Installing...');
    }
}
```