### PR TITLE
[5.7] Fix pagination: when using onEachSide(), if parameter is less than 2, getUrlSlider() method returns extra links

### DIFF
--- a/src/Illuminate/Pagination/UrlWindow.php
+++ b/src/Illuminate/Pagination/UrlWindow.php
@@ -73,7 +73,7 @@ class UrlWindow
      */
     protected function getUrlSlider($onEachSide)
     {
-        $window = $onEachSide * 2;
+        $window = $onEachSide * $onEachSide < 2 ? 3 : 2;
 
         if (! $this->hasPages()) {
             return ['first' => null, 'slider' => null, 'last' => null];

--- a/tests/Pagination/UrlWindowTest.php
+++ b/tests/Pagination/UrlWindowTest.php
@@ -42,12 +42,16 @@ class UrlWindowTest extends TestCase
          */
         $p = new LengthAwarePaginator($array, count($array), 1, 8);
         $window = new UrlWindow($p);
+	    $slider = [];
+	    for ($i = 5; $i <= 11; $i++) {
+		    $slider[$i] = '/?page='.$i;
+	    }
         $last = [];
-        for ($i = 5; $i <= 13; $i++) {
+        for ($i = 12; $i <= 13; $i++) {
             $last[$i] = '/?page='.$i;
         }
 
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => null, 'last' => $last], $window->get());
+        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => $slider, 'last' => $last], $window->get());
     }
 
     public function testCustomUrlRangeForAWindowOfLinks()


### PR DESCRIPTION
When an user chooses to show less than 2 links using the new onEachSide() method, extra links are shown to the enduser. See below.

**Current functionality:**
`'^' marks active`
```php
Posts::paginate(2); // 9 pages

// Current Page 2
{{ $posts->onEachSide(0)->links() }}
// Results: 1|2|...|2|...|8|9
//            ^     ^

// Current Page 3
{{ $posts->onEachSide(1)->links() }}
// Results: 1|2|...|2|3|4|...|8|9
//                    ^

// Current Page 7
{{ $posts->onEachSide(1)->links() }}
// Results: 1|2|...|6|7|8|...|8|9
//                    ^

// Current Page 8
{{ $posts->onEachSide(0)->links() }}
// Results: 1|2|...|8|...|8|9
//                  ^     ^
```

**Proposed functionality:**
`'^' marks active`
```php
Posts::paginate(2); // 9 pages

// Current Page 2
{{ $posts->onEachSide(0)->links() }}
// Results: 1|2|3|4|5|...|8|9
//            ^

// Current Page 3
{{ $posts->onEachSide(1)->links() }}
// Results: 1|2|3|4|5|...|8|9
//              ^

// Current Page 7
{{ $posts->onEachSide(1)->links() }}
// Results: 1|2|...|4|5|6|7|8|9
//                        ^

// Current Page 8
{{ $posts->onEachSide(0)->links() }}
// Results: 1|2|...|4|5|6|7|8|9
//                          ^
```