### PR TITLE
[5.7] Show maintenance message on error page

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/503.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/503.blade.php
@@ -8,4 +8,4 @@
 </div>
 @endsection
 
-@section('message', __('Sorry, we are doing some maintenance. Please check back soon.'))
+@section('message', __($exception->getMessage() ?: 'Sorry, we are doing some maintenance. Please check back soon.'))


### PR DESCRIPTION
When the maintenance mode is enabled with a custom message, the error page still shows the default message:

    php artisan down --message="Upgrading Database"

 > Sorry, we are doing some maintenance. Please check back soon.

With this PR, the view uses the specified message if available.

Fixes #25426.