### PR TITLE
[5.7] Add Missing @throws Docblock

### DIFF
--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -28,9 +28,9 @@ class Connector
     /**
      * Create a new PDO connection.
      *
-     * @param  string $dsn
-     * @param  array $config
-     * @param  array $options
+     * @param  string  $dsn
+     * @param  array   $config
+     * @param  array   $options
      * @return \PDO
      *
      * @throws \Exception

--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -28,10 +28,12 @@ class Connector
     /**
      * Create a new PDO connection.
      *
-     * @param  string  $dsn
-     * @param  array   $config
-     * @param  array   $options
+     * @param  string $dsn
+     * @param  array $config
+     * @param  array $options
      * @return \PDO
+     *
+     * @throws \Exception
      */
     public function createConnection($dsn, array $config, array $options)
     {


### PR DESCRIPTION
This PR applies the missing @throws Docblock to the `createConnection` function.