### PR TITLE
[5.7] Adding view:cache to optimize

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -29,6 +29,7 @@ class OptimizeCommand extends Command
     {
         $this->call('config:cache');
         $this->call('route:cache');
+        $this->call('view:cache');
 
         $this->info('Files cached successfully!');
     }


### PR DESCRIPTION
Adding `view:cache` to `optimize` command, we do clear it at `optimize:clear` (https://github.com/laravel/framework/blob/5.7/src/Illuminate/Foundation/Console/OptimizeClearCommand.php#L30).