### PR TITLE
[5.6] Add str_between function for retrieving a string between two substrings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -80,6 +80,39 @@ class Str
     }
 
     /**
+     * Get the portion of a string between two given strings.
+     *
+     * @param  string  $subject
+     * @param  string  $start
+     * @param  string  $end
+     * @param  bool  $insensitive
+     * @param  bool  $innerOnly
+     * @param  bool  $inverse
+     *
+     * @return string
+     */
+    public static function between($string, $start, $end, $insensitive = false, $innerOnly = true, $inverse = false)
+    {
+        if ($insensitive) {
+            $string = strtolower($string);
+            $start = strtolower($start);
+            $end = strtolower($end);
+        }
+        if (($startPosition = strpos($string, $start)) === false || ($endPosition = strpos($string, $end)) === false) {
+            return false;
+        }
+        if ($innerOnly) {
+            $startPosition += strlen($start);
+            $endPosition -= strlen($end);
+        }
+        $between = substr($string, $startPosition, ($endPosition + strlen($end)) - $startPosition);
+        if ($inverse) {
+            return str_replace($between, '', $string);
+        }
+        return $between;
+    }
+
+    /**
      * Convert a value to camel case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -82,7 +82,7 @@ class Str
     /**
      * Get the portion of a string between two given strings.
      *
-     * @param  string  $subject
+     * @param  string  $haystack
      * @param  string  $start
      * @param  string  $end
      * @param  bool  $insensitive
@@ -90,7 +90,7 @@ class Str
      * @param  bool  $inverse
      * @return string
      */
-    public static function between($string, $start, $end, $insensitive = false, $innerOnly = true, $inverse = false)
+    public static function between($haystack, $start, $end, $insensitive = false, $innerOnly = true, $inverse = false)
     {
         if ($insensitive) {
             $string = strtolower($string);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -88,7 +88,6 @@ class Str
      * @param  bool  $insensitive
      * @param  bool  $innerOnly
      * @param  bool  $inverse
-     *
      * @return string
      */
     public static function between($string, $start, $end, $insensitive = false, $innerOnly = true, $inverse = false)


### PR DESCRIPTION
The proposed `str_between` function returns a string between two substrings. 

This can be useful for retrieving dynamic/varying content between two fixed strings (such as text or html blocks).

## Usage
```php
$between = str_between("My name is John, and my number is 555-555-5555.", "My name is ", ", and my number");
```
Returns `John`

## Options
- $insensitive (bool): default false, toggles case sensitivity
- $innerOnly (bool): default true, toggles whether $start and $end substrings are returned
- $inverse (bool): default false, when true will return content before $start and after $end