### PR TITLE
[5.6] Fix translation escaping

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -265,6 +265,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
 
         foreach ($replace as $key => $value) {
             $value = e($value);
+
             $line = str_replace(
                 [':'.$key, ':'.Str::upper($key), ':'.Str::ucfirst($key)],
                 [$value, Str::upper($value), Str::ucfirst($value)],

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -264,6 +264,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $replace = $this->sortReplacements($replace);
 
         foreach ($replace as $key => $value) {
+            $value = e($value);
             $line = str_replace(
                 [':'.$key, ':'.Str::upper($key), ':'.Str::ucfirst($key)],
                 [$value, Str::upper($value), Str::ucfirst($value)],

--- a/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
@@ -18,7 +18,7 @@ trait CompilesTranslations
             return "<?php \$__env->startTranslation{$expression}; ?>";
         }
 
-        return "<?php echo e(app('translator')->getFromJson{$expression}); ?>";
+        return "<?php echo app('translator')->getFromJson{$expression}; ?>";
     }
 
     /**
@@ -28,7 +28,7 @@ trait CompilesTranslations
      */
     protected function compileEndlang()
     {
-        return '<?php echo e($__env->renderTranslation()); ?>';
+        return '<?php echo $__env->renderTranslation(); ?>';
     }
 
     /**
@@ -39,6 +39,6 @@ trait CompilesTranslations
      */
     protected function compileChoice($expression)
     {
-        return "<?php echo e(app('translator')->choice{$expression}); ?>";
+        return "<?php echo app('translator')->choice{$expression}; ?>";
     }
 }

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -49,6 +49,20 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('foo', $t->get('foo::bar.foo'));
     }
 
+    public function testTransMethodProperlyLoadsAndRetrievesItemWithHTMLReplacements()
+    {
+        $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze :foo']);
+        $this->assertSame('breeze &lt;p&gt;test&lt;/p&gt;', $t->trans('foo.bar', ['foo' => '<p>test</p>'], 'en'));
+    }
+
+    public function testTransMethodProperlyLoadsAndRetrievesItemWithHTMLInTheMessage()
+    {
+        $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze <p>test</p>']);
+        $this->assertSame('breeze <p>test</p>', $t->trans('foo.bar', [], 'en'));
+    }
+
     public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization()
     {
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(null)->setConstructorArgs([$this->getLoader(), 'en'])->getMock();

--- a/tests/View/Blade/BladeExpressionTest.php
+++ b/tests/View/Blade/BladeExpressionTest.php
@@ -6,13 +6,13 @@ class BladeExpressionTest extends AbstractBladeTestCase
 {
     public function testExpressionsOnTheSameLine()
     {
-        $this->assertEquals('<?php echo e(app(\'translator\')->getFromJson(foo(bar(baz(qux(breeze())))))); ?> space () <?php echo e(app(\'translator\')->getFromJson(foo(bar))); ?>', $this->compiler->compileString('@lang(foo(bar(baz(qux(breeze()))))) space () @lang(foo(bar))'));
+        $this->assertEquals('<?php echo app(\'translator\')->getFromJson(foo(bar(baz(qux(breeze()))))); ?> space () <?php echo app(\'translator\')->getFromJson(foo(bar)); ?>', $this->compiler->compileString('@lang(foo(bar(baz(qux(breeze()))))) space () @lang(foo(bar))'));
     }
 
     public function testExpressionWithinHTML()
     {
         $this->assertEquals('<html <?php echo e($foo); ?>>', $this->compiler->compileString('<html {{ $foo }}>'));
         $this->assertEquals('<html<?php echo e($foo); ?>>', $this->compiler->compileString('<html{{ $foo }}>'));
-        $this->assertEquals('<html <?php echo e($foo); ?> <?php echo e(app(\'translator\')->getFromJson(\'foo\')); ?>>', $this->compiler->compileString('<html {{ $foo }} @lang(\'foo\')>'));
+        $this->assertEquals('<html <?php echo e($foo); ?> <?php echo app(\'translator\')->getFromJson(\'foo\'); ?>>', $this->compiler->compileString('<html {{ $foo }} @lang(\'foo\')>'));
     }
 }

--- a/tests/View/Blade/BladeLangTest.php
+++ b/tests/View/Blade/BladeLangTest.php
@@ -7,13 +7,13 @@ class BladeLangTest extends AbstractBladeTestCase
     public function testStatementThatContainsNonConsecutiveParenthesisAreCompiled()
     {
         $string = "Foo @lang(function_call('foo(blah)')) bar";
-        $expected = "Foo <?php echo e(app('translator')->getFromJson(function_call('foo(blah)'))); ?> bar";
+        $expected = "Foo <?php echo app('translator')->getFromJson(function_call('foo(blah)')); ?> bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testLanguageAndChoicesAreCompiled()
     {
-        $this->assertEquals('<?php echo e(app(\'translator\')->getFromJson(\'foo\')); ?>', $this->compiler->compileString("@lang('foo')"));
-        $this->assertEquals('<?php echo e(app(\'translator\')->choice(\'foo\', 1)); ?>', $this->compiler->compileString("@choice('foo', 1)"));
+        $this->assertEquals('<?php echo app(\'translator\')->getFromJson(\'foo\'); ?>', $this->compiler->compileString("@lang('foo')"));
+        $this->assertEquals('<?php echo app(\'translator\')->choice(\'foo\', 1); ?>', $this->compiler->compileString("@choice('foo', 1)"));
     }
 }


### PR DESCRIPTION
Fixes #25515 

https://github.com/laravel/framework/commit/d3c0a369057d0b6ebf29b5f51c903b1a85e3e09b was a security fix because there was an XSS vulnerability when passing parameters as the second method to @lang. Unfortunately the fix escaped the whole output instead of only the parameters that were being replaced which resulted in a major breaking change (because people can no longer use HTML tags inside translations) -> https://github.com/laravel/framework/pull/25408. This PR fixes that by escaping only the parameters that are being replaced so that there can't be any XSS, but doing it this way still allows people to have HTML in the translation files.