### PR TITLE
[5.7] Don't use fully qualified classnames in Broadcasting tests

### DIFF
--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -24,7 +24,7 @@ class BroadcastEventTest extends TestCase
 
         $event = new TestBroadcastEvent;
 
-        (new \Illuminate\Broadcasting\BroadcastEvent($event))->handle($broadcaster);
+        (new BroadcastEvent($event))->handle($broadcaster);
     }
 
     public function testManualParameterSpecification()


### PR DESCRIPTION
use short ::class notation for Broadcasting tests