### PR TITLE
[5.6] Support JSON SELECT queries on SQLite

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -933,6 +933,17 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Wrap the given JSON path.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function wrapJsonPath($value)
+    {
+        return '\'$."'.str_replace('->', '"."', $value).'"\'';
+    }
+
+    /**
      * Determine if the given string is a JSON selector.
      *
      * @param  string  $value

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -273,4 +273,23 @@ class SQLiteGrammar extends Grammar
             'delete from '.$this->wrapTable($query->from) => [],
         ];
     }
+
+    /**
+     * Wrap the given JSON selector.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function wrapJsonSelector($value)
+    {
+        $parts = explode('->', $value, 2);
+
+        $field = $this->wrap($parts[0]);
+
+        $path = count($parts) > 1 ? ', '.$this->wrapJsonPath($parts[1]) : '';
+
+        $selector = 'json_extract('.$field.$path.')';
+
+        return $selector;
+    }
 }

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -473,17 +473,6 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Wrap the given JSON path.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    protected function wrapJsonPath($value)
-    {
-        return '\'$."'.str_replace('->', '"."', $value).'"\'';
-    }
-
-    /**
      * Wrap a table in keyword identifiers.
      *
      * @param  \Illuminate\Database\Query\Expression|string  $table

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2094,6 +2094,21 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from [users] where json_value([items], \'$."price"."in_usd"\') = ? and json_value([items], \'$."age"\') = ?', $builder->toSql());
     }
 
+    public function testSqliteWrappingJson()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('items->price')->from('users')->where('users.items->price', '=', 1)->orderBy('items->price');
+        $this->assertEquals('select json_extract("items", \'$."price"\') from "users" where json_extract("users"."items", \'$."price"\') = ? order by json_extract("items", \'$."price"\') asc', $builder->toSql());
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
+        $this->assertEquals('select * from "users" where json_extract("items", \'$."price"."in_usd"\') = ?', $builder->toSql());
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1)->where('items->age', '=', 2);
+        $this->assertEquals('select * from "users" where json_extract("items", \'$."price"."in_usd"\') = ? and json_extract("items", \'$."age"\') = ?', $builder->toSql());
+    }
+
     public function testSQLiteOrderBy()
     {
         $builder = $this->getSQLiteBuilder();


### PR DESCRIPTION
Adds JSON `SELECT` queries to SQLite:

```php
DB::table('users')->select('items->price')->where('items->price', 1)->orderBy('items->price');
```

In order for this to work, the [JSON1 extension](https://www.sqlite.org/json1.html) has to be enabled. That's the case in the latest versions of Homestead.

Users without the extension will get an error: `General error: 1 no such function: json_extract`
Of course, that's not really helpful. But to detect this beforehand, we would have to run an extra `pragma compile_options` query and look for `ENABLE_JSON1`.

There is apparently no way to support `whereJsonContains()`.

There is no integration test because the JSON1 extension isn't available on Travis CI (I tried).