### PR TITLE
[5.7] Fix artisan PendingCommand run method return value

### DIFF
--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -128,10 +128,6 @@ class PendingCommand
      */
     public function run()
     {
-        if ($this->hasExecuted) {
-            return;
-        }
-
         $this->hasExecuted = true;
 
         $this->mockConsoleOutput();
@@ -215,6 +211,10 @@ class PendingCommand
      */
     public function __destruct()
     {
+        if ($this->hasExecuted) {
+            return;
+        }
+
         $this->run();
     }
 }


### PR DESCRIPTION
Moved `hasExecuted` check to `__destruct` method because it's the only place where we need to be sure that command call wouldn't be duplicated.
Otherwise we will require to change signature of the `run` method. Right now it must return integer only.