### PR TITLE
[5.7] Queued Closures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "^1.12",
         "nesbot/carbon": "^1.26.3",
+        "opis/closure": "^3.1",
         "psr/container": "^1.0",
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^3.7",

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -4,7 +4,9 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\HtmlString;
 use Illuminate\Container\Container;
+use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Queue\SerializableClosure;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\Routing\UrlGenerator;
@@ -390,6 +392,10 @@ if (! function_exists('dispatch')) {
      */
     function dispatch($job)
     {
+        if ($job instanceof Closure) {
+            $job = new CallQueuedClosure(new SerializableClosure($job));
+        }
+
         return new PendingDispatch($job);
     }
 }

--- a/src/Illuminate/Queue/CallQueuedClosure.php
+++ b/src/Illuminate/Queue/CallQueuedClosure.php
@@ -4,8 +4,6 @@ namespace Illuminate\Queue;
 
 use ReflectionFunction;
 use Illuminate\Bus\Queueable;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Contracts\Container\Container;

--- a/src/Illuminate/Queue/CallQueuedClosure.php
+++ b/src/Illuminate/Queue/CallQueuedClosure.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use ReflectionFunction;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Contracts\Container\Container;
+
+class CallQueuedClosure implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The serializable Closure instance.
+     *
+     * @var \Illuminate\Queue\SerializableClosure
+     */
+    public $closure;
+
+    /**
+     * Indicate if the job should be deleted when models are missing.
+     *
+     * @var bool
+     */
+    public $deleteWhenMissingModels = true;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param  \Illuminate\Queue\SerializableClosure
+     * @return void
+     */
+    public function __construct(SerializableClosure $closure)
+    {
+        $this->closure = $closure;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return void
+     */
+    public function handle(Container $container)
+    {
+        $container->call($this->closure->getClosure());
+    }
+
+    /**
+     * Get the display name for the queued job.
+     *
+     * @return string
+     */
+    public function displayName()
+    {
+        $reflection = new ReflectionFunction($this->closure->getClosure());
+
+        return 'Closure ('.basename($reflection->getFileName()).':'.$reflection->getStartLine().')';
+    }
+}

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Queue;
 
+use Illuminate\Support\Str;
+use Opis\Closure\SerializableClosure;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Connectors\SqsConnector;
 use Illuminate\Queue\Connectors\NullConnector;
@@ -30,14 +32,11 @@ class QueueServiceProvider extends ServiceProvider
     public function register()
     {
         $this->registerManager();
-
         $this->registerConnection();
-
         $this->registerWorker();
-
         $this->registerListener();
-
         $this->registerFailedJobServices();
+        $this->registerOpisSecurityKey();
     }
 
     /**
@@ -213,6 +212,20 @@ class QueueServiceProvider extends ServiceProvider
         return new DatabaseFailedJobProvider(
             $this->app['db'], $config['database'], $config['table']
         );
+    }
+
+    /**
+     * Configure Opis Closure signing for security.
+     *
+     * @return void
+     */
+    protected function registerOpisSecurityKey()
+    {
+        if (Str::startsWith($key = config('app.key'), 'base64:')) {
+            $key = base64_decode(substr($key, 7));
+        }
+
+        SerializableClosure::setSecretKey($key);
     }
 
     /**

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -221,7 +221,7 @@ class QueueServiceProvider extends ServiceProvider
      */
     protected function registerOpisSecurityKey()
     {
-        if (Str::startsWith($key = config('app.key'), 'base64:')) {
+        if (Str::startsWith($key = $this->app['config']->get('app.key'), 'base64:')) {
             $key = base64_decode(substr($key, 7));
         }
 

--- a/src/Illuminate/Queue/SerializableClosure.php
+++ b/src/Illuminate/Queue/SerializableClosure.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
+use Opis\Closure\SerializableClosure as OpisSerializableClosure;
+
+class SerializableClosure extends OpisSerializableClosure
+{
+    use SerializesAndRestoresModelIdentifiers;
+
+    /**
+     * Transform the use variables before serialization.
+     *
+     * @param  array  $data The Closure's use variables
+     * @return array
+     */
+    protected function transformUseVariables($data)
+    {
+        foreach ($data as $key => $value) {
+            $data[$key] = $this->getSerializedPropertyValue($value);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Resolve the use variables after unserialization.
+     *
+     * @param  array  $data The Closure's transformed use variables
+     * @return array
+     */
+    protected function resolveUseVariables($data)
+    {
+        foreach ($data as $key => $value) {
+            $data[$key] = $this->getRestoredPropertyValue($value);
+        }
+
+        return $data;
+    }
+}

--- a/src/Illuminate/Queue/SerializableClosure.php
+++ b/src/Illuminate/Queue/SerializableClosure.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue;
 
-use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 use Opis\Closure\SerializableClosure as OpisSerializableClosure;
 
 class SerializableClosure extends OpisSerializableClosure

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -21,6 +21,7 @@
         "illuminate/database": "5.7.*",
         "illuminate/filesystem": "5.7.*",
         "illuminate/support": "5.7.*",
+        "opis/closure": "^3.1",
         "symfony/debug": "^4.1",
         "symfony/process": "^4.1"
     },


### PR DESCRIPTION
This reintroduces a feature that was previously present in early versions of Laravel queues. However, there have been improvements to serializable closure libraries in the meantime which allows for better security and better handling of Eloquent models and collections. Namely, signing closures with a hash to prevent modification and arbitrary code execution, as well as transforming and resolving models and collections to ModelIdentifier instances.