### PR TITLE
[5.7] Let the user limit attempts be resolved by a method.

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -71,12 +71,16 @@ class ThrottleRequests
      */
     protected function resolveMaxAttempts($request, $maxAttempts)
     {
+        $user = $request->user();
+
         if (Str::contains($maxAttempts, '|')) {
-            $maxAttempts = explode('|', $maxAttempts, 2)[$request->user() ? 1 : 0];
+            $maxAttempts = explode('|', $maxAttempts, 2)[$user !== null ? 1 : 0];
         }
 
-        if (! is_numeric($maxAttempts) && $request->user()) {
-            $maxAttempts = $request->user()->{$maxAttempts};
+        if (! is_numeric($maxAttempts) && $user !== null) {
+            $maxAttempts = method_exists($user, $maxAttempts)
+                ? $user->{$maxAttempts}()
+                : $user->{$maxAttempts};
         }
 
         return (int) $maxAttempts;

--- a/tests/Integration/Http/Fixtures/User.php
+++ b/tests/Integration/Http/Fixtures/User.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable
+{
+    public $quota = 10;
+
+    public function quotaLimitFunction()
+    {
+        return 20;
+    }
+}


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In some situations we want to have more options to retrieve the the user limit when throttling request.

For instance, this limit might be set on group level or in the configuration; not necessary at the user level.

This PR introduces the possibility to declare a resolving method within the `Authenticatable` model and declare it as an option when using the `ThrottleRequests` middleware.

```php
class User extends Authenticatable
{
    // 1. A custom method to return the limit.
    // 'throttle:quotaLimitFunction,1'
    public function quotaLimitFunction()
    {
        return 20;
    }

    // 2. Fallback to the property.
    // 'throttle:quota,1'
    public $quota = 10;
}
```

---

*Note:*

The method will be chosen first as an option, then the attribute will be taken in consideration.
This could potentially be a breaking change if a function already has the same name as the attribute inside the `Authenticatable` model.