### PR TITLE
[5.7] Mail recipient and notifiable preferred locale

### DIFF
--- a/src/Illuminate/Contracts/Translation/HasLocalePreference.php
+++ b/src/Illuminate/Contracts/Translation/HasLocalePreference.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Contracts\Translation;
+
+interface HasLocalePreference
+{
+    /**
+     * @return string|null
+     */
+    public function preferredLocale();
+}

--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Mail;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Translation\HasLocalePreference;
 
 class PendingMail
 {
@@ -74,6 +75,10 @@ class PendingMail
     public function to($users)
     {
         $this->to = $users;
+
+        if (! $this->locale && $users instanceof HasLocalePreference) {
+            $this->locale($users->preferredLocale());
+        }
 
         return $this;
     }

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Collection as ModelCollection;
 
 class NotificationSender
@@ -95,7 +96,7 @@ class NotificationSender
                 continue;
             }
 
-            $this->withLocale($notification->locale ?? $this->locale, function () use ($viaChannels, $notifiable, $original) {
+            $this->withLocale($this->preferredLocale($notifiable, $notification), function () use ($viaChannels, $notifiable, $original) {
                 $notificationId = Str::uuid()->toString();
 
                 foreach ((array) $viaChannels as $channel) {
@@ -103,6 +104,23 @@ class NotificationSender
                 }
             });
         }
+    }
+
+    /**
+     * Get the locale for the notification preferred by this notifiable.
+     *
+     * @param  mixed  $notifiable
+     * @param  mixed  $notification
+     *
+     * @return string|null
+     */
+    protected function preferredLocale($notifiable, $notification)
+    {
+        return $notification->locale ?? $this->locale ?? value(function () use ($notifiable) {
+            if ($notifiable instanceof HasLocalePreference) {
+                return $notifiable->preferredLocale();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
This wraps up localized notifications introduced by https://github.com/laravel/framework/pull/23178, https://github.com/laravel/framework/pull/24451, and https://github.com/laravel/framework/pull/24919.

Users can have a preferred locale (likely stored in the `users` database table) which the `Mail` and `Notification` services will use when queuing jobs.

## Why store a user locale preference?

1. To allow admin-triggered or automated scheduled notifications in the expected language.
2. Clean up excessive need to call `Mail::locale()` and `Notification::locale()`. A typical localized scenario:
   * Default app locale: `'en'`
   * http://mydomain.com/de/ requests have middleware call `App::setLocale('de')` for German translations
   * When queued, this mailable is actually delivered using the app's default `'en'` instead of '`de`'
     ```php
     User::create(request()->all());
     Mail::to($user)->queue(new OrderConfirmation($order));
     ```
   * This call will translate the mailable as expected:
     ```php
     Mail::to($user)->locale(app()->getLocale())->queue(new OrderConfirmation($order))
     ```
   * However this means **every translated mailable sent in a codebase needs to call** `Mail::to()->locale()`
     * likewise for `Notification::locale()`

## Example `User` model with stored locale preference

```php
use Illuminate\Contracts\Translation\HasLocalePreference;

class User extends Model implements HasLocalePreference
{
    public function preferredLocale()
    {
        return $this->locale;
    }
}
```

```php
$user = User::create([
    'email' => 'taylor@laravel.com',
    'locale' => 'de',
]);
```

These four calls will send the notification in German:

* `$user->notify(new OrderConfirmation($order))`
* `Notification::send($user, new OrderConfirmation($order))`
* `Mail::to($user)->queue(new OrderConfirmation($order)`
* `Mail::to($user)->send(new OrderConfirmation($order)`

## Notifying multiple recipients with mixed locale preferences

```php
$users = collect([
    User::create([
        'email' => 'taylor@laravel.com',
        'locale' => 'en',
    ]),
    User::create([
        'email' => 'mohamed@laravel.com',
        'locale' => 'ar',
    ]),
]);
```

This call will notify Taylor in English and Mohamed in Arabic:

* `Notification::send($users, new OrderConfirmation($order))`

This call will send the email _in the application's default locale_:

* `Mail::to($users)->queue(new OrderConfirmation($order))`

Back in February I wrote a rambling explanation here: https://github.com/laravel/framework/pull/23178#issuecomment-367798775 In summary, different message bodies would deviate from the email spec. If user-land wishes to breakup mailables into multiple translated emails being sent out, `Illuminate\Mail\Mailer` is macroable. e.g.,

```php
Illuminate\Mail\Mailer::macro('queueTranslated', function ($users, $mailable) {
    return collect()->wrap($users)->groupBy->preferredLocale()->map(function ($users, $locale) use ($mailable) {
        return Mail::to($users)->locale($locale)->queue($mailable);
    });
});

Mail::queueTranslated(
    $users, new Newsletter(request('body'))
);
```

## Overriding user preferred locale

If admins sending email wish to choose the locale, the `locale()` method call is used instead of the recipient's preference. These four calls will send the notification in English even if `$user` has a German preference:

* `$user->notify((new OrderConfirmation($order))->locale('en'))`
* `Notification::locale('en')->send($user, new OrderConfirmation($order))`
* `Mail::to($user)->locale('en')->queue(new OrderConfirmation($order))`
* `Mail::to($user)->locale('en')->send(new OrderConfirmation($order))`

## Auth scaffolding `User` model class

It might be worth introducing an empty implementation of this contract to https://github.com/laravel/laravel/blob/master/app/User.php?

```php
class User extends Authenticatable implements HasLocalePreference
{
    use Notifiable;

    // ...

    public function preferredLocale()
    {
    }
}
````

Returning `null` has no effect on the `Mail` and `Notification` services (the app default locale is used instead) so new projects are aware they can implement this feature. However I imagine a small percentage of Laravel projects actually use translations so it could be considered more scaffolding noise to strip out. Maybe just some laravel.com docs will do.