### PR TITLE
Allow email verification middleware to work with API routes

### DIFF
--- a/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
+++ b/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
@@ -13,14 +13,18 @@ class EnsureEmailIsVerified
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
      */
     public function handle($request, Closure $next)
     {
         if (! $request->user() ||
             ($request->user() instanceof MustVerifyEmail &&
             ! $request->user()->hasVerifiedEmail())) {
-            return Redirect::route('verification.notice');
+            if ($request->expectsJson()) {
+                abort(403, 'Your email address is not verified.');
+            } else {
+                return Redirect::route('verification.notice');
+            }
         }
 
         return $next($request);


### PR DESCRIPTION
Currently if you apply the email verification middleware to an API route (XHR) you get strange/broken behaviour because of the redirect.
So, when the request expects JSON, just return a 403. This solves my issues.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
