### PR TITLE
[5.7] Changed `assertTrue` to `assertEquals` in `PendingCommand`

### DIFF
--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -141,8 +141,8 @@ class PendingCommand
         }
 
         if ($this->expectedExitCode !== null) {
-            $this->test->assertTrue(
-                $exitCode == $this->expectedExitCode,
+            $this->test->assertEquals(
+                $this->expectedExitCode, $exitCode,
                 "Expected status code {$this->expectedExitCode} but received {$exitCode}."
             );
         }


### PR DESCRIPTION
 - changed `assertTrue` to `assertEquals` in `Foundation/Testing/PendingCommand.php`

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
