### PR TITLE
[5.7] Added default array value for redis config

### DIFF
--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -22,7 +22,7 @@ class RedisServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('redis', function ($app) {
-            $config = $app->make('config')->get('database.redis');
+            $config = $app->make('config')->get('database.redis', []);
 
             return new RedisManager($app, Arr::pull($config, 'client', 'predis'), $config);
         });


### PR DESCRIPTION
If the redis config is missing from the database configuration then there's an error due to the first argument to `Arr::pull()` being `null` and not an array:

`array_key_exists() expects parameter 2 to be array, null given`

Line 27 already defines a default value for the client part of the configuration so it's not actually required to have any configuration to create the instance of `RedisManager`.

After this change having no Redis configuation at all will still result in an InvalidArgumentException if the Redis connection is used:

`Redis connection [default] not configured.`

But this is more descriptive and easier to debug than the `array_key_exists` error.