### PR TITLE
Handle Amazon Aurora/RDS DNS "Connection Lost" messages

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -29,6 +29,7 @@ trait DetectsLostConnections
             'Error writing data to the connection',
             'Resource deadlock avoided',
             'Transaction() on null',
+            'Name or service not known',
         ]);
     }
 }


### PR DESCRIPTION
Using Amazon Aurora, laravel throws PDO occasionally like:

SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Name or service not known

When these happen, existing retry logic should be engaged.  We're using 5.4 (for php compatibility reasons), so PR is against that version.