### PR TITLE
[5.7] Adding the verified/unverified email scopes

### DIFF
--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -35,7 +35,7 @@ trait MustVerifyEmail
     {
         $this->notify(new Notifications\VerifyEmail);
     }
-    
+
     /**
      * Scope the unverified emails.
      *

--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -35,4 +35,28 @@ trait MustVerifyEmail
     {
         $this->notify(new Notifications\VerifyEmail);
     }
+    
+    /**
+     * Scope the unverified emails.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeUnverifiedEmail($query)
+    {
+        return $query->whereNull('email_verified_at');
+    }
+
+    /**
+     * Scope the verified emails.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeVerifiedEmail($query)
+    {
+        return $query->whereNotNull('email_verified_at');
+    }
 }


### PR DESCRIPTION
I want also change the `markEmailAsVerified` method to make sure the `email_verified_at` change only once by doing this:

```php
/**
  * Mark the given user's email as verified.
  *
  * @return bool
  */
public function markEmailAsVerified()
{
    if ($this->hasVerifiedEmail()) {
        return false;
    }

    return $this->forceFill([
        'email_verified_at' => $this->freshTimestamp(),
    ])->save();
}
```

I'm going to add the tests if the PR is accepted :+1: 