### PR TITLE
[5.8] getDirty() cast values (equal to attributes)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1074,7 +1074,9 @@ trait HasAttributes
 
         foreach ($this->getAttributes() as $key => $value) {
             if (! $this->originalIsEquivalent($key, $value)) {
-                $dirty[$key] = $value;
+                $dirty[$key] = $this->hasCast($key)
+                    ? $this->castAttribute($key, $value)
+                    : $value;
             }
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -94,6 +94,34 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty('datetimeAttribute'));
     }
 
+    public function testDirtyAttributesCasting()
+    {
+        $obj = new stdClass;
+        $obj->foo = 'bar';
+
+        $casts = [
+            'intAttribute' => '1',
+            'floatAttribute' => '4.0',
+            'stringAttribute' => 2.5,
+            'boolAttribute' => 1,
+            'booleanAttribute' => 0,
+            'objectAttribute' => ['foo' => 'bar'],
+            'arrayAttribute' => $obj,
+            'jsonAttribute' => ['foo' => 'bar'],
+            'timestampAttribute' => '2017-03-18'
+        ];
+
+        $model = new EloquentModelCastingStub;
+        EloquentModelStub::unguard();
+        $model->fill($casts);
+        EloquentModelStub::reguard();
+        $dirty = $model->getDirty();
+
+        foreach ($casts as $cast => $value) {
+            $this->assertEquals($model->{$cast}, $dirty[$cast]);
+        }
+    }
+
     public function testCleanAttributes()
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -108,7 +108,7 @@ class DatabaseEloquentModelTest extends TestCase
             'objectAttribute' => ['foo' => 'bar'],
             'arrayAttribute' => $obj,
             'jsonAttribute' => ['foo' => 'bar'],
-            'timestampAttribute' => '2017-03-18'
+            'timestampAttribute' => '2017-03-18',
         ];
 
         $model = new EloquentModelCastingStub;


### PR DESCRIPTION
Hi,

my wish is can we add in function [getDirty()](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L1071) to cast all values?

Problem is when i try to compare a attribute from dirty its not equal
try to cast a json object to array

```
// current attribute
"texts": {"text1": [], "text2": [], ....

// dirty attribute
"texts": "{\"text1\":[],\"text2\":[],\  ....

// with other casts the same (see test)
```

