### PR TITLE
[5.7] Trim model class name when passing in middleware

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -72,7 +72,7 @@ class Authorize
      */
     protected function getModel($request, $model)
     {
-        return $this->isClassName($model) ? $model : $request->route($model, $model);
+        return $this->isClassName($model) ? trim($model) : $request->route($model, $model);
     }
 
     /**


### PR DESCRIPTION
Hi,

When passing php class names in middleware, for example
```php
// routes/web.php
Route::post('/', 'Job\DocumentController@store')->name('store')
            ->middleware('can:create, App\Models\JobDocument');
// Notice the whitespace after comma (,) in middleware()
```
Developer can accidentally add a whitespace before class name.
This whitespace will cause the linked policy not to be found and cause a 403 http response.

It took me hours to figure out why the policy class is not being loaded. 

**More insights here** -
Laravel resolves for registered policy here
https://github.com/laravel/framework/blob/2dd96e9e5251e0970fc8b003c5b86e0114c22331/src/Illuminate/Auth/Access/Gate.php#L514

The registered policies array look like this
```
array:4 [▼
  "App\Models\Job" => "App\Policies\JobPolicy"
  "App\Models\Admin" => "App\Policies\AdminPolicy"
  "App\Models\UserDocument" => "App\Policies\UserDocumentPolicy"
  "App\Models\JobDocument" => "App\Policies\JobDocumentPolicy"
]
```

Having a space in model php class fails the `isset($this->policies[$class])` condition.
The  `trim` will ensure that `isset` call will not fail in this condition.
I don't see any side effects trimming the class name here.

Thanks.

