### PR TITLE
[5.7] Output schedule tasks run time just like queue job

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -79,7 +79,7 @@ class ScheduleRunCommand extends Command
         }
 
         if (! $this->eventsRan) {
-            $this->info('No scheduled commands are ready to run.');
+            $this->info($this->nowString().' No scheduled commands are ready to run.');
         }
     }
 
@@ -94,7 +94,7 @@ class ScheduleRunCommand extends Command
         if ($this->schedule->serverShouldRun($event, $this->startedAt)) {
             $this->runEvent($event);
         } else {
-            $this->line('<info>Skipping command (has already run on another server):</info> '.$event->getSummaryForDisplay());
+            $this->line('<info>'.$this->nowString().' Skipping command (has already run on another server):</info> '.$event->getSummaryForDisplay());
         }
     }
 
@@ -106,10 +106,23 @@ class ScheduleRunCommand extends Command
      */
     protected function runEvent($event)
     {
-        $this->line('<info>Running scheduled command:</info> '.$event->getSummaryForDisplay());
+        $summary = $event->getSummaryForDisplay();
+        $this->line('<info>'.$this->nowString().' Running scheduled command:</info> '.$summary);
 
         $event->run($this->laravel);
 
+        $this->line('<info>'.$this->nowString().' Scheduled command finished:</info> '.$summary);
+
         $this->eventsRan = true;
+    }
+
+    /**
+     * Return string format for current date time.
+     *
+     * @return string
+     */
+    protected function nowString(): string
+    {
+        return '['.Carbon::now()->format('Y-m-d H:i:s').']';
     }
 }


### PR DESCRIPTION
The current output of `schedule:run` is like

```
Running scheduled command: '/usr/bin/php7.2' 'artisan' task1-name > '/dev/null' 2>&1
No scheduled commands are ready to run.
No scheduled commands are ready to run.
No scheduled commands are ready to run.
No scheduled commands are ready to run.
Running scheduled command: '/usr/bin/php7.2' 'artisan' task2-name > '/dev/null' 2>&1
No scheduled commands are ready to run.
No scheduled commands are ready to run.
```

We don't know the exact time of task running.

This PR adds a DateTime string at the beginning of the output:

```
[2018-09-10 06:20:01] Running scheduled command: '/usr/bin/php7.2' 'artisan' cron:test-task-1-min > '/dev/null' 2>&1
[2018-09-10 06:20:02] Scheduled command finished: '/usr/bin/php7.2' 'artisan' cron:test-task-1-min > '/dev/null' 2>&1
[2018-09-10 06:20:02] Running scheduled command: '/usr/bin/php7.2' 'artisan' cron:test-task-2-min > '/dev/null' 2>&1
[2018-09-10 06:20:05] Scheduled command finished: '/usr/bin/php7.2' 'artisan' cron:test-task-2-min > '/dev/null' 2>&1
[2018-09-10 06:20:05] Running scheduled command: '/usr/bin/php7.2' 'artisan' cron:test-task-5-min > '/dev/null' 2>&1
[2018-09-10 06:20:10] Scheduled command finished: '/usr/bin/php7.2' 'artisan' cron:test-task-5-min > '/dev/null' 2>&1
[2018-09-10 06:21:01] Running scheduled command: '/usr/bin/php7.2' 'artisan' cron:test-task-1-min > '/dev/null' 2>&1
[2018-09-10 06:21:02] Scheduled command finished: '/usr/bin/php7.2' 'artisan' cron:test-task-1-min > '/dev/null' 2>&1
[2018-09-10 06:22:01] Running scheduled command: '/usr/bin/php7.2' 'artisan' cron:test-task-1-min > '/dev/null' 2>&1
[2018-09-10 06:22:03] Scheduled command finished: '/usr/bin/php7.2' 'artisan' cron:test-task-1-min > '/dev/null' 2>&1
[2018-09-10 06:22:03] Running scheduled command: '/usr/bin/php7.2' 'artisan' cron:test-task-2-min > '/dev/null' 2>&1
[2018-09-10 06:22:05] Scheduled command finished: '/usr/bin/php7.2' 'artisan' cron:test-task-2-min > '/dev/null' 2>&1
```

like what queue worker does, it makes debugging schedule-related problems easier.