### PR TITLE
[5.7] Fix broken email subcopy template escaping

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -51,12 +51,12 @@
 @component('mail::subcopy')
 @lang(
     "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
-    'into your web browser: [:actionURL](:actionURL)',
+    'into your web browser: ',
     [
-        'actionText' => $actionText,
-        'actionURL' => $actionUrl
+        'actionText' => $actionText
     ]
 )
+[{{ $actionUrl }}]({!! $actionUrl !!})
 @endcomponent
 @endisset
 @endcomponent


### PR DESCRIPTION
Laravel 5.6.36 (https://github.com/laravel/framework/commit/d3c0a369057d0b6ebf29b5f51c903b1a85e3e09b) introduced a security change to prevent XSS in some situations.

Unfortunately a byproduct of this is a number of breaking changes as documented https://github.com/laravel/framework/issues/25515, https://github.com/laravel/framework/issues/25501, https://github.com/laravel/framework/pull/25408, https://github.com/laravel/framework/commit/d3c0a369057d0b6ebf29b5f51c903b1a85e3e09b#commitcomment-30368450, https://github.com/laravel/framework/issues/25716, https://github.com/laravel/framework/issues/25430

One of those breaking changes linked above is email subcopy links do not work out of the box on a fresh Laravel 5.7 install (i.e. email verification subcopy links are broken).

This PR pulls the URL out of the `@lang` section on the email template, and places it immediately after, allowing the raw url to be un-escaped as required to generate a correct URL. Fixes https://github.com/laravel/framework/issues/25716

### **Before PR:**

![image](https://user-images.githubusercontent.com/1210658/45852273-440e8300-bd82-11e8-8b10-23c91f435065.png)

### **After PR:**

![image](https://user-images.githubusercontent.com/1210658/45852345-b3847280-bd82-11e8-8651-d3693eef26fa.png)


_p.s. if this PR is accepted we'll need to backport to 5.6_