### PR TITLE
[5.7] Add missing Arrayable typehints

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -27,7 +27,7 @@ interface ResponseFactory
      * Create a new response for a given view.
      *
      * @param  string  $view
-     * @param  array  $data
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\Response

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -986,7 +986,7 @@ if (! function_exists('view')) {
      * Get the evaluated view contents for the given view.
      *
      * @param  string  $view
-     * @param  array   $data
+     * @param  \Illuminate\Contracts\Support\Arrayable|array   $data
      * @param  array   $mergeData
      * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
      */

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -71,7 +71,7 @@ class ResponseFactory implements FactoryContract
      * Create a new response for a given view.
      *
      * @param  string  $view
-     * @param  array  $data
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\Response

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -260,7 +260,7 @@ class Router implements RegistrarContract, BindingRegistrar
      *
      * @param  string  $uri
      * @param  string  $view
-     * @param  array  $data
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @return \Illuminate\Routing\Route
      */
     public function view($uri, $view, $data = [])

--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 
 /**
  * @method static \Illuminate\Http\Response make(string $content = '', int $status = 200, array $headers = [])
- * @method static \Illuminate\Http\Response view(string $view, array $data = [], int $status = 200, array $headers = [])
+ * @method static \Illuminate\Http\Response view(string $view, \Illuminate\Contracts\Support\Arrayable | array $data = [], int $status = 200, array $headers = [])
  * @method static \Illuminate\Http\JsonResponse json(string | array $data = [], int $status = 200, array $headers = [], int $options = 0)
  * @method static \Illuminate\Http\JsonResponse jsonp(string $callback, string | array $data = [], int $status = 200, array $headers = [], int $options = 0)
  * @method static \Symfony\Component\HttpFoundation\StreamedResponse stream(\Closure $callback, int $status = 200, array $headers = [])

--- a/src/Illuminate/Support/Facades/View.php
+++ b/src/Illuminate/Support/Facades/View.php
@@ -4,8 +4,8 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static bool exists(string $view)
- * @method static \Illuminate\Contracts\View\View file(string $path, array $data = [], array $mergeData = [])
- * @method static \Illuminate\Contracts\View\View make(string $view, array $data = [], array $mergeData = [])
+ * @method static \Illuminate\Contracts\View\View file(string $path, \Illuminate\Contracts\Support\Arrayable | array $data = [], array $mergeData = [])
+ * @method static \Illuminate\Contracts\View\View make(string $view, \Illuminate\Contracts\Support\Arrayable | array $data = [], array $mergeData = [])
  * @method static mixed share(array | string $key, $value = null)
  * @method static array composer(array | string $views, \Closure | string $callback)
  * @method static array creator(array | string $views, \Closure | string $callback)


### PR DESCRIPTION
This is continuation of #25669:

> It's possible to pass data to view using object that implements \Illuminate\Contracts\Support\Arrayable contract.

- https://github.com/laravel/framework/blob/5.7/src/Illuminate/View/Factory.php#L237