### PR TITLE
[5.6] Fix whereTime() on SQL Server

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -104,6 +104,20 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile a "where time" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereTime(Builder $query, $where)
+    {
+        $value = $this->parameter($where['value']);
+
+        return 'cast('.$this->wrap($where['column']).' as time) '.$where['operator'].' '.$value;
+    }
+
+    /**
      * Compile a "JSON contains" statement into SQL.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -404,6 +404,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
+    public function testWhereTimeSqlServer()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereTime('created_at', '22:00');
+        $this->assertEquals('select * from [users] where cast([created_at] as time) = ?', $builder->toSql());
+        $this->assertEquals([0 => '22:00'], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereTime('created_at', new Raw('NOW()'));
+        $this->assertEquals('select * from [users] where cast([created_at] as time) = NOW()', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+    }
+
     public function testWhereDatePostgres()
     {
         $builder = $this->getPostgresBuilder();


### PR DESCRIPTION
`whereTime()` doesn't work on SQL Server. There is no `time()` function:

```php
User::whereTime('created_at', '12:34:56')->get();

// expected: select * from [users] where cast([created_at] as time) = '12:34:56'
// actual:   select * from [users] where time([created_at]) = '12:34:56'
```