### PR TITLE
[5.7] Use "optimize:clear" in "app:name" command

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -79,7 +79,7 @@ class AppNameCommand extends Command
 
         $this->composer->dumpAutoloads();
 
-        $this->call('clear-compiled');
+        $this->call('optimize:clear');
     }
 
     /**


### PR DESCRIPTION
We should use "optimize:clear" instead of "clear-compiled" only and this is why :

The namespace of the application can be used in views for example when injecting services:

```php
@inject('metrics', 'App\Services\MetricsService')
```

The namespace of the application can be used within the cache, for example : Data cached of table using polymorphic relationships.
(Of course the user must update the database data himself)

The cached routes.

Of course calling the "clear-compiled" is already done within the "optimize:clear" so there is no backward incompatibility issues.