### PR TITLE
[5.7] Clean up route methods.

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -129,17 +129,32 @@ class Route
      */
     public function __construct($methods, $uri, $action)
     {
+        $this->methods = $this->cleanMethods($methods);
         $this->uri = $uri;
-        $this->methods = (array) $methods;
         $this->action = $this->parseAction($action);
-
-        if (in_array('GET', $this->methods) && ! in_array('HEAD', $this->methods)) {
-            $this->methods[] = 'HEAD';
-        }
 
         if (isset($this->action['prefix'])) {
             $this->prefix($this->action['prefix']);
         }
+    }
+
+    /**
+     * Clean the methods.
+     *
+     * @param  mixed  $methods
+     * @return array
+     */
+    protected function cleanMethods($methods)
+    {
+        $methods = array_unique(array_map('strtoupper', (array) $methods));
+
+        if (in_array('GET', $methods) && ! in_array('HEAD', $methods)) {
+            $methods[] = 'HEAD';
+        }
+
+        sort($methods);
+
+        return $methods;
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -152,9 +152,7 @@ class Route
             $methods[] = 'HEAD';
         }
 
-        sort($methods);
-
-        return $methods;
+        return array_values($methods);
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -23,6 +23,19 @@ use Illuminate\Routing\Middleware\SubstituteBindings;
 
 class RoutingRouteTest extends TestCase
 {
+    public function testRouteMethodsShouldBeUppercasedAndUnique()
+    {
+        $route = new Route(['put', 'patch', 'PUT', 'POST'], 'foo', function () {
+            return 'bar';
+        });
+
+        $this->assertSame([
+            'PATCH',
+            'POST',
+            'PUT',
+        ], $route->methods());
+    }
+
     public function testBasicDispatchingOfRoutes()
     {
         $router = $this->getRouter();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -30,9 +30,9 @@ class RoutingRouteTest extends TestCase
         });
 
         $this->assertSame([
+            'PUT',
             'PATCH',
             'POST',
-            'PUT',
         ], $route->methods());
     }
 


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR targets `5.7` as I feel it could hardly be a breaking change.

The following change allows to pass method verbs as lowercase and they will be converted to uppercase.
Also duplicate verbs will be skipped.