### PR TITLE
[5.7] [WIP] Support iterable objects as targets for data_get()

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -49,21 +49,13 @@ class Arr
         $results = [];
 
         foreach ($array as $values) {
-            if (is_array($values)) {
-                $results = array_merge($results, $values);
-            } elseif ($values instanceof Collection) {
-                $results = array_merge($results, $values->all());
-            } elseif (is_iterable($values)) {
-                foreach ($values as $key => $value) {
-                    if (is_int($key)) {
-                        $results[] = $value;
-                    } else {
-                        $results[$key] = $value;
-                    }
-                }
-            } else {
+            if ($values instanceof Collection) {
+                $values = $values->all();
+            } elseif (! is_array($values)) {
                 continue;
             }
+
+            $results = array_merge($results, $values);
         }
 
         return $results;

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -49,13 +49,21 @@ class Arr
         $results = [];
 
         foreach ($array as $values) {
-            if ($values instanceof Collection) {
-                $values = $values->all();
-            } elseif (! is_array($values)) {
+            if (is_array($values)) {
+                $results = array_merge($results, $values);
+            } elseif ($values instanceof Collection) {
+                $results = array_merge($results, $values->all());
+            } elseif (is_iterable($values)) {
+                foreach ($values as $key => $value) {
+                    if (is_int($key)) {
+                        $results[] = $value;
+                    } else {
+                        $results[$key] = $value;
+                    }
+                }
+            } else {
                 continue;
             }
-
-            $results = array_merge($results, $values);
         }
 
         return $results;

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -463,7 +463,11 @@ if (! function_exists('data_get')) {
                     return value($default);
                 }
 
-                $result = Arr::pluck($target, $key);
+                $result = [];
+
+                foreach ($target as $item) {
+                    $result[] = data_get($item, $key);
+                }
 
                 return in_array('*', $key) ? Arr::collapse($result) : $result;
             }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -469,7 +469,7 @@ if (! function_exists('data_get')) {
                     $result[] = data_get($item, $key);
                 }
 
-                return $result;
+                return in_array('*', $key) ? Arr::collapse($result) : $result;
             }
 
             if (Arr::accessible($target) && Arr::exists($target, $segment)) {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -469,7 +469,7 @@ if (! function_exists('data_get')) {
                     $result[] = data_get($item, $key);
                 }
 
-                return in_array('*', $key) ? Arr::collapse($result) : $result;
+                return $result;
             }
 
             if (Arr::accessible($target) && Arr::exists($target, $segment)) {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -459,7 +459,7 @@ if (! function_exists('data_get')) {
             if ($segment === '*') {
                 if ($target instanceof Collection) {
                     $target = $target->all();
-                } elseif (! is_array($target)) {
+                } elseif (! is_iterable($target)) {
                     return value($default);
                 }
 


### PR DESCRIPTION
A follow-up to the quite old #12638.

* See commit descriptions for helpful notes.
* As a reminder, codes `if ($value instanceof Collection) { $value = $value->all(); }` are not mandatory but for performances (iterate on plain array).