### PR TITLE
[5.5] Fix EventTest testBuildCommand on Windows

### DIFF
--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -15,20 +15,20 @@ class EventTest extends TestCase
 
     public function testBuildCommand()
     {
-        $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
+        $isWindows = DIRECTORY_SEPARATOR == '\\';
+        $quote = ($isWindows) ? '"' : "'";
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
 
-        $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
+        $defaultOutput = ($isWindows) ? 'NUL' : '/dev/null';
         $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1", $event->buildCommand());
-
-        $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
         $event->runInBackground();
 
-        $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
-        $this->assertSame("(php -i > {$quote}{$defaultOutput}{$quote} 2>&1 ; '".PHP_BINARY."' artisan schedule:finish \"framework/schedule-c65b1c374c37056e0c57fccb0c08d724ce6f5043\") > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
+        $commandSeparator = ($isWindows ? '&' : ';');
+        $scheduleId = '"framework' . DIRECTORY_SEPARATOR . 'schedule-c65b1c374c37056e0c57fccb0c08d724ce6f5043"';
+        $this->assertSame("(php -i > {$quote}{$defaultOutput}{$quote} 2>&1 {$commandSeparator} {$quote}".PHP_BINARY."{$quote} artisan schedule:finish {$scheduleId}) > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
     }
 
     public function testBuildCommandSendOutputTo()

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -27,7 +27,7 @@ class EventTest extends TestCase
         $event->runInBackground();
 
         $commandSeparator = ($isWindows ? '&' : ';');
-        $scheduleId = '"framework' . DIRECTORY_SEPARATOR . 'schedule-c65b1c374c37056e0c57fccb0c08d724ce6f5043"';
+        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-c65b1c374c37056e0c57fccb0c08d724ce6f5043"';
         $this->assertSame("(php -i > {$quote}{$defaultOutput}{$quote} 2>&1 {$commandSeparator} {$quote}".PHP_BINARY."{$quote} artisan schedule:finish {$scheduleId}) > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
     }
 

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -35,7 +35,8 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
         $console->shouldReceive('find')->with('migrate:reset')->andReturn($resetCommand);
         $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
 
-        $resetCommand->shouldReceive('run')->with(new InputMatcher("--database --path --force 'migrate:reset'"), m::any());
+        $quote = DIRECTORY_SEPARATOR == '\\' ? '"' : "'";
+        $resetCommand->shouldReceive('run')->with(new InputMatcher("--database --path --force {$quote}migrate:reset{$quote}"), m::any());
         $migrateCommand->shouldReceive('run')->with(new InputMatcher('--database --path --force migrate'), m::any());
 
         $this->runCommand($command);
@@ -57,7 +58,8 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
         $console->shouldReceive('find')->with('migrate:rollback')->andReturn($rollbackCommand);
         $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
 
-        $rollbackCommand->shouldReceive('run')->with(new InputMatcher("--database --path --step=2 --force 'migrate:rollback'"), m::any());
+        $quote = DIRECTORY_SEPARATOR == '\\' ? '"' : "'";
+        $rollbackCommand->shouldReceive('run')->with(new InputMatcher("--database --path --step=2 --force {$quote}migrate:rollback{$quote}"), m::any());
         $migrateCommand->shouldReceive('run')->with(new InputMatcher('--database --path --force migrate'), m::any());
 
         $this->runCommand($command, ['--step' => 2]);

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -23,7 +23,7 @@ class DatabaseMigrationResetCommandTest extends TestCase
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
-        $migrator->shouldReceive('reset')->once()->with([__DIR__.'/migrations'], false);
+        $migrator->shouldReceive('reset')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], false);
         $migrator->shouldReceive('getNotes')->andReturn([]);
 
         $this->runCommand($command);
@@ -38,7 +38,7 @@ class DatabaseMigrationResetCommandTest extends TestCase
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with('foo');
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
-        $migrator->shouldReceive('reset')->once()->with([__DIR__.'/migrations'], true);
+        $migrator->shouldReceive('reset')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], true);
         $migrator->shouldReceive('getNotes')->andReturn([]);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -22,7 +22,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], ['pretend' => false, 'step' => 0]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 0]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
 
         $this->runCommand($command);
@@ -36,7 +36,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], ['pretend' => false, 'step' => 2]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 2]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
 
         $this->runCommand($command, ['--step' => 2]);
@@ -50,7 +50,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with('foo');
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], true);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], true);
         $migrator->shouldReceive('getNotes')->andReturn([]);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
@@ -64,7 +64,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with('foo');
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], ['pretend' => true, 'step' => 2]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => 2]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2]);

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -61,7 +61,7 @@ class FilesystemAdapterTest extends TestCase
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
-        $this->assertEquals($this->tempDir.'/file.txt', $filesystemAdapter->path('file.txt'));
+        $this->assertEquals($this->tempDir.DIRECTORY_SEPARATOR.'file.txt', $filesystemAdapter->path('file.txt'));
     }
 
     public function testGet()
@@ -90,7 +90,7 @@ class FilesystemAdapterTest extends TestCase
         file_put_contents($this->tempDir.'/file.txt', 'World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $filesystemAdapter->prepend('file.txt', 'Hello ');
-        $this->assertStringEqualsFile($this->tempDir.'/file.txt', "Hello \nWorld");
+        $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello '.PHP_EOL.'World');
     }
 
     public function testAppend()
@@ -98,7 +98,7 @@ class FilesystemAdapterTest extends TestCase
         file_put_contents($this->tempDir.'/file.txt', 'Hello ');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $filesystemAdapter->append('file.txt', 'Moon');
-        $this->assertStringEqualsFile($this->tempDir.'/file.txt', "Hello \nMoon");
+        $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello '.PHP_EOL.'Moon');
     }
 
     public function testDelete()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -47,7 +47,8 @@ class FilesystemTest extends TestCase
         $files = new Filesystem;
         $files->chmod($this->tempDir.'/file.txt', 0755);
         $filePermission = substr(sprintf('%o', fileperms($this->tempDir.'/file.txt')), -4);
-        $this->assertEquals('0755', $filePermission);
+        $expectedPermissions = DIRECTORY_SEPARATOR == '\\' ? '0666' : '0755';
+        $this->assertEquals($expectedPermissions, $filePermission);
     }
 
     public function testGetChmod()
@@ -56,8 +57,9 @@ class FilesystemTest extends TestCase
         chmod($this->tempDir.'/file.txt', 0755);
 
         $files = new Filesystem;
-        $filePermisson = $files->chmod($this->tempDir.'/file.txt');
-        $this->assertEquals('0755', $filePermisson);
+        $filePermission = $files->chmod($this->tempDir.'/file.txt');
+        $expectedPermissions = DIRECTORY_SEPARATOR == '\\' ? '0666' : '0755';
+        $this->assertEquals($expectedPermissions, $filePermission);
     }
 
     public function testDeleteRemovesFiles()


### PR DESCRIPTION
I suggest running tests before pushing my another PR.

When I tried to do it, I noticed that I have 20 broken tests out of the box.

![image](https://user-images.githubusercontent.com/13823215/45598122-4322cd80-b9df-11e8-9f38-acbddda2b2af.png)

So I decided to fix them in an appropriate way.

Fixing all broken tests allow Windows users to contribute to your project without having false broken tests