### PR TITLE
[5.8] Use PHP's configured default character set when outputting from "e" helper function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -557,7 +557,7 @@ if (! function_exists('e')) {
             return $value->toHtml();
         }
 
-        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8', $doubleEncode);
+        return htmlspecialchars($value, ENT_QUOTES, ini_get('default_charset'), $doubleEncode);
     }
 }
 


### PR DESCRIPTION
Rationale is in #25689

Re-post of #25690 - against master this time because it is a potential breaking change.