### PR TITLE
[5.7] Work around phpredis bug

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -215,6 +215,13 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         return $this->executeRaw(array_merge(['zadd', $key], $dictionary));
     }
 
+    public function rpush($key,array $values)
+    {
+        array_unshift($values,$key);
+        return $this->command('rpush',$values);
+    }
+
+
     /**
      * Return elements with score between $min and $max.
      *


### PR DESCRIPTION
<pre>
//Before the change
Redis::connection()->rpush('test_key',['test_value']);
var_dump( Redis::connection()->lRange('test_key', 0, -1) );
//use phpredis output:  
//array(1) { [0]=> string(5) "Array" }
//use predis output: 
//array(1) { [0]=> string(10) "test_value" }
</pre>
