### PR TITLE
[5.7] Show which packages are newly discovered

### DIFF
--- a/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
+++ b/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
@@ -29,11 +29,17 @@ class PackageDiscoverCommand extends Command
      */
     public function handle(PackageManifest $manifest)
     {
+        $previousPackages = array_keys($manifest->previousManifest ?? []);
+
         $manifest->build();
 
         foreach (array_keys($manifest->manifest) as $package) {
-            $this->line("Discovered Package: <info>{$package}</info>");
+            $new = in_array($package, $previousPackages) ? '' : ' <comment>(new)</comment>';
+
+            $this->line("Discovered Package: <info>{$package}</info>{$new}");
         }
+
+        $manifest->storePreviousManifest();
 
         $this->info('Package manifest generated successfully.');
     }

--- a/tests/Foundation/FoundationPackageManifestTest.php
+++ b/tests/Foundation/FoundationPackageManifestTest.php
@@ -18,7 +18,7 @@ class FoundationPackageManifestTest extends TestCase
     }
 
     /** @test */
-    function it_can_stores_a_previous_packages_manifest()
+    public function it_can_stores_a_previous_packages_manifest()
     {
         @unlink(__DIR__.'/fixtures/packages.php');
         @unlink(__DIR__.'/fixtures/packages-previous.php');

--- a/tests/Foundation/FoundationPackageManifestTest.php
+++ b/tests/Foundation/FoundationPackageManifestTest.php
@@ -16,4 +16,24 @@ class FoundationPackageManifestTest extends TestCase
         $this->assertEquals(['Foo' => 'Foo\\Facade'], $manifest->aliases());
         unlink(__DIR__.'/fixtures/packages.php');
     }
+
+    /** @test */
+    function it_can_stores_a_previous_packages_manifest()
+    {
+        @unlink(__DIR__.'/fixtures/packages.php');
+        @unlink(__DIR__.'/fixtures/packages-previous.php');
+
+        $manifest = new PackageManifest(new Filesystem, __DIR__.'/fixtures', __DIR__.'/fixtures/packages.php');
+
+        $manifest->build();
+
+        $this->assertFileNotExists($manifest->previousManifestPath);
+
+        $manifest->storePreviousManifest();
+
+        $this->assertFileEquals($manifest->manifestPath, $manifest->previousManifestPath);
+
+        unlink(__DIR__.'/fixtures/packages.php');
+        unlink(__DIR__.'/fixtures/packages-previous.php');
+    }
 }


### PR DESCRIPTION
This PR makes `artisan package:discover` show which packages are newly discovered. I got the idea after seeing [this tweet by Freek van der Herten](https://twitter.com/freekmurze/status/1045756677100900353). Being able to see which packages are newly discovered is nice, but i have to admit it isn't really useful.

![image](https://user-images.githubusercontent.com/7202674/46403999-4d91d680-c704-11e8-8c27-7c801013ca21.png)

This PR works by creating a `bootstrap/cache/packages-previous.php` file when running `artisan package:discover`. The command then uses that file next time it is run to figure out which packages are newly discovered. 

I'm not really happy with how this PR is implemented, but creating a cached file of the previously discovered packages is the best solution i could think of. We can't use the real package manifest because it is always deleted when running any composer command (see [`ComposerScript::clearCompiled`](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Foundation/ComposerScripts.php#L62)).

Another problem i ran into was that while Laravel is booting, [`PackageManifest::providers`](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Foundation/PackageManifest.php#L68) and [`PackageManifest::aliases`](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Foundation/PackageManifest.php#L80) are called, they create a new package manifest if one doesn't exist yet.

This effectively means that currently the `PackageDiscoverCommand` doesn't actually do anything. When a new package is installed, the existing package manifest is deleted, then while Laravel is booting it creates a new package manifest, then the `PackageDiscoverCommand` is called and creates the same package manifest again.

