### PR TITLE
[5.7] Add columns for a polymorphic table with unique index

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1169,6 +1169,22 @@ class Blueprint
     }
 
     /**
+     * Add columns for a polymorphic table with unique index.
+     *
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @return void
+     */
+    public function uniqueMorphs($name, $indexName = null)
+    {
+        $this->string("{$name}_type");
+
+        $this->unsignedBigInteger("{$name}_id");
+
+        $this->unique(["{$name}_type", "{$name}_id"], $indexName);
+    }
+
+    /**
      * Adds the `remember_token` column to the table.
      *
      * @return \Illuminate\Support\Fluent


### PR DESCRIPTION
Similar to the requirement for `nullableMorphs()`, as `$table->morphs('taggable')` doesn't support appending the `unique()` index modifier.

Adding a `uniqueMorphs` method allows creation of the polymorphic columns with a `unique()` index, useful for enforcing a one-to-one polymorphic relationship.

Fully backwards compatible since no existing methods are modified.