### PR TITLE
[5.6] logoutOtherDevices breaks "remember me" cookie

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -546,10 +546,12 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         if (! $this->user()) {
             return;
         }
-
-        return tap($this->user()->forceFill([
+        $forceFillResult = tap($this->user()->forceFill([
             $attribute => Hash::make($password),
         ]))->save();
+        $this->queueRecallerCookie($this->user());
+
+        return $forceFillResult;
     }
 
     /**


### PR DESCRIPTION
**Current issue**:
Before this PR the remember me cookie would break when the user used the function `logoutOtherDevices()`.  See issue #24857 
`logoutOtherDevices()` changes the password hash. Now we have a mismatch because the new password hash is not the same as the one saved in  the "remember me" cookie.

**Fixes**:
After the forceFill of the user with the new hashed password, the method `queueRecallerCookie()` now gets called to generate/set a new cookie so the current user can be authenticated with the cookie if the session expires.

Cheers