### PR TITLE
[5.7] Changed phpDoc from `\Illuminate\Contracts\Foundation\Application` to `\Illuminate\Foundation\Application` in `ServiceProvider`.

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -9,7 +9,7 @@ abstract class ServiceProvider
     /**
      * The application instance.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var \Illuminate\Foundation\Application
      */
     protected $app;
 
@@ -37,7 +37,7 @@ abstract class ServiceProvider
     /**
      * Create a new service provider instance.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Foundation\Application  $app
      * @return void
      */
     public function __construct($app)


### PR DESCRIPTION


 - Changed phpDoc from `\Illuminate\Contracts\Foundation\Application` to `\Illuminate\Foundation\Application` in `ServiceProvider`, since in class which extend this class we have used methods which not present in contract but class has method.
 **For example:**
  - in Notifications/NotificationServiceProvider.php we have used `resourcePath` method
  - in Mail/MailServiceProvider.php we also have used `resourcePath` method

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
