### PR TITLE
Allow to extend grammar without issues;

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -81,7 +81,7 @@ class Grammar extends BaseGrammar
             // To compile the query, we'll spin through each component of the query and
             // see if that component exists. If it does we'll just call the compiler
             // function for the component which is responsible for making the SQL.
-            if (! is_null($query->$component)) {
+            if (isset($query->$component) && ! is_null($query->$component)) {
                 $method = 'compile'.ucfirst($component);
 
                 $sql[$component] = $this->$method($query, $query->$component);


### PR DESCRIPTION
I would like to extend grammar.
For example for mysql i would like to use windows functions.

If i derive from MySqlGrammar and set own variables for dictionary defined in
```
    protected $selectComponents = [
```

I am getting RuntimeException. Now when isset is being used no such thing happens.