### PR TITLE
[5.8] Add method to Guard contract

### DIFF
--- a/CHANGELOG-5.8.md
+++ b/CHANGELOG-5.8.md
@@ -1,0 +1,3 @@
+## not released
+
+- add methods `authenticate` and `hasUser` to `\Illuminate\Contracts\Auth\Guard` contract

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -7,6 +7,20 @@ interface Guard
     /**
      * Determine if the current user is authenticated.
      *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public function authenticate();
+
+    /**
+     * Determine if the guard has a user instance.
+     *
+     * @return bool
+     */
+    public function hasUser();
+
+    /**
+     * Determine if the current user is authenticated.
+     *
      * @return bool
      */
     public function check();
@@ -47,11 +61,4 @@ interface Guard
      * @return void
      */
     public function setUser(Authenticatable $user);
-
-    /**
-     * Determine if the guard has a user instance.
-     *
-     * @return bool
-     */
-    public function hasUser();
 }

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -47,4 +47,11 @@ interface Guard
      * @return void
      */
     public function setUser(Authenticatable $user);
+
+    /**
+     * Determine if the guard has a user instance.
+     *
+     * @return bool
+     */
+    public function hasUser();
 }


### PR DESCRIPTION
[5.8] Add method to Guard contract
- Added methods to the guard contract, since this method present in all Laravel Guards, but we could not use this if we will use the contact.

It is pretty the same PR as https://github.com/laravel/framework/pull/25616