### PR TITLE
[5.7] Fix database cache on PostgreSQL

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -4,8 +4,10 @@ namespace Illuminate\Cache;
 
 use Closure;
 use Exception;
+use Illuminate\Support\Str;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\ConnectionInterface;
 
 class DatabaseStore implements Store
@@ -78,7 +80,7 @@ class DatabaseStore implements Store
             return;
         }
 
-        return unserialize($cache->value);
+        return $this->unserialize($cache->value);
     }
 
     /**
@@ -93,7 +95,7 @@ class DatabaseStore implements Store
     {
         $key = $this->prefix.$key;
 
-        $value = serialize($value);
+        $value = $this->serialize($value);
 
         $expiration = $this->getTime() + (int) ($minutes * 60);
 
@@ -157,7 +159,7 @@ class DatabaseStore implements Store
 
             $cache = is_array($cache) ? (object) $cache : $cache;
 
-            $current = unserialize($cache->value);
+            $current = $this->unserialize($cache->value);
 
             // Here we'll call this callback function that was given to the function which
             // is used to either increment or decrement the function. We use a callback
@@ -172,7 +174,7 @@ class DatabaseStore implements Store
             // since database cache values are encrypted by default with secure storage
             // that can't be easily read. We will return the new value after storing.
             $this->table()->where('key', $prefixed)->update([
-                'value' => serialize($new),
+                'value' => $this->serialize($new),
             ]);
 
             return $new;
@@ -252,5 +254,37 @@ class DatabaseStore implements Store
     public function getPrefix()
     {
         return $this->prefix;
+    }
+
+    /**
+     * Serialize the given value.
+     *
+     * @param  mixed  $value
+     * @return string
+     */
+    protected function serialize($value)
+    {
+        $result = serialize($value);
+
+        if ($this->connection instanceof PostgresConnection && Str::contains($result, "\0")) {
+            $result = base64_encode($result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Unserialize the given value.
+     *
+     * @param  string  $value
+     * @return mixed
+     */
+    protected function unserialize($value)
+    {
+        if ($this->connection instanceof PostgresConnection && ! Str::contains($value, [':', ';'])) {
+            $value = base64_decode($value);
+        }
+
+        return unserialize($value);
     }
 }


### PR DESCRIPTION
Storing serialized objects in the database cache doesn't work on PostgreSQL:

```php
Schema::create('cache', function ($table) {
    $table->string('key')->unique();
    $table->text('value');
    $table->integer('expiration');
});

Cache::put('user', new User(), 1);
Cache::get('user');
```

Retrieving the value throws an exception:

 > unserialize(): Error at offset 21 of 25 bytes

The database cache uses `serialize()` to serialize the value. For objects, the serialization contains null bytes. PostgreSQL can't store null bytes in a text column, truncates the string (`O:8:"App\User":27:{s:11:"`) and thereby breaks the unserialization.

The proposed solution is using Base64 encoding *if* the serialized value contains a null byte. When the value is retrieved, we can detect the Base64 encoding by looking for `:` or `;`. A Base64-encoded string can't contain this characters; a serialized string always contains at least one of them.

I used this to find the possible data type serializations:

```php
dd(
    serialize(null),
    serialize(true),
    serialize(1),
    serialize(1.0),
    serialize('a'),
    serialize([]),
    serialize((object) [])
);
```

This would only be a breaking change if someone was actually using the corrupted serialization – which makes no sense.

An alternative approach is storing the value in a binary column (`bytea`). This would also require changes to the `DatabaseStore` *and* the user would have to adjust the migration. With the Base64 encoding, the user doesn't have to worry about the used database. The only downside is the increased payload size.

Fixes #25466.