### PR TITLE
[5.7] Allow Model destroy method to accept a collection of ids

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -7,7 +7,6 @@ use ArrayAccess;
 use JsonSerializable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\ForwardsCalls;
@@ -15,6 +14,7 @@ use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Contracts\Queue\QueueableCollection;
+use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
@@ -836,7 +836,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // type value or get this total count of records deleted for logging, etc.
         $count = 0;
 
-        if ($ids instanceof Collection) {
+        if ($ids instanceof BaseCollection) {
             $ids = $ids->all();
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -7,6 +7,7 @@ use ArrayAccess;
 use JsonSerializable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\ForwardsCalls;
@@ -825,7 +826,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Destroy the models for the given IDs.
      *
-     * @param  array|int  $ids
+     * @param  \Illuminate\Support\Collection|array|int  $ids
      * @return int
      */
     public static function destroy($ids)
@@ -835,7 +836,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // type value or get this total count of records deleted for logging, etc.
         $count = 0;
 
-        $ids = is_array($ids) ? $ids : func_get_args();
+        $ids = $ids instanceof Collection ? $ids->all() :
+            (is_array($ids) ? $ids : func_get_args());
 
         // We will actually pull the models from the database table and call delete on
         // each of them individually so that their events get fired properly with a

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -836,8 +836,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // type value or get this total count of records deleted for logging, etc.
         $count = 0;
 
-        $ids = $ids instanceof Collection ? $ids->all() :
-            (is_array($ids) ? $ids : func_get_args());
+        if ($ids instanceof Collection) {
+            $ids = $ids->all();
+        }
+
+        $ids = is_array($ids) ? $ids : func_get_args();
 
         // We will actually pull the models from the database table and call delete on
         // each of them individually so that their events get fired properly with a

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -193,6 +193,11 @@ class DatabaseEloquentModelTest extends TestCase
         $result = EloquentModelDestroyStub::destroy(1, 2, 3);
     }
 
+    public function testDestroyMethodCallsQueryBuilderCorrectlyWithCollection()
+    {
+        $result = EloquentModelDestroyStub::destroy(new \Illuminate\Database\Eloquent\Collection([1,2,3]));
+    }
+
     public function testWithMethodCallsQueryBuilderCorrectly()
     {
         $result = EloquentModelWithStub::with('foo', 'bar');

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -195,7 +195,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testDestroyMethodCallsQueryBuilderCorrectlyWithCollection()
     {
-        $result = EloquentModelDestroyStub::destroy(new \Illuminate\Database\Eloquent\Collection([1,2,3]));
+        $result = EloquentModelDestroyStub::destroy(new \Illuminate\Database\Eloquent\Collection([1, 2, 3]));
     }
 
     public function testWithMethodCallsQueryBuilderCorrectly()


### PR DESCRIPTION
Currently the `destroy()` method on an eloquent model accepts both an array of ids to destroy and a list of ids as arguments.

However, if the destroy method is given a `Collection` of ids (such as from a `pluck()`) it will destroy only the first id in the collection.  This is potentially unexpected behaviour from the developers point of view as no error is seen and an item is removed from the database.

This PR checks the value passed to the `destroy()` method and if it is an instance of `Collection` calls the 'all()' method to convert it to an array.