### PR TITLE
[5.7] Db return collection item implements \ArrayAccess interface

### DIFF
--- a/src/Illuminate/Contracts/Database/DataWrap.php
+++ b/src/Illuminate/Contracts/Database/DataWrap.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Contracts\Database;
+
+interface DataWrap extends \ArrayAccess
+{
+    public function __construct($attributes);
+
+    /**
+     * Determine if the given attribute exists.
+     *
+     * @param  mixed $offset
+     * @return bool
+     */
+    public function offsetExists($offset);
+
+    /**
+     * Get the value for a given offset.
+     *
+     * @param  mixed $offset
+     * @return mixed
+     */
+    public function offsetGet($offset);
+
+    /**
+     * Determine if an attribute or relation exists on the model.
+     *
+     * @param  string $key
+     * @return bool
+     */
+    public function __isset($key);
+
+    /**
+     * Unset an attribute on the model.
+     *
+     * @param  string $key
+     * @return void
+     */
+    public function __unset($key);
+
+    /**
+     * Dynamically retrieve attributes on the model.
+     *
+     * @param  string $key
+     * @return mixed
+     */
+    public function __get($key);
+
+    /**
+     * Dynamically set attributes on the model.
+     *
+     * @param  string $key
+     * @param  mixed $value
+     * @return void
+     */
+    public function __set($key, $value);
+
+    /**
+     * Convert the data to its string representation.
+     *
+     * @return string
+     */
+    public function __toString();
+
+    /**
+     * Convert the data to its json representation.
+     *
+     * @return string
+     */
+    public function toJson();
+}

--- a/src/Illuminate/Database/Query/DataWrap.php
+++ b/src/Illuminate/Database/Query/DataWrap.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Illuminate\Database\Query;
+
+use Illuminate\Contracts\Database\DataWrap as DataWrapContracts;
+
+class DataWrap implements DataWrapContracts
+{
+    protected $attributes = [];
+
+    public function __construct($attributes)
+    {
+        $this->attributes = $attributes;
+    }
+
+    /**
+     * Dynamically retrieve attributes on the model.
+     *
+     * @param  string $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->offsetGet($key);
+    }
+
+    /**
+     * Dynamically set attributes on the model.
+     *
+     * @param  string $key
+     * @param  mixed $value
+     * @return void
+     */
+    public function __set($key, $value)
+    {
+        $this->offsetSet($key, $value);
+    }
+
+    /**
+     * Determine if the given attribute exists.
+     *
+     * @param  mixed $offset
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->attributes[$offset]);
+    }
+
+    /**
+     * Get the value for a given offset.
+     *
+     * @param  mixed $offset
+     * @return mixed
+     */
+    public function offsetGet($offset)
+    {
+        return $this->attributes[$offset];
+    }
+
+    /**
+     * Set the value for a given offset.
+     *
+     * @param  mixed $offset
+     * @param  mixed $value
+     * @return void
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->attributes[$offset] = $value;
+    }
+
+    /**
+     * Unset the value for a given offset.
+     *
+     * @param  mixed $offset
+     * @return void
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->attributes[$offset]);
+    }
+
+    /**
+     * Determine if an attribute or relation exists on the model.
+     *
+     * @param  string $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        return $this->offsetExists($key);
+    }
+
+    /**
+     * Unset an attribute on the model.
+     *
+     * @param  string $key
+     * @return void
+     */
+    public function __unset($key)
+    {
+        $this->offsetUnset($key);
+    }
+
+    /**
+     * Convert the model to its string representation.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toJson();
+    }
+
+    public function toJson()
+    {
+        return json_encode($this->attributes);
+    }
+}

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query\Processors;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\DataWrap;
 
 class Processor
 {
@@ -15,6 +16,11 @@ class Processor
      */
     public function processSelect(Builder $query, $results)
     {
+        if (is_array($results)) {
+            foreach ($results as $key => $result) {
+                $results[$key] = new DataWrap((array)$result);
+            }
+        }
         return $results;
     }
 

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -18,9 +18,10 @@ class Processor
     {
         if (is_array($results)) {
             foreach ($results as $key => $result) {
-                $results[$key] = new DataWrap((array)$result);
+                $results[$key] = new DataWrap((array) $result);
             }
         }
+
         return $results;
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2337,8 +2337,8 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilderWithProcessor();
         $builder->getConnection()->shouldReceive('select')->once()
-                ->andReturn([(object)['id' => 1, 'name' => 'Albert']]);
-        $builder->select('*')->get()->map(function($user) {
+                ->andReturn([(object) ['id' => 1, 'name' => 'Albert']]);
+        $builder->select('*')->get()->map(function ($user) {
             return $user['id'];
         });
     }
@@ -2347,7 +2347,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilderWithProcessor();
         $builder->getConnection()->shouldReceive('select')->once()
-            ->andReturn([(object)['id' => 1, 'name' => 'Albert']]);
+            ->andReturn([(object) ['id' => 1, 'name' => 'Albert']]);
         $builder->select('*')->first()['id'];
     }
 
@@ -2355,8 +2355,8 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilderWithProcessor();
         $builder->getConnection()->shouldReceive('select')->once()
-            ->andReturn([(object)['id' => 1, 'name' => 'Albert']]);
-        $builder->select('*')->get()->map(function($user) {
+            ->andReturn([(object) ['id' => 1, 'name' => 'Albert']]);
+        $builder->select('*')->get()->map(function ($user) {
             return $user->id;
         });
     }
@@ -2365,7 +2365,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilderWithProcessor();
         $builder->getConnection()->shouldReceive('select')->once()
-            ->andReturn([(object)['id' => 1, 'name' => 'Albert']]);
+            ->andReturn([(object) ['id' => 1, 'name' => 'Albert']]);
         $builder->select('*')->first()->id;
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2333,6 +2333,42 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock(false)->get();
     }
 
+    public function testSelectUseArrayAccess()
+    {
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->getConnection()->shouldReceive('select')->once()
+                ->andReturn([(object)['id' => 1, 'name' => 'Albert']]);
+        $builder->select('*')->get()->map(function($user) {
+            return $user['id'];
+        });
+    }
+
+    public function testFirstUseArrayAccess()
+    {
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->andReturn([(object)['id' => 1, 'name' => 'Albert']]);
+        $builder->select('*')->first()['id'];
+    }
+
+    public function testSelectUseStdClass()
+    {
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->andReturn([(object)['id' => 1, 'name' => 'Albert']]);
+        $builder->select('*')->get()->map(function($user) {
+            return $user->id;
+        });
+    }
+
+    public function testFirstUseStdClass()
+    {
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->andReturn([(object)['id' => 1, 'name' => 'Albert']]);
+        $builder->select('*')->first()->id;
+    }
+
     public function testBindingOrder()
     {
         $expectedSql = 'select * from "users" inner join "othertable" on "bar" = ? where "registered" = ? group by "city" having "population" > ? order by match ("foo") against(?)';


### PR DESCRIPTION
related: https://github.com/laravel/ideas/issues/1335

I suggestion, Db return stdClass object implements ArrayAccess interface.
This way developers do not need to distinguish results from models or databases in terms of accessing data