### PR TITLE
[5.8] Updated the container for better PSR-11 ContainerInterface compliance

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -160,7 +160,8 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function has($id)
     {
-        return $this->bound($id);
+        return $this->bound($id) ||
+               class_exists($id);
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1021,7 +1021,7 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
-        $this->assertTrue($container->has('Illuminate\Tests\Container\IContainerContractStub'));
+        $this->assertTrue($container->bound('Illuminate\Tests\Container\IContainerContractStub'));
     }
 
     public function testContainerCanBindAnyWord()
@@ -1047,6 +1047,12 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $container->get('Taylor');
+    }
+
+    public function testCanResolveUnknownEntry()
+    {
+        $container = new Container();
+        $this->assertTrue($container->has('Illuminate\Tests\Container\ContainerTestUnknownEntry'));
     }
 }
 
@@ -1211,4 +1217,8 @@ class ContainerTestContextInjectInstantiations implements IContainerContractStub
     {
         static::$instantiations++;
     }
+}
+
+class ContainerTestUnknownEntry
+{
 }


### PR DESCRIPTION
I think the current implementation of PSR-11 breaks the contract. The interface only describes the has() and get() methods but the has() returns false on autowired classes. 

The docs for PSR-11 for the has() method state: 
> Returns true if the container can return an entry for the given identifier. Returns false otherwise.

Because the container can autowire classes it think it should return true in case of a class that it can autowire because it's able to return an entry for the given identifier even if it's unknown.

For example I've made a composer package that can run independently from any framework, as long as you provide a PSR-11 compliant Container. Currently the only way to get my code to work with the Laravel Container is to use the make() method as I refuse to bind hundreds (if not thousands) of classes from the multiple Laravel repositories I maintain and their respective required composer packages. As the make() method is not defined in the PSR and I can't use the has() method, this means the Laravel Container breaks the contract and I have to add some Laravel specific code.

I've made a simplified version of a Factory class to state whats wrong with the current implementation
```
<?php

namespace Vendor\Package;

class Factory {

    private $container;

    public function __construct(\Psr\Container\ContainerInterface $container)
    {

        $this->container = $container;

    }

    public function get($param)
    {

        // Do some stuff to generate a class name
        $class = $param;

        if ($this->container instanceof \Illuminate\Container\Container) {
            if (!class_exists($class)) {
                throw new ClassNotFoundException();
            }

            return $this->container->make($class);
        }
        else {
            if (!$this->container->has($class)) {
                throw new ClassNotFoundException();
            }

            return $this->container->get($class);
        }

    }

}
```

After the made changes the Factory doesn't require the Laravel specific code and will look like this:
```
<?php

namespace Vendor\Package;

class Factory {

    private $container;

    public function __construct(\Psr\Container\ContainerInterface $container)
    {

        $this->container = $container;

    }

    public function get($param)
    {

        // Do some stuff to generate a class name
        $class = $param;

        if (!$this->container->has($class)) {
            throw new ClassNotFoundException();
        }

        return $this->container->get($class);
    }

}
```