### PR TITLE
[5.8] Fix column overriding in HasManyThrough relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -207,7 +207,7 @@ class HasManyThrough extends Relation
         // relationship as this will allow us to quickly access all of the related
         // models without having to do nested looping which will be quite slow.
         foreach ($results as $result) {
-            $dictionary[$result->{$this->firstKey}][] = $result;
+            $dictionary[$result->_first_key][] = $result;
         }
 
         return $dictionary;
@@ -410,7 +410,7 @@ class HasManyThrough extends Relation
             $columns = [$this->related->getTable().'.*'];
         }
 
-        return array_merge($columns, [$this->getQualifiedFirstKeyName()]);
+        return array_merge($columns, [$this->getQualifiedFirstKeyName().' as _first_key']);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -163,7 +163,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
             'email',
             'created_at',
             'updated_at',
-            'country_id',
+            '_first_key',
         ], array_keys($post->getAttributes()));
     }
 
@@ -175,7 +175,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertEquals([
             'title',
             'body',
-            'country_id',
+            '_first_key',
         ], array_keys($post->getAttributes()));
     }
 
@@ -195,7 +195,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
                 'email',
                 'created_at',
                 'updated_at',
-                'country_id', ], array_keys($post->getAttributes()));
+                '_first_key', ], array_keys($post->getAttributes()));
         });
     }
 
@@ -216,7 +216,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
                 'email',
                 'created_at',
                 'updated_at',
-                'country_id', ], array_keys($post->getAttributes()));
+                '_first_key', ], array_keys($post->getAttributes()));
         }
     }
 
@@ -235,7 +235,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
                 'email',
                 'created_at',
                 'updated_at',
-                'country_id', ], array_keys($post->getAttributes()));
+                '_first_key', ], array_keys($post->getAttributes()));
         });
     }
 

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -58,7 +58,7 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
 
         $teamMates = $user->teamMatesWithGlobalScope;
 
-        $this->assertEquals(['id' => 2, 'owner_id' => 1], $teamMates[0]->getAttributes());
+        $this->assertEquals(['id' => 2, '_first_key' => 1], $teamMates[0]->getAttributes());
     }
 
     public function test_has_self()


### PR DESCRIPTION
When the related table of a `HasManyThrough` relationship contains a column with the same name as the `$firstKey` in the intermediate table (selected for eager loading), the intermediate value overrides the related value:

```php
Schema::create('users', function ($table) {
    $table->increments('id');
});

Schema::create('teams', function ($table) {
    $table->increments('id');
    $table->integer('owner_id');
});

Schema::create('projects', function ($table) {
    $table->increments('id');
    $table->integer('owner_id');
});

class User extends Model
{
    public function projects()
    {
        return $this->hasManyThrough(Project::class, Team::class, 'owner_id', 'owner_id');
    }
}

User::with('projects')->get();

// Contains "teams.owner_id" instead of "projects.owner_id".
dump($users[0]->projects[0]->owner_id);
```

We can fix this by adding an alias to the `$firstKey` column (that hopefully nobody uses as a column name):

```sql
select "projects".*, "teams"."owner_id" as "_first_key"
from "projects" inner join "teams" on "teams"."id" = "projects"."owner_id"
where "teams"."owner_id" in (?)
```

There already are [eager loading tests](https://github.com/laravel/framework/blob/e232d03d6cc9dd25c9e4edc36a3965a48fef9f68/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php#L102).

Fixes #17918.