### PR TITLE
[5.6] Fix self relation existence queries with custom keys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -274,7 +274,7 @@ class BelongsTo extends Relation
         $query->getModel()->setTable($hash);
 
         return $query->whereColumn(
-            $hash.'.'.$query->getModel()->getKeyName(), '=', $this->getQualifiedForeignKey()
+            $hash.'.'.$this->ownerKey, '=', $this->getQualifiedForeignKey()
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -510,7 +510,7 @@ class HasManyThrough extends Relation
         $query->getModel()->setTable($hash);
 
         return $query->select($columns)->whereColumn(
-            $parentQuery->getQuery()->from.'.'.$query->getModel()->getKeyName(), '=', $this->getQualifiedFirstKeyName()
+            $parentQuery->getQuery()->from.'.'.$this->localKey, '=', $this->getQualifiedFirstKeyName()
         );
     }
 

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentBelongsToTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentBelongsToTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('slug')->nullable();
+            $table->unsignedInteger('parent_id')->nullable();
+            $table->string('parent_slug')->nullable();
+        });
+
+        $user = User::create(['slug' => str_random()]);
+        User::create(['parent_id' => $user->id, 'parent_slug' => $user->slug]);
+    }
+
+    public function test_has_self()
+    {
+        $users = User::has('parent')->get();
+
+        $this->assertEquals(1, $users->count());
+    }
+
+    public function test_has_self_custom_owner_key()
+    {
+        $users = User::has('parentBySlug')->get();
+
+        $this->assertEquals(1, $users->count());
+    }
+}
+
+class User extends Model
+{
+    public $timestamps = false;
+    protected $guarded = ['id'];
+
+    public function parent()
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    public function parentBySlug()
+    {
+        return $this->belongsTo(self::class, 'parent_slug', 'slug');
+    }
+}


### PR DESCRIPTION
`BelongsTo` doesn't use custom owner keys on self relation existence queries. It always uses the model's primary key instead:

```php
class User extends Model
{
    public function parent()
    {
        return $this->belongsTo(self::class, 'parent_id', 'owner_key');
    }
}

User::has('parent')->get();
```
```sql
# expected
[...] where "laravel_reserved_0"."owner_key" = "users"."parent_id"

# actual
[...] where "laravel_reserved_0"."id" = "users"."parent_id"
```

The same issue affects `HasManyThrough` relationships with custom local keys.

Fixes #24721.