### PR TITLE
Added the ability to disable escaping parameters (#25917)

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -903,15 +903,16 @@ if (! function_exists('trans')) {
      * @param  string  $key
      * @param  array   $replace
      * @param  string  $locale
+     * @param  bool    $escaping_params
      * @return \Illuminate\Contracts\Translation\Translator|string|array|null
      */
-    function trans($key = null, $replace = [], $locale = null)
+    function trans($key = null, $replace = [], $locale = null, $escaping_params = true)
     {
         if (is_null($key)) {
             return app('translator');
         }
 
-        return app('translator')->trans($key, $replace, $locale);
+        return app('translator')->trans($key, $replace, $locale, $escaping_params);
     }
 }
 
@@ -923,11 +924,12 @@ if (! function_exists('trans_choice')) {
      * @param  int|array|\Countable  $number
      * @param  array   $replace
      * @param  string  $locale
+     * @param  bool    $escaping_params
      * @return string
      */
-    function trans_choice($key, $number, array $replace = [], $locale = null)
+    function trans_choice($key, $number, array $replace = [], $locale = null, $escaping_params = true)
     {
-        return app('translator')->transChoice($key, $number, $replace, $locale);
+        return app('translator')->transChoice($key, $number, $replace, $locale, $escaping_params);
     }
 }
 
@@ -936,13 +938,14 @@ if (! function_exists('__')) {
      * Translate the given message.
      *
      * @param  string  $key
-     * @param  array  $replace
+     * @param  array   $replace
      * @param  string  $locale
+     * @param  bool    $escaping_params
      * @return string|array|null
      */
-    function __($key, $replace = [], $locale = null)
+    function __($key, $replace = [], $locale = null, $escaping_params = true)
     {
-        return app('translator')->getFromJson($key, $replace, $locale);
+        return app('translator')->getFromJson($key, $replace, $locale, $escaping_params);
     }
 }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -51,6 +51,13 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     protected $selector;
 
     /**
+     * A parameter that determines if parameters should be escaped.
+     *
+     * @var bool
+     */
+    protected $escaping_params = true;
+
+    /**
      * Create a new translator instance.
      *
      * @param  \Illuminate\Contracts\Translation\Loader  $loader
@@ -94,10 +101,13 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  string  $key
      * @param  array   $replace
      * @param  string  $locale
+     * @param  bool    $escaping_params
      * @return string|array|null
      */
-    public function trans($key, array $replace = [], $locale = null)
+    public function trans($key, array $replace = [], $locale = null, $escaping_params = false)
     {
+        $this->escaping_params = $escaping_params;
+
         return $this->get($key, $replace, $locale);
     }
 
@@ -142,13 +152,16 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * Get the translation for a given key from the JSON translation files.
      *
      * @param  string  $key
-     * @param  array  $replace
+     * @param  array   $replace
      * @param  string  $locale
+     * @param  bool    $escaping_params
      * @return string|array|null
      */
-    public function getFromJson($key, array $replace = [], $locale = null)
+    public function getFromJson($key, array $replace = [], $locale = null, $escaping_params = true)
     {
         $locale = $locale ?: $this->locale;
+
+        $this->escaping_params = $escaping_params;
 
         // For JSON translations, there is only one file per locale, so we will simply load
         // that file and then we will be ready to check the array for the key. These are
@@ -178,10 +191,13 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  int|array|\Countable  $number
      * @param  array   $replace
      * @param  string  $locale
+     * @param  bool    $escaping_params
      * @return string
      */
-    public function transChoice($key, $number, array $replace = [], $locale = null)
+    public function transChoice($key, $number, array $replace = [], $locale = null, $escaping_params = true)
     {
+        $this->escaping_params = $escaping_params;
+
         return $this->choice($key, $number, $replace, $locale);
     }
 
@@ -264,7 +280,9 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $replace = $this->sortReplacements($replace);
 
         foreach ($replace as $key => $value) {
-            $value = e($value);
+            if($this->escaping_params) {
+                $value = e($value);
+            }
 
             $line = str_replace(
                 [':'.$key, ':'.Str::upper($key), ':'.Str::ucfirst($key)],

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -280,7 +280,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $replace = $this->sortReplacements($replace);
 
         foreach ($replace as $key => $value) {
-            if($this->escaping_params) {
+            if ($this->escaping_params) {
                 $value = e($value);
             }
 


### PR DESCRIPTION
For use:
```php
__($key, $replace = [], $locale = null, $escaping_params = true)
trans($key, $replace = [], $locale = null, $escaping_params = true)
trans_choice($key, $number, $replace = [], $locale = null, $escaping_params = true)
```

```blade
{!! __('foo.bar', ['value' => '123&nbsp;456'], null, false) !!}
{!! trans('foo.bar', ['value' => '123&nbsp;456'], null, false) !!}
{!! trans_choice('foo.bar', 123456, ['value' => '123&nbsp;456'], null, false) !!}
```

Result (source):
```
from 123&nbsp;456 points
```

And with escaping string:
```blade
{!! __('foo.bar', ['value' => '123&nbsp;456']) !!}
```
Returned
```
from 123&amp;nbsp;456 points
```