### PR TITLE
[5.7] Add dynamic pluck() to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -4,7 +4,6 @@ namespace Illuminate\Support;
 
 use stdClass;
 use Countable;
-use Exception;
 use ArrayAccess;
 use Traversable;
 use ArrayIterator;
@@ -1912,19 +1911,23 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Dynamically access collection proxies.
+     * Dynamically access collection proxies and pluck values.
      *
      * @param  string  $key
      * @return mixed
-     *
-     * @throws \Exception
      */
     public function __get($key)
     {
-        if (! in_array($key, static::$proxies)) {
-            throw new Exception("Property [{$key}] does not exist on this collection instance.");
+        if (in_array($key, static::$proxies)) {
+            return new HigherOrderCollectionProxy($this, $key);
         }
 
-        return new HigherOrderCollectionProxy($this, $key);
+        $result = $this->pluck($key);
+
+        if ($result->first() instanceof self) {
+            $result = $result->flatten();
+        }
+
+        return $result;
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Support;
 
 use stdClass;
-use Exception;
 use ArrayAccess;
 use Mockery as m;
 use ReflectionClass;
@@ -2742,12 +2741,13 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['foo' => 3, 'bar' => ['nested' => 'two']], $collection->toArray());
     }
 
-    public function testItThrowsExceptionWhenTryingToAccessNoProxyProperty()
+    public function testDynamicPluck()
     {
-        $collection = new Collection();
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Property [foo] does not exist on this collection instance.');
-        $collection->foo;
+        $data = new Collection([['name' => 'foo'], ['name' => 'bar']]);
+        $this->assertEquals(['foo', 'bar'], $data->name->all());
+
+        $data = new Collection([['name' => new Collection(['foo'])], ['name' => new Collection(['bar'])]]);
+        $this->assertEquals(['foo', 'bar'], $data->name->all());
     }
 
     public function testGetWithNullReturnsNull()


### PR DESCRIPTION
We can use `Collection::__get()` to implement a dynamic `pluck()`:

```php
$data = collect([['name' => 'foo'], ['name' => 'bar']]);
$names = $data->name;
```

This is especially useful for relationships:

```php
$users = User::with('posts.comments')->get();

// Before...
$comments = $users->pluck('posts')->flatten()->pluck('comments')->flatten();

// Now...
$comments = $users->posts->comments;
```

The only limitation is that the `$key` can't be the name of a higher order proxy.

Would it make sense to add the "flatten" feature to `pluck()` itself?