### PR TITLE
[5.7] Extend Eloquent\Builder::$passthru

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -70,6 +70,7 @@ class Builder
     protected $passthru = [
         'insert', 'insertGetId', 'getBindings', 'toSql',
         'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection',
+        'getGrammar', 'getProcessor', 'getRawBindings',
     ];
 
     /**


### PR DESCRIPTION
Calling `Eloquent\Builder::getGrammar()` returns the builder itself (`$this`), not the expected grammar:

```php
$query = User::query();
dump($query === $query->getGrammar()); // true
```

We have to add the method to the `$passthru` list (used by `__call()`).
The same goes for `getProcessor()` and `getRawBindings()`.

Fixes #25789.