### PR TITLE
[5.6] `ReflectionClass($class))->newInstanceWithoutConstructor()` replaced to `$this->container->make($class)`.

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -495,7 +495,7 @@ class Dispatcher implements DispatcherContract
      */
     protected function createListenerAndJob($class, $method, $arguments)
     {
-        $listener = (new ReflectionClass($class))->newInstanceWithoutConstructor();
+        $listener = $this->container->make($class);
 
         return [$listener, $this->propagateListenerOptions(
             $listener, new CallQueuedListener($class, $method, $arguments)


### PR DESCRIPTION
Fixes #25272 (please see full description into it) and seems #22880