### PR TITLE
[5.6] Fix relationships with global scope columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -568,9 +568,9 @@ class BelongsToMany extends Relation
         // First we'll add the proper select columns onto the query so it is run with
         // the proper columns. Then, we will get the results and hydrate out pivot
         // models with the result of those columns as a separate model relation.
-        $columns = $this->query->getQuery()->columns ? [] : $columns;
-
         $builder = $this->query->applyScopes();
+
+        $columns = $builder->getQuery()->columns ? [] : $columns;
 
         $models = $builder->addSelect(
             $this->shouldSelect($columns)

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -461,8 +461,10 @@ class HasManyThrough extends Relation
      */
     protected function prepareQueryBuilder($columns = ['*'])
     {
-        return $this->query->applyScopes()->addSelect(
-            $this->shouldSelect($this->query->getQuery()->columns ? [] : $columns)
+        $builder = $this->query->applyScopes();
+
+        return $builder->addSelect(
+            $this->shouldSelect($builder->getQuery()->columns ? [] : $columns)
         );
     }
 

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -45,6 +45,19 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         $this->assertEquals([$mate1->id, $mate2->id], $user->teamMates->pluck('id')->toArray());
         $this->assertEquals([$user->id], User::has('teamMates')->pluck('id')->toArray());
     }
+
+    public function test_global_scope_columns()
+    {
+        $user = User::create(['name' => str_random()]);
+
+        $team1 = Team::create(['owner_id' => $user->id]);
+
+        User::create(['name' => str_random(), 'team_id' => $team1->id]);
+
+        $teamMates = $user->teamMatesWithGlobalScope;
+
+        $this->assertEquals(['id' => 2, 'owner_id' => 1], $teamMates[0]->getAttributes());
+    }
 }
 
 class User extends Model
@@ -56,6 +69,27 @@ class User extends Model
     public function teamMates()
     {
         return $this->hasManyThrough(self::class, Team::class, 'owner_id', 'team_id');
+    }
+
+    public function teamMatesWithGlobalScope()
+    {
+        return $this->hasManyThrough(UserWithGlobalScope::class, Team::class, 'owner_id', 'team_id');
+    }
+}
+
+class UserWithGlobalScope extends Model
+{
+    public $table = 'users';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope(function ($query) {
+            $query->select('users.id');
+        });
     }
 }
 


### PR DESCRIPTION
`BelongsToMany` relationships don't respect global scopes that limit the selected columns:

```php
class Role extends Model
{
    public static function boot()
    {
        parent::boot();

        static::addGlobalScope(function ($query) {
            $query->select('roles.id');
        });
    }
}

class User extends Model
{
    public function roles()
    {
        return $this->belongsToMany(Role::class);
    }
}

User::first()->roles;
```
```sql
# expected
select "roles"."id", "role_user"."user_id" as "pivot_user_id", [...]

# actual
select "roles"."id", "roles".*, "role_user"."user_id" as "pivot_user_id", [...]
```

This issue also affects `HasManyThrough` relationships.

Fixes #22482.