### PR TITLE
Fixed docblock in render method of Mail/Mailable

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -195,7 +195,7 @@ class Mailable implements MailableContract, Renderable
     /**
      * Render the mailable into a view.
      *
-     * @return \Illuminate\View\View
+     * @return string
      */
     public function render()
     {


### PR DESCRIPTION
Just noticed that the `render()` method returns a `string`, and not `\Illuminate\View\View`. 
