### PR TITLE
[5.7] Fix prefixed table indexes

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -71,9 +71,10 @@ class Blueprint
      *
      * @param  string  $table
      * @param  \Closure|null  $callback
+     * @param  string  $prefix
      * @return void
      */
-    public function __construct($table, Closure $callback = null, $prefix = null)
+    public function __construct($table, Closure $callback = null, $prefix = '')
     {
         $this->table = $table;
         $this->prefix = $prefix;

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -22,6 +22,13 @@ class Blueprint
     protected $table;
 
     /**
+     * The prefix of the table the blueprint describes.
+     *
+     * @var string
+     */
+    protected $prefix;
+
+    /**
      * The columns that should be added to the table.
      *
      * @var \Illuminate\Database\Schema\ColumnDefinition[]
@@ -66,9 +73,10 @@ class Blueprint
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function __construct($table, Closure $callback = null)
+    public function __construct($table, Closure $callback = null, $prefix = null)
     {
         $this->table = $table;
+        $this->prefix = $prefix;
 
         if (! is_null($callback)) {
             $callback($this);
@@ -1242,7 +1250,7 @@ class Blueprint
      */
     protected function createIndexName($type, array $columns)
     {
-        $index = strtolower($this->table.'_'.implode('_', $columns).'_'.$type);
+        $index = strtolower($this->prefix.$this->table.'_'.implode('_', $columns).'_'.$type);
 
         return str_replace(['-', '.'], '_', $index);
     }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -273,7 +273,7 @@ class Builder
      */
     protected function createBlueprint($table, Closure $callback = null)
     {
-        $prefix = $this->connection->getConfig('prefix_indexes') ? $this->connection->getConfig('prefix') : null;
+        $prefix = $this->connection->getConfig('prefix_indexes') ? $this->connection->getConfig('prefix') : '';
 
         if (isset($this->resolver)) {
             return call_user_func($this->resolver, $table, $callback, $prefix);

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -273,11 +273,13 @@ class Builder
      */
     protected function createBlueprint($table, Closure $callback = null)
     {
+        $prefix = $this->connection->getConfig('prefix_index') ? $this->connection->getConfig('prefix') : null;
+
         if (isset($this->resolver)) {
-            return call_user_func($this->resolver, $table, $callback);
+            return call_user_func($this->resolver, $table, $callback, $prefix);
         }
 
-        return new Blueprint($table, $callback);
+        return new Blueprint($table, $callback, $prefix);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -273,7 +273,7 @@ class Builder
      */
     protected function createBlueprint($table, Closure $callback = null)
     {
-        $prefix = $this->connection->getConfig('prefix_index') ? $this->connection->getConfig('prefix') : null;
+        $prefix = $this->connection->getConfig('prefix_indexes') ? $this->connection->getConfig('prefix') : null;
 
         if (isset($this->resolver)) {
             return call_user_func($this->resolver, $table, $callback, $prefix);

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -101,7 +101,6 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals('prefix_geo_coordinates_spatialindex', $commands[0]->index);
     }
 
-
     public function testDefaultCurrentTimestamp()
     {
         $base = new Blueprint('users', function ($table) {

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -47,6 +47,24 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals('geo_coordinates_spatialindex', $commands[0]->index);
     }
 
+    public function testIndexDefaultNamesWhenPrefixSupplied()
+    {
+        $blueprint = new Blueprint('users', null, 'prefix_');
+        $blueprint->unique(['foo', 'bar']);
+        $commands = $blueprint->getCommands();
+        $this->assertEquals('prefix_users_foo_bar_unique', $commands[0]->index);
+
+        $blueprint = new Blueprint('users', null, 'prefix_');
+        $blueprint->index('foo');
+        $commands = $blueprint->getCommands();
+        $this->assertEquals('prefix_users_foo_index', $commands[0]->index);
+
+        $blueprint = new Blueprint('geo', null, 'prefix_');
+        $blueprint->spatialIndex('coordinates');
+        $commands = $blueprint->getCommands();
+        $this->assertEquals('prefix_geo_coordinates_spatialindex', $commands[0]->index);
+    }
+
     public function testDropIndexDefaultNames()
     {
         $blueprint = new Blueprint('users');
@@ -64,6 +82,25 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $commands = $blueprint->getCommands();
         $this->assertEquals('geo_coordinates_spatialindex', $commands[0]->index);
     }
+
+    public function testDropIndexDefaultNamesWhenPrefixSupplied()
+    {
+        $blueprint = new Blueprint('users', null, 'prefix_');
+        $blueprint->dropUnique(['foo', 'bar']);
+        $commands = $blueprint->getCommands();
+        $this->assertEquals('prefix_users_foo_bar_unique', $commands[0]->index);
+
+        $blueprint = new Blueprint('users', null, 'prefix_');
+        $blueprint->dropIndex(['foo']);
+        $commands = $blueprint->getCommands();
+        $this->assertEquals('prefix_users_foo_index', $commands[0]->index);
+
+        $blueprint = new Blueprint('geo', null, 'prefix_');
+        $blueprint->dropSpatialIndex(['coordinates']);
+        $commands = $blueprint->getCommands();
+        $this->assertEquals('prefix_geo_coordinates_spatialindex', $commands[0]->index);
+    }
+
 
     public function testDefaultCurrentTimestamp()
     {

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -71,4 +71,39 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
 
         $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasColumn('table1', 'name'));
     }
+
+
+    public function testHasColumnAndIndexWithPrefixIndexDisabled()
+    {
+        $this->db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => 'example_',
+            'prefix_index' => false,
+        ]);
+
+        $this->db->connection()->getSchemaBuilder()->create('table1', function ($table) {
+            $table->integer('id');
+            $table->string('name')->index();
+        });
+
+        $this->assertTrue(array_key_exists("table1_name_index", $this->db->connection()->getDoctrineSchemaManager()->listTableIndexes('example_table1')));
+    }
+
+    public function testHasColumnAndIndexWithPrefixIndexEnabled()
+    {
+        $this->db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => 'example_',
+            'prefix_index' => true,
+        ]);
+
+        $this->db->connection()->getSchemaBuilder()->create('table1', function ($table) {
+            $table->integer('id');
+            $table->string('name')->index();
+        });
+
+        $this->assertTrue(array_key_exists("example_table1_name_index", $this->db->connection()->getDoctrineSchemaManager()->listTableIndexes('example_table1')));
+    }
 }

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -72,7 +72,6 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasColumn('table1', 'name'));
     }
 
