### PR TITLE
[5.7] Enable passing options to custom presets

### DIFF
--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -12,7 +12,9 @@ class PresetCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'preset { type : The preset type (none, bootstrap, vue, react) }';
+    protected $signature = 'preset 
+                            { type : The preset type (none, bootstrap, vue, react) }
+                            { --pass=* : Pass values to custom preset commands }';
 
     /**
      * The console command description.

--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -14,7 +14,7 @@ class PresetCommand extends Command
      */
     protected $signature = 'preset 
                             { type : The preset type (none, bootstrap, vue, react) }
-                            { --pass=* : Pass values to custom preset commands }';
+                            { --option=* : Pass options to custom preset commands }';
 
     /**
      * The console command description.


### PR DESCRIPTION
The ability to create our own presets is very convenient. But currently it is not possible to have customization in the user made preset commands by passing options to it. For example if i am making a preset for tachyon css and want the dev to choose a js framework from either vue or react along with the choice of creating auth pages or not, its not possible with `php artisan preset tachyon` alone.

This pr enables passing of multiple values to the custom presets through `--option=`, which can be used as ...
`php artisan preset tachyon --option=vue --option=cdn --option=version:4.0` or 
`php artisan preset tachyon --option=react --option=auth`
.
This opens many possibilities for creating presets which will simplify and make frontend dev much faster.

This is a non breaking change and works as intended without affecting the default presets.

---
The array of values passed can be accessed in the following way.

```
PresetCommand::macro('tachyon', function($command){
    $options =  $command->option('option'), 
    ....
    ....
});
```


---
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
