### PR TITLE
[5.6] Fix withCount() and withoutGlobalScopes()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -152,12 +152,12 @@ class Builder
      */
     public function withoutGlobalScopes(array $scopes = null)
     {
-        if (is_array($scopes)) {
-            foreach ($scopes as $scope) {
-                $this->withoutGlobalScope($scope);
-            }
-        } else {
-            $this->scopes = [];
+        if (! is_array($scopes)) {
+            $scopes = array_keys($this->scopes);
+        }
+
+        foreach ($scopes as $scope) {
+            $this->withoutGlobalScope($scope);
         }
 
         return $this;

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -28,6 +28,11 @@ class EloquentWithCountTest extends DatabaseTestCase
             $table->increments('id');
             $table->integer('two_id');
         });
+
+        Schema::create('four', function ($table) {
+            $table->increments('id');
+            $table->integer('one_id');
+        });
     }
 
     /**
@@ -49,6 +54,18 @@ class EloquentWithCountTest extends DatabaseTestCase
             ['id' => 1, 'twos_count' => 1],
         ], $results->get()->toArray());
     }
+
+    public function test_global_scopes()
+    {
+        $one = Model1::create();
+        $one->fours()->create();
+
+        $result = Model1::withCount('fours')->first();
+        $this->assertEquals(0, $result->fours_count);
+
+        $result = Model1::withCount('allFours')->first();
+        $this->assertEquals(1, $result->all_fours_count);
+    }
 }
 
 class Model1 extends Model
@@ -60,6 +77,16 @@ class Model1 extends Model
     public function twos()
     {
         return $this->hasMany(Model2::class, 'one_id');
+    }
+
+    public function fours()
+    {
+        return $this->hasMany(Model4::class, 'one_id');
+    }
+
+    public function allFours()
+    {
+        return $this->fours()->withoutGlobalScopes();
     }
 }
 
@@ -88,6 +115,22 @@ class Model3 extends Model
 
         static::addGlobalScope('app', function ($builder) {
             $builder->where('idz', '>', 0);
+        });
+    }
+}
+
+class Model4 extends Model
+{
+    public $table = 'four';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('app', function ($builder) {
+            $builder->where('id', '>', 1);
         });
     }
 }


### PR DESCRIPTION
`withoutGlobalScopes()` doesn't work on `withCount()` relationships:

```php
class Post extends Model {
    use SoftDeletes;
}

class User extends Model {
    public function allPosts() {
        return $this->hasMany(Post::class)->withoutGlobalScopes();
    }
}

User::withCount('allPosts')->get();
```

```sql
# expected
select "users".*,
  (select count(*)
   from "posts"
   where "users"."id" = "posts"."user_id")
  as "all_posts_count"
from "users"

# actual
select "users".*,
  (select count(*)
   from "posts"
   where "users"."id" = "posts"."user_id"
     and "posts"."deleted_at" is null) <--- The SoftDeletes scope should be missing.
  as "all_posts_count"
from "users"
```

This is caused by the way `withCount()` and `mergeConstraintsFrom()` merge the scopes.

We can fix it by explicitly adding all the scopes to `$removedScopes` (via `withoutGlobalScope()`).