### PR TITLE
[5.6] Fix get original content when using model collections for response resources

### DIFF
--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -44,6 +44,10 @@ class ResourceResponse implements Responsable
         ), function ($response) use ($request) {
             $response->original = $this->resource->resource;
 
+            if ($response->original instanceof Collection) {
+                $response->original = $response->original->pluck('resource');
+            }
+
             $this->resource->withResponse($request, $response);
         });
     }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -534,7 +534,7 @@ class ResourceTest extends TestCase
         $this->assertTrue($createdPost->is($response->getOriginalContent()));
     }
 
-    public function test_original_on_response_is_collection_of_model_when_collection_resource()
+    public function test_original_on_response_is_paginated_collection_of_model_when_collection_resource()
     {
         $createdPosts = collect([
             new Post(['id' => 5, 'title' => 'Test Title']),
@@ -542,6 +542,23 @@ class ResourceTest extends TestCase
         ]);
         Route::get('/', function () use ($createdPosts) {
             return new EmptyPostCollectionResource(new LengthAwarePaginator($createdPosts, 10, 15, 1));
+        });
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+        $createdPosts->each(function ($post) use ($response) {
+            $this->assertTrue($response->getOriginalContent()->contains($post));
+        });
+    }
+
+    public function test_original_on_response_is_collection_of_model_when_collection_resource()
+    {
+        $createdPosts = collect([
+            new Post(['id' => 5, 'title' => 'Test Title']),
+            new Post(['id' => 6, 'title' => 'Test Title 2']),
+        ]);
+        Route::get('/', function () use ($createdPosts) {
+            return new EmptyPostCollectionResource($createdPosts);
         });
         $response = $this->withoutExceptionHandling()->get(
             '/', ['Accept' => 'application/json']


### PR DESCRIPTION
Hello,
I stumbled upon a small bug when using the response `getOriginalContent()` method in my tests.

Whenever I pass a paginator instance to a resource like `UserResource::collection($paginatedUsers)` and I use the `getOriginalContent()` method to assert it contains the correct users, it works as expected - it gives me a collection of user models.

If I use an eloquent collection,  I get back the resource instead of the model and can no longer make use of the `$this->assertTrue($response->getOriginalContent()->contains($model))` assertion.