### PR TITLE
[5.7] Get always true when doing a delete cache query

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -223,7 +223,7 @@ class DatabaseStore implements Store
      */
     public function flush()
     {
-        $this->table()->delete();
+        $this->table()->truncate();
 
         return true;
     }

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -223,7 +223,9 @@ class DatabaseStore implements Store
      */
     public function flush()
     {
-        return $this->table()->delete() >= 0;
+        $this->table()->delete();
+
+        return true;
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -223,7 +223,7 @@ class DatabaseStore implements Store
      */
     public function flush()
     {
-        $this->table()->truncate();
+        $this->table()->delete();
 
         return true;
     }

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -223,7 +223,7 @@ class DatabaseStore implements Store
      */
     public function flush()
     {
-        return (bool) $this->table()->delete();
+        return $this->table()->delete() >= 0;
     }
 
     /**


### PR DESCRIPTION
Based on [this commit](https://github.com/laravel/framework/commit/ad670c8423a5fdfc929644f63db1b7ca39a8ba59), the command `php artisan cache:clear` will always fail when using a database cache driver and cache table is empty.
