### PR TITLE
[5.7] Add --step to migrate:fresh command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -132,7 +132,7 @@ class FreshCommand extends Command
             ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run'],
 
             ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder'],
-            
+
             ['step', null, InputOption::VALUE_NONE, 'Force the migrations to be run so they can be rolled back individually'],
         ];
     }

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -52,6 +52,7 @@ class FreshCommand extends Command
             '--path' => $this->input->getOption('path'),
             '--realpath' => $this->input->getOption('realpath'),
             '--force' => true,
+            '--step' => $this->option('step'),
         ]);
 
         if ($this->needsSeeding()) {
@@ -131,6 +132,8 @@ class FreshCommand extends Command
             ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run'],
 
             ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder'],
+            
+            ['step', null, InputOption::VALUE_NONE, 'Force the migrations to be run so they can be rolled back individually'],
         ];
     }
 }


### PR DESCRIPTION
The `migrate:fresh` is a useful command, but currently there is no option to repeat the migration in steps using migrate:fresh when required.

This pr adds the missing feature, which can be run by adding --step option to migrate:fresh
`php artisan migrate:fresh --step`

It is a non breaking change and works as intended with other options as well.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
