### PR TITLE
[5.7] Fill the email belonging to the token on the showResetForm

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -4,9 +4,9 @@ namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Auth\Events\PasswordReset;
 

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Auth\Events\PasswordReset;
 
@@ -24,8 +25,16 @@ trait ResetsPasswords
      */
     public function showResetForm(Request $request, $token = null)
     {
+        $email = '';
+        if (is_null($token) == false) {
+            $email = DB::table('password_resets')
+                ->select('email')
+                ->where('token', $token)
+                ->first()->email;
+        }
+
         return view('auth.passwords.reset')->with(
-            ['token' => $token, 'email' => $request->email]
+            ['token' => $token, 'email' => $request->get('email', $email)]
         );
     }
 

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -27,7 +27,9 @@ trait ResetsPasswords
     {
         $email = '';
         if (is_null($token) == false) {
-            $email = DB::table('password_resets')
+            $provider = config('auth.defaults.passwords');
+            $table = config(sprintf('auth.passwords.%s.table', $provider));
+            $email = DB::table($table)
                 ->select('email')
                 ->where('token', $token)
                 ->first()->email;

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -29,10 +29,11 @@ trait ResetsPasswords
         if (is_null($token) == false) {
             $provider = config('auth.defaults.passwords');
             $table = config(sprintf('auth.passwords.%s.table', $provider));
-            $email = DB::table($table)
+            $record = DB::table($table)
                 ->select('email')
                 ->where('token', $token)
-                ->first()->email;
+                ->first();
+            $email = optional($record)->email;
         }
 
         return view('auth.passwords.reset')->with(


### PR DESCRIPTION
This gets the email belonging to the token a user has used to reset their password.
When the user arrives at the showResetForm, their email is already filled in.
This makes it easier and quicker to fill in the form.

It won't break any existing features as it passes it as the default on the request getter for the email field. If the email is already in the request, than that email will be used.
If no token can be found, than the default value will be an empty string.

