### PR TITLE
[5.6] Added functions morphsUnique & dropMorphsUnique

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -434,6 +434,19 @@ class Blueprint
     }
 
     /**
+     * Indicate that the polymorphic columns should be dropped.
+     *
+     * @param  string  $name
+     * @param  string|null  $uniqueName
+     * @return void
+     */
+    public function dropMorphsUnique($name, $uniqueName = null)
+    {
+        $this->dropUnique($uniqueName ?: $this->createIndexName('unique', ["{$name}_type", "{$name}_id"]));
+        $this->dropColumn("{$name}_type", "{$name}_id");
+    }
+
+    /**
      * Rename the table to a given name.
      *
      * @param  string  $to
@@ -1150,6 +1163,20 @@ class Blueprint
         $this->unsignedBigInteger("{$name}_id");
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
+    }
+
+    /**
+     * Add the proper columns for a polymorphic table with a unique index.
+     *
+     * @param  string  $name
+     * @param  string|null  $uniqueName
+     * @return void
+     */
+    public function morphsUnique($name, $uniqueName = null)
+    {
+        $this->string("{$name}_type");
+        $this->unsignedBigInteger("{$name}_id");
+        $this->unique(["{$name}_type", "{$name}_id"], $uniqueName);
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -269,6 +269,17 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `photos` drop `imageable_type`, drop `imageable_id`', $statements[1]);
     }
 
+    public function testDropMorphsUnique()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropMorphsUnique('profile');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertEquals('alter table `users` drop index `users_profile_type_profile_id_unique`', $statements[0]);
+        $this->assertEquals('alter table `users` drop `profile_type`, drop `profile_id`', $statements[1]);
+    }
+
     public function testRenameTable()
     {
         $blueprint = new Blueprint('users');
@@ -932,6 +943,17 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
+    }
+
+    public function testAddingMorphsUnique()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->morphsUnique('profile');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertEquals('alter table `users` add `profile_type` varchar(255) not null, add `profile_id` bigint unsigned not null', $statements[0]);
+        $this->assertEquals('alter table `users` add unique `users_profile_type_profile_id_unique`(`profile_type`, `profile_id`)', $statements[1]);
     }
 
     public function testDropAllTables()


### PR DESCRIPTION
Add a unique index in morphs function. Useful for morphOne relationships.

### Actually
__Write:__
```php
    $table->morphs('profile');
```

__Equals to:__
```php
    $table->string('profile_type');
    $table->unsignedBigInteger('profile_id');
    $table->index(['profile_type', 'profile_id']);
```
### The problem
If I need a unique index I can not use ```morphs()``` because I would have two type of indexes.

__Write:__
```php
    $table->morphs('profile');
    $table->unique(['profile_type', 'profile_id']);
```

__Equals to:__
```php
    $table->string('profile_type');
    $table->unsignedBigInteger('profile_id');
    $table->index(['profile_type', 'profile_id']);
    $table->unique(['profile_type', 'profile_id']);
```

### Proposal
Add ```morphsUnique``` function.

__Write:__
```php
    $table->morphsUnique('profile');
```

__Equals to:__
```php
    $table->string('profile_type');
    $table->unsignedBigInteger('profile_id');
    $table->unique(['profile_type', 'profile_id']);
```
