### PR TITLE
[5.7] [Test Coverage] Route Implicit Binding

### DIFF
--- a/tests/Integration/Routing/RouteImplicitBindingTest.php
+++ b/tests/Integration/Routing/RouteImplicitBindingTest.php
@@ -57,7 +57,7 @@ class RouteImplicitBindingTest extends TestCase
             ->assertJsonFragment([
                 'id' => $this->user->id,
                 'email' => 'awesome@laravel.com',
-                'password' => 'vault'
+                'password' => 'vault',
             ]);
     }
 
@@ -88,7 +88,7 @@ class RouteImplicitBindingTest extends TestCase
             ->assertJsonFragment([
                 'id' => $this->user->id,
                 'email' => 'awesome@laravel.com',
-                'password' => 'vault'
+                'password' => 'vault',
             ]);
     }
 

--- a/tests/Integration/Routing/RouteImplicitBindingTest.php
+++ b/tests/Integration/Routing/RouteImplicitBindingTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider;
+
+class RouteImplicitBindingTest extends TestCase
+{
+    protected $user;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [RouteServiceProvider::class];
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->loadLaravelMigrations();
+
+        $this->user = User::create([
+            'name' => 'Laravel',
+            'email' => 'awesome@laravel.com',
+            'password' => 'vault',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function implicit_route_binding()
+    {
+        Route::middleware(SubstituteBindings::class)->get('/users/{user}', function (User $user) {
+            return $user;
+        });
+
+        $this->get("/users/{$this->user->id}")
+            ->assertSuccessful()
+            ->assertJsonFragment([
+                'id' => $this->user->id,
+                'email' => 'awesome@laravel.com',
+                'password' => 'vault'
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function invalid_id_gives_404()
+    {
+        Route::middleware(SubstituteBindings::class)->get('/users/{user}', function (User $user) {
+            return $user;
+        });
+
+        $this->get('/users/999')
+            ->assertStatus(404);
+    }
+
+    /**
+     * @test
+     */
+    public function snake_case_works_for_camel_case_model_classes()
+    {
+        Route::middleware(SubstituteBindings::class)->get('/{snake_guest_user}', function (GuestUser $snakeGuestUser) {
+            return $snakeGuestUser;
+        });
+
+        $this->get('/1')
+            ->assertSuccessful()
+            ->assertJsonFragment([
+                'id' => $this->user->id,
+                'email' => 'awesome@laravel.com',
+                'password' => 'vault'
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function substitute_bindings_must_have_a_valid_route_binding_name()
+    {
+        Route::middleware(SubstituteBindings::class)->get('/{invalid}', function (User $user) {
+            return $user;
+        });
+
+        // This test proves that when the Route Variable name {invalid} does not match the variable name {user},
+        // it will not load the record. It will, however, instantiate a new Eloquent Object and run the route
+        // normally. Is this th expected behavior?
+        $this->get('/1')
+            ->assertSuccessful()
+            ->assertJson([]);
+    }
+}
+
+class User extends Model
+{
+    protected $guarded = [];
+}
+
+class GuestUser extends Model
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+}

--- a/tests/Integration/Routing/RouteImplicitBindingTest.php
+++ b/tests/Integration/Routing/RouteImplicitBindingTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Routing;
 
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider;
@@ -34,7 +35,13 @@ class RouteImplicitBindingTest extends TestCase
     {
         parent::setUp();
 
-        $this->loadLaravelMigrations();
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+            $table->string('name')->nullable();
+            $table->string('password');
+            $table->timestamps();
+        });
 
         $this->user = User::create([
             'name' => 'Laravel',


### PR DESCRIPTION
While running PHPunit Coverage Report, I noticed that the framework has quite a number of classes that are 100% uncovered by tests. This Pull Request covers [SubstituteBindings Middleware](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Routing/Middleware/SubstituteBindings.php) and [ImplicitRouteBinding](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Routing/ImplicitRouteBinding.php) with just a small set of integration tests.

I intend to write a number of more PRs to add coverage to parts of the framework that has none or very shallow code coverage. If these PRs are undesirable, please let me know.

Thanks!