### PR TITLE
[5.7] Allow list of values as argument for SeeInOrder assertions

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -341,11 +341,13 @@ class TestResponse
     /**
      * Assert that the given strings are contained in order within the response.
      *
-     * @param  array  $values
+     * @param  array|mixed  $values
      * @return $this
      */
-    public function assertSeeInOrder(array $values)
+    public function assertSeeInOrder($values)
     {
+        $values = is_array($values) ? $values : func_get_args();
+
         PHPUnit::assertThat($values, new SeeInOrder($this->getContent()));
 
         return $this;
@@ -367,11 +369,13 @@ class TestResponse
     /**
      * Assert that the given strings are contained in order within the response text.
      *
-     * @param  array  $values
+     * @param  array|mixed  $values
      * @return $this
      */
-    public function assertSeeTextInOrder(array $values)
+    public function assertSeeTextInOrder($values)
     {
+        $values = is_array($values) ? $values : func_get_args();
+
         PHPUnit::assertThat($values, new SeeInOrder(strip_tags($this->getContent())));
 
         return $this;

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -42,6 +42,8 @@ class FoundationTestResponseTest extends TestCase
 
         $response->assertSeeInOrder(['foo', 'bar', 'baz']);
 
+        $response->assertSeeInOrder('foo', 'bar', 'baz');
+
         $response->assertSeeInOrder(['foo', 'bar', 'baz', 'foo']);
     }
 
@@ -83,6 +85,8 @@ class FoundationTestResponseTest extends TestCase
         ]);
 
         $response->assertSeeTextInOrder(['foobar', 'baz']);
+
+        $response->assertSeeTextInOrder('foobar', 'baz');
 
         $response->assertSeeTextInOrder(['foobar', 'baz', 'foo']);
     }


### PR DESCRIPTION
This PR makes it possible to give a list of values to `assertSeeInOrder` and `assertSeeTextInOrder`.

Example:
```php
/** @test */
function users_are_in_alphabetical_order()
{
    $this->get('/api/users')
        ->assertStatus(200)    
        ->assertSeeInOrder('Bobby', 'Hank');
}
```
