### PR TITLE
[5.6] Fix MorphTo lazy loading and withoutGlobalScopes()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -231,6 +231,8 @@ class MorphTo extends BelongsTo
      */
     public function withoutGlobalScopes(array $scopes = null)
     {
+        $this->getQuery()->withoutGlobalScopes($scopes);
+
         $this->macroBuffer[] = [
             'method' => __FUNCTION__,
             'parameters' => [$scopes],

--- a/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
+++ b/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
@@ -63,6 +63,14 @@ class EloquentMorphToGlobalScopesTest extends DatabaseTestCase
         $this->assertNotNull($comments[0]->commentable);
         $this->assertNotNull($comments[1]->commentable);
     }
+
+    public function test_lazy_loading()
+    {
+        $comment = Comment::latest('id')->first();
+        $post = $comment->commentable()->withoutGlobalScopes()->first();
+
+        $this->assertNotNull($post);
+    }
 }
 
 class Comment extends Model


### PR DESCRIPTION
#25331 fixed `withoutGlobalScopes()` when eager loading `MorphTo` relationships.
This broke lazy loading:

```php
class Comment extends Model
{
    public function commentable()
    {
        return $this->morphTo()->withoutGlobalScopes();
    }
}

class Post extends Model
{
    use SoftDeletes;
}

Comment::first()->commentable;
```
```sql
# expected
select * from "posts" where "posts"."id" = ? limit 1

# actual
select * from "posts" where "posts"."id" = ? and "posts"."deleted_at" is null limit 1
```

The `$macroBuffer` is only used for eager loading. For lazy loading, we have to pass `withoutGlobalScopes()` through to the query.

Fixes #25402.