### PR TITLE
[5.7] Support for multi-dimension in array_get

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -293,6 +293,10 @@ class Arr
             return $array[$key] ?? value($default);
         }
 
+        $key = str_replace(['[', ']'], '.', $key);
+        $key = str_replace('..', '.', $key);
+        $key = trim($key, '.');
+
         foreach (explode('.', $key) as $segment) {
             if (static::accessible($array) && static::exists($array, $segment)) {
                 $array = $array[$segment];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -273,6 +273,100 @@ class SupportArrTest extends TestCase
         $this->assertEmpty(Arr::get([], null, 'default'));
     }
 
+    public function testGetMultiDimension()
+    {
+        $array = [
+            'response' => [
+                'results' => [
+                    [
+                        'value' => 'one',
+                    ],
+                    [
+                        'value' => 'two',
+                    ]
+                ]
+            ]
+        ];
+
+        $this->assertEquals(['value' => 'two'], Arr::get($array, 'response.results[1]'));
+
+        $array = [
+            'response' => [
+                'results' => [
+                    [
+                        'value' => 'one',
+                    ],
+                    [
+                        'value' => 'two',
+                    ]
+                ]
+            ]
+        ];
+
+        $this->assertEquals('two', Arr::get($array, 'response.results[1].value'));
+
+        $array = [
+            'response' => [
+                'results' => [
+                    [
+                        [
+                            'item' => 'one',
+                        ],
+                        [
+                            'item' => 'two',
+                        ]
+                    ],
+                    [
+                        [
+                            'item' => 'three',
+                        ],
+                        [
+                            'item' => 'four',
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->assertEquals('three', Arr::get($array, 'response.results[1][0].item'));
+
+        $array = [
+            'response' => [
+                'results' => [
+                    [
+                       'product' => [
+                           'price' => 1,
+                           'images' => [
+                               [
+                                   'alt' => 'Abc 123',
+                               ],
+                               [
+                                   'alt' => 'Abc 234',
+                               ]
+                           ]
+                       ]
+                    ],
+                    [
+                        'product' => [
+                            'price' => 5,
+                            'images' => [
+                                [
+                                    'alt' => 'Abc 222',
+                                ],
+                                [
+                                    'alt' => 'Abc 333',
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->assertEquals('Abc 234', Arr::get($array, 'response.results.0.product.images.1.alt'));
+        $this->assertEquals('Abc 234', Arr::get($array, 'response.results[0].product.images.1.alt'));
+    }
+
     public function testHas()
     {
         $array = ['products.desk' => ['price' => 100]];


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This pull request allows for an improved dot-notation to be used on array_get calls.

Currently, you can use indexes with dot notation, this PR brings in support for the "array" format of it too.