### PR TITLE
[5.7] Fix app stub when register route option is set to false

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -44,7 +44,9 @@
                                 <a class="nav-link" href="{{ route('login') }}">{{ __('Login') }}</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="{{ route('register') }}">{{ __('Register') }}</a>
+                                @if(Route::has('register'))
+                                    <a class="nav-link" href="{{ route('register') }}">{{ __('Register') }}</a>
+                                @endif
                             </li>
                         @else
                             <li class="nav-item dropdown">

--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -44,7 +44,7 @@
                                 <a class="nav-link" href="{{ route('login') }}">{{ __('Login') }}</a>
                             </li>
                             <li class="nav-item">
-                                @if(Route::has('register'))
+                                @if (Route::has('register'))
                                     <a class="nav-link" href="{{ route('register') }}">{{ __('Register') }}</a>
                                 @endif
                             </li>


### PR DESCRIPTION
Fix the 'Route [register] not defined' in the app.blade.php that comes with the authentication scaffolding. This error occurs if the register => false option is issued wich has been added with #25556. 