### PR TITLE
[5.7] Csrf Verification should accept named routes

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -105,7 +105,7 @@ class VerifyCsrfToken
                 $except = trim($except, '/');
             }
 
-            if ($request->fullUrlIs($except) || $request->is($except)) {
+            if ($request->fullUrlIs($except) || $request->is($except) || $request->routeIs($except)) {
                 return true;
             }
         }


### PR DESCRIPTION
The exceptions array doesn't currently accept named routes.
