### PR TITLE
[5.7] Add MustVerifyEmailContract to User model

### DIFF
--- a/src/Illuminate/Foundation/Auth/User.php
+++ b/src/Illuminate/Foundation/Auth/User.php
@@ -10,11 +10,13 @@ use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
+use Illuminate\Contracts\Auth\MustVerifyEmail as MustVerifyEmailContract;
 
 class User extends Model implements
     AuthenticatableContract,
     AuthorizableContract,
-    CanResetPasswordContract
+    CanResetPasswordContract,
+    MustVerifyEmailContract
 {
     use Authenticatable, Authorizable, CanResetPassword, MustVerifyEmail;
 }


### PR DESCRIPTION
missing this contract will cause "$event->user instanceof MustVerifyEmail" in Illuminate\Auth\Listeners\SendEmailVerificationNotification return false unless you add it to you user model manually.