### PR TITLE
Fix FileStore flush behavior

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -142,7 +142,7 @@ class FileStore implements Store
     public function flush()
     {
         if (! $this->files->isDirectory($this->directory)) {
-            return false;
+            return true;
         }
 
         foreach ($this->files->directories($this->directory) as $directory) {

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -164,7 +164,7 @@ class CacheFileStoreTest extends TestCase
 
         $store = new FileStore($files, __DIR__.'--wrong');
         $result = $store->flush();
-        $this->assertFalse($result, 'Flush should not clean directory');
+        $this->assertTrue($result, 'Flush should ignore nonexisting directory and report success');
     }
 
     protected function mockFilesystem()


### PR DESCRIPTION
Fixes #25451.

https://github.com/laravel/framework/commit/6130483660dff949eca3824f477042191efc3266 causes the cache:clear command to fail with an error message if the cache data directory (_storage/framework/cache/data_ by default) doesn't exist.

This PR adjusts the FileStore's flush command to report success (true) if the data directory doesn't exist, instead of returning false (and causing the error message to be displayed).
This seems like the correct behavior to me, since a nonexisting directory should be considered "already flushed".
A test had to be adjusted accordingly.