### PR TITLE
[5.7] Replace all placeholders for comparison rules (gt/gte/lt/lte) properly

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -259,7 +259,11 @@ trait ReplacesAttributes
      */
     protected function replaceGt($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
+        if (is_null($value = $this->getValue($parameters[0]))) {
+            return str_replace(':value', $parameters[0], $message);
+        }
+
+        return str_replace(':value', $this->getSize($parameters[0], $value), $message);
     }
 
     /**
@@ -273,7 +277,11 @@ trait ReplacesAttributes
      */
     protected function replaceLt($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
+        if (is_null($value = $this->getValue($parameters[0]))) {
+            return str_replace(':value', $parameters[0], $message);
+        }
+
+        return str_replace(':value', $this->getSize($parameters[0], $value), $message);
     }
 
     /**
@@ -287,7 +295,11 @@ trait ReplacesAttributes
      */
     protected function replaceGte($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
+        if (is_null($value = $this->getValue($parameters[0]))) {
+            return str_replace(':value', $parameters[0], $message);
+        }
+
+        return str_replace(':value', $this->getSize($parameters[0], $value), $message);
     }
 
     /**
@@ -301,7 +313,11 @@ trait ReplacesAttributes
      */
     protected function replaceLte($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':value', $this->getSize($parameters[0], $this->getValue($parameters[0])), $message);
+        if (is_null($value = $this->getValue($parameters[0]))) {
+            return str_replace(':value', $parameters[0], $message);
+        }
+
+        return str_replace(':value', $this->getSize($parameters[0], $value), $message);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -263,7 +263,7 @@ trait ReplacesAttributes
             return str_replace(':value', $parameters[0], $message);
         }
 
