### PR TITLE
[5.7] Remove Hash::check() for password verification

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -152,8 +152,14 @@ class DatabaseUserProvider implements UserProvider
      */
     public function validateCredentials(UserContract $user, array $credentials)
     {
-        return $this->hasher->check(
-            $credentials['password'], $user->getAuthPassword()
+        $hashed = $user->getAuthPassword();
+
+        if (strlen($hashed) === 0) {
+            return false;
+        }
+
+        return password_verify(
+            $credentials['password'], $hashed
         );
     }
 }

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -138,8 +138,13 @@ class EloquentUserProvider implements UserProvider
     public function validateCredentials(UserContract $user, array $credentials)
     {
         $plain = $credentials['password'];
+        $hashed = $user->getAuthPassword();
 
-        return $this->hasher->check($plain, $user->getAuthPassword());
+        if (strlen($hashed) === 0) {
+            return false;
+        }
+
+        return password_verify($plain, $hashed);
     }
 
     /**

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -123,7 +123,6 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertTrue($result);
     }
 
-
     public function testCredentialValidationUsingUnknownAlgorithm()
     {
         $conn = m::mock('Illuminate\Database\Connection');

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -115,11 +115,23 @@ class AuthDatabaseUserProviderTest extends TestCase
     {
         $conn = m::mock('Illuminate\Database\Connection');
         $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
-        $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
-        $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
-        $result = $provider->validateCredentials($user, ['password' => 'plain']);
+        $user->shouldReceive('getAuthPassword')->once()->andReturn('$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm');
+        $result = $provider->validateCredentials($user, ['password' => 'secret']);
+
+        $this->assertTrue($result);
+    }
+
+
+    public function testCredentialValidationUsingUnknownAlgorithm()
+    {
+        $conn = m::mock('Illuminate\Database\Connection');
+        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
+        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user->shouldReceive('getAuthPassword')->once()->andReturn('$1$0590adc6$WVAjBIam8sJCgDieJGLey0');
+        $result = $provider->validateCredentials($user, ['password' => 's3cr3t']);
 
         $this->assertTrue($result);
     }

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -90,11 +90,22 @@ class AuthEloquentUserProviderTest extends TestCase
     {
         $conn = m::mock('Illuminate\Database\Connection');
         $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
-        $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
         $provider = new EloquentUserProvider($hasher, 'foo');
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
-        $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
-        $result = $provider->validateCredentials($user, ['password' => 'plain']);
+        $user->shouldReceive('getAuthPassword')->once()->andReturn('$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm');
+        $result = $provider->validateCredentials($user, ['password' => 'secret']);
+
+        $this->assertTrue($result);
+    }
+
+    public function testCredentialValidationUsingUnknownAlgorithm()
+    {
+        $conn = m::mock('Illuminate\Database\Connection');
+        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $provider = new EloquentUserProvider($hasher, 'foo');
+        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user->shouldReceive('getAuthPassword')->once()->andReturn('$1$0590adc6$WVAjBIam8sJCgDieJGLey0');
+        $result = $provider->validateCredentials($user, ['password' => 's3cr3t']);
 
         $this->assertTrue($result);
     }


### PR DESCRIPTION
As of 5.7.0, Laravel now verify the hash algorithm before using `password_verify()`, while this is more secure for hashing in general this cause a regression bugs for password verification on authentication flow:

* Laravel now only allow application using `bcrypt` to verify `bcrypt` password, any older hashing is no longer supported. #25586
* You no longer able to change from `bcrypt` to a stronger algorithm on your existing applications. #25458
