### PR TITLE
show class name to be seeded

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -119,7 +119,7 @@ abstract class Seeder
         }
 
         if ($this->silent === false && isset($this->command)) {
-            $this->command->getOutput()->writeln("<info>Seeding:</info> ".get_class($this));
+            $this->command->getOutput()->writeln('<info>Seeding:</info> '.get_class($this));
         }
 
         return isset($this->container)

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -23,6 +23,8 @@ abstract class Seeder
      */
     protected $command;
 
+    protected $silent = false;
+
     /**
      * Seed the given connection from the given path.
      *
@@ -32,13 +34,11 @@ abstract class Seeder
      */
     public function call($class, $silent = false)
     {
+        $this->silent = $silent;
+
         $classes = Arr::wrap($class);
 
         foreach ($classes as $class) {
-            if ($silent === false && isset($this->command)) {
-                $this->command->getOutput()->writeln("<info>Seeding:</info> $class");
-            }
-
             $this->resolve($class)->__invoke();
         }
 
@@ -116,6 +116,10 @@ abstract class Seeder
     {
         if (! method_exists($this, 'run')) {
             throw new InvalidArgumentException('Method [run] missing from '.get_class($this));
+        }
+
+        if ($this->silent === false && isset($this->command)) {
+            $this->command->getOutput()->writeln("<info>Seeding:</info> ".get_class($this));
         }
 
         return isset($this->container)

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -34,10 +34,7 @@ class DatabaseSeederTest extends TestCase
     {
         $seeder = new TestSeeder;
         $seeder->setContainer($container = m::mock('Illuminate\Container\Container'));
-        $output = m::mock('Symfony\Component\Console\Output\OutputInterface');
-        $output->shouldReceive('writeln')->once()->andReturn('foo');
         $command = m::mock('Illuminate\Console\Command');
-        $command->shouldReceive('getOutput')->once()->andReturn($output);
         $seeder->setCommand($command);
         $container->shouldReceive('make')->once()->with('ClassName')->andReturn($child = m::mock(Seeder::class));
         $child->shouldReceive('setContainer')->once()->with($container)->andReturn($child);


### PR DESCRIPTION
https://github.com/laravel/framework/issues/11375

this change is to show which seeder classes are to be seeded.

if you have DatabaseSeeder class like bellow,

```
 public function run()
    {
        $this->call(UserTableSeeder::class);
    }
```
it shows messages like this.

```
Seeding: DatabaseSeeder
Seeding: UserTableSeeder
```
if you run db:seed --class=UserTableSeeder,
it shows message like this

```
Seeding: UserTableSeeder
```
