### PR TITLE
[5.7] Use ::class notation for tests

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -358,7 +358,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', \Illuminate\Tests\Auth\AccessGateTestClass::class.'@foo');
+        $gate->define('foo', AccessGateTestClass::class.'@foo');
 
         $this->assertTrue($gate->check('foo'));
     }
@@ -367,7 +367,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', \Illuminate\Tests\Auth\AccessGateTestInvokableClass::class);
+        $gate->define('foo', AccessGateTestInvokableClass::class);
 
         $this->assertTrue($gate->check('foo'));
     }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -8,6 +8,7 @@ use Illuminate\Cookie\CookieJar;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\SessionGuard;
 use Illuminate\Auth\Events\Failed;
+use Illuminate\Auth\Events\Logout;
 use Illuminate\Auth\Events\Attempting;
 use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Contracts\Session\Session;
@@ -307,7 +308,7 @@ class AuthGuardTest extends TestCase
         $provider->shouldReceive('updateRememberToken')->once();
         $events->shouldReceive('dispatch')->once()->with(m::type(Authenticated::class));
         $mock->setUser($user);
-        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Auth\Events\Logout::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(Logout::class));
         $mock->logout();
     }
 

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Routing\Middleware\SubstituteBindings;
@@ -220,7 +221,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
     public function testModelInstanceAsParameter()
     {
-        $instance = m::mock(\Illuminate\Database\Eloquent\Model::class);
+        $instance = m::mock(Model::class);
 
         $this->gate()->define('success', function ($user, $model) use ($instance) {
             $this->assertSame($model, $instance);

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -3,10 +3,12 @@
 namespace Illuminate\Tests\Console;
 
 use Mockery as m;
+use Illuminate\Console\Command;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Console\Application;
 use Illuminate\Contracts\Events\Dispatcher;
-use Symfony\Component\Console\Command\Command;
-use Illuminate\Contracts\Foundation\Application;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
 class ConsoleApplicationTest extends TestCase
 {
@@ -18,8 +20,8 @@ class ConsoleApplicationTest extends TestCase
     public function testAddSetsLaravelInstance()
     {
         $app = $this->getMockConsole(['addToParent']);
-        $command = m::mock(\Illuminate\Console\Command::class);
-        $command->shouldReceive('setLaravel')->once()->with(m::type(Application::class));
+        $command = m::mock(Command::class);
+        $command->shouldReceive('setLaravel')->once()->with(m::type(ApplicationContract::class));
         $app->expects($this->once())->method('addToParent')->with($this->equalTo($command))->will($this->returnValue($command));
         $result = $app->add($command);
 
@@ -29,7 +31,7 @@ class ConsoleApplicationTest extends TestCase
     public function testLaravelNotSetOnSymfonyCommands()
     {
         $app = $this->getMockConsole(['addToParent']);
-        $command = m::mock(Command::class);
+        $command = m::mock(SymfonyCommand::class);
         $command->shouldReceive('setLaravel')->never();
         $app->expects($this->once())->method('addToParent')->with($this->equalTo($command))->will($this->returnValue($command));
         $result = $app->add($command);
@@ -40,8 +42,8 @@ class ConsoleApplicationTest extends TestCase
     public function testResolveAddsCommandViaApplicationResolution()
     {
         $app = $this->getMockConsole(['addToParent']);
-        $command = m::mock(Command::class);
-        $app->getLaravel()->shouldReceive('make')->once()->with('foo')->andReturn(m::mock(Command::class));
+        $command = m::mock(SymfonyCommand::class);
+        $app->getLaravel()->shouldReceive('make')->once()->with('foo')->andReturn(m::mock(SymfonyCommand::class));
         $app->expects($this->once())->method('addToParent')->with($this->equalTo($command))->will($this->returnValue($command));
         $result = $app->resolve('foo');
 
@@ -50,10 +52,10 @@ class ConsoleApplicationTest extends TestCase
 
     protected function getMockConsole(array $methods)
     {
-        $app = m::mock(Application::class, ['version' => '5.7']);
+        $app = m::mock(ApplicationContract::class, ['version' => '5.7']);
         $events = m::mock(Dispatcher::class, ['dispatch' => null]);
 
-        return $this->getMockBuilder(\Illuminate\Console\Application::class)->setMethods($methods)->setConstructorArgs([
+        return $this->getMockBuilder(Application::class)->setMethods($methods)->setConstructorArgs([
             $app, $events, 'test-version',
         ])->getMock();
     }

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Console;
 use Mockery as m;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Application;
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\EventMutex;
 
@@ -32,7 +33,7 @@ class ConsoleScheduledEventTest extends TestCase
 
     public function testBasicCronCompilation()
     {
-        $app = m::mock('Illuminate\Foundation\Application[isDownForMaintenance,environment]');
+        $app = m::mock(Application::class.'[isDownForMaintenance,environment]');
         $app->shouldReceive('isDownForMaintenance')->andReturn(false);
         $app->shouldReceive('environment')->andReturn('production');
 
@@ -76,7 +77,7 @@ class ConsoleScheduledEventTest extends TestCase
 
     public function testEventIsDueCheck()
     {
-        $app = m::mock('Illuminate\Foundation\Application[isDownForMaintenance,environment]');
+        $app = m::mock(Application::class.'[isDownForMaintenance,environment]');
         $app->shouldReceive('isDownForMaintenance')->andReturn(false);
         $app->shouldReceive('environment')->andReturn('production');
         Carbon::setTestNow(Carbon::create(2015, 1, 1, 0, 0, 0));
@@ -92,7 +93,7 @@ class ConsoleScheduledEventTest extends TestCase
 
     public function testTimeBetweenChecks()
     {
-        $app = m::mock('Illuminate\Foundation\Application[isDownForMaintenance,environment]');
+        $app = m::mock(Application::class.'[isDownForMaintenance,environment]');
         $app->shouldReceive('isDownForMaintenance')->andReturn(false);
         $app->shouldReceive('environment')->andReturn('production');
         Carbon::setTestNow(Carbon::now()->startOfDay()->addHours(9));

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Cookie;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Cookie\CookieJar;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 
 class CookieTest extends TestCase
@@ -71,11 +72,11 @@ class CookieTest extends TestCase
         $cookie->queue($cookie->make('foo', 'bar'));
         $this->assertArrayHasKey('foo', $cookie->getQueuedCookies());
         $this->assertTrue($cookie->hasQueued('foo'));
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Cookie', $cookie->queued('foo'));
+        $this->assertInstanceOf(Cookie::class, $cookie->queued('foo'));
         $cookie->queue('qu', 'ux');
         $this->assertArrayHasKey('qu', $cookie->getQueuedCookies());
         $this->assertTrue($cookie->hasQueued('qu'));
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Cookie', $cookie->queued('qu'));
+        $this->assertInstanceOf(Cookie::class, $cookie->queued('qu'));
     }
 
     public function testUnqueue()

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -41,8 +41,8 @@ class EncryptCookiesTest extends TestCase
     public function testSetCookieEncryption()
     {
         $this->router->get($this->setCookiePath, [
-            'middleware' => 'Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestMiddleware',
-            'uses' => 'Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestController@setCookies',
+            'middleware' => EncryptCookiesTestMiddleware::class,
+            'uses' => EncryptCookiesTestController::class.'@setCookies',
         ]);
 
         $response = $this->router->dispatch(Request::create($this->setCookiePath, 'GET'));
@@ -58,8 +58,8 @@ class EncryptCookiesTest extends TestCase
     public function testQueuedCookieEncryption()
     {
         $this->router->get($this->queueCookiePath, [
-            'middleware' => ['Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestMiddleware', 'Illuminate\Tests\Cookie\Middleware\AddQueuedCookiesToResponseTestMiddleware'],
-            'uses' => 'Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestController@queueCookies',
+            'middleware' => [EncryptCookiesTestMiddleware::class, AddQueuedCookiesToResponseTestMiddleware::class],
+            'uses' => EncryptCookiesTestController::class.'@queueCookies',
         ]);
 
         $response = $this->router->dispatch(Request::create($this->queueCookiePath, 'GET'));


### PR DESCRIPTION
Use short ::class notation for following tests
* Auth
* Console
* Cookie