### PR TITLE
[5.7] Remove X-UA-Compatible meta tag

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -2,7 +2,6 @@
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- CSRF Token -->

--- a/src/Illuminate/Foundation/Exceptions/views/layout.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/layout.blade.php
@@ -2,7 +2,6 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <title>@yield('title')</title>


### PR DESCRIPTION
There's no reason to include the X-UA-Compatible meta tag anymore. Microsoft do not support IE8, 9 and 10 (which are the only browsers it is supported in). 

Including this tag also goes against Microsoft best practices, as is redundant for most users, even if they were using an outdated browser like IE 10. See: https://stackoverflow.com/a/26348511/199700