### PR TITLE
Corrected instanceof operator usage while using push() function on model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -7,6 +7,7 @@ use ArrayAccess;
 use JsonSerializable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\ForwardsCalls;


### PR DESCRIPTION
Function push() uses instanceof operator to compare if given relation is a collection. But Collection Class is not resolved correctly and always returns false even if the given entry is a collection. This leads to an Exception.
