### PR TITLE
[5.7] Let the Rule handles Arraybale values set.

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Validation;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Contracts\Support\Arrayable;
 
 class Rule
 {
@@ -35,12 +35,12 @@ class Rule
     /**
      * Get an in constraint builder instance.
      *
-     * @param  array|string|\Illuminate\Support\Collection  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $values
      * @return \Illuminate\Validation\Rules\In
      */
     public static function in($values)
     {
-        if ($values instanceof Collection) {
+        if ($values instanceof Arrayable) {
             $values = $values->toArray();
         }
 
@@ -50,12 +50,12 @@ class Rule
     /**
      * Get a not_in constraint builder instance.
      *
-     * @param  array|string|\Illuminate\Support\Collection  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $values
      * @return \Illuminate\Validation\Rules\NotIn
      */
     public static function notIn($values)
     {
-        if ($values instanceof Collection) {
+        if ($values instanceof Arrayable) {
             $values = $values->toArray();
         }
 

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Validation;
 use Illuminate\Validation\Rule;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Validation\Rules\In;
+use Illuminate\Tests\Validation\fixtures\Values;
 
 class ValidationInRuleTest extends TestCase
 {
@@ -27,6 +28,10 @@ class ValidationInRuleTest extends TestCase
         $this->assertEquals('in:"1","2","3","4"', (string) $rule);
 
         $rule = Rule::in(collect([1, 2, 3, 4]));
+
+        $this->assertEquals('in:"1","2","3","4"', (string) $rule);
+
+        $rule = Rule::in(new Values);
 
         $this->assertEquals('in:"1","2","3","4"', (string) $rule);
 

--- a/tests/Validation/fixtures/Values.php
+++ b/tests/Validation/fixtures/Values.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Validation\fixtures;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class Values implements Arrayable
+{
+    public function toArray()
+    {
+        return [1, 2, 3, 4];
+    }
+}


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When using a `Rule` class, we might want to retrieve values from an `Arrayable` object, and not necessary a `Collection` or an `array`.

---

As `in` and `notIn` methods already rely on the `toArray` method, there is no reason of limiting so much the type `$values`: we can pass an `Arrayable` as an argument.