### PR TITLE
[5.7] MethodNotAllowedHTTPException on Intended Redirect

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -82,7 +82,11 @@ class Redirector
      */
     public function guest($path, $status = 302, $headers = [], $secure = null)
     {
-        $this->session->put('url.intended', $this->generator->full());
+        $request = $this->generator->getRequest();
+
+        if ($request->method() === 'GET' && $request->route() && !$request->ajax()) {
+            $this->session->put('url.intended', $this->generator->full());
+        }
 
         return $this->to($path, $status, $headers, $secure);
     }

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -84,7 +84,7 @@ class Redirector
     {
         $request = $this->generator->getRequest();
 
-        $intended = $request->method() === 'GET' && $request->route() && !$request->ajax() ?
+        $intended = $request->method() === 'GET' && $request->route() && ! $request->ajax() ?
             $this->generator->full() :
             $this->generator->previous();
 

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -84,9 +84,11 @@ class Redirector
     {
         $request = $this->generator->getRequest();
 
-        if ($request->method() === 'GET' && $request->route() && !$request->ajax()) {
-            $this->session->put('url.intended', $this->generator->full());
-        }
+        $intended = $request->method() === 'GET' && $request->route() && !$request->ajax() ?
+            $this->generator->full() :
+            $this->generator->previous();
+
+        $this->session->put('url.intended', $intended);
 
         return $this->to($path, $status, $headers, $secure);
     }

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -75,7 +75,7 @@ class RoutingRedirectorTest extends TestCase
 
     public function testGuestPutPreviousUrlInSession()
     {
-        $this->request->shouldReceive('method')->once()->andReturn('POST');
+        $this->request->shouldReceive('method')->once()->andReturn('POST')->byDefault();
         $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
         $this->url->shouldReceive('previous')->once()->andReturn('http://foo.com/bar');
 

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -20,8 +20,8 @@ class RoutingRedirectorTest extends TestCase
 
         $this->request = m::mock('Illuminate\Http\Request');
         $this->request->shouldReceive('method')->andReturn('GET')->byDefault();
-        $this->request->shouldReceive('route')->andReturn(true);
-        $this->request->shouldReceive('ajax')->andReturn(false);
+        $this->request->shouldReceive('route')->andReturn(true)->byDefault();
+        $this->request->shouldReceive('ajax')->andReturn(false)->byDefault();
         $this->request->headers = $this->headers;
 
         $this->url = m::mock('Illuminate\Routing\UrlGenerator');

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -19,7 +19,7 @@ class RoutingRedirectorTest extends TestCase
         $this->headers = m::mock('Symfony\Component\HttpFoundation\HeaderBag');
 
         $this->request = m::mock('Illuminate\Http\Request');
-        $this->request->shouldReceive('method')->andReturn('GET');
+        $this->request->shouldReceive('method')->andReturn('GET')->byDefault();
         $this->request->shouldReceive('route')->andReturn(true);
         $this->request->shouldReceive('ajax')->andReturn(false);
         $this->request->headers = $this->headers;
@@ -75,7 +75,7 @@ class RoutingRedirectorTest extends TestCase
 
     public function testGuestPutPreviousUrlInSession()
     {
-        $this->request->shouldReceive('method')->once()->andReturn('POST')->byDefault();
+        $this->request->shouldReceive('method')->once()->andReturn('POST');
         $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
         $this->url->shouldReceive('previous')->once()->andReturn('http://foo.com/bar');
 

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -70,6 +70,17 @@ class RoutingRedirectorTest extends TestCase
         $this->assertEquals('http://foo.com/login', $response->getTargetUrl());
     }
 
+    public function testGuestPutPreviousUrlInSession()
+    {
+        $this->request->shouldReceive('method')->andReturn('POST');
+        $this->session->shouldReceive('get')->once()->with('_previous.url')->andReturn('http://foo.com/bar');
+        $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
+
+        $response = $this->redirect->guest('login');
+
+        $this->assertEquals('http://foo.com/login', $response->getTargetUrl());
+    }
+
     public function testIntendedRedirectToIntendedUrlInSession()
     {
         $this->session->shouldReceive('pull')->with('url.intended', '/')->andReturn('http://foo.com/bar');

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -19,6 +19,9 @@ class RoutingRedirectorTest extends TestCase
         $this->headers = m::mock('Symfony\Component\HttpFoundation\HeaderBag');
 
         $this->request = m::mock('Illuminate\Http\Request');
+        $this->request->shouldReceive('method')->andReturn('POST');
+        $this->request->shouldReceive('route')->andReturn(true);
+        $this->request->shouldReceive('ajax')->andReturn(false);
         $this->request->headers = $this->headers;
 
         $this->url = m::mock('Illuminate\Routing\UrlGenerator');
@@ -72,9 +75,9 @@ class RoutingRedirectorTest extends TestCase
 
     public function testGuestPutPreviousUrlInSession()
     {
-        $this->request->shouldReceive('method')->andReturn('POST');
-        $this->session->shouldReceive('get')->once()->with('_previous.url')->andReturn('http://foo.com/bar');
+        $this->request->shouldReceive('method')->once()->andReturn('POST');
         $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
+        $this->url->shouldReceive('previous')->once()->andReturn('http://foo.com/bar');
 
         $response = $this->redirect->guest('login');
 

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -19,7 +19,7 @@ class RoutingRedirectorTest extends TestCase
         $this->headers = m::mock('Symfony\Component\HttpFoundation\HeaderBag');
 
         $this->request = m::mock('Illuminate\Http\Request');
-        $this->request->shouldReceive('method')->andReturn('POST');
+        $this->request->shouldReceive('method')->andReturn('GET');
         $this->request->shouldReceive('route')->andReturn(true);
         $this->request->shouldReceive('ajax')->andReturn(false);
         $this->request->headers = $this->headers;


### PR DESCRIPTION
### Environment:

- Laravel Version: 5.5.40
- PHP Version: 7.0
- Database Driver & Version: N/A

### Description:

`redirect()->intended()` can redirect the user to a bad route if the user interacts with a form after session timeout. This leads to errors being shown to a user from reasonable use of the application and is surprisingly difficult to avoid or work around.

### Steps To Reproduce:

- Have an expired session or no session.
- POST to a route protected by the 'auth' middleware that does not have a corresponding GET route.
  - Easy way to do this is to login, navigate to a form, wait a while, then submit the form.
- Authenticate and be redirected to the POST route.
- Receive `MethodNotAllowedHTTPException`.

### Proposed Solution:

Alter `\Illuminate\Routing\Redirector::guest()` to check if the current request is suitable for redirection and if the requested route isn't suitable for redirect, don't store it as `url.intended` and instead store the "previous" URL as the intended route to get the user back to being as close as possible to the failed request.