### PR TITLE
[5.7] Add "sometimes" validation test

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3282,6 +3282,9 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
 
+        $v = new Validator($trans, [['bar' => 'baz']], ['*.foo' => 'sometimes|required|string']);
+        $this->assertTrue($v->passes());
+
         // $data = ['names' => [['second' => []]]];
         // $v = new Validator($trans, $data, ['names.*.second' => 'sometimes|required']);
         // $this->assertFalse($v->passes());


### PR DESCRIPTION
#24012 accidentally fixed an issue with optional validation:

```php
$v = Validator::make([['bar' => 'baz']], ['*.foo' => 'sometimes|required']);
dump($v->passes()); // false in Laravel < 5.6.18
```

This PR adds a test to avoid regression.