### PR TITLE
[5.7] Don't mock console output by default

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -2,10 +2,13 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\PendingCommand;
 
 trait InteractsWithConsole
 {
+    protected $mockConsoleOutput = false;
+
     /**
      * All of the expected output lines.
      *
@@ -29,6 +32,10 @@ trait InteractsWithConsole
      */
     public function artisan($command, $parameters = [])
     {
+        if (! $this->mockConsoleOutput) {
+            return $this->app[Kernel::class]->call($command, $parameters);
+        }
+
         $this->beforeApplicationDestroyed(function () {
             if (count($this->expectedQuestions)) {
                 $this->fail('Question "'.array_first($this->expectedQuestions)[0].'" was not asked.');
@@ -40,5 +47,12 @@ trait InteractsWithConsole
         });
 
         return new PendingCommand($this, $this->app, $command, $parameters);
+    }
+
+    protected function withMockedConsoleOutput()
+    {
+        $this->mockConsoleOutput = true;
+
+        return $this;
     }
 }

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Foundation\Testing\PendingCommand;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Contracts\Console\Kernel;
 
@@ -19,14 +20,27 @@ class ConsoleApplicationTest extends TestCase
     {
         $exitCode = $this->artisan('foo:bar', [
             'id' => 1,
-        ])->assertExitCode(0);
+        ]);
+
+        $this->assertSame(0, $exitCode);
     }
 
     public function test_artisan_call_using_command_class()
     {
         $exitCode = $this->artisan(FooCommandStub::class, [
             'id' => 1,
-        ])->assertExitCode(0);
+        ]);
+
+        $this->assertSame(0, $exitCode);
+    }
+
+    public function test_artisan_call_using_command_class_with_mocked_output()
+    {
+        $pendingCommand = $this->withMockedConsoleOutput()->artisan(FooCommandStub::class, ['id' => 1]);
+
+        $this->assertInstanceOf(PendingCommand::class, $pendingCommand);
+
+        $pendingCommand->assertExitCode(0);
     }
 }
 

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Tests\Integration\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Foundation\Testing\PendingCommand;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\PendingCommand;
 
 class ConsoleApplicationTest extends TestCase
 {


### PR DESCRIPTION
https://github.com/laravel/framework/pull/25270 added a way to test console output, it does this by always mocking console output. This causes the problem that if you have interactive questions in your commands, you always have to set expectations on the mock even if you don't want to test your console output.

I have a project where i have added some interactive questions in my seeders to have more options when seeding the database. (related PR: https://github.com/laravel/framework/pull/25304). In 5.6, when running the tests the questions are answered with the default answer. In 5.7 these tests fail because i am not setting expectations on the mocks:
```
2) Tests\Unit\PagesTest::user_pages_work
Mockery\Exception\BadMethodCallException: Received Mockery_1_Illuminate_Console_OutputStyle::askQuestion(), but no expectations were specified
```

This PR makes it so that console output is not mocked by default. If you want to test console output you have to explicitly call `withMockedConsoleOutput()` in your test. I'm not sure if this is the best solution to this problem, could you take a look at it @themsaid?
