### PR TITLE
[5.7] Add getStreamedContent to TestResponse class

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Illuminate\Foundation\Testing\Constraints\SeeInOrder;
 
 /**
@@ -26,6 +27,13 @@ class TestResponse
      * @var \Illuminate\Http\Response
      */
     public $baseResponse;
+
+    /**
+     * The streamed content of the response.
+     *
+     * @var string
+     */
+    protected $streamedContent;
 
     /**
      * Create a new test response instance.
@@ -947,6 +955,28 @@ class TestResponse
         }
 
         dd($content);
+    }
+
+    /**
+     * Get the streamed content from the response.
+     *
+     * @return string
+     */
+    public function getStreamedContent()
+    {
+        if (! is_null($this->streamedContent)) {
+            return $this->streamedContent;
+        }
+
+        if (! $this->baseResponse instanceof StreamedResponse) {
+            PHPUnit::fail('The response is not a streamed response.');
+        }
+
+        ob_start();
+
+        $this->sendContent();
+
+        return $this->streamedContent = ob_get_clean();
     }
 
     /**


### PR DESCRIPTION
This PR adds a new `getStreamedContent` method to the TestResponse class. The main reason for adding this is to be able to test the response content coming from a `Storage::download()`call, but it can be applied for any streamed response testing.

The content is cached on the class because Symfony's StreamedResponse class only streams it once. This would allow the user to call this method multiple times without having to worry if the content was already streamed or not.