### PR TITLE
[5.6] Delete unneeded code after https://github.com/laravel/framework/pull/25392

### DIFF
--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -102,8 +102,4 @@ class DatabaseSoftDeletingTraitStub
     {
         return defined('static::UPDATED_AT') ? static::UPDATED_AT : 'updated_at';
     }
-
-    public function syncOriginal()
-    {
-    }
 }


### PR DESCRIPTION
I have deleted unneeded code after reverting of  https://github.com/laravel/framework/pull/25392

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
