### PR TITLE
[5.5] Fix pivot timestamp columns without parent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -216,7 +216,9 @@ class Pivot extends Model
      */
     public function getCreatedAtColumn()
     {
-        return $this->pivotParent->getCreatedAtColumn();
+        return ($this->pivotParent)
+                        ? $this->pivotParent->getCreatedAtColumn()
+                        : parent::getCreatedAtColumn();
     }
 
     /**
@@ -226,6 +228,8 @@ class Pivot extends Model
      */
     public function getUpdatedAtColumn()
     {
-        return $this->pivotParent->getUpdatedAtColumn();
+        return ($this->pivotParent)
+                        ? $this->pivotParent->getUpdatedAtColumn()
+                        : parent::getUpdatedAtColumn();
     }
 }

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class DatabaseEloquentPivotTest extends TestCase
@@ -127,6 +128,29 @@ class DatabaseEloquentPivotTest extends TestCase
 
         $this->assertEquals('pivot', $pivot->getTable());
     }
+
+    public function testPivotModelWithParentReturnsParentsTimestampColumns()
+    {
+        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent->shouldReceive('getCreatedAtColumn')->andReturn('parent_created_at');
+        $parent->shouldReceive('getUpdatedAtColumn')->andReturn('parent_updated_at');
+
+        $pivotWithParent = new Pivot();
+        $pivotWithParent->pivotParent = $parent;
+
+        $this->assertEquals('parent_created_at', $pivotWithParent->getCreatedAtColumn());
+        $this->assertEquals('parent_updated_at', $pivotWithParent->getUpdatedAtColumn());
+    }
+
+    public function testPivotModelWithoutParentReturnsModelTimestampColumns()
+    {
+        $model = new DummyModel();
+
+        $pivotWithoutParent = new Pivot();
+
+        $this->assertEquals($model->getCreatedAtColumn(), $pivotWithoutParent->getCreatedAtColumn());
+        $this->assertEquals($model->getUpdatedAtColumn(), $pivotWithoutParent->getUpdatedAtColumn());
+    }
 }
 
 class DatabaseEloquentPivotTestDateStub extends \Illuminate\Database\Eloquent\Relations\Pivot
@@ -159,4 +183,8 @@ class DatabaseEloquentPivotTestJsonCastStub extends \Illuminate\Database\Eloquen
     protected $casts = [
         'foo' => 'json',
     ];
+}
+
+class DummyModel extends Model
+{
 }


### PR DESCRIPTION
Backport of #23917 and https://github.com/laravel/framework/commit/7ab30b2be55bd2ced6a602840d2849a1743c87b0.

Fixes #25745.