### PR TITLE
[5.7] Fix DurationLimiter not using Redis connection proxy to call eval command

### DIFF
--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -99,9 +99,9 @@ class DurationLimiter
      */
     public function acquire()
     {
-        $results = $this->redis->command('eval', [
-            $this->luaScript(), 1, $this->name, microtime(true), time(), $this->decay, $this->maxLocks,
-        ]);
+        $results = $this->redis->eval(
+            $this->luaScript(), 1, $this->name, microtime(true), time(), $this->decay, $this->maxLocks
+        );
 
         $this->decaysAt = $results[1];
 


### PR DESCRIPTION
This is a partial revert from #23225 and fix for #25456.

This currently breaks using `Redis::throttle()` functionality when using the `phpredis` driver on 5.7.