### PR TITLE
[5.7] Don't use fully qualified classnames in Auth tests

### DIFF
--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -2,9 +2,13 @@
 
 namespace Illuminate\Tests\Auth;
 
+use stdClass;
 use Mockery as m;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Connection;
+use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Auth\Passwords\DatabaseTokenRepository;
 
 class AuthDatabaseTokenRepositoryTest extends TestCase
@@ -28,11 +32,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('make')->once()->andReturn('hashed-token');
-        $repo->getConnection()->shouldReceive('table')->times(2)->with('table')->andReturn($query = m::mock(\stdClass::class));
+        $repo->getConnection()->shouldReceive('table')->times(2)->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('delete')->once();
         $query->shouldReceive('insert')->once();
-        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
+        $user = m::mock(CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->times(2)->andReturn('email');
 
         $results = $repo->create($user);
@@ -44,10 +48,10 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     public function testExistReturnsFalseIfNoRowFoundForUser()
     {
         $repo = $this->getRepo();
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('first')->once()->andReturn(null);
-        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
+        $user = m::mock(CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'token'));
@@ -56,11 +60,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     public function testExistReturnsFalseIfRecordIsExpired()
     {
         $repo = $this->getRepo();
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subSeconds(300000)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
+        $user = m::mock(CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'token'));
@@ -70,11 +74,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->once()->with('token', 'hashed-token')->andReturn(true);
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subMinutes(10)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
+        $user = m::mock(CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
 
         $this->assertTrue($repo->exists($user, 'token'));
@@ -84,11 +88,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->once()->with('wrong-token', 'hashed-token')->andReturn(false);
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subMinutes(10)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
+        $user = m::mock(CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'wrong-token'));
@@ -97,10 +101,10 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     public function testDeleteMethodDeletesByToken()
     {
         $repo = $this->getRepo();
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('delete')->once();
-        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
+        $user = m::mock(CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
 
         $repo->delete($user);
@@ -109,7 +113,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     public function testDeleteExpiredMethodDeletesExpiredTokens()
     {
         $repo = $this->getRepo();
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('created_at', '<', m::any())->andReturn($query);
         $query->shouldReceive('delete')->once();
 
@@ -119,8 +123,8 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     protected function getRepo()
     {
         return new DatabaseTokenRepository(
-            m::mock(\Illuminate\Database\Connection::class),
-            m::mock(\Illuminate\Contracts\Hashing\Hasher::class),
+            m::mock(Connection::class),
+            m::mock(Hasher::class),
             'table', 'key');
     }
 }

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -5,7 +5,10 @@ namespace Illuminate\Tests\Auth;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\GenericUser;
+use Illuminate\Database\Connection;
+use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Auth\DatabaseUserProvider;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 class AuthDatabaseUserProviderTest extends TestCase
 {
@@ -16,24 +19,24 @@ class AuthDatabaseUserProviderTest extends TestCase
 
     public function testRetrieveByIDReturnsUserWhenUserIsFound()
     {
-        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $conn = m::mock(Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('find')->once()->with(1)->andReturn(['id' => 1, 'name' => 'Dayle']);
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher = m::mock(Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveById(1);
 
-        $this->assertInstanceOf(\Illuminate\Auth\GenericUser::class, $user);
+        $this->assertInstanceOf(GenericUser::class, $user);
         $this->assertEquals(1, $user->getAuthIdentifier());
         $this->assertEquals('Dayle', $user->name);
     }
 
     public function testRetrieveByIDReturnsNullWhenUserIsNotFound()
     {
-        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $conn = m::mock(Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('find')->once()->with(1)->andReturn(null);
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher = m::mock(Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveById(1);
 
@@ -45,10 +48,10 @@ class AuthDatabaseUserProviderTest extends TestCase
         $mockUser = new \stdClass();
         $mockUser->remember_token = 'a';
 
-        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $conn = m::mock(Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('find')->once()->with(1)->andReturn($mockUser);
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher = m::mock(Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByToken(1, 'a');
 
@@ -57,10 +60,10 @@ class AuthDatabaseUserProviderTest extends TestCase
 
     public function testRetrieveTokenWithBadIdentifierReturnsNull()
     {
-        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $conn = m::mock(Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('find')->once()->with(1)->andReturn(null);
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher = m::mock(Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByToken(1, 'a');
 
@@ -72,10 +75,10 @@ class AuthDatabaseUserProviderTest extends TestCase
         $mockUser = new \stdClass();
         $mockUser->remember_token = null;
 
-        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $conn = m::mock(Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('find')->once()->with(1)->andReturn($mockUser);
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher = m::mock(Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByToken(1, 'a');
 
@@ -84,27 +87,27 @@ class AuthDatabaseUserProviderTest extends TestCase
 
     public function testRetrieveByCredentialsReturnsUserWhenUserIsFound()
     {
-        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $conn = m::mock(Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('where')->once()->with('username', 'dayle');
         $conn->shouldReceive('whereIn')->once()->with('group', ['one', 'two']);
         $conn->shouldReceive('first')->once()->andReturn(['id' => 1, 'name' => 'taylor']);
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher = m::mock(Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByCredentials(['username' => 'dayle', 'password' => 'foo', 'group' => ['one', 'two']]);
 
-        $this->assertInstanceOf(\Illuminate\Auth\GenericUser::class, $user);
+        $this->assertInstanceOf(GenericUser::class, $user);
         $this->assertEquals(1, $user->getAuthIdentifier());
         $this->assertEquals('taylor', $user->name);
     }
 
     public function testRetrieveByCredentialsReturnsNullWhenUserIsFound()
     {
-        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $conn = m::mock(Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('where')->once()->with('username', 'dayle');
         $conn->shouldReceive('first')->once()->andReturn(null);
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher = m::mock(Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByCredentials(['username' => 'dayle']);
 
@@ -113,11 +116,11 @@ class AuthDatabaseUserProviderTest extends TestCase
 
     public function testCredentialValidation()
     {
-        $conn = m::mock(\Illuminate\Database\Connection::class);
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $conn = m::mock(Connection::class);
+        $hasher = m::mock(Hasher::class);
         $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
         $result = $provider->validateCredentials($user, ['password' => 'plain']);
 

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -2,9 +2,13 @@
 
 namespace Illuminate\Tests\Auth;
 
+use stdClass;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Connection;
+use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Auth\EloquentUserProvider;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 class AuthEloquentUserProviderTest extends TestCase
 {
@@ -16,7 +20,7 @@ class AuthEloquentUserProviderTest extends TestCase
     public function testRetrieveByIDReturnsUser()
     {
         $provider = $this->getProviderMock();
-        $mock = m::mock(\stdClass::class);
+        $mock = m::mock(stdClass::class);
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
         $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
@@ -29,11 +33,11 @@ class AuthEloquentUserProviderTest extends TestCase
 
     public function testRetrieveByTokenReturnsUser()
     {
-        $mockUser = m::mock(\stdClass::class);
+        $mockUser = m::mock(stdClass::class);
         $mockUser->shouldReceive('getRememberToken')->once()->andReturn('a');
 
         $provider = $this->getProviderMock();
-        $mock = m::mock(\stdClass::class);
+        $mock = m::mock(stdClass::class);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
         $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
         $mock->shouldReceive('first')->once()->andReturn($mockUser);
@@ -46,7 +50,7 @@ class AuthEloquentUserProviderTest extends TestCase
     public function testRetrieveTokenWithBadIdentifierReturnsNull()
     {
         $provider = $this->getProviderMock();
-        $mock = m::mock(\stdClass::class);
+        $mock = m::mock(stdClass::class);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
         $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
         $mock->shouldReceive('first')->once()->andReturn(null);
@@ -58,11 +62,11 @@ class AuthEloquentUserProviderTest extends TestCase
 
     public function testRetrieveByBadTokenReturnsNull()
     {
-        $mockUser = m::mock(\stdClass::class);
+        $mockUser = m::mock(stdClass::class);
         $mockUser->shouldReceive('getRememberToken')->once()->andReturn(null);
 
         $provider = $this->getProviderMock();
-        $mock = m::mock(\stdClass::class);
+        $mock = m::mock(stdClass::class);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
         $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
         $mock->shouldReceive('first')->once()->andReturn($mockUser);
@@ -75,7 +79,7 @@ class AuthEloquentUserProviderTest extends TestCase
     public function testRetrieveByCredentialsReturnsUser()
     {
         $provider = $this->getProviderMock();
-        $mock = m::mock(\stdClass::class);
+        $mock = m::mock(stdClass::class);
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('where')->once()->with('username', 'dayle');
         $mock->shouldReceive('whereIn')->once()->with('group', ['one', 'two']);
@@ -88,11 +92,11 @@ class AuthEloquentUserProviderTest extends TestCase
 
     public function testCredentialValidation()
     {
-        $conn = m::mock(\Illuminate\Database\Connection::class);
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $conn = m::mock(Connection::class);
+        $hasher = m::mock(Hasher::class);
         $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
         $provider = new EloquentUserProvider($hasher, 'foo');
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
         $result = $provider->validateCredentials($user, ['password' => 'plain']);
 
@@ -101,18 +105,18 @@ class AuthEloquentUserProviderTest extends TestCase
 
     public function testModelsCanBeCreated()
     {
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
-        $provider = new EloquentUserProvider($hasher, \Illuminate\Tests\Auth\EloquentProviderUserStub::class);
+        $hasher = m::mock(Hasher::class);
+        $provider = new EloquentUserProvider($hasher, EloquentProviderUserStub::class);
         $model = $provider->createModel();
 
-        $this->assertInstanceOf(\Illuminate\Tests\Auth\EloquentProviderUserStub::class, $model);
+        $this->assertInstanceOf(EloquentProviderUserStub::class, $model);
     }
 
     protected function getProviderMock()
     {
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher = m::mock(Hasher::class);
 
-        return $this->getMockBuilder(\Illuminate\Auth\EloquentUserProvider::class)->setMethods(['createModel'])->setConstructorArgs([$hasher, 'foo'])->getMock();
+        return $this->getMockBuilder(EloquentUserProvider::class)->setMethods(['createModel'])->setConstructorArgs([$hasher, 'foo'])->getMock();
     }
 }
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -4,10 +4,19 @@ namespace Illuminate\Tests\Auth;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Cookie\CookieJar;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\SessionGuard;
 use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Attempting;
 use Illuminate\Auth\Events\Authenticated;
+use Illuminate\Contracts\Session\Session;
+use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Contracts\Events\Dispatcher;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Encryption\Encrypter;
 
 class AuthGuardTest extends TestCase
 {
@@ -19,7 +28,7 @@ class AuthGuardTest extends TestCase
     public function testBasicReturnsNullOnValidAttempt()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock(\Illuminate\Auth\SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
+        $guard = m::mock(SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
         $guard->shouldReceive('check')->once()->andReturn(false);
         $guard->shouldReceive('attempt')->once()->with(['email' => 'foo@bar.com', 'password' => 'secret'])->andReturn(true);
         $request = Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
@@ -31,7 +40,7 @@ class AuthGuardTest extends TestCase
     public function testBasicReturnsNullWhenAlreadyLoggedIn()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock(\Illuminate\Auth\SessionGuard::class.'[check]', ['default', $provider, $session]);
+        $guard = m::mock(SessionGuard::class.'[check]', ['default', $provider, $session]);
         $guard->shouldReceive('check')->once()->andReturn(true);
         $guard->shouldReceive('attempt')->never();
         $request = Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
@@ -46,10 +55,10 @@ class AuthGuardTest extends TestCase
     public function testBasicReturnsResponseOnFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock(\Illuminate\Auth\SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
+        $guard = m::mock(SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
         $guard->shouldReceive('check')->once()->andReturn(false);
         $guard->shouldReceive('attempt')->once()->with(['email' => 'foo@bar.com', 'password' => 'secret'])->andReturn(false);
-        $request = \Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
+        $request = Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
         $guard->setRequest($request);
         $guard->basic('email');
     }
@@ -57,10 +66,10 @@ class AuthGuardTest extends TestCase
     public function testBasicWithExtraConditions()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock(\Illuminate\Auth\SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
+        $guard = m::mock(SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
         $guard->shouldReceive('check')->once()->andReturn(false);
         $guard->shouldReceive('attempt')->once()->with(['email' => 'foo@bar.com', 'password' => 'secret', 'active' => 1])->andReturn(true);
-        $request = \Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
+        $request = Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
         $guard->setRequest($request);
 
         $guard->basic('email', ['active' => 1]);
@@ -69,10 +78,10 @@ class AuthGuardTest extends TestCase
     public function testBasicWithExtraArrayConditions()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock(\Illuminate\Auth\SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
+        $guard = m::mock(SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
         $guard->shouldReceive('check')->once()->andReturn(false);
         $guard->shouldReceive('attempt')->once()->with(['email' => 'foo@bar.com', 'password' => 'secret', 'active' => 1, 'type' => [1, 2, 3]])->andReturn(true);
-        $request = \Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
+        $request = Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
         $guard->setRequest($request);
 
         $guard->basic('email', ['active' => 1, 'type' => [1, 2, 3]]);
@@ -81,7 +90,7 @@ class AuthGuardTest extends TestCase
     public function testAttemptCallsRetrieveByCredentials()
     {
         $guard = $this->getGuard();
-        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $guard->setDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo']);
@@ -91,10 +100,10 @@ class AuthGuardTest extends TestCase
     public function testAttemptReturnsUserInterface()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $guard = $this->getMockBuilder(SessionGuard::class)->setMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $guard->setDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
-        $user = $this->createMock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = $this->createMock(Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->with($user, ['foo'])->andReturn(true);
         $guard->expects($this->once())->method('login')->with($this->equalTo($user));
@@ -104,7 +113,7 @@ class AuthGuardTest extends TestCase
     public function testAttemptReturnsFalseIfUserNotGiven()
     {
         $mock = $this->getGuard();
-        $mock->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $mock->setDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $mock->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn(null);
@@ -114,8 +123,8 @@ class AuthGuardTest extends TestCase
     public function testLoginStoresIdentifierInSession()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $user = m::mock(Authenticatable::class);
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
@@ -139,11 +148,11 @@ class AuthGuardTest extends TestCase
     public function testLoginFiresLoginAndAuthenticatedEvents()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $mock->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
-        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Auth\Events\Login::class));
-        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Auth\Events\Authenticated::class));
+        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock->setDispatcher($events = m::mock(Dispatcher::class));
+        $user = m::mock(Authenticatable::class);
+        $events->shouldReceive('dispatch')->once()->with(m::type(Login::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(Authenticated::class));
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
@@ -154,7 +163,7 @@ class AuthGuardTest extends TestCase
     public function testFailedAttemptFiresFailedEvent()
     {
         $guard = $this->getGuard();
-        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $guard->setDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn(null);
@@ -163,7 +172,7 @@ class AuthGuardTest extends TestCase
 
     public function testAuthenticateReturnsUserWhenUserIsNotNull()
     {
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $guard = $this->getGuard()->setUser($user);
 
         $this->assertEquals($user, $guard->authenticate());
@@ -171,9 +180,9 @@ class AuthGuardTest extends TestCase
 
     public function testSetUserFiresAuthenticatedEvent()
     {
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $guard = $this->getGuard();
-        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $guard->setDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Authenticated::class));
         $guard->setUser($user);
     }
@@ -192,7 +201,7 @@ class AuthGuardTest extends TestCase
 
     public function testHasUserReturnsTrueWhenUserIsNotNull()
     {
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $guard = $this->getGuard()->setUser($user);
 
         $this->assertTrue($guard->hasUser());
@@ -208,7 +217,7 @@ class AuthGuardTest extends TestCase
 
     public function testIsAuthedReturnsTrueWhenUserIsNotNull()
     {
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $mock = $this->getGuard();
         $mock->setUser($user);
         $this->assertTrue($mock->check());
@@ -218,7 +227,7 @@ class AuthGuardTest extends TestCase
     public function testIsAuthedReturnsFalseWhenUserIsNull()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['user'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['user'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->expects($this->exactly(2))->method('user')->will($this->returnValue(null));
         $this->assertFalse($mock->check());
         $this->assertTrue($mock->guest());
@@ -226,7 +235,7 @@ class AuthGuardTest extends TestCase
 
     public function testUserMethodReturnsCachedUser()
     {
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $mock = $this->getGuard();
         $mock->setUser($user);
         $this->assertSame($user, $mock->user());
@@ -243,7 +252,7 @@ class AuthGuardTest extends TestCase
     {
         $mock = $this->getGuard();
         $mock->getSession()->shouldReceive('get')->once()->andReturn(1);
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $mock->getProvider()->shouldReceive('retrieveById')->once()->with(1)->andReturn($user);
         $this->assertSame($user, $mock->user());
         $this->assertSame($user, $mock->getUser());
@@ -252,16 +261,16 @@ class AuthGuardTest extends TestCase
     public function testLogoutRemovesSessionTokenAndRememberMeCookie()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $mock->setCookieJar($cookies = m::mock(\Illuminate\Cookie\CookieJar::class));
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock->setCookieJar($cookies = m::mock(CookieJar::class));
+        $user = m::mock(Authenticatable::class);
         $user->shouldReceive('setRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('getRecallerName')->will($this->returnValue('bar'));
         $mock->expects($this->once())->method('recaller')->will($this->returnValue('non-null-cookie'));
         $provider->shouldReceive('updateRememberToken')->once();
 
-        $cookie = m::mock(\Symfony\Component\HttpFoundation\Cookie::class);
+        $cookie = m::mock(Cookie::class);
         $cookies->shouldReceive('forget')->once()->with('bar')->andReturn($cookie);
         $cookies->shouldReceive('queue')->once()->with($cookie);
         $mock->getSession()->shouldReceive('remove')->once()->with('foo');
@@ -273,9 +282,9 @@ class AuthGuardTest extends TestCase
     public function testLogoutDoesNotEnqueueRememberMeCookieForDeletionIfCookieDoesntExist()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $mock->setCookieJar($cookies = m::mock(\Illuminate\Cookie\CookieJar::class));
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['getName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock->setCookieJar($cookies = m::mock(CookieJar::class));
+        $user = m::mock(Authenticatable::class);
         $user->shouldReceive('setRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('recaller')->will($this->returnValue(null));
@@ -290,10 +299,10 @@ class AuthGuardTest extends TestCase
     public function testLogoutFiresLogoutEvent()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->expects($this->once())->method('clearUserDataFromStorage');
-        $mock->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $mock->setDispatcher($events = m::mock(Dispatcher::class));
+        $user = m::mock(Authenticatable::class);
         $user->shouldReceive('setRememberToken')->once();
         $provider->shouldReceive('updateRememberToken')->once();
         $events->shouldReceive('dispatch')->once()->with(m::type(Authenticated::class));
@@ -305,14 +314,14 @@ class AuthGuardTest extends TestCase
     public function testLoginMethodQueuesCookieWhenRemembering()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = new \Illuminate\Auth\SessionGuard('default', $provider, $session, $request);
+        $guard = new SessionGuard('default', $provider, $session, $request);
         $guard->setCookieJar($cookie);
-        $foreverCookie = new \Symfony\Component\HttpFoundation\Cookie($guard->getRecallerName(), 'foo');
+        $foreverCookie = new Cookie($guard->getRecallerName(), 'foo');
         $cookie->shouldReceive('forever')->once()->with($guard->getRecallerName(), 'foo|recaller|bar')->andReturn($foreverCookie);
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
         $session->shouldReceive('migrate')->once();
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthIdentifier')->andReturn('foo');
         $user->shouldReceive('getAuthPassword')->andReturn('bar');
         $user->shouldReceive('getRememberToken')->andReturn('recaller');
@@ -324,14 +333,14 @@ class AuthGuardTest extends TestCase
     public function testLoginMethodCreatesRememberTokenIfOneDoesntExist()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = new \Illuminate\Auth\SessionGuard('default', $provider, $session, $request);
+        $guard = new SessionGuard('default', $provider, $session, $request);
         $guard->setCookieJar($cookie);
-        $foreverCookie = new \Symfony\Component\HttpFoundation\Cookie($guard->getRecallerName(), 'foo');
+        $foreverCookie = new Cookie($guard->getRecallerName(), 'foo');
         $cookie->shouldReceive('forever')->once()->andReturn($foreverCookie);
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
         $session->shouldReceive('migrate')->once();
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthIdentifier')->andReturn('foo');
         $user->shouldReceive('getAuthPassword')->andReturn('foo');
         $user->shouldReceive('getRememberToken')->andReturn(null);
@@ -344,9 +353,9 @@ class AuthGuardTest extends TestCase
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
 
-        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
+        $guard = m::mock(SessionGuard::class, ['default', $provider, $session])->makePartial();
 
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user);
         $guard->shouldReceive('login')->once()->with($user, false);
 
@@ -356,7 +365,7 @@ class AuthGuardTest extends TestCase
     public function testLoginUsingIdFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
+        $guard = m::mock(SessionGuard::class, ['default', $provider, $session])->makePartial();
 
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(11)->andReturn(null);
         $guard->shouldNotReceive('login');
@@ -367,9 +376,9 @@ class AuthGuardTest extends TestCase
     public function testOnceUsingIdSetsUser()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
+        $guard = m::mock(SessionGuard::class, ['default', $provider, $session])->makePartial();
 
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user);
         $guard->shouldReceive('setUser')->once()->with($user);
 
@@ -379,7 +388,7 @@ class AuthGuardTest extends TestCase
     public function testOnceUsingIdFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
+        $guard = m::mock(SessionGuard::class, ['default', $provider, $session])->makePartial();
 
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(11)->andReturn(null);
         $guard->shouldNotReceive('setUser');
@@ -391,10 +400,10 @@ class AuthGuardTest extends TestCase
     {
         $guard = $this->getGuard();
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $request = \Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [$guard->getRecallerName() => 'id|recaller|baz']);
-        $guard = new \Illuminate\Auth\SessionGuard('default', $provider, $session, $request);
+        $request = Request::create('/', 'GET', [], [$guard->getRecallerName() => 'id|recaller|baz']);
+        $guard = new SessionGuard('default', $provider, $session, $request);
         $guard->getSession()->shouldReceive('get')->once()->with($guard->getName())->andReturn(null);
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByToken')->once()->with('id', 'recaller')->andReturn($user);
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $guard->getSession()->shouldReceive('put')->with($guard->getName(), 'bar')->once();
@@ -406,8 +415,8 @@ class AuthGuardTest extends TestCase
     public function testLoginOnceSetsUser()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $guard = m::mock(SessionGuard::class, ['default', $provider, $session])->makePartial();
+        $user = m::mock(Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->once()->with($user, ['foo'])->andReturn(true);
         $guard->shouldReceive('setUser')->once()->with($user);
@@ -417,8 +426,8 @@ class AuthGuardTest extends TestCase
     public function testLoginOnceFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $guard = m::mock(SessionGuard::class, ['default', $provider, $session])->makePartial();
+        $user = m::mock(Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->once()->with($user, ['foo'])->andReturn(false);
         $this->assertFalse($guard->once(['foo']));
@@ -428,21 +437,21 @@ class AuthGuardTest extends TestCase
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
 
-        return new \Illuminate\Auth\SessionGuard('default', $provider, $session, $request);
+        return new SessionGuard('default', $provider, $session, $request);
     }
 
     protected function getMocks()
     {
         return [
-            m::mock(\Illuminate\Contracts\Session\Session::class),
-            m::mock(\Illuminate\Contracts\Auth\UserProvider::class),
-            \Symfony\Component\HttpFoundation\Request::create('/', 'GET'),
-            m::mock(\Illuminate\Cookie\CookieJar::class),
+            m::mock(Session::class),
+            m::mock(UserProvider::class),
+            Request::create('/', 'GET'),
+            m::mock(CookieJar::class),
         ];
     }
 
     protected function getCookieJar()
     {
-        return new \Illuminate\Cookie\CookieJar(Request::create('/foo', 'GET'), m::mock(\Illuminate\Contracts\Encryption\Encrypter::class), ['domain' => 'foo.com', 'path' => '/', 'secure' => false, 'httpOnly' => false]);
+        return new CookieJar(Request::create('/foo', 'GET'), m::mock(Encrypter::class), ['domain' => 'foo.com', 'path' => '/', 'secure' => false, 'httpOnly' => false]);
     }
 }

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Events\Dispatcher;
 use Illuminate\Routing\Controller;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
@@ -63,10 +64,10 @@ class AuthorizesResourcesTest extends TestCase
      */
     protected function assertHasMiddleware($controller, $method, $middleware)
     {
-        $router = new Router(new \Illuminate\Events\Dispatcher);
+        $router = new Router(new Dispatcher);
 
-        $router->aliasMiddleware('can', \Illuminate\Tests\Auth\AuthorizesResourcesMiddleware::class);
-        $router->get($method)->uses(\Illuminate\Tests\Auth\AuthorizesResourcesController::class.'@'.$method);
+        $router->aliasMiddleware('can', AuthorizesResourcesMiddleware::class);
+        $router->get($method)->uses(AuthorizesResourcesController::class.'@'.$method);
 
         $this->assertEquals(
             'caught '.$middleware,


### PR DESCRIPTION
use short ::class notation for Auth tests
