### PR TITLE
[5.7] Move Unit tests from Auth folder to Unit/Auth folder.

### DIFF
--- a/tests/Unit/Auth/AuthAccessGateTest.php
+++ b/tests/Unit/Auth/AuthAccessGateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Auth;
+namespace Illuminate\Tests\Unit\Auth;
 
 use stdClass;
 use PHPUnit\Framework\TestCase;
@@ -336,7 +336,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', '\Illuminate\Tests\Auth\AccessGateTestClass@foo');
+        $gate->define('foo', '\Illuminate\Tests\Unit\Auth\AccessGateTestClass@foo');
 
         $this->assertTrue($gate->check('foo'));
     }
@@ -345,7 +345,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', '\Illuminate\Tests\Auth\AccessGateTestInvokableClass');
+        $gate->define('foo', \Illuminate\Tests\Unit\Auth\AccessGateTestInvokableClass::class);
 
         $this->assertTrue($gate->check('foo'));
     }

--- a/tests/Unit/Auth/AuthAccessResponseTest.php
+++ b/tests/Unit/Auth/AuthAccessResponseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Auth;
+namespace Illuminate\Tests\Unit\Auth;
 
 use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\Access\Response;

--- a/tests/Unit/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Unit/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Auth;
+namespace Illuminate\Tests\Unit\Auth;
 
 use Mockery as m;
 use Illuminate\Support\Carbon;

--- a/tests/Unit/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Unit/Auth/AuthDatabaseUserProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Auth;
+namespace Illuminate\Tests\Unit\Auth;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Unit/Auth/AuthEloquentUserProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Auth;
+namespace Illuminate\Tests\Unit\Auth;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -102,17 +102,17 @@ class AuthEloquentUserProviderTest extends TestCase
     public function testModelsCanBeCreated()
     {
         $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
-        $provider = new EloquentUserProvider($hasher, 'Illuminate\Tests\Auth\EloquentProviderUserStub');
+        $provider = new EloquentUserProvider($hasher, \Illuminate\Tests\Unit\Auth\EloquentProviderUserStub::class);
         $model = $provider->createModel();
 
-        $this->assertInstanceOf('Illuminate\Tests\Auth\EloquentProviderUserStub', $model);
+        $this->assertInstanceOf(\Illuminate\Tests\Unit\Auth\EloquentProviderUserStub::class, $model);
     }
 
     protected function getProviderMock()
     {
         $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
 
-        return $this->getMockBuilder('Illuminate\Auth\EloquentUserProvider')->setMethods(['createModel'])->setConstructorArgs([$hasher, 'foo'])->getMock();
+        return $this->getMockBuilder(\Illuminate\Auth\EloquentUserProvider::class)->setMethods(['createModel'])->setConstructorArgs([$hasher, 'foo'])->getMock();
     }
 }
 

--- a/tests/Unit/Auth/AuthGuardTest.php
+++ b/tests/Unit/Auth/AuthGuardTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Auth;
+namespace Illuminate\Tests\Unit\Auth;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
+++ b/tests/Unit/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Auth;
+namespace Illuminate\Tests\Unit\Auth;
 
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Auth\User;

--- a/tests/Unit/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Unit/Auth/AuthPasswordBrokerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Auth;
+namespace Illuminate\Tests\Unit\Auth;
 
 use Mockery as m;
 use Illuminate\Support\Arr;

--- a/tests/Unit/Auth/AuthTokenGuardTest.php
+++ b/tests/Unit/Auth/AuthTokenGuardTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Auth;
+namespace Illuminate\Tests\Unit\Auth;
 
 use Mockery;
 use Illuminate\Http\Request;

--- a/tests/Unit/Auth/AuthenticatableTest.php
+++ b/tests/Unit/Auth/AuthenticatableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Auth;
+namespace Illuminate\Tests\Unit\Auth;
 
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Auth\User;

--- a/tests/Unit/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Unit/Auth/AuthenticateMiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Auth;
+namespace Illuminate\Tests\Unit\Auth;
 
 use stdClass;
 use Mockery as m;

--- a/tests/Unit/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Unit/Auth/AuthorizeMiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Auth;
+namespace Illuminate\Tests\Unit\Auth;
 
 use stdClass;
 use Mockery as m;

--- a/tests/Unit/Auth/AuthorizesResourcesTest.php
+++ b/tests/Unit/Auth/AuthorizesResourcesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Auth;
+namespace Illuminate\Tests\Unit\Auth;
 
 use Closure;
 use Illuminate\Http\Request;
@@ -65,8 +65,8 @@ class AuthorizesResourcesTest extends TestCase
     {
         $router = new Router(new \Illuminate\Events\Dispatcher);
 
-        $router->aliasMiddleware('can', '\Illuminate\Tests\Auth\AuthorizesResourcesMiddleware');
-        $router->get($method)->uses('\Illuminate\Tests\Auth\AuthorizesResourcesController@'.$method);
+        $router->aliasMiddleware('can', \Illuminate\Tests\Unit\Auth\AuthorizesResourcesMiddleware::class);
+        $router->get($method)->uses('\Illuminate\Tests\Unit\Auth\AuthorizesResourcesController@'.$method);
 
         $this->assertEquals(
             'caught '.$middleware,


### PR DESCRIPTION
We have the `Integration` folder for `Integration` tests.
Could we have also a `Unit` folder for unit tests?

In this PR I have moved tests from Auth folder to Unit\Auth folder. In case if it will be accepted, then I can move other tests.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
