### PR TITLE
[5.7] Remove unnecessary conditional

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -171,9 +171,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function resolved($abstract)
     {
-        if ($this->isAlias($abstract)) {
-            $abstract = $this->getAlias($abstract);
-        }
+        $abstract = $this->getAlias($abstract);
 
         return isset($this->resolved[$abstract]) ||
                isset($this->instances[$abstract]);


### PR DESCRIPTION
`$this->getAlias($abstract)` will return `$abstract` if it is not an alias.