### PR TITLE
[5.7] Simplify MorphOneOrMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -68,19 +68,6 @@ abstract class MorphOneOrMany extends HasOneOrMany
     }
 
     /**
-     * Attach a model instance to the parent model.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    public function save(Model $model)
-    {
-        $model->setAttribute($this->getMorphType(), $this->morphClass);
-
-        return parent::save($model);
-    }
-
-    /**
      * Set the foreign ID and type for creating a related model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model


### PR DESCRIPTION
Overriding the `save()` method is not necessary. `parent::save()` calls `setForeignAttributesForCreate()` which already sets the morph type.