### PR TITLE
[5.7] remove temporary variable

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -36,8 +36,8 @@ trait InteractsWithDatabase
     protected function assertDatabaseMissing($table, array $data, $connection = null)
     {
         $this->assertThat(
-            $table, new ReverseConstraint(new HasInDatabase($this->getConnection($connection), $data)
-        ));
+            $table, new ReverseConstraint(new HasInDatabase($this->getConnection($connection), $data))
+        );
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -35,11 +35,9 @@ trait InteractsWithDatabase
      */
     protected function assertDatabaseMissing($table, array $data, $connection = null)
     {
-        $constraint = new ReverseConstraint(
-            new HasInDatabase($this->getConnection($connection), $data)
-        );
-
-        $this->assertThat($table, $constraint);
+        $this->assertThat(
+            $table, new ReverseConstraint(new HasInDatabase($this->getConnection($connection), $data)
+        ));
 
         return $this;
     }


### PR DESCRIPTION
removes temporary variable, and makes the method consistent with `assertDatabaseHas()` and `assertSoftDeleted()`