### PR TITLE
[5.7] Call Pending artisan command immediately

### DIFF
--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -105,6 +105,16 @@ class PendingCommand
     }
 
     /**
+     * Call the given command immediately.
+     *
+     * @return int
+     */
+    public function callNow()
+    {
+        return $this->app[Kernel::class]->call($this->command, $this->parameters);
+    }
+
+    /**
      * Mock the application's console output.
      *
      * @return void
@@ -168,7 +178,7 @@ class PendingCommand
         $this->mockConsoleOutput();
 
         try {
-            $exitCode = $this->app[Kernel::class]->call($this->command, $this->parameters);
+            $exitCode = $this->callNow();
         } catch (NoMatchingExpectationException $e) {
             if ($e->getMethodName() == 'askQuestion') {
                 $this->test->fail('Unexpected question "'.$e->getActualArguments()[0]->getQuestion().'" was asked.');

--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -48,6 +48,13 @@ class PendingCommand
     protected $expectedExitCode;
 
     /**
+     * Determine if command was called.
+     *
+     * @var bool
+     */
+    private $isCalled = false;
+
+    /**
      * Create a new pending console command run.
      *
      * @param  \PHPUnit\Framework\TestCase  $test
@@ -111,6 +118,8 @@ class PendingCommand
      */
     public function callNow()
     {
+        $this->isCalled = true;
+
         return $this->app[Kernel::class]->call($this->command, $this->parameters);
     }
 
@@ -175,6 +184,10 @@ class PendingCommand
      */
     public function __destruct()
     {
+        if ($this->isCalled) {
+            return;
+        }
+
         $this->mockConsoleOutput();
 
         try {

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -28,6 +28,28 @@ class ConsoleApplicationTest extends TestCase
             'id' => 1,
         ])->assertExitCode(0);
     }
+
+    public function test_artisan_call_now()
+    {
+        $outputWithoutMock = $this->artisan('foo:bar', [
+            'id' => 1,
+        ])->callNow();
+
+        $this->assertSame(0, $outputWithoutMock);
+    }
+
+    public function test_artisan_with_mock_call_after_call_now()
+    {
+        $outputWithoutMock = $this->artisan('foo:bar', [
+            'id' => 1,
+        ])->callNow();
+        $outputWithMock = $this->artisan('foo:bar', [
+            'id' => 1,
+        ]);
+
+        $this->assertSame(0, $outputWithoutMock);
+        $outputWithMock->assertExitCode(0);
+    }
 }
 
 class FooCommandStub extends Command


### PR DESCRIPTION
Related to: https://github.com/orchestral/testbench/issues/229

This is alternative solution for PR #25573

Sometimes there is requirement to check what has happened in application after the artisan command call. When we don't care about output, but about exact job results. We are not able to do the checks since Laravel 5.7 artisan command executing in `__destruct` method.

With this change we can call pending artisan command immediately.

```php
$exitCode = $this->artisan('foo:bar')->callNow();
```

Before:
```php
public function test_something()
{
    $this->withoutMockingConsoleOutput();
    $output = $this->artisan('foo:bar', [
        'id' => 1,
    ]);

    // We have no way to call artisan with mocking for this test anymore
}
```

After:
```php
public function test_something()
{
    $exitCode = $this->artisan('foo:bar', [
        'id' => 1,
    ])->callNow();

    $this->artisan('baz:bar', [
        'id' => 1,
    ])->assertExitCode(0);
}
```
Inspired from notifications `sendNow()` and dispatcher `dispatchNow()` methods.