### PR TITLE
[5.8] Support fallback routes for different methods

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -217,14 +217,15 @@ class Router implements RegistrarContract, BindingRegistrar
      * Register a new Fallback route with the router.
      *
      * @param  \Closure|array|string|null  $action
+     * @param  array|string  $methods
      * @return \Illuminate\Routing\Route
      */
-    public function fallback($action)
+    public function fallback($action, $methods = 'GET')
     {
         $placeholder = 'fallbackPlaceholder';
 
         return $this->addRoute(
-            'GET', "{{$placeholder}}", $action
+            $methods, "{{$placeholder}}", $action
         )->where($placeholder, '.*')->fallback();
     }
 

--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -95,4 +95,23 @@ class FallbackRouteTest extends TestCase
         $this->assertContains('one', $this->get('/one')->getContent());
         $this->assertEquals(200, $this->get('/one')->getStatusCode());
     }
+
+    public function test_methods()
+    {
+        Route::fallback(function () {
+            return 'GET';
+        });
+        Route::fallback(function () {
+            return 'POST';
+        }, 'POST');
+
+        $this->get('non-existing')
+            ->assertSee('GET')
+            ->assertOk();
+        $this->post('non-existing')
+            ->assertSee('POST')
+            ->assertOk();
+        $this->put('non-existing')
+            ->assertStatus(405);
+    }
 }


### PR DESCRIPTION
`Route::fallback()` currently only supports `GET` (and `HEAD`) requests.

With this PR, people can use one fallback route for multiple HTTP methods:

```php
Route::fallback('FallbackController@fallback', ['GET', 'POST']);
```

Or they can specify different fallback routes:

```php
Route::fallback('FallbackController@fallbackGet');
Route::fallback('FallbackController@fallbackPost', 'POST');
```

Fixes #25550.