### PR TITLE
[5.8] Add columns and compact options to route:list command

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -115,7 +115,7 @@ class RouteListCommand extends Command
     protected function getRouteInformation(Route $route)
     {
         return $this->filterRoute([
-            'domain'   => $route->domain(),
+            'domain' => $route->domain(),
             'method' => implode('|', $route->methods()),
             'uri'    => $route->uri(),
             'name'   => $route->getName(),


### PR DESCRIPTION
This PR adds some extra options to the route:list command to specify what columns should be included in the output.

### `--columns`

Array input to specify columns to include in the output.

![image](https://user-images.githubusercontent.com/6287961/45696879-cae61480-bb64-11e8-9015-efd608df2a3a.png)

Nice use case: `alias routels='php artisan route:list --columns=method --columns=uri'` for the output above.

### `--compact` or `-c`

Alias for `--columns=method --columns=uri --columns=action`

![image](https://user-images.githubusercontent.com/6287961/45698751-0551b080-bb69-11e8-955d-8d0d36eaf254.png)

Use case: no more truncated lines in terminal :)

### Why is this breaking?

For some reason the domain information for a route was being put in the routes array as `host` (even though the column header is "Domain"). This caused some issues for my PR and also causes `--sort=host` to sort the domain column. 
See line 109 here: https://github.com/laravel/framework/blob/9f313ce9bb5ad49a06ae78d33fbdd1c92a0e21f6/src/Illuminate/Foundation/Console/RouteListCommand.php#L106-L116

As I fix I renamed the array key from `host` to `domain` but this breaks the `--sort=host`.

### Why this PR?

The route:list table truncates in projects with long namespaces/urls (even with a fullscreen terminal):

![image](https://user-images.githubusercontent.com/6287961/45698110-958ef600-bb67-11e8-8a36-7a284945fdfe.png)
