### PR TITLE
Print SQL query with bindings

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2895,8 +2895,8 @@ class Builder
             return $sql;
         }
 
-        array_walk($bindings, function($value) use (&$sql) {
-            $value = is_string($value)? var_export($value, true) : $value;
+        array_walk($bindings, function ($value) use (&$sql) {
+            $value = is_string($value) ? var_export($value, true) : $value;
 
             $sql = preg_replace("/\?/", $value, $sql, 1);
         });

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2885,7 +2885,7 @@ class Builder
      *
      * @return string
      */
-    public function toSqlBinded()
+    public function toSqlBound()
     {
         $sql = $this->toSql();
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2891,13 +2891,13 @@ class Builder
 
         $bindings = $this->getBindings();
 
-        if(count($bindings) == 0) {
+        if (count($bindings) == 0) {
             return $sql;
         }
 
         array_walk($bindings, function($value) use (&$sql) {
             $value = is_string($value)? var_export($value, true) : $value;
-            
+
             $sql = preg_replace("/\?/", $value, $sql, 1);
         });
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2879,4 +2879,28 @@ class Builder
 
         static::throwBadMethodCallException($method);
     }
+
+    /**
+     * Print SQL query with bindings.
+     *
+     * @return string
+     */
+    public function toSqlBinded()
+    {
+        $sql = $this->toSql();
+
+        $bindings = $this->getBindings();
+
+        if(count($bindings) == 0) {
+            return $sql;
+        }
+
+        array_walk($bindings, function($value) use (&$sql) {
+            $value = is_string($value)? var_export($value, true) : $value;
+            
+            $sql = preg_replace("/\?/", $value, $sql, 1);
+        });
+
+        return $sql;
+    }
 }


### PR DESCRIPTION
This PR, will help developpers to see the SQL query with the bindings.

How to use it : 

$query = DB::table('users')->where('email', "blaBla")->where('id', 1);
$query->toSqlBound()

Result : 

select * from `users` where `email` = 'blaBla' and `id` = 1