### PR TITLE
[5.7] Don't use fully qualified classnames in Console tests

### DIFF
--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -4,6 +4,9 @@ namespace Illuminate\Tests\Console;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Contracts\Events\Dispatcher;
+use Symfony\Component\Console\Command\Command;
+use Illuminate\Contracts\Foundation\Application;
 
 class ConsoleApplicationTest extends TestCase
 {
@@ -16,7 +19,7 @@ class ConsoleApplicationTest extends TestCase
     {
         $app = $this->getMockConsole(['addToParent']);
         $command = m::mock(\Illuminate\Console\Command::class);
-        $command->shouldReceive('setLaravel')->once()->with(m::type(\Illuminate\Contracts\Foundation\Application::class));
+        $command->shouldReceive('setLaravel')->once()->with(m::type(Application::class));
         $app->expects($this->once())->method('addToParent')->with($this->equalTo($command))->will($this->returnValue($command));
         $result = $app->add($command);
 
@@ -26,7 +29,7 @@ class ConsoleApplicationTest extends TestCase
     public function testLaravelNotSetOnSymfonyCommands()
     {
         $app = $this->getMockConsole(['addToParent']);
-        $command = m::mock(\Symfony\Component\Console\Command\Command::class);
+        $command = m::mock(Command::class);
         $command->shouldReceive('setLaravel')->never();
         $app->expects($this->once())->method('addToParent')->with($this->equalTo($command))->will($this->returnValue($command));
         $result = $app->add($command);
@@ -37,8 +40,8 @@ class ConsoleApplicationTest extends TestCase
     public function testResolveAddsCommandViaApplicationResolution()
     {
         $app = $this->getMockConsole(['addToParent']);
-        $command = m::mock(\Symfony\Component\Console\Command\Command::class);
-        $app->getLaravel()->shouldReceive('make')->once()->with('foo')->andReturn(m::mock(\Symfony\Component\Console\Command\Command::class));
+        $command = m::mock(Command::class);
+        $app->getLaravel()->shouldReceive('make')->once()->with('foo')->andReturn(m::mock(Command::class));
         $app->expects($this->once())->method('addToParent')->with($this->equalTo($command))->will($this->returnValue($command));
         $result = $app->resolve('foo');
 
@@ -47,8 +50,8 @@ class ConsoleApplicationTest extends TestCase
 
     protected function getMockConsole(array $methods)
     {
-        $app = m::mock(\Illuminate\Contracts\Foundation\Application::class, ['version' => '5.7']);
-        $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class, ['dispatch' => null]);
+        $app = m::mock(Application::class, ['version' => '5.7']);
+        $events = m::mock(Dispatcher::class, ['dispatch' => null]);
 
         return $this->getMockBuilder(\Illuminate\Console\Application::class)->setMethods($methods)->setConstructorArgs([
             $app, $events, 'test-version',


### PR DESCRIPTION
use short ::class notation for Console tests