### PR TITLE
[5.7] Adds route resources option

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -287,12 +287,13 @@ class Router implements RegistrarContract, BindingRegistrar
      * Register an array of resource controllers.
      *
      * @param  array  $resources
+     * @param  array  $options
      * @return void
      */
-    public function resources(array $resources)
+    public function resources(array $resources, array $options = [])
     {
         foreach ($resources as $name => $controller) {
-            $this->resource($name, $controller);
+            $this->resource($name, $controller, $options);
         }
     }
 
@@ -321,12 +322,13 @@ class Router implements RegistrarContract, BindingRegistrar
      * Register an array of API resource controllers.
      *
      * @param  array  $resources
+     * @param  array  $options
      * @return void
      */
-    public function apiResources(array $resources)
+    public function apiResources(array $resources, array $options = [])
     {
         foreach ($resources as $name => $controller) {
-            $this->apiResource($name, $controller);
+            $this->apiResource($name, $controller, $options);
         }
     }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -230,6 +230,71 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('resource-middleware');
     }
 
+    public function testCanRegisterResourcesWithExceptOption()
+    {
+        $this->router->resources([
+            'resource-one'      => \Illuminate\Tests\Routing\RouteRegistrarControllerStubOne::class,
+            'resource-two'      => \Illuminate\Tests\Routing\RouteRegistrarControllerStubTwo::class,
+            'resource-three'    => \Illuminate\Tests\Routing\RouteRegistrarControllerStubThree::class,
+        ], ['except' => ['create', 'show']]);
+
+        $this->assertCount(15, $this->router->getRoutes());
+
+        foreach (['one', 'two', 'three'] as $resource) {
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.index'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.store'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.edit'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.update'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.destroy'));
+
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.create'));
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.show'));
+        }
+    }
+
+    public function testCanRegisterResourcesWithOnlyOption()
+    {
+        $this->router->resources([
+            'resource-one'      => \Illuminate\Tests\Routing\RouteRegistrarControllerStubOne::class,
+            'resource-two'      => \Illuminate\Tests\Routing\RouteRegistrarControllerStubTwo::class,
+            'resource-three'    => \Illuminate\Tests\Routing\RouteRegistrarControllerStubThree::class,
+        ], ['only' => ['create', 'show']]);
+
+        $this->assertCount(6, $this->router->getRoutes());
+
+        foreach (['one', 'two', 'three'] as $resource) {
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.create'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.show'));
+
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.index'));
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.store'));
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.edit'));
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.update'));
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.destroy'));
+        }
+    }
+
+    public function testCanRegisterResourcesWithoutOption()
+    {
+        $this->router->resources([
+            'resource-one'      => \Illuminate\Tests\Routing\RouteRegistrarControllerStubOne::class,
+            'resource-two'      => \Illuminate\Tests\Routing\RouteRegistrarControllerStubTwo::class,
+            'resource-three'    => \Illuminate\Tests\Routing\RouteRegistrarControllerStubThree::class,
+        ]);
+
+        $this->assertCount(21, $this->router->getRoutes());
+
+        foreach (['one', 'two', 'three'] as $resource) {
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.index'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.create'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.store'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.show'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.edit'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.update'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.destroy'));
+        }
+    }
+
     public function testCanAccessRegisteredResourceRoutesAsRouteCollection()
     {
         $resource = $this->router->middleware('resource-middleware')
@@ -268,6 +333,72 @@ class RouteRegistrarTest extends TestCase
 
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.update'));
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
+    }
+
+    public function testCanRegisterApiResourcesWithExceptOption()
+    {
+        $this->router->apiResources([
+            'resource-one'      => \Illuminate\Tests\Routing\RouteRegistrarControllerStubOne::class,
+            'resource-two'      => \Illuminate\Tests\Routing\RouteRegistrarControllerStubTwo::class,
+            'resource-three'    => \Illuminate\Tests\Routing\RouteRegistrarControllerStubThree::class,
+        ], ['except' => ['create', 'show']]);
+
+        $this->assertCount(12, $this->router->getRoutes());
+
+        foreach (['one', 'two', 'three'] as $resource) {
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.index'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.store'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.update'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.destroy'));
+
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.create'));
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.show'));
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.edit'));
+        }
+    }
+
+    public function testCanRegisterApiResourcesWithOnlyOption()
+    {
+        $this->router->apiResources([
+            'resource-one'      => \Illuminate\Tests\Routing\RouteRegistrarControllerStubOne::class,
+            'resource-two'      => \Illuminate\Tests\Routing\RouteRegistrarControllerStubTwo::class,
+            'resource-three'    => \Illuminate\Tests\Routing\RouteRegistrarControllerStubThree::class,
+        ], ['only' => ['index', 'show']]);
+
+        $this->assertCount(6, $this->router->getRoutes());
+
+        foreach (['one', 'two', 'three'] as $resource) {
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.index'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.show'));
+
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.store'));
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.update'));
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.destroy'));
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.create'));
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.edit'));
+        }
+    }
+
+    public function testCanRegisterApiResourcesWithoutOption()
+    {
+        $this->router->apiResources([
+            'resource-one'      => \Illuminate\Tests\Routing\RouteRegistrarControllerStubOne::class,
+            'resource-two'      => \Illuminate\Tests\Routing\RouteRegistrarControllerStubTwo::class,
+            'resource-three'    => \Illuminate\Tests\Routing\RouteRegistrarControllerStubThree::class,
+        ]);
+
+        $this->assertCount(15, $this->router->getRoutes());
+
+        foreach (['one', 'two', 'three'] as $resource) {
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.index'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.show'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.store'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.update'));
+            $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.destroy'));
+
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.create'));
+            $this->assertFalse($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.edit'));
+        }
     }
 
     public function testUserCanRegisterApiResource()


