### PR TITLE
[5.5] Fix assertCookie() now cookies are unserialized by default

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -145,11 +145,12 @@ class TestResponse
      *
      * @param  string  $cookieName
      * @param  mixed  $value
+     * @param  bool  $unserialize
      * @return $this
      */
-    public function assertPlainCookie($cookieName, $value = null)
+    public function assertPlainCookie($cookieName, $value = null, $unserialize = false)
     {
-        $this->assertCookie($cookieName, $value, false);
+        $this->assertCookie($cookieName, $value, false, $unserialize);
 
         return $this;
     }
@@ -160,9 +161,10 @@ class TestResponse
      * @param  string  $cookieName
      * @param  mixed  $value
      * @param  bool  $encrypted
+     * @param  bool  $unserialize
      * @return $this
      */
-    public function assertCookie($cookieName, $value = null, $encrypted = true)
+    public function assertCookie($cookieName, $value = null, $encrypted = true, $unserialize = false)
     {
         PHPUnit::assertNotNull(
             $cookie = $this->getCookie($cookieName),
@@ -176,7 +178,7 @@ class TestResponse
         $cookieValue = $cookie->getValue();
 
         $actual = $encrypted
-            ? app('encrypter')->decrypt($cookieValue) : $cookieValue;
+            ? app('encrypter')->decrypt($cookieValue, $unserialize) : $cookieValue;
 
         PHPUnit::assertEquals(
             $value, $actual,


### PR DESCRIPTION
Same PR as @derekmd's https://github.com/laravel/framework/pull/25149, but for version 5.5.
The LTS branch was missing this fix.