### PR TITLE
[5.8] Support JSON queries on MariaDB

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -966,15 +966,16 @@ class Grammar extends BaseGrammar
      * Split the given JSON selector into the field and the optional path and wrap them separately.
      *
      * @param  string  $column
+     * @param  string  $delimiter
      * @return array
      */
-    protected function wrapJsonFieldAndPath($column)
+    protected function wrapJsonFieldAndPath($column, $delimiter = '->')
     {
-        $parts = explode('->', $column, 2);
+        $parts = explode($delimiter, $column, 2);
 
         $field = $this->wrap($parts[0]);
 
-        $path = count($parts) > 1 ? ', '.$this->wrapJsonPath($parts[1]) : '';
+        $path = count($parts) > 1 ? ', '.$this->wrapJsonPath($parts[1], $delimiter) : '';
 
         return [$field, $path];
     }
@@ -983,11 +984,12 @@ class Grammar extends BaseGrammar
      * Wrap the given JSON path.
      *
      * @param  string  $value
+     * @param  string  $delimiter
      * @return string
      */
-    protected function wrapJsonPath($value)
+    protected function wrapJsonPath($value, $delimiter = '->')
     {
-        return '\'$."'.str_replace('->', '"."', $value).'"\'';
+        return '\'$."'.str_replace($delimiter, '"."', $value).'"\'';
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -297,11 +297,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function wrapJsonSelector($value)
     {
-        $parts = explode('->', $value, 2);
-
-        $field = $this->wrap($parts[0]);
-
-        $path = count($parts) > 1 ? ', '.$this->wrapJsonPath($parts[1]) : '';
+        list($field, $path) = $this->wrapJsonFieldAndPath($value);
 
         $selector = 'json_extract('.$field.$path.')';
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -476,11 +476,9 @@ class SqlServerGrammar extends Grammar
      */
     protected function wrapJsonSelector($value)
     {
-        $parts = explode('->', $value, 2);
+        list($field, $path) = $this->wrapJsonFieldAndPath($value);
 
-        $field = $this->wrapSegments(explode('.', array_shift($parts)));
-
-        return 'json_value('.$field.', '.$this->wrapJsonPath($parts[0]).')';
+        return 'json_value('.$field.$path.')';
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2003,7 +2003,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->sku', '=', 'foo-bar');
-        $this->assertEquals('select * from `users` where `items`->\'$."sku"\' = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where json_extract(`items`, \'$."sku"\') = ?', $builder->toSql());
         $this->assertCount(1, $builder->getRawBindings()['where']);
         $this->assertEquals('foo-bar', $builder->getRawBindings()['where'][0]);
     }
@@ -2012,35 +2012,41 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price', '=', 1);
-        $this->assertEquals('select * from `users` where `items`->\'$."price"\' = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where json_extract(`items`, \'$."price"\') = ?', $builder->toSql());
     }
 
     public function testMySqlWrappingJsonWithDouble()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price', '=', 1.5);
-        $this->assertEquals('select * from `users` where `items`->\'$."price"\' = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where json_extract(`items`, \'$."price"\') = ?', $builder->toSql());
     }
 
     public function testMySqlWrappingJsonWithBoolean()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true);
-        $this->assertEquals('select * from `users` where `items`->\'$."available"\' = true', $builder->toSql());
+        $this->assertEquals('select * from `users` where json_extract(`items`, \'$."available"\') = true', $builder->toSql());
     }
 
     public function testMySqlWrappingJsonWithBooleanAndIntegerThatLooksLikeOne()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true)->where('items->active', '=', false)->where('items->number_available', '=', 0);
-        $this->assertEquals('select * from `users` where `items`->\'$."available"\' = true and `items`->\'$."active"\' = false and `items`->\'$."number_available"\' = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where json_extract(`items`, \'$."available"\') = true and json_extract(`items`, \'$."active"\') = false and json_extract(`items`, \'$."number_available"\') = ?', $builder->toSql());
     }
 
     public function testMySqlWrappingJsonWithoutQuote()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->>sku', '=', 'foo-bar');
-        $this->assertEquals('select * from `users` where `items`->>\'$."sku"\' = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where json_unquote(json_extract(`items`, \'$."sku"\')) = ?', $builder->toSql());
+        $this->assertCount(1, $builder->getRawBindings()['where']);
+        $this->assertEquals('foo-bar', $builder->getRawBindings()['where'][0]);
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->where('items->>price->>in_usd', '=', 'foo-bar');
+        $this->assertEquals('select * from `users` where json_unquote(json_extract(`items`, \'$."price"."in_usd"\')) = ?', $builder->toSql());
         $this->assertCount(1, $builder->getRawBindings()['where']);
         $this->assertEquals('foo-bar', $builder->getRawBindings()['where'][0]);
     }
