### PR TITLE
[5.8] Fix loose "in_array" validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -981,7 +981,7 @@ trait ValidatesAttributes
             return Str::is($parameters[0], $key);
         });
 
-        return in_array($value, $otherValues);
+        return in_array($value, $otherValues, true);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -998,6 +998,10 @@ class ValidationValidatorTest extends TestCase
         $trans->addLines(['validation.in_array' => 'The value of :attribute does not exist in :other.'], 'en');
         $v = new Validator($trans, ['foo' => [1, 2, 3], 'bar' => [1, 2]], ['foo.*' => 'in_array:bar.*']);
         $this->assertEquals('The value of foo.2 does not exist in bar.*.', $v->messages()->first('foo.2'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => '1a', 'bar' => [1]], ['foo' => 'in_array:bar.*']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateConfirmed()


### PR DESCRIPTION
PHP's [`in_array()`](http://php.net/manual/en/function.in-array.php) uses loose comparison by default.
This can cause validations to pass (when they shouldn't):

```php
$v = Validator::make(['haystack' => [1], 'needle' => '1a'], ['needle' => 'in_array:haystack.*']);
dump($v->passes()); // true
```

It's a breaking change because it changes the validation result when "equal" values have different types:

```php
$v = Validator::make(['haystack' => [1], 'needle' => '1'], ['needle' => 'in_array:haystack.*']);
dump($v->passes()); // false
```