### PR TITLE
[5.7] Auth/Access/Response::__toString method always should return string

### DIFF
--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -35,10 +35,10 @@ class Response
     /**
      * Get the string representation of the message.
      *
-     * @return string|null
+     * @return string
      */
     public function __toString()
     {
-        return $this->message();
+        return (string) $this->message();
     }
 }

--- a/tests/Auth/AuthAccessResponseTest.php
+++ b/tests/Auth/AuthAccessResponseTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Tests\Auth;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Auth\Access\Response;
+
+class AuthAccessResponseTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testStringMethodWillReturnString()
+    {
+        $response = new Response('some data');
+        $this->assertSame('some data', (string) $response);
+
+        $response = new Response();
+        $this->assertSame('', (string) $response);
+    }
+}


### PR DESCRIPTION
 __toString should return a string, in other cases, it will emit the FatalError.

in $this->message() we can have a null value, and this will emit an Error
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
