### PR TITLE
[5.7] Fix `withoutMockingConsoleOutput`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -63,7 +63,7 @@ trait InteractsWithConsole
     protected function withoutMockingConsoleOutput()
     {
         $this->mockConsoleOutput = false;
-        
+
         $this->app->offsetUnset(OutputStyle::class);
 
         return $this;

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\PendingCommand;
 
@@ -62,6 +63,8 @@ trait InteractsWithConsole
     protected function withoutMockingConsoleOutput()
     {
         $this->mockConsoleOutput = false;
+        
+        $this->app->offsetUnset(OutputStyle::class);
 
         return $this;
     }


### PR DESCRIPTION
Yesterday https://github.com/laravel/framework/pull/25454 was merged, but [it was changed](https://github.com/laravel/framework/commit/055fe52dbb7169dc51bd5d5deeb05e8da9be0470) so that it mocks console output by default. You can call `withoutMockingConsoleOutput()` if you don't want to mock console output.

The problem with this is that [`PendingCommand`](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Foundation/Testing/PendingCommand.php#L132) binds the mocked `OutputStyle` in the container. This means that running any artisan command (like the `RefreshDatabase` trait does) will permanently mock the console output, causing `withoutMockingConsoleOutput()` to not work.

This PR unbinds the mocked `OutputStyle` from the container when calling `withoutMockingConsoleOutput()`

Also, since the others parts of the framework (such as notifications or the queue) have to be explicitly mocked, is it a better idea to not mock console output by default?