### PR TITLE
[5.7] delete empty lines in changelog-5.7

### DIFF
--- a/CHANGELOG-5.7.md
+++ b/CHANGELOG-5.7.md
@@ -3,11 +3,9 @@
 ## v5.7.1 (2018-09-04)
 
 ### Fixed
-
 - Fixed an issue with basic auth when no field is defined
 
 ### Changed
-
 - Remove X-UA-Compatible meta tag ([#25442](https://github.com/laravel/framework/pull/25442))
 - Added default array value for redis config ([#25443](https://github.com/laravel/framework/pull/25443))
 


### PR DESCRIPTION
 - delete empty lines in changelog-5.7 as it was in `changelog-5.6` / `changelog-5.5` / `changelog-5.4` / `changelog-5.3` / `changelog-5.2`

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
