### PR TITLE
[5.6] Fix typo

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -21,7 +21,7 @@ trait DatabaseRule
     protected $column;
 
     /**
-     * There extra where clauses for the query.
+     * The extra where clauses for the query.
      *
      * @var array
      */


### PR DESCRIPTION
This fixes a minor typo in one docblock for database driven validation rules.