### PR TITLE
Require factory files only once

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -272,7 +272,7 @@ class Factory implements ArrayAccess
 
         if (is_dir($path)) {
             foreach (Finder::create()->files()->name('*.php')->in($path) as $file) {
-                require $file->getRealPath();
+                require_once $file->getRealPath();
             }
         }
 


### PR DESCRIPTION
__Resubmission due to: https://github.com/laravel/framework/pull/25389#issuecomment-417654947__

I'm using some kind of enum class inside a factory file to define constants for all the possible factory states. 
PHPUnit stops with the error: `PHP Fatal error:  Cannot declare class ..., because the name is already in use in ...`

Probably my use case does not seem valid to everyone. 
I could use string literals 😈for the states or move the enum into another file – whatever. 

Anyways I don't think the factory file should be required multiple times. Is there a good reason for not using `require_once` because otherwise I'd be glad to see this being merged.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
