### PR TITLE
[5.8] Add support for associative arrays to wherePivot

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -313,7 +313,7 @@ class BelongsToMany extends Relation
     /**
      * Set a where clause for a pivot table column.
      *
-     * @param  string  $column
+     * @param  string|array  $column
      * @param  string  $operator
      * @param  mixed   $value
      * @param  string  $boolean
@@ -323,7 +323,16 @@ class BelongsToMany extends Relation
     {
         $this->pivotWheres[] = func_get_args();
 
-        return $this->where($this->table.'.'.$column, $operator, $value, $boolean);
+        // If the column is an array, we will assume that it is an array of key-value pairs
+        if (is_array($column)) {
+            foreach ($column as $key => $value) {
+                $pivotPrefixedColumn[$this->table.'.'.$key] = $value;
+            }
+        } else {
+            $pivotPrefixedColumn = $this->table.'.'.$column;
+        }
+
+        return $this->where($pivotPrefixedColumn, $operator, $value, $boolean);
     }
 
     /**


### PR DESCRIPTION
Before this PR, it was possible to filter the results returned by belongsToMany using wherePivot only based on one column.

This PR adds the ability to specify an array of key-value pairs as the first attribute of wherePivot. With this, one can filter through many columns in the pivot table. Indeed, the pivot table might have some extra columns with useful information.

As per the code, if the first attribute $column is not an array, the normal behaviour would still work.