### PR TITLE
[5.7] Use url() function instead of plain url

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/illustrated-layout.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/illustrated-layout.blade.php
@@ -469,7 +469,7 @@
                         @yield('message')
                     </p>
 
-                    <a href="/">
+                    <a href="{{ url('/') }}">
                         <button class="bg-transparent text-grey-darkest font-bold uppercase tracking-wide py-3 px-6 border-2 border-grey-light hover:border-grey rounded-lg">
                             {{ __('Go Home') }}
                         </button>


### PR DESCRIPTION
Hello,

Use `url()` function `href="{{ url('/') }}"` instead of the plain url `href="/"` on the error page.

Thanks
