### PR TITLE
[5.7] Only update the locate if the the locale is actually different

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1048,6 +1048,10 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function setLocale($locale)
     {
+        if ($this->isLocale($locale)) {
+            return;
+        }
+
         $this['config']->set('app.locale', $locale);
 
         $this['translator']->setLocale($locale);

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -58,6 +58,35 @@ class SendingMailWithLocaleTest extends TestCase
         );
     }
 
+    public function test_mail_sent_with_new_locale_raises_event()
+    {
+        Event::fake();
+
+        Mail::to('test@mail.com')->locale($locale = 'ar')->send(new TestMail);
+
+        Event::assertDispatched(LocaleUpdated::class, function ($event) use ($locale) {
+            return $event->locale === $locale;
+        });
+    }
+
+    public function test_mail_sent_with_default_locale_does_not_raise_event()
+    {
+        Event::fake();
+
+        Mail::to('test@mail.com')->locale('en')->send(new TestMail);
+
+        Event::assertNotDispatched(LocaleUpdated::class);
+    }
+
+    public function test_mail_sent_without_locale_does_not_raise_event()
+    {
+        Event::fake();
+
+        Mail::to('test@mail.com')->send(new TestMail);
+
+        Event::assertNotDispatched(LocaleUpdated::class);
+    }
+
     public function test_mail_is_sent_with_selected_locale()
     {
         Mail::to('test@mail.com')->locale('ar')->send(new TestMail());

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -128,6 +128,50 @@ class SendingNotificationsWithLocaleTest extends TestCase
         );
     }
 
+    public function test_notification_sent_without_locale_does_not_raise_event()
+    {
+        Event::fake();
+
+        $user = NotifiableLocalizedUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        $user->notify((new GreetingMailNotification));
+
+        Event::assertNotDispatched(LocaleUpdated::class);
+    }
+
+    public function test_notification_sent_with_default_locale_does_not_raise_event()
+    {
+        Event::fake();
+
+        $user = NotifiableLocalizedUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        $user->notify((new GreetingMailNotification)->locale('en'));
+
+        Event::assertNotDispatched(LocaleUpdated::class);
+    }
+
+    public function test_notification_sent_with_new_locale_raises_event()
+    {
+        Event::fake();
+
+        $user = NotifiableLocalizedUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        $user->notify((new GreetingMailNotification)->locale($locale = 'fr'));
+
+        Event::assertDispatched(LocaleUpdated::class, function ($event) use ($locale) {
+            return $event->locale === $locale;
+        });
+    }
+
     public function test_mail_is_sent_with_locale_updated_listeners_called()
     {
         Carbon::setTestNow(Carbon::parse('2018-07-25'));


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

It feels strange to raise a `LocaleUpdated` event when the value of the locale has not actually changed.

---

As an example, I would like to refer to Eloquent models events: we would not expect a Updated event to be raised after using `->update()` unless one of the updated attributes was actually different in a previous state.
