### PR TITLE
[5.7] Do not pass the guard instance to the authentication events

### DIFF
--- a/src/Illuminate/Auth/Events/Attempting.php
+++ b/src/Illuminate/Auth/Events/Attempting.php
@@ -5,9 +5,9 @@ namespace Illuminate\Auth\Events;
 class Attempting
 {
     /**
-     * The authentication guard implementation.
+     * The authentication guard name.
      *
-     * @var \Illuminate\Contracts\Auth\StatefulGuard
+     * @var string
      */
     public $guard;
 
@@ -28,7 +28,7 @@ class Attempting
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
+     * @param  string  $guard
      * @param  array  $credentials
      * @param  bool  $remember
      * @return void

--- a/src/Illuminate/Auth/Events/Authenticated.php
+++ b/src/Illuminate/Auth/Events/Authenticated.php
@@ -9,9 +9,9 @@ class Authenticated
     use SerializesModels;
 
     /**
-     * The authentication guard implementation.
+     * The authentication guard name.
      *
-     * @var \Illuminate\Contracts\Auth\StatefulGuard
+     * @var string
      */
     public $guard;
 
@@ -25,7 +25,7 @@ class Authenticated
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
+     * @param  string  $guard
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */

--- a/src/Illuminate/Auth/Events/Failed.php
+++ b/src/Illuminate/Auth/Events/Failed.php
@@ -5,9 +5,9 @@ namespace Illuminate\Auth\Events;
 class Failed
 {
     /**
-     * The authentication guard implementation.
+     * The authentication guard name.
      *
-     * @var \Illuminate\Contracts\Auth\StatefulGuard
+     * @var string
      */
     public $guard;
 
@@ -28,7 +28,7 @@ class Failed
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
+     * @param  string  $guard
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @param  array  $credentials
      * @return void

--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -9,9 +9,9 @@ class Login
     use SerializesModels;
 
     /**
-     * The authentication guard implementation.
+     * The authentication guard name.
      *
-     * @var \Illuminate\Contracts\Auth\StatefulGuard
+     * @var string
      */
     public $guard;
 
@@ -32,7 +32,7 @@ class Login
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
+     * @param  string $guard
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  bool  $remember
      * @return void

--- a/src/Illuminate/Auth/Events/Logout.php
+++ b/src/Illuminate/Auth/Events/Logout.php
@@ -9,9 +9,9 @@ class Logout
     use SerializesModels;
 
     /**
-     * The authenticationg guard implementation.
+     * The authentication guard name.
      *
-     * @var \Illuminate\Contracts\Auth\StatefulGuard
+     * @var string
      */
     public $guard;
 
@@ -25,7 +25,7 @@ class Logout
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
+     * @param  string $guard
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -493,7 +493,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         }
 
         if (isset($this->events)) {
-            $this->events->dispatch(new Events\Logout($this, $user));
+            $this->events->dispatch(new Events\Logout($this->name, $user));
         }
 
         // Once we have fired the logout event we will clear the users out of memory
@@ -580,7 +580,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Events\Attempting(
-                $this, $credentials, $remember
+                $this->name, $credentials, $remember
             ));
         }
     }
@@ -596,7 +596,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Events\Login(
-                $this, $user, $remember
+                $this->name, $user, $remember
             ));
         }
     }
@@ -611,7 +611,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Events\Authenticated(
-                $this, $user
+                $this->name, $user
             ));
         }
     }
@@ -627,7 +627,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Events\Failed(
-                $this, $user, $credentials
+                $this->name, $user, $credentials
             ));
         }
     }


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

PR #25261 breaks usage of queued listeners on authentication events as it passes the Guard instance which can contain closure based inner properties thus is not serializable

This PR changes the behavior to pass only the guard name to the events constructors so:
1. The intended feature fro PR #25261  is still present
2. Any queued listeners can be serialized

I am working in the tests right now to prevent future issues
