### PR TITLE
[5.7] Added symfony/process to console composer.json

### DIFF
--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -32,7 +32,7 @@
     },
     "suggest": {
         "dragonmantank/cron-expression": "Required to use scheduling component (^2.0).",
-        "guzzlehttp/guzzle": "Required to use the ping methods on schedules (^6.0).",
+        "guzzlehttp/guzzle": "Required to use the ping methods on schedules (^6.0)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -17,7 +17,8 @@
         "php": "^7.1.3",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*",
-        "symfony/console": "^4.1"
+        "symfony/console": "^4.1",
+        "symfony/process": "^4.1"
     },
     "autoload": {
         "psr-4": {
@@ -32,7 +33,6 @@
     "suggest": {
         "dragonmantank/cron-expression": "Required to use scheduling component (^2.0).",
         "guzzlehttp/guzzle": "Required to use the ping methods on schedules (^6.0).",
-        "symfony/process": "Required to use scheduling component (^4.1)."
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
#25815 

If not installed ` symfony/process `, cannot run normally. Therefore should be forced to depend on a single component ` symfony/process `