### PR TITLE
[5.7] [WIP] Allow fully qualified class names on routes grouped by namespace

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -529,8 +529,18 @@ class Router implements RegistrarContract, BindingRegistrar
     {
         $group = end($this->groupStack);
 
-        return isset($group['namespace']) && strpos($class, '\\') !== 0 && ! class_exists($class)
-                ? $group['namespace'].'\\'.$class : $class;
+        $classWithNamespace = $group['namespace'].'\\'.$class;
+
+        if (class_exists($classWithNamespace)) {
+            return $classWithNamespace;
+        }
+
+        if (class_exists($class)) {
+            return $class;
+        }
+
+        return isset($group['namespace']) && strpos($class, '\\') !== 0
+            ? $classWithNamespace : $class;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -529,7 +529,7 @@ class Router implements RegistrarContract, BindingRegistrar
     {
         $group = end($this->groupStack);
 
-        return isset($group['namespace']) && strpos($class, '\\') !== 0
+        return isset($group['namespace']) && strpos($class, '\\') !== 0 && ! class_exists($class)
                 ? $group['namespace'].'\\'.$class : $class;
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -529,10 +529,8 @@ class Router implements RegistrarContract, BindingRegistrar
     {
         $group = end($this->groupStack);
 
-        $classWithNamespace = $group['namespace'].'\\'.$class;
-
-        if (class_exists($classWithNamespace)) {
-            return $classWithNamespace;
+        if (isset($group['namespace']) && class_exists($group['namespace'].'\\'.$class)) {
+            return $group['namespace'].'\\'.$class;
         }
 
         if (class_exists($class)) {
@@ -540,7 +538,7 @@ class Router implements RegistrarContract, BindingRegistrar
         }
 
         return isset($group['namespace']) && strpos($class, '\\') !== 0
-            ? $classWithNamespace : $class;
+            ? $group['namespace'].'\\'.$class : $class;
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1454,6 +1454,17 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar2', 'GET'))->getContent());
     }
 
+    public function testDispatchingCallableActionClassesWithFullyQualifiedClassName()
+    {
+        $router = $this->getRouter();
+
+        $router->group(['namespace' => '\\App\\FakeNamespace'], function () use ($router) {
+            $router->get('foo/bar', ActionStub::class);
+        });
+
+        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+    }
+
     public function testResponseIsReturned()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
routes file declared with a group namespace cannot use fully qualified class names.

In example:

```
// routes/web.php
Route::get('users', \App\Http\Controllers\UsersIndexController::class);
```

This will fail because the Router component will concatenate the namespace to the action, having this result as action: `App\Http\Controllers\App\Http\Controllers\UsersIndexController`

This code will check if the class is a valid existing class name, and if it does it will not concatenate the grouped namespace before the action.