### PR TITLE
[5.7] Remove unused view tests

### DIFF
--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -96,16 +96,4 @@ class ViewBladeCompilerTest extends TestCase
     {
         return m::mock('Illuminate\Filesystem\Filesystem');
     }
-
-    public function testGetTagsProvider()
-    {
-        return [
-            ['{{', '}}'],
-            ['{{{', '}}}'],
-            ['[[', ']]'],
-            ['[[[', ']]]'],
-            ['((', '))'],
-            ['(((', ')))'],
-        ];
-    }
 }


### PR DESCRIPTION
While I was reading illuminate/view component and it's tests, I found a method called "testGetTagsProvider". I don't know why it is named with "test" as the prefix and "Provider" as the suffix. But it has no meaning and isn't currently used anymore. Therefore, I just help to remove it.

Please explain to me if I miss something important!

Thanks!
