### PR TITLE
[5.7] Add the ability to skip algorithm checking

### DIFF
--- a/src/Illuminate/Hashing/Argon2IdHasher.php
+++ b/src/Illuminate/Hashing/Argon2IdHasher.php
@@ -16,7 +16,7 @@ class Argon2IdHasher extends ArgonHasher
      */
     public function check($value, $hashedValue, array $options = [])
     {
-        if ($this->info($hashedValue)['algoName'] !== 'argon2id') {
+        if ($this->verifyAlgorithm && $this->info($hashedValue)['algoName'] !== 'argon2id') {
             throw new RuntimeException('This password does not use the Argon2id algorithm.');
         }
 

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -29,6 +29,13 @@ class ArgonHasher extends AbstractHasher implements HasherContract
     protected $threads = 2;
 
     /**
+     * Indicates whether to perform an algorithm check.
+     *
+     * @var bool
+     */
+    protected $verifyAlgorithm = true;
+
+    /**
      * Create a new hasher instance.
      *
      * @param  array  $options
@@ -39,6 +46,7 @@ class ArgonHasher extends AbstractHasher implements HasherContract
         $this->time = $options['time'] ?? $this->time;
         $this->memory = $options['memory'] ?? $this->memory;
         $this->threads = $options['threads'] ?? $this->threads;
+        $this->verifyAlgorithm = $options['verifyAlgorithm'] ?? $this->verifyAlgorithm;
     }
 
     /**
@@ -85,7 +93,7 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      */
     public function check($value, $hashedValue, array $options = [])
     {
-        if ($this->info($hashedValue)['algoName'] !== 'argon2i') {
+        if ($this->verifyAlgorithm && $this->info($hashedValue)['algoName'] !== 'argon2i') {
             throw new RuntimeException('This password does not use the Argon2i algorithm.');
         }
 

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -15,6 +15,13 @@ class BcryptHasher extends AbstractHasher implements HasherContract
     protected $rounds = 10;
 
     /**
+     * Indicates whether to perform an algorithm check.
+     *
+     * @var bool
+     */
+    protected $verifyAlgorithm = true;
+
+    /**
      * Create a new hasher instance.
      *
      * @param  array  $options
@@ -23,6 +30,7 @@ class BcryptHasher extends AbstractHasher implements HasherContract
     public function __construct(array $options = [])
     {
         $this->rounds = $options['rounds'] ?? $this->rounds;
+        $this->verifyAlgorithm = $options['verify_algorithm'] ?? $this->verifyAlgorithm;
     }
 
     /**
@@ -57,7 +65,7 @@ class BcryptHasher extends AbstractHasher implements HasherContract
      */
     public function check($value, $hashedValue, array $options = [])
     {
-        if ($this->info($hashedValue)['algoName'] !== 'bcrypt') {
+        if ($this->verifyAlgorithm && $this->info($hashedValue)['algoName'] !== 'bcrypt') {
             throw new RuntimeException('This password does not use the Bcrypt algorithm.');
         }
 


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
See #25458.

Upon updating to 5.7 a portion of my user accounts can no longer login (#25458) due to the algorithm checking in place. I think it would be wise to allow us to toggle this feature as and when needed. 

Although ideally there should be complete consistency in terms of the hashing algorithm one uses, sometime this is not the case. For me, I have hashes that have originated from other applications and unfortunately some of them appear to have used an older version of bycrpt.
https://en.wikipedia.org/wiki/Bcrypt#Versioning_history 

Below we have an example of the issue that I am running into. Because PHP doesn't recognise my bcrypt hash.

**Example**
```php
$hash = '$2a$10$Wrk/FoakWwkX/tT0A/No5uu3IZrVu/e27QHTgpjHlPUQS3HwK0ei2';
password_verify('Test12345', $hash); // bool(true) 
password_get_info($hash); // array(3) { ["algo"]=> int(0) ["algoName"]=> string(7) "unknown" ["options"]=> array(0) { } }
```
Because the above returns an `algoName` of `unknown` the exception is thrown.
```php
public function check($value, $hashedValue, array $options = [])
{
    if ($this->info($hashedValue)['algoName'] !== 'bcrypt') {
        throw new RuntimeException('This password does not use the Bcrypt algorithm.');
    }
    return parent::check($value, $hashedValue, $options);
}
```
https://github.com/laravel/framework/blob/5.7/src/Illuminate/Hashing/BcryptHasher.php#L60

PHP's `password_get_info()` function _only_ recognises the `$2y$` prefix. https://github.com/php/php-src/blob/master/ext/standard/password.c#L81

### Solution 
I have added an option that you can specify in you config to turn on and off the algorithm checking (obviously on by default).

```
    'bcrypt' [
        'check' => false
    ],       
```

The issue in the ticket (#25458) is slightly different to my use case, but check it out.

If the is a more intelligent way of going about fixing this, do let me know.

