### PR TITLE
[5.6] Fixes for job queuing errors

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -96,7 +96,7 @@ class Schedule
             $job = is_string($job) ? resolve($job) : $job;
 
             if ($job instanceof ShouldQueue) {
-                dispatch($job)->onQueue($queue);
+                dispatch($job->onQueue($queue));
             } else {
                 dispatch_now($job);
             }


### PR DESCRIPTION
Platform: Lumen 5.6
When using scheduled jobs with queuing there is an error appear in log files:
Running scheduled command: App\Jobs\CheckIncomeJob

In Schedule.php line 99:

  Call to a member function onQueue() on string
This patch fixes this error

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
