### PR TITLE
[5.8] Validate Custom Blade Directive Names

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -4,6 +4,7 @@ namespace Illuminate\View\Compilers;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 
 class BladeCompiler extends Compiler implements CompilerInterface
 {
@@ -473,6 +474,10 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function directive($name, callable $handler)
     {
+        if (!preg_match('/^\w+(?:::\w+)?$/x', $name)) {
+            throw new InvalidArgumentException("The directive name [{$name}] is not valid.");
+        }
+
         $this->customDirectives[$name] = $handler;
     }
 

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -474,7 +474,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function directive($name, callable $handler)
     {
-        if (!preg_match('/^\w+(?:::\w+)?$/x', $name)) {
+        if (! preg_match('/^\w+(?:::\w+)?$/x', $name)) {
             throw new InvalidArgumentException("The directive name [{$name}] is not valid.");
         }
 

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -52,24 +52,30 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testValidCustomNames()
     {
-        $this->assertNull($this->compiler->directive('custom', function () {}));
-        $this->assertNull($this->compiler->directive('custom_custom', function () {}));
-        $this->assertNull($this->compiler->directive('customCustom', function () {}));
-        $this->assertNull($this->compiler->directive('custom::custom', function () {}));
+        $this->assertNull($this->compiler->directive('custom', function () {
+        }));
+        $this->assertNull($this->compiler->directive('custom_custom', function () {
+        }));
+        $this->assertNull($this->compiler->directive('customCustom', function () {
+        }));
+        $this->assertNull($this->compiler->directive('custom::custom', function () {
+        }));
     }
 
     public function testInvalidCustomNames()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The directive name [custom-custom] is not valid.');
-        $this->compiler->directive('custom-custom', function () {});
+        $this->compiler->directive('custom-custom', function () {
+        });
     }
 
     public function testInvalidCustomNames2()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The directive name [custom:custom] is not valid.');
-        $this->compiler->directive('custom:custom', function () {});
+        $this->compiler->directive('custom:custom', function () {
+        });
     }
 
     public function testCustomExtensionOverwritesCore()

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -50,6 +50,28 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testValidCustomNames()
+    {
+        $this->assertNull($this->compiler->directive('custom', function () {}));
+        $this->assertNull($this->compiler->directive('custom_custom', function () {}));
+        $this->assertNull($this->compiler->directive('customCustom', function () {}));
+        $this->assertNull($this->compiler->directive('custom::custom', function () {}));
+    }
+
+    public function testInvalidCustomNames()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The directive name [custom-custom] is not valid.');
+        $this->compiler->directive('custom-custom', function () {});
+    }
+
+    public function testInvalidCustomNames2()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The directive name [custom:custom] is not valid.');
+        $this->compiler->directive('custom:custom', function () {});
+    }
+
     public function testCustomExtensionOverwritesCore()
     {
         $this->compiler->directive('foreach', function ($expression) {


### PR DESCRIPTION
This PR is in response to Taylor's suggestion in #4540.

Currently when we register custom Blade directives, we accept any name. This name may not actually work correctly when compiled, with a common example being a name using a dash ('custom-directive'). It also fails silently, so it can be difficult to debug.

This PR throws an exception when trying to register an invalid name.

There is no `expectNoException()` method, so for the valid names, I just assert that the method returns null.

The reason I have 2 tests for invalid names is because if I had both assertions in one test, the second one would never get executed.  If someone has some insight there, would love to hear it.