### PR TITLE
[5.7] Allow invokable objects to be passed to Eloquent where clauses

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -211,7 +211,7 @@ class Builder
     /**
      * Add a basic where clause to the query.
      *
-     * @param  string|array|\Closure  $column
+     * @param  string|array|\Callable  $column
      * @param  mixed   $operator
      * @param  mixed   $value
      * @param  string  $boolean
@@ -219,7 +219,7 @@ class Builder
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
-        if ($column instanceof Closure) {
+        if (is_callable($column)) {
             $column($query = $this->model->newModelQuery());
 
             $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
@@ -233,7 +233,7 @@ class Builder
     /**
      * Add an "or where" clause to the query.
      *
-     * @param  \Closure|array|string  $column
+     * @param  \Callable|array|string  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder|static

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -191,6 +191,17 @@ class DatabaseEloquentIntegrationTest extends TestCase
         }
     }
 
+    public function testModelRetrievalWithCallableClass()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
+        $this->assertEquals(2, EloquentTestUser::count());
+
+        $this->assertFalse(EloquentTestUser::where(new EmailQuery('taylorotwell@gmail.com'))->doesntExist());
+        $this->assertTrue(EloquentTestUser::where(new EmailQuery('mohamed@laravel.com'))->doesntExist());
+    }
+
     public function testBasicModelCollectionRetrieval()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
@@ -1819,5 +1830,20 @@ class EloquentTouchingComment extends Eloquent
     public function post()
     {
         return $this->belongsTo('Illuminate\Tests\Database\EloquentTouchingPost', 'post_id');
+    }
+}
+
+class EmailQuery
+{
+    protected $email;
+
+    public function __construct($email)
+    {
+        $this->email = $email;
+    }
+
+    public function __invoke($q)
+    {
+        return $q->where('email', $this->email);
     }
 }


### PR DESCRIPTION
This pull request allows users to pass an `Invokable Object` to where methods of models, which enhances the functionality of passing `Closures`.

It might be helpful when trying to build some queries with many inputs, such as search forms or filterable tables. Here is an example for possible usage:

```PHP
Item::query()
    ->where(new OrLikeQuery($request->get('brands', []), 'brand'))
    ->where(new OrLikeQuery($request->get('colors', []), 'colors'))
    ->get();

class OrLikeQuery
{
    protected $filters;
    protected $columnName;

    public function __construct($filters, $columnName)
    {
        $this->filters = $filters;
        $this->columnName = $columnName;
    }

    public function __invoke($query)
    {
        foreach ($this->filters as $criteria) {
            $query->orWhere($this->columnName, 'like', "%{$criteria}%");
        }
    }
}
```
