### PR TITLE
[5.7] Pass authorization by default in form requests

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -150,7 +150,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
             return $this->container->call([$this, 'authorize']);
         }
 
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
I never really understood why this is false by default. It's annoying to always need to implement an `authorize` function that returns true in when you don't care about authorization. 

If auth isn't a concern, you shouldn't need to implement an auth method.