### PR TITLE
[5.7] Queue worker stopped by SIGTERM should quit peacefully

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -198,10 +198,8 @@ class Worker
     protected function stopIfNecessary(WorkerOptions $options, $lastRestart)
     {
         if ($this->shouldQuit) {
-            $this->kill();
-        }
-
-        if ($this->memoryExceeded($options->memory)) {
+            $this->stop();
+        } elseif ($this->memoryExceeded($options->memory)) {
             $this->stop(12);
         } elseif ($this->queueShouldRestart($lastRestart)) {
             $this->stop();


### PR DESCRIPTION
the worker process shouldn't send SIGKILL to itself in this case,
when a worker killed with SIGKILL, process supervisor would think
it is an "unclean exit", and act differently.

#25358 continued, as @taylorotwell demands a thorough explanation, I will try my best, please forgive my poor English. In the first PR, I don't think it needs a lengthy explanation, as it is obviously a bug, in my opinion, besides, there is little information to infer the intention of the author [in the commit introduced this behavior](https://github.com/laravel/framework/commit/f2beb2bbce11433283ba52744dbe7134aa55cbfa), either in [the Queue document](https://laravel.com/docs/5.6/queues).

For a daemon process, using SIGTERM to notify it to exit nicely is a common practice, example: [celery](http://docs.celeryproject.org/en/latest/userguide/workers.html#stopping-the-worker
), [gunicorn](http://docs.gunicorn.org/en/stable/signals.html#master-process), [mysql](https://dev.mysql.com/doc/refman/8.0/en/server-shutdown.html), [runnit](http://smarden.org/runit/runsv.8.html), a process will exit nicely with status zero. SIGKILL [is very different](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html) from SIGTERM, a user process cannot handle it and will exit immediately, it is usually a mean [to terminate a process when it is not responding](https://www.freedesktop.org/software/systemd/man/systemd.kill.html), a process will leave a non-zero exit status. SIGKILL is not a ["clean signal"](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=) seen by systemd or superiord. 

I expect a process to exit gracefully after sending it a SIGTERM. With current behavior, the worker process handled SIGTERM, but it later exit with a status indicates it is terminated by SIGKILL. You can't know from the exit code whether the process is exit normally or not. It is odd to me, I can't figure out the reason behind this odd behavior.

There are two places set `shouldQuit`, one is the SIGTERM handler, another is `stopWorkerIfLostConnection`, aside from the SIGTERM handling convention, if the worker process could enter `stopIfNecessary` function in the work loop, it indicates the process is not stuck, there is no reason to kill it with SIGKILL.
