### PR TITLE
[5.7] Support custom accessor on whenPivotLoaded()

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -172,18 +172,19 @@ trait ConditionallyLoadsAttributes
      * @param  string  $table
      * @param  mixed  $value
      * @param  mixed  $default
+     * @param  string  $accessor
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    protected function whenPivotLoaded($table, $value, $default = null)
+    protected function whenPivotLoaded($table, $value, $default = null, $accessor = 'pivot')
     {
         if (func_num_args() === 2) {
             $default = new MissingValue;
         }
 
         return $this->when(
-            $this->resource->pivot &&
-            ($this->resource->pivot instanceof $table ||
-             $this->resource->pivot->getTable() === $table),
+            $this->resource->$accessor &&
+            ($this->resource->$accessor instanceof $table ||
+             $this->resource->$accessor->getTable() === $table),
             ...[$value, $default]
         );
     }


### PR DESCRIPTION
`whenPivotLoaded()` doesn't work if the relationship uses a custom accessor with `->as('accessor')`.

You can now specify it as the fourth parameter:

```php
return [
    'expires_at' => $this->whenPivotLoaded('role_user', function () {
        return $this->accessor->expires_at;
    }, new MissingValue, 'accessor'),
];
```

`new MissingValue` is necessary as the third parameter (`$default = null`) because `whenPivotLoaded()` behaves differently depending on the number of parameters:

```php
'key' => $this->whenPivotLoaded($table, $value)       // "key" missing
'key' => $this->whenPivotLoaded($table, $value, null) // "key": null
```

I don't think this requires a separate test. The existing one already tests the default `pivot` accessor.

Fixes #25596.
