### PR TITLE
[5.7] Use ::class notation for Bus tests.

### DIFF
--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -3,9 +3,14 @@
 namespace Illuminate\Tests\Bus;
 
 use Mockery as m;
+use RuntimeException;
+use Illuminate\Bus\Queueable;
 use Illuminate\Bus\Dispatcher;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Config\Repository as Config;
 
 class BusDispatcherTest extends TestCase
@@ -19,20 +24,20 @@ class BusDispatcherTest extends TestCase
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
-            $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+            $mock = m::mock(Queue::class);
             $mock->shouldReceive('push')->once();
 
             return $mock;
         });
 
-        $dispatcher->dispatch(m::mock('Illuminate\Contracts\Queue\ShouldQueue'));
+        $dispatcher->dispatch(m::mock(ShouldQueue::class));
     }
 
     public function testCommandsThatShouldQueueIsQueuedUsingCustomHandler()
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
-            $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+            $mock = m::mock(Queue::class);
             $mock->shouldReceive('push')->once();
 
             return $mock;
@@ -45,8 +50,8 @@ class BusDispatcherTest extends TestCase
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
-            $mock = m::mock('Illuminate\Contracts\Queue\Queue');
-            $mock->shouldReceive('laterOn')->once()->with('foo', 10, m::type('Illuminate\Tests\Bus\BusDispatcherTestSpecificQueueAndDelayCommand'));
+            $mock = m::mock(Queue::class);
+            $mock->shouldReceive('laterOn')->once()->with('foo', 10, m::type(BusDispatcherTestSpecificQueueAndDelayCommand::class));
 
             return $mock;
         });
@@ -57,7 +62,7 @@ class BusDispatcherTest extends TestCase
     public function testDispatchNowShouldNeverQueue()
     {
         $container = new Container;
-        $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+        $mock = m::mock(Queue::class);
         $mock->shouldReceive('push')->never();
         $dispatcher = new Dispatcher($container, function () use ($mock) {
             return $mock;
@@ -69,7 +74,7 @@ class BusDispatcherTest extends TestCase
     public function testDispatcherCanDispatchStandAloneHandler()
     {
         $container = new Container;
-        $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+        $mock = m::mock(Queue::class);
         $dispatcher = new Dispatcher($container, function () use ($mock) {
             return $mock;
         });
@@ -96,7 +101,7 @@ class BusDispatcherTest extends TestCase
         });
 
         $dispatcher = new Dispatcher($container, function () {
-            $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+            $mock = m::mock(Queue::class);
             $mock->shouldReceive('push')->once();
 
             return $mock;
@@ -110,6 +115,7 @@ class BusDispatcherTest extends TestCase
 
 class BusInjectionStub
 {
+    //
 }
 
 class BusDispatcherBasicCommand
@@ -127,7 +133,7 @@ class BusDispatcherBasicCommand
     }
 }
 
-class BusDispatcherTestCustomQueueCommand implements \Illuminate\Contracts\Queue\ShouldQueue
+class BusDispatcherTestCustomQueueCommand implements ShouldQueue
 {
     public function queue($queue, $command)
     {
@@ -135,7 +141,7 @@ class BusDispatcherTestCustomQueueCommand implements \Illuminate\Contracts\Queue
     }
 }
 
-class BusDispatcherTestSpecificQueueAndDelayCommand implements \Illuminate\Contracts\Queue\ShouldQueue
+class BusDispatcherTestSpecificQueueAndDelayCommand implements ShouldQueue
 {
     public $queue = 'foo';
     public $delay = 10;
@@ -143,6 +149,7 @@ class BusDispatcherTestSpecificQueueAndDelayCommand implements \Illuminate\Contr
 
 class StandAloneCommand
 {
+    //
 }
 
 class StandAloneHandler
@@ -153,13 +160,12 @@ class StandAloneHandler
     }
 }
 
-class ShouldNotBeDispatched implements \Illuminate\Contracts\Queue\ShouldQueue
+class ShouldNotBeDispatched implements ShouldQueue
 {
-    use \Illuminate\Bus\Queueable,
-        \Illuminate\Queue\InteractsWithQueue;
+    use InteractsWithQueue, Queueable;
 
     public function handle()
     {
-        throw new \RuntimeException('This should not be run');
+        throw new RuntimeException('This should not be run');
     }
 }

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -10,8 +10,8 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Config\Repository as Config;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 class BusDispatcherTest extends TestCase
 {


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Use `::class` notation for `Bus` tests.
