### PR TITLE
[5.7] Resolve Blade facade to named service

### DIFF
--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -31,6 +31,6 @@ class Blade extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return static::$app['view']->getEngineResolver()->resolve('blade')->getCompiler();
+        return 'blade.compiler';
     }
 }


### PR DESCRIPTION
I am unsure whether the manual resolution was added for a specific purpose. I am *assuming* it was just there because the [first version of the `ViewServiceProvider`](https://github.com/laravel/framework/blob/de69bb287c5017d1acb7d47a6db1dedf578036d6/src/Illuminate/View/ViewServiceProvider.php) did not register a binding for the Blade compiler.