### PR TITLE
[5.7] simplify getRedirectUrl method in FormRequest.

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -130,9 +130,11 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
         if ($this->redirect) {
             return $url->to($this->redirect);
-        } elseif ($this->redirectRoute) {
+        }
+        if ($this->redirectRoute) {
             return $url->route($this->redirectRoute);
-        } elseif ($this->redirectAction) {
+        }
+        if ($this->redirectAction) {
             return $url->action($this->redirectAction);
         }
 


### PR DESCRIPTION
We did not have a reason for use `ifelse`statement since if the previous statue is true, then we returned a value.

Also `if` operator faster then `ifelse`,

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
