### PR TITLE
[5.7] Add artisanWithoutMock test method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -56,6 +56,22 @@ trait InteractsWithConsole
     }
 
     /**
+     * Call artisan command without mocking and return code.
+     *
+     * @param  string  $command
+     * @param  array  $parameters
+     * @return \Illuminate\Foundation\Testing\PendingCommand|int
+     */
+    public function artisanWithoutMock($command, $parameters = [])
+    {
+        $this->withoutMockingConsoleOutput();
+        $output = $this->artisan($command, $parameters);
+        $this->mockConsoleOutput = true;
+
+        return $output;
+    }
+
+    /**
      * Disable mocking the console output.
      *
      * @return $this

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -28,6 +28,28 @@ class ConsoleApplicationTest extends TestCase
             'id' => 1,
         ])->assertExitCode(0);
     }
+
+    public function test_artisan_without_mock_call()
+    {
+        $outputWithoutMock = $this->artisanWithoutMock('foo:bar', [
+            'id' => 1,
+        ]);
+
+        $this->assertSame(0, $outputWithoutMock);
+    }
+
+    public function test_artisan_with_mock_call_after_without_mock_call()
+    {
+        $outputWithoutMock = $this->artisanWithoutMock('foo:bar', [
+            'id' => 1,
+        ]);
+        $outputWithMock = $this->artisan('foo:bar', [
+            'id' => 1,
+        ]);
+
+        $this->assertSame(0, $outputWithoutMock);
+        $outputWithMock->assertExitCode(0);
+    }
 }
 
 class FooCommandStub extends Command


### PR DESCRIPTION
Related to: https://github.com/orchestral/testbench/issues/229

Alternative solution: #25574 

Adds ability to call artisan without mock for one command only and not disable mocking for all the test.

Before:
```php
public function test_something()
{
    $this->withoutMockingConsoleOutput();
    $output = $this->artisan('foo:bar', [
        'id' => 1,
    ]);

    // We have no way to call artisan with mocking for this test anymore
}
```

After:
```php
public function test_something()
{
    $output = $this->artisanWithoutMock('foo:bar', [
        'id' => 1,
    ]);

    $this->artisan('baz:bar', [
        'id' => 1,
    ])->assertExitCode(0);
}
```

Thanks @crynobone for the idea :+1: