### PR TITLE
[5.7] Fixed phpUnit tests:

### DIFF
--- a/tests/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
+++ b/tests/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
@@ -17,7 +17,7 @@ class AuthListenersSendEmailVerificationNotificationHandleFunctionTest extends T
     {
         $user = $this->getMockBuilder(MustVerifyEmail::class)->getMock();
         $user->method('hasVerifiedEmail')->willReturn(false);
-        $user->expects($this->exactly(1))->method('sendEmailVerificationNotification');
+        $user->expects($this->once())->method('sendEmailVerificationNotification');
 
         $listener = new SendEmailVerificationNotification();
 
@@ -30,7 +30,7 @@ class AuthListenersSendEmailVerificationNotificationHandleFunctionTest extends T
     public function testUserIsNotInstanceOfMustVerifyEmail()
     {
         $user = $this->getMockBuilder(User::class)->getMock();
-        $user->expects($this->exactly(0))->method('sendEmailVerificationNotification');
+        $user->expects($this->never())->method('sendEmailVerificationNotification');
 
         $listener = new SendEmailVerificationNotification();
 
@@ -44,7 +44,7 @@ class AuthListenersSendEmailVerificationNotificationHandleFunctionTest extends T
     {
         $user = $this->getMockBuilder(MustVerifyEmail::class)->getMock();
         $user->method('hasVerifiedEmail')->willReturn(true);
-        $user->expects($this->exactly(0))->method('sendEmailVerificationNotification');
+        $user->expects($this->never())->method('sendEmailVerificationNotification');
 
         $listener = new SendEmailVerificationNotification();
 


### PR DESCRIPTION
 - changed `$this->exactly(1)` to `$this->once()`
 - changed `$this->exactly(0)` to `$this->never()`

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
