### PR TITLE
[5.8] Resolve Blade facade to named service

### DIFF
--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -31,6 +31,6 @@ class Blade extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return static::$app['view']->getEngineResolver()->resolve('blade')->getCompiler();
+        return 'blade.compiler';
     }
 }


### PR DESCRIPTION
Next shot at #25391.

This time I am sending it to 5.8, so that we have plenty of time to find out if this causes any problems.
Which I doubt, because...

>  I am *assuming* it was just there because the [first version of the `ViewServiceProvider`](https://github.com/laravel/framework/blob/de69bb287c5017d1acb7d47a6db1dedf578036d6/src/Illuminate/View/ViewServiceProvider.php) did not register a binding for the Blade compiler.

Also, I'd love some feedback on this:

> The only other facade that does not return a string from `getFacadeAccessor()` is the [`Schema` facade](https://github.com/laravel/framework/blob/45daf1edc68a7b9708e7c0fd146d81485d7b3a20/src/Illuminate/Support/Facades/Schema.php#L34).
>
> If we replace that logic with a binding (we'd have to register a new one), we could get rid of some complexity because we could require all facades to return a string from that method.