### PR TITLE
[5.7] Improve JSON UPDATE queries on MySQL

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -194,13 +194,9 @@ class MySqlGrammar extends Grammar
      */
     protected function compileJsonUpdateColumn($key, JsonExpression $value)
     {
-        $path = explode('->', $key);
+        list($field, $path) = $this->wrapJsonFieldAndPath($key);
 
-        $field = $this->wrapValue(array_shift($path));
-
-        $accessor = "'$.\"".implode('"."', $path)."\"'";
-
-        return "{$field} = json_set({$field}, {$accessor}, {$value->getValue()})";
+        return "{$field} = json_set({$field}{$path}, {$value->getValue()})";
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -211,8 +211,7 @@ class MySqlGrammar extends Grammar
     public function prepareBindingsForUpdate(array $bindings, array $values)
     {
         $values = collect($values)->reject(function ($value, $column) {
-            return $this->isJsonSelector($column) &&
-                in_array(gettype($value), ['boolean', 'integer', 'double']);
+            return $this->isJsonSelector($column) && is_bool($value);
         })->all();
 
         return parent::prepareBindingsForUpdate($bindings, $values);

--- a/src/Illuminate/Database/Query/JsonExpression.php
+++ b/src/Illuminate/Database/Query/JsonExpression.php
@@ -30,6 +30,7 @@ class JsonExpression extends Expression
         switch ($type = gettype($value)) {
             case 'boolean':
                 return $value ? 'true' : 'false';
+            case 'NULL':
             case 'integer':
             case 'double':
             case 'string':

--- a/src/Illuminate/Database/Query/JsonExpression.php
+++ b/src/Illuminate/Database/Query/JsonExpression.php
@@ -27,6 +27,10 @@ class JsonExpression extends Expression
      */
     protected function getJsonBindingParameter($value)
     {
+        if ($value instanceof Expression) {
+            return $value->getValue();
+        }
+
         switch ($type = gettype($value)) {
             case 'boolean':
                 return $value ? 'true' : 'false';

--- a/src/Illuminate/Database/Query/JsonExpression.php
+++ b/src/Illuminate/Database/Query/JsonExpression.php
@@ -32,7 +32,6 @@ class JsonExpression extends Expression
                 return $value ? 'true' : 'false';
             case 'integer':
             case 'double':
-                return $value;
             case 'string':
                 return '?';
             case 'object':

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2002,7 +2002,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $result = $builder->from('users')->where('active', '=', 1)->update(['meta->name->first_name' => 'John', 'meta->name->last_name' => 'Doe']);
     }
 
-    public function testMySqlUpdateWithJsonRemovesBindingsCorrectly()
+    public function testMySqlUpdateWithJsonPreparesBindingsCorrectly()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\MySqlGrammar;
         $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
@@ -2020,8 +2020,8 @@ class DatabaseQueryBuilderTest extends TestCase
         $connection->shouldReceive('update')
             ->once()
             ->with(
-                'update `users` set `options` = json_set(`options`, \'$."size"\', 45), `updated_at` = ? where `id` = ?',
-                ['2015-05-26 22:02:06', 0]
+                'update `users` set `options` = json_set(`options`, \'$."size"\', ?), `updated_at` = ? where `id` = ?',
+                [45, '2015-05-26 22:02:06', 0]
             );
         $builder = new Builder($connection, $grammar, $processor);
         $builder->from('users')->where('id', '=', 0)->update(['options->size' => 45, 'updated_at' => '2015-05-26 22:02:06']);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2029,6 +2029,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update `users` set `options` = json_set(`options`, \'$."size"\', ?)', [null]);
         $builder->from('users')->update(['options->size' => null]);
+
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update `users` set `options` = json_set(`options`, \'$."size"\', 45)', []);
+        $builder->from('users')->update(['options->size' => new Raw('45')]);
     }
 
     public function testMySqlWrappingJsonWithString()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2025,6 +2025,10 @@ class DatabaseQueryBuilderTest extends TestCase
             );
         $builder = new Builder($connection, $grammar, $processor);
         $builder->from('users')->where('id', '=', 0)->update(['options->size' => 45, 'updated_at' => '2015-05-26 22:02:06']);
+
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update `users` set `options` = json_set(`options`, \'$."size"\', ?)', [null]);
+        $builder->from('users')->update(['options->size' => null]);
     }
 
     public function testMySqlWrappingJsonWithString()


### PR DESCRIPTION
 - Simplifies `compileJsonUpdateColumn()` by using `wrapJsonFieldAndPath()`.
 - #13242 fixed boolean values by placing them in the query as raw expressions: ``json_set(`options`, '$."enable"', false)``. The PR used the same technique for integer and doubles values, which is actually not necessary. I think we should use bindings as much as possible.
- Adds support for `null` values.
- Adds support for raw expressions.