### PR TITLE
[5.6] Skip SplFileInfo dependent tests on Windows

### DIFF
--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1162,6 +1162,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertEquals(['id' => 3, 'email' => 'taylorotwell@gmail.com'], $notStoredUser->toArray());
         $this->assertNull($freshNotStoredUser);
+        \Illuminate\Support\Carbon::setTestNow();
     }
 
     public function testFreshMethodOnCollection()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -512,7 +512,7 @@ class FilesystemTest extends TestCase
      * \Symfony\Component\Finder\Finder which uses
      * \Symfony\Component\Finder\Iterator\RecursiveDirectoryIterator which uses
      * \Symfony\Component\Finder\SplFileInfo which locks directories on Windows ands cause problems
-     * on delete and create iterated directories
+     * on delete and create iterated directories.
      */
     private function skipSplDependentOnWindows()
     {

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -133,6 +133,8 @@ class FilesystemTest extends TestCase
 
     public function testFilesMethod()
     {
+        $this->skipSplDependentOnWindows();
+
         mkdir($this->tempDir.'/foo');
         file_put_contents($this->tempDir.'/foo/1.txt', '1');
         file_put_contents($this->tempDir.'/foo/2.txt', '2');
@@ -360,6 +362,8 @@ class FilesystemTest extends TestCase
 
     public function testAllFilesFindsFiles()
     {
+        $this->skipSplDependentOnWindows();
+
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         file_put_contents($this->tempDir.'/bar.txt', 'bar');
         $files = new Filesystem;
@@ -373,6 +377,8 @@ class FilesystemTest extends TestCase
 
     public function testDirectoriesFindsDirectories()
     {
+        $this->skipSplDependentOnWindows();
+
         mkdir($this->tempDir.'/foo');
         mkdir($this->tempDir.'/bar');
         $files = new Filesystem;
@@ -454,6 +460,8 @@ class FilesystemTest extends TestCase
 
     public function testFilesMethodReturnsFileInfoObjects()
     {
+        $this->skipSplDependentOnWindows();
+
         mkdir($this->tempDir.'/foo');
         file_put_contents($this->tempDir.'/foo/1.txt', '1');
         file_put_contents($this->tempDir.'/foo/2.txt', '2');
@@ -465,6 +473,8 @@ class FilesystemTest extends TestCase
 
     public function testAllFilesReturnsFileInfoObjects()
     {
+        $this->skipSplDependentOnWindows();
+
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         file_put_contents($this->tempDir.'/bar.txt', 'bar');
         $files = new Filesystem;
@@ -495,5 +505,19 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $filesystem = new Filesystem;
         $this->assertEquals('acbd18db4cc2f85cedef654fccc4a4d8', $filesystem->hash($this->tempDir.'/foo.txt'));
+    }
+
+    /**
+     * Skip Filesystem methods which use
+     * \Symfony\Component\Finder\Finder which uses
+     * \Symfony\Component\Finder\Iterator\RecursiveDirectoryIterator which uses
+     * \Symfony\Component\Finder\SplFileInfo which locks directories on Windows ands cause problems
+     * on delete and create iterated directories
+     */
+    private function skipSplDependentOnWindows()
+    {
+        if (DIRECTORY_SEPARATOR == '\\') {
+            $this->markTestSkipped('Skip \Symfony\Component\Finder\SplFileInfo dependent methods which broke other tests on Windows');
+        }
     }
 }


### PR DESCRIPTION
I noticed that we have 33 broken tests on Windows
![image](https://user-images.githubusercontent.com/13823215/45785372-b42ee300-bc74-11e8-9602-5914dd09457b.png)

I dug into the problem and noticed that they caused by not deleted folders due to permission error

![image](https://user-images.githubusercontent.com/13823215/45785611-afb6fa00-bc75-11e8-9e0b-fa8247720157.png)

I don't know how to resolve this correctly without skipping.

[This advice](https://stackoverflow.com/a/22822981/6625548) doesn't help. I tried set iterator value to null with link usage but it has no effect
```
foreach ($files->allFiles($this->tempDir) as &$file) {
    $allFiles[] = $file->getFilename();
    $file = null;
}
```

Maybe someone has some advice on how to fix this in an appropriate way?

Also, I've fixed problem with DB format testing which was caused by mocked `Carbon::now()`
![image](https://user-images.githubusercontent.com/13823215/45786262-569c9580-bc78-11e8-9984-8c580e33c37f.png)