### PR TITLE
[5.8] Updated the container for better PSR-11 ContainerInterface compliance

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -160,7 +160,8 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function has($id)
     {
-        return $this->bound($id);
+        return $this->bound($id) ||
+               class_exists($id);
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -175,6 +175,7 @@ class Container implements ArrayAccess, ContainerContract
     {
         try {
             $reflector = new ReflectionClass($id);
+
             return $reflector->isInstantiable();
         } catch (ReflectionException $e) {
             return false;

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -166,7 +166,7 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Determine if the given id resolves to a class and if it is an instantiable class
+     * Determine if the given id resolves to a class and if it is an instantiable class.
      *
      * @param  string  $id
      * @return bool
@@ -176,7 +176,7 @@ class Container implements ArrayAccess, ContainerContract
         try {
             $reflector = new ReflectionClass($id);
             return $reflector->isInstantiable();
-        } catch(ReflectionException $e) {
+        } catch (ReflectionException $e) {
             return false;
         }
     }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -6,6 +6,7 @@ use Closure;
 use ArrayAccess;
 use LogicException;
 use ReflectionClass;
+use ReflectionException;
 use ReflectionParameter;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container as ContainerContract;
@@ -161,7 +162,23 @@ class Container implements ArrayAccess, ContainerContract
     public function has($id)
     {
         return $this->bound($id) ||
-               class_exists($id);
+               $this->isInstantiable($id);
+    }
+
+    /**
+     * Determine if the given id resolves to a class and if it is an instantiable class
+     *
+     * @param  string  $id
+     * @return bool
+     */
+    private function isInstantiable($id)
+    {
+        try {
+            $reflector = new ReflectionClass($id);
+            return $reflector->isInstantiable();
+        } catch(ReflectionException $e) {
+            return false;
+        }
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1021,7 +1021,7 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
-        $this->assertTrue($container->has('Illuminate\Tests\Container\IContainerContractStub'));
+        $this->assertTrue($container->bound('Illuminate\Tests\Container\IContainerContractStub'));
     }
 
     public function testContainerCanBindAnyWord()
@@ -1047,6 +1047,12 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $container->get('Taylor');
+    }
+
+    public function testCanResolveUnknownEntry()
+    {
+        $container = new Container();
+        $this->assertTrue($container->has('Illuminate\Tests\Container\ContainerTestUnknownEntry'));
     }
 }
 
@@ -1211,4 +1217,8 @@ class ContainerTestContextInjectInstantiations implements IContainerContractStub
     {
         static::$instantiations++;
     }
+}
+
+class ContainerTestUnknownEntry
+{
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1052,6 +1052,11 @@ class ContainerTest extends TestCase
     public function testCanResolveUnknownEntry()
     {
         $container = new Container();
+        $this->assertFalse($container->has('Taylor'));
+        $this->assertFalse($container->has('Illuminate\Tests\Container\ContainerTestUnknownEntryInterface'));
+        $this->assertFalse($container->has('Illuminate\Tests\Container\ContainerTestUnknownEntryTrait'));
+        $this->assertFalse($container->has('Illuminate\Tests\Container\AbstractContainerTestUnknownEntry'));
+        $this->assertFalse($container->has('Illuminate\Tests\Container\ContainerTestUnknownEntryPrivateConstructor'));
         $this->assertTrue($container->has('Illuminate\Tests\Container\ContainerTestUnknownEntry'));
     }
 }
@@ -1219,6 +1224,26 @@ class ContainerTestContextInjectInstantiations implements IContainerContractStub
     }
 }
 
-class ContainerTestUnknownEntry
+interface ContainerTestUnknownEntryInterface
 {
+}
+
+trait ContainerTestUnknownEntryTrait
+{
+}
+
+abstract class AbstractContainerTestUnknownEntry
+{
+}
+
+class ContainerTestUnknownEntryPrivateConstructor
+{
+    private function __construct()
+    {
+    }
+}
+
+class ContainerTestUnknownEntry extends AbstractContainerTestUnknownEntry implements ContainerTestUnknownEntryInterface
+{
+    use ContainerTestUnknownEntryTrait;
 }

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -24,21 +24,21 @@ class MakesHttpRequestsTest extends TestCase
             return $request;
         };
 
-        $this->assertFalse($this->app->has(MyMiddleware::class));
+        $this->assertFalse($this->app->bound(MyMiddleware::class));
         $this->assertEquals(
             'fooWithMiddleware',
             $this->app->make(MyMiddleware::class)->handle('foo', $next)
         );
 
         $this->withoutMiddleware(MyMiddleware::class);
-        $this->assertTrue($this->app->has(MyMiddleware::class));
+        $this->assertTrue($this->app->bound(MyMiddleware::class));
         $this->assertEquals(
             'foo',
             $this->app->make(MyMiddleware::class)->handle('foo', $next)
         );
 
         $this->withMiddleware(MyMiddleware::class);
-        $this->assertFalse($this->app->has(MyMiddleware::class));
+        $this->assertFalse($this->app->bound(MyMiddleware::class));
         $this->assertEquals(
             'fooWithMiddleware',
             $this->app->make(MyMiddleware::class)->handle('foo', $next)


### PR DESCRIPTION
@laurencei To be honest I did not run the HTTP tests because I wasn't able to configure PHPUnit properly. Tried for an hour or 2 but kept on getting hundreds of errors. By simply looking at the failed test I understand my changes cause it to fail. I can fix those, but as @deleugpn states this implementation might be a bit flawed...

After a quick test and checking the PHP docs, only abstract classes will cause a problem. class_exists will return false on interface and traits and they both have their own respective _exists methods. I've updated my code to check through the Reflection API if the identifier resolves to an instantiable class.

Then the only thing remaining is the comment made by @taylorotwell made here https://github.com/laravel/framework/pull/21327#issuecomment-331430213 :
> Just because a class is concrete doesn't mean the Laravel container can resolve it. What if it has an interface dependency that isn't configured?

To that my response is:
Why would you check if all the dependencies are resolvable for a unbound class if you don't do that for a bound class? I mean currently I can bind any class with unresolvable dependencies and the code would break just as hard.