-        return str_replace(':value', $this->getSize($parameters[0], $value), $message);
+        return str_replace(':value', $this->getSize($attribute, $value), $message);
     }
 
     /**
@@ -281,7 +281,7 @@ trait ReplacesAttributes
             return str_replace(':value', $parameters[0], $message);
         }
 
-        return str_replace(':value', $this->getSize($parameters[0], $value), $message);
+        return str_replace(':value', $this->getSize($attribute, $value), $message);
     }
 
     /**
@@ -299,7 +299,7 @@ trait ReplacesAttributes
             return str_replace(':value', $parameters[0], $message);
         }
 
-        return str_replace(':value', $this->getSize($parameters[0], $value), $message);
+        return str_replace(':value', $this->getSize($attribute, $value), $message);
     }
 
     /**
@@ -317,7 +317,7 @@ trait ReplacesAttributes
             return str_replace(':value', $parameters[0], $message);
         }
 
-        return str_replace(':value', $this->getSize($parameters[0], $value), $message);
+        return str_replace(':value', $this->getSize($attribute, $value), $message);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1533,6 +1533,154 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('file', $v->messages()->first('photo'));
     }
 
+    public function testValidateGtPlaceHolderIsReplacedProperly()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines([
+            'validation.gt.numeric' => ':value',
+            'validation.gt.string' => ':value',
+            'validation.gt.file' => ':value',
+            'validation.gt.array' => ':value'
+        ], 'en');
+
+        $v = new Validator($trans, ['items' => '3'], ['items' => 'gt:4']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(4, $v->messages()->first('items'));
+
+        $v = new Validator($trans, ['items' => 3, 'more' => 5], ['items' => 'numeric|gt:more']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(5, $v->messages()->first('items'));
+
+        $v = new Validator($trans, ['items' => 'abc', 'more' => 'abcde'], ['items' => 'gt:more']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(5, $v->messages()->first('items'));
+
+        $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file->expects($this->any())->method('getSize')->will($this->returnValue(4072));
+        $file->expects($this->any())->method('isValid')->will($this->returnValue(true));
+        $biggerFile = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $biggerFile->expects($this->any())->method('getSize')->will($this->returnValue(5120));
+        $biggerFile->expects($this->any())->method('isValid')->will($this->returnValue(true));
+        $v = new Validator($trans, ['photo' => $file, 'bigger' => $biggerFile], ['photo' => 'file|gt:bigger']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(5, $v->messages()->first('photo'));
+
+        $v = new Validator($trans, ['items' => [1,2,3], 'more' => [0,1,2,3]], ['items' => 'gt:more']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(4, $v->messages()->first('items'));
+    }
+
+    public function testValidateLtPlaceHolderIsReplacedProperly()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines([
+            'validation.lt.numeric' => ':value',
+            'validation.lt.string' => ':value',
+            'validation.lt.file' => ':value',
+            'validation.lt.array' => ':value'
+        ], 'en');
+
+        $v = new Validator($trans, ['items' => '3'], ['items' => 'lt:2']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(2, $v->messages()->first('items'));
+
+        $v = new Validator($trans, ['items' => 3, 'less' => 2], ['items' => 'numeric|lt:less']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(2, $v->messages()->first('items'));
+
+        $v = new Validator($trans, ['items' => 'abc', 'less' => 'ab'], ['items' => 'lt:less']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(2, $v->messages()->first('items'));
+
+        $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file->expects($this->any())->method('getSize')->will($this->returnValue(4072));
+        $file->expects($this->any())->method('isValid')->will($this->returnValue(true));
+        $smallerFile = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $smallerFile->expects($this->any())->method('getSize')->will($this->returnValue(2048));
+        $smallerFile->expects($this->any())->method('isValid')->will($this->returnValue(true));
+        $v = new Validator($trans, ['photo' => $file, 'smaller' => $smallerFile], ['photo' => 'file|lt:smaller']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(2, $v->messages()->first('photo'));
+
+        $v = new Validator($trans, ['items' => [1,2,3], 'less' => [0,1]], ['items' => 'lt:less']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(2, $v->messages()->first('items'));
+    }
+
+    public function testValidateGtePlaceHolderIsReplacedProperly()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines([
+            'validation.gte.numeric' => ':value',
+            'validation.gte.string' => ':value',
+            'validation.gte.file' => ':value',
+            'validation.gte.array' => ':value'
+        ], 'en');
+
+        $v = new Validator($trans, ['items' => '3'], ['items' => 'gte:4']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(4, $v->messages()->first('items'));
+
+        $v = new Validator($trans, ['items' => 3, 'more' => 5], ['items' => 'numeric|gte:more']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(5, $v->messages()->first('items'));
+
+        $v = new Validator($trans, ['items' => 'abc', 'more' => 'abcde'], ['items' => 'gte:more']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(5, $v->messages()->first('items'));
+
+        $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file->expects($this->any())->method('getSize')->will($this->returnValue(4072));
+        $file->expects($this->any())->method('isValid')->will($this->returnValue(true));
+        $biggerFile = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $biggerFile->expects($this->any())->method('getSize')->will($this->returnValue(5120));
+        $biggerFile->expects($this->any())->method('isValid')->will($this->returnValue(true));
+        $v = new Validator($trans, ['photo' => $file, 'bigger' => $biggerFile], ['photo' => 'file|gte:bigger']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(5, $v->messages()->first('photo'));
+
+        $v = new Validator($trans, ['items' => [1,2,3], 'more' => [0,1,2,3]], ['items' => 'gte:more']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(4, $v->messages()->first('items'));
+    }
+
+    public function testValidateLtePlaceHolderIsReplacedProperly()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines([
+            'validation.lte.numeric' => ':value',
+            'validation.lte.string' => ':value',
+            'validation.lte.file' => ':value',
+            'validation.lte.array' => ':value'
+        ], 'en');
+
+        $v = new Validator($trans, ['items' => '3'], ['items' => 'lte:2']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(2, $v->messages()->first('items'));
+
+        $v = new Validator($trans, ['items' => 3, 'less' => 2], ['items' => 'numeric|lte:less']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(2, $v->messages()->first('items'));
+
+        $v = new Validator($trans, ['items' => 'abc', 'less' => 'ab'], ['items' => 'lte:less']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(2, $v->messages()->first('items'));
+
+        $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file->expects($this->any())->method('getSize')->will($this->returnValue(4072));
+        $file->expects($this->any())->method('isValid')->will($this->returnValue(true));
+        $smallerFile = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $smallerFile->expects($this->any())->method('getSize')->will($this->returnValue(2048));
+        $smallerFile->expects($this->any())->method('isValid')->will($this->returnValue(true));
+        $v = new Validator($trans, ['photo' => $file, 'smaller' => $smallerFile], ['photo' => 'file|lte:smaller']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(2, $v->messages()->first('photo'));
+
+        $v = new Validator($trans, ['items' => [1,2,3], 'less' => [0,1]], ['items' => 'lte:less']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(2, $v->messages()->first('items'));
+    }
+
     public function testValidateIn()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1540,7 +1540,7 @@ class ValidationValidatorTest extends TestCase
             'validation.gt.numeric' => ':value',
             'validation.gt.string' => ':value',
             'validation.gt.file' => ':value',
-            'validation.gt.array' => ':value'
+            'validation.gt.array' => ':value',
         ], 'en');
 
         $v = new Validator($trans, ['items' => '3'], ['items' => 'gt:4']);
@@ -1565,7 +1565,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $this->assertEquals(5, $v->messages()->first('photo'));
 
-        $v = new Validator($trans, ['items' => [1,2,3], 'more' => [0,1,2,3]], ['items' => 'gt:more']);
+        $v = new Validator($trans, ['items' => [1, 2, 3], 'more' => [0, 1, 2, 3]], ['items' => 'gt:more']);
         $this->assertFalse($v->passes());
         $this->assertEquals(4, $v->messages()->first('items'));
     }
@@ -1577,7 +1577,7 @@ class ValidationValidatorTest extends TestCase
             'validation.lt.numeric' => ':value',
             'validation.lt.string' => ':value',
             'validation.lt.file' => ':value',
-            'validation.lt.array' => ':value'
+            'validation.lt.array' => ':value',
         ], 'en');
 
         $v = new Validator($trans, ['items' => '3'], ['items' => 'lt:2']);
@@ -1602,7 +1602,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $this->assertEquals(2, $v->messages()->first('photo'));
 
-        $v = new Validator($trans, ['items' => [1,2,3], 'less' => [0,1]], ['items' => 'lt:less']);
+        $v = new Validator($trans, ['items' => [1, 2, 3], 'less' => [0, 1]], ['items' => 'lt:less']);
         $this->assertFalse($v->passes());
         $this->assertEquals(2, $v->messages()->first('items'));
     }
@@ -1614,7 +1614,7 @@ class ValidationValidatorTest extends TestCase
             'validation.gte.numeric' => ':value',
             'validation.gte.string' => ':value',
             'validation.gte.file' => ':value',
-            'validation.gte.array' => ':value'
+            'validation.gte.array' => ':value',
         ], 'en');
 
         $v = new Validator($trans, ['items' => '3'], ['items' => 'gte:4']);
@@ -1639,7 +1639,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $this->assertEquals(5, $v->messages()->first('photo'));
 
-        $v = new Validator($trans, ['items' => [1,2,3], 'more' => [0,1,2,3]], ['items' => 'gte:more']);
+        $v = new Validator($trans, ['items' => [1, 2, 3], 'more' => [0, 1, 2, 3]], ['items' => 'gte:more']);
         $this->assertFalse($v->passes());
         $this->assertEquals(4, $v->messages()->first('items'));
     }
@@ -1651,7 +1651,7 @@ class ValidationValidatorTest extends TestCase
             'validation.lte.numeric' => ':value',
             'validation.lte.string' => ':value',
             'validation.lte.file' => ':value',
-            'validation.lte.array' => ':value'
+            'validation.lte.array' => ':value',
         ], 'en');
 
         $v = new Validator($trans, ['items' => '3'], ['items' => 'lte:2']);
@@ -1676,7 +1676,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $this->assertEquals(2, $v->messages()->first('photo'));
 
-        $v = new Validator($trans, ['items' => [1,2,3], 'less' => [0,1]], ['items' => 'lte:less']);
+        $v = new Validator($trans, ['items' => [1, 2, 3], 'less' => [0, 1]], ['items' => 'lte:less']);
         $this->assertFalse($v->passes());
         $this->assertEquals(2, $v->messages()->first('items'));
     }


### PR DESCRIPTION
The bug is explained here #25481. TLDR; The replacer method replaces the place holder with a 0 instead of the actual value that we're comparing against.