### PR TITLE
[5.6] Fix nullable MorphTo and $touches

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -224,6 +224,21 @@ class MorphTo extends BelongsTo
     }
 
     /**
+     * Touch all of the related models for the relationship.
+     *
+     * @return void
+     */
+    public function touch()
+    {
+        // If there is no related model, we'll just return to prevent an invalid query.
+        if (is_null($this->ownerKey)) {
+            return;
+        }
+
+        parent::touch();
+    }
+
+    /**
      * Remove all or passed registered global scopes.
      *
      * @param  array|null  $scopes

--- a/tests/Integration/Database/EloquentMorphToTouchesTest.php
+++ b/tests/Integration/Database/EloquentMorphToTouchesTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphToTouchesTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphToTouchesTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->nullableMorphs('commentable');
+        });
+
+        Post::create();
+    }
+
+    public function test_not_null()
+    {
+        $comment = (new Comment)->commentable()->associate(Post::first());
+
+        \DB::enableQueryLog();
+
+        $comment->save();
+
+        $this->assertCount(2, \DB::getQueryLog());
+    }
+
+    public function test_null()
+    {
+        \DB::enableQueryLog();
+
+        Comment::create();
+
+        $this->assertCount(1, \DB::getQueryLog());
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    protected $touches = ['commentable'];
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Post extends Model
+{
+}


### PR DESCRIPTION
Using `$touches` with a `MorphTo` relationships breaks without a related model:

```php
Schema::create('comments', function ($table) {
    $table->increments('id');
    $table->nullableMorphs('commentable');
});

class Comment extends Model
{
    protected $touches = ['commentable'];

    public function commentable()
    {
        return $this->morphTo();
    }
}

Comment::create();
```

This throws an exception:

> Unknown column 'comments.' in 'where clause'
> (SQL: update `comments` set `updated_at` = 2018-09-04 02:24:54 where `comments`.`` is null)

We can detect this case by checking the `$ownerKey` and so prevent the invalid query.

Fixes #25434.