### PR TITLE
Add `priority` option to the composer.json of service provider.

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -117,6 +117,7 @@ class PackageManifest
         }
 
         $ignoreAll = in_array('*', $ignore = $this->packagesToIgnore());
+        $defaultPriority = 100;
 
         $this->write(collect($packages)->mapWithKeys(function ($package) {
             return [$this->format($package['name']) => $package['extra']['laravel'] ?? []];
@@ -124,7 +125,9 @@ class PackageManifest
             $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);
         })->reject(function ($configuration, $package) use ($ignore, $ignoreAll) {
             return $ignoreAll || in_array($package, $ignore);
-        })->filter()->all());
+        })->filter()->sortByDesc(function ($configuration) use ($defaultPriority) {
+            return $configuration['priority'] ?? $defaultPriority;
+        })->all());
     }
 
     /**


### PR DESCRIPTION
Hi!

I found a use case of how controlling the order of the package's service provider to be loaded could be helpful.

## My scenario
I want to bind some classes of [Passport](https://laravel.com/docs/master/passport) to my own implementations before Passport's service provider calling `$this->app->make`.

Currently, the order of instantiating the service providers determined by the  package's name (alphabet order), so if I want to my service provider be loaded before Passport's, I have to make the first letter of my package's name before `P`, so if my package's name is `O-package` it'll be loaded before Passport's service provider, if my package's name is `Q-package` it'll be loaded after Passport's service provider. There's no way to control the loading order.

This PR adds a `priority` option to the `composer.json` of service provider to allow the user to specify the loading priority. Higher numbers correspond with earlier execution(the default value is `100`).

So in the `composer.json` of my package I can determine the loading order of my service provider like this now:

```json
{
    "name": "yaquawa/Q-package",
    "extra": {
        "laravel": {
            "providers": [
                "Yaquawa\\Laravel\\ServiceProvider"
            ],
            "priority": 200
        }
    }
}
```

A tiny tweak, but could improve flexibility a lot 🤤