### PR TITLE
[5.7] Add MailFake methods to docblock in Mail facade

### DIFF
--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Testing\Fakes\MailFake;
  * @method static bool hasQueued(string $mailable)
  *
  * @see \Illuminate\Mail\Mailer
+ * @see \Illuminate\Support\Testing\Fakes\MailFake
  */
 class Mail extends Facade
 {

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -12,6 +12,16 @@ use Illuminate\Support\Testing\Fakes\MailFake;
  * @method static array failures()
  * @method static mixed queue(string|array|\Illuminate\Contracts\Mail\Mailable $view, string $queue = null)
  * @method static mixed later(\DateTimeInterface|\DateInterval|int $delay, string|array|\Illuminate\Contracts\Mail\Mailable $view, string $queue = null)
+ * @method static void assertSent(string $mailable, \Closure|string $callback = null)
+ * @method static void assertNotSent(string $mailable, \Closure|string $callback = null)
+ * @method static void assertNothingSent()
+ * @method static void assertQueued(string $mailable, \Closure|string $callback = null)
+ * @method static void assertNotQueued(string $mailable, \Closure|string $callback = null)
+ * @method static void assertNothingQueued()
+ * @method static \Illuminate\Support\Collection sent(string $mailable, \Closure|string $callback = null)
+ * @method static bool hasSent(string $mailable)
+ * @method static \Illuminate\Support\Collection queued(string $mailable, \Closure|string $callback = null)
+ * @method static bool hasQueued(string $mailable)
  *
  * @see \Illuminate\Mail\Mailer
  */


### PR DESCRIPTION
This PR adds the methods from the `MailFake` class to the `Mail` facade so that these can be auto-completed in IDE's like PhpStorm as well.
