### PR TITLE
[5.7] Add support for multiple classes on contextual binding

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -134,12 +134,22 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Define a contextual binding.
      *
-     * @param  string  $concrete
+     * @param  string|array  $concrete
      * @return \Illuminate\Contracts\Container\ContextualBindingBuilder
      */
     public function when($concrete)
     {
-        return new ContextualBindingBuilder($this, $this->getAlias($concrete));
+        if (is_array($concrete)) {
+            $alias = [];
+
+            foreach($concrete as $c) {
+                $alias[] = $this->getAlias($c);
+            }
+        } else {
+            $alias = $this->getAlias($concrete);
+        }
+
+        return new ContextualBindingBuilder($this, $alias);
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -142,7 +142,7 @@ class Container implements ArrayAccess, ContainerContract
         if (is_array($concrete)) {
             $alias = [];
 
-            foreach($concrete as $c) {
+            foreach ($concrete as $c) {
                 $alias[] = $this->getAlias($c);
             }
         } else {

--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -31,7 +31,7 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
      * Create a new contextual binding builder.
      *
      * @param  \Illuminate\Container\Container  $container
-     * @param  string  $concrete
+     * @param  string|array  $concrete
      * @return void
      */
     public function __construct(Container $container, $concrete)
@@ -61,8 +61,14 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
      */
     public function give($implementation)
     {
-        $this->container->addContextualBinding(
-            $this->concrete, $this->needs, $implementation
-        );
+        if (is_array($this->concrete)) {
+            foreach($this->concrete as $c) {
+                $this->container->addContextualBinding($c, $this->needs, $implementation);
+            }
+        } else {
+            $this->container->addContextualBinding(
+                $this->concrete, $this->needs, $implementation
+            );
+        }
     }
 }

--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -62,7 +62,7 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
     public function give($implementation)
     {
         if (is_array($this->concrete)) {
-            foreach($this->concrete as $c) {
+            foreach ($this->concrete as $c) {
                 $this->container->addContextualBinding($c, $this->needs, $implementation);
             }
         } else {

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -93,7 +93,7 @@ interface Container extends ContainerInterface
     /**
      * Define a contextual binding.
      *
-     * @param  string  $concrete
+     * @param  string|array  $concrete
      * @return \Illuminate\Contracts\Container\ContextualBindingBuilder
      */
     public function when($concrete);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -703,6 +703,30 @@ class ContainerTest extends TestCase
         );
     }
 
+    public function testContextualBindingWorksForMultipleClasses()
+    {
+        $container = new Container;
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->when([ContainerTestContextInjectTwo::class, ContainerTestContextInjectThree::class])->needs(IContainerContractStub::class)->give(ContainerImplementationStubTwo::class);
+
+        $this->assertInstanceOf(
+            ContainerImplementationStub::class,
+            $container->make(ContainerTestContextInjectOne::class)->impl
+        );
+
+        $this->assertInstanceOf(
+            ContainerImplementationStubTwo::class,
+            $container->make(ContainerTestContextInjectTwo::class)->impl
+        );
+
+        $this->assertInstanceOf(
+            ContainerImplementationStubTwo::class,
+            $container->make(ContainerTestContextInjectThree::class)->impl
+        );
+    }
+
     public function testContextualBindingDoesntOverrideNonContextualResolution()
     {
         $container = new Container;
@@ -1167,6 +1191,15 @@ class ContainerTestContextInjectTwo
     }
 }
 
+class ContainerTestContextInjectThree
+{
+    public $impl;
+
+    public function __construct(IContainerContractStub $impl)
+    {
+        $this->impl = $impl;
+    }
+}
 class ContainerStaticMethodStub
 {
     public static function inject(ContainerConcreteStub $stub, $default = 'taylor')


### PR DESCRIPTION
I often need to add contextual binding for different non standard use cases. When doing this I recognized that I often have to define multiple contextual bindings for the same interface.

Consider the following example:
```php
$this->app->when(PhotoController::class)
          ->needs(Filesystem::class)
          ->give(function () {
              return Storage::disk('s3');
          });

$this->app->when(VideoController::class)
          ->needs(Filesystem::class)
          ->give(function () {
              return Storage::disk('s3');
          });

$this->app->when(UploadController::class)
          ->needs(Filesystem::class)
          ->give(function () {
              return Storage::disk('local');
          });
```

This pull request adds the possibility to define the contextual binding for `PhotoController` and `VideoController` at once and should ease and shorten the service container bindings.

```php
$this->app->when([PhotoController::class, VideoController::class])
          ->needs(Filesystem::class)
          ->give(function () {
              return Storage::disk('s3');
          });

$this->app->when(UploadController::class)
          ->needs(Filesystem::class)
          ->give(function () {
              return Storage::disk('local');
          });
```
