### PR TITLE
[5.7] Support JSON UPDATE queries on PostgreSQL

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2027,6 +2027,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->where('id', '=', 0)->update(['options->size' => 45, 'updated_at' => '2015-05-26 22:02:06']);
     }
 
+    public function testPostgresUpdateWrappingJson()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('update')
+            ->with('update "users" set "options" = jsonb_set("options"::jsonb, \'{"name","first_name"}\', ?)', ['"John"']);
+        $builder->from('users')->update(['options->name->first_name' => 'John']);
+
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('update')
+            ->with('update "users" set "options" = jsonb_set("options"::jsonb, \'{"language"}\', \'null\')', []);
+        $builder->from('users')->update(['options->language' => new Raw("'null'")]);
+    }
+
     public function testMySqlWrappingJsonWithString()
     {
         $builder = $this->getMySqlBuilder();


### PR DESCRIPTION
Adds support for JSON UPDATE queries on [PostgreSQL 9.5+](https://www.postgresql.org/docs/9.5/static/functions-json.html):

```php
DB::table('users')->update(['options->language' => 'en']);
DB::table('users')->update(['options->languages' => ['en']]);
DB::table('users')->update(['options->language' => DB::raw("'null'")]);
```

Fixes #23271.