### PR TITLE
[5.7] Add json extension to composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "php": "^7.1.3",
         "ext-mbstring": "*",
         "ext-openssl": "*",
+        "ext-json": "*",
         "doctrine/inflector": "^1.1",
         "dragonmantank/cron-expression": "^2.0",
         "erusev/parsedown": "^1.7",


### PR DESCRIPTION
json is used extensively throughout the framework, so we should list the extension requirement in composer.