### PR TITLE
[5.7] urldecode base64 decrypted payload

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -131,6 +131,7 @@ class Encrypter implements EncrypterContract
      */
     public function decrypt($payload, $unserialize = true)
     {
+        $payload = urldecode($payload);
         $payload = $this->getJsonPayload($payload);
 
         $iv = base64_decode($payload['iv']);


### PR DESCRIPTION
**Motivation**
There are periodically reports from users of `DecryptException` while trying to make requests (probably mostly AJAX requests). For example, there are 55 DecryptException reports at https://stackoverflow.com/search?q=DecryptException. I'm not experienced with laravel but I quickly encountered this when working from https://github.com/fwartner/laravel-docker as a base.

**Fix**
https://github.com/laravel/framework/issues/11006#issuecomment-157690697 correctly identified a fix - PHP urlencodes cookie values when it sets them, and sometimes that creates invalid json. Whether or not PHP should urlencode such values is sort of an open question (see https://stackoverflow.com/questions/49205195/should-cookie-values-be-url-encoded) but it does.

I guess most frontend developers are running `decodeURIComponent()` on the XSRF-TOKEN cookie value if they are dealing with this manually (see https://stackoverflow.com/questions/44652194/laravel-decryptexception-the-payload-is-invalid/46506413#46506413). If they've already decoded it, I don't think running it again breaks anything.

In my case, I'm wanting to work with the Insomnia client smoothly to iterate on an API. I set up a template to take the cookie value but not sure how decode it automatically. Patching the framework lets me bypass the issue.
![image](https://user-images.githubusercontent.com/5614134/46262423-e848a600-c4b5-11e8-8602-6aeb4a2b0c01.png)