### PR TITLE
[5.6] Throw exception for has() with MorphTo relationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -3,9 +3,11 @@
 namespace Illuminate\Database\Eloquent\Concerns;
 
 use Closure;
+use RuntimeException;
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
@@ -28,6 +30,10 @@ trait QueriesRelationships
         }
 
         $relation = $this->getRelationWithoutConstraints($relation);
+
+        if ($relation instanceof MorphTo) {
+            throw new RuntimeException('has() and whereHas() do not support MorphTo relationships.');
+        }
 
         // If we only need to check for the existence of the relation, then we can optimize
         // the subquery to only run a "where exists" clause instead of this full "count"

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -717,6 +717,14 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals($questionMarksCount, $bindingsCount);
     }
 
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testHasOnMorphToRelationship()
+    {
+        EloquentTestPhoto::has('imageable')->get();
+    }
+
     public function testBelongsToManyRelationshipModelsAreProperlyHydratedOverChunkedRequest()
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
It's a long-known issue that `has()` and `whereHas()` don't support `MorphTo` relationships (#5429, #18523). There are workarounds, but the fundamental problem is basically unfixable.

Depending on the actual code, the user gets an exception (e.g. "unknown column") or the query "successfully" executes pointless SQL:

```php
Comment::has('commentable')->get();
```
```sql
select *
from "comments"
where exists (
  select *
  from "comments" as "laravel_reserved_0"
  where "laravel_reserved_0"."id" = "laravel_reserved_0"."commentable_id"
)
```

With this PR, the user at least receives a proper exception.
Should we include a link to one of the GitHub issues (for the workarounds)?