### PR TITLE
[5.5] Use getter method for access primary key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1345,7 +1345,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getForeignKey()
     {
-        return Str::snake(class_basename($this)).'_'.$this->primaryKey;
+        return Str::snake(class_basename($this)).'_'.$this->getKeyName();
     }
 
     /**


### PR DESCRIPTION
Copy of PR #23362, for the 5.5 branch.

We would  like to use [a package](https://github.com/spatie/laravel-binary-uuid) that overrides `getKeyName` on a model. This works for the primary keys. But, because `getForeignKey` is using the `primaryKey` property directly, it doesn't work for relations. This means that when `getKeyName` returns 'uuid' on a model called Book, `getForeignKey` would still return 'book_id' instead of 'book_uuid`.