### PR TITLE
[5.7] Support custom accessor on whenPivotLoaded()

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -176,14 +176,28 @@ trait ConditionallyLoadsAttributes
      */
     protected function whenPivotLoaded($table, $value, $default = null)
     {
-        if (func_num_args() === 2) {
+        return $this->whenPivotLoadedAs('pivot', ...func_get_args());
+    }
+
+    /**
+     * Execute a callback if the given pivot table with a custom accessor has been loaded.
+     *
+     * @param  string  $accessor
+     * @param  string  $table
+     * @param  mixed  $value
+     * @param  mixed  $default
+     * @return \Illuminate\Http\Resources\MissingValue|mixed
+     */
+    protected function whenPivotLoadedAs($accessor, $table, $value, $default = null)
+    {
+        if (func_num_args() === 3) {
             $default = new MissingValue;
         }
 
         return $this->when(
-            $this->resource->pivot &&
-            ($this->resource->pivot instanceof $table ||
-             $this->resource->pivot->getTable() === $table),
+            $this->resource->$accessor &&
+            ($this->resource->$accessor instanceof $table ||
+            $this->resource->$accessor->getTable() === $table),
             ...[$value, $default]
         );
     }

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalPivotRelationship.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalPivotRelationship.php
@@ -13,6 +13,11 @@ class PostResourceWithOptionalPivotRelationship extends PostResource
                     'foo' => 'bar',
                 ];
             }),
+            'custom_subscription' => $this->whenPivotLoadedAs('accessor', Subscription::class, function () {
+                return [
+                    'foo' => 'bar',
+                ];
+            }),
         ];
     }
 }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -244,6 +244,31 @@ class ResourceTest extends TestCase
         ]);
     }
 
+    public function test_resources_may_have_optional_pivot_relationships_with_custom_accessor()
+    {
+        Route::get('/', function () {
+            $post = new Post(['id' => 5]);
+            $post->setRelation('accessor', new Subscription);
+
+            return new PostResourceWithOptionalPivotRelationship($post);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'id' => 5,
+                'custom_subscription' => [
+                    'foo' => 'bar',
+                ],
+            ],
+        ]);
+    }
+
     public function test_resource_is_url_routable()
     {
         $post = new PostResource(new Post([


### PR DESCRIPTION
This is an improved re-submit of #25625.

There is now a separate `whenPivotLoadedAs()` method to avoid breaking changes:

```php
return [
    'expires_at' => $this->whenPivotLoadedAs('accessor', 'role_user', function () {
        return $this->accessor->expires_at;
    }),
];
```

Fixes #25596.