### PR TITLE
[5.7] Improve Collection::fresh()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -255,7 +255,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $freshModels = $model->newQueryWithoutScopes()
             ->with(is_string($with) ? func_get_args() : $with)
-            ->whereIn($model->getKeyName(), $this->modelKeys())
+            ->whereKey($this->modelKeys())
             ->get()
             ->getDictionary();
 


### PR DESCRIPTION
[`whereKey()`](https://github.com/laravel/framework/blob/a4fe383b9dd2c7d2da034900f30667e8fce3365a/src/Illuminate/Database/Eloquent/Builder.php#L183) supports arrays.