### PR TITLE
[5.7] Make email verification scaffolding translatable

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/verify.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/verify.stub
@@ -5,17 +5,17 @@
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="card">
-                <div class="card-header">Verify Your Email Address</div>
+                <div class="card-header">{{ __('Verify Your Email Address') }}</div>
 
                 <div class="card-body">
                     @if (session('resent'))
                         <div class="alert alert-success" role="alert">
-                            A fresh verification link has been sent to your email address.
+                            {{ __('A fresh verification link has been sent to your email address.') }}
                         </div>
                     @endif
 
-                    Before proceeding, please check your email for a verification link.
-                    If you did not receive the email, <a href="{{ route('verification.resend') }}">click here to request another</a>.
+                    {{ __('Before proceeding, please check your email for a verification link.') }}
+                    {{ __('If you did not receive the email') }}, <a href="{{ route('verification.resend') }}">{{ __('click here to request another') }}</a>.
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The email verification scaffolding has hardcoded english strings. These can be easily
made translatable by using the __() helper and the new feature to use
translation strings in a JSON file. This enables (along with
translatable mailables) will allow easy creation of language
packages.
