### PR TITLE
[5.8] hyphen-case the Syslog program name

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -236,24 +236,6 @@ class MorphTo extends BelongsTo
     }
 
     /**
-     * Remove all or passed registered global scopes.
-     *
-     * @param  array|null  $scopes
-     * @return $this
-     */
-    public function withoutGlobalScopes(array $scopes = null)
-    {
-        $this->getQuery()->withoutGlobalScopes($scopes);
-
-        $this->macroBuffer[] = [
-            'method' => __FUNCTION__,
-            'parameters' => [$scopes],
-        ];
-
-        return $this;
-    }
-
-    /**
      * Get the foreign key "type" name.
      *
      * @return string
@@ -298,7 +280,13 @@ class MorphTo extends BelongsTo
     public function __call($method, $parameters)
     {
         try {
-            return parent::__call($method, $parameters);
+            $result = parent::__call($method, $parameters);
+
+            if (in_array($method, ['select', 'selectRaw', 'selectSub', 'addSelect', 'withoutGlobalScopes'])) {
+                $this->macroBuffer[] = compact('method', 'parameters');
+            }
+
+            return $result;
         }
 
         // If we tried to call a method that does not exist on the parent Builder instance,

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -29,7 +29,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.7.5';
+    const VERSION = '5.7.6';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -285,7 +285,7 @@ class LogManager implements LoggerInterface
     {
         return new Monolog($this->parseChannel($config), [
             $this->prepareHandler(new SyslogHandler(
-                $this->app['config']['app.name'], $config['facility'] ?? LOG_USER, $this->level($config))
+                snake_case($this->app['config']['app.name'], '-'), $config['facility'] ?? LOG_USER, $this->level($config))
             ),
         ]);
     }

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -285,7 +285,7 @@ class LogManager implements LoggerInterface
     {
         return new Monolog($this->parseChannel($config), [
             $this->prepareHandler(new SyslogHandler(
-                snake_case($this->app['config']['app.name'], '-'), $config['facility'] ?? LOG_USER, $this->level($config))
+                Str::snake($this->app['config']['app.name'], '-'), $config['facility'] ?? LOG_USER, $this->level($config))
             ),
         ]);
     }

--- a/tests/Integration/Database/EloquentMorphToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphToSelectTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphToSelectTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphToSelectTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('commentable_type');
+            $table->integer('commentable_id');
+        });
+
+        $post = Post::create();
+        (new Comment)->commentable()->associate($post)->save();
+    }
+
+    public function test_select()
+    {
+        $comments = Comment::with('commentable:id')->get();
+
+        $this->assertEquals(['id' => 1], $comments[0]->commentable->getAttributes());
+    }
+
+    public function test_select_raw()
+    {
+        $comments = Comment::with(['commentable' => function ($query) {
+            $query->selectRaw('id');
+        }])->get();
+
+        $this->assertEquals(['id' => 1], $comments[0]->commentable->getAttributes());
+    }
+
+    public function test_select_sub()
+    {
+        $comments = Comment::with(['commentable' => function ($query) {
+            $query->selectSub(function ($query) {
+                $query->select('id');
+            }, 'id');
+        }])->get();
+
+        $this->assertEquals(['id' => 1], $comments[0]->commentable->getAttributes());
+    }
+
+    public function test_add_select()
+    {
+        $comments = Comment::with(['commentable' => function ($query) {
+            $query->addSelect('id');
+        }])->get();
+
+        $this->assertEquals(['id' => 1], $comments[0]->commentable->getAttributes());
+    }
+
+    public function test_lazy_loading()
+    {
+        $comment = Comment::first();
+        $post = $comment->commentable()->select('id')->first();
+
+        $this->assertEquals(['id' => 1], $post->getAttributes());
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Post extends Model
+{
+}


### PR DESCRIPTION
Follow existing program name conventions to have more readable logs. When using spaces, it looks kinda weird in Papertrail. Not sure about other services.
Eg. 'My Cool App' would be: my-cool-app, similar to other services (systemd-logind etc)

Papertrail also uses some logic to filter or group by name, which fails when using spaces..