### PR TITLE
[5.8] Only allow strings for resolving facade roots

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -145,15 +145,11 @@ abstract class Facade
     /**
      * Resolve the facade root instance from the container.
      *
-     * @param  string|object  $name
+     * @param  string  $name
      * @return mixed
      */
     protected static function resolveFacadeInstance($name)
     {
-        if (is_object($name)) {
-            return $name;
-        }
-
         if (isset(static::$resolvedInstance[$name])) {
             return static::$resolvedInstance[$name];
         }


### PR DESCRIPTION
Because of #25497 and #25512, all facades in core are now properly
using service identifiers (strings) for resolving their "root"
service from the container. This means that the hack for resolving
objects directly can now be removed.

In case you're wondering why this is necessary: As far as I can
tell, facade features like ::swap() did not work with these types
of facades (Blade and Schema), because those methods did not deal
with the possibility of objects being returned.
