### PR TITLE
[5.7] [Option 2] Improve PSR-11 implementation

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -606,11 +606,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function get($id)
     {
-        if ($this->has($id)) {
-            return $this->resolve($id);
-        }
-
-        throw new EntryNotFoundException;
+        return $this->resolve($id);
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1041,11 +1041,22 @@ class ContainerTest extends TestCase
     }
 
     /**
-     * @expectedException \Psr\Container\ContainerExceptionInterface
+     * @expectedException \ReflectionException
      */
     public function testUnknownEntryThrowsException()
     {
         $container = new Container;
+        $container->get('Taylor');
+    }
+
+    /**
+     * @expectedException \Psr\Container\ContainerExceptionInterface
+     */
+    public function testBoundEntriesThrowsContainerExceptionWhenNotResolvable()
+    {
+        $container = new Container;
+        $container->bind('Taylor', IContainerContractStub::class);
+
         $container->get('Taylor');
     }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1041,12 +1041,20 @@ class ContainerTest extends TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Container\EntryNotFoundException
+     * @expectedException \Psr\Container\ContainerExceptionInterface
      */
     public function testUnknownEntryThrowsException()
     {
         $container = new Container;
         $container->get('Taylor');
+    }
+
+    public function testContainerCanResolveClasses()
+    {
+        $container = new Container;
+        $class = $container->get(ContainerConcreteStub::class);
+
+        $this->assertInstanceOf(ContainerConcreteStub::class, $class);
     }
 }
 


### PR DESCRIPTION
Same description of https://github.com/laravel/framework/pull/25870, but with the following differences: 

- A simpler implementation with less feedback.
- The PSR-11 user will not be able to differentiate a `NotFoundExceptionInterface` from a `ContainerExceptionInterface`.

The Usage for this one would be as follows. The container might throw ReflectionException when the identifier is not a class name. Although this would not be fully compatible with PSR-11, it would still give a lot more benefit when using the container than the current implementation.

```
function (ContainerInterface $container) {
    // ...

    try {
        $class = $container->get($identifier);
    } catch (ContainerExceptionInterface | ReflectionException $e) 
        // Cannot resolve $identifier
    } 
}
```