### PR TITLE
[5.7] [Option 1] Improve PSR-11 implementation

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -606,11 +606,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function get($id)
     {
-        if ($this->has($id)) {
-            return $this->resolve($id);
-        }
-
-        throw new EntryNotFoundException;
+        return $this->resolve($id);
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Container;
 
 use Closure;
+use Exception;
 use ArrayAccess;
 use LogicException;
 use ReflectionClass;
@@ -606,7 +607,15 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function get($id)
     {
-        return $this->resolve($id);
+        try {
+            return $this->resolve($id);
+        } catch (Exception $e) {
+            if ($this->has($id)) {
+                throw $e;
+            }
+
+            throw new EntryNotFoundException;
+        }
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1041,7 +1041,7 @@ class ContainerTest extends TestCase
     }
 
     /**
-     * @expectedException \Psr\Container\ContainerExceptionInterface
+     * @expectedException \Illuminate\Container\EntryNotFoundException
      */
     public function testUnknownEntryThrowsException()
     {

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1041,12 +1041,20 @@ class ContainerTest extends TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Container\EntryNotFoundException
+     * @expectedException \Psr\Container\ContainerExceptionInterface
      */
     public function testUnknownEntryThrowsException()
     {
         $container = new Container;
         $container->get('Taylor');
+    }
+
+    public function testContainerCanResolveClasses()
+    {
+        $container = new Container;
+        $class = $container->get(ContainerConcreteStub::class);
+
+        $this->assertInstanceOf(ContainerConcreteStub::class, $class);
     }
 }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1049,6 +1049,17 @@ class ContainerTest extends TestCase
         $container->get('Taylor');
     }
 
+    /**
+     * @expectedException \Psr\Container\ContainerExceptionInterface
+     */
+    public function testBoundEntriesThrowsContainerExceptionWhenNotResolvable()
+    {
+        $container = new Container;
+        $container->bind('Taylor', IContainerContractStub::class);
+
+        $container->get('Taylor');
+    }
+
     public function testContainerCanResolveClasses()
     {
         $container = new Container;


### PR DESCRIPTION
I've recently tried to implement a small lib to bridge between a Laravel app and a legacy app and I finally understood why so many people tried to change the PSR-11 implementation, which frankly I got it quite wrong. Ref https://github.com/laravel/framework/pull/25682, https://github.com/laravel/framework/pull/25678, https://github.com/laravel/framework/pull/21335, https://github.com/laravel/framework/pull/21327, https://github.com/laravel/framework/pull/19822 and https://github.com/laravel/ideas/issues/803.

### The Method

Let's look at the possibilities of `$container->get($identifier);` call.

1- `$identifier` has been explicitly bound and the container **can** resolve it.
2- `$identifier` has been explicitly bound and the container **cannot** resolve it.
3- `$identifier` has not been explicitly bound, but the container **can** resolve it.
4- `$identifier` has not been explicitly bound and the container **cannot** resolve it.

### The Problem

Right now, only option 1 and 2 works when using PSR-11 with Laravel container. Something has to explicitly bind into the Laravel container in order for it to work. If it was never bound before, it will not try to do anything. PSR-11 doesn't offer any way to bind things into the container, only resolve out of it.

### The Proposal

By making `has` an alias of `resolve / make`, we cover all 4 scenarios with `get`. 

1- It will resolve explicitly bound into their concrete.
2- It will throw `ContainerExceptionInterface` when trying to resolve explicitly bound into their concrete.
3- It will try to resolve non-explicitly bound (auto-wire).
4- It will fail to resolve anything non-resolvable.

### The Usage

If this patch gets applied, package developers can opt to ignore the `has` method and use Laravel container as follow: 

```
function (ContainerInterface $container) {
    // ...

    try {
        $class = $container->get($identifier);
    } catch (ContainerExceptionInterface $e) 
        // Cannot resolve $identifier
    } 
}
```

or even 

```
function (\Psr\Container\ContainerInterface $container) {
    // ...

    try {
        $class = $container->get($identifier);
    } catch (\Psr\Container\NotFoundExceptionInterface $e) 
        // $identifier was not bound or cannot be resolved, so let's return a default value.

       return new MyDefaultImplementationOfIdentifier();
    } catch (\Psr\Container\ContainerExceptionInterface $e) 
        // Cannot resolve $identifier
    } 
}
```