### PR TITLE
Removed forced forward slash for SQS queue names

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -140,7 +140,7 @@ class SqsQueue extends Queue implements QueueContract
         $queue = $queue ?: $this->default;
 
         return filter_var($queue, FILTER_VALIDATE_URL) === false
-                        ? rtrim($this->prefix, '/').'/'.$queue : $queue;
+            ? $this->prefix.$queue : $queue;
     }
 
     /**


### PR DESCRIPTION
I appreciate that the forward slash allows the user to miss it out on the prefix, however in situations where the queue name itself has a prefix this causes issues.

Consider the use case I ran into - I had the following queues:
* `default`
* `notifications`
* `search`

I also have two environments:
* `production`
* `staging`

On SQS the queue name must be unique which causes an issue as the queue name is hard coded. Rather than doing a hacky solution, such as placing my queue names in a config file, it would be nice if we could just prefix the queue names:

* `production-default`
* `production-notifications`
* `production-search`
* `staging-default`
* `staging-notifications`
* `staging-search`

And the queue name remains as the hard coded `notifications` in the jobs that push to this queue.

In the queue config, the prefix could then amended:

```php

// From
[
    'prefix' => 'https://sqs.eu-west-1.amazonaws.com/your-account-id/'
]

// To
[
    'prefix' => 'https://sqs.eu-west-1.amazonaws.com/your-account-id/staging-'
]
```

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
