### PR TITLE
[5.7] Small cleaning and refactoring HttpJsonResponseTest

### DIFF
--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -4,72 +4,64 @@ namespace Illuminate\Tests\Http;
 
 use JsonSerializable;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
 class HttpJsonResponseTest extends TestCase
 {
-    public function testSetAndRetrieveJsonableData()
+    /**
+     * @dataProvider setAndRetrieveDataProvider
+     *
+     * @param  $data
+     */
+    public function testSetAndRetrieveData($data): void
     {
-        $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestJsonableObject);
-        $data = $response->getData();
-        $this->assertInstanceOf('stdClass', $data);
-        $this->assertEquals('bar', $data->foo);
+        $response = new JsonResponse($data);
+
+        $this->assertInstanceOf(\stdClass::class, $response->getData());
+        $this->assertEquals('bar', $response->getData()->foo);
     }
 
-    public function testSetAndRetrieveJsonSerializeData()
+    public function setAndRetrieveDataProvider(): array
     {
-        $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestJsonSerializeObject);
-        $data = $response->getData();
-        $this->assertInstanceOf('stdClass', $data);
-        $this->assertEquals('bar', $data->foo);
-    }
-
-    public function testSetAndRetrieveArrayableData()
-    {
-        $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestArrayableObject);
-        $data = $response->getData();
-        $this->assertInstanceOf('stdClass', $data);
-        $this->assertEquals('bar', $data->foo);
-    }
-
-    public function testSetAndRetrieveData()
-    {
-        $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar']);
-        $data = $response->getData();
-        $this->assertInstanceOf('stdClass', $data);
-        $this->assertEquals('bar', $data->foo);
+        return [
+            'Jsonable data' => [new JsonResponseTestJsonableObject],
+            'JsonSerializable data' => [new JsonResponseTestJsonSerializeObject],
+            'Arrayable data' => [new JsonResponseTestArrayableObject],
+            'Array data' => [['foo' => 'bar']],
+        ];
     }
 
     public function testGetOriginalContent()
     {
-        $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestArrayableObject);
+        $response = new JsonResponse(new JsonResponseTestArrayableObject);
         $this->assertInstanceOf(JsonResponseTestArrayableObject::class, $response->getOriginalContent());
 
-        $response = new \Illuminate\Http\JsonResponse;
+        $response = new JsonResponse;
         $response->setData(new JsonResponseTestArrayableObject);
         $this->assertInstanceOf(JsonResponseTestArrayableObject::class, $response->getOriginalContent());
     }
 
     public function testSetAndRetrieveOptions()
     {
-        $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar']);
+        $response = new JsonResponse(['foo' => 'bar']);
         $response->setEncodingOptions(JSON_PRETTY_PRINT);
         $this->assertSame(JSON_PRETTY_PRINT, $response->getEncodingOptions());
     }
 
     public function testSetAndRetrieveDefaultOptions()
     {
-        $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar']);
+        $response = new JsonResponse(['foo' => 'bar']);
         $this->assertSame(0, $response->getEncodingOptions());
     }
 
     public function testSetAndRetrieveStatusCode()
     {
-        $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar'], 404);
+        $response = new JsonResponse(['foo' => 'bar'], 404);
         $this->assertSame(404, $response->getStatusCode());
 
-        $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar']);
+        $response = new JsonResponse(['foo' => 'bar']);
         $response->setStatusCode(404);
         $this->assertSame(404, $response->getStatusCode());
     }
@@ -83,7 +75,7 @@ class HttpJsonResponseTest extends TestCase
      */
     public function testInvalidArgumentExceptionOnJsonError($data)
     {
-        new \Illuminate\Http\JsonResponse(['data' => $data]);
+        new JsonResponse(['data' => $data]);
     }
 
     /**
@@ -93,7 +85,7 @@ class HttpJsonResponseTest extends TestCase
      */
     public function testGracefullyHandledSomeJsonErrorsWithPartialOutputOnError($data)
     {
-        new \Illuminate\Http\JsonResponse(['data' => $data], 200, [], JSON_PARTIAL_OUTPUT_ON_ERROR);
+        new JsonResponse(['data' => $data], 200, [], JSON_PARTIAL_OUTPUT_ON_ERROR);
     }
 
     /**


### PR DESCRIPTION
No functionality changes, just a few small improvements:

- import `JsonResponse` into `HttpJsonResponseTest` to make its usage shorter;
- use data provider on `HttpJsonResponseTest::testSetAndRetrieveData` to avoid code duplication;