### PR TITLE
[5.7] Support and format Carbon instances for date queries

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Database\Query;
 
 use Closure;
-use DateTime;
 use RuntimeException;
+use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -1071,7 +1071,7 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
-        if ($value instanceof DateTime) {
+        if ($value instanceof DateTimeInterface) {
             $value = $value->format('Y-m-d');
         }
 
@@ -1110,7 +1110,7 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
-        if ($value instanceof DateTime) {
+        if ($value instanceof DateTimeInterface) {
             $value = $value->format('H:i:s');
         }
 
@@ -1149,7 +1149,7 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
-        if ($value instanceof DateTime) {
+        if ($value instanceof DateTimeInterface) {
             $value = $value->format('d');
         }
 
@@ -1188,7 +1188,7 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
-        if ($value instanceof DateTime) {
+        if ($value instanceof DateTimeInterface) {
             $value = $value->format('m');
         }
 
@@ -1227,7 +1227,7 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
-        if ($value instanceof DateTime) {
+        if ($value instanceof DateTimeInterface) {
             $value = $value->format('Y');
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1061,7 +1061,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed  $value
+     * @param  \DateTimeInterface|string|int  $value
      * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
@@ -1083,7 +1083,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed $value
+     * @param  \DateTimeInterface|string|int  $value
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereDate($column, $operator, $value = null)
@@ -1100,7 +1100,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string   $operator
-     * @param  mixed   $value
+     * @param  \DateTimeInterface|string|int  $value
      * @param  string   $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
@@ -1122,7 +1122,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string   $operator
-     * @param  mixed   $value
+     * @param  \DateTimeInterface|string|int  $value
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereTime($column, $operator, $value = null)
@@ -1139,7 +1139,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed  $value
+     * @param  \DateTimeInterface|string|int  $value
      * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
@@ -1161,7 +1161,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed  $value
+     * @param  \DateTimeInterface|string|int  $value
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereDay($column, $operator, $value = null)
@@ -1178,7 +1178,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed  $value
+     * @param  \DateTimeInterface|string|int  $value
      * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
@@ -1200,7 +1200,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed  $value
+     * @param  \DateTimeInterface|string|int  $value
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereMonth($column, $operator, $value = null)
@@ -1217,7 +1217,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed  $value
+     * @param  \DateTimeInterface|string|int  $value
      * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
@@ -1239,7 +1239,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed  $value
+     * @param  \DateTimeInterface|string|int  $value
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereYear($column, $operator, $value = null)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3,11 +3,11 @@
 namespace Illuminate\Database\Query;
 
 use Closure;
+use DateTime;
 use RuntimeException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Traits\Macroable;
@@ -1071,8 +1071,8 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
-        if ($value instanceof Carbon) {
-            $value = $value->toDateString();
+        if ($value instanceof DateTime) {
+            $value = $value->format('Y-m-d');
         }
 
         return $this->addDateBasedWhere('Date', $column, $operator, $value, $boolean);
@@ -1110,8 +1110,8 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
-        if ($value instanceof Carbon) {
-            $value = $value->toTimeString();
+        if ($value instanceof DateTime) {
+            $value = $value->format('H:i:s');
         }
 
         return $this->addDateBasedWhere('Time', $column, $operator, $value, $boolean);
@@ -1149,7 +1149,7 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
-        if ($value instanceof Carbon) {
+        if ($value instanceof DateTime) {
             $value = $value->format('d');
         }
 
@@ -1188,7 +1188,7 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
-        if ($value instanceof Carbon) {
+        if ($value instanceof DateTime) {
             $value = $value->format('m');
         }
 
@@ -1227,7 +1227,7 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
-        if ($value instanceof Carbon) {
+        if ($value instanceof DateTime) {
             $value = $value->format('Y');
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -7,6 +7,7 @@ use RuntimeException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Traits\Macroable;
@@ -1070,6 +1071,10 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
+        if ($value instanceof Carbon) {
+            $value = $value->toDateString();
+        }
+
         return $this->addDateBasedWhere('Date', $column, $operator, $value, $boolean);
     }
 
@@ -1104,6 +1109,10 @@ class Builder
         list($value, $operator) = $this->prepareValueAndOperator(
             $value, $operator, func_num_args() === 2
         );
+
+        if ($value instanceof Carbon) {
+            $value = $value->toTimeString();
+        }
 
         return $this->addDateBasedWhere('Time', $column, $operator, $value, $boolean);
     }
@@ -1140,6 +1149,10 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
+        if ($value instanceof Carbon) {
+            $value = $value->format('d');
+        }
+
         return $this->addDateBasedWhere('Day', $column, $operator, $value, $boolean);
     }
 
@@ -1175,6 +1188,10 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
+        if ($value instanceof Carbon) {
+            $value = $value->format('m');
+        }
+
         return $this->addDateBasedWhere('Month', $column, $operator, $value, $boolean);
     }
 
@@ -1209,6 +1226,10 @@ class Builder
         list($value, $operator) = $this->prepareValueAndOperator(
             $value, $operator, func_num_args() === 2
         );
+
+        if ($value instanceof Carbon) {
+            $value = $value->format('Y');
+        }
 
         return $this->addDateBasedWhere('Year', $column, $operator, $value, $boolean);
     }

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -29,26 +29,31 @@ class QueryBuilderTest extends DatabaseTestCase
     public function testWhereDate()
     {
         $this->assertSame(1, DB::table('posts')->whereDate('created_at', '2018-01-02')->count());
+        $this->assertSame(1, DB::table('posts')->whereDate('created_at', new Carbon('2018-01-02'))->count());
     }
 
     public function testWhereDay()
     {
         $this->assertSame(1, DB::table('posts')->whereDay('created_at', '02')->count());
+        $this->assertSame(1, DB::table('posts')->whereDay('created_at', new Carbon('2018-01-02'))->count());
     }
 
     public function testWhereMonth()
     {
         $this->assertSame(1, DB::table('posts')->whereMonth('created_at', '01')->count());
+        $this->assertSame(1, DB::table('posts')->whereMonth('created_at', new Carbon('2018-01-02'))->count());
     }
 
     public function testWhereYear()
     {
         $this->assertSame(1, DB::table('posts')->whereYear('created_at', '2018')->count());
         $this->assertSame(1, DB::table('posts')->whereYear('created_at', 2018)->count());
+        $this->assertSame(1, DB::table('posts')->whereYear('created_at', new Carbon('2018-01-02'))->count());
     }
 
     public function testWhereTime()
     {
         $this->assertSame(1, DB::table('posts')->whereTime('created_at', '03:04:05')->count());
+        $this->assertSame(1, DB::table('posts')->whereTime('created_at', new Carbon('2018-01-02 03:04:05'))->count());
     }
 }


### PR DESCRIPTION
This is an implementation designed to address issue #25311. Basically it comes down to what happens when you pass a Carbon instance into any of the date query helpers like `whereDate` etc. Under the hood Laravel will pass the whole date time string in which means you won't get the results that you expect.

This change will have Laravel automatically format the instance to match the query type being executed so there's no need for the developer to have to think about it. I feel like this solution was a little better than wrapping the value in the same date function in the SQL because it's more database agnostic.