@@ -2053,15 +2059,15 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getMySqlBuilder();
         $builder->select('items->price')->from('users')->where('users.items->price', '=', 1)->orderBy('items->price');
-        $this->assertEquals('select `items`->\'$."price"\' from `users` where `users`.`items`->\'$."price"\' = ? order by `items`->\'$."price"\' asc', $builder->toSql());
+        $this->assertEquals('select json_extract(`items`, \'$."price"\') from `users` where json_extract(`users`.`items`, \'$."price"\') = ? order by json_extract(`items`, \'$."price"\') asc', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
-        $this->assertEquals('select * from `users` where `items`->\'$."price"."in_usd"\' = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where json_extract(`items`, \'$."price"."in_usd"\') = ?', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1)->where('items->age', '=', 2);
-        $this->assertEquals('select * from `users` where `items`->\'$."price"."in_usd"\' = ? and `items`->\'$."age"\' = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where json_extract(`items`, \'$."price"."in_usd"\') = ? and json_extract(`items`, \'$."age"\') = ?', $builder->toSql());
     }
 
     public function testPostgresWrappingJson()
@@ -2689,12 +2695,12 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereJsonContains('users.options->languages', ['en']);
-        $this->assertEquals('select * from `users` where json_contains(`users`.`options`->\'$."languages"\', ?)', $builder->toSql());
+        $this->assertEquals('select * from `users` where json_contains(`users`.`options`, ?, \'$."languages"\')', $builder->toSql());
         $this->assertEquals(['["en"]'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonContains('options->languages', new Raw("'[\"en\"]'"));
-        $this->assertEquals('select * from `users` where `id` = ? or json_contains(`options`->\'$."languages"\', \'["en"]\')', $builder->toSql());
+        $this->assertEquals('select * from `users` where `id` = ? or json_contains(`options`, \'["en"]\', \'$."languages"\')', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
     }
 
@@ -2747,12 +2753,12 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereJsonDoesntContain('options->languages', ['en']);
-        $this->assertEquals('select * from `users` where not json_contains(`options`->\'$."languages"\', ?)', $builder->toSql());
+        $this->assertEquals('select * from `users` where not json_contains(`options`, ?, \'$."languages"\')', $builder->toSql());
         $this->assertEquals(['["en"]'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonDoesntContain('options->languages', new Raw("'[\"en\"]'"));
-        $this->assertEquals('select * from `users` where `id` = ? or not json_contains(`options`->\'$."languages"\', \'["en"]\')', $builder->toSql());
+        $this->assertEquals('select * from `users` where `id` = ? or not json_contains(`options`, \'["en"]\', \'$."languages"\')', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
     }
 


### PR DESCRIPTION
Laravel uses the `->` operator to query JSON columns on MySQL:

```sql
select * from `users` where `options`->'$."language"' = ?
```

This operator is specific to MySQL and not available on MariaDB. We can support both databases by using the `JSON_EXTRACT()` function instead ([MySQL](https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#function_json-extract), [MariaDB](https://mariadb.com/kb/en/library/json_extract/)):

```sql
select * from `users` where json_extract(`options`, '$."language"') = ?
```

From the MySQL documentation:

 > The -> operator serves as an alias for the JSON_EXTRACT() function [...]

The `->>` operator can be used to unquote the JSON result (`User::select('options->>language')`). In this case, we have to wrap `JSON_EXTRACT()` in `JSON_UNQUOTE()` ([MySQL](https://dev.mysql.com/doc/refman/8.0/en/json-modification-functions.html#function_json-unquote), [MariaDB](https://mariadb.com/kb/en/library/json_unquote/)).

For `whereJsonContains()` we have to split the JSON selector into the field and the path and pass the optional path as the third parameter ([MySQL](https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#function_json-contains), [MariaDB](https://mariadb.com/kb/en/library/json_contains/)).

`whereJsonLength()` already supports MariaDB.

This is a breaking change for people who select JSON values without a column alias:

```php
$user = User::select('options->language')->first();
dd($user->{'`options`->\'$."language"\''});
```

This PR also simplifies `SQLiteGrammar` and `SqlServerGrammar` by using `wrapJsonFieldAndPath()`.
