### PR TITLE
[5.7] Fix issue that prevents manipulation of overloaded Eloquent model JSON columns

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "doctrine/inflector": "^1.1",
         "dragonmantank/cron-expression": "^2.0",
         "erusev/parsedown": "^1.7",
+        "judahnator/json-manipulator": "^1.2",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "^1.12",
         "nesbot/carbon": "^1.26.3",

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use function judahnator\JsonManipulator\load_json;
 use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
@@ -489,6 +490,12 @@ trait HasAttributes
             case 'array':
             case 'json':
                 return $this->fromJson($value);
+            case 'json_object':
+                $value ?: $this->attributes[$key] = '{}';
+                return load_json($this->attributes[$key]);
+            case 'json_array':
+                $value ?: $this->attributes[$key] = '[]';
+                return load_json($this->attributes[$key]);
             case 'collection':
                 return new BaseCollection($this->fromJson($value));
             case 'date':
@@ -901,7 +908,7 @@ trait HasAttributes
      */
     protected function isJsonCastable($key)
     {
-        return $this->hasCast($key, ['array', 'json', 'object', 'collection']);
+        return $this->hasCast($key, ['array', 'json', 'json_array', 'json_object', 'object', 'collection']);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,13 +2,13 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use function judahnator\JsonManipulator\load_json;
 use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
+use function judahnator\JsonManipulator\load_json;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\JsonEncodingException;
@@ -492,9 +492,11 @@ trait HasAttributes
                 return $this->fromJson($value);
             case 'json_object':
                 $value ?: $this->attributes[$key] = '{}';
+
                 return load_json($this->attributes[$key]);
             case 'json_array':
                 $value ?: $this->attributes[$key] = '[]';
+
                 return load_json($this->attributes[$key]);
             case 'collection':
                 return new BaseCollection($this->fromJson($value));

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -18,7 +18,8 @@
         "php": "^7.1.3",
         "illuminate/container": "5.7.*",
         "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/support": "5.7.*",
+        "judahnator/json-manipulator": "^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
+++ b/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
@@ -2,10 +2,9 @@
 
 namespace Illuminate\Tests\Database;
 
+use PHPUnit\Framework\TestCase;
 use judahnator\JsonManipulator\JsonArray;
 use judahnator\JsonManipulator\JsonObject;
-use function judahnator\JsonManipulator\load_json;
-use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
@@ -156,6 +155,6 @@ class TableForCasting extends Eloquent
         'json_attributes' => 'json',
         'object_attributes' => 'object',
         'json_array_attributes' => 'json_array',
-        'json_object_attributes' => 'json_object'
+        'json_object_attributes' => 'json_object',
     ];
 }

--- a/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
+++ b/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Tests\Database;
 
+use judahnator\JsonManipulator\JsonArray;
+use judahnator\JsonManipulator\JsonObject;
+use function judahnator\JsonManipulator\load_json;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
@@ -35,6 +38,8 @@ class DatabaseEloquentCastsDatabaseStringTest extends TestCase
             $table->string('array_attributes');
             $table->string('json_attributes');
             $table->string('object_attributes');
+            $table->string('json_array_attributes');
+            $table->string('json_object_attributes');
             $table->timestamps();
         });
     }
@@ -59,6 +64,8 @@ class DatabaseEloquentCastsDatabaseStringTest extends TestCase
             'array_attributes' => ['key1'=>'value1'],
             'json_attributes' => ['json_key'=>'json_value'],
             'object_attributes' => ['json_key'=>'json_value'],
+            'json_array_attributes' => ['value1', 'value2'],
+            'json_object_attributes' => ['key1' => 'value1'],
         ]);
         $this->assertSame('{"key1":"value1"}', $model->getOriginal('array_attributes'));
         $this->assertSame(['key1'=>'value1'], $model->getAttribute('array_attributes'));
