### PR TITLE
[5.7] causes problem when we write unit-test in `cache('foo')`

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -239,7 +239,11 @@ if (! function_exists('cache')) {
         }
 
         if (is_string($arguments[0])) {
-            return app('cache')->get($arguments[0], $arguments[1] ?? null);
+            if (! array_key_exists(1, $arguments)) {
+                return app('cache')->get($arguments[0]);
+            } else {
+                return app('cache')->get($arguments[0], $arguments[1] ?? null);
+            }
         }
 
         if (! is_array($arguments[0])) {

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -26,10 +26,14 @@ class FoundationHelpersTest extends TestCase
         cache(['foo' => 'bar'], 1);
 
         // 3. cache('foo');
-        $cache->shouldReceive('get')->once()->andReturn('bar');
+        $cache->shouldReceive('get')->once()->with('foo')->andReturn('bar');
         $this->assertEquals('bar', cache('foo'));
 
-        // 4. cache('baz', 'default');
+        // 4. cache('foo', null);
+        $cache->shouldReceive('get')->once()->with('foo', null)->andReturn('bar');
+        $this->assertEquals('bar', cache('foo', null));
+
+        // 5. cache('baz', 'default');
         $cache->shouldReceive('get')->once()->with('baz', 'default')->andReturn('default');
         $this->assertEquals('default', cache('baz', 'default'));
     }


### PR DESCRIPTION
https://laravel.com/docs/5.7/facades#facades-vs-helper-functions
> There is absolutely no practical difference between facades and helper functions. When using helper functions, you may still test them exactly as you would the corresponding facade.

The above statement is incorrect in regards to `cache('foo')`

```
public function testBasicExample()
{
    Cache::shouldReceive('get')
         ->with('key')
         ->andReturn('value');

    $this->visit('/cache')
         ->see('value');
}
```
This sample code can’t work because cache method changes parameters.

When we call `cache('foo')`, this method call `Cache::get('foo', null)`. So it causes problem when we write unit-test.