### PR TITLE
[5.6] Fix: revert model syncing after soft-delete

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -76,9 +76,7 @@ trait SoftDeletes
             $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($time);
         }
 
-        if ($query->update($columns)) {
-            $this->syncOriginal();
-        }
+        $query->update($columns);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -268,6 +268,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         /** @var SoftDeletesTestUser $userModel */
         $userModel = SoftDeletesTestUser::find(2);
         $userModel->delete();
+        $userModel->syncOriginal();
         $this->assertEquals($now->toDateTimeString(), $userModel->getOriginal('deleted_at'));
         $this->assertNull(SoftDeletesTestUser::find(2));
         $this->assertEquals($userModel, SoftDeletesTestUser::withTrashed()->find(2));
@@ -283,6 +284,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         /** @var SoftDeletesTestUser $userModel */
         $userModel = SoftDeletesTestUser::find(2);
         $userModel->delete();
+        $userModel->syncOriginal();
         $userModel->restore();
 
         $this->assertEquals($userModel->id, SoftDeletesTestUser::find(2)->id);
@@ -301,6 +303,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals($userModel->deleted_at, SoftDeletesTestUser::find(1)->deleted_at);
         $this->assertEquals($userModel->getOriginal('deleted_at'), SoftDeletesTestUser::find(1)->deleted_at);
         $userModel->delete();
+        $userModel->syncOriginal();
         $this->assertNull(SoftDeletesTestUser::find(1));
         $this->assertEquals($userModel->deleted_at, SoftDeletesTestUser::withTrashed()->find(1)->deleted_at);
         $this->assertEquals($userModel->getOriginal('deleted_at'), SoftDeletesTestUser::withTrashed()->find(1)->deleted_at);


### PR DESCRIPTION
This reverts the changes made in [PR #24400](https://github.com/laravel/framework/pull/24400)

**Why?**
By immediately syncing the original model array, you could no longer retrieve changed values from the `'deleted'` model event. This differs from the behavior of other model events such as `'created'` and `'updated'`.

Since you can manually call `syncOriginal` anyway, it seems it would be more desirable to leave the behavior of `deleted` in line with the other model events than to break this behavior for everyone without offering an opt-out:

```
$userModel->delete();
$userModel->syncOriginal();
$userModel->restore();
```

**Tests**
I have left in the tests from the previous PR and just added the manual syncing to show that those cases are still supported. By all means I can remove them.

If required I can also add some tests to ensure that changes on the model can be accessed after deleting.

Let me know.