### PR TITLE
[5.7] getDirty() cast values (equal to attributes)

### DIFF
--- a/CHANGELOG-5.7.md
+++ b/CHANGELOG-5.7.md
@@ -15,6 +15,7 @@
 ### Changed
 - Remove `Hash::check()` for password verification ([#25677](https://github.com/laravel/framework/pull/25677))
 
+
 ## v5.7.3 (2018-09-11)
 
 ### Changed
@@ -40,6 +41,7 @@
 ### Deprecated
 - Make `ensureOutputIsBeingCapturedForEmail` method deprecated in `Illuminate/Console/Scheduling/Event.php`
  
+ 
 ## v5.7.2 (2018-09-06)
 
 ### Added
@@ -58,6 +60,7 @@
 ### Fixed
 - Do not send email verification if user is already verified ([#25450](https://github.com/laravel/framework/pull/25450))
 - Fixed required carbon version ([#394f79f9a6651b103f6e065cb4470b4b347239ea](https://github.com/laravel/framework/commit/394f79f9a6651b103f6e065cb4470b4b347239ea))
+
 
 ## v5.7.1 (2018-09-04)
 

--- a/CHANGELOG-5.7.md
+++ b/CHANGELOG-5.7.md
@@ -1,5 +1,18 @@
 # Release Notes for 5.7.x
 
+## v5.7.5 (2018-09-20)
+
+### Added
+- Add callback hook for building mailable data in `\Illuminate\Mail\Mailable` ([7dc3d8d35ad8bcd3b18334a44320e3162b9f6dc1](https://github.com/laravel/framework/commit/7dc3d8d35ad8bcd3b18334a44320e3162b9f6dc1))
+
+### Fixed
+- Make any column searchable with `like` in PostgreSQL ([#25698](https://github.com/laravel/framework/pull/25698))
+- Remove trailing newline from hot url in `mix` helper ([#25699](https://github.com/laravel/framework/pull/25699))
+
+### Changed 
+- Revert of "Remove `Hash::check()` for password verification" ([2e78bf472832cd68ef7d80c73dbb722a62ee1429](https://github.com/laravel/framework/commit/2e78bf472832cd68ef7d80c73dbb722a62ee1429)) 
+ 
+ 
 ## v5.7.4 (2018-09-18)
 
 ### Added

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -152,14 +152,8 @@ class DatabaseUserProvider implements UserProvider
      */
     public function validateCredentials(UserContract $user, array $credentials)
     {
-        $hashed = $user->getAuthPassword();
-
-        if (strlen($hashed) === 0) {
-            return false;
-        }
-
-        return password_verify(
-            $credentials['password'], $hashed
+        return $this->hasher->check(
+            $credentials['password'], $user->getAuthPassword()
         );
     }
 }

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -138,13 +138,8 @@ class EloquentUserProvider implements UserProvider
     public function validateCredentials(UserContract $user, array $credentials)
     {
         $plain = $credentials['password'];
-        $hashed = $user->getAuthPassword();
 
-        if (strlen($hashed) === 0) {
-            return false;
-        }
-
-        return password_verify($plain, $hashed);
+        return $this->hasher->check($plain, $user->getAuthPassword());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1074,7 +1074,9 @@ trait HasAttributes
 
         foreach ($this->getAttributes() as $key => $value) {
             if (! $this->originalIsEquivalent($key, $value)) {
-                $dirty[$key] = $value;
+                $dirty[$key] = $this->hasCast($key)
+                    ? $this->castAttribute($key, $value)
+                    : $value;
             }
         }
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -29,7 +29,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.7.4';
+    const VERSION = '5.7.5';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Exceptions/views/illustrated-layout.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/illustrated-layout.blade.php
@@ -469,7 +469,7 @@
                         @yield('message')
                     </p>
 
-                    <a href="/">
+                    <a href="{{ url('/') }}">
                         <button class="bg-transparent text-grey-darkest font-bold uppercase tracking-wide py-3 px-6 border-2 border-grey-light hover:border-grey rounded-lg">
                             {{ __('Go Home') }}
                         </button>

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -51,12 +51,12 @@
 @component('mail::subcopy')
 @lang(
     "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
-    'into your web browser: [:actionURL](:actionURL)',
+    'into your web browser: ',
     [
-        'actionText' => $actionText,
-        'actionURL' => $actionUrl
+        'actionText' => $actionText
     ]
 )
+[{{ $actionUrl }}]({!! $actionUrl !!})
 @endcomponent
 @endisset
 @endcomponent

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -115,22 +115,11 @@ class AuthDatabaseUserProviderTest extends TestCase
     {
         $conn = m::mock('Illuminate\Database\Connection');
         $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
-        $user->shouldReceive('getAuthPassword')->once()->andReturn('$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm');
-        $result = $provider->validateCredentials($user, ['password' => 'secret']);
-
-        $this->assertTrue($result);
-    }
-
-    public function testCredentialValidationUsingUnknownAlgorithm()
-    {
-        $conn = m::mock('Illuminate\Database\Connection');
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
-        $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
-        $user->shouldReceive('getAuthPassword')->once()->andReturn('$1$0590adc6$WVAjBIam8sJCgDieJGLey0');
-        $result = $provider->validateCredentials($user, ['password' => 's3cr3t']);
+        $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
+        $result = $provider->validateCredentials($user, ['password' => 'plain']);
 
         $this->assertTrue($result);
     }

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -90,22 +90,11 @@ class AuthEloquentUserProviderTest extends TestCase
     {
         $conn = m::mock('Illuminate\Database\Connection');
         $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
         $provider = new EloquentUserProvider($hasher, 'foo');
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
-        $user->shouldReceive('getAuthPassword')->once()->andReturn('$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm');
-        $result = $provider->validateCredentials($user, ['password' => 'secret']);
-
-        $this->assertTrue($result);
-    }
-
-    public function testCredentialValidationUsingUnknownAlgorithm()
-    {
-        $conn = m::mock('Illuminate\Database\Connection');
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
-        $provider = new EloquentUserProvider($hasher, 'foo');
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
-        $user->shouldReceive('getAuthPassword')->once()->andReturn('$1$0590adc6$WVAjBIam8sJCgDieJGLey0');
-        $result = $provider->validateCredentials($user, ['password' => 's3cr3t']);
+        $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
+        $result = $provider->validateCredentials($user, ['password' => 'plain']);
 
         $this->assertTrue($result);
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -94,6 +94,34 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty('datetimeAttribute'));
     }
 
+    public function testDirtyAttributesCasting()
+    {
+        $obj = new stdClass;
+        $obj->foo = 'bar';
+
+        $casts = [
+            'intAttribute' => '1',
+            'floatAttribute' => '4.0',
+            'stringAttribute' => 2.5,
+            'boolAttribute' => 1,
+            'booleanAttribute' => 0,
+            'objectAttribute' => ['foo' => 'bar'],
+            'arrayAttribute' => $obj,
+            'jsonAttribute' => ['foo' => 'bar'],
+            'timestampAttribute' => '2017-03-18'
+        ];
+
+        $model = new EloquentModelCastingStub;
+        EloquentModelStub::unguard();
+        $model->fill($casts);
+        EloquentModelStub::reguard();
+        $dirty = $model->getDirty();
+
+        foreach ($casts as $cast => $value) {
+            $this->assertEquals($model->{$cast}, $dirty[$cast]);
+        }
+    }
+
     public function testCleanAttributes()
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);


### PR DESCRIPTION
Hi,

my wish is can we add in function [getDirty()](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L1071) to cast all values?

Problem is when i try to compare a attribute from dirty its not equal
try to cast a json object to array

```
// current attribute
"texts": {"text1": [], "text2": [], ....

// dirty attribute
"texts": "{\"text1\":[],\"text2\":[],\  ....

// with other casts the same (see test)
```

