### PR TITLE
[5.7] Add missing Responsable phpdoc typehint

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -25,7 +25,7 @@ if (! function_exists('abort')) {
     /**
      * Throw an HttpException with the given data.
      *
-     * @param  \Symfony\Component\HttpFoundation\Response|int     $code
+     * @param  \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int     $code
      * @param  string  $message
      * @param  array   $headers
      * @return void


### PR DESCRIPTION
`abort` helper function can also accept anything that implements `Responsable`

This PR adds the missing typehint to param doc block.
