### PR TITLE
[5.7] Use native string comparison instead

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -73,7 +73,7 @@ class KeyGenerateCommand extends Command
     {
         $currentKey = $this->laravel['config']['app.key'];
 
-        if (strlen($currentKey) !== 0 && (! $this->confirmToProceed())) {
+        if ($currentKey !== '' && (! $this->confirmToProceed())) {
             return false;
         }
 


### PR DESCRIPTION
It's faster than calling function `strlen()`.