### PR TITLE
fullUrl & fullUrlWithQuery trailing slash issue

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -108,7 +108,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         $query = $this->getQueryString();
 
-        $question = $this->getBaseUrl().$this->getPathInfo() == '/' ? '/?' : '?';
+        $question = $this->getPathInfo() == '/' ? '/?' : '?';
 
         return $query ? $this->url().$question.$query : $this->url();
     }
@@ -121,7 +121,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function fullUrlWithQuery(array $query)
     {
-        $question = $this->getBaseUrl().$this->getPathInfo() == '/' ? '/?' : '?';
+        $question = $this->getPathInfo() == '/' ? '/?' : '?';
 
         return count($this->query()) > 0
             ? $this->url().$question.http_build_query(array_merge($this->query(), $query))


### PR DESCRIPTION
I realized that the comparison between $this->getBaseUrl().$this->getPathInfo() == '/' never be true. That caused that the url will be always without last trailing slash
 I propose to remove $this->getBaseUrl() from comparison