### PR TITLE
[5.7] Rename method without breaking changes

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -411,11 +411,23 @@ class Event
     }
 
     /**
+     * @deprecated please use ensureOutputIsBeingCaptured
+     *
      * Ensure that output is being captured for email.
      *
      * @return void
      */
     protected function ensureOutputIsBeingCapturedForEmail()
+    {
+        $this->ensureOutputIsBeingCaptured();
+    }
+
+    /**
+     * Ensure that the command output is being captured.
+     *
+     * @return void
+     */
+    protected function ensureOutputIsBeingCaptured()
     {
         if (is_null($this->output) || $this->output == $this->getDefaultOutput()) {
             $this->sendOutputTo(storage_path('logs/schedule-'.sha1($this->mutexName()).'.log'));

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -376,7 +376,7 @@ class Event
      */
     public function emailOutputTo($addresses, $onlyIfOutputExists = false)
     {
-        $this->ensureOutputIsBeingCaptured();
+        $this->ensureOutputIsBeingCapturedForEmail();
 
         $addresses = Arr::wrap($addresses);
 
@@ -399,11 +399,11 @@ class Event
     }
 
     /**
-     * Ensure that the command output is being captured.
+     * Ensure that output is being captured for email.
      *
      * @return void
      */
-    protected function ensureOutputIsBeingCaptured()
+    protected function ensureOutputIsBeingCapturedForEmail()
     {
         if (is_null($this->output) || $this->output == $this->getDefaultOutput()) {
             $this->sendOutputTo(storage_path('logs/schedule-'.sha1($this->mutexName()).'.log'));


### PR DESCRIPTION
This reverts commit 2e01692

@taylorotwell , I have returned the `ensureOutputIsBeingCapturedForEmail` method, since it can be overloading within some app.

I have proposed to delete the method in the 5.8
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