-
     public function testHasColumnAndIndexWithPrefixIndexDisabled()
     {
         $this->db->addConnection([
@@ -87,7 +86,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
             $table->string('name')->index();
         });
 
-        $this->assertTrue(array_key_exists("table1_name_index", $this->db->connection()->getDoctrineSchemaManager()->listTableIndexes('example_table1')));
+        $this->assertArrayHasKey('table1_name_index', $this->db->connection()->getDoctrineSchemaManager()->listTableIndexes('example_table1'));
     }
 
     public function testHasColumnAndIndexWithPrefixIndexEnabled()
@@ -104,6 +103,6 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
             $table->string('name')->index();
         });
 
-        $this->assertTrue(array_key_exists("example_table1_name_index", $this->db->connection()->getDoctrineSchemaManager()->listTableIndexes('example_table1')));
+        $this->assertArrayHasKey('example_table1_name_index', $this->db->connection()->getDoctrineSchemaManager()->listTableIndexes('example_table1'));
     }
 }

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -79,7 +79,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
             'driver' => 'sqlite',
             'database' => ':memory:',
             'prefix' => 'example_',
-            'prefix_index' => false,
+            'prefix_indexes' => false,
         ]);
 
         $this->db->connection()->getSchemaBuilder()->create('table1', function ($table) {
@@ -96,7 +96,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
             'driver' => 'sqlite',
             'database' => ':memory:',
             'prefix' => 'example_',
-            'prefix_index' => true,
+            'prefix_indexes' => true,
         ]);
 
         $this->db->connection()->getSchemaBuilder()->create('table1', function ($table) {


### PR DESCRIPTION
This is an attempt to fix https://github.com/laravel/framework/issues/7889. This issue is the oldest outstanding Laravel Framework issue at over 3.5 years old (March 2015) - so I thought I'd give it a crack. 😄 

Also fixes duplicates of the original issue - https://github.com/laravel/framework/issues/23142, https://github.com/laravel/framework/pull/13683 and https://github.com/laravel/framework/issues/9040

Essentially the problem boils down that the `Blueprint` class prepares the SQL commands without taking into account the database connection prefix. While the table prefix stuff is handled further up, we need to do the table indexes inside the `Blueprint` class.

This is a non-breaking and full backwards compatible change; I've set default behavior for existing projects to maintain current behavior. This is because migrations and foreign keys etc could break mid-project, so they need to maintain existing behavior unless they want to manually change.

All new projects will default to the new behavior - but it is fully configurable either way. 

I've done https://github.com/laravel/laravel/pull/4783 as a related PR with the new config option if this one is accepted.