### PR TITLE
[5.8] Cache/TaggableStore.php implement `Illuminate\Contracts\Cache\Store`

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Cache;
 
-use Illuminate\Contracts\Cache\Store;
-
-class ApcStore extends TaggableStore implements Store
+class ApcStore extends TaggableStore
 {
     use RetrievesMultipleKeys;
 

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Cache;
 
-use Illuminate\Contracts\Cache\Store;
-
-class ArrayStore extends TaggableStore implements Store
+class ArrayStore extends TaggableStore
 {
     use RetrievesMultipleKeys;
 

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -4,11 +4,10 @@ namespace Illuminate\Cache;
 
 use Memcached;
 use ReflectionMethod;
-use Illuminate\Contracts\Cache\Store;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Contracts\Cache\LockProvider;
 
-class MemcachedStore extends TaggableStore implements LockProvider, Store
+class MemcachedStore extends TaggableStore implements LockProvider
 {
     use InteractsWithTime;
 

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Cache;
 
-use Illuminate\Contracts\Cache\Store;
-
-class NullStore extends TaggableStore implements Store
+class NullStore extends TaggableStore
 {
     use RetrievesMultipleKeys;
 

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -2,10 +2,9 @@
 
 namespace Illuminate\Cache;
 
-use Illuminate\Contracts\Cache\Store;
 use Illuminate\Contracts\Redis\Factory as Redis;
 
-class RedisStore extends TaggableStore implements Store
+class RedisStore extends TaggableStore
 {
     /**
      * The Redis factory implementation.

--- a/src/Illuminate/Cache/TaggableStore.php
+++ b/src/Illuminate/Cache/TaggableStore.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Cache;
 
-abstract class TaggableStore
+use Illuminate\Contracts\Cache\Store;
+
+abstract class TaggableStore implements Store
 {
     /**
      * Begin executing a new tags operation.


### PR DESCRIPTION

 1. within TaggableStore class we have tags method.
 2. Tags method create a `TaggedCache` with first argument `$this`
 3. TaggedCache in constructor first argument has `\Illuminate\Contracts\Cache\Store` type

So TaggableStore should implement `\Illuminate\Contracts\Cache\Store` interface, in other case someone can extend `TaggableStore`, but not implement the `\Illuminate\Contracts\Cache\Store` and `TaggableStore:tags` will be broken.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
