### PR TITLE
[5.7] Update docblocks for tuple notation in action helpers

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -54,7 +54,7 @@ interface UrlGenerator
     /**
      * Get the URL to a controller action.
      *
-     * @param  string  $action
+     * @param  string|array  $action
      * @param  mixed $parameters
      * @param  bool $absolute
      * @return string

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -91,7 +91,7 @@ if (! function_exists('action')) {
     /**
      * Generate the URL to a controller action.
      *
-     * @param  string  $name
+     * @param  string|array  $name
      * @param  mixed   $parameters
      * @param  bool    $absolute
      * @return string

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -160,7 +160,7 @@ class Redirector
     /**
      * Create a new redirect response to a controller action.
      *
-     * @param  string  $action
+     * @param  string|array  $action
      * @param  mixed   $parameters
      * @param  int     $status
      * @param  array   $headers


### PR DESCRIPTION
This PR adds the `array` argument type to the action helpers that now support #24738's tuple notation. 