### PR TITLE
[5.7] add test for `Route [$routeName] not defined.` exception

### DIFF
--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Routing;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Routing\RouteCollection;
@@ -546,6 +547,20 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals($url->to('/'), $url->previous());
 
         $this->assertEquals($url->to('/foo'), $url->previous('/foo'));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Route [not_exists_route] not defined.
+     */
+    public function testRouteNotDefinedException()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('http://www.foo.com/')
+        );
+
+        $url->route('not_exists_route');
     }
 }
 


### PR DESCRIPTION
 - add test for `Route [$routeName] not defined.` exception since in https://github.com/laravel/framework/issues/25636 we got this exception, but we do not have test for this case

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
