### PR TITLE
PasswordBroker should not hardcode minimum length of password

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -172,7 +172,7 @@ class PasswordBroker implements PasswordBrokerContract
             $credentials['password_confirmation'],
         ];
 
-        return $password === $confirm && mb_strlen($password) >= 6;
+        return $password === $confirm;
     }
 
     /**


### PR DESCRIPTION
Validation rules for resetting password already exist below.
https://github.com/laravel/framework/blob/5.7/src/Illuminate/Foundation/Auth/ResetsPasswords.php#L69

When I want to set minimum lenght of password to less than 6, I have to override not only [rules](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Foundation/Auth/ResetsPasswords.php#L64) method, but also [reset](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Foundation/Auth/ResetsPasswords.php#L38) method.
It is bothersome.