### PR TITLE
[5.6] Revert "escape lang directive echos"

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
@@ -18,7 +18,7 @@ trait CompilesTranslations
             return "<?php \$__env->startTranslation{$expression}; ?>";
         }
 
-        return "<?php echo e(app('translator')->getFromJson{$expression}); ?>";
+        return "<?php echo app('translator')->getFromJson{$expression}; ?>";
     }
 
     /**
@@ -28,7 +28,7 @@ trait CompilesTranslations
      */
     protected function compileEndlang()
     {
-        return '<?php echo e($__env->renderTranslation()); ?>';
+        return '<?php echo $__env->renderTranslation(); ?>';
     }
 
     /**
@@ -39,6 +39,6 @@ trait CompilesTranslations
      */
     protected function compileChoice($expression)
     {
-        return "<?php echo e(app('translator')->choice{$expression}); ?>";
+        return "<?php echo app('translator')->choice{$expression}; ?>";
     }
 }

--- a/tests/View/Blade/BladeExpressionTest.php
+++ b/tests/View/Blade/BladeExpressionTest.php
@@ -6,13 +6,13 @@ class BladeExpressionTest extends AbstractBladeTestCase
 {
     public function testExpressionsOnTheSameLine()
     {
-        $this->assertEquals('<?php echo e(app(\'translator\')->getFromJson(foo(bar(baz(qux(breeze())))))); ?> space () <?php echo e(app(\'translator\')->getFromJson(foo(bar))); ?>', $this->compiler->compileString('@lang(foo(bar(baz(qux(breeze()))))) space () @lang(foo(bar))'));
+        $this->assertEquals('<?php echo app(\'translator\')->getFromJson(foo(bar(baz(qux(breeze()))))); ?> space () <?php echo app(\'translator\')->getFromJson(foo(bar)); ?>', $this->compiler->compileString('@lang(foo(bar(baz(qux(breeze()))))) space () @lang(foo(bar))'));
     }
 
     public function testExpressionWithinHTML()
     {
         $this->assertEquals('<html <?php echo e($foo); ?>>', $this->compiler->compileString('<html {{ $foo }}>'));
         $this->assertEquals('<html<?php echo e($foo); ?>>', $this->compiler->compileString('<html{{ $foo }}>'));
-        $this->assertEquals('<html <?php echo e($foo); ?> <?php echo e(app(\'translator\')->getFromJson(\'foo\')); ?>>', $this->compiler->compileString('<html {{ $foo }} @lang(\'foo\')>'));
+        $this->assertEquals('<html <?php echo e($foo); ?> <?php echo app(\'translator\')->getFromJson(\'foo\'); ?>>', $this->compiler->compileString('<html {{ $foo }} @lang(\'foo\')>'));
     }
 }

--- a/tests/View/Blade/BladeLangTest.php
+++ b/tests/View/Blade/BladeLangTest.php
@@ -7,13 +7,13 @@ class BladeLangTest extends AbstractBladeTestCase
     public function testStatementThatContainsNonConsecutiveParenthesisAreCompiled()
     {
         $string = "Foo @lang(function_call('foo(blah)')) bar";
-        $expected = "Foo <?php echo e(app('translator')->getFromJson(function_call('foo(blah)'))); ?> bar";
+        $expected = "Foo <?php echo app('translator')->getFromJson(function_call('foo(blah)')); ?> bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testLanguageAndChoicesAreCompiled()
     {
-        $this->assertEquals('<?php echo e(app(\'translator\')->getFromJson(\'foo\')); ?>', $this->compiler->compileString("@lang('foo')"));
-        $this->assertEquals('<?php echo e(app(\'translator\')->choice(\'foo\', 1)); ?>', $this->compiler->compileString("@choice('foo', 1)"));
+        $this->assertEquals('<?php echo app(\'translator\')->getFromJson(\'foo\'); ?>', $this->compiler->compileString("@lang('foo')"));
+        $this->assertEquals('<?php echo app(\'translator\')->choice(\'foo\', 1); ?>', $this->compiler->compileString("@choice('foo', 1)"));
     }
 }


### PR DESCRIPTION
d3c0a369057d0b6ebf29b5f51c903b1a85e3e09b is a breaking change because you can no longer use HTML tags inside translations:

### 5.6.35:
![zrzut ekranu 2018-09-02 16 26 42](https://user-images.githubusercontent.com/98191/44957008-fd3d1400-aecc-11e8-99de-7394ff89112d.png)

### 5.6.36:
![zrzut ekranu 2018-09-02 14 09 20](https://user-images.githubusercontent.com/98191/44956987-c8c95800-aecc-11e8-97c1-11b03e1360f8.png)

Now instead of:
```
@lang('Hello')
```

I need to use something like:

```
{{ new HtmlString(__('Hello')) }}
{!! __('Hello') !!}
```

This affected more than one application.