### PR TITLE
[5.7] Use ::class notation for Cache tests

### DIFF
--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -2,35 +2,37 @@
 
 namespace Illuminate\Tests\Cache;
 
+use Illuminate\Cache\ApcStore;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Cache\ApcWrapper;
 
 class CacheApcStoreTest extends TestCase
 {
     public function testGetReturnsNullWhenNotFound()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['get'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['get'])->getMock();
         $apc->expects($this->once())->method('get')->with($this->equalTo('foobar'))->will($this->returnValue(null));
-        $store = new \Illuminate\Cache\ApcStore($apc, 'foo');
+        $store = new ApcStore($apc, 'foo');
         $this->assertNull($store->get('bar'));
     }
 
     public function testAPCValueIsReturned()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['get'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['get'])->getMock();
         $apc->expects($this->once())->method('get')->will($this->returnValue('bar'));
-        $store = new \Illuminate\Cache\ApcStore($apc);
+        $store = new ApcStore($apc);
         $this->assertEquals('bar', $store->get('foo'));
     }
 
     public function testGetMultipleReturnsNullWhenNotFoundAndValueWhenFound()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['get'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['get'])->getMock();
         $apc->expects($this->exactly(3))->method('get')->willReturnMap([
             ['foo', 'qux'],
             ['bar', null],
             ['baz', 'norf'],
         ]);
-        $store = new \Illuminate\Cache\ApcStore($apc);
+        $store = new ApcStore($apc);
         $this->assertEquals([
             'foo'   => 'qux',
             'bar'   => null,
@@ -40,15 +42,15 @@ class CacheApcStoreTest extends TestCase
 
     public function testSetMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['put'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['put'])->getMock();
         $apc->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60));
-        $store = new \Illuminate\Cache\ApcStore($apc);
+        $store = new ApcStore($apc);
         $store->put('foo', 'bar', 1);
     }
 
     public function testSetMultipleMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['put'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['put'])->getMock();
         $apc->expects($this->exactly(3))->method('put')->withConsecutive([
             $this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60),
         ], [
@@ -56,7 +58,7 @@ class CacheApcStoreTest extends TestCase
         ], [
             $this->equalTo('bar'), $this->equalTo('norf'), $this->equalTo(60),
         ]);
-        $store = new \Illuminate\Cache\ApcStore($apc);
+        $store = new ApcStore($apc);
         $store->putMany([
             'foo'   => 'bar',
             'baz'   => 'qux',
@@ -66,41 +68,41 @@ class CacheApcStoreTest extends TestCase
 
     public function testIncrementMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['increment'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['increment'])->getMock();
         $apc->expects($this->once())->method('increment')->with($this->equalTo('foo'), $this->equalTo(5));
-        $store = new \Illuminate\Cache\ApcStore($apc);
+        $store = new ApcStore($apc);
         $store->increment('foo', 5);
     }
 
     public function testDecrementMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['decrement'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['decrement'])->getMock();
         $apc->expects($this->once())->method('decrement')->with($this->equalTo('foo'), $this->equalTo(5));
-        $store = new \Illuminate\Cache\ApcStore($apc);
+        $store = new ApcStore($apc);
         $store->decrement('foo', 5);
     }
 
     public function testStoreItemForeverProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['put'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['put'])->getMock();
         $apc->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0));
-        $store = new \Illuminate\Cache\ApcStore($apc);
+        $store = new ApcStore($apc);
         $store->forever('foo', 'bar');
     }
 
     public function testForgetMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['delete'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['delete'])->getMock();
         $apc->expects($this->once())->method('delete')->with($this->equalTo('foo'));
-        $store = new \Illuminate\Cache\ApcStore($apc);
+        $store = new ApcStore($apc);
         $store->forget('foo');
     }
 
     public function testFlushesCached()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['flush'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['flush'])->getMock();
         $apc->expects($this->once())->method('flush')->willReturn(true);
