### PR TITLE
[5.7] fixed return php doc in `Routing/Middleware/ThrottleRequests.php`

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -39,7 +39,7 @@ class ThrottleRequests
      * @param  \Closure  $next
      * @param  int|string  $maxAttempts
      * @param  float|int  $decayMinutes
-     * @return mixed
+     * @return \Symfony\Component\HttpFoundation\Response
      * @throws \Illuminate\Http\Exceptions\ThrottleRequestsException
      */
     public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1)


### PR DESCRIPTION
 - fixed return php doc in `Routing/Middleware/ThrottleRequests.php` for handle method;

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
