### PR TITLE
Using transChoice instead of trans while formatting error messages

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -54,7 +54,9 @@ trait FormatsMessages
         // messages out of the translator service for this validation rule.
         $key = "validation.{$lowerRule}";
 
-        if ($key != ($value = $this->translator->trans($key))) {
+        $choice = trans('validation.attribute_gender.' . $attribute) == 'f' ? 1 : 0;
+
+        if ($key != ($value = $this->translator->transChoice($key, $choice))) {
             return $value;
         }
 


### PR DESCRIPTION
For some languages, messages need to be formatted differently based on the attribute word gender (masculine or feminine). And based on this update, developers can define the `attribute_gender` under the `resources/lang/{LANG_CODE}/validation.php` by using either `m` value for "masculine" or `f` for "feminine". 

On the other hand, the message could be written in the two choices (0 for masculine and 1 is for feminine):
`'required' => ':attribute مطلوب.|:attribute مطلوبة.'`

In either case, if there's no definition for the "attribute_gender" or there weren't choices for the message itself, it will fallback to the default value.

Please, take a look at this snippet for further details: 
https://gist.github.com/majebry/e598c335777fdbb0c671a987b998cdfb

By implementing this addition, the validation error messages will look smarter for the users and will give the developer a tool to easily control that.