### PR TITLE
[5.7] Add minutely to scheduling frequencies

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -72,6 +72,16 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run every minute.
+     *
+     * @return $this
+     */
+    public function minutely()
+    {
+        return $this->everyMinute();
+    }
+
+    /**
      * Schedule the event to run every five minutes.
      *
      * @return $this


### PR DESCRIPTION
Since we have descriptive short syntaxes for scheduling a command "hourly", "daily", "monthly"... it would be nice to have "minutely" instead of just "everyMinute".

This does not break anything and will not affect anything since it is a simple addition in form of an alias for the everyMinute function.

Feel free to ignore and delete this request if there if you don't want it included.

Thank you.