### PR TITLE
Remove void return statement

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -118,8 +118,10 @@ abstract class Seeder
             throw new InvalidArgumentException('Method [run] missing from '.get_class($this));
         }
 
-        return isset($this->container)
-                    ? $this->container->call([$this, 'run'])
-                    : $this->run();
+        if (isset($this->container)) {
+            $this->container->call([$this, 'run']);
+        } else {
+            $this->run();
+        }
     }
 }


### PR DESCRIPTION
As the Seeder's `run` methods shouldn't return anything and like the phpdoc states, `__invoke` should return void.
