### PR TITLE
[5.7] Authorize Middleware Doesn't Accept String Parameters

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -72,7 +72,7 @@ class Authorize
      */
     protected function getModel($request, $model)
     {
-        return $this->isClassName($model) ? $model : $request->route($model);
+        return $this->isClassName($model) ? $model : $request->route($model, $model);
     }
 
     /**

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -86,6 +86,24 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertEquals($response->content(), 'success');
     }
 
+    public function testSimpleAbilityWithStringParameter()
+    {
+        $this->gate()->define('view-dashboard', function ($user, $param) {
+            return $param === 'true';
+        });
+
+        $this->router->get('dashboard', [
+            'middleware' => Authorize::class.':view-dashboard,true',
+            'uses' => function () {
+                return 'success';
+            },
+        ]);
+
+        $response = $this->router->dispatch(Request::create('dashboard', 'GET'));
+
+        $this->assertEquals($response->content(), 'success');
+    }
+
     /**
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
      * @expectedExceptionMessage This action is unauthorized.

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -104,6 +104,24 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertEquals($response->content(), 'success');
     }
 
+    public function testSimpleAbilityWithStringParameterFromRouteParameter()
+    {
+        $this->gate()->define('view-dashboard', function ($user, $param) {
+            return $param === 'true';
+        });
+
+        $this->router->get('dashboard/{route_parameter}', [
+            'middleware' => Authorize::class.':view-dashboard,route_parameter',
+            'uses' => function () {
+                return 'success';
+            },
+        ]);
+
+        $response = $this->router->dispatch(Request::create('dashboard/true', 'GET'));
+
+        $this->assertEquals($response->content(), 'success');
+    }
+
     /**
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
      * @expectedExceptionMessage This action is unauthorized.


### PR DESCRIPTION
When using authorization gates, they can be used with arbitrary parameters that aren't necessarily models. E.g.

In blade templates:

```
@can('ability', 'some_value')
```

And, as middleware via `authorize` in controllers:

```php
$this->authorize('ability', 'some_value')
```

However, when trying to do that at the route middleware level, the `Authorize` middleware always assumes the parameter will be a model. So it's not possible to do the following:

```php
Route::middleware('can:ability,some_value')
```

This breaks currently as `getGateArguments` (and then `getModel`) assumes the parameter will be a model (or class name) and tries to resolve it from route parameters as so. So the above example would be turned into an array of arguments like `[null]` instead.

This can be solved quite simply by passing the `$model` value as the default value to the `route()` call.

It doesn't seem like this should cause any existing breakage, as it currently returns an array of null values in this case. Tests also don't fail with the change - only with the new test case added here (before the fix). This also makes the behaviour more consist across all usage.
