### PR TITLE
[5.7] Attach all disk attachments and not only first one

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -381,7 +381,7 @@ class Mailable implements MailableContract, Renderable
                 FilesystemFactory::class
             )->disk($attachment['disk']);
 
-            return $message->attachData(
+            $message->attachData(
                 $storage->get($attachment['path']),
                 $attachment['name'] ?? basename($attachment['path']),
                 array_merge(['mime' => $storage->mimeType($attachment['path'])], $attachment['options'])


### PR DESCRIPTION
At the moment when you attach 2 files, for example:

```php
->attachFromStorageDisk('cdn', 'one.jpg')
->attachFromStorageDisk('cdn', 'two.jpg')
```

only the first one is really attached because of this `return` inside loop.
