### PR TITLE
[5.7] Type check for assertExitCode(0)

### DIFF
--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -140,7 +140,7 @@ class PendingCommand
             }
         }
 
-        if ($this->expectedExitCode != null) {
+        if ($this->expectedExitCode !== null) {
             $this->test->assertTrue(
                 $exitCode == $this->expectedExitCode,
                 "Expected status code {$this->expectedExitCode} but received {$exitCode}."


### PR DESCRIPTION
Currently Laravel does not run tests to assert the command exited with code `0` because `$true = (null == 0)`, but `$false = (null === 0)`. Type checking allows the tests to run correctly.