### PR TITLE
[5.7] Use ::class notation for Auth tests.

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -336,7 +336,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', '\Illuminate\Tests\Auth\AccessGateTestClass@foo');
+        $gate->define('foo', \Illuminate\Tests\Auth\AccessGateTestClass::class.'@foo');
 
         $this->assertTrue($gate->check('foo'));
     }
@@ -345,7 +345,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', '\Illuminate\Tests\Auth\AccessGateTestInvokableClass');
+        $gate->define('foo', \Illuminate\Tests\Auth\AccessGateTestInvokableClass::class);
 
         $this->assertTrue($gate->check('foo'));
     }

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -28,11 +28,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('make')->once()->andReturn('hashed-token');
-        $repo->getConnection()->shouldReceive('table')->times(2)->with('table')->andReturn($query = m::mock('stdClass'));
+        $repo->getConnection()->shouldReceive('table')->times(2)->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('delete')->once();
         $query->shouldReceive('insert')->once();
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->times(2)->andReturn('email');
 
         $results = $repo->create($user);
@@ -44,10 +44,10 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     public function testExistReturnsFalseIfNoRowFoundForUser()
     {
         $repo = $this->getRepo();
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('first')->once()->andReturn(null);
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'token'));
@@ -56,11 +56,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     public function testExistReturnsFalseIfRecordIsExpired()
     {
         $repo = $this->getRepo();
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subSeconds(300000)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'token'));
@@ -70,11 +70,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->once()->with('token', 'hashed-token')->andReturn(true);
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subMinutes(10)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
 
         $this->assertTrue($repo->exists($user, 'token'));
@@ -84,11 +84,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->once()->with('wrong-token', 'hashed-token')->andReturn(false);
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subMinutes(10)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'wrong-token'));
@@ -97,10 +97,10 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     public function testDeleteMethodDeletesByToken()
     {
         $repo = $this->getRepo();
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('delete')->once();
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
 
         $repo->delete($user);
@@ -109,7 +109,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     public function testDeleteExpiredMethodDeletesExpiredTokens()
     {
         $repo = $this->getRepo();
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->once()->with('created_at', '<', m::any())->andReturn($query);
         $query->shouldReceive('delete')->once();
 
@@ -119,8 +119,8 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     protected function getRepo()
     {
         return new DatabaseTokenRepository(
-            m::mock('Illuminate\Database\Connection'),
-            m::mock('Illuminate\Contracts\Hashing\Hasher'),
+            m::mock(\Illuminate\Database\Connection::class),
+            m::mock(\Illuminate\Contracts\Hashing\Hasher::class),
             'table', 'key');
     }
 }

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -16,24 +16,24 @@ class AuthDatabaseUserProviderTest extends TestCase
 
     public function testRetrieveByIDReturnsUserWhenUserIsFound()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('find')->once()->with(1)->andReturn(['id' => 1, 'name' => 'Dayle']);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveById(1);
 
-        $this->assertInstanceOf('Illuminate\Auth\GenericUser', $user);
+        $this->assertInstanceOf(\Illuminate\Auth\GenericUser::class, $user);
         $this->assertEquals(1, $user->getAuthIdentifier());
         $this->assertEquals('Dayle', $user->name);
     }
 
     public function testRetrieveByIDReturnsNullWhenUserIsNotFound()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('find')->once()->with(1)->andReturn(null);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveById(1);
 
@@ -45,10 +45,10 @@ class AuthDatabaseUserProviderTest extends TestCase
         $mockUser = new \stdClass();
         $mockUser->remember_token = 'a';
 
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('find')->once()->with(1)->andReturn($mockUser);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByToken(1, 'a');
 
@@ -57,10 +57,10 @@ class AuthDatabaseUserProviderTest extends TestCase
 
     public function testRetrieveTokenWithBadIdentifierReturnsNull()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('find')->once()->with(1)->andReturn(null);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByToken(1, 'a');
 
@@ -72,10 +72,10 @@ class AuthDatabaseUserProviderTest extends TestCase
         $mockUser = new \stdClass();
         $mockUser->remember_token = null;
 
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('find')->once()->with(1)->andReturn($mockUser);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByToken(1, 'a');
 
@@ -84,27 +84,27 @@ class AuthDatabaseUserProviderTest extends TestCase
 
     public function testRetrieveByCredentialsReturnsUserWhenUserIsFound()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('where')->once()->with('username', 'dayle');
         $conn->shouldReceive('whereIn')->once()->with('group', ['one', 'two']);
         $conn->shouldReceive('first')->once()->andReturn(['id' => 1, 'name' => 'taylor']);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByCredentials(['username' => 'dayle', 'password' => 'foo', 'group' => ['one', 'two']]);
 
-        $this->assertInstanceOf('Illuminate\Auth\GenericUser', $user);
+        $this->assertInstanceOf(\Illuminate\Auth\GenericUser::class, $user);
         $this->assertEquals(1, $user->getAuthIdentifier());
         $this->assertEquals('taylor', $user->name);
     }
 
     public function testRetrieveByCredentialsReturnsNullWhenUserIsFound()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('where')->once()->with('username', 'dayle');
         $conn->shouldReceive('first')->once()->andReturn(null);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByCredentials(['username' => 'dayle']);
 
@@ -113,11 +113,11 @@ class AuthDatabaseUserProviderTest extends TestCase
 
     public function testCredentialValidation()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
         $result = $provider->validateCredentials($user, ['password' => 'plain']);
 

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -16,7 +16,7 @@ class AuthEloquentUserProviderTest extends TestCase
     public function testRetrieveByIDReturnsUser()
     {
         $provider = $this->getProviderMock();
-        $mock = m::mock('stdClass');
+        $mock = m::mock(\stdClass::class);
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
         $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
@@ -29,11 +29,11 @@ class AuthEloquentUserProviderTest extends TestCase
 
     public function testRetrieveByTokenReturnsUser()
     {
-        $mockUser = m::mock('stdClass');
+        $mockUser = m::mock(\stdClass::class);
         $mockUser->shouldReceive('getRememberToken')->once()->andReturn('a');
 
         $provider = $this->getProviderMock();
-        $mock = m::mock('stdClass');
+        $mock = m::mock(\stdClass::class);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
         $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
         $mock->shouldReceive('first')->once()->andReturn($mockUser);
@@ -46,7 +46,7 @@ class AuthEloquentUserProviderTest extends TestCase
     public function testRetrieveTokenWithBadIdentifierReturnsNull()
     {
         $provider = $this->getProviderMock();
-        $mock = m::mock('stdClass');
+        $mock = m::mock(\stdClass::class);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
         $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
         $mock->shouldReceive('first')->once()->andReturn(null);
@@ -58,11 +58,11 @@ class AuthEloquentUserProviderTest extends TestCase
 
     public function testRetrieveByBadTokenReturnsNull()
     {
-        $mockUser = m::mock('stdClass');
+        $mockUser = m::mock(\stdClass::class);
         $mockUser->shouldReceive('getRememberToken')->once()->andReturn(null);
 
         $provider = $this->getProviderMock();
-        $mock = m::mock('stdClass');
+        $mock = m::mock(\stdClass::class);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
         $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
         $mock->shouldReceive('first')->once()->andReturn($mockUser);
@@ -75,7 +75,7 @@ class AuthEloquentUserProviderTest extends TestCase
     public function testRetrieveByCredentialsReturnsUser()
     {
         $provider = $this->getProviderMock();
-        $mock = m::mock('stdClass');
+        $mock = m::mock(\stdClass::class);
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('where')->once()->with('username', 'dayle');
         $mock->shouldReceive('whereIn')->once()->with('group', ['one', 'two']);
@@ -88,11 +88,11 @@ class AuthEloquentUserProviderTest extends TestCase
 
     public function testCredentialValidation()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
         $provider = new EloquentUserProvider($hasher, 'foo');
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
         $result = $provider->validateCredentials($user, ['password' => 'plain']);
 
@@ -101,18 +101,18 @@ class AuthEloquentUserProviderTest extends TestCase
 
     public function testModelsCanBeCreated()
     {
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
-        $provider = new EloquentUserProvider($hasher, 'Illuminate\Tests\Auth\EloquentProviderUserStub');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $provider = new EloquentUserProvider($hasher, \Illuminate\Tests\Auth\EloquentProviderUserStub::class);
         $model = $provider->createModel();
 
-        $this->assertInstanceOf('Illuminate\Tests\Auth\EloquentProviderUserStub', $model);
+        $this->assertInstanceOf(\Illuminate\Tests\Auth\EloquentProviderUserStub::class, $model);
     }
 
     protected function getProviderMock()
     {
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
 
-        return $this->getMockBuilder('Illuminate\Auth\EloquentUserProvider')->setMethods(['createModel'])->setConstructorArgs([$hasher, 'foo'])->getMock();
+        return $this->getMockBuilder(\Illuminate\Auth\EloquentUserProvider::class)->setMethods(['createModel'])->setConstructorArgs([$hasher, 'foo'])->getMock();
     }
 }
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -19,7 +19,7 @@ class AuthGuardTest extends TestCase
     public function testBasicReturnsNullOnValidAttempt()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard[check,attempt]', ['default', $provider, $session]);
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
         $guard->shouldReceive('check')->once()->andReturn(false);
         $guard->shouldReceive('attempt')->once()->with(['email' => 'foo@bar.com', 'password' => 'secret'])->andReturn(true);
         $request = Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
@@ -31,7 +31,7 @@ class AuthGuardTest extends TestCase
     public function testBasicReturnsNullWhenAlreadyLoggedIn()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard[check]', ['default', $provider, $session]);
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class.'[check]', ['default', $provider, $session]);
         $guard->shouldReceive('check')->once()->andReturn(true);
         $guard->shouldReceive('attempt')->never();
         $request = Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
@@ -46,7 +46,7 @@ class AuthGuardTest extends TestCase
     public function testBasicReturnsResponseOnFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard[check,attempt]', ['default', $provider, $session]);
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
         $guard->shouldReceive('check')->once()->andReturn(false);
         $guard->shouldReceive('attempt')->once()->with(['email' => 'foo@bar.com', 'password' => 'secret'])->andReturn(false);
         $request = \Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
@@ -57,7 +57,7 @@ class AuthGuardTest extends TestCase
     public function testBasicWithExtraConditions()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard[check,attempt]', ['default', $provider, $session]);
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
         $guard->shouldReceive('check')->once()->andReturn(false);
         $guard->shouldReceive('attempt')->once()->with(['email' => 'foo@bar.com', 'password' => 'secret', 'active' => 1])->andReturn(true);
         $request = \Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
@@ -69,7 +69,7 @@ class AuthGuardTest extends TestCase
     public function testBasicWithExtraArrayConditions()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard[check,attempt]', ['default', $provider, $session]);
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
         $guard->shouldReceive('check')->once()->andReturn(false);
         $guard->shouldReceive('attempt')->once()->with(['email' => 'foo@bar.com', 'password' => 'secret', 'active' => 1, 'type' => [1, 2, 3]])->andReturn(true);
         $request = \Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
@@ -81,7 +81,7 @@ class AuthGuardTest extends TestCase
     public function testAttemptCallsRetrieveByCredentials()
     {
         $guard = $this->getGuard();
-        $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo']);
@@ -91,10 +91,10 @@ class AuthGuardTest extends TestCase
     public function testAttemptReturnsUserInterface()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $guard = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
-        $user = $this->createMock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = $this->createMock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->with($user, ['foo'])->andReturn(true);
         $guard->expects($this->once())->method('login')->with($this->equalTo($user));
@@ -104,7 +104,7 @@ class AuthGuardTest extends TestCase
     public function testAttemptReturnsFalseIfUserNotGiven()
     {
         $mock = $this->getGuard();
-        $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $mock->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $mock->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn(null);
@@ -114,8 +114,8 @@ class AuthGuardTest extends TestCase
     public function testLoginStoresIdentifierInSession()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
@@ -139,11 +139,11 @@ class AuthGuardTest extends TestCase
     public function testLoginFiresLoginAndAuthenticatedEvents()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Auth\Events\Login'));
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Auth\Events\Authenticated'));
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Auth\Events\Login::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Auth\Events\Authenticated::class));
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
@@ -154,7 +154,7 @@ class AuthGuardTest extends TestCase
     public function testFailedAttemptFiresFailedEvent()
     {
         $guard = $this->getGuard();
-        $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn(null);
@@ -163,7 +163,7 @@ class AuthGuardTest extends TestCase
 
     public function testAuthenticateReturnsUserWhenUserIsNotNull()
     {
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard = $this->getGuard()->setUser($user);
 
         $this->assertEquals($user, $guard->authenticate());
@@ -171,9 +171,9 @@ class AuthGuardTest extends TestCase
 
     public function testSetUserFiresAuthenticatedEvent()
     {
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard = $this->getGuard();
-        $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Authenticated::class));
         $guard->setUser($user);
     }
@@ -192,7 +192,7 @@ class AuthGuardTest extends TestCase
 
     public function testHasUserReturnsTrueWhenUserIsNotNull()
     {
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard = $this->getGuard()->setUser($user);
 
         $this->assertTrue($guard->hasUser());
@@ -208,7 +208,7 @@ class AuthGuardTest extends TestCase
 
     public function testIsAuthedReturnsTrueWhenUserIsNotNull()
     {
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $mock = $this->getGuard();
         $mock->setUser($user);
         $this->assertTrue($mock->check());
@@ -218,7 +218,7 @@ class AuthGuardTest extends TestCase
     public function testIsAuthedReturnsFalseWhenUserIsNull()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['user'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['user'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->expects($this->exactly(2))->method('user')->will($this->returnValue(null));
         $this->assertFalse($mock->check());
         $this->assertTrue($mock->guest());
@@ -226,7 +226,7 @@ class AuthGuardTest extends TestCase
 
     public function testUserMethodReturnsCachedUser()
     {
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $mock = $this->getGuard();
         $mock->setUser($user);
         $this->assertSame($user, $mock->user());
@@ -243,7 +243,7 @@ class AuthGuardTest extends TestCase
     {
         $mock = $this->getGuard();
         $mock->getSession()->shouldReceive('get')->once()->andReturn(1);
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $mock->getProvider()->shouldReceive('retrieveById')->once()->with(1)->andReturn($user);
         $this->assertSame($user, $mock->user());
         $this->assertSame($user, $mock->getUser());
@@ -252,16 +252,16 @@ class AuthGuardTest extends TestCase
     public function testLogoutRemovesSessionTokenAndRememberMeCookie()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock->setCookieJar($cookies = m::mock(\Illuminate\Cookie\CookieJar::class));
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('setRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('getRecallerName')->will($this->returnValue('bar'));
         $mock->expects($this->once())->method('recaller')->will($this->returnValue('non-null-cookie'));
         $provider->shouldReceive('updateRememberToken')->once();
 
-        $cookie = m::mock('Symfony\Component\HttpFoundation\Cookie');
+        $cookie = m::mock(\Symfony\Component\HttpFoundation\Cookie::class);
         $cookies->shouldReceive('forget')->once()->with('bar')->andReturn($cookie);
         $cookies->shouldReceive('queue')->once()->with($cookie);
         $mock->getSession()->shouldReceive('remove')->once()->with('foo');
@@ -273,9 +273,9 @@ class AuthGuardTest extends TestCase
     public function testLogoutDoesNotEnqueueRememberMeCookieForDeletionIfCookieDoesntExist()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock->setCookieJar($cookies = m::mock(\Illuminate\Cookie\CookieJar::class));
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('setRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('recaller')->will($this->returnValue(null));
@@ -290,15 +290,15 @@ class AuthGuardTest extends TestCase
     public function testLogoutFiresLogoutEvent()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->expects($this->once())->method('clearUserDataFromStorage');
-        $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $mock->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('setRememberToken')->once();
         $provider->shouldReceive('updateRememberToken')->once();
         $events->shouldReceive('dispatch')->once()->with(m::type(Authenticated::class));
         $mock->setUser($user);
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Auth\Events\Logout'));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Auth\Events\Logout::class));
         $mock->logout();
     }
 
@@ -312,7 +312,7 @@ class AuthGuardTest extends TestCase
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
         $session->shouldReceive('migrate')->once();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('getAuthIdentifier')->andReturn('foo');
         $user->shouldReceive('getAuthPassword')->andReturn('bar');
         $user->shouldReceive('getRememberToken')->andReturn('recaller');
@@ -331,7 +331,7 @@ class AuthGuardTest extends TestCase
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
         $session->shouldReceive('migrate')->once();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('getAuthIdentifier')->andReturn('foo');
         $user->shouldReceive('getAuthPassword')->andReturn('foo');
         $user->shouldReceive('getRememberToken')->andReturn(null);
@@ -344,9 +344,9 @@ class AuthGuardTest extends TestCase
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
 
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
 
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user);
         $guard->shouldReceive('login')->once()->with($user, false);
 
@@ -356,7 +356,7 @@ class AuthGuardTest extends TestCase
     public function testLoginUsingIdFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
 
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(11)->andReturn(null);
         $guard->shouldNotReceive('login');
@@ -367,9 +367,9 @@ class AuthGuardTest extends TestCase
     public function testOnceUsingIdSetsUser()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
 
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user);
         $guard->shouldReceive('setUser')->once()->with($user);
 
@@ -379,7 +379,7 @@ class AuthGuardTest extends TestCase
     public function testOnceUsingIdFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
 
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(11)->andReturn(null);
         $guard->shouldNotReceive('setUser');
@@ -394,7 +394,7 @@ class AuthGuardTest extends TestCase
         $request = \Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [$guard->getRecallerName() => 'id|recaller|baz']);
         $guard = new \Illuminate\Auth\SessionGuard('default', $provider, $session, $request);
         $guard->getSession()->shouldReceive('get')->once()->with($guard->getName())->andReturn(null);
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByToken')->once()->with('id', 'recaller')->andReturn($user);
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $guard->getSession()->shouldReceive('put')->with($guard->getName(), 'bar')->once();
@@ -406,8 +406,8 @@ class AuthGuardTest extends TestCase
     public function testLoginOnceSetsUser()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->once()->with($user, ['foo'])->andReturn(true);
         $guard->shouldReceive('setUser')->once()->with($user);
@@ -417,8 +417,8 @@ class AuthGuardTest extends TestCase
     public function testLoginOnceFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->once()->with($user, ['foo'])->andReturn(false);
         $this->assertFalse($guard->once(['foo']));
@@ -434,15 +434,15 @@ class AuthGuardTest extends TestCase
     protected function getMocks()
     {
         return [
-            m::mock('Illuminate\Contracts\Session\Session'),
-            m::mock('Illuminate\Contracts\Auth\UserProvider'),
+            m::mock(\Illuminate\Contracts\Session\Session::class),
+            m::mock(\Illuminate\Contracts\Auth\UserProvider::class),
             \Symfony\Component\HttpFoundation\Request::create('/', 'GET'),
-            m::mock('Illuminate\Cookie\CookieJar'),
+            m::mock(\Illuminate\Cookie\CookieJar::class),
         ];
     }
 
     protected function getCookieJar()
     {
-        return new \Illuminate\Cookie\CookieJar(Request::create('/foo', 'GET'), m::mock('Illuminate\Contracts\Encryption\Encrypter'), ['domain' => 'foo.com', 'path' => '/', 'secure' => false, 'httpOnly' => false]);
+        return new \Illuminate\Cookie\CookieJar(Request::create('/foo', 'GET'), m::mock(\Illuminate\Contracts\Encryption\Encrypter::class), ['domain' => 'foo.com', 'path' => '/', 'secure' => false, 'httpOnly' => false]);
     }
 }

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -17,7 +17,7 @@ class AuthPasswordBrokerTest extends TestCase
     public function testIfUserIsNotFoundErrorRedirectIsReturned()
     {
         $mocks = $this->getMocks();
-        $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['getUser', 'makeErrorRedirect'])->setConstructorArgs(array_values($mocks))->getMock();
+        $broker = $this->getMockBuilder(\Illuminate\Auth\Passwords\PasswordBroker::class)->setMethods(['getUser', 'makeErrorRedirect'])->setConstructorArgs(array_values($mocks))->getMock();
         $broker->expects($this->once())->method('getUser')->will($this->returnValue(null));
 
         $this->assertEquals(PasswordBroker::INVALID_USER, $broker->sendResetLink(['credentials']));
@@ -38,7 +38,7 @@ class AuthPasswordBrokerTest extends TestCase
     public function testUserIsRetrievedByCredentials()
     {
         $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals($user, $broker->getUser(['foo']));
     }
@@ -46,8 +46,8 @@ class AuthPasswordBrokerTest extends TestCase
     public function testBrokerCreatesTokenAndRedirectsWithoutError()
     {
         $mocks = $this->getMocks();
-        $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $broker = $this->getMockBuilder(\Illuminate\Auth\Passwords\PasswordBroker::class)->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
         $mocks['tokens']->shouldReceive('create')->once()->with($user)->andReturn('token');
         $callback = function () {
         };
@@ -69,7 +69,7 @@ class AuthPasswordBrokerTest extends TestCase
     {
         $creds = ['password' => 'foo', 'password_confirmation' => 'bar'];
         $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function () {
         }));
@@ -79,7 +79,7 @@ class AuthPasswordBrokerTest extends TestCase
     {
         $creds = ['password' => null, 'password_confirmation' => null];
         $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function () {
         }));
@@ -89,7 +89,7 @@ class AuthPasswordBrokerTest extends TestCase
     {
         $creds = ['password' => 'abc', 'password_confirmation' => 'abc'];
         $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function () {
         }));
@@ -102,7 +102,7 @@ class AuthPasswordBrokerTest extends TestCase
         $broker->validator(function ($credentials) {
             return strlen($credentials['password']) >= 7;
         });
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function () {
         }));
@@ -111,8 +111,8 @@ class AuthPasswordBrokerTest extends TestCase
     public function testRedirectReturnedByRemindWhenRecordDoesntExistInTable()
     {
         $creds = ['token' => 'token'];
-        $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['validateNewPassword'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(Arr::except($creds, ['token']))->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $broker = $this->getMockBuilder(\Illuminate\Auth\Passwords\PasswordBroker::class)->setMethods(['validateNewPassword'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(Arr::except($creds, ['token']))->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
         $broker->expects($this->once())->method('validateNewPassword')->will($this->returnValue(true));
         $mocks['tokens']->shouldReceive('exists')->with($user, 'token')->andReturn(false);
 
@@ -123,8 +123,8 @@ class AuthPasswordBrokerTest extends TestCase
     public function testResetRemovesRecordOnReminderTableAndCallsCallback()
     {
         unset($_SERVER['__password.reset.test']);
-        $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['validateReset', 'getPassword', 'getToken'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
-        $broker->expects($this->once())->method('validateReset')->will($this->returnValue($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword')));
+        $broker = $this->getMockBuilder(\Illuminate\Auth\Passwords\PasswordBroker::class)->setMethods(['validateReset', 'getPassword', 'getToken'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
+        $broker->expects($this->once())->method('validateReset')->will($this->returnValue($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class)));
         $mocks['tokens']->shouldReceive('delete')->once()->with($user);
         $callback = function ($user, $password) {
             $_SERVER['__password.reset.test'] = compact('user', 'password');
@@ -144,9 +144,9 @@ class AuthPasswordBrokerTest extends TestCase
     protected function getMocks()
     {
         return [
-            'tokens' => m::mock('Illuminate\Auth\Passwords\TokenRepositoryInterface'),
-            'users'  => m::mock('Illuminate\Contracts\Auth\UserProvider'),
-            'mailer' => m::mock('Illuminate\Contracts\Mail\Mailer'),
+            'tokens' => m::mock(\Illuminate\Auth\Passwords\TokenRepositoryInterface::class),
+            'users'  => m::mock(\Illuminate\Contracts\Auth\UserProvider::class),
+            'mailer' => m::mock(\Illuminate\Contracts\Mail\Mailer::class),
             'view'   => 'resetLinkView',
         ];
     }

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -65,8 +65,8 @@ class AuthorizesResourcesTest extends TestCase
     {
         $router = new Router(new \Illuminate\Events\Dispatcher);
 
-        $router->aliasMiddleware('can', '\Illuminate\Tests\Auth\AuthorizesResourcesMiddleware');
-        $router->get($method)->uses('\Illuminate\Tests\Auth\AuthorizesResourcesController@'.$method);
+        $router->aliasMiddleware('can', \Illuminate\Tests\Auth\AuthorizesResourcesMiddleware::class);
+        $router->get($method)->uses(\Illuminate\Tests\Auth\AuthorizesResourcesController::class.'@'.$method);
 
         $this->assertEquals(
             'caught '.$middleware,


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Use :`:class` notation for `/Auth` tests.

Providing the `::class` notation makes it way faster to access the referenced class in every modern IDEs