### PR TITLE
[5.7] Use Route::getName().

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -84,15 +84,14 @@ class RouteCollection implements Countable, IteratorAggregate
         // If the route has a name, we will add it to the name look-up table so that we
         // will quickly be able to find any route associate with a name and not have
         // to iterate through every route every time we need to perform a look-up.
-        $action = $route->getAction();
-
-        if (isset($action['as'])) {
-            $this->nameList[$action['as']] = $route;
+        if ($name = $route->getName()) {
+            $this->nameList[$name] = $route;
         }
 
         // When the route is routing to a controller we will also store the action that
         // is used by the route. This will let us reverse route to controllers while
         // processing a request and easily generate URLs to the given controllers.
+        $action = $route->getAction();
         if (isset($action['controller'])) {
             $this->addToActionList($action, $route);
         }


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

No need to recreate the logic that is already available in `Route`: we can re-use `getName()` function