### PR TITLE
[5.7] Change docblock type dynamic to mixed in variadic arguments

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -645,7 +645,7 @@ class Route
     /**
      * Determine whether the route's name matches the given patterns.
      *
-     * @param  dynamic  $patterns
+     * @param  mixed  ...$patterns
      * @return bool
      */
     public function named(...$patterns)

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1076,7 +1076,7 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Alias for the "currentRouteNamed" method.
      *
-     * @param  dynamic  $patterns
+     * @param  mixed  ...$patterns
      * @return bool
      */
     public function is(...$patterns)
@@ -1087,7 +1087,7 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Determine if the current route matches a pattern.
      *
-     * @param  dynamic  $patterns
+     * @param  mixed  ...$patterns
      * @return bool
      */
     public function currentRouteNamed(...$patterns)


### PR DESCRIPTION
I think `dynamic` type should be changed to `mixed` because `dynamic` is not supported yet and we should follow the phpdoc on variadic arguments
`@param type ...$parameter`