### PR TITLE
[5.8] Add force update method to ignore mass assignment exception

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -589,6 +589,20 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Update the model in the database. Force mass assignment.
+     *
+     * @param  array  $attributes
+     * @param  array  $options
+     * @return $this
+     */
+    public function forceUpdate(array $attributes = [], array $options = [])
+    {
+        return static::unguarded(function () use ($attributes, $options) {
+            return $this->update($attributes, $options);
+        });
+    }
+
+    /**
      * Save the model and all of its relationships.
      *
      * @return bool

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -898,6 +898,17 @@ class DatabaseEloquentModelTest extends TestCase
         );
     }
 
+    public function testForceUpdateMethodUpdatesModelWithGuardedAttributes()
+    {
+        $_SERVER['__eloquent.saved'] = false;
+        $model = new EloquentModelSaveStub;
+        $model->exists = true;
+        $model->guard(['*']);
+        $model->forceUpdate(['name' => 'Taylor']);
+        $this->assertTrue($_SERVER['__eloquent.saved']);
+        $this->assertEquals('Taylor', $model->name);
+    }
+
     public function testUnguardAllowsAnythingToBeSet()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
Adds a `forceUpdate` method to force mass assignment. This is similar to the `forceCreate` method and would have similar use cases. This should avoid confusion for users who would assume that a `forceUpdate` method is available due to the existence of the `forceCreate` method.