### PR TITLE
[5.5] Add release notes for latest 5.5.4x releases

### DIFF
--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -1,5 +1,23 @@
 # Release Notes for 5.5.x
 
+## v5.5.43 (2018-09-02)
+
+### Changed
+- Patch Blade's `@lang` directive so it now escapes HTML tags ([010c1a2](https://github.com/laravel/framework/commit/010c1a23ba2a9c04aa83154ba0c8b7dc5de862da))
+> **BREAKING CHANGE**: This change is known to have broken many applications. Please upgrade with caution. Check out the discussion on the issue in the commit's comments and in [#25408](https://github.com/laravel/framework/pull/25408).
+- Remove undefined variable from compact ([#25193](https://github.com/laravel/framework/pull/25193))
+- Update queue worker memory usage to use the "real" amount of memory used ([#25211](https://github.com/laravel/framework/pull/25211))
+- Use getter method for access primary key ([#25303](https://github.com/laravel/framework/pull/25303))
+- Use the getAttributes method on insert ([#25349](https://github.com/laravel/framework/pull/25349))
+
+### Fixed
+- Fix URL validation pattern ([#25197](https://github.com/laravel/framework/pull/25197)) 
+- Fix MorphTo lazy eager loading ([#25252](https://github.com/laravel/framework/pull/25252))
+- Handle AWS Connection Lost ([#25294](https://github.com/laravel/framework/pull/25294)) 
+- Make Auth/Recaller handle serialized and unserialized cookies ([#25301](https://github.com/laravel/framework/pull/25301))
+- Fix BelongsToMany with custom `$relatedKey` ([#25221](https://github.com/laravel/framework/pull/25221))
+- Fix `assertCookie()` since now cookies are unserialized by default ([#25347](https://github.com/laravel/framework/pull/25347))
+
 ## v5.5.42 (2018-08-08)
 
 ### Changed

--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -1,5 +1,18 @@
 # Release Notes for 5.5.x
 
+## v5.5.41 (2018-08-01)
+
+### Changed
+- Update PostgresGrammar.php ([#23810](https://github.com/laravel/framework/pull/23810))
+- Check for timestamps when creating pivot model from raw attributes as well ([#23963](https://github.com/laravel/framework/pull/23963))
+- Added two Azure SQL Server "connection lost" messages ([#24566](https://github.com/laravel/framework/pull/24566)) ([#24954](https://github.com/laravel/framework/pull/24954))
+
+### Fixed
+- Added compatibility with MySQL 8.0.11 (GA) ([#24038](https://github.com/laravel/framework/pull/24038))
+- Fix unsetting http query parameters when fetching request by HEAD ([#24076](https://github.com/laravel/framework/pull/24076))
+- Validation bypass for `before` and `after` rules when paired with `date_format` rule. ([#24191](https://github.com/laravel/framework/pull/24191))
+- Fix `$withCount` binding problems ([cab365a](https://github.com/laravel/framework/commit/cab365a85a0fa3e4f7113390de4a5b31f64748e2))
+
 ## v5.5.40 (2018-03-30)
 
 ### Changed

--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -1,5 +1,10 @@
 # Release Notes for 5.5.x
 
+## v5.5.42 (2018-08-08)
+
+### Changed
+- Make serialization of cookie values optional ([7fc1dc5...6550ae9](https://github.com/laravel/framework/compare/v5.5.41%E2%80%A6c5dc9c8))
+
 ## v5.5.41 (2018-08-01)
 
 ### Changed


### PR DESCRIPTION
This adds release notes for LTS releases from `5.5.41` to `5.5.43`.

Fixes #25621.