### PR TITLE
[5.7] allow to set default time zone for scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -297,9 +297,8 @@ class Event
     {
         $date = Carbon::now();
 
-        if ($this->timezone) {
-            $date->setTimezone($this->timezone);
-        }
+        $timezone = $this->timezone ?: config('app.scheduler_timezone', 'UTC');
+        $date->setTimezone($timezone);
 
         return CronExpression::factory($this->expression)->isDue($date->toDateTimeString());
     }


### PR DESCRIPTION
this PR is related to this one: https://github.com/laravel/ideas/issues/221

you can set default time zone for scheduler in config/app.php as below.

```
'scheduler_timezone' => 'America/New_York',
```
