### PR TITLE
[5.7] Remove trailing newline from hot url

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -581,7 +581,7 @@ if (! function_exists('mix')) {
         }
 
         if (file_exists(public_path($manifestDirectory.'/hot'))) {
-            $url = file_get_contents(public_path($manifestDirectory.'/hot'));
+            $url = rtrim(file_get_contents(public_path($manifestDirectory.'/hot')));
 
             if (Str::startsWith($url, ['http://', 'https://'])) {
                 return new HtmlString(Str::after($url, ':').$path);


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The `hot` file created in the `public` directory by `mix` ends with a newline.

Which is then passed on to the html, which does not look like that was intended:

![screen shot 2018-09-19 at 10 23 44](https://user-images.githubusercontent.com/3179271/45740771-4a6ff400-bbf6-11e8-9f0a-f804f9e6ca27.png)

▲ current | patch ▼

![screen shot 2018-09-19 at 10 23 26](https://user-images.githubusercontent.com/3179271/45740774-4ba12100-bbf6-11e8-8fde-e90b47415fe5.png)

