### PR TITLE
[5.7] No need to check if $signature is set twice.

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -102,18 +102,13 @@ class Command extends SymfonyCommand
             $this->configureUsingFluentDefinition();
         } else {
             parent::__construct($this->name);
+            $this->specifyParameters();
         }
 
         // Once we have constructed the command, we'll set the description and other
-        // related properties of the command. If a signature wasn't used to build
-        // the command we'll set the arguments and the options on this command.
+        // related properties of the command.
         $this->setDescription($this->description);
-
         $this->setHidden($this->isHidden());
-
-        if (! isset($this->signature)) {
-            $this->specifyParameters();
-        }
     }
 
     /**


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
No need to check if `$signature` is set twice.