### PR TITLE
Fixed 'queue:retry all' making it extremely fast with many failed_jobs and small memory footprint.

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -53,7 +53,7 @@ class RetryCommand extends Command
         $ids = (array) $this->argument('id');
 
         if (count($ids) === 1 && $ids[0] === 'all') {
-            $ids = Arr::pluck($this->laravel['queue.failer']->all(), 'id');
+            $ids = $this->laravel['queue.failer']->all();
         }
 
         return $ids;

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue\Console;
 
-use Illuminate\Support\Arr;
 use Illuminate\Console\Command;
 
 class RetryCommand extends Command

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -52,7 +52,7 @@ class RetryCommand extends Command
         $ids = (array) $this->argument('id');
 
         if (count($ids) === 1 && $ids[0] === 'all') {
-            $ids = $this->laravel['queue.failer']->all();
+            $ids = $this->laravel['queue.failer']->getAllFailedJobIds();
         }
 
         return $ids;

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -70,7 +70,7 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
      */
     public function all()
     {
-        return $this->getTable()->orderBy('id', 'desc')->get()->all();
+        return $this->getTable()->get(['id'])->all();
     }
 
     /**

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -70,8 +70,20 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
      */
     public function all()
     {
+        return $this->getTable()->orderBy('id', 'desc')->get()->all();
+    }
+
+    /**
+     * Get a list of all the failed jobs IDs.
+     *
+     * @return array
+     */
+    public function getAllFailedJobIds()
+    {
         return $this->getTable()->get(['id'])->all();
     }
+
+
 
     /**
      * Get a single failed job.

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -82,9 +82,7 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
     {
         return $this->getTable()->get(['id'])->all();
     }
-
-
-
+    
     /**
      * Get a single failed job.
      *

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -82,7 +82,7 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
     {
         return $this->getTable()->get(['id'])->all();
     }
-    
+
     /**
      * Get a single failed job.
      *


### PR DESCRIPTION
When the failed_jobs table has many jobs (and making it huge in size); the queue:retry all fails to load all jobs in memory.

In my case due to a network issue, 1.5 million jobs failed over night and the table was 23Gb in size.