### PR TITLE
[5.7] Add ngram collection method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -128,6 +128,31 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Returns a new collection containing sub-collections with n consecutive elements.
+     * If the length is zero, negative or greater than the size of the collection,
+     * an empty collection will be returned.
+     *
+     * @param int $length
+     * @return static
+     */
+    public function aperture($length = 2)
+    {
+        if ($length < 1) {
+            return new self;
+        }
+
+        $idx = 0;
+        $limit = $this->count() - ($length - 1);
+        $collection = new self;
+        while ($idx < $limit) {
+            $collection->push($this->slice($idx, $length)->values());
+            $idx++;
+        }
+
+        return $collection;
+    }
+
+    /**
      * Get all of the items in the collection.
      *
      * @return array

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -138,12 +138,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function aperture($length = 2)
     {
         if ($length < 1) {
-            return new self;
+            return new static;
         }
 
         $idx = 0;
         $limit = $this->count() - ($length - 1);
-        $collection = new self;
+        $collection = new static;
         while ($idx < $limit) {
             $collection->push($this->slice($idx, $length)->values());
             $idx++;

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -128,24 +128,34 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Returns a new collection containing sub-collections with n consecutive elements.
-     * If the length is zero, negative or greater than the size of the collection,
-     * an empty collection will be returned.
+     * Returns a new collection containing sub-collections with overlapping n-grams.
+     * If n is zero or greater than the size of the collection, an empty collection will be returned.
      *
-     * @param int $length
+     * <code>
+     * $collection = collect([1, 2, 3, 4, 5])
+     * $collection->ngram()->toArray(); // [[1, 2], [2, 3], [3, 4], [4, 5]]
+     * $collection->ngram(3)->toArray(); // [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+     * </code>
+     *
+     * @param int $n
      * @return static
+     * @throws \InvalidArgumentException When $n is negative
      */
-    public function aperture($length = 2)
+    public function ngram($n = 2)
     {
-        if ($length < 1) {
+        if ($n < 0) {
+            throw new \InvalidArgumentException("n can't be negative");
+        }
+
+        if ($n == 0) {
             return new static;
         }
 
         $idx = 0;
-        $limit = $this->count() - ($length - 1);
+        $limit = $this->count() - ($n - 1);
         $collection = new static;
         while ($idx < $limit) {
-            $collection->push($this->slice($idx, $length)->values());
+            $collection->push($this->slice($idx, $n)->values());
             $idx++;
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2384,34 +2384,34 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([3, 4, 5, 6], $collection->slice(-6, -2)->values()->toArray());
     }
 
-    public function testApertureDefaultLength()
+    public function testNgramDefaultLength()
     {
         $collection = new Collection([1, 2, 3, 4, 5, 6]);
-        $this->assertEquals([[1, 2], [2, 3], [3, 4], [4, 5], [5, 6]], $collection->aperture()->toArray());
+        $this->assertEquals([[1, 2], [2, 3], [3, 4], [4, 5], [5, 6]], $collection->ngram()->toArray());
     }
 
-    public function testApertureOneLength()
+    public function testNgramOneLength()
     {
         $collection = new Collection([1, 2, 3]);
-        $this->assertEquals([[1], [2], [3]], $collection->aperture(1)->toArray());
+        $this->assertEquals([[1], [2], [3]], $collection->ngram(1)->toArray());
     }
 
-    public function testApertureTooLongLength()
+    public function testNgramTooLongLength()
     {
         $collection = new Collection([1, 2, 3]);
-        $this->assertEquals([], $collection->aperture(5)->toArray());
+        $this->assertEquals([], $collection->ngram(5)->toArray());
     }
 
-    public function testApertureNegativeLength()
+    public function testNgramNegativeLength()
     {
         $collection = new Collection([1, 2, 3]);
-        $this->assertEquals([], $collection->aperture(-1)->toArray());
+        $this->assertEquals([], $collection->ngram(-1)->toArray());
     }
 
-    public function testApertureZeroLength()
+    public function testNgramZeroLength()
     {
         $collection = new Collection([1, 2, 3]);
-        $this->assertEquals([], $collection->aperture(0)->toArray());
+        $this->assertEquals([], $collection->ngram(0)->toArray());
     }
 
     public function testCollectionFromTraversable()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2404,8 +2404,9 @@ class SupportCollectionTest extends TestCase
 
     public function testNgramNegativeLength()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $collection = new Collection([1, 2, 3]);
-        $this->assertEquals([], $collection->ngram(-1)->toArray());
+        $collection->ngram(-1);
     }
 
     public function testNgramZeroLength()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2384,6 +2384,36 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([3, 4, 5, 6], $collection->slice(-6, -2)->values()->toArray());
     }
 
+    public function testApertureDefaultLength()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5, 6]);
+        $this->assertEquals([[1, 2], [2, 3], [3, 4], [4, 5], [5, 6]], $collection->aperture()->toArray());
+    }
+
+    public function testApertureOneLength()
+    {
+        $collection = new Collection([1, 2, 3]);
+        $this->assertEquals([[1], [2], [3]], $collection->aperture(1)->toArray());
+    }
+
+    public function testApertureTooLongLength()
+    {
+        $collection = new Collection([1, 2, 3]);
+        $this->assertEquals([], $collection->aperture(5)->toArray());
+    }
+
+    public function testApertureNegativeLength()
+    {
+        $collection = new Collection([1, 2, 3]);
+        $this->assertEquals([], $collection->aperture(-1)->toArray());
+    }
+
+    public function testApertureZeroLength()
+    {
+        $collection = new Collection([1, 2, 3]);
+        $this->assertEquals([], $collection->aperture(0)->toArray());
+    }
+
     public function testCollectionFromTraversable()
     {
         $collection = new Collection(new \ArrayObject([1, 2, 3]));


### PR DESCRIPTION
This PR adds a new collection method that transforms an existing collection into overlapping n-grams (default `$n`: 2). A negative `$n` leads to an `InvalidArgumentException`.

Examples:
`collect([1, 2, 3, 4])->ngram()->toArray(); // [[1, 2], [2, 3], [3, 4]]`
`collect([1, 2, 3, 4])->ngram(1)->toArray(); // [[1], [2], [3], [4]]`
`collect([1, 2, 3, 4])->ngram(0)->toArray(); //  []`
`collect([1, 2, 3, 4])->ngram(-1)->toArray(); //  InvalidArgumentException`
`collect([1, 2, 3, 4, 5])->ngram(3)->toArray(); // [[1, 2, 3], [2, 3, 4], [3, 4, 5]]`