-        $store = new \Illuminate\Cache\ApcStore($apc);
+        $store = new ApcStore($apc);
         $result = $store->flush();
         $this->assertTrue($result);
     }

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -32,7 +32,7 @@ class CacheArrayStoreTest extends TestCase
 
     public function testStoreItemForeverProperlyStoresInArray()
     {
-        $mock = $this->getMockBuilder('Illuminate\Cache\ArrayStore')->setMethods(['put'])->getMock();
+        $mock = $this->getMockBuilder(ArrayStore::class)->setMethods(['put'])->getMock();
         $mock->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0));
         $mock->forever('foo', 'bar');
     }

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -2,10 +2,13 @@
 
 namespace Illuminate\Tests\Cache;
 
+use stdClass;
 use Exception;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\DatabaseStore;
+use Illuminate\Database\Connection;
+use Illuminate\Database\PostgresConnection;
 
 class CacheDatabaseStoreTest extends TestCase
 {
@@ -17,7 +20,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testNullIsReturnedWhenItemNotFound()
     {
         $store = $this->getStore();
-        $table = m::mock('stdClass');
+        $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn(null);
@@ -27,8 +30,8 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testNullIsReturnedAndItemDeletedWhenItemIsExpired()
     {
-        $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['forget'])->setConstructorArgs($this->getMocks())->getMock();
-        $table = m::mock('stdClass');
+        $store = $this->getMockBuilder(DatabaseStore::class)->setMethods(['forget'])->setConstructorArgs($this->getMocks())->getMock();
+        $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn((object) ['expiration' => 1]);
@@ -40,7 +43,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testDecryptedValueIsReturnedWhenItemIsValid()
     {
         $store = $this->getStore();
-        $table = m::mock('stdClass');
+        $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn((object) ['value' => serialize('bar'), 'expiration' => 999999999999999]);
@@ -51,7 +54,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testValueIsReturnedOnPostgres()
     {
         $store = $this->getPostgresStore();
-        $table = m::mock('stdClass');
+        $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn((object) ['value' => base64_encode(serialize('bar')), 'expiration' => 999999999999999]);
@@ -61,8 +64,8 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testValueIsInsertedWhenNoExceptionsAreThrown()
     {
-        $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
-        $table = m::mock('stdClass');
+        $store = $this->getMockBuilder(DatabaseStore::class)->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
+        $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->will($this->returnValue(1));
         $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61]);
@@ -72,8 +75,8 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testValueIsUpdatedWhenInsertThrowsException()
     {
-        $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
-        $table = m::mock('stdClass');
+        $store = $this->getMockBuilder(DatabaseStore::class)->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
+        $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->will($this->returnValue(1));
         $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61])->andReturnUsing(function () {
@@ -87,8 +90,8 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testValueIsInsertedOnPostgres()
     {
-        $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['getTime'])->setConstructorArgs($this->getPostgresMocks())->getMock();
-        $table = m::mock('stdClass');
+        $store = $this->getMockBuilder(DatabaseStore::class)->setMethods(['getTime'])->setConstructorArgs($this->getPostgresMocks())->getMock();
+        $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->will($this->returnValue(1));
         $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => base64_encode(serialize("\0")), 'expiration' => 61]);
@@ -98,7 +101,7 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testForeverCallsStoreItemWithReallyLongTime()
     {
-        $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['put'])->setConstructorArgs($this->getMocks())->getMock();
+        $store = $this->getMockBuilder(DatabaseStore::class)->setMethods(['put'])->setConstructorArgs($this->getMocks())->getMock();
         $store->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(5256000));
         $store->forever('foo', 'bar');
     }
