### PR TITLE
Update MySqlGrammar.php

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -575,7 +575,7 @@ class MySqlGrammar extends Grammar
      */
     protected function typeBoolean(Fluent $column)
     {
-        return 'tinyint(1)';
+        return 'bit(1)';
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -604,7 +604,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` tinyint(1) not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` bit(1) not null', $statements[0]);
     }
 
     public function testAddingEnum()


### PR DESCRIPTION
For size and speed optimization.
Because for boolean values needs only 1 bit, and tinyint(1) keeps 1byte=8bit