### PR TITLE
[5.7] Clean up cache integration tests

### DIFF
--- a/tests/Integration/Cache/MemcachedCacheLockTest.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTest.php
@@ -6,15 +6,12 @@ use Memcached;
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 
 /**
  * @group integration
  */
-class CacheLockTest extends TestCase
+class MemcachedCacheLockTest extends TestCase
 {
-    use InteractsWithRedis;
-
     public function setUp()
     {
         parent::setUp();
@@ -35,19 +32,6 @@ class CacheLockTest extends TestCase
         Cache::store('memcached')->lock('foo')->release();
     }
 
-    public function test_redis_locks_can_be_acquired_and_released()
-    {
-        $this->ifRedisAvailable(function () {
-            Cache::store('redis')->lock('foo')->release();
-            $this->assertTrue(Cache::store('redis')->lock('foo', 10)->get());
-            $this->assertFalse(Cache::store('redis')->lock('foo', 10)->get());
-            Cache::store('redis')->lock('foo')->release();
-            $this->assertTrue(Cache::store('redis')->lock('foo', 10)->get());
-            $this->assertFalse(Cache::store('redis')->lock('foo', 10)->get());
-            Cache::store('redis')->lock('foo')->release();
-        });
-    }
-
     public function test_memcached_locks_can_block_for_seconds()
     {
         Carbon::setTestNow();
@@ -59,21 +43,6 @@ class CacheLockTest extends TestCase
 
         Cache::store('memcached')->lock('foo')->release();
         $this->assertTrue(Cache::store('memcached')->lock('foo', 10)->block(1));
-    }
-
-    public function test_redis_locks_can_block_for_seconds()
-    {
-        $this->ifRedisAvailable(function () {
-            Carbon::setTestNow();
-
-            Cache::store('redis')->lock('foo')->release();
-            $this->assertEquals('taylor', Cache::store('redis')->lock('foo', 10)->block(1, function () {
-                return 'taylor';
-            }));
-
-            Cache::store('redis')->lock('foo')->release();
-            $this->assertTrue(Cache::store('redis')->lock('foo', 10)->block(1));
-        });
     }
 
     public function test_locks_can_run_callbacks()

--- a/tests/Integration/Cache/MemcachedCacheLockTest.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
+use Memcached;
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Cache;
@@ -18,6 +19,20 @@ class MemcachedCacheLockTest extends TestCase
         if (! extension_loaded('memcached')) {
             $this->markTestSkipped('Memcached module not installed');
         }
+
+        // Determine whether there is a running Memcached instance
+        $testConnection = new Memcached;
+        $testConnection->addServer(
+            env('MEMCACHED_HOST', '127.0.0.1'),
+            env('MEMCACHED_PORT', 11211)
+        );
+        $testConnection->getVersion();
+
+        if ($testConnection->getResultCode() > Memcached::RES_SUCCESS) {
+            $this->markTestSkipped('Memcached could not establish a connection');
+        }
+
+        $testConnection->quit();
     }
 
     public function test_memcached_locks_can_be_acquired_and_released()

--- a/tests/Integration/Cache/MemcachedCacheLockTest.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
-use Memcached;
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Cache;
@@ -16,7 +15,7 @@ class MemcachedCacheLockTest extends TestCase
     {
         parent::setUp();
 
-        if (! class_exists(Memcached::class)) {
+        if (! extension_loaded('memcached')) {
             $this->markTestSkipped('Memcached module not installed');
         }
     }

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -14,31 +14,41 @@ class RedisCacheLockTest extends TestCase
 {
     use InteractsWithRedis;
 
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->setUpRedis();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $this->tearDownRedis();
+    }
+
     public function test_redis_locks_can_be_acquired_and_released()
     {
-        $this->ifRedisAvailable(function () {
-            Cache::store('redis')->lock('foo')->release();
-            $this->assertTrue(Cache::store('redis')->lock('foo', 10)->get());
-            $this->assertFalse(Cache::store('redis')->lock('foo', 10)->get());
-            Cache::store('redis')->lock('foo')->release();
-            $this->assertTrue(Cache::store('redis')->lock('foo', 10)->get());
-            $this->assertFalse(Cache::store('redis')->lock('foo', 10)->get());
-            Cache::store('redis')->lock('foo')->release();
-        });
+        Cache::store('redis')->lock('foo')->release();
+        $this->assertTrue(Cache::store('redis')->lock('foo', 10)->get());
+        $this->assertFalse(Cache::store('redis')->lock('foo', 10)->get());
+        Cache::store('redis')->lock('foo')->release();
+        $this->assertTrue(Cache::store('redis')->lock('foo', 10)->get());
+        $this->assertFalse(Cache::store('redis')->lock('foo', 10)->get());
+        Cache::store('redis')->lock('foo')->release();
     }
 
     public function test_redis_locks_can_block_for_seconds()
     {
-        $this->ifRedisAvailable(function () {
-            Carbon::setTestNow();
+        Carbon::setTestNow();
 
-            Cache::store('redis')->lock('foo')->release();
-            $this->assertEquals('taylor', Cache::store('redis')->lock('foo', 10)->block(1, function () {
-                return 'taylor';
-            }));
+        Cache::store('redis')->lock('foo')->release();
+        $this->assertEquals('taylor', Cache::store('redis')->lock('foo', 10)->block(1, function () {
+            return 'taylor';
+        }));
 
-            Cache::store('redis')->lock('foo')->release();
-            $this->assertTrue(Cache::store('redis')->lock('foo', 10)->block(1));
-        });
+        Cache::store('redis')->lock('foo')->release();
+        $this->assertTrue(Cache::store('redis')->lock('foo', 10)->block(1));
     }
 }

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Cache;
+
+use Illuminate\Support\Carbon;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+
+/**
+ * @group integration
+ */
+class RedisCacheLockTest extends TestCase
+{
+    use InteractsWithRedis;
+
+    public function test_redis_locks_can_be_acquired_and_released()
+    {
+        $this->ifRedisAvailable(function () {
+            Cache::store('redis')->lock('foo')->release();
+            $this->assertTrue(Cache::store('redis')->lock('foo', 10)->get());
+            $this->assertFalse(Cache::store('redis')->lock('foo', 10)->get());
+            Cache::store('redis')->lock('foo')->release();
+            $this->assertTrue(Cache::store('redis')->lock('foo', 10)->get());
+            $this->assertFalse(Cache::store('redis')->lock('foo', 10)->get());
+            Cache::store('redis')->lock('foo')->release();
+        });
+    }
+
+    public function test_redis_locks_can_block_for_seconds()
+    {
+        $this->ifRedisAvailable(function () {
+            Carbon::setTestNow();
+
+            Cache::store('redis')->lock('foo')->release();
+            $this->assertEquals('taylor', Cache::store('redis')->lock('foo', 10)->block(1, function () {
+                return 'taylor';
+            }));
+
+            Cache::store('redis')->lock('foo')->release();
+            $this->assertTrue(Cache::store('redis')->lock('foo', 10)->block(1));
+        });
+    }
+}


### PR DESCRIPTION
**This is #25523 re-targeted at v5.7.**

I noticed the Memcached tests were failing on my machine, because Memcached was not set up properly. The PHP extension was not installed, but could not connect to any server...

I would have expected these to be skipped instead of failing in this scenario.

Other small changes while I was at it:
- Check for Memcached extension to be installed instead of a class to be available (which could, in theory, happen for another reason).
- Split up Memcached and Redis tests, so the latter won't be skipped because the former isn't available.
- For the Redis cache lock tests, use PhpUnit's `setUp` and `tearDown` instead of a custom mechanism.