### PR TITLE
[5.6] Fix the replace placeholder methods for the the comparison rules (gt/lt/gte/lte).

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -259,7 +259,11 @@ trait ReplacesAttributes
      */
     protected function replaceGt($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
+        if (is_null($value = $this->getValue($parameters[0]))) {
+            return str_replace(':value', $parameters[0], $message);
+        }
+
+        return str_replace(':value', $this->getSize($parameters[0], $value), $message);
     }
 
     /**
@@ -273,7 +277,11 @@ trait ReplacesAttributes
      */
     protected function replaceLt($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
+        if (is_null($value = $this->getValue($parameters[0]))) {
+            return str_replace(':value', $parameters[0], $message);
+        }
+
+        return str_replace(':value', $this->getSize($parameters[0], $value), $message);
     }
 
     /**
@@ -287,7 +295,11 @@ trait ReplacesAttributes
      */
     protected function replaceGte($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
+        if (is_null($value = $this->getValue($parameters[0]))) {
+            return str_replace(':value', $parameters[0], $message);
+        }
+
+        return str_replace(':value', $this->getSize($parameters[0], $value), $message);
     }
 
     /**
@@ -301,7 +313,11 @@ trait ReplacesAttributes
      */
     protected function replaceLte($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
+        if (is_null($value = $this->getValue($parameters[0]))) {
+            return str_replace(':value', $parameters[0], $message);
+        }
+
+        return str_replace(':value', $this->getSize($parameters[0], $value), $message);
     }
 
     /**


### PR DESCRIPTION
This PR fixes #25481, basically the replaceMethod will check for the attribute if not present it will replace the placeholder with the passed value.
