### PR TITLE
memcache: Specify the expire parameter in seconds if possible

### DIFF
--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -13,6 +13,11 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
     use InteractsWithTime;
 
     /**
+     * Maximum value of expire period that can be specified as delta (in minutes)
+     */
+    const REALTIME_MAXDELTA_IN_MINUTES = 60 * 24 * 30;
+
+    /**
      * The Memcached instance.
      *
      * @var \Memcached
@@ -103,7 +108,7 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
      */
     public function put($key, $value, $minutes)
     {
-        $this->memcached->set($this->prefix.$key, $value, $this->toTimestamp($minutes));
+        $this->memcached->set($this->prefix.$key, $value, $this->toExpireParam($minutes));
     }
 
     /**
@@ -121,7 +126,7 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
             $prefixedValues[$this->prefix.$key] = $value;
         }
 
-        $this->memcached->setMulti($prefixedValues, $this->toTimestamp($minutes));
+        $this->memcached->setMulti($prefixedValues, $this->toExpireParam($minutes));
     }
 
     /**
@@ -134,7 +139,7 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
      */
     public function add($key, $value, $minutes)
     {
-        return $this->memcached->add($this->prefix.$key, $value, $this->toTimestamp($minutes));
+        return $this->memcached->add($this->prefix.$key, $value, $this->toExpireParam($minutes));
     }
 
     /**
@@ -204,6 +209,28 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
     public function flush()
     {
         return $this->memcached->flush();
+    }
+
+    /**
+     * convert the given number of minutes to integer suitable for expire param
+     *
+     * If it doesn't exceeds 30 days, convert it to number of seconds
+     * Otherwise, convert it to unixtime
+     *
+     * @param  int  $minutes
+     * @return int
+     */
+    protected function toExpireParam($minutes)
+    {
+        if ($minutes <= 0) {
+            return 0; // never expire
+        }
+
+        if ($minutes <= self::REALTIME_MAXDELTA_IN_MINUTES) {
+            return $minutes * 60;
+        }
+
+        return $this->toTimestamp($minutes);
     }
 
     /**

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -13,7 +13,7 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
     use InteractsWithTime;
 
     /**
-     * Maximum value of expire period that can be specified as delta (in minutes)
+     * Maximum value of expire period that can be specified as delta (in minutes).
      */
     const REALTIME_MAXDELTA_IN_MINUTES = 60 * 24 * 30;
 
@@ -212,7 +212,7 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
     }
 
     /**
-     * convert the given number of minutes to integer suitable for expire param
+     * convert the given number of minutes to integer suitable for expire param.
      *
      * If it doesn't exceeds 30 days, convert it to number of seconds
      * Otherwise, convert it to unixtime

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -57,18 +57,39 @@ class CacheMemcachedStoreTest extends TestCase
         ]));
     }
 
-    public function testSetMethodProperlyCallsMemcache()
+    /**
+     * @param int  $minutes
+     * @param int  $expectedExpire
+     * @param bool $useUnixtime
+     * @dataProvider setMethodProperlyCallsMemcacheProvider
+     */
+    public function testSetMethodProperlyCallsMemcache($minutes, $expectedExpire, $useUnixtime)
     {
         if (! class_exists(Memcached::class)) {
             $this->markTestSkipped('Memcached module not installed');
         }
 
         \Illuminate\Support\Carbon::setTestNow($now = \Illuminate\Support\Carbon::now());
+        if ($useUnixtime) {
+            $expectedExpire += $now->timestamp;
+        }
         $memcache = $this->getMockBuilder('Memcached')->setMethods(['set'])->getMock();
-        $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo($now->timestamp + 60));
+        $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo($expectedExpire));
         $store = new MemcachedStore($memcache);
-        $store->put('foo', 'bar', 1);
+        $store->put('foo', 'bar', $minutes);
         \Illuminate\Support\Carbon::setTestNow();
+    }
+
+    public function setMethodProperlyCallsMemcacheProvider()
+    {
+        return [
+            '-1min' => [-1, 0, false],
+            '0' => [0, 0, false],
+            '1min' => [1, 60, false],
+            '30days' => [30 * 24 * 60, 30 * 24 * 60 * 60, false],
+            '30days+1min' => [30 * 24 * 60 + 1, 30 * 24 * 60 * 60 + 60, true],
+            '31days' => [31 * 24 * 60, 31 * 24 * 60 * 60, true],
+            ];
     }
 
     public function testIncrementMethodProperlyCallsMemcache()


### PR DESCRIPTION
# SUMMARY

Specify the expire parameter in number of seconds if possible

# DESCRIPTION

Memcached uses an internal clock based on monotonic clock and when the expire parameter is given as unixtime, memcached interprets it as the time in this internal clock.

Because memcached's internal clock is monotonic, there are differences in the way it goes from the system clock (normally synchronized with ntp), and the difference may become large. For example, I have seen that the internal clock is about 30 minutes advanced for memcached two years after startup.

In the current implementation of `\Illuminate\Cache\MemcachedStore` class, `$minutes` parameter of `put()`, `add()`, etc, has always been converted to unix timestamp. 

This causes problems when the difference between memcached 's internal clock and realtime is large.

For example, let's say that memcached's internal clock is advanced by 10 minutes. If you specify 5 for `$minutes` and call the `put()` method, the value of the expire parameter will be a unixtime which is 5 minutes after the current time of the clock of the system on which the application is running. Since this is already a past in memcached's internal clock, the data will expire instantly.

This patch avoids this problem by using seconds instead of unix timestamp for the expire parameter when possible (ie for time within 30 days).
