### PR TITLE
[5.7] Add missing properties in class tests

### DIFF
--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -19,6 +19,7 @@ class AuthorizeMiddlewareTest extends TestCase
 {
     protected $container;
     protected $user;
+    protected $router;
 
     public function tearDown()
     {

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -14,6 +14,11 @@ use Illuminate\Console\Scheduling\CacheSchedulingMutex;
 
 class ConsoleEventSchedulerTest extends TestCase
 {
+    /**
+     * @var Schedule
+     */
+    private $schedule;
+
     public function setUp()
     {
         parent::setUp();

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 class DatabaseMigratorIntegrationTest extends TestCase
 {
     protected $db;
+    protected $migrator;
 
     /**
      * Bootstrap Eloquent.

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -20,6 +20,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 class SendingMailNotificationsTest extends TestCase
 {
     public $mailer;
+    public $markdown;
 
     public function tearDown()
     {

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -7,6 +7,11 @@ use Illuminate\Pagination\LengthAwarePaginator;
 
 class LengthAwarePaginatorTest extends TestCase
 {
+    /**
+     * @var LengthAwarePaginator
+     */
+    private $p;
+
     public function setUp()
     {
         $this->p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -13,6 +13,8 @@ use Illuminate\Support\Testing\Fakes\EventFake;
 
 class SupportFacadesEventTest extends TestCase
 {
+    private $events;
+
     protected function setUp()
     {
         parent::setUp();

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -11,6 +11,16 @@ use PHPUnit\Framework\Constraint\ExceptionMessage;
 
 class SupportTestingMailFakeTest extends TestCase
 {
+    /**
+     * @var MailFake
+     */
+    private $fake;
+
+    /**
+     * @var MailableStub
+     */
+    private $mailable;
+
     protected function setUp()
     {
         parent::setUp();

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -11,6 +11,21 @@ use Illuminate\Support\Testing\Fakes\NotificationFake;
 
 class SupportTestingNotificationFakeTest extends TestCase
 {
+    /**
+     * @var NotificationFake
+     */
+    private $fake;
+
+    /**
+     * @var NotificationStub
+     */
+    private $notification;
+
+    /**
+     * @var UserStub
+     */
+    private $user;
+
     protected function setUp()
     {
         parent::setUp();

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -11,6 +11,16 @@ use PHPUnit\Framework\Constraint\ExceptionMessage;
 
 class SupportTestingQueueFakeTest extends TestCase
 {
+    /**
+     * @var QueueFake
+     */
+    private $fake;
+
+    /**
+     * @var JobStub
+     */
+    private $job;
+
     protected function setUp()
     {
         parent::setUp();


### PR DESCRIPTION
Founded with PHPStan, some properties were missing tests classes 