### PR TITLE
[5.7] Add an optional $childModel parameter to eloquent models newFromBuilder frunction

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -406,13 +406,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function newFromBuilder($attributes = [], $connection = null, self $childModel = null)
     {
-        $model = $childModel ? : $this;
+        $model = $childModel ?: $this;
 
         $model = $model->newInstance([], true);
 
         $model->setRawAttributes((array) $attributes, true);
 
-        $model->setConnection($connection ? : $model->getConnectionName());
+        $model->setConnection($connection ?: $model->getConnectionName());
 
         $model->fireModelEvent('retrieved', false);
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -401,15 +401,18 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      *
      * @param  array  $attributes
      * @param  string|null  $connection
+     * @param \Illuminate\Database\Eloquent\Model $childModel
      * @return static
      */
-    public function newFromBuilder($attributes = [], $connection = null)
+    public function newFromBuilder($attributes = [], $connection = null, self $childModel = null)
     {
-        $model = $this->newInstance([], true);
+        $model = $childModel ? : $this;
+
+        $model = $model->newInstance([], true);
 
         $model->setRawAttributes((array) $attributes, true);
 
-        $model->setConnection($connection ?: $this->getConnectionName());
+        $model->setConnection($connection ? : $model->getConnectionName());
 
         $model->fireModelEvent('retrieved', false);
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -362,7 +362,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['date_2010-01-01 00:00:00', 'date_2011-01-01 00:00:00'], $builder->pluck('created_at')->all());
     }
 
-    public function testPluckWithoutModelGetterJustReturnTheAttributesFoundInDatabase()
+    public function testPluckWithoutModelGetterJustReturnsTheAttributesFoundInDatabase()
     {
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('pluck')->with('name', '')->andReturn(new BaseCollection(['bar', 'baz']));


### PR DESCRIPTION
### Changes
This little change just adds an additional parameter to the `newFromBuilder` function of the default eloquent model. It provides some help for developers who try to build some kind of hierarchy between eloquent models. With the new parameter you can define which model instance should be returned from the builder for each database record instead of just of returning an instance of $this' class no matter what. 
The PR does not break any existing functionality, since the parameter is only optional and it's default value is the same as was used before.
The other commit just fixes a little typo. I won't go into that any further ;)
### Reason / Potential Use Cases
In my case I had a `Component` model with a type attribute that defines a specific kind of component. 
I also added sub classes of my Component model to outsource type-specific functionality, but still be able to share common.  
By using (global) scopes I could then modify the base query to only return the results with the correct type for each sub component.
The problem came when I queried the components via the Component parent model. It actually worked as expected, but each instance was obviously an instance of the parent Component class which was not what I wanted. Instead, I wanted the builder to automatically return the correct sub class instance.  

To achieve this I had to overwrite the `newFromBuilder` method with something like in the following example:
 ```php
public function newFromBuilder($attributes = [], $connection = null)
{
    // assume the type attribute is a qualified model class name
    $class  =array_get((array)$attributes, 'type', self::class);
    $model = new $class();

    $model = $model->newInstance([], true);

    $model->setRawAttributes((array)$attributes, true);

    $model->setConnection($connection ? : $this->getConnectionName());

    $model->fireModelEvent('retrieved', false);

    return $model;
}
```
#### Why is that bad?
The problem with the above code is that it is essentially duplication of framework-internal code that I would very much like to avoid.
With my fix I can just call the parent implementation and pass the correct instance like: 
 ```php
public function newFromBuilder($attributes = [], $connection = null, \Illuminate\Database\Eloquent\Model $childModel)
{
    $class  =array_get((array)$attributes, 'type');
    $model = $class ? new $class() : $this;
    
    return parent::newFromBuilder($attributes, $connection, $model);
}
```