### PR TITLE
[5.8] Don't call redirectTo() when you don't need it

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -64,8 +64,14 @@ class Authenticate
             }
         }
 
+        $redirectTo = '';
+
+        if ( !$request->wantsJson() ) {
+            $redirectTo = $this->redirectTo($request);
+        }
+
         throw new AuthenticationException(
-            'Unauthenticated.', $guards, $this->redirectTo($request)
+            'Unauthenticated.', $guards, $redirectTo
         );
     }
 

--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -66,7 +66,7 @@ class Authenticate
 
         $redirectTo = '';
 
-        if ( !$request->wantsJson() ) {
+        if (! $request->wantsJson()) {
             $redirectTo = $this->redirectTo($request);
         }
 


### PR DESCRIPTION
Sometimes We Write some logic in the `redirectTo()` method, as well as creating an API based workflow on the same codebase, there are some cases where the logic we write get executed even in the API because by default, laravel calls the `\Illuminate\Auth\Middleware\Authenticate::redirectTo()` to pass it as the 3rd param to the `AuthenticationException`, so we need to be able to ignore the useless call of that method if the request excepts json `wantsJson()`.

Sorry if I didn't explain it in words perfectly.
