### PR TITLE
Add Schema::hasTable('users') as default in migration create.stub

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/create.stub
@@ -13,10 +13,12 @@ class DummyClass extends Migration
      */
     public function up()
     {
-        Schema::create('DummyTable', function (Blueprint $table) {
-            $table->increments('id');
-            $table->timestamps();
-        });
+        if (!Schema::hasTable('DummyTable')) {
+            Schema::create('DummyTable', function (Blueprint $table) {
+                $table->increments('id');
+                $table->timestamps();
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
Simple logic check (using the pre-existing feature of the framework) to only create a DB schema if a table of the same name doesn't already exist. 

It seems to me that those of us who use the Artisan command to generate a migration would appreciate this by default and it should help mitigate "already exists" errors. 

It nicely mirrors the `if` logic in the `down` method. 
This may also apply to `update.stub`. 
I'd also encourage its use in package migrations, particularly as packages may offer migrations with the same name as the local project. 

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
