### PR TITLE
Ensures that 'optional' method returns instance of Optional

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -721,11 +721,11 @@ if (! function_exists('optional')) {
      */
     function optional($value = null, callable $callback = null)
     {
-        if (is_null($callback)) {
-            return new Optional($value);
-        } elseif (! is_null($value)) {
+        if(! is_null($value) && ! is_null($callback)) {
             return $callback($value);
         }
+
+        return new Optional($value);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -721,7 +721,7 @@ if (! function_exists('optional')) {
      */
     function optional($value = null, callable $callback = null)
     {
-        if(! is_null($value) && ! is_null($callback)) {
+        if (! is_null($value) && ! is_null($callback)) {
             return $callback($value);
         }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -790,7 +790,7 @@ class SupportHelpersTest extends TestCase
             throw new RuntimeException(
                 'The optional callback should not be called for null'
             );
-        }));
+        })->missing);
 
         $this->assertEquals(10, optional(5, function ($number) {
             return $number * 2;


### PR DESCRIPTION
It is expected that the `optional` helper method would return an instance of `Illuminate\Support\Optional`. 
Currently, the following code would throw an exception:
```
optional(null, function ($value) {
    return $value;
})->invalidProperty;
```
So, I've modified the code a bit to fix it. This PR is to ensure that the callback method would only be called for not null `$value`. 