### PR TITLE
[5.7] Stop sending email verification if user already verified

### DIFF
--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -46,6 +46,10 @@ trait VerifiesEmails
      */
     public function resend(Request $request)
     {
+        if ($request->user()->hasVerifiedEmail()) {
+            return redirect($this->redirectPath());
+        }
+
         $request->user()->sendEmailVerificationNotification();
 
         return back()->with('resent', true);


### PR DESCRIPTION
Laravel will keep sending email verification even if the user already verified. This PR will stop sending email verification if user's email already verified.