### PR TITLE
[5.7] Deleted duplicated doc-block from Log Facade.

### DIFF
--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -15,9 +15,6 @@ namespace Illuminate\Support\Facades;
  * @method static mixed channel(string $channel = null)
  * @method static \Psr\Log\LoggerInterface stack(array $channels, string $channel = null)
  *
- * @method static self channel(string $channel)
- * @method static self stack(array $channels)
- *
  * @see \Illuminate\Log\Logger
  */
 class Log extends Facade


### PR DESCRIPTION
This do-block was added to the 5.7 version. Also at the same time, this doc-block was added to the 5.6, so now on 5.7, we have 2 version of doc-block for this methods ;)

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
