### PR TITLE
[5.7] Add Unit test for `Auth/Access/Gate.php:define` when InvalidArgumentException caused;

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -454,6 +454,30 @@ class AuthAccessGateTest extends TestCase
     }
 
     /**
+     * @dataProvider notCallableDataProvider
+     * @expectedException \InvalidArgumentException
+     */
+    public function test_define_second_parametter_should_be_string_or_callable($callback)
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->define('foo', $callback);
+    }
+
+    /**
+     * @return array
+     */
+    public function notCallableDataProvider()
+    {
+        return [
+            [1],
+            [new \stdClass()],
+            [[]],
+            [1.1],
+        ];
+    }
+
+    /**
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
      * @expectedExceptionMessage You are not an admin.
      */


### PR DESCRIPTION
…

 - added unit test for `Auth/Access/Gate.php:define` when InvalidArgumentException caused since we did not have a test for this case;

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
