### PR TITLE
[5.7] Fix tag cache clearing when using Redis

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -77,14 +77,14 @@ class RedisTaggedCache extends TaggedCache
     /**
      * Remove all items from the cache.
      *
-     * @return void
+     * @return bool
      */
     public function flush()
     {
         $this->deleteForeverKeys();
         $this->deleteStandardKeys();
 
-        parent::flush();
+        return parent::flush();
     }
 
     /**

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -56,11 +56,13 @@ class TaggedCache extends Repository
     /**
      * Remove all items from the cache.
      *
-     * @return void
+     * @return bool
      */
     public function flush()
     {
         $this->tags->reset();
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
After https://github.com/laravel/framework/pull/25254 we already got the fix for the `DatabaseStore` (https://github.com/laravel/framework/pull/25579) and now this fixes the `RedisTaggedCache` store as its `flush` method wasn't returning a `bool` value like the interface specifies so the command `php artisan cache:clear --tags="foo"` would always "fail" with the message `Failed to clear cache. Make sure you have the appropriate permissions.` as `null` would be returned.

Fixes #25547
