### PR TITLE
[5.7] Change doc block type for getOutput method

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -566,7 +566,7 @@ class Command extends SymfonyCommand
     /**
      * Get the output implementation.
      *
-     * @return \Symfony\Component\Console\Output\OutputInterface
+     * @return \Illuminate\Console\OutputStyle
      */
     public function getOutput()
     {


### PR DESCRIPTION
`Command` class uses the `OutputStyle` for the `\Symfony\Component\Console\Output\OutputInterface` implementation. Which has some different methods than the interface.

Also the [doc block](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Console/Command.php#L39) for the `output` property in the class already says its `OutputStyle`