### PR TITLE
[5.7] Simplify collection average

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -147,9 +147,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $callback = $this->valueRetriever($callback);
 
-        $items = $this->map(function ($value) use ($callback) {
-            return $callback($value);
-        })->filter(function ($value) {
+        $items = $this->map($callback)->filter(function ($value) {
             return ! is_null($value);
         });
 
@@ -1684,7 +1682,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get a value retrieving callback.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @return callable
      */
     protected function valueRetriever($value)


### PR DESCRIPTION
Let's take a look at the Collection::avg() method!

We have already got a valid callback via the Collection::valueRetriever() method, so we needn't to create a new Closure.