### PR TITLE
[5.7] Add check for attributes array type in exception list on TrimString middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -28,4 +28,23 @@ class TrimStrings extends TransformsRequest
 
         return is_string($value) ? trim($value) : $value;
     }
+    
+    /**
+     * Clean the given value.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function cleanValue($key, $value)
+    {
+        if (is_array($value)) {
+            if(!in_array($key, $this->except, true)){
+                return $this->cleanArray($value);
+            } else {
+                return $value;
+            }
+        }
+        return $this->transform($key, $value);
+    }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -39,7 +39,7 @@ class TrimStrings extends TransformsRequest
     protected function cleanValue($key, $value)
     {
         if (is_array($value)) {
-            if(! in_array($key, $this->except, true)){
+            if (! in_array($key, $this->except, true)) {
                 return $this->cleanArray($value);
             } else {
                 return $value;

--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -28,7 +28,7 @@ class TrimStrings extends TransformsRequest
 
         return is_string($value) ? trim($value) : $value;
     }
-    
+
     /**
      * Clean the given value.
      *
@@ -39,12 +39,13 @@ class TrimStrings extends TransformsRequest
     protected function cleanValue($key, $value)
     {
         if (is_array($value)) {
-            if(!in_array($key, $this->except, true)){
+            if(! in_array($key, $this->except, true)){
                 return $this->cleanArray($value);
             } else {
                 return $value;
             }
         }
+
         return $this->transform($key, $value);
     }
 }


### PR DESCRIPTION
This patch corrects the ability to add attributes with an array type to the exception list on TrimStrings middleware

When I was developing my application, I ran into a problem. In my model, there were attributes with an array type. I had a need to disable trim for all elements in the array. First, I tried to add into the property $except, but I did not achieve a result. Then I discovered that in the logic of the work this moment is missed. Therefore, I propose my own version.