### PR TITLE
[5.5] Use the getAttributes method on insert

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -681,7 +681,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // If the model has an incrementing key, we can use the "insertGetId" method on
         // the query builder, which will give us back the final inserted ID for this
         // table from the database. Not all tables have to be incrementing though.
-        $attributes = $this->attributes;
+        $attributes = $this->getAttributes();
 
         if ($this->getIncrementing()) {
             $this->insertAndSetId($query, $attributes);


### PR DESCRIPTION
The performInsert() method grabs the attributes property directly without using getAttributes(). The performUpdate() method uses getAttributes().

As far as I can see, there are no reasons that this method can't be called on insert, because if the $attributes property is set and populated, getAttributes() returns the values.

This will force Eloquent to honour its own API and help anyone that overrides this method for any reason.