### PR TITLE
Add passedValidation callback to FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -76,6 +76,12 @@ class FormRequest extends Request implements ValidatesWhenResolved
         if (method_exists($this, 'withValidator')) {
             $this->withValidator($validator);
         }
+        
+        if (method_exists($this, 'passedValidation')) {
+            $validator->after(function(Validator $validator) {
+                $this->passedValidation($validator);
+            });
+        }
 
         return $validator;
     }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -78,7 +78,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
         }
         
         if (method_exists($this, 'passedValidation')) {
-            $validator->after(function(Validator $validator) {
+            $validator->after(function (Validator $validator) {
                 $this->passedValidation($validator);
             });
         }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -76,7 +76,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
         if (method_exists($this, 'withValidator')) {
             $this->withValidator($validator);
         }
-        
+
         if (method_exists($this, 'passedValidation')) {
             $validator->after(function (Validator $validator) {
                 $this->passedValidation($validator);


### PR DESCRIPTION
Right now if you want to modify the data of a request after validation to do something like calculate a composite value, or convert some data from a public format to a format more usable by the rest of your application you need to do

```php
public function withValidator(Validator $validator)
{
    $validator->after(function() {
        $this->offsetSet('height', ($this->input('feet') * 12) + $this->input('inches'));
    });
}
```

This PR automatically adds an after callback to call a `passedValidation` method on your FormRequest if one has been defined meaning you can simply do 

```php
public function passedValidation() 
{
    $this->offsetSet('height', ($this->input('feet') * 12) + $this->input('inches'));
}
```

The validator is passed in as the first parameter to match the existing `failedValidation` method although for most usecases this likely is not required.

This is highly unlikely to break any existing applications unless they by chance have defined a `passedValidation` method already on their form request and the method is non-idempotent.