@@ -70,6 +77,13 @@ class DatabaseEloquentCastsDatabaseStringTest extends TestCase
         $stdClass = new \stdClass();
         $stdClass->json_key = 'json_value';
         $this->assertEquals($stdClass, $model->getAttribute('object_attributes'));
+
+        $this->assertSame('["value1","value2"]', $model->getOriginal('json_array_attributes'));
+        $this->assertSame('value1', $model->getAttribute('json_array_attributes')[0]);
+        $this->assertSame('value2', $model->getAttribute('json_array_attributes')[1]);
+
+        $this->assertSame('{"key1":"value1"}', $model->getOriginal('json_object_attributes'));
+        $this->assertSame('value1', $model->getAttribute('json_object_attributes')->key1);
     }
 
     public function testSavingCastedEmptyAttributesToDatabase()
@@ -79,6 +93,8 @@ class DatabaseEloquentCastsDatabaseStringTest extends TestCase
             'array_attributes' => [],
             'json_attributes' => [],
             'object_attributes' => [],
+            'json_array_attributes' => [],
+            'json_object_attributes' => new \stdClass(),
         ]);
         $this->assertSame('[]', $model->getOriginal('array_attributes'));
         $this->assertSame([], $model->getAttribute('array_attributes'));
@@ -88,6 +104,12 @@ class DatabaseEloquentCastsDatabaseStringTest extends TestCase
 
         $this->assertSame('[]', $model->getOriginal('object_attributes'));
         $this->assertSame([], $model->getAttribute('object_attributes'));
+
+        $this->assertSame('[]', $model->getOriginal('json_array_attributes'));
+        $this->assertInstanceOf(JsonArray::class, $model->getAttribute('json_array_attributes'));
+
+        $this->assertSame('{}', $model->getOriginal('json_object_attributes'));
+        $this->assertInstanceOf(JsonObject::class, $model->getAttribute('json_object_attributes'));
     }
 
     /**
@@ -133,5 +155,7 @@ class TableForCasting extends Eloquent
         'array_attributes' => 'array',
         'json_attributes' => 'json',
         'object_attributes' => 'object',
+        'json_array_attributes' => 'json_array',
+        'json_object_attributes' => 'json_object'
     ];
 }


### PR DESCRIPTION
Hello Laravel Team!

The Problem:
-----------------

In various projects I have worked on I have seen this error when working with JSON columns:
```php
$myModel = MyModel::find($n);
$myModel->json_column->some_key = 'some value';
// PHP Notice:  Indirect modification of overloaded property App/MyModel::$json_column has no effect in...
```

The work around is to use the Laravel getter/setter to update the entire field at once and not just the bit that you want, like this:
```php
$myModel = MyModel::find($n);
$jsonTemp = $myModel->json_column;
$jsonTemp->some_key = 'some value';
$myModel->json_column = $jsonTemp;
unset($jsonTemp);
```

The Solution:
-----------------

This issue was discussed a bit in this [laravel/ideas](https://github.com/laravel/ideas/issues/1275) issue. If implemented, it would allow in-place changes of JSON column nested attributes. For example, lets say your JSON column had this data:
```json
{
  "an_array": [
    "foo",
    {
      "nested": "value"
    }
  ]
}
```

Using these changes, you could do this and it would work:
```php
$myModel = MyModel::find($n);
$myModel->json_column->an_array[1]->nested = 'edited value';
$myModel->save();
```

Changes Required For The User:
------------------------------------------

As you can see looking through the updated code I left existing functionality in place and added two new casts. "json_object" and "json_array". They are functionally identical, with the only change being if the initial value the user sees when creating a fresh object will be an object or array.

In order for the user to take advantage of these changes they will just need to change the cast they are using from "json" to "json_object" or "json_array".
```php
class MyModel extends Model
{
  $casts = [
    'json_column' => 'json_object'
  ]
}
```

Summary:
-------------

With these changes you can manipulate JSON attributes, even deeply nested ones, as if they were native PHP objects or arrays.

I believe I covered everything in tests. If I missed anything let me know.

I look forward to the feedback!