### PR TITLE
[5.7] Fix each() on BelongsToMany relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -674,6 +674,24 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Execute a callback over each item while chunking.
+     *
+     * @param  callable  $callback
+     * @param  int  $count
+     * @return bool
+     */
+    public function each(callable $callback, $count = 1000)
+    {
+        return $this->chunk($count, function ($results) use ($callback) {
+            foreach ($results as $key => $value) {
+                if ($callback($value, $key) === false) {
+                    return false;
+                }
+            }
+        });
+    }
+
+    /**
      * Hydrate the pivot table relationship on the models.
      *
      * @param  array  $models

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -737,6 +737,18 @@ class DatabaseEloquentIntegrationTest extends TestCase
         });
     }
 
+    public function testBelongsToManyRelationshipModelsAreProperlyHydratedOverEachRequest()
+    {
+        $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        $friend = $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
+
+        EloquentTestUser::first()->friends()->each(function ($result) use ($user, $friend) {
+            $this->assertEquals('abigailotwell@gmail.com', $result->email);
+            $this->assertEquals($user->id, $result->pivot->user_id);
+            $this->assertEquals($friend->id, $result->pivot->friend_id);
+        });
+    }
+
     public function testBasicHasManyEagerLoading()
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
`each()` doesn't work properly on `BelongsToMany` relationships. The relationship has its own `chunk()` method (that takes care of the pivot columns and the pivot relation), but it doesn't get called. Since `each()` is defined in the query builder, it only calls the query builder's `chunk()` method.

We just have to copy the query builder's `each()` method to the relationship.
#24096 fixed the same issue for `HasManyThrough` relationships.

We could also put `each()` in the `Relation` class and cover both `BelongsToMany` and `HasManyThrough` relationships with a single method.