### PR TITLE
[5.7] Always use --no-interaction when seeding database in tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -84,7 +84,7 @@ trait InteractsWithDatabase
      */
     public function seed($class = 'DatabaseSeeder')
     {
-        $this->artisan('db:seed', ['--class' => $class]);
+        $this->artisan('db:seed', ['--class' => $class, '--no-interaction' => true]);
 
         return $this;
     }


### PR DESCRIPTION
I've added some interactive questions in my seeders to have more options when seeding the database. This works great when seeding manually, but when running tests `$this->seed()` gets stuck on these questions.

Passing the `--no-interaction` flag selects the default option for these questions and prevents the tests from getting stuck.

