### PR TITLE
[5.7] Always show seeder info

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -62,6 +62,8 @@ class SeedCommand extends Command
         Model::unguarded(function () {
             $this->getSeeder()->__invoke();
         });
+
+        $this->info('Database seeding completed successfully.');
     }
 
     /**


### PR DESCRIPTION
There is currently no default seeder output.

For example - if your `DatabaseSeeder` looks like this:

```
class DatabaseSeeder extends Seeder
{
    public function run()
    {
         factory(\App\User::class)->create();
    }
}
```

and you run `db:seed` - you get:

![image](https://user-images.githubusercontent.com/1210658/46338658-196ed500-c674-11e8-97e9-a26d1c702c6a.png)

That is because the `Seeding: xxx` is only added if you use `->call(Seeder::class)` inside your seeds.

This PR adds a default

![image](https://user-images.githubusercontent.com/1210658/46338680-2b507800-c674-11e8-9359-b07bdd5a5cc1.png)

and if you are running multiple seeders

![image](https://user-images.githubusercontent.com/1210658/46338725-4a4f0a00-c674-11e8-9254-9a29e122eae6.png)

Closes https://github.com/laravel/framework/issues/11375 from 2015 :)