### PR TITLE
[5.8] Use the getDirty method on insert instead of getAttributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -779,7 +779,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // If the model has an incrementing key, we can use the "insertGetId" method on
         // the query builder, which will give us back the final inserted ID for this
         // table from the database. Not all tables have to be incrementing though.
-        $attributes = $this->getAttributes();
+        $attributes = $this->getDirty();
 
         if ($this->getIncrementing()) {
             $this->insertAndSetId($query, $attributes);


### PR DESCRIPTION
Same as #25559, except this time targeting new version as you said you wouldn't change something like this on a point release.

Below is a comment from previous PR:
In #25349 performInsert() was changed to use getAttributes() instead of accessing $attributes property directly, thus having more similar behavior to performUpdate().

I think it is better to use getDirty() in performInsert() as well.

Currently if we override getAttributes() method and return additional property the insert is going to fail, while update can pass if we override originalIsEquivalent() and return true for that additional property.