### PR TITLE
[5.7] Send an event when the user's email is verified

### DIFF
--- a/src/Illuminate/Auth/Events/Verified.php
+++ b/src/Illuminate/Auth/Events/Verified.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Auth\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class Verified
+{
+    use SerializesModels;
+
+    /**
+     * The verified user.
+     *
+     * @var \Illuminate\Contracts\Auth\MustVerifyEmail
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\MustVerifyEmail  $user
+     * @return void
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -17,11 +17,11 @@ trait MustVerifyEmail
     /**
      * Mark the given user's email as verified.
      *
-     * @return void
+     * @return bool
      */
     public function markEmailAsVerified()
     {
-        $this->forceFill(['email_verified_at' => $this->freshTimestamp()])->save();
+        return $this->forceFill(['email_verified_at' => $this->freshTimestamp()])->save();
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Auth;
 
+use Illuminate\Auth\Events\Verified;
 use Illuminate\Http\Request;
 
 trait VerifiesEmails
@@ -30,7 +31,9 @@ trait VerifiesEmails
     public function verify(Request $request)
     {
         if ($request->route('id') == $request->user()->getKey()) {
-            $request->user()->markEmailAsVerified();
+            if ($request->user()->markEmailAsVerified()) {
+                event(new Verified($request->user()));
+            }
         }
 
         return redirect($this->redirectPath());

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Foundation\Auth;
 
-use Illuminate\Auth\Events\Verified;
 use Illuminate\Http\Request;
+use Illuminate\Auth\Events\Verified;
 
 trait VerifiesEmails
 {


### PR DESCRIPTION
Upon user email verification we may like to take certain immediate actions. For example, once we have verified that the user has a valid email from a certain company domain, we may assign a role automatically.

I tried grepping for existing email verification tests, but couldn't find any. I prefer creating tests, but I think completely testing the email verification feature is outside the scope of this PR. If I missed the tests, please point me to them.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
