### PR TITLE
[5.7] Add ability to update any section of package.json

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/Preset.php
+++ b/src/Illuminate/Foundation/Console/Presets/Preset.php
@@ -23,16 +23,18 @@ class Preset
     /**
      * Update the "package.json" file.
      *
-     * @param  bool  $dev
+     * @param  bool|string  $configurationKey
      * @return void
      */
-    protected static function updatePackages($dev = true)
+    protected static function updatePackages($configurationKey = true)
     {
         if (! file_exists(base_path('package.json'))) {
             return;
         }
 
-        $configurationKey = $dev ? 'devDependencies' : 'dependencies';
+        if (is_bool($configurationKey)) {
+            $configurationKey = $configurationKey ? 'devDependencies' : 'dependencies';
+        }
 
         $packages = json_decode(file_get_contents(base_path('package.json')), true);
 


### PR DESCRIPTION
In continuation of the previous PRs (#24189, #25457 ) I suggest one more.
I noticed that developers who need to update, for example, a section of scripts, often completely overwrite the existing package.json file.
Let's give ability to pass name of section as parameter of static::updatePackages.
```php
static::updatePackages('scripts');
```
For back compatibility, we also support boolean as parameter.

Maybe there are best variants for doing this, but I think, that this variant is the least breaking.