### PR TITLE
[5.8] Register binding for schema facade

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -65,6 +65,10 @@ class DatabaseServiceProvider extends ServiceProvider
         $this->app->bind('db.connection', function ($app) {
             return $app['db']->connection();
         });
+
+        $this->app->bind('db.schema', function ($app) {
+            return $app['db']->connection()->getSchemaBuilder();
+        });
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -25,12 +25,12 @@ class Schema extends Facade
     }
 
     /**
-     * Get a schema builder instance for the default connection.
+     * Get the registered name of the component.
      *
-     * @return \Illuminate\Database\Schema\Builder
+     * @return string
      */
     protected static function getFacadeAccessor()
     {
-        return static::$app['db']->connection()->getSchemaBuilder();
+        return 'db.schema';
     }
 }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -32,6 +32,9 @@ class DatabaseMigratorIntegrationTest extends TestCase
 
         $container = new \Illuminate\Container\Container;
         $container->instance('db', $db->getDatabaseManager());
+        $container->bind('db.schema', function ($c) {
+            return $c['db']->connection()->getSchemaBuilder();
+        });
         \Illuminate\Support\Facades\Facade::setFacadeApplication($container);
 
         $this->migrator = new Migrator(


### PR DESCRIPTION
As proposed in #25391 and #25497, this registers a binding in the container that the `Schema` facade can use.

This means all facades in Laravel's core use strings to describe the facade root, which could let us remove some complexity from the base facade class in a next step. :smiley: 

**Open question:**
- Do we want to register an alias for this binding? That would be `\Illuminate\Database\Schema\Builder` in this case.