### PR TITLE
Middleware priorities were moved to laravel/laravel.

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -70,14 +70,7 @@ class Kernel implements KernelContract
      *
      * @var array
      */
-    protected $middlewarePriority = [
-        \Illuminate\Session\Middleware\StartSession::class,
-        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-        \Illuminate\Auth\Middleware\Authenticate::class,
-        \Illuminate\Session\Middleware\AuthenticateSession::class,
-        \Illuminate\Routing\Middleware\SubstituteBindings::class,
-        \Illuminate\Auth\Middleware\Authorize::class,
-    ];
+    protected $middlewarePriority = [];
 
     /**
      * Create a new HTTP kernel instance.


### PR DESCRIPTION
As we have https://github.com/laravel/laravel/pull/4757 merged for `laravel/laravel`, we need to remove middleware priorities from the `laravel/framework` to have the single point of truth.

We do the same for the `$middleware`, `$middlewareGroups` and `$routeMiddleware` arrays.

PS: Related to an issue https://github.com/laravel/framework/issues/25446.