### PR TITLE
[5.6] Refactor NotificationSlackChannelTest to provide a useful output on the test failures, and small type fix

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -33,7 +33,7 @@ class SlackWebhookChannel
      *
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Notification  $notification
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return void
      */
     public function send($notifiable, Notification $notification)
     {


### PR DESCRIPTION
By default, when we mock something with `shouldReceive('methodName')->with($arguments)` and when the test fails Mockery shows a message like `Mockery\Exception\NoMatchingExpectationException: No matching handler found` which is not very helpful because it doesn't show what exactly is wrong with the `$arguments` (and here we have a big array so it is really difficult to find an error on it).

With the current changes, we can actually see the difference between what our object expects and what we are sending to it.

Here is how it can show a theoretical error now:
```php
1) Illuminate\Tests\Notifications\NotificationSlackChannelTest::testValidatePayloadOnSend with data set "payloadWithIcon" (Illuminate\Tests\Notifications\NotificationSlackChannelTestNotification Object (...), array(array('Ghostbot', ':ghost:', '#ghost-talk', 'Content', array(array('Laravel', 'https://laravel.com', 'Attachment Content', 'Attachment Fallback', array(array('Project', 'Laravel', true)), array('text'), 'Laravel', 'https://laravel.com/fake.png', 'Author', 'https://laravel.com/fake_author', 'https://laravel.com/fake_author.png', 1234567890)))))
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
                 'fallback' => 'Attachment Fallback'
                 'fields' => Array (...)
                 'footer' => 'Laravel'
-                'footer_icon' => 'https://laravel.com/fake.png'
                 'mrkdwn_in' => Array (...)
                 'text' => 'Attachment Content'
                 'title' => 'Laravel'
                 'title_link' => 'https://laravel.com'
                 'ts' => 1234567890
+                'footer_icons' => 'https://laravel.com/fake.png'
             )
         )
         'channel' => '#ghost-talk'
```

The main change in the PR is that `shouldReceive('post')->with('url', $payload)` have changed to the `shouldReceive('post')->andReturnUsing(   )` construction, plus I moved separate test cases to the data provider.