### PR TITLE
[5.8] Remove superfluous getDefaultNamespace method

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -126,17 +126,6 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Get the default namespace for the class.
-     *
-     * @param  string  $rootNamespace
-     * @return string
-     */
-    protected function getDefaultNamespace($rootNamespace)
-    {
-        return $rootNamespace;
-    }
-
-    /**
      * Get the console command options.
      *
      * @return array


### PR DESCRIPTION
`getDefaultNamespace` method in `Illuminate\Foundation\Console\ModelMakeCommand` class is exactly the same as one in the parent class `Illuminate\Console\GeneratorCommand`. This PR is just a minor cleanup. I am not aware of any circumstances under which it could be a breaking change.