### PR TITLE
[5.7] Use spl_object_hash() for Notifiable IDs in NotificationFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -111,11 +111,9 @@ class NotificationFake implements NotificationFactory, NotificationDispatcher
      */
     public function assertTimesSent($expectedCount, $notification)
     {
-        $actualCount = collect($this->notifications)
-            ->flatten(1)
-            ->reduce(function ($count, $sent) use ($notification) {
-                return $count + count($sent[$notification] ?? []);
-            }, 0);
+        $actualCount = collect($this->notifications)->reduce(function ($count, $sent) use ($notification) {
+            return $count + \count($sent[$notification] ?? []);
+        }, 0);
 
         PHPUnit::assertSame(
             $expectedCount, $actualCount,
@@ -169,11 +167,7 @@ class NotificationFake implements NotificationFactory, NotificationDispatcher
      */
     protected function notificationsFor($notifiable, $notification)
     {
-        if (isset($this->notifications[get_class($notifiable)][$notifiable->getKey()][$notification])) {
-            return $this->notifications[get_class($notifiable)][$notifiable->getKey()][$notification];
-        }
-
-        return [];
+        return $this->notifications[\spl_object_hash($notifiable)][$notification] ?? [];
     }
 
     /**
@@ -206,7 +200,7 @@ class NotificationFake implements NotificationFactory, NotificationDispatcher
                 $notification->id = Str::uuid()->toString();
             }
 
-            $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)][] = [
+            $this->notifications[\spl_object_hash($notifiable)][get_class($notification)][] = [
                 'notification' => $notification,
                 'channels' => $notification->via($notifiable),
                 'notifiable' => $notifiable,


### PR DESCRIPTION
This replaces the dependency on the `getKey()` method, which may not be available if the Notifiable is not an Eloquent model.

Since a Notifiable can be extremely flexible and doesn’t follow a specific interface, `spl_object_hash()` works well as an identifier for an object instance in a pinch. Conveniently, this is also a bit more stable for the current test stubs, which return an empty string from `getKey()` as they have no identity yet.

Null coalesce was used to reduce code (yay PHP 7!).