### PR TITLE
Add ability to update any section of package.json

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -236,24 +236,6 @@ class MorphTo extends BelongsTo
     }
 
     /**
-     * Remove all or passed registered global scopes.
-     *
-     * @param  array|null  $scopes
-     * @return $this
-     */
-    public function withoutGlobalScopes(array $scopes = null)
-    {
-        $this->getQuery()->withoutGlobalScopes($scopes);
-
-        $this->macroBuffer[] = [
-            'method' => __FUNCTION__,
-            'parameters' => [$scopes],
-        ];
-
-        return $this;
-    }
-
-    /**
      * Get the foreign key "type" name.
      *
      * @return string
@@ -298,7 +280,13 @@ class MorphTo extends BelongsTo
     public function __call($method, $parameters)
     {
         try {
-            return parent::__call($method, $parameters);
+            $result = parent::__call($method, $parameters);
+
+            if (in_array($method, ['select', 'selectRaw', 'selectSub', 'addSelect', 'withoutGlobalScopes'])) {
+                $this->macroBuffer[] = compact('method', 'parameters');
+            }
+
+            return $result;
         }
 
         // If we tried to call a method that does not exist on the parent Builder instance,

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -29,7 +29,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.7.5';
+    const VERSION = '5.7.6';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Console/Presets/Preset.php
+++ b/src/Illuminate/Foundation/Console/Presets/Preset.php
@@ -23,16 +23,14 @@ class Preset
     /**
      * Update the "package.json" file.
      *
-     * @param  bool  $dev
+     * @param  string  $configurationKey
      * @return void
      */
-    protected static function updatePackages($dev = true)
+    protected static function updatePackages($configurationKey = 'devDependencies')
     {
         if (! file_exists(base_path('package.json'))) {
             return;
         }
-
-        $configurationKey = $dev ? 'devDependencies' : 'dependencies';
 
         $packages = json_decode(file_get_contents(base_path('package.json')), true);
 

--- a/tests/Integration/Database/EloquentMorphToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphToSelectTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphToSelectTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphToSelectTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('commentable_type');
+            $table->integer('commentable_id');
+        });
+
+        $post = Post::create();
+        (new Comment)->commentable()->associate($post)->save();
+    }
+
+    public function test_select()
+    {
+        $comments = Comment::with('commentable:id')->get();
+
+        $this->assertEquals(['id' => 1], $comments[0]->commentable->getAttributes());
+    }
+
+    public function test_select_raw()
+    {
+        $comments = Comment::with(['commentable' => function ($query) {
+            $query->selectRaw('id');
+        }])->get();
+
+        $this->assertEquals(['id' => 1], $comments[0]->commentable->getAttributes());
+    }
+
+    public function test_select_sub()
+    {
+        $comments = Comment::with(['commentable' => function ($query) {
+            $query->selectSub(function ($query) {
+                $query->select('id');
+            }, 'id');
+        }])->get();
+
+        $this->assertEquals(['id' => 1], $comments[0]->commentable->getAttributes());
+    }
+
+    public function test_add_select()
+    {
+        $comments = Comment::with(['commentable' => function ($query) {
+            $query->addSelect('id');
+        }])->get();
+
+        $this->assertEquals(['id' => 1], $comments[0]->commentable->getAttributes());
+    }
+
+    public function test_lazy_loading()
+    {
+        $comment = Comment::first();
+        $post = $comment->commentable()->select('id')->first();
+
+        $this->assertEquals(['id' => 1], $post->getAttributes());
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Post extends Model
+{
+}


### PR DESCRIPTION
From #25700
> In continuation of the previous PRs (#24189, #25457 ) I suggest one more.
> I noticed that developers who need to update, for example, a section of scripts, often completely overwrite the existing package.json file.
> Let's give ability to pass name of section as parameter of static::updatePackages.
> 
> ```
> static::updatePackages('scripts');
> ```
> 
> For back compatibility, we also support boolean as parameter.
> 
> Maybe there are best variants for doing this, but I think, that this variant is the least breaking.

Boolean param replaced by string param with name of section in package.json
