### PR TITLE
[5.6] sleep on connection lost

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -251,10 +251,12 @@ class Worker
             $this->exceptions->report($e);
 
             $this->stopWorkerIfLostConnection($e);
+            $this->sleep(1);
         } catch (Throwable $e) {
             $this->exceptions->report($e = new FatalThrowableError($e));
 
             $this->stopWorkerIfLostConnection($e);
+            $this->sleep(1);
         }
     }
 


### PR DESCRIPTION
Fixes #25273 
This is the best place I find to enforce a minimum sleep of 1 seconds on queue connection issues.