### PR DESCRIPTION
This PR adds the options parameter when using `Route::resources` and `Route::apiResources` by taking an options array as the second parameter. These are then passed to each of the resource function calls.


An example of the suggested addition
```php

Route::resources([
        'resource-one'      => 'ResourceOneController',
        'resource-two'      => 'ResourceTwoController',
        'resource-three'    => 'ResourceThreeController',
    ], [ 'except' => [ 'create', 'show' ] ] );

```

Which can replace doing:
```php
Route::resource('resource-one', 'ResourceOneController', ['except' => ['create', 'show']]);
Route::resource('resource-two', 'ResourceTwoController', ['except' => ['create', 'show']]);
Route::resource('resource-three', 'ResourceThreeController', ['except' => ['create', 'show']]);

```

Which in the end would generate:

```

POST      | resource-one                          | resouce-one.store      | App\Http\Controllers\ResourceOne@store      | web |
GET|HEAD  | resource-one                          | resouce-one.index      | App\Http\Controllers\ResourceOne@index      | web |
DELETE    | resource-one/{resource_one}           | resouce-one.destroy    | App\Http\Controllers\ResourceOne@destroy    | web |
PUT|PATCH | resource-one/{resource_one}           | resouce-one.update     | App\Http\Controllers\ResourceOne@update     | web |
GET|HEAD  | resource-one/{resource_one}/edit      | resouce-one.edit       | App\Http\Controllers\ResourceOne@edit       | web |

POST      | resource-two                          | resouce-two.store      | App\Http\Controllers\ResourceTwo@store      | web |
GET|HEAD  | resource-two                          | resouce-two.index      | App\Http\Controllers\ResourceTwo@index      | web |
DELETE    | resource-two/{resource_two}           | resouce-two.destroy    | App\Http\Controllers\ResourceTwo@destroy    | web |
PUT|PATCH | resource-two/{resource_two}           | resouce-two.update     | App\Http\Controllers\ResourceTwo@update     | web |
GET|HEAD  | resource-two/{resource_two}/edit      | resouce-two.edit       | App\Http\Controllers\ResourceTwo@edit       | web |

POST      | resource-three                        | resouce-three.store    | App\Http\Controllers\ResourceThree@store    | web |
GET|HEAD  | resource-three                        | resouce-three.index    | App\Http\Controllers\ResourceThree@index    | web |
DELETE    | resource-three/{resource_three}       | resouce-three.destroy  | App\Http\Controllers\ResourceThree@destroy  | web |
PUT|PATCH | resource-three/{resource_three}       | resouce-three.update   | App\Http\Controllers\ResourceThree@update   | web |
GET|HEAD  | resource-three/{resource_three}/edit  | resouce-three.edit     | App\Http\Controllers\ResourceThree@edit     | web |


```

(previous PR laravel/framework#25278)