### PR TITLE
[5.7] Pass configuration key parameter to updatePackageArray in Preset

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/Preset.php
+++ b/src/Illuminate/Foundation/Console/Presets/Preset.php
@@ -37,7 +37,8 @@ class Preset
         $packages = json_decode(file_get_contents(base_path('package.json')), true);
 
         $packages[$configurationKey] = static::updatePackageArray(
-            array_key_exists($configurationKey, $packages) ? $packages[$configurationKey] : []
+            array_key_exists($configurationKey, $packages) ? $packages[$configurationKey] : [],
+            $configurationKey
         );
 
         ksort($packages[$configurationKey]);


### PR DESCRIPTION
Small improvement of https://github.com/laravel/framework/pull/24189.
Now we can update "dependency" block or "devDependency" block in package.json.
But we have no way to updating both blocks at the same time, because updatePackageArray method just returns array of packages without specifying is this dev-dependency or dependency.

After small change we can write something like in our preset code:
```php
protected static function updatePackageArray(array $packages, $configurationKey)
{
    return $configurationKey === 'dependencies' : self::getDependencies($packages) ? self::getDevDependencies($packages);
}
```