### PR TITLE
[5.5] Make Auth/Recaller handle serialized and unserialized cookies

### DIFF
--- a/src/Illuminate/Auth/Recaller.php
+++ b/src/Illuminate/Auth/Recaller.php
@@ -21,7 +21,7 @@ class Recaller
      */
     public function __construct($recaller)
     {
-        $this->recaller = $recaller;
+        $this->recaller = @unserialize($recaller, false) ?: $recaller;
     }
 
     /**


### PR DESCRIPTION
Backport of #25167.

Can you release 5.5.43 (`Application::VERSION` is still at 5.5.41)?