### PR TITLE
[5.8] Bumped minimum PHP version to 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
-    - php: 7.1
-      env: setup=lowest
     - php: 7.2
     - php: 7.2
       env: setup=lowest

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "^1.1",

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "illuminate/http": "5.8.*",
         "illuminate/queue": "5.8.*",

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "psr/log": "^1.0",
         "illuminate/bus": "5.8.*",
         "illuminate/contracts": "5.8.*",

--- a/src/Illuminate/Bus/composer.json
+++ b/src/Illuminate/Bus/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "illuminate/pipeline": "5.8.*",
         "illuminate/support": "5.8.*"

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*"
     },

--- a/src/Illuminate/Config/composer.json
+++ b/src/Illuminate/Config/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*"
     },

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*",
         "symfony/console": "^4.1"

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "psr/container": "^1.0"
     },

--- a/src/Illuminate/Contracts/composer.json
+++ b/src/Illuminate/Contracts/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "psr/container": "^1.0",
         "psr/simple-cache": "^1.0"
     },

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*",
         "symfony/http-foundation": "^4.1",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/container": "5.8.*",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*"

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "illuminate/contracts": "5.8.*",

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/container": "5.8.*",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*"

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*",
         "symfony/finder": "^4.1"

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*"
     },

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/session": "5.8.*",
         "illuminate/support": "5.8.*",
         "symfony/http-foundation": "^4.1",

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*",
         "monolog/monolog": "^1.11"

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "erusev/parsedown": "^1.7",
         "illuminate/container": "5.8.*",
         "illuminate/contracts": "5.8.*",

--- a/src/Illuminate/Notifications/composer.json
+++ b/src/Illuminate/Notifications/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/broadcasting": "5.8.*",
         "illuminate/bus": "5.8.*",
         "illuminate/container": "5.8.*",

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*"
     },

--- a/src/Illuminate/Pipeline/composer.json
+++ b/src/Illuminate/Pipeline/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*"
     },

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/console": "5.8.*",
         "illuminate/container": "5.8.*",
         "illuminate/contracts": "5.8.*",

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*",
         "predis/predis": "^1.0"

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/container": "5.8.*",
         "illuminate/contracts": "5.8.*",
         "illuminate/http": "5.8.*",

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "illuminate/filesystem": "5.8.*",
         "illuminate/support": "5.8.*",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-mbstring": "*",
         "doctrine/inflector": "^1.1",
         "illuminate/contracts": "5.8.*",

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.8.*",
         "illuminate/filesystem": "5.8.*",
         "illuminate/support": "5.8.*"

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/container": "5.8.*",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*",

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/container": "5.8.*",
         "illuminate/contracts": "5.8.*",
         "illuminate/events": "5.8.*",


### PR DESCRIPTION
Historical PHP version minimum requirements:

| Laravel | PHP |
|---------|-----|
| 4.0     | `>=5.3.0` |
| 4.1     | `>=5.3.0` |
| 4.2     | `>=5.4.0` |
| 5.0     | `>=5.4.0` |
| 5.1     | `>=5.5.9` |
| 5.2     | `>=5.5.9` |
| 5.3     | `>=5.6.4` |
| 5.4     | `>=5.6.4` |
| 5.5     | `>=7.0` |
| 5.6     | `^7.1.3` |
| 5.7     | `^7.1.3` |
| 5.8     | `^7.2`?? |
| 5.9     | `^7.2`?? |

With the exception of Laravel 5.6 bumping earlier than usual, the minimum PHP vesion shifts every other Laravel release. Onwards to PHP 7.2! 🚀 