### PR TITLE
[5.7] Normalize user logged in application for testing purposes

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -15,8 +15,7 @@ trait InteractsWithAuthentication
      */
     public function actingAs(UserContract $user, $driver = null)
     {
-        $this->normalizeUser($user);
-        $this->be($user, $driver);
+        $this->be($this->getNormalizeUser($user), $driver);
 
         return $this;
     }
@@ -24,11 +23,14 @@ trait InteractsWithAuthentication
     /**
      * Normalize the currently logged in user for the application.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable $user
+     * @return \Illuminate\Contracts\Auth\Authenticatable
      */
-    protected function normalizeUser(UserContract $user)
+    protected function getNormalizeUser(UserContract $user)
     {
         $user->wasRecentlyCreated = false;
+
+        return $user;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -15,9 +15,20 @@ trait InteractsWithAuthentication
      */
     public function actingAs(UserContract $user, $driver = null)
     {
+        $this->normalizeUser($user);
         $this->be($user, $driver);
 
         return $this;
+    }
+
+    /**
+     * Normalize the currently logged in user for the application
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     */
+    protected function normalizeUser(UserContract $user)
+    {
+        $user->wasRecentlyCreated = false;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -22,7 +22,7 @@ trait InteractsWithAuthentication
     }
 
     /**
-     * Normalize the currently logged in user for the application
+     * Normalize the currently logged in user for the application.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      */

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -15,7 +15,7 @@ trait InteractsWithAuthentication
      */
     public function actingAs(UserContract $user, $driver = null)
     {
-        $this->be($this->getNormalizeUser($user), $driver);
+        $this->be($this->getNormalizedUser($user), $driver);
 
         return $this;
     }
@@ -26,7 +26,7 @@ trait InteractsWithAuthentication
      * @param  \Illuminate\Contracts\Auth\Authenticatable $user
      * @return \Illuminate\Contracts\Auth\Authenticatable
      */
-    protected function getNormalizeUser(UserContract $user)
+    protected function getNormalizedUser(UserContract $user)
     {
         $user->wasRecentlyCreated = false;
 


### PR DESCRIPTION
The actingAs method used in testing to make request as authenticated user may response with unexpected status, example found in this issue #25775

I added a normalize user method to setting wasRecentlyCreated property to false to avoid this. 

We could use this method in the future to normalize user properties like we are in a real environment.