### PR TITLE
[5.7] Add field to denote if the user email was verified in the current request.

### DIFF
--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -5,6 +5,13 @@ namespace Illuminate\Auth;
 trait MustVerifyEmail
 {
     /**
+     * Indicates if the user was verified during the current request lifecycle.
+     *
+     * @var bool
+     */
+    public $wasRecentlyVerified = false;
+
+    /**
      * Determine if the user has verified their email address.
      *
      * @return bool
@@ -21,7 +28,7 @@ trait MustVerifyEmail
      */
     public function markEmailAsVerified()
     {
-        return $this->forceFill([
+        return $this->wasRecentlyVerified = $this->forceFill([
             'email_verified_at' => $this->freshTimestamp(),
         ])->save();
     }


### PR DESCRIPTION
This PR adds a `wasRecentlyVerified` boolean to the `MustVerifyEmail` trait. Like the `wasRecentlyCreated` boolean on the `Model`, this field is used to denote if the user was verified during the current request.

I did not see any existing tests for email verification, but I am happy to add some for this feature with guidance. I didn't know if it should be part of the eloquent integration test or if it should somehow be standalone.

I'm not sure if this is considered a breaking change. It adds a new public variable. If that is considered breaking, I can retarget this at master.

Thanks,
Patrick