### PR TITLE
[5.6] Allow load relations with similar keys using strict comparisson

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -223,7 +223,7 @@ abstract class Relation
     {
         return collect($models)->map(function ($value) use ($key) {
             return $key ? $value->getAttribute($key) : $value->getKey();
-        })->values()->unique()->sort()->all();
+        })->values()->unique(nul, true)->sort()->all();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -223,7 +223,7 @@ abstract class Relation
     {
         return collect($models)->map(function ($value) use ($key) {
             return $key ? $value->getAttribute($key) : $value->getKey();
-        })->values()->unique(nul, true)->sort()->all();
+        })->values()->unique(null, true)->sort()->all();
     }
 
     /**


### PR DESCRIPTION
Currently if you want to load a relation using a non integer primary key, you are not able to load all the relations. 

This is caused because when you load a relation it does a unique for all the given keys and produce the shortest query as possible. It works as expected with integer, but if you use string, the comparison is not strict so you may find cases like 5.60 is merged with 5.6 because in a "==" comparison they are the same.

Backwards incompatibility are not expected.

I didn't add a test because I didn't find one checking this behaviour. If you can indicate me where is it, I will add a new test to avoid regressions.

Bug introduced in https://github.com/laravel/framework/pull/4126. It explains why is unique needed.