### PR TITLE
[5.5] Fixes @param type on when() method.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -419,7 +419,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Apply the callback if the value is truthy.
      *
-     * @param  bool  $value
+     * @param  mixed  $value
      * @param  callable  $callback
      * @param  callable  $default
      * @return mixed


### PR DESCRIPTION
The `when` function on the `Collection` class expects `$value` to be a  boolean.

This function passes `$value` to the given callback function so it should accept a param of type `mixed`.

Example taken from the [tests](https://github.com/laravel/framework/blob/5.6/tests/Support/SupportCollectionTest.php#L2568):

```
$collection = new Collection(['michael', 'tom']);
$collection->when('adam', function ($collection, $newName) {
     return $collection->push($newName);
});
```