### PR TITLE
[5.7] Support MorphTo eager loading with selected columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -236,24 +236,6 @@ class MorphTo extends BelongsTo
     }
 
     /**
-     * Remove all or passed registered global scopes.
-     *
-     * @param  array|null  $scopes
-     * @return $this
-     */
-    public function withoutGlobalScopes(array $scopes = null)
-    {
-        $this->getQuery()->withoutGlobalScopes($scopes);
-
-        $this->macroBuffer[] = [
-            'method' => __FUNCTION__,
-            'parameters' => [$scopes],
-        ];
-
-        return $this;
-    }
-
-    /**
      * Get the foreign key "type" name.
      *
      * @return string
@@ -298,7 +280,13 @@ class MorphTo extends BelongsTo
     public function __call($method, $parameters)
     {
         try {
-            return parent::__call($method, $parameters);
+            $result = parent::__call($method, $parameters);
+
+            if (in_array($method, ['select', 'selectRaw', 'selectSub', 'addSelect', 'withoutGlobalScopes'])) {
+                $this->macroBuffer[] = compact('method', 'parameters');
+            }
+
+            return $result;
         }
 
         // If we tried to call a method that does not exist on the parent Builder instance,

--- a/tests/Integration/Database/EloquentMorphToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphToSelectTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphToSelectTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphToSelectTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('commentable_type');
+            $table->integer('commentable_id');
+        });
+
+        $post = Post::create();
+        (new Comment)->commentable()->associate($post)->save();
+    }
+
+    public function test_select()
+    {
+        $comments = Comment::with('commentable:id')->get();
+
+        $this->assertEquals(['id' => 1], $comments[0]->commentable->getAttributes());
+    }
+
+    public function test_select_raw()
+    {
+        $comments = Comment::with(['commentable' => function ($query) {
+            $query->selectRaw('id');
+        }])->get();
+
+        $this->assertEquals(['id' => 1], $comments[0]->commentable->getAttributes());
+    }
+
+    public function test_select_sub()
+    {
+        $comments = Comment::with(['commentable' => function ($query) {
+            $query->selectSub(function ($query) {
+                $query->select('id');
+            }, 'id');
+        }])->get();
+
+        $this->assertEquals(['id' => 1], $comments[0]->commentable->getAttributes());
+    }
+
+    public function test_add_select()
+    {
+        $comments = Comment::with(['commentable' => function ($query) {
+            $query->addSelect('id');
+        }])->get();
+
+        $this->assertEquals(['id' => 1], $comments[0]->commentable->getAttributes());
+    }
+
+    public function test_lazy_loading()
+    {
+        $comment = Comment::first();
+        $post = $comment->commentable()->select('id')->first();
+
+        $this->assertEquals(['id' => 1], $post->getAttributes());
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Post extends Model
+{
+}


### PR DESCRIPTION
When eager loading `MorphTo` relationships, you can't limit the selected columns (of course, these columns have to be available in all the related tables):

```php
Comment::with('commentable:id,title')->get();
```
```sql
# expected
select "id", "title" from "posts" where "posts"."id" in (?)

# actual
select * from "posts" where "posts"."id" in (?)
```

As with `withoutGlobalScopes()` (#25331), we can use the `$macroBuffer` to fix this. We can also simplify the whole implementation.

Fixes #2966.