### PR TITLE
[5.8] add authenticate method to the guard contract

### DIFF
--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -7,6 +7,13 @@ interface Guard
     /**
      * Determine if the current user is authenticated.
      *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public function authenticate();
+
+    /**
+     * Determine if the current user is authenticated.
+     *
      * @return bool
      */
     public function check();


### PR DESCRIPTION
 - we have `authenticate` method to the Guard contract, since it is present within the GuardHelper trait, but we can not use this method based on the contact;

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
