### PR TITLE
Queue worker stopped by SIGTERM should quit peacefully

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -198,10 +198,8 @@ class Worker
     protected function stopIfNecessary(WorkerOptions $options, $lastRestart)
     {
         if ($this->shouldQuit) {
-            $this->kill();
-        }
-
-        if ($this->memoryExceeded($options->memory)) {
+            $this->stop();
+        } elseif ($this->memoryExceeded($options->memory)) {
             $this->stop(12);
         } elseif ($this->queueShouldRestart($lastRestart)) {
             $this->stop();


### PR DESCRIPTION
worker shouln't send SIGKILL to itself in this case, when a
worker killed with SIGKILL, process supervisor would think
it is a "unclean exit", and act differently.
