### PR TITLE
[5.6] only clear cached routes file if there are no fresh routes

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -50,11 +50,11 @@ class RouteCacheCommand extends Command
      */
     public function handle()
     {
-        $this->call('route:clear');
-
         $routes = $this->getFreshApplicationRoutes();
 
         if (count($routes) === 0) {
+            $this->call('route:clear');
+
             return $this->error("Your application doesn't have any routes.");
         }
 


### PR DESCRIPTION
Currently, the `route:cache` command is clearing cached routes before generating new ones creating a potential race condition for requests being served during the execution of this command. The command will replace the cached routes file if the fresh application has routes so there is only a need to clear the route cache if the fresh application has no routes.

The following PR should prevent the exception below being thrown, where the application passes a `routesAreCached()` method in `RouteServiceProvider::boot()` , but fails to require the cached file as it has since been deleted by the `route:cache` command.

```
Symfony\Component\Debug\Exception\FatalErrorException Illuminate\Foundation\Support\Providers\RouteServiceProvider::Illuminate\Foundation\Support\Providers\{closure}(): Failed opening required '/bootstrap/cache/routes.php' (include_path='.:/usr/share/php') 
    vendor/laravel/framework/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php:62 [main]
```