### PR TITLE
[5.7] Fix actingAs

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -29,6 +29,10 @@ trait InteractsWithAuthentication
      */
     public function be(UserContract $user, $driver = null)
     {
+        if (isset($user->wasRecentlyCreated) && $user->wasRecentlyCreated) {
+            $user->wasRecentlyCreated = false;
+        }
+
         $this->app['auth']->guard($driver)->setUser($user);
 
         $this->app['auth']->shouldUse($driver);


### PR DESCRIPTION
This fixes https://github.com/laravel/framework/issues/25868 (and duplicates https://github.com/laravel/framework/issues/21107, https://github.com/laravel/framework/issues/25775 and https://github.com/laravel/framework/issues/23270)

So fresh install of Laravel 5.7:

```
Route::get('/test', function () {
    return Auth::user();
});

public function testBasicTest()
{
    $user = factory(\App\User::class)->create();
    $response = $this->actingAs($user)->get('/test');
    $response->assertOk();
}
```

This test fails - because `Response status code [201] does not match expected 200 status code.`

This is a bug.

The `$user` was created **before** the start of the reqeust. i.e. we did not create a new user and return it inside of `/test`.  The creation of `$user` is just to setup the requirements of the test.

The point of `201` is the request was successful **and** you created a resource. But in the test above - I did not create a resource _inside_ of that request.

This PR ensures that anyone pre-authenticated (using `actingAs()` or `be()`) is never marked as newly created - since that is logically impossible (you cant be pre-authenticated against a resource that doesnt exist before the request even begins).

In other words - you must already have a preexisting user to `be/act` as them
