### PR TITLE
[5.6] Fix MorphTo eager loading and withoutGlobalScopes()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -244,6 +244,22 @@ class MorphTo extends BelongsTo
     }
 
     /**
+     * Remove all or passed registered global scopes.
+     *
+     * @param  array|null  $scopes
+     * @return $this
+     */
+    public function withoutGlobalScopes(array $scopes = null)
+    {
+        $this->macroBuffer[] = [
+            'method' => __FUNCTION__,
+            'parameters' => [$scopes],
+        ];
+
+        return $this;
+    }
+
+    /**
      * Replay stored macro calls on the actual related instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query

--- a/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
+++ b/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphToGlobalScopesTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphToGlobalScopesTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->softDeletes();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('commentable_type');
+            $table->integer('commentable_id');
+        });
+
+        $post = Post::create();
+        (new Comment)->commentable()->associate($post)->save();
+
+        $post = tap(Post::create())->delete();
+        (new Comment)->commentable()->associate($post)->save();
+    }
+
+    public function test_with_global_scopes()
+    {
+        $comments = Comment::with('commentable')->get();
+
+        $this->assertNotNull($comments[0]->commentable);
+        $this->assertNull($comments[1]->commentable);
+    }
+
+    public function test_without_global_scope()
+    {
+        $comments = Comment::with(['commentable' => function ($query) {
+            $query->withoutGlobalScopes([SoftDeletingScope::class]);
+        }])->get();
+
+        $this->assertNotNull($comments[0]->commentable);
+        $this->assertNotNull($comments[1]->commentable);
+    }
+
+    public function test_without_global_scopes()
+    {
+        $comments = Comment::with(['commentable' => function ($query) {
+            $query->withoutGlobalScopes();
+        }])->get();
+
+        $this->assertNotNull($comments[0]->commentable);
+        $this->assertNotNull($comments[1]->commentable);
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Post extends Model
+{
+    use SoftDeletes;
+
+    public $timestamps = false;
+}


### PR DESCRIPTION
`withoutGlobalScopes()` doesn't work when eager loading `MorphTo` relationships:

```php
class Comment extends Model {
    public function commentable() {
        return $this->morphTo()->withoutGlobalScopes();
    }
}

class Post extends Model {
    use SoftDeletes;
}

Comment::with('commentable')->get();
```
```sql
# expected
select * from "posts" where "posts"."id" in (?, ?)

# actual
select * from "posts" where "posts"."id" in (?, ?) and "posts"."deleted_at" is null
```

`MorphTo` uses a temporary query (based on `Comment`) to build the relationship. At this point, `withoutGlobalScopes()` can only remove scopes that were registered on `Comment`. When `getResultsByType()` finally executes individual queries for the different related models, the global scopes get re-applied.

We can fix it by catching the `withoutGlobalScopes()` calls and using the `$macroBuffer` to apply them later to the individual queries.

Fixes #18052 and #21856.