### PR TITLE
[5.7] Use ClientInterface proper request() method

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -64,7 +64,8 @@ class MailgunTransport extends Transport
 
         $message->setBcc([]);
 
-        $this->client->post(
+        $this->client->request(
+            'POST',
             "https://{$this->endpoint}/v3/{$this->domain}/messages.mime",
             $this->payload($message, $to)
         );

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -41,7 +41,7 @@ class MandrillTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
-        $this->client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', [
+        $this->client->request('POST', 'https://mandrillapp.com/api/1.0/messages/send-raw.json', [
             'form_params' => [
                 'key' => $this->key,
                 'to' => $this->getTo($message),

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -54,7 +54,7 @@ class SparkPostTransport extends Transport
 
         $message->setBcc([]);
 
-        $response = $this->client->post($this->getEndpoint(), [
+        $response = $this->client->request('POST', $this->getEndpoint(), [
             'headers' => [
                 'Authorization' => $this->key,
             ],


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

`\GuzzleHttp\ClientInterface::post` method does not exist.
We can use `\GuzzleHttp\ClientInterface::request` instead