### PR TITLE
[5.7] Allow array callables to be passed to Gate::before()

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -332,7 +332,7 @@ class Gate implements GateContract
      * Determine whether the callback/method can be called with the given user.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
-     * @param  \Closure|string  $class
+     * @param  \Closure|string|array  $class
      * @param  string|null $method
      * @return bool
      */
@@ -344,6 +344,15 @@ class Gate implements GateContract
 
         if (! is_null($method)) {
             return $this->methodAllowsGuests($class, $method);
+        }
+
+        // If the "class" is actually a callable array, it may be either
+        // two strings (when using a static method), or it could be a
+        // concrete instance of an object, plus the method's name.
+        if (is_array($class)) {
+            $className = is_string($class[0]) ? $class[0] : get_class($class[0]);
+
+            return $this->methodAllowsGuests($className, $class[1]);
         }
 
         return $this->callbackAllowsGuests($class);

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -26,6 +26,28 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->check('bar'));
     }
 
+    public function test_before_can_take_an_array_callback()
+    {
+        $gate = new Gate(new Container, function () {
+            return null;
+        });
+
+        $gate->before([new AccessGateTestBeforeCallback, 'allowEverything']);
+
+        $this->assertTrue($gate->check('anything'));
+    }
+
+    public function test_before_can_take_an_array_callback_with_static_method()
+    {
+        $gate = new Gate(new Container, function () {
+            return null;
+        });
+
+        $gate->before([AccessGateTestBeforeCallback::class, 'allowEverything']);
+
+        $this->assertTrue($gate->check('anything'));
+    }
+
     public function test_before_can_allow_guests()
     {
         $gate = new Gate(new Container, function () {
@@ -795,6 +817,19 @@ class AccessGateTestPolicyWithNonGuestBefore
     }
 
     public function update($user, AccessGateTestDummy $dummy)
+    {
+        return true;
+    }
+}
+
+class AccessGateTestBeforeCallback
+{
+    public static function allowEverything($user = null)
+    {
+        return true;
+    }
+
+    public static function allowEverythingStatically($user = null)
     {
         return true;
     }


### PR DESCRIPTION
Before the changes in this PR, calling `Gate::before([$object, 'method'])` actually threw an error. This broke `laravel-debugbar`, and they had to switch to wrapping it in a closure: barryvdh/laravel-debugbar#867

![image](https://user-images.githubusercontent.com/1403741/46219166-9ddbf380-c314-11e8-8284-91e234a93e90.png)
