### PR TITLE
[5.7] Don't print the generated application key

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -48,7 +48,7 @@ class KeyGenerateCommand extends Command
 
         $this->laravel['config']['app.key'] = $key;
 
-        $this->info("Application key [$key] set successfully.");
+        $this->info("Application key set successfully.");
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -48,7 +48,7 @@ class KeyGenerateCommand extends Command
 
         $this->laravel['config']['app.key'] = $key;
 
-        $this->info("Application key set successfully.");
+        $this->info('Application key set successfully.');
     }
 
     /**


### PR DESCRIPTION
The `artisan key:generate` command prints the generated application key in the console. Since the application key should be secret, it might be a better idea to not print the key. That way there is no chance it will end up in console history or a log file.

This PR makes the `artisan key:generate` command not print the generated key.