### PR TITLE
[5.7] fixed doc block for handleQueryException;

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -700,12 +700,12 @@ class Connection implements ConnectionInterface
     /**
      * Handle a query exception.
      *
-     * @param  \Exception  $e
+     * @param  \Illuminate\Database\QueryException  $e
      * @param  string  $query
      * @param  array  $bindings
      * @param  \Closure  $callback
      * @return mixed
-     * @throws \Exception
+     * @throws \Illuminate\Database\QueryException
      */
     protected function handleQueryException($e, $query, $bindings, Closure $callback)
     {


### PR DESCRIPTION
 - changed first argument from `\Exception` to `\Illuminate\Database\QueryException` since we called `tryAgainIfCausedByLostConnection` with `\Illuminate\Database\QueryException`

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
