### PR TITLE
[5.7] Add Log::fake()

### DIFF
--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Support\Facades;
 
+use Illuminate\Support\Testing\Fakes\LogFake;
+
 /**
  * @method static void emergency(string $message, array $context = [])
  * @method static void alert(string $message, array $context = [])
@@ -14,11 +16,29 @@ namespace Illuminate\Support\Facades;
  * @method static void log($level, string $message, array $context = [])
  * @method static mixed channel(string $channel = null)
  * @method static \Psr\Log\LoggerInterface stack(array $channels, string $channel = null)
+ * @method static void assertLogged($level, $callback = null)
+ * @method static void assertLoggedTimes($level, $times = 1)
+ * @method static void assertNotLogged($level, $callback = null)
+ * @method static void assertNothingLogged()
+ * @method static \Illuminate\Support\Collection logged($level, $callback = null)
+ * @method static bool hasLogged($level)
+ * @method static bool hasNotLogged($level)
  *
  * @see \Illuminate\Log\Logger
+ * @see \Illuminate\Support\Testing\Fakes\LogFake
  */
 class Log extends Facade
 {
+    /**
+     * Replace the bound instance with a fake.
+     *
+     * @return void
+     */
+    public static function fake()
+    {
+        static::swap(new LogFake);
+    }
+
     /**
      * Get the registered name of the component.
      *

--- a/src/Illuminate/Support/Testing/Fakes/LogChannelFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/LogChannelFake.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Support\Testing\Fakes;
+
+class LogChannelFake
+{
+    protected $name;
+
+    protected $logger;
+
+    public function __construct($logger, $name = null)
+    {
+        $this->logger = $logger;
+
+        $this->name = $name;
+    }
+
+    public function __call($method, $arguments)
+    {
+        $this->logger->setCurrentChannel($this->name);
+
+        $this->logger->{$method}(...$arguments);
+
+        $this->logger->setCurrentChannel(null);
+    }
+}

--- a/src/Illuminate/Support/Testing/Fakes/LogFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/LogFake.php
@@ -1,0 +1,391 @@
+<?php
+
+namespace Illuminate\Support\Testing\Fakes;
+
+use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class LogFake implements LoggerInterface
+{
+    /**
+     * All of the created logs.
+     *
+     * @var array
+     */
+    protected $logs = [];
+
+    /**
+     * The channel being logged to.
+     */
+    protected $currentChannel;
+
+    /**
+     * Assert if a log was created based on a truth-test callback.
+     *
+     * @param  string  $level
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public function assertLogged($level, $callback = null)
+    {
+        if (is_numeric($callback)) {
+            return $this->assertLoggedTimes($level, $callback);
+        }
+
+        PHPUnit::assertTrue(
+            $this->logged($level, $callback)->count() > 0,
+            "The expected log with level [{$level}] was not logged."
+        );
+    }
+
+    /**
+     * Assert if a log was created a number of times.
+     *
+     * @param  string  $level
+     * @param  int  $times
+     * @return void
+     */
+    public function assertLoggedTimes($level, $times = 1)
+    {
+        PHPUnit::assertTrue(
+            ($count = $this->logged($level)->count()) === $times,
+            "The expected log with level [{$level}] was logged {$count} times instead of {$times} times."
+        );
+    }
+
+    /**
+     * Determine if a log was not created based on a truth-test callback.
+     *
+     * @param  string  $level
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public function assertNotLogged($level, $callback = null)
+    {
+        PHPUnit::assertTrue(
+            $this->logged($level, $callback)->count() === 0,
+            "The unexpected log with level [{$level}] was logged."
+        );
+    }
+
+    /**
+     * Assert that no logs were created.
+     *
+     * @return void
+     */
+    public function assertNothingLogged()
+    {
+        PHPUnit::assertEmpty($this->logs, 'Logs were created.');
+    }
+
+    /**
+     * Get all of the logs matching a truth-test callback.
+     *
+     * @param  string  $level
+     * @param  callable|null  $callback
+     * @return \Illuminate\Support\Collection
+     */
+    public function logged($level, $callback = null)
+    {
+        $callback = $callback ?: function () {
+            return true;
+        };
+
+        return $this->logsOf($level)->filter(function ($log) use ($callback) {
+            return $callback($log['message'], $log['context']);
+        });
+    }
+
+    /**
+     * Determine if the given log level has been created.
+     *
+     * @param  string  $level
+     * @return bool
+     */
+    public function hasLogged($level)
+    {
+        return $this->logsOf($level)->isNotEmpty();
+    }
+
+    /**
+     * Determine if the given log level has not been created.
+     *
+     * @param  string  $level
+     * @return bool
+     */
+    public function hasNotLogged($level)
+    {
+        return ! $this->hasLogged($level);
+    }
+
+    /**
+     * Get all of the created logs for a given level.
+     *
+     * @param  string  $type
+     * @return \Illuminate\Support\Collection
+     */
+    protected function logsOf($level)
+    {
+        return collect($this->logs)->filter(function ($log) use ($level) {
+            return $log['level'] === $level && $log['channel'] === $this->getCurrentChannel();
+        });
+    }
+
+    /**
+     * Log an emergency message to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function emergency($message, array $context = [])
+    {
+        $this->writeLog(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log an alert message to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function alert($message, array $context = [])
+    {
+        $this->writeLog(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log a critical message to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function critical($message, array $context = [])
+    {
+        $this->writeLog(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log an error message to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function error($message, array $context = [])
+    {
+        $this->writeLog(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log a warning message to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function warning($message, array $context = [])
+    {
+        $this->writeLog(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log a notice to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function notice($message, array $context = [])
+    {
+        $this->writeLog(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log an informational message to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function info($message, array $context = [])
+    {
+        $this->writeLog(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log a debug message to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function debug($message, array $context = [])
+    {
+        $this->writeLog(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log a message to the logs.
+     *
+     * @param  string  $level
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function log($level, $message, array $context = [])
+    {
+        $this->writeLog($level, $message, $context);
+    }
+
+    /**
+     * Dynamically pass log calls into the writer.
+     *
+     * @param  string  $level
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function write($level, $message, array $context = [])
+    {
+        $this->writeLog($level, $message, $context);
+    }
+
+    /**
+     * Write a message to the log.
+     *
+     * @param  string  $level
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    protected function writeLog($level, $message, $context)
+    {
+        $this->logs[] = [
+            'level' => $level,
+            'message' => $message,
+            'context' => $context,
+            'channel' => $this->getCurrentChannel(),
+        ];
+    }
+
+    /**
+     * Get the underlying logger implementation.
+     *
+     * @return $this
+     */
+    public function getLogger()
+    {
+        return $this;
+    }
+
+    /**
+     * Get a log channel instance.
+     *
+     * @param  string|null  $channel
+     * @return \Illuminate\Support\Testing\Fakes\LogChannelFake
+     */
+    public function channel($channel = null)
+    {
+        return $this->driver($channel);
+    }
+
+    /**
+     * Get a log driver instance.
+     *
+     * @param  string|null  $driver
+     * @return \Illuminate\Support\Testing\Fakes\LogChannelFake
+     */
+    public function driver($driver = null)
+    {
+        return new LogChannelFake($this, $driver);
+    }
+
+    /**
+     * Create a new, on-demand aggregate logger instance.
+     *
+     * @param  array  $channels
+     * @param  string|null  $channel
+     * @return \Illuminate\Support\Testing\Fakes\LogChannelFake
+     */
+    public function stack(array $channels, $channel = null)
+    {
+        return $this->driver('Stack:'.$this->createStackChannelName($channels, $channel));
+    }
+
+    /**
+     * Create a stack based channel name.
+     *
+     * @param  array  $channels
+     * @param  string|null  $channel
+     * @return string
+     */
+    protected function createStackChannelName($channels, $channel)
+    {
+        return collect($channels)->sort()->prepend($channel ?? 'default_testing_stack_channel')->implode('.');
+    }
+
+    /**
+     * Set the current channel being logged to.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function setCurrentChannel($name)
+    {
+        $this->currentChannel = $name;
+    }
+
+    /**
+     * Get the current channel being logged to.
+     *
+     * @return string
+     */
+    protected function getCurrentChannel()
+    {
+        return $this->currentChannel ?? $this->getDefaultDriver();
+    }
+
+    /**
+     * Get the default log driver name.
+     *
+     * @return string
+     */
+    public function getDefaultDriver()
+    {
+        return config('logging.default');
+    }
+
+     /**
+     * Set the default log driver name.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function setDefaultDriver($name)
+    {
+        config()->set('logging.default', $name);
+    }
+
+    public function listen()
+    {
+        //
+    }
+
+    public function extend()
+    {
+        //
+    }
+
+    public function getEventDispatcher()
+    {
+        //
+    }
+
+    public function setEventDispatcher()
+    {
+        //
+    }
+}

--- a/tests/Log/LogFakeTest.php
+++ b/tests/Log/LogFakeTest.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Support\Testing\Fakes\LogFake;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\Constraint\ExceptionMessage;
+
+class LogFakeTest extends TestCase
+{
+    protected $message = 'Oh Hai Mark!';
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Container::setInstance(new Container)->singleton('config', function () {
+            return new Config(['logging' => ['default' => ['stack']]]);
+        });
+    }
+
+    public function testAssertLogged()
+    {
+        $log = new LogFake;
+
+        try {
+            $log->assertLogged('info');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected log with level [info] was not logged.'));
+        }
+
+        $log->info($this->message);
+
+        $log->assertLogged('info');
+    }
+
+    public function testAssertLoggedWithNumericCallback()
+    {
+        $log = new LogFake;
+
+        try {
+            $log->assertLogged('info', 1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected log with level [info] was logged 0 times instead of 1 times.'));
+        }
+
+        $log->info($this->message);
+
+        $log->assertLogged('info', 1);
+    }
+
+    public function testAssertLoggedWithMessageCheckingCallback()
+    {
+        $log = new LogFake;
+
+        try {
+            $log->assertLogged('info', function ($message) {
+                return $message === $this->message;
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected log with level [info] was not logged.'));
+        }
+
+        $log->info($this->message);
+
+        $log->assertLogged('info', function ($message) {
+            return $message === $this->message;
+        });
+    }
+
+    public function testAssertLoggedTimes()
+    {
+        $log = new LogFake;
+
+        try {
+            $log->assertLoggedTimes('info', 1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected log with level [info] was logged 0 times instead of 1 times.'));
+        }
+
+        $log->info($this->message);
+
+        $log->assertLoggedTimes('info', 1);
+    }
+
+    public function testAssertNotLogged()
+    {
+        $log = new LogFake;
+
+        $log->assertNotLogged('info');
+
+        try {
+            $log->info($this->message);
+            $log->assertNotLogged('info');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected log with level [info] was logged.'));
+        }
+    }
+
+    public function testAssertNotLoggedWithCallback()
+    {
+        $log = new LogFake;
+
+        $log->assertNotLogged('info', function ($message) {
+            return $message === $this->message;
+        });
+
+        try {
+            $log->info($this->message);
+            $log->assertNotLogged('info', function ($message) {
+                return $message === $this->message;
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected log with level [info] was logged.'));
+        }
+    }
+
+    public function testAssertNothingLogged()
+    {
+        $log = new LogFake;
+
+        $log->assertNothingLogged();
+
+        try {
+            $log->info($this->message);
+            $log->assertNothingLogged();
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('Logs were created.'));
+        }
+    }
+
+    public function testLogged()
+    {
+        $log = new LogFake;
+
+        $this->assertTrue($log->logged('info')->isEmpty());
+
+        $log->info($this->message);
+        $this->assertFalse($log->logged('info')->isEmpty());
+    }
+
+    public function testLoggedWithCallback()
+    {
+        $log = new LogFake;
+
+        $this->assertTrue($log->logged('info', function ($message) {
+            return $this->message === $message;
+        })->isEmpty());
+
+        $log->info($this->message);
+
+        $this->assertFalse($log->logged('info', function ($message) {
+            return $this->message === $message;
+        })->isEmpty());
+    }
+
+    public function testHasLogged()
+    {
+        $log = new LogFake;
+
+        $this->assertFalse($log->hasLogged('info'));
+
+        $log->info($this->message);
+
+        $this->assertTrue($log->hasLogged('info'));
+    }
+
+    public function testHasNotLogged()
+    {
+        $log = new LogFake;
+
+        $this->assertTrue($log->hasNotLogged('info'));
+
+        $log->info($this->message);
+
+        $this->assertFalse($log->hasNotLogged('info'));
+    }
+
+    public function testCurrentChannelIsTakenIntoAccount()
+    {
+        $log = new LogFake;
+
+        $log->channel('slack')->info($this->message);
+
+        $log->assertNotLogged('info');
+        $log->channel('slack')->assertLogged('info');
+    }
+
+    public function testCurrentStackIsTakenIntoAccount()
+    {
+        $log = new LogFake;
+
+        $log->stack(['bugsnag', 'sentry'], 'dev_team')->info($this->message);
+
+        $log->assertNotLogged('info');
+        $log->stack(['bugsnag', 'sentry'], 'dev_team')->assertLogged('info');
+    }
+
+    public function testCanHaveStackChannelsInAnyOrder()
+    {
+        $log = new LogFake;
+
+        $log->stack(['bugsnag', 'sentry'], 'dev_team')->info($this->message);
+
+        $log->assertNotLogged('info');
+        $log->stack(['sentry', 'bugsnag'], 'dev_team')->assertLogged('info');
+    }
+
+    public function testDifferentiatesBetweenStacksWithANameAndThoseWithout()
+    {
+        $log = new LogFake;
+
+        $log->stack(['bugsnag', 'sentry'], 'dev_team')->info($this->message);
+        $log->stack(['bugsnag', 'sentry'])->alert($this->message);
+
+        $log->stack(['sentry', 'bugsnag'], 'dev_team')->assertNotLogged('alert');
+        $log->stack(['sentry', 'bugsnag'])->assertNotLogged('info');
+    }
+
+    public function testDifferentiatesBetweenStacksAndChannelsWithTheSameName()
+    {
+        $log = new LogFake;
+
+        $log->stack(['bugsnag', 'sentry'])->info($this->message);
+        $log->channel('bugsnag.sentry')->alert($this->message);
+
+        $log->stack(['bugsnag', 'sentry'])->assertNotLogged('alert');
+        $log->channel('bugsnag.sentry')->assertNotLogged('info');
+
+        $log->stack(['bugsnag', 'sentry'], 'name')->info($this->message);
+        $log->channel('name.bugsnag.sentry')->alert($this->message);
+
+        $log->stack(['name', 'bugsnag', 'sentry'])->assertNotLogged('alert');
+        $log->channel('name.bugsnag.sentry')->assertNotLogged('info');
+    }
+}


### PR DESCRIPTION
This PR introduces the ability to fake the logger, like you can with many other services during testing. There are a couple of instances where faking the logger can come in handy. I wanted to ensure that certain logging was happening in the Exception handler, depending on certain criteria in my tests. This fake helped me make that happen.

It takes into account the new logging system introduced in 5.6. I think the implementation (shown in the examples) is the way to go, but I'd say I'm a lightweight logger user, so feedback and criticisms to improve this is appreciated.

### Basic example

```php
Log::fake();

Log::alert('Donuts have arrived');

Log::assertLogged('alert', function ($message, $context) {
    return str_contains($message, 'Donuts');
});
```

### Channels and stacks

My thinking with channels and stacks is that keeping them separated and checking them the way they are called on the facade makes for a more consistent experience, instead of passing through a string or stack array as another argument to the assert methods.

#### Channel example

```php
Log::fake();

Log::channel('slack')->alert('Donuts have arrived');

Log::assertLogged('alert');  ❌ FAILS
Log::channel('slack')->assertLogged('alert');  ✅ PASSES
```

#### Stack example

```php
Log::fake();

Log::stack(['bugsnag', 'sentry'])->alert('Donuts have arrived');

Log::assertLogged('alert'); ❌ FAILS
Log::stack(['bugsnag', 'sentry'])->assertLogged('alert');  ✅ PASSES
Log::stack(['sentry', 'bugsnag'])->assertLogged('alert');  ✅ PASSES
```

I put this up on `laravel/ideas` a while ago and it seems there are a _few_ people out there that might benefit from this: https://github.com/laravel/ideas/issues/1084