### PR TITLE
[5.7] Support custom user provider names in generator commands

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -171,7 +171,7 @@ abstract class GeneratorCommand extends Command
     {
         $stub = str_replace(
             ['DummyNamespace', 'DummyRootNamespace', 'NamespacedDummyUserModel'],
-            [$this->getNamespace($name), $this->rootNamespace(), config('auth.providers.users.model')],
+            [$this->getNamespace($name), $this->rootNamespace(), $this->userProviderModel()],
             $stub
         );
 
@@ -221,6 +221,19 @@ abstract class GeneratorCommand extends Command
     protected function rootNamespace()
     {
         return $this->laravel->getNamespace();
+    }
+
+    /**
+     * Get the configured model for the provider.
+     *
+     * @return string|null
+     */
+    protected function userProviderModel()
+    {
+        $guard = config('auth.defaults.guard');
+        $provider = config("auth.guards.{$guard}.provider");
+
+        return config("auth.providers.{$provider}.model");
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
@@ -37,7 +37,7 @@ class ChannelMakeCommand extends GeneratorCommand
     {
         return str_replace(
             'DummyUser',
-            class_basename(config('auth.providers.users.model')),
+            class_basename($this->userProviderModel()),
             parent::buildClass($name)
         );
     }

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -54,13 +54,14 @@ class PolicyMakeCommand extends GeneratorCommand
      */
     protected function replaceUserNamespace($stub)
     {
-        if (! config('auth.providers.users.model')) {
+        $model = $this->userProviderModel();
+        if (! $model) {
             return $stub;
         }
 
         return str_replace(
             $this->rootNamespace().'User',
-            config('auth.providers.users.model'),
+            $model,
             $stub
         );
     }
@@ -90,7 +91,7 @@ class PolicyMakeCommand extends GeneratorCommand
 
         $model = class_basename(trim($model, '\\'));
 
-        $dummyUser = class_basename(config('auth.providers.users.model'));
+        $dummyUser = class_basename($this->userProviderModel());
 
         $dummyModel = Str::camel($model) === 'user' ? 'model' : $model;
 


### PR DESCRIPTION
The generator commands only worked when the `auth.providers.user` configuration was used. When you change this to something else, the user model wouldn't be replaced correctly.

I refactored the retrieval of the authentication model to a seperate method called `userProviderModel()`. Then I searched and replaced all occurrences of `config('auth.providers.users.model')`. 

I don't know if this is the way you'd like to implement this method. But it fixes the bug. I'll keep the PR open for feedback and edits.
