### PR TITLE
[5.7] Make any column searchable with `like` in PostgreSQL (and fix Global Search in Laravel Nova)

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -24,38 +24,33 @@ class PostgresGrammar extends Grammar
     /**
      * {@inheritdoc}
      *
-     * @param Builder $query
-     * @param array   $where
-     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
      * @return string
      */
     protected function whereBasic(Builder $query, $where)
     {
         // Special treatment for like clauses. In order to make
         // any column searchable, we need to convert it to text.
-        if (Str::contains($where['operator'], 'like')) {
+        if (Str::contains(strtolower($where['operator']), 'like')) {
             return $this->whereBasicLike($query, $where);
         }
 
-        $value = $this->parameter($where['value']);
-
-        return $this->wrap($where['column']).' '.$where['operator'].' '.$value;
+        return parent::whereBasic($query, $where);
     }
 
     /**
-     * Compile a "where like" clause. Suffix column with text conversion
-     * to make numeric columns searchable.
+     * Compile "where like", "where ilike", "where not like" and "where not ilike" clauses.
      *
-     * @param Builder $query
-     * @param array   $where
-     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
      * @return string
      */
     protected function whereBasicLike(Builder $query, $where)
     {
         $value = $this->parameter($where['value']);
 
-        return $this->wrap($where['column']).' :: text '.$where['operator'].' '.$value;
+        return $this->wrap($where['column']).'::text '.$where['operator'].' '.$value;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Database\Query\Builder;
 
 class PostgresGrammar extends Grammar
@@ -19,6 +20,43 @@ class PostgresGrammar extends Grammar
         '&&', '@>', '<@', '?', '?|', '?&', '||', '-', '-', '#-',
         'is distinct from', 'is not distinct from',
     ];
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param Builder $query
+     * @param array   $where
+     *
+     * @return string
+     */
+    protected function whereBasic(Builder $query, $where)
+    {
+        // Special treatment for like clauses. In order to make
+        // any column searchable, we need to convert it to text.
+        if (Str::contains($where['operator'], 'like')) {
+            return $this->whereBasicLike($query, $where);
+        }
+
+        $value = $this->parameter($where['value']);
+
+        return $this->wrap($where['column']).' '.$where['operator'].' '.$value;
+    }
+
+    /**
+     * Compile a "where like" clause. Suffix column with text conversion
+     * to make numeric columns searchable.
+     *
+     * @param Builder $query
+     * @param array   $where
+     *
+     * @return string
+     */
+    protected function whereBasicLike(Builder $query, $where)
+    {
+        $value = $this->parameter($where['value']);
+
+        return $this->wrap($where['column']).' :: text '.$where['operator'].' '.$value;
+    }
 
     /**
      * Compile a "where date" clause.

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -461,6 +461,34 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
+    public function testWhereLikePostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where('id', 'like', '1');
+        $this->assertEquals('select * from "users" where "id"::text like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where('id', 'LIKE', '1');
+        $this->assertEquals('select * from "users" where "id"::text LIKE ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where('id', 'ilike', '1');
+        $this->assertEquals('select * from "users" where "id"::text ilike ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where('id', 'not like', '1');
+        $this->assertEquals('select * from "users" where "id"::text not like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where('id', 'not ilike', '1');
+        $this->assertEquals('select * from "users" where "id"::text not ilike ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+    }
+
     public function testWhereDateSqlite()
     {
         $builder = $this->getSQLiteBuilder();


### PR DESCRIPTION
This small change actually became necessary to make Global Search in Laravel Nova on PostgreSQL possible.

See related issue here: https://github.com/laravel/nova-issues/issues/46

Postgres doesn't like to compare non text fields using like without strict type conversion, so we need to add it.