### PR TITLE
[5.7] Add Test suffix to misnamed tests

### DIFF
--- a/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
+++ b/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
-class DatabaseEloquentCastsDatabaseString extends TestCase
+class DatabaseEloquentCastsDatabaseStringTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
-class DatabaseEloquentTimestamps extends TestCase
+class DatabaseEloquentTimestampsTest extends TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
Two Database tests did not have the `Test` suffix in the name, and thus are not running. 👍 