### PR TITLE
[5.6] Fix mailables always being queued for later if using Queueable trait

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -157,7 +157,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function queue(Queue $queue)
     {
-        if (property_exists($this, 'delay')) {
+        if (isset($this->delay)) {
             return $this->later($this->delay, $queue);
         }
 


### PR DESCRIPTION
Currently if a Mailable uses the `\Illuminate\Bus\Queueable` trait, which is the default when using `make:mail`, it will always end up calling `\Illuminate\Mail\Mailable::later` because it is only checking if the `delay` property exists and not whether it is actually set.

This is a problem when using a 3rd part queue driver like https://github.com/shiftonelabs/laravel-sqs-fifo-queue which doesn't allow things to be queued for later since sqs fifo queues do not support it.

This fixes that problem by checking whether `delay` is actually set.