### PR TITLE
[5.7] Add ability to add middleware to individual routes in a route resource.

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -137,6 +137,17 @@ class PendingResourceRegistration
     }
 
     /**
+     * @param  array|strings  $middlewares
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function middlewares($middlewares)
+    {
+        $this->options['middlewares'] = $middlewares;
+
+        return $this;
+    }
+
+    /**
      * Set a middleware to the resource.
      *
      * @param  mixed  $middleware

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -360,7 +360,23 @@ class ResourceRegistrar
         $action = ['as' => $name, 'uses' => $controller.'@'.$method];
 
         if (isset($options['middleware'])) {
-            $action['middleware'] = $options['middleware'];
+            $action['middleware'] = is_array($options['middleware'])
+                ? implode(',', $options['middleware'])
+                : $options['middleware'];
+        }
+
+        if (isset($options['middlewares']) && isset($options['middlewares'][$method])) {
+            $middleware = $options['middlewares'][$method];
+
+            $middleware = is_array($middleware)
+                ? implode(',', $middleware)
+                : $middleware;
+
+            if (! isset($action['middleware'])) {
+                $action['middleware'] = $middleware;
+            } else {
+                $action['middleware'] .= ','.$middleware;
+            }
         }
 
         return $action;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1129,8 +1129,8 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->resource('foo', 'FooController', [
             'middlewares' => [
-                'index' => 'custom-foo-index'
-            ]
+                'index' => 'custom-foo-index',
+            ],
         ]);
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1126,6 +1126,18 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foo-bars/{foo_bar}', $routes[0]->uri());
         $this->assertEquals('prefix.foo-bars.show', $routes[0]->getName());
 
+        $router = $this->getRouter();
+        $router->resource('foo', 'FooController', [
+            'middlewares' => [
+                'index' => 'custom-foo-index'
+            ]
+        ]);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('custom-foo-index', $routes[0]->action['middleware']);
+        $this->assertArrayNotHasKey('middleware', $routes[1]->action);
+
         ResourceRegistrar::verbs([
             'create' => 'ajouter',
             'edit' => 'modifier',


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR allows developers to run the following code similar to [how names are done](https://laravel.com/docs/5.7/controllers#restful-naming-resource-routes).

    Route::resource('posts', 'PostsController', [
        'middleware' => [
            'index' => 'custom-index-name',
            'store' => 'custom-store-name'
        ]
    ]);

    // or
    Route::resource('posts', 'PostsController')->middlewares([
        'index' => 'custom-index-name',
        'store' => 'custom-store-name'
    ]);

Edge cases such as mixtures of string and array middlewares are correctly handled.