### PR TITLE
[5.8] Add previous method to UrlGenerator interface

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -12,6 +12,14 @@ interface UrlGenerator
     public function current();
 
     /**
+     * Get the URL for the previous request.
+     *
+     * @param  mixed  $fallback
+     * @return string
+     */
+    public function previous($fallback = false);
+
+    /**
      * Generate an absolute URL to the given path.
      *
      * @param  string  $path


### PR DESCRIPTION
The UrlGenerator interface does not contain the previous() method that is implemented by the UrlGenerator class

Adding it allows me to use previous() while referencing the interface (and keep my IDE happy).

It would add an extra burden on other implementations of that interface that are out in the wild, making it a breaking change.

(Reapplied https://github.com/laravel/framework/pull/25609 to master instead of 5.7)