### PR TITLE
[5.7] Do not send email verification if user is already verified

### DIFF
--- a/src/Illuminate/Auth/Listeners/SendEmailVerificationNotification.php
+++ b/src/Illuminate/Auth/Listeners/SendEmailVerificationNotification.php
@@ -15,7 +15,7 @@ class SendEmailVerificationNotification
      */
     public function handle(Registered $event)
     {
-        if ($event->user instanceof MustVerifyEmail) {
+        if ($event->user instanceof MustVerifyEmail && ! $event->user->hasVerifiedEmail()) {
             $event->user->sendEmailVerificationNotification();
         }
     }


### PR DESCRIPTION
Hey guys,

So I'm using Socialite to register users. I'm dispatching the Registered event and since my model now extends MustVerifyEmail, it sends out an email to users which are already verified (force filled by my FB/Google integration).

This makes sure that a "verified" user does not receive the email, so if in your registration process you mark them as verified, they will not receive the email.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
