### PR TITLE
[5.7] Fix assertions about service provider registration

### DIFF
--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -35,7 +35,7 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $app->register($provider);
 
-        $this->assertTrue(in_array($class, $app->getLoadedProviders()));
+        $this->assertArrayHasKey($class, $app->getLoadedProviders());
     }
 
     public function testClassesAreBoundWhenServiceProviderIsRegistered()
@@ -44,7 +44,7 @@ class FoundationApplicationTest extends TestCase
         $provider = new ServiceProviderForTestingThree($app);
         $app->register($provider);
 
-        $this->assertTrue(in_array(get_class($provider), $app->getLoadedProviders()));
+        $this->assertArrayHasKey(get_class($provider), $app->getLoadedProviders());
 
         $this->assertInstanceOf(ConcreteClass::class, $app->make(AbstractClass::class));
     }
@@ -55,7 +55,7 @@ class FoundationApplicationTest extends TestCase
         $provider = new ServiceProviderForTestingThree($app);
         $app->register($provider);
 
-        $this->assertTrue(in_array(get_class($provider), $app->getLoadedProviders()));
+        $this->assertArrayHasKey(get_class($provider), $app->getLoadedProviders());
 
         $instance = $app->make(AbstractClass::class);
 
@@ -70,7 +70,7 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $app->register($provider);
 
-        $this->assertTrue(in_array($class, $app->getLoadedProviders()));
+        $this->assertArrayHasKey($class, $app->getLoadedProviders());
     }
 
     public function testDeferredServicesMarkedAsBound()


### PR DESCRIPTION
I think these assertions can give some false positives.

The `getLoadedProviders()` method will return an array of true's, keyed by provider class names. Like this:

`
[
    'Illuminate\Events\EventServiceProvider' => true, 
    'Illuminate\Log\LogServiceProvider' => true,
    'Illuminate\Routing\RoutingServiceProvider' => true
]
`

`in_array($class, $app->getLoadedProviders())` will do a non-strict comparison and return `true` as long as `$class == true`. So even if $class was not registered, the assertion can still pass.