### PR TITLE
[5.7] Add options for SES Mailer

### DIFF
--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -15,14 +15,23 @@ class SesTransport extends Transport
     protected $ses;
 
     /**
+     * Transmission options.
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    /**
      * Create a new SES transport instance.
      *
      * @param  \Aws\Ses\SesClient  $ses
+     * @param  array  $options
      * @return void
      */
-    public function __construct(SesClient $ses)
+    public function __construct(SesClient $ses, $options = [])
     {
         $this->ses = $ses;
+        $this->options = $options;
     }
 
     /**
@@ -32,17 +41,43 @@ class SesTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
-        $headers = $message->getHeaders();
+        $result = $this->ses->sendRawEmail(
+            array_merge(
+                $this->options,
+                [
+                    'Source' => key($message->getSender() ?: $message->getFrom()),
+                    'RawMessage' => [
+                        'Data' => $message->toString(),
+                    ],
+                ]
+            )
+        );
 
-        $headers->addTextHeader('X-SES-Message-ID', $this->ses->sendRawEmail([
-            'Source' => key($message->getSender() ?: $message->getFrom()),
-            'RawMessage' => [
-                'Data' => $message->toString(),
-            ],
-        ])->get('MessageId'));
+        $message->getHeaders()->addTextHeader('X-SES-Message-ID', $result->get('MessageId'));
 
         $this->sendPerformed($message);
 
         return $this->numberOfRecipients($message);
+    }
+
+    /**
+     * Get the transmission options being used by the transport.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * Set the transmission options being used by the transport.
+     *
+     * @param  array  $options
+     * @return array
+     */
+    public function setOptions(array $options)
+    {
+        return $this->options = $options;
     }
 }

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -77,9 +77,10 @@ class TransportManager extends Manager
             'version' => 'latest', 'service' => 'email',
         ]);
 
-        return new SesTransport(new SesClient(
-            $this->addSesCredentials($config)
-        ));
+        return new SesTransport(
+            new SesClient($this->addSesCredentials($config)),
+            $config['options'] ?? []
+        );
     }
 
     /**


### PR DESCRIPTION
This PR allows the developer to add options to the SES mailer, in a similar fashion that is already possible with SparkPost mailer.

Developer may add their options into `config/services.php` like so:

```php
    'ses' => [
        'key' => env('AWS_S3_KEY'),
        'secret' => env('AWS_S3_SECRET'),
        'region' => env('AWS_S3_REGION', 'eu-west-1'),
        'options' => [
            'ConfigurationSetName' => 'Default',
            'Tags' => [
                [
                    'Name' => 'foo',
                    'Value' => 'bar',
                ]
            ],
        ],
    ],
```

This is particularly useful for `ConfigurationSetName` (needed for SES to send notifications for open and click events) and `Tags`.

If merged, I will subsequently send a PR for updating the doc.