### PR TITLE
[5.6] Fix dropAllTables() and dropAllViews() on SQLite

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -242,6 +242,16 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile the SQL needed to rebuild the database.
+     *
+     * @return string
+     */
+    public function compileRebuild()
+    {
+        return 'vacuum';
+    }
+
+    /**
      * Compile a drop column command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -20,6 +20,8 @@ class SQLiteBuilder extends Builder
         $this->connection->select($this->grammar->compileDropAllTables());
 
         $this->connection->select($this->grammar->compileDisableWriteableSchema());
+
+        $this->connection->select($this->grammar->compileRebuild());
     }
 
     /**
@@ -34,6 +36,8 @@ class SQLiteBuilder extends Builder
         $this->connection->select($this->grammar->compileDropAllViews());
 
         $this->connection->select($this->grammar->compileDisableWriteableSchema());
+
+        $this->connection->select($this->grammar->compileRebuild());
     }
 
     /**

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\SchemaTest;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class SchemaBuilderTest extends DatabaseTestCase
+{
+    public function test_drop_all_tables()
+    {
+        Schema::create('table', function ($table) {
+            $table->increments('id');
+        });
+
+        Schema::dropAllTables();
+
+        Schema::create('table', function ($table) {
+            $table->increments('id');
+        });
+
+        $this->assertTrue(true);
+    }
+
+    public function test_drop_all_views()
+    {
+        DB::statement('create view "view"("id") as select 1');
+
+        Schema::dropAllViews();
+
+        DB::statement('create view "view"("id") as select 1');
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
`Schema::dropAllTables()` and `dropAllViews()` don't work on SQLite in-memory databases. They delete the entries from the `sqlite_master ` table, but that doesn't actually remove the tables/views. We have to rebuild the database with [`VACUUM`](https://www.sqlite.org/lang_vacuum.html).

The tests are designed to fail with an exception ("table already exists") if the code doesn't work. Testing `Schema::hasTable()` doesn't work because it only looks for an entry in the `sqlite_master` table.