@@ -106,7 +109,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testItemsMayBeRemovedFromCache()
     {
         $store = $this->getStore();
-        $table = m::mock('stdClass');
+        $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('delete')->once();
@@ -117,7 +120,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testItemsMayBeFlushedFromCache()
     {
         $store = $this->getStore();
-        $table = m::mock('stdClass');
+        $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('delete')->once()->andReturn(2);
 
@@ -128,8 +131,8 @@ class CacheDatabaseStoreTest extends TestCase
     public function testIncrementReturnsCorrectValues()
     {
         $store = $this->getStore();
-        $table = m::mock('stdClass');
-        $cache = m::mock('stdClass');
+        $table = m::mock(stdClass::class);
+        $cache = m::mock(stdClass::class);
 
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
             return $closure();
@@ -167,8 +170,8 @@ class CacheDatabaseStoreTest extends TestCase
     public function testDecrementReturnsCorrectValues()
     {
         $store = $this->getStore();
-        $table = m::mock('stdClass');
-        $cache = m::mock('stdClass');
+        $table = m::mock(stdClass::class);
+        $cache = m::mock(stdClass::class);
 
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
             return $closure();
@@ -205,21 +208,21 @@ class CacheDatabaseStoreTest extends TestCase
 
     protected function getStore()
     {
-        return new DatabaseStore(m::mock('Illuminate\Database\Connection'), 'table', 'prefix');
+        return new DatabaseStore(m::mock(Connection::class), 'table', 'prefix');
     }
 
     protected function getPostgresStore()
     {
-        return new DatabaseStore(m::mock('Illuminate\Database\PostgresConnection'), 'table', 'prefix');
+        return new DatabaseStore(m::mock(PostgresConnection::class), 'table', 'prefix');
     }
 
     protected function getMocks()
     {
-        return [m::mock('Illuminate\Database\Connection'), 'table', 'prefix'];
+        return [m::mock(Connection::class), 'table', 'prefix'];
     }
 
     protected function getPostgresMocks()
     {
-        return [m::mock('Illuminate\Database\PostgresConnection'), 'table', 'prefix'];
+        return [m::mock(PostgresConnection::class), 'table', 'prefix'];
     }
 }

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -4,6 +4,9 @@ namespace Illuminate\Tests\Cache;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+use Illuminate\Events\Dispatcher;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\KeyWritten;
 use Illuminate\Cache\Events\CacheMissed;
@@ -177,12 +180,12 @@ class CacheEventsTest extends TestCase
 
     protected function getDispatcher()
     {
-        return m::mock('Illuminate\Events\Dispatcher');
+        return m::mock(Dispatcher::class);
     }
 
     protected function getRepository($dispatcher)
     {
-        $repository = new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore);
+        $repository = new Repository(new ArrayStore);
         $repository->put('baz', 'qux', 99);
         $repository->tags('taylor')->put('baz', 'qux', 99);
         $repository->setEventDispatcher($dispatcher);

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Cache;
 use Illuminate\Support\Carbon;
 use Illuminate\Cache\FileStore;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class CacheFileStoreTest extends TestCase
@@ -48,7 +49,7 @@ class CacheFileStoreTest extends TestCase
         $files = $this->mockFilesystem();
         $contents = '0000000000';
         $files->expects($this->once())->method('get')->will($this->returnValue($contents));
-        $store = $this->getMockBuilder('Illuminate\Cache\FileStore')->setMethods(['forget'])->setConstructorArgs([$files, __DIR__])->getMock();
+        $store = $this->getMockBuilder(FileStore::class)->setMethods(['forget'])->setConstructorArgs([$files, __DIR__])->getMock();
         $store->expects($this->once())->method('forget');
         $value = $store->get('foo');
         $this->assertNull($value);
@@ -66,7 +67,7 @@ class CacheFileStoreTest extends TestCase
     public function testStoreItemProperlyStoresValues()
     {
         $files = $this->mockFilesystem();
-        $store = $this->getMockBuilder('Illuminate\Cache\FileStore')->setMethods(['expiration'])->setConstructorArgs([$files, __DIR__])->getMock();
+        $store = $this->getMockBuilder(FileStore::class)->setMethods(['expiration'])->setConstructorArgs([$files, __DIR__])->getMock();
         $store->expects($this->once())->method('expiration')->with($this->equalTo(10))->will($this->returnValue(1111111111));
         $contents = '1111111111'.serialize('Hello World');
         $hash = sha1('foo');
@@ -169,6 +170,6 @@ class CacheFileStoreTest extends TestCase
 
     protected function mockFilesystem()
     {
-        return $this->createMock('Illuminate\Filesystem\Filesystem');
+        return $this->createMock(Filesystem::class);
     }
 }

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Cache;
 use Memcached;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Cache\MemcachedConnector;
 
 class CacheMemcachedConnectorTest extends TestCase
 {
@@ -101,7 +102,7 @@ class CacheMemcachedConnectorTest extends TestCase
 
     protected function connectorMock()
     {
-        return $this->getMockBuilder('Illuminate\Cache\MemcachedConnector')->setMethods(['createMemcachedInstance'])->getMock();
+        return $this->getMockBuilder(MemcachedConnector::class)->setMethods(['createMemcachedInstance'])->getMock();
     }
 
     protected function connect(

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Cache;
 
 use Memcached;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\MemcachedStore;
 
@@ -63,12 +64,12 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        \Illuminate\Support\Carbon::setTestNow($now = \Illuminate\Support\Carbon::now());
+        Carbon::setTestNow($now = Carbon::now());
         $memcache = $this->getMockBuilder('Memcached')->setMethods(['set'])->getMock();
         $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo($now->timestamp + 60));
         $store = new MemcachedStore($memcache);
         $store->put('foo', 'bar', 1);
-        \Illuminate\Support\Carbon::setTestNow();
+        Carbon::setTestNow();
     }
 
     public function testIncrementMethodProperlyCallsMemcache()
@@ -127,7 +128,7 @@ class CacheMemcachedStoreTest extends TestCase
 
         $memcache = $this->getMockBuilder('Memcached')->setMethods(['flush'])->getMock();
         $memcache->expects($this->once())->method('flush')->willReturn(true);
-        $store = new \Illuminate\Cache\MemcachedStore($memcache);
+        $store = new MemcachedStore($memcache);
         $result = $store->flush();
         $this->assertTrue($result);
     }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -4,6 +4,8 @@ namespace Illuminate\Tests\Cache;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Cache\RedisStore;
+use Illuminate\Contracts\Redis\Factory;
 
 class CacheRedisStoreTest extends TestCase
 {
@@ -144,6 +146,6 @@ class CacheRedisStoreTest extends TestCase
 
     protected function getRedis()
     {
-        return new \Illuminate\Cache\RedisStore(m::mock('Illuminate\Contracts\Redis\Factory'), 'prefix');
+        return new RedisStore(m::mock(Factory::class), 'prefix');
     }
 }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -8,6 +8,12 @@ use Mockery as m;
 use DateTimeImmutable;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\RedisStore;
+use Illuminate\Cache\Repository;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Store;
 
 class CacheRepositoryTest extends TestCase
 {
@@ -140,9 +146,9 @@ class CacheRepositoryTest extends TestCase
 
     public function testCacheAddCallsRedisStoreAdd()
     {
-        $store = m::mock(\Illuminate\Cache\RedisStore::class);
+        $store = m::mock(RedisStore::class);
         $store->shouldReceive('add')->once()->with('k', 'v', 60)->andReturn(true);
-        $repository = new \Illuminate\Cache\Repository($store);
+        $repository = new Repository($store);
         $this->assertTrue($repository->add('k', 'v', 60));
     }
 
@@ -230,8 +236,8 @@ class CacheRepositoryTest extends TestCase
 
     public function testAllTagsArePassedToTaggableStore()
     {
-        $store = m::mock('Illuminate\Cache\ArrayStore');
-        $repo = new \Illuminate\Cache\Repository($store);
+        $store = m::mock(ArrayStore::class);
+        $repo = new Repository($store);
 
         $taggedCache = m::mock();
         $taggedCache->shouldReceive('setDefaultCacheTime');
@@ -241,8 +247,8 @@ class CacheRepositoryTest extends TestCase
 
     protected function getRepository()
     {
-        $dispatcher = new \Illuminate\Events\Dispatcher(m::mock('Illuminate\Container\Container'));
-        $repository = new \Illuminate\Cache\Repository(m::mock('Illuminate\Contracts\Cache\Store'));
+        $dispatcher = new Dispatcher(m::mock(Container::class));
+        $repository = new Repository(m::mock(Store::class));
 
         $repository->setEventDispatcher($dispatcher);
 

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -4,8 +4,13 @@ namespace Illuminate\Tests\Cache;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Composer;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
 use Illuminate\Cache\Console\CacheTableCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Illuminate\Database\Migrations\MigrationCreator;
 
 class CacheTableCommandTest extends TestCase
 {
@@ -17,10 +22,10 @@ class CacheTableCommandTest extends TestCase
     public function testCreateMakesMigration()
     {
         $command = new CacheTableCommandTestStub(
-            $files = m::mock('Illuminate\Filesystem\Filesystem'),
-            $composer = m::mock('Illuminate\Support\Composer')
+            $files = m::mock(Filesystem::class),
+            $composer = m::mock(Composer::class)
         );
-        $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
+        $creator = m::mock(MigrationCreator::class)->shouldIgnoreMissing();
 
         $app = new Application;
         $app->useDatabasePath(__DIR__);
@@ -37,7 +42,7 @@ class CacheTableCommandTest extends TestCase
 
     protected function runCommand($command, $input = [])
     {
-        return $command->run(new \Symfony\Component\Console\Input\ArrayInput($input), new \Symfony\Component\Console\Output\NullOutput);
+        return $command->run(new ArrayInput($input), new NullOutput);
     }
 }
 

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -3,10 +3,14 @@
 namespace Illuminate\Tests\Cache;
 
 use DateTime;
+use stdClass;
 use DateInterval;
 use Mockery as m;
+use Illuminate\Cache\TagSet;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\ArrayStore;
+use Illuminate\Contracts\Cache\Store;
+use Illuminate\Cache\RedisTaggedCache;
 
 class CacheTaggedCacheTest extends TestCase
 {
@@ -80,13 +84,13 @@ class CacheTaggedCacheTest extends TestCase
 
     public function testRedisCacheTagsPushForeverKeysCorrectly()
     {
-        $store = m::mock('Illuminate\Contracts\Cache\Store');
-        $tagSet = m::mock('Illuminate\Cache\TagSet', [$store, ['foo', 'bar']]);
+        $store = m::mock(Store::class);
+        $tagSet = m::mock(TagSet::class, [$store, ['foo', 'bar']]);
         $tagSet->shouldReceive('getNamespace')->andReturn('foo|bar');
         $tagSet->shouldReceive('getNames')->andReturn(['foo', 'bar']);
-        $redis = new \Illuminate\Cache\RedisTaggedCache($store, $tagSet);
+        $redis = new RedisTaggedCache($store, $tagSet);
         $store->shouldReceive('getPrefix')->andReturn('prefix:');
-        $store->shouldReceive('connection')->andReturn($conn = m::mock('stdClass'));
+        $store->shouldReceive('connection')->andReturn($conn = m::mock(stdClass::class));
         $conn->shouldReceive('sadd')->once()->with('prefix:foo:forever_ref', 'prefix:'.sha1('foo|bar').':key1');
         $conn->shouldReceive('sadd')->once()->with('prefix:bar:forever_ref', 'prefix:'.sha1('foo|bar').':key1');
 
@@ -97,13 +101,13 @@ class CacheTaggedCacheTest extends TestCase
 
     public function testRedisCacheTagsPushStandardKeysCorrectly()
     {
-        $store = m::mock('Illuminate\Contracts\Cache\Store');
-        $tagSet = m::mock('Illuminate\Cache\TagSet', [$store, ['foo', 'bar']]);
+        $store = m::mock(Store::class);
+        $tagSet = m::mock(TagSet::class, [$store, ['foo', 'bar']]);
         $tagSet->shouldReceive('getNamespace')->andReturn('foo|bar');
         $tagSet->shouldReceive('getNames')->andReturn(['foo', 'bar']);
-        $redis = new \Illuminate\Cache\RedisTaggedCache($store, $tagSet);
+        $redis = new RedisTaggedCache($store, $tagSet);
         $store->shouldReceive('getPrefix')->andReturn('prefix:');
-        $store->shouldReceive('connection')->andReturn($conn = m::mock('stdClass'));
+        $store->shouldReceive('connection')->andReturn($conn = m::mock(stdClass::class));
         $conn->shouldReceive('sadd')->once()->with('prefix:foo:standard_ref', 'prefix:'.sha1('foo|bar').':key1');
         $conn->shouldReceive('sadd')->once()->with('prefix:bar:standard_ref', 'prefix:'.sha1('foo|bar').':key1');
         $store->shouldReceive('push')->with(sha1('foo|bar').':key1', 'key1:value');
@@ -113,12 +117,12 @@ class CacheTaggedCacheTest extends TestCase
 
     public function testRedisCacheTagsCanBeFlushed()
     {
-        $store = m::mock('Illuminate\Contracts\Cache\Store');
-        $tagSet = m::mock('Illuminate\Cache\TagSet', [$store, ['foo', 'bar']]);
+        $store = m::mock(Store::class);
+        $tagSet = m::mock(TagSet::class, [$store, ['foo', 'bar']]);
         $tagSet->shouldReceive('getNamespace')->andReturn('foo|bar');
-        $redis = new \Illuminate\Cache\RedisTaggedCache($store, $tagSet);
+        $redis = new RedisTaggedCache($store, $tagSet);
         $store->shouldReceive('getPrefix')->andReturn('prefix:');
-        $store->shouldReceive('connection')->andReturn($conn = m::mock('stdClass'));
+        $store->shouldReceive('connection')->andReturn($conn = m::mock(stdClass::class));
 
         // Forever tag keys
         $conn->shouldReceive('smembers')->once()->with('prefix:foo:forever_ref')->andReturn(['key1', 'key2']);

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -3,12 +3,15 @@
 namespace Illuminate\Tests\Cache;
 
 use Mockery as m;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
 use Illuminate\Cache\Console\ClearCommand;
 use Illuminate\Contracts\Cache\Repository;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 
 class ClearCommandTest extends TestCase
 {
@@ -39,9 +42,9 @@ class ClearCommandTest extends TestCase
     {
         parent::setUp();
 
-        $this->cacheManager = m::mock('Illuminate\Cache\CacheManager');
-        $this->files = m::mock('Illuminate\Filesystem\Filesystem');
-        $this->cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
+        $this->cacheManager = m::mock(CacheManager::class);
+        $this->files = m::mock(Filesystem::class);
+        $this->cacheRepository = m::mock(Repository::class);
         $this->command = new ClearCommandTestStub($this->cacheManager, $this->files);
 
         $app = new Application;
@@ -83,7 +86,7 @@ class ClearCommandTest extends TestCase
     {
         $this->files->shouldReceive('files')->andReturn([]);
 
-        $this->cacheManager->shouldReceive('store')->once()->with('bar')->andThrow('InvalidArgumentException');
+        $this->cacheManager->shouldReceive('store')->once()->with('bar')->andThrow(InvalidArgumentException::class);
         $this->cacheRepository->shouldReceive('flush')->never();
 
         $this->runCommand($this->command, ['store' => 'bar']);
@@ -140,7 +143,7 @@ class ClearCommandTest extends TestCase
 
     protected function runCommand($command, $input = [])
     {
-        return $command->run(new \Symfony\Component\Console\Input\ArrayInput($input), new \Symfony\Component\Console\Output\NullOutput);
+        return $command->run(new ArrayInput($input), new NullOutput);
     }
 }
 


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
use ::class notation for Cache tests 