### PR TITLE
[5.6] Added functions morphsUnique & dropMorphsUnique

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -438,14 +438,11 @@ class Blueprint
      * Indicate that the polymorphic columns should be dropped.
      *
      * @param  string  $name
-     * @param  string|null  $indexName
      * @param  string|null  $uniqueName
      * @return void
      */
-    public function dropMorphsUnique($name, $indexName = null, $uniqueName = null)
+    public function dropMorphsUnique($name, $uniqueName = null)
     {
-        $this->dropIndex($indexName ?: $this->createIndexName('index', ["{$name}_type", "{$name}_id"]));
-
         $this->dropUnique($uniqueName ?: $this->createIndexName('unique', ["{$name}_type", "{$name}_id"]));
 
         $this->dropColumn("{$name}_type", "{$name}_id");
@@ -1174,17 +1171,14 @@ class Blueprint
      * Add the proper columns for a polymorphic table with a unique index.
      *
      * @param  string  $name
-     * @param  string|null  $indexName
      * @param  string|null  $uniqueName
      * @return void
      */
-    public function morphsUnique($name, $indexName = null, $uniqueName = null)
+    public function morphsUnique($name, $uniqueName = null)
     {
         $this->string("{$name}_type");
 
         $this->unsignedBigInteger("{$name}_id");
-
-        $this->index(["{$name}_type", "{$name}_id"], $indexName);
 
         $this->unique(["{$name}_type", "{$name}_id"], $uniqueName);
     }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -219,8 +219,7 @@ class Blueprint
                 $value = $column->{$attributeName};
 
                 $this->addCommand(
-                    $commandName,
-                    compact('value', 'column')
+                    $commandName, compact('value', 'column')
                 );
             }
         }
@@ -1234,8 +1233,7 @@ class Blueprint
         $index = $index ?: $this->createIndexName($type, $columns);
 
         return $this->addCommand(
-            $type,
-            compact('index', 'columns', 'algorithm')
+            $type, compact('index', 'columns', 'algorithm')
         );
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -219,7 +219,8 @@ class Blueprint
                 $value = $column->{$attributeName};
 
                 $this->addCommand(
-                    $commandName, compact('value', 'column')
+                    $commandName,
+                    compact('value', 'column')
                 );
             }
         }
@@ -429,6 +430,23 @@ class Blueprint
     public function dropMorphs($name, $indexName = null)
     {
         $this->dropIndex($indexName ?: $this->createIndexName('index', ["{$name}_type", "{$name}_id"]));
+
+        $this->dropColumn("{$name}_type", "{$name}_id");
+    }
+
+    /**
+     * Indicate that the polymorphic columns should be dropped.
+     *
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @param  string|null  $uniqueName
+     * @return void
+     */
+    public function dropMorphsUnique($name, $indexName = null, $uniqueName = null)
+    {
+        $this->dropIndex($indexName ?: $this->createIndexName('index', ["{$name}_type", "{$name}_id"]));
+
+        $this->dropUnique($uniqueName ?: $this->createIndexName('unique', ["{$name}_type", "{$name}_id"]));
 
         $this->dropColumn("{$name}_type", "{$name}_id");
     }
@@ -1153,6 +1171,25 @@ class Blueprint
     }
 
     /**
+     * Add the proper columns for a polymorphic table with a unique index.
+     *
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @param  string|null  $uniqueName
+     * @return void
+     */
+    public function morphsUnique($name, $indexName = null, $uniqueName = null)
+    {
+        $this->string("{$name}_type");
+
+        $this->unsignedBigInteger("{$name}_id");
+
+        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+
+        $this->unique(["{$name}_type", "{$name}_id"], $uniqueName);
+    }
+
+    /**
      * Add nullable columns for a polymorphic table.
      *
      * @param  string  $name
@@ -1197,7 +1234,8 @@ class Blueprint
         $index = $index ?: $this->createIndexName($type, $columns);
 
         return $this->addCommand(
-            $type, compact('index', 'columns', 'algorithm')
+            $type,
+            compact('index', 'columns', 'algorithm')
         );
     }
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -269,6 +269,17 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `photos` drop `imageable_type`, drop `imageable_id`', $statements[1]);
     }
 
+    public function testDropMorphsUnique()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropMorphsUnique('profile');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertEquals('alter table `users` drop index `users_profile_type_profile_id_unique`', $statements[0]);
+        $this->assertEquals('alter table `users` drop `profile_type`, drop `profile_id`', $statements[1]);
+    }
+
     public function testRenameTable()
     {
         $blueprint = new Blueprint('users');
@@ -932,6 +943,17 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
+    }
+
+    public function testAddingMorphsUnique()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->morphsUnique('profile');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertEquals('alter table `users` add `profile_type` varchar(255) not null, add `profile_id` bigint unsigned not null', $statements[0]);
+        $this->assertEquals('alter table `users` add unique `users_profile_type_profile_id_unique`(`profile_type`, `profile_id`)', $statements[1]);
     }
 
     public function testDropAllTables()


### PR DESCRIPTION
Add a unique index in morphs function. Useful for morphOne relationships.

__Write:__
```php
    $table->morphs('profile');
    $table->unique(['profile_type', 'profile_id']);
```

__Equals to:__
```php
    $table->morphsUnique('profile');
```

