### PR TITLE
Throw an exception when an atom is supplied to foreach

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -820,9 +820,15 @@ class Builder
      * @param  string  $boolean
      * @param  bool    $not
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function whereIn($column, $values, $boolean = 'and', $not = false)
     {
+        if (!$this->isValidWhereInValues($values)) {
+            throw new InvalidArgumentException("Invalid values supplied to whereIn");
+        }
+
         $type = $not ? 'NotIn' : 'In';
 
         if ($values instanceof EloquentBuilder) {
@@ -864,6 +870,21 @@ class Builder
         }
 
         return $this;
+    }
+
+    /**
+     * Determine if $values is a valid argument to whereIn
+     *
+     * @param  mixed  $values
+     * @return bool
+     */
+    protected function isValidWhereInValues($values)
+    {
+        return $values instanceof EloquentBuilder ||
+            $values instanceof self ||
+            $values instanceof Closure ||
+            $values instanceof Arrayable ||
+            is_array($values);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -670,6 +670,26 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Invalid values supplied to whereIn
+     */
+    public function testWhereInThrowsExceptionOnAtomicValue()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereIn('id', 1);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Invalid values supplied to whereIn
+     */
+    public function testOrWhereInThrowsExceptionOnAtomicValue()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', 1);
+    }
+
     public function testEmptyWhereNotIns()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
When you are building a query and pass in an atomic value to `whereIn` It fails with the message
"Invalid argument supplied for foreach()" which is not very informative. 
I've added a test and throw an `InvalidArgumentException` with an error message that will make it easier to find the problem. 

