### PR TITLE
[5.7] Adjust PHPDoc in the MustVerifyEmail contract

### DIFF
--- a/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
@@ -14,7 +14,7 @@ interface MustVerifyEmail
     /**
      * Mark the given user's email as verified.
      *
-     * @return void
+     * @return bool
      */
     public function markEmailAsVerified();
 


### PR DESCRIPTION
I adjusted the PHPDoc in the MustVerifyEmail contract to match the behaviour of the trait. I only noticed this after PR #25449 was merged.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
