### PR TITLE
[5.7] Allow addHttpCookie to be a function

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -73,7 +73,7 @@ class VerifyCsrfToken
             $this->tokensMatch($request)
         ) {
             return tap($next($request), function ($response) use ($request) {
-                if ($this->addHttpCookie) {
+                if ($this->shouldAddHttpCookie()) {
                     $this->addCookieToResponse($request, $response);
                 }
             });
@@ -185,5 +185,20 @@ class VerifyCsrfToken
     public static function serialized()
     {
         return EncryptCookies::serialized('XSRF-TOKEN');
+    }
+
+    /*
+     * Get the decision to add the Http cookie to the request..
+     *
+     * @return bool
+     */
+
+    public function shouldAddHttpCookie()
+    {
+        if (method_exists($this, 'addHttpCookie')) {
+            return $this->addHttpCookie();
+        }
+
+        return property_exists($this, 'addHttpCookie') ? $this->addHttpCookie : true;
     }
 }


### PR DESCRIPTION
This PR allow `addHttpCookie` to be a function.
I've used the `redirectPath` method of the `RedirectsUsers` trait as inspiration.

---

It's particularly useful for use cases where the cookie needs to be added only for certain routes

eg.

```php
protected function addHttpCookie()
{
    return request()->is('nova');
}
```

I haven't found tests files related to the middleware so I haven't written tests. If there's some, can you point me to them so that I can write some?