### PR TITLE
[5.7] Fixes the error when $resource is null

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -110,6 +110,10 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function toArray($request)
     {
+        if(is_null($this->resource)) {
+            return [];
+        }
+        
         return is_array($this->resource)
             ? $this->resource
             : $this->resource->toArray();

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -110,7 +110,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function toArray($request)
     {
-        if(is_null($this->resource)) {
+        if (is_null($this->resource)) {
             return [];
         }
         


### PR DESCRIPTION
When a user uses JsonResource class to pass a generic message instead of a model, the $resource variable will be set to null. In that case php throws an exception "call to undefined method toArray() on a null object".

This change will simply return an empty array and no error is thrown

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
