### PR TITLE
[5.7] Use ::class notation for tests

### DIFF
--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Auth;
 
-use Mockery;
+use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Auth\TokenGuard;
 use PHPUnit\Framework\TestCase;
@@ -12,12 +12,12 @@ class AuthTokenGuardTest extends TestCase
 {
     protected function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function testUserCanBeRetrievedByQueryStringVariable()
     {
-        $provider = Mockery::mock(UserProvider::class);
+        $provider = m::mock(UserProvider::class);
         $user = new AuthTokenGuardTestUser;
         $user->id = 1;
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn($user);
@@ -35,7 +35,7 @@ class AuthTokenGuardTest extends TestCase
 
     public function testUserCanBeRetrievedByAuthHeaders()
     {
-        $provider = Mockery::mock(UserProvider::class);
+        $provider = m::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn((object) ['id' => 1]);
         $request = Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo', 'PHP_AUTH_PW' => 'foo']);
 
@@ -48,7 +48,7 @@ class AuthTokenGuardTest extends TestCase
 
     public function testUserCanBeRetrievedByBearerToken()
     {
-        $provider = Mockery::mock(UserProvider::class);
+        $provider = m::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn((object) ['id' => 1]);
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer foo']);
 
@@ -61,7 +61,7 @@ class AuthTokenGuardTest extends TestCase
 
     public function testValidateCanDetermineIfCredentialsAreValid()
     {
-        $provider = Mockery::mock(UserProvider::class);
+        $provider = m::mock(UserProvider::class);
         $user = new AuthTokenGuardTestUser;
         $user->id = 1;
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn($user);
@@ -74,7 +74,7 @@ class AuthTokenGuardTest extends TestCase
 
     public function testValidateCanDetermineIfCredentialsAreInvalid()
     {
-        $provider = Mockery::mock(UserProvider::class);
+        $provider = m::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn(null);
         $request = Request::create('/', 'GET', ['api_token' => 'foo']);
 
@@ -85,7 +85,7 @@ class AuthTokenGuardTest extends TestCase
 
     public function testValidateIfApiTokenIsEmpty()
     {
-        $provider = Mockery::mock(UserProvider::class);
+        $provider = m::mock(UserProvider::class);
         $request = Request::create('/', 'GET', ['api_token' => '']);
 
         $guard = new TokenGuard($provider, $request);
@@ -95,7 +95,7 @@ class AuthTokenGuardTest extends TestCase
 
     public function testItAllowsToPassCustomRequestInSetterAndUseItForValidation()
     {
-        $provider = Mockery::mock(UserProvider::class);
+        $provider = m::mock(UserProvider::class);
         $user = new AuthTokenGuardTestUser;
         $user->id = 1;
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'custom'])->andReturn($user);
@@ -111,7 +111,7 @@ class AuthTokenGuardTest extends TestCase
 
     public function testUserCanBeRetrievedByBearerTokenWithCustomKey()
     {
-        $provider = Mockery::mock(UserProvider::class);
+        $provider = m::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn((object) ['id' => 1]);
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer foo']);
 
@@ -124,7 +124,7 @@ class AuthTokenGuardTest extends TestCase
 
     public function testUserCanBeRetrievedByQueryStringVariableWithCustomKey()
     {
-        $provider = Mockery::mock(UserProvider::class);
+        $provider = m::mock(UserProvider::class);
         $user = new AuthTokenGuardTestUser;
         $user->id = 1;
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn($user);
@@ -142,7 +142,7 @@ class AuthTokenGuardTest extends TestCase
 
     public function testUserCanBeRetrievedByAuthHeadersWithCustomField()
     {
-        $provider = Mockery::mock(UserProvider::class);
+        $provider = m::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn((object) ['id' => 1]);
         $request = Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo', 'PHP_AUTH_PW' => 'foo']);
 
@@ -155,7 +155,7 @@ class AuthTokenGuardTest extends TestCase
 
     public function testValidateCanDetermineIfCredentialsAreValidWithCustomKey()
     {
-        $provider = Mockery::mock(UserProvider::class);
+        $provider = m::mock(UserProvider::class);
         $user = new AuthTokenGuardTestUser;
         $user->id = 1;
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn($user);
@@ -168,7 +168,7 @@ class AuthTokenGuardTest extends TestCase
 
     public function testValidateCanDetermineIfCredentialsAreInvalidWithCustomKey()
     {
-        $provider = Mockery::mock(UserProvider::class);
+        $provider = m::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn(null);
         $request = Request::create('/', 'GET', ['custom_token_field' => 'foo']);
 
@@ -179,7 +179,7 @@ class AuthTokenGuardTest extends TestCase
 
     public function testValidateIfApiTokenIsEmptyWithCustomKey()
     {
-        $provider = Mockery::mock(UserProvider::class);
+        $provider = m::mock(UserProvider::class);
         $request = Request::create('/', 'GET', ['custom_token_field' => '']);
 
         $guard = new TokenGuard($provider, $request, 'custom_token_field', 'custom_token_field');

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Cache;
 
+use Closure;
 use stdClass;
 use Exception;
 use Mockery as m;
@@ -134,7 +135,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $cache = m::mock(stdClass::class);
 
-        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
+        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
@@ -144,7 +145,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertFalse($store->increment('foo'));
 
         $cache->value = serialize('bar');
-        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
+        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
@@ -154,7 +155,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertFalse($store->increment('foo'));
 
         $cache->value = serialize(2);
-        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
+        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
@@ -173,7 +174,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $cache = m::mock(stdClass::class);
 
-        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
+        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
@@ -183,7 +184,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertFalse($store->decrement('foo'));
 
         $cache->value = serialize('bar');
-        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
+        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
@@ -193,7 +194,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertFalse($store->decrement('foo'));
 
         $cache->value = serialize(3);
-        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
+        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -93,7 +93,7 @@ class CacheMemcachedConnectorTest extends TestCase
 
     protected function memcachedMockWithAddServer($returnedVersion = [])
     {
-        $memcached = m::mock('stdClass');
+        $memcached = m::mock(stdClass::class);
         $memcached->shouldReceive('addServer')->once()->with($this->getHost(), $this->getPort(), $this->getWeight());
         $memcached->shouldReceive('getServerList')->once()->andReturn([]);
 

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -15,7 +15,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder('stdClass')->setMethods(['get', 'getResultCode'])->getMock();
+        $memcache = $this->getMockBuilder(stdClass::class)->setMethods(['get', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('get')->with($this->equalTo('foo:bar'))->will($this->returnValue(null));
         $memcache->expects($this->once())->method('getResultCode')->will($this->returnValue(1));
         $store = new MemcachedStore($memcache, 'foo');
@@ -28,7 +28,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder('stdClass')->setMethods(['get', 'getResultCode'])->getMock();
+        $memcache = $this->getMockBuilder(stdClass::class)->setMethods(['get', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('get')->will($this->returnValue('bar'));
         $memcache->expects($this->once())->method('getResultCode')->will($this->returnValue(0));
         $store = new MemcachedStore($memcache);
@@ -41,7 +41,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder('stdClass')->setMethods(['getMulti', 'getResultCode'])->getMock();
+        $memcache = $this->getMockBuilder(stdClass::class)->setMethods(['getMulti', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('getMulti')->with(
             ['foo:foo', 'foo:bar', 'foo:baz']
         )->will($this->returnValue([

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Container;
 
+use Closure;
 use stdClass;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
@@ -503,7 +504,7 @@ class ContainerTest extends TestCase
             return func_get_args();
         }, ['bar' => 'taylor']);
 
-        $this->assertInstanceOf('Closure', $result);
+        $this->assertInstanceOf(Closure::class, $result);
         $result = $result();
 
         $this->assertInstanceOf(stdClass::class, $result[0]);
@@ -933,7 +934,7 @@ class ContainerTest extends TestCase
     public function testResolvingCallbacksShouldBeFiredWhenCalledWithAliases()
     {
         $container = new Container;
-        $container->alias('stdClass', 'std');
+        $container->alias(stdClass::class, 'std');
         $container->resolving('std', function ($object) {
             return $object->name = 'taylor';
         });

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use PDO;
 use Mockery as m;
 use ReflectionProperty;
 use PHPUnit\Framework\TestCase;
@@ -42,10 +43,10 @@ class DatabaseConnectionFactoryTest extends TestCase
 
     public function testConnectionCanBeCreated()
     {
-        $this->assertInstanceOf('PDO', $this->db->connection()->getPdo());
-        $this->assertInstanceOf('PDO', $this->db->connection()->getReadPdo());
-        $this->assertInstanceOf('PDO', $this->db->connection('read_write')->getPdo());
-        $this->assertInstanceOf('PDO', $this->db->connection('read_write')->getReadPdo());
+        $this->assertInstanceOf(PDO::class, $this->db->connection()->getPdo());
+        $this->assertInstanceOf(PDO::class, $this->db->connection()->getReadPdo());
+        $this->assertInstanceOf(PDO::class, $this->db->connection('read_write')->getPdo());
+        $this->assertInstanceOf(PDO::class, $this->db->connection('read_write')->getReadPdo());
     }
 
     public function testSingleConnectionNotCreatedUntilNeeded()
@@ -56,8 +57,8 @@ class DatabaseConnectionFactoryTest extends TestCase
         $readPdo = new ReflectionProperty(get_class($connection), 'readPdo');
         $readPdo->setAccessible(true);
 
-        $this->assertNotInstanceOf('PDO', $pdo->getValue($connection));
-        $this->assertNotInstanceOf('PDO', $readPdo->getValue($connection));
+        $this->assertNotInstanceOf(PDO::class, $pdo->getValue($connection));
+        $this->assertNotInstanceOf(PDO::class, $readPdo->getValue($connection));
     }
 
     public function testReadWriteConnectionsNotCreatedUntilNeeded()
@@ -68,8 +69,8 @@ class DatabaseConnectionFactoryTest extends TestCase
         $readPdo = new ReflectionProperty(get_class($connection), 'readPdo');
         $readPdo->setAccessible(true);
 
-        $this->assertNotInstanceOf('PDO', $pdo->getValue($connection));
-        $this->assertNotInstanceOf('PDO', $readPdo->getValue($connection));
+        $this->assertNotInstanceOf(PDO::class, $pdo->getValue($connection));
+        $this->assertNotInstanceOf(PDO::class, $readPdo->getValue($connection));
     }
 
     /**

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use PDO;
+use DateTime;
 use Exception;
 use Mockery as m;
 use PDOException;
@@ -357,7 +358,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testPrepareBindings()
     {
-        $date = m::mock('DateTime');
+        $date = m::mock(DateTime::class);
         $date->shouldReceive('format')->once()->with('foo')->andReturn('bar');
         $bindings = ['test' => $date];
         $conn = $this->getMockConnection();

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -31,7 +31,7 @@ class DatabaseConnectorTest extends TestCase
     public function testMySqlConnectCallsCreateConnectionWithProperArguments($dsn, $config)
     {
         $connector = $this->getMockBuilder(MySqlConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('PDO');
+        $connection = m::mock(PDO::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $connection->shouldReceive('prepare')->once()->with('set names \'utf8\' collate \'utf8_unicode_ci\'')->andReturn($connection);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use Closure;
 use stdClass;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -522,24 +523,24 @@ class DatabaseEloquentBuilderTest extends TestCase
         $eagers = $builder->getEagerLoads();
 
         $this->assertEquals(['orders', 'orders.lines'], array_keys($eagers));
-        $this->assertInstanceOf('Closure', $eagers['orders']);
-        $this->assertInstanceOf('Closure', $eagers['orders.lines']);
+        $this->assertInstanceOf(Closure::class, $eagers['orders']);
+        $this->assertInstanceOf(Closure::class, $eagers['orders.lines']);
 
         $builder = $this->getBuilder();
         $builder->with('orders', 'orders.lines');
         $eagers = $builder->getEagerLoads();
 
         $this->assertEquals(['orders', 'orders.lines'], array_keys($eagers));
-        $this->assertInstanceOf('Closure', $eagers['orders']);
-        $this->assertInstanceOf('Closure', $eagers['orders.lines']);
+        $this->assertInstanceOf(Closure::class, $eagers['orders']);
+        $this->assertInstanceOf(Closure::class, $eagers['orders.lines']);
 
         $builder = $this->getBuilder();
         $builder->with(['orders.lines']);
         $eagers = $builder->getEagerLoads();
 
         $this->assertEquals(['orders', 'orders.lines'], array_keys($eagers));
-        $this->assertInstanceOf('Closure', $eagers['orders']);
-        $this->assertInstanceOf('Closure', $eagers['orders.lines']);
+        $this->assertInstanceOf(Closure::class, $eagers['orders']);
+        $this->assertInstanceOf(Closure::class, $eagers['orders.lines']);
 
         $builder = $this->getBuilder();
         $builder->with(['orders' => function () {
@@ -555,7 +556,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         }]);
         $eagers = $builder->getEagerLoads();
 
-        $this->assertInstanceOf('Closure', $eagers['orders']);
+        $this->assertInstanceOf(Closure::class, $eagers['orders']);
         $this->assertNull($eagers['orders']());
         $this->assertEquals('foo', $eagers['orders.lines']());
     }

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
+use Foo\Bar\EloquentModelNamespacedStub;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -283,7 +284,7 @@ class DatabaseEloquentMorphTest extends TestCase
         require_once __DIR__.'/stubs/EloquentModelNamespacedStub.php';
 
         Relation::morphMap([
-            $alias => 'Foo\Bar\EloquentModelNamespacedStub',
+            $alias => EloquentModelNamespacedStub::class,
         ]);
 
         $builder = m::mock(Builder::class);
@@ -291,7 +292,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
-        $parent = m::mock('Foo\Bar\EloquentModelNamespacedStub');
+        $parent = m::mock(EloquentModelNamespacedStub::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
         $parent->shouldReceive('getMorphClass')->andReturn($alias);
         $builder->shouldReceive('where')->once()->with('table.morph_type', $alias);

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use Exception;
 use Mockery as m;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
@@ -199,11 +200,11 @@ class DatabaseEloquentRelationTest extends TestCase
                 $this->assertTrue($related::isIgnoringTouch());
                 $this->assertTrue($relatedChild::isIgnoringTouch());
 
-                throw new \Exception();
+                throw new Exception();
             });
 
             $this->fail('Exception was not thrown');
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             // Does nothing.
         }
 

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use Closure;
 use stdClass;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -108,7 +109,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $connectionMock = m::mock(Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('getSchemaBuilder')->once()->andReturn($schema);
-        $schema->shouldReceive('create')->once()->with('migrations', m::type('Closure'));
+        $schema->shouldReceive('create')->once()->with('migrations', m::type(Closure::class));
 
         $repo->createRepository();
     }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
-use Mockery;
+use Mockery as m;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Console\OutputStyle;
@@ -44,7 +44,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
             new Filesystem
         );
 
-        $output = Mockery::mock(OutputStyle::class);
+        $output = m::mock(OutputStyle::class);
         $output->shouldReceive('writeln');
 
         $this->migrator->setOutput($output);

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
-use Mockery;
+use Mockery as m;
 use Illuminate\Database\Seeder;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Console\OutputStyle;
@@ -19,19 +19,19 @@ class SeedCommandTest extends TestCase
         $input = new ArrayInput(['--force' => true, '--database' => 'sqlite']);
         $output = new NullOutput;
 
-        $seeder = Mockery::mock(Seeder::class);
+        $seeder = m::mock(Seeder::class);
         $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
         $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
         $seeder->shouldReceive('__invoke')->once();
 
-        $resolver = Mockery::mock(ConnectionResolverInterface::class);
+        $resolver = m::mock(ConnectionResolverInterface::class);
         $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
 
-        $container = Mockery::mock(Container::class);
+        $container = m::mock(Container::class);
         $container->shouldReceive('call');
         $container->shouldReceive('environment')->once()->andReturn('testing');
         $container->shouldReceive('make')->with('DatabaseSeeder')->andReturn($seeder);
-        $container->shouldReceive('make')->with(OutputStyle::class, Mockery::any())->andReturn(
+        $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
             new OutputStyle($input, $output)
         );
 
@@ -47,6 +47,6 @@ class SeedCommandTest extends TestCase
 
     protected function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -6,6 +6,10 @@ use Exception;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Events\CallQueuedListener;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 class EventsDispatcherTest extends TestCase
@@ -43,8 +47,8 @@ class EventsDispatcherTest extends TestCase
 
     public function testContainerResolutionOfEventHandlers()
     {
-        $d = new Dispatcher($container = m::mock('Illuminate\Container\Container'));
-        $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock('stdClass'));
+        $d = new Dispatcher($container = m::mock(Container::class));
+        $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock(stdClass::class));
         $handler->shouldReceive('onFooEvent')->once()->with('foo', 'bar');
         $d->listen('foo', 'FooHandler@onFooEvent');
         $d->fire('foo', ['foo', 'bar']);
@@ -52,8 +56,8 @@ class EventsDispatcherTest extends TestCase
 
     public function testContainerResolutionOfEventHandlersWithDefaultMethods()
     {
-        $d = new Dispatcher($container = m::mock('Illuminate\Container\Container'));
-        $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock('stdClass'));
+        $d = new Dispatcher($container = m::mock(Container::class));
+        $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock(stdClass::class));
         $handler->shouldReceive('handle')->once()->with('foo', 'bar');
         $d->listen('foo', 'FooHandler');
         $d->fire('foo', ['foo', 'bar']);
@@ -188,17 +192,17 @@ class EventsDispatcherTest extends TestCase
     public function testQueuedEventHandlersAreQueued()
     {
         $d = new Dispatcher;
-        $queue = m::mock('Illuminate\Contracts\Queue\Queue');
+        $queue = m::mock(Queue::class);
 
         $queue->shouldReceive('connection')->once()->with(null)->andReturnSelf();
 
-        $queue->shouldReceive('pushOn')->once()->with(null, m::type('Illuminate\Events\CallQueuedListener'));
+        $queue->shouldReceive('pushOn')->once()->with(null, m::type(CallQueuedListener::class));
 
         $d->setQueueResolver(function () use ($queue) {
             return $queue;
         });
 
-        $d->listen('some.event', 'Illuminate\Tests\Events\TestDispatcherQueuedHandler@someMethod');
+        $d->listen('some.event', TestDispatcherQueuedHandler::class.'@someMethod');
         $d->fire('some.event', ['foo', 'bar']);
     }
 
@@ -206,7 +210,7 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('Illuminate\Tests\Events\ExampleEvent', function () {
+        $d->listen(ExampleEvent::class, function () {
             $_SERVER['__event.test'] = 'baz';
         });
         $d->fire(new ExampleEvent);
@@ -218,7 +222,7 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('Illuminate\Tests\Events\SomeEventInterface', function () {
+        $d->listen(SomeEventInterface::class, function () {
             $_SERVER['__event.test'] = 'bar';
         });
         $d->fire(new AnotherEvent);
@@ -230,10 +234,10 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('Illuminate\Tests\Events\AnotherEvent', function () {
+        $d->listen(AnotherEvent::class, function () {
             $_SERVER['__event.test1'] = 'fooo';
         });
-        $d->listen('Illuminate\Tests\Events\SomeEventInterface', function () {
+        $d->listen(SomeEventInterface::class, function () {
             $_SERVER['__event.test2'] = 'baar';
         });
         $d->fire(new AnotherEvent);
@@ -265,14 +269,14 @@ class EventsDispatcherTest extends TestCase
     }
 }
 
-class TestDispatcherQueuedHandler implements \Illuminate\Contracts\Queue\ShouldQueue
+class TestDispatcherQueuedHandler implements ShouldQueue
 {
     public function handle()
     {
     }
 }
 
-class TestDispatcherQueuedHandlerCustomQueue implements \Illuminate\Contracts\Queue\ShouldQueue
+class TestDispatcherQueuedHandlerCustomQueue implements ShouldQueue
 {
     public function handle()
     {

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Filesystem;
 
+use SplFileInfo;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use League\Flysystem\Adapter\Ftp;
@@ -139,8 +140,8 @@ class FilesystemTest extends TestCase
         mkdir($this->tempDir.'/foo/bar');
         $files = new Filesystem;
         $results = $files->files($this->tempDir.'/foo');
-        $this->assertInstanceOf('SplFileInfo', $results[0]);
-        $this->assertInstanceOf('SplFileInfo', $results[1]);
+        $this->assertInstanceOf(SplFileInfo::class, $results[0]);
+        $this->assertInstanceOf(SplFileInfo::class, $results[1]);
         unset($files);
     }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use stdClass;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Events\LocaleUpdated;
+use Illuminate\Foundation\Bootstrap\RegisterFacades;
 
 class FoundationApplicationTest extends TestCase
 {
@@ -18,11 +20,11 @@ class FoundationApplicationTest extends TestCase
     public function testSetLocaleSetsLocaleAndFiresLocaleChangedEvent()
     {
         $app = new Application;
-        $app['config'] = $config = m::mock('stdClass');
+        $app['config'] = $config = m::mock(stdClass::class);
         $config->shouldReceive('set')->once()->with('app.locale', 'foo');
-        $app['translator'] = $trans = m::mock('stdClass');
+        $app['translator'] = $trans = m::mock(stdClass::class);
         $trans->shouldReceive('setLocale')->once()->with('foo');
-        $app['events'] = $events = m::mock('stdClass');
+        $app['events'] = $events = m::mock(stdClass::class);
         $events->shouldReceive('dispatch')->once()->with(m::type(LocaleUpdated::class));
 
         $app->setLocale('foo');
@@ -99,8 +101,8 @@ class FoundationApplicationTest extends TestCase
         $this->assertTrue($app->bound('foo'));
         $one = $app->make('foo');
         $two = $app->make('foo');
-        $this->assertInstanceOf('stdClass', $one);
-        $this->assertInstanceOf('stdClass', $two);
+        $this->assertInstanceOf(stdClass::class, $one);
+        $this->assertInstanceOf(stdClass::class, $two);
         $this->assertSame($one, $two);
     }
 
@@ -119,7 +121,7 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $app->setDeferredServices(['foo' => ApplicationDeferredServiceProviderCountStub::class]);
         $obj = $app->make('foo');
-        $this->assertInstanceOf('stdClass', $obj);
+        $this->assertInstanceOf(stdClass::class, $obj);
         $this->assertSame($obj, $app->make('foo'));
         $this->assertEquals(1, ApplicationDeferredServiceProviderCountStub::$count);
     }
@@ -194,7 +196,6 @@ class FoundationApplicationTest extends TestCase
         };
         $app->afterLoadingEnvironment($closure);
         $this->assertArrayHasKey(0, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables'));
-        // $this->assertSame($closure, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables')[0]);
     }
 
     public function testBeforeBootstrappingAddsClosure()
@@ -202,9 +203,8 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $closure = function () {
         };
-        $app->beforeBootstrapping('Illuminate\Foundation\Bootstrap\RegisterFacades', $closure);
+        $app->beforeBootstrapping(RegisterFacades::class, $closure);
         $this->assertArrayHasKey(0, $app['events']->getListeners('bootstrapping: Illuminate\Foundation\Bootstrap\RegisterFacades'));
-        // $this->assertSame($closure, $app['events']->getListeners('bootstrapping: Illuminate\Foundation\Bootstrap\RegisterFacades')[0]);
     }
 
     public function testAfterBootstrappingAddsClosure()
@@ -212,9 +212,8 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $closure = function () {
         };
-        $app->afterBootstrapping('Illuminate\Foundation\Bootstrap\RegisterFacades', $closure);
+        $app->afterBootstrapping(RegisterFacades::class, $closure);
         $this->assertArrayHasKey(0, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\RegisterFacades'));
-        // $this->assertSame($closure, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\RegisterFacades')[0]);
     }
 }
 

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -4,6 +4,8 @@ namespace Illuminate\Tests\Foundation;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Composer;
+use Illuminate\Filesystem\Filesystem;
 
 class FoundationComposerTest extends TestCase
 {
@@ -16,9 +18,9 @@ class FoundationComposerTest extends TestCase
     {
         $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
 
-        $composer = $this->getMockBuilder('Illuminate\Support\Composer')->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__])->getMock();
+        $composer = $this->getMockBuilder(Composer::class)->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock(Filesystem::class), __DIR__])->getMock();
         $files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(true);
-        $process = m::mock('stdClass');
+        $process = m::mock(stdClass::class);
         $composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
         $process->shouldReceive('setCommandLine')->once()->with($escape.PHP_BINARY.$escape.' composer.phar dump-autoload');
         $process->shouldReceive('run')->once();
@@ -28,9 +30,9 @@ class FoundationComposerTest extends TestCase
 
     public function testDumpAutoloadRunsTheCorrectCommandWhenComposerIsntPresent()
     {
-        $composer = $this->getMockBuilder('Illuminate\Support\Composer')->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__])->getMock();
+        $composer = $this->getMockBuilder(Composer::class)->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock(Filesystem::class), __DIR__])->getMock();
         $files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(false);
-        $process = m::mock('stdClass');
+        $process = m::mock(stdClass::class);
         $composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
         $process->shouldReceive('setCommandLine')->once()->with('composer dump-autoload');
         $process->shouldReceive('run')->once();

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Foundation;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\EnvironmentDetector;
 
 class FoundationEnvironmentDetectorTest extends TestCase
 {
@@ -14,7 +15,7 @@ class FoundationEnvironmentDetectorTest extends TestCase
 
     public function testClosureCanBeUsedForCustomEnvironmentDetection()
     {
-        $env = new \Illuminate\Foundation\EnvironmentDetector;
+        $env = new EnvironmentDetector;
 
         $result = $env->detect(function () {
             return 'foobar';
@@ -24,7 +25,7 @@ class FoundationEnvironmentDetectorTest extends TestCase
 
     public function testConsoleEnvironmentDetection()
     {
-        $env = new \Illuminate\Foundation\EnvironmentDetector;
+        $env = new EnvironmentDetector;
 
         $result = $env->detect(function () {
             return 'foobar';

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -2,16 +2,22 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use stdClass;
 use Exception;
 use Mockery as m;
+use RuntimeException;
 use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Routing\Redirector;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Routing\ResponseFactory;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Foundation\Exceptions\Handler;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 
 class FoundationExceptionsHandlerTest extends TestCase
 {
@@ -27,7 +33,7 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $this->config = m::mock(Config::class);
 
-        $this->request = m::mock('stdClass');
+        $this->request = m::mock(stdClass::class);
 
         $this->container = Container::setInstance(new Container);
 
@@ -35,10 +41,10 @@ class FoundationExceptionsHandlerTest extends TestCase
             return $this->config;
         });
 
-        $this->container->singleton('Illuminate\Contracts\Routing\ResponseFactory', function () {
-            return new \Illuminate\Routing\ResponseFactory(
-                m::mock(\Illuminate\Contracts\View\Factory::class),
-                m::mock(\Illuminate\Routing\Redirector::class)
+        $this->container->singleton(ResponseFactoryContract::class, function () {
+            return new ResponseFactory(
+                m::mock(Factory::class),
+                m::mock(Redirector::class)
             );
         });
 
@@ -56,7 +62,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->container->instance(LoggerInterface::class, $logger);
         $logger->shouldReceive('error')->withArgs(['Exception message', m::hasKey('exception')]);
 
-        $this->handler->report(new \RuntimeException('Exception message'));
+        $this->handler->report(new RuntimeException('Exception message'));
     }
 
     public function testReturnsJsonWithStackTraceWhenAjaxRequestAndDebugTrue()

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use stdClass;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
@@ -16,10 +17,10 @@ class FoundationHelpersTest extends TestCase
     public function testCache()
     {
         $app = new Application;
-        $app['cache'] = $cache = m::mock('stdClass');
+        $app['cache'] = $cache = m::mock(stdClass::class);
 
         // 1. cache()
-        $this->assertInstanceOf('stdClass', cache());
+        $this->assertInstanceOf(stdClass::class, cache());
 
         // 2. cache(['foo' => 'bar'], 1);
         $cache->shouldReceive('put')->once()->with('foo', 'bar', 1);

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -4,6 +4,11 @@ namespace Illuminate\Tests\Foundation;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Foundation\ProviderRepository;
+use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
 class FoundationProviderRepositoryTest extends TestCase
 {
@@ -14,12 +19,12 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testServicesAreRegisteredWhenManifestIsNotRecompiled()
     {
-        $app = m::mock('Illuminate\Foundation\Application');
+        $app = m::mock(Application::class);
 
-        $repo = m::mock('Illuminate\Foundation\ProviderRepository[createProvider,loadManifest,shouldRecompile]', [$app, m::mock('Illuminate\Filesystem\Filesystem'), [__DIR__.'/services.php']]);
+        $repo = m::mock(ProviderRepository::class.'[createProvider,loadManifest,shouldRecompile]', [$app, m::mock(Filesystem::class), [__DIR__.'/services.php']]);
         $repo->shouldReceive('loadManifest')->once()->andReturn(['eager' => ['foo'], 'deferred' => ['deferred'], 'providers' => ['providers'], 'when' => []]);
         $repo->shouldReceive('shouldRecompile')->once()->andReturn(false);
-        $provider = m::mock('Illuminate\Support\ServiceProvider');
+        $provider = m::mock(ServiceProvider::class);
 
         $app->shouldReceive('register')->once()->with('foo');
         $app->shouldReceive('runningInConsole')->andReturn(false);
@@ -30,21 +35,21 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testManifestIsProperlyRecompiled()
     {
-        $app = m::mock('Illuminate\Foundation\Application');
+        $app = m::mock(Application::class);
 
-        $repo = m::mock('Illuminate\Foundation\ProviderRepository[createProvider,loadManifest,writeManifest,shouldRecompile]', [$app, m::mock('Illuminate\Filesystem\Filesystem'), [__DIR__.'/services.php']]);
+        $repo = m::mock(ProviderRepository::class.'[createProvider,loadManifest,writeManifest,shouldRecompile]', [$app, m::mock(Filesystem::class), [__DIR__.'/services.php']]);
 
         $repo->shouldReceive('loadManifest')->once()->andReturn(['eager' => [], 'deferred' => ['deferred']]);
         $repo->shouldReceive('shouldRecompile')->once()->andReturn(true);
 
         // foo mock is just a deferred provider
-        $repo->shouldReceive('createProvider')->once()->with('foo')->andReturn($fooMock = m::mock('stdClass'));
+        $repo->shouldReceive('createProvider')->once()->with('foo')->andReturn($fooMock = m::mock(stdClass::class));
         $fooMock->shouldReceive('isDeferred')->once()->andReturn(true);
         $fooMock->shouldReceive('provides')->once()->andReturn(['foo.provides1', 'foo.provides2']);
         $fooMock->shouldReceive('when')->once()->andReturn([]);
 
         // bar mock is added to eagers since it's not reserved
-        $repo->shouldReceive('createProvider')->once()->with('bar')->andReturn($barMock = m::mock('Illuminate\Support\ServiceProvider'));
+        $repo->shouldReceive('createProvider')->once()->with('bar')->andReturn($barMock = m::mock(ServiceProvider::class));
         $barMock->shouldReceive('isDeferred')->once()->andReturn(false);
         $repo->shouldReceive('writeManifest')->once()->andReturnUsing(function ($manifest) {
             return $manifest;
@@ -59,7 +64,7 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testShouldRecompileReturnsCorrectValue()
     {
-        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock('Illuminate\Contracts\Foundation\Application'), new \Illuminate\Filesystem\Filesystem, __DIR__.'/services.php');
+        $repo = new ProviderRepository(m::mock(ApplicationContract::class), new Filesystem, __DIR__.'/services.php');
         $this->assertTrue($repo->shouldRecompile(null, []));
         $this->assertTrue($repo->shouldRecompile(['providers' => ['foo']], ['foo', 'bar']));
         $this->assertFalse($repo->shouldRecompile(['providers' => ['foo']], ['foo']));
@@ -67,7 +72,7 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testLoadManifestReturnsParsedJSON()
     {
-        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock('Illuminate\Contracts\Foundation\Application'), $files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__.'/services.php');
+        $repo = new ProviderRepository(m::mock(ApplicationContract::class), $files = m::mock(Filesystem::class), __DIR__.'/services.php');
         $files->shouldReceive('exists')->once()->with(__DIR__.'/services.php')->andReturn(true);
         $files->shouldReceive('getRequire')->once()->with(__DIR__.'/services.php')->andReturn($array = ['users' => ['dayle' => true], 'when' => []]);
 
@@ -76,7 +81,7 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testWriteManifestStoresToProperLocation()
     {
-        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock('Illuminate\Contracts\Foundation\Application'), $files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__.'/services.php');
+        $repo = new ProviderRepository(m::mock(ApplicationContract::class), $files = m::mock(Filesystem::class), __DIR__.'/services.php');
         $files->shouldReceive('put')->once()->with(__DIR__.'/services.php', '<?php return '.var_export(['foo'], true).';');
 
         $result = $repo->writeManifest(['foo']);

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use Mockery as m;
 use JsonSerializable;
 use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
@@ -362,7 +363,7 @@ class FoundationTestResponseTest extends TestCase
     private function makeMockResponse($content)
     {
         $baseResponse = tap(new Response, function ($response) use ($content) {
-            $response->setContent(\Mockery::mock(View::class, $content));
+            $response->setContent(m::mock(View::class, $content));
         });
 
         return TestResponse::fromBaseResponse($baseResponse);

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -3,12 +3,15 @@
 namespace Illuminate\Tests\Hashing;
 
 use PHPUnit\Framework\TestCase;
+use Illuminate\Hashing\ArgonHasher;
+use Illuminate\Hashing\BcryptHasher;
+use Illuminate\Hashing\Argon2IdHasher;
 
 class HasherTest extends TestCase
 {
     public function testBasicBcryptHashing()
     {
-        $hasher = new \Illuminate\Hashing\BcryptHasher;
+        $hasher = new BcryptHasher;
         $value = $hasher->make('password');
         $this->assertNotSame('password', $value);
         $this->assertTrue($hasher->check('password', $value));
@@ -23,7 +26,7 @@ class HasherTest extends TestCase
             $this->markTestSkipped('PHP not compiled with Argon2i hashing support.');
         }
 
-        $hasher = new \Illuminate\Hashing\ArgonHasher;
+        $hasher = new ArgonHasher;
         $value = $hasher->make('password');
         $this->assertNotSame('password', $value);
         $this->assertTrue($hasher->check('password', $value));
@@ -38,7 +41,7 @@ class HasherTest extends TestCase
             $this->markTestSkipped('PHP not compiled with Argon2id hashing support.');
         }
 
-        $hasher = new \Illuminate\Hashing\Argon2IdHasher;
+        $hasher = new Argon2IdHasher;
         $value = $hasher->make('password');
         $this->assertNotSame('password', $value);
         $this->assertTrue($hasher->check('password', $value));
@@ -56,9 +59,9 @@ class HasherTest extends TestCase
             $this->markTestSkipped('PHP not compiled with Argon2i hashing support.');
         }
 
-        $argonHasher = new \Illuminate\Hashing\ArgonHasher(['verify' => true]);
+        $argonHasher = new ArgonHasher(['verify' => true]);
         $argonHashed = $argonHasher->make('password');
-        (new \Illuminate\Hashing\BcryptHasher(['verify' => true]))->check('password', $argonHashed);
+        (new BcryptHasher(['verify' => true]))->check('password', $argonHashed);
     }
 
     /**
@@ -66,9 +69,9 @@ class HasherTest extends TestCase
      */
     public function testBasicArgon2iVerification()
     {
-        $bcryptHasher = new \Illuminate\Hashing\BcryptHasher(['verify' => true]);
+        $bcryptHasher = new BcryptHasher(['verify' => true]);
         $bcryptHashed = $bcryptHasher->make('password');
-        (new \Illuminate\Hashing\ArgonHasher(['verify' => true]))->check('password', $bcryptHashed);
+        (new ArgonHasher(['verify' => true]))->check('password', $bcryptHashed);
     }
 
     /**
@@ -76,8 +79,8 @@ class HasherTest extends TestCase
      */
     public function testBasicArgon2idVerification()
     {
-        $bcryptHasher = new \Illuminate\Hashing\BcryptHasher(['verify' => true]);
+        $bcryptHasher = new BcryptHasher(['verify' => true]);
         $bcryptHashed = $bcryptHasher->make('password');
-        (new \Illuminate\Hashing\Argon2IdHasher(['verify' => true]))->check('password', $bcryptHashed);
+        (new Argon2IdHasher(['verify' => true]))->check('password', $bcryptHashed);
     }
 }

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -4,8 +4,13 @@ namespace Illuminate\Tests\Http;
 
 use Mockery as m;
 use Illuminate\Http\Request;
+use Illuminate\Session\Store;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\ViewErrorBag;
 use Illuminate\Http\RedirectResponse;
+use Symfony\Component\HttpFoundation\Cookie;
+use Illuminate\Contracts\Support\MessageProvider;
 
 class HttpRedirectResponseTest extends TestCase
 {
@@ -30,7 +35,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(Store::class));
         $session->shouldReceive('flash')->twice();
         $response->with(['name', 'age']);
     }
@@ -39,7 +44,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $this->assertCount(0, $response->headers->getCookies());
-        $this->assertEquals($response, $response->withCookie(new \Symfony\Component\HttpFoundation\Cookie('foo', 'bar')));
+        $this->assertEquals($response, $response->withCookie(new Cookie('foo', 'bar')));
         $cookies = $response->headers->getCookies();
         $this->assertCount(1, $cookies);
         $this->assertEquals('foo', $cookies[0]->getName());
@@ -50,7 +55,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(Store::class));
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor', 'age' => 26]);
         $response->withInput();
     }
@@ -59,7 +64,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(Store::class));
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $response->onlyInput('name');
     }
@@ -68,7 +73,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(Store::class));
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $response->exceptInput('age');
     }
@@ -77,11 +82,11 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
-        $session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new \Illuminate\Support\ViewErrorBag);
-        $session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
-        $provider = m::mock('Illuminate\Contracts\Support\MessageProvider');
-        $provider->shouldReceive('getMessageBag')->once()->andReturn(new \Illuminate\Support\MessageBag);
+        $response->setSession($session = m::mock(Store::class));
+        $session->shouldReceive('get')->with('errors', m::type(ViewErrorBag::class))->andReturn(new ViewErrorBag);
+        $session->shouldReceive('flash')->once()->with('errors', m::type(ViewErrorBag::class));
+        $provider = m::mock(MessageProvider::class);
+        $provider->shouldReceive('getMessageBag')->once()->andReturn(new MessageBag);
         $response->withErrors($provider);
     }
 
@@ -92,7 +97,7 @@ class HttpRedirectResponseTest extends TestCase
         $this->assertNull($response->getSession());
 
         $request = Request::create('/', 'GET');
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(Store::class);
         $response->setRequest($request);
         $response->setSession($session);
         $this->assertSame($request, $response->getRequest());
@@ -103,9 +108,9 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
-        $session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new \Illuminate\Support\ViewErrorBag);
-        $session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
+        $response->setSession($session = m::mock(Store::class));
+        $session->shouldReceive('get')->with('errors', m::type(ViewErrorBag::class))->andReturn(new ViewErrorBag);
+        $session->shouldReceive('flash')->once()->with('errors', m::type(ViewErrorBag::class));
         $provider = ['foo' => 'bar'];
         $response->withErrors($provider);
     }
@@ -114,7 +119,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(Store::class));
         $session->shouldReceive('flash')->once()->with('foo', 'bar');
         $response->withFoo('bar');
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -5,8 +5,11 @@ namespace Illuminate\Tests\Http;
 use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
+use Illuminate\Session\Store;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Http\UploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 
 class HttpRequestTest extends TestCase
 {
@@ -350,8 +353,8 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('Taylor', $request['name']);
         $this->assertEquals('Bob', $request->input('foo', 'Bob'));
 
-        $request = Request::create('/', 'GET', [], [], ['file' => new \Symfony\Component\HttpFoundation\File\UploadedFile(__FILE__, 'foo.php')]);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\File\UploadedFile', $request['file']);
+        $request = Request::create('/', 'GET', [], [], ['file' => new SymfonyUploadedFile(__FILE__, 'foo.php')]);
+        $this->assertInstanceOf(SymfonyUploadedFile::class, $request['file']);
     }
 
     public function testArrayAccess()
@@ -484,7 +487,7 @@ class HttpRequestTest extends TestCase
             ],
         ];
         $request = Request::create('/', 'GET', [], [], $files);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\File\UploadedFile', $request->file('foo'));
+        $this->assertInstanceOf(SymfonyUploadedFile::class, $request->file('foo'));
     }
 
     public function testHasFileMethod()
@@ -597,14 +600,14 @@ class HttpRequestTest extends TestCase
 
     public function testAllInputReturnsInputAndFiles()
     {
-        $file = $this->getMockBuilder('Illuminate\Http\UploadedFile')->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
+        $file = $this->getMockBuilder(UploadedFile::class)->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
         $request = Request::create('/?boom=breeze', 'GET', ['foo' => 'bar'], [], ['baz' => $file]);
         $this->assertEquals(['foo' => 'bar', 'baz' => $file, 'boom' => 'breeze'], $request->all());
     }
 
     public function testAllInputReturnsNestedInputAndFiles()
     {
-        $file = $this->getMockBuilder('Illuminate\Http\UploadedFile')->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
+        $file = $this->getMockBuilder(UploadedFile::class)->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
         $request = Request::create('/?boom=breeze', 'GET', ['foo' => ['bar' => 'baz']], [], ['foo' => ['photo' => $file]]);
         $this->assertEquals(['foo' => ['bar' => 'baz', 'photo' => $file], 'boom' => 'breeze'], $request->all());
     }
@@ -666,7 +669,7 @@ class HttpRequestTest extends TestCase
     public function testOldMethodCallsSession()
     {
         $request = Request::create('/', 'GET');
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(Store::class);
         $session->shouldReceive('getOldInput')->once()->with('foo', 'bar')->andReturn('boom');
         $request->setLaravelSession($session);
         $this->assertEquals('boom', $request->old('foo', 'bar'));
@@ -675,7 +678,7 @@ class HttpRequestTest extends TestCase
     public function testFlushMethodCallsSession()
     {
         $request = Request::create('/', 'GET');
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(Store::class);
         $session->shouldReceive('flashInput')->once();
         $request->setLaravelSession($session);
         $request->flush();
@@ -956,7 +959,7 @@ class HttpRequestTest extends TestCase
 
     public function testHttpRequestFlashCallsSessionFlashInputWithInputData()
     {
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(Store::class);
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor', 'email' => 'foo']);
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
         $request->setLaravelSession($session);
@@ -965,7 +968,7 @@ class HttpRequestTest extends TestCase
 
     public function testHttpRequestFlashOnlyCallsFlashWithProperParameters()
     {
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(Store::class);
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
         $request->setLaravelSession($session);
@@ -974,7 +977,7 @@ class HttpRequestTest extends TestCase
 
     public function testHttpRequestFlashExceptCallsFlashWithProperParameters()
     {
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(Store::class);
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
         $request->setLaravelSession($session);

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -2,10 +2,15 @@
 
 namespace Illuminate\Tests\Integration\Auth;
 
+use Illuminate\Auth\Events\Login;
 use Orchestra\Testbench\TestCase;
+use Illuminate\Auth\Events\Failed;
+use Illuminate\Auth\Events\Logout;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Auth\Events\Attempting;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Auth\EloquentUserProvider;
+use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Tests\Integration\Auth\Fixtures\AuthenticationTestUser;
 
 /**
@@ -123,13 +128,13 @@ class AuthenticationTest extends TestCase
         );
         $this->assertFalse($this->app['auth']->check());
         $this->assertNull($this->app['auth']->user());
-        Event::assertDispatched(\Illuminate\Auth\Events\Attempting::class, function ($event) {
+        Event::assertDispatched(Attempting::class, function ($event) {
             $this->assertEquals('web', $event->guard);
             $this->assertEquals(['email' => 'wrong', 'password' => 'password'], $event->credentials);
 
             return true;
         });
-        Event::assertDispatched(\Illuminate\Auth\Events\Failed::class, function ($event) {
+        Event::assertDispatched(Failed::class, function ($event) {
             $this->assertEquals('web', $event->guard);
             $this->assertEquals(['email' => 'wrong', 'password' => 'password'], $event->credentials);
             $this->assertNull($event->user);
@@ -151,19 +156,19 @@ class AuthenticationTest extends TestCase
         $this->assertInstanceOf(AuthenticationTestUser::class, $this->app['auth']->user());
         $this->assertTrue($this->app['auth']->check());
 
-        Event::assertDispatched(\Illuminate\Auth\Events\Attempting::class, function ($event) {
+        Event::assertDispatched(Attempting::class, function ($event) {
             $this->assertEquals('web', $event->guard);
             $this->assertEquals(['email' => 'email', 'password' => 'password'], $event->credentials);
 
             return true;
         });
-        Event::assertDispatched(\Illuminate\Auth\Events\Login::class, function ($event) {
+        Event::assertDispatched(Login::class, function ($event) {
             $this->assertEquals('web', $event->guard);
             $this->assertEquals(1, $event->user->id);
 
             return true;
         });
-        Event::assertDispatched(\Illuminate\Auth\Events\Authenticated::class, function ($event) {
+        Event::assertDispatched(Authenticated::class, function ($event) {
             $this->assertEquals('web', $event->guard);
             $this->assertEquals(1, $event->user->id);
 
@@ -194,7 +199,7 @@ class AuthenticationTest extends TestCase
 
         $this->app['auth']->logout();
         $this->assertNull($this->app['auth']->user());
-        Event::assertDispatched(\Illuminate\Auth\Events\Logout::class, function ($event) {
+        Event::assertDispatched(Logout::class, function ($event) {
             $this->assertEquals('web', $event->guard);
             $this->assertEquals(1, $event->user->id);
 

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
  * @group integration
@@ -161,7 +162,7 @@ class CustomPivotCastTestProject extends Model
     }
 }
 
-class CustomPivotCastTestCollaborator extends \Illuminate\Database\Eloquent\Relations\Pivot
+class CustomPivotCastTestCollaborator extends Pivot
 {
     protected $casts = [
         'permissions' => 'json',

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -7,6 +7,7 @@ use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factory;
+use Illuminate\Database\Eloquent\Collection;
 
 /**
  * @group integration
@@ -175,8 +176,8 @@ class EloquentFactoryBuilderTest extends TestCase
 
         $instances = factory(FactoryBuildableUser::class, 3)->make();
 
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $users);
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $instances);
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertInstanceOf(Collection::class, $instances);
         $this->assertCount(3, $users);
         $this->assertCount(3, $instances);
         $this->assertCount(3, FactoryBuildableUser::find($users->pluck('id')->toArray()));

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 
@@ -33,7 +34,7 @@ class EloquentModelTest extends DatabaseTestCase
         ]);
 
         $user->fill([
-            'nullable_date' => $now = \Illuminate\Support\Carbon::now(),
+            'nullable_date' => $now = Carbon::now(),
         ]);
         $this->assertTrue($user->isDirty('nullable_date'));
 

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Mail;
 
-use Mockery;
+use Mockery as m;
 use Illuminate\Mail\Mailable;
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
@@ -22,7 +22,7 @@ class SendingMailWithLocaleTest extends TestCase
     {
         parent::tearDown();
 
-        Mockery::close();
+        m::close();
     }
 
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -2,7 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Notifications;
 
-use Mockery;
+use Mockery as m;
+use Illuminate\Mail\Message;
 use Illuminate\Mail\Markdown;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Contracts\Mail\Mailer;
@@ -26,7 +27,7 @@ class SendingMailNotificationsTest extends TestCase
     {
         parent::tearDown();
 
-        Mockery::close();
+        m::close();
     }
 
     protected function getEnvironmentSetUp($app)
@@ -41,8 +42,8 @@ class SendingMailNotificationsTest extends TestCase
             'prefix' => '',
         ]);
 
-        $this->mailer = Mockery::mock(Mailer::class);
-        $this->markdown = Mockery::mock(Markdown::class);
+        $this->mailer = m::mock(Mailer::class);
+        $this->markdown = m::mock(Markdown::class);
 
         $app->extend(Markdown::class, function () {
             return $this->markdown;
@@ -81,8 +82,8 @@ class SendingMailNotificationsTest extends TestCase
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),
-            Mockery::on(function ($closure) {
-                $message = Mockery::mock(\Illuminate\Mail\Message::class);
+            m::on(function ($closure) {
+                $message = m::mock(Message::class);
 
                 $message->shouldReceive('to')->once()->with(['taylor@laravel.com']);
 
@@ -125,8 +126,8 @@ class SendingMailNotificationsTest extends TestCase
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),
-            Mockery::on(function ($closure) {
-                $message = Mockery::mock(\Illuminate\Mail\Message::class);
+            m::on(function ($closure) {
+                $message = m::mock(Message::class);
 
                 $message->shouldReceive('to')->once()->with(['taylor@laravel.com' => 'Taylor Otwell', 'foo_taylor@laravel.com']);
 
@@ -168,8 +169,8 @@ class SendingMailNotificationsTest extends TestCase
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),
-            Mockery::on(function ($closure) {
-                $message = Mockery::mock(\Illuminate\Mail\Message::class);
+            m::on(function ($closure) {
+                $message = m::mock(Message::class);
 
                 $message->shouldReceive('to')->once()->with(['taylor@laravel.com']);
 
@@ -201,8 +202,8 @@ class SendingMailNotificationsTest extends TestCase
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),
-            Mockery::on(function ($closure) {
-                $message = Mockery::mock(\Illuminate\Mail\Message::class);
+            m::on(function ($closure) {
+                $message = m::mock(Message::class);
 
                 $message->shouldReceive('to')->once()->with(['foo_taylor@laravel.com', 'bar_taylor@laravel.com']);
 
@@ -302,7 +303,7 @@ class TestMailNotificationWithMailable extends Notification
 
     public function toMail($notifiable)
     {
-        $mailable = Mockery::mock(Mailable::class);
+        $mailable = m::mock(Mailable::class);
 
         $mailable->shouldReceive('send')->once();
 

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -4,7 +4,9 @@ namespace Illuminate\Tests\Integration\Queue;
 
 use Schema;
 use Orchestra\Testbench\TestCase;
+use Illuminate\Queue\SerializesModels;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
 
 /**
  * @group integration
@@ -135,7 +137,7 @@ class ModelSerializationTest extends TestCase
         ]);
 
         $serialized = serialize(new ModelSerializationTestClass(
-            new \Illuminate\Database\Eloquent\Collection([$user, $user2])
+            new Collection([$user, $user2])
         ));
 
         unserialize($serialized);
@@ -191,7 +193,7 @@ class ModelSerializationTest extends TestCase
     public function it_serializes_an_empty_collection()
     {
         $serialized = serialize(new ModelSerializationTestClass(
-            new \Illuminate\Database\Eloquent\Collection([])
+            new Collection([])
         ));
 
         unserialize($serialized);
@@ -245,7 +247,7 @@ class Product extends Model
 
 class ModelSerializationTestClass
 {
-    use \Illuminate\Queue\SerializesModels;
+    use SerializesModels;
 
     public $user;
 
@@ -257,7 +259,7 @@ class ModelSerializationTestClass
 
 class ModelRelationSerializationTestClass
 {
-    use \Illuminate\Queue\SerializesModels;
+    use SerializesModels;
 
     public $order;
 

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -4,7 +4,11 @@ namespace Illuminate\Tests\Log;
 
 use Mockery as m;
 use Illuminate\Log\Logger;
+use Monolog\Logger as Monolog;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
 class LogLoggerTest extends TestCase
 {
@@ -15,7 +19,7 @@ class LogLoggerTest extends TestCase
 
     public function testMethodsPassErrorAdditionsToMonolog()
     {
-        $writer = new Logger($monolog = m::mock('Monolog\Logger'));
+        $writer = new Logger($monolog = m::mock(Monolog::class));
         $monolog->shouldReceive('error')->once()->with('foo', []);
 
         $writer->error('foo');
@@ -23,10 +27,10 @@ class LogLoggerTest extends TestCase
 
     public function testLoggerFiresEventsDispatcher()
     {
-        $writer = new Logger($monolog = m::mock('Monolog\Logger'), $events = new \Illuminate\Events\Dispatcher);
+        $writer = new Logger($monolog = m::mock(Monolog::class), $events = new Dispatcher);
         $monolog->shouldReceive('error')->once()->with('foo', []);
 
-        $events->listen(\Illuminate\Log\Events\MessageLogged::class, function ($event) {
+        $events->listen(MessageLogged::class, function ($event) {
             $_SERVER['__log.level'] = $event->level;
             $_SERVER['__log.message'] = $event->message;
             $_SERVER['__log.context'] = $event->context;
@@ -50,19 +54,19 @@ class LogLoggerTest extends TestCase
      */
     public function testListenShortcutFailsWithNoDispatcher()
     {
-        $writer = new Logger($monolog = m::mock('Monolog\Logger'));
+        $writer = new Logger($monolog = m::mock(Monolog::class));
         $writer->listen(function () {
         });
     }
 
     public function testListenShortcut()
     {
-        $writer = new Logger($monolog = m::mock('Monolog\Logger'), $events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $writer = new Logger($monolog = m::mock(Monolog::class), $events = m::mock(DispatcherContract::class));
 
         $callback = function () {
             return 'success';
         };
-        $events->shouldReceive('listen')->with(\Illuminate\Log\Events\MessageLogged::class, $callback)->once();
+        $events->shouldReceive('listen')->with(MessageLogged::class, $callback)->once();
 
         $writer->listen($callback);
     }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -2,10 +2,19 @@
 
 namespace Illuminate\Tests\Mail;
 
+use stdClass;
 use Mockery as m;
+use Swift_Mailer;
+use Swift_Message;
+use Swift_Transport;
 use Illuminate\Mail\Mailer;
+use Swift_Mime_SimpleMessage;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\HtmlString;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Mail\Events\MessageSending;
+use Illuminate\Contracts\Events\Dispatcher;
 
 class MailMailerTest extends TestCase
 {
@@ -17,10 +26,10 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperViewContent()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
-        $message = m::mock('Swift_Mime_SimpleMessage');
+        $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $message = m::mock(Swift_Mime_SimpleMessage::class);
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
-        $view = m::mock('stdClass');
+        $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
@@ -37,10 +46,10 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperViewContentUsingHtmlStrings()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
-        $message = m::mock('Swift_Mime_SimpleMessage');
+        $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $message = m::mock(Swift_Mime_SimpleMessage::class);
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
-        $view = m::mock('stdClass');
+        $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->never();
         $view->shouldReceive('render')->never();
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
@@ -58,10 +67,10 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperViewContentUsingHtmlMethod()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
-        $message = m::mock('Swift_Mime_SimpleMessage');
+        $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $message = m::mock(Swift_Mime_SimpleMessage::class);
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
-        $view = m::mock('stdClass');
+        $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->never();
         $view->shouldReceive('render')->never();
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
@@ -78,10 +87,10 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperPlainViewContent()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
-        $message = m::mock('Swift_Mime_SimpleMessage');
+        $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $message = m::mock(Swift_Mime_SimpleMessage::class);
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
-        $view = m::mock('stdClass');
+        $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', 'message' => $message])->andReturn($view);
         $view->shouldReceive('render')->twice()->andReturn('rendered.view');
@@ -100,10 +109,10 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperPlainViewContentWhenExplicit()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
-        $message = m::mock('Swift_Mime_SimpleMessage');
+        $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $message = m::mock(Swift_Mime_SimpleMessage::class);
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
-        $view = m::mock('stdClass');
+        $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', 'message' => $message])->andReturn($view);
         $view->shouldReceive('render')->twice()->andReturn('rendered.view');
@@ -123,12 +132,12 @@ class MailMailerTest extends TestCase
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMailer();
-        $view = m::mock('stdClass');
+        $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $this->setSwiftMailer($mailer);
         $mailer->alwaysFrom('taylorotwell@gmail.com', 'Taylor Otwell');
-        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type('Swift_Message'), [])->andReturnUsing(function ($message) {
+        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), [])->andReturnUsing(function ($message) {
             $this->assertEquals(['taylorotwell@gmail.com' => 'Taylor Otwell'], $message->getFrom());
         });
         $mailer->send('foo', ['data'], function ($m) {
@@ -139,9 +148,9 @@ class MailMailerTest extends TestCase
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMailer();
-        $mailer->getSwiftMailer()->shouldReceive('getTransport')->andReturn($transport = m::mock('Swift_Transport'));
+        $mailer->getSwiftMailer()->shouldReceive('getTransport')->andReturn($transport = m::mock(Swift_Transport::class));
         $transport->shouldReceive('stop');
-        $view = m::mock('stdClass');
+        $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $swift = new FailingSwiftMailerStub;
@@ -156,15 +165,15 @@ class MailMailerTest extends TestCase
     public function testEventsAreDispatched()
     {
         unset($_SERVER['__mailer.test']);
-        $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('until')->once()->with(m::type('Illuminate\Mail\Events\MessageSending'));
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Mail\Events\MessageSent'));
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('until')->once()->with(m::type(MessageSending::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(MessageSent::class));
         $mailer = $this->getMailer($events);
-        $view = m::mock('stdClass');
+        $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $this->setSwiftMailer($mailer);
-        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type('Swift_Message'), []);
+        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), []);
         $mailer->send('foo', ['data'], function ($m) {
         });
     }
@@ -184,14 +193,14 @@ class MailMailerTest extends TestCase
 
     protected function getMailer($events = null)
     {
-        return new Mailer(m::mock('Illuminate\Contracts\View\Factory'), m::mock('Swift_Mailer'), $events);
+        return new Mailer(m::mock(Factory::class), m::mock(Swift_Mailer::class), $events);
     }
 
     public function setSwiftMailer($mailer)
     {
-        $swift = m::mock('Swift_Mailer');
-        $swift->shouldReceive('createMessage')->andReturn(new \Swift_Message);
-        $swift->shouldReceive('getTransport')->andReturn($transport = m::mock('Swift_Transport'));
+        $swift = m::mock(Swift_Mailer::class);
+        $swift->shouldReceive('createMessage')->andReturn(new Swift_Message);
+        $swift->shouldReceive('getTransport')->andReturn($transport = m::mock(Swift_Transport::class));
         $transport->shouldReceive('stop');
         $mailer->setSwiftMailer($swift);
 
@@ -200,7 +209,7 @@ class MailMailerTest extends TestCase
 
     protected function getMocks()
     {
-        return [m::mock('Illuminate\Contracts\View\Factory'), m::mock('Swift_Mailer')];
+        return [m::mock(Factory::class), m::mock(Swift_Mailer::class)];
     }
 }
 
@@ -213,7 +222,7 @@ class FailingSwiftMailerStub
 
     public function getTransport()
     {
-        $transport = m::mock('Swift_Transport');
+        $transport = m::mock(Swift_Transport::class);
         $transport->shouldReceive('stop');
 
         return $transport;

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -2,19 +2,22 @@
 
 namespace Illuminate\Tests\Mail;
 
+use Mockery as m;
+use Illuminate\View\Factory;
+use Illuminate\Mail\Markdown;
 use PHPUnit\Framework\TestCase;
 
 class MailMarkdownTest extends TestCase
 {
     public function tearDown()
     {
-        \Mockery::close();
+        m::close();
     }
 
     public function testRenderFunctionReturnsHtml()
     {
-        $viewFactory = \Mockery::mock('Illuminate\View\Factory');
-        $markdown = new \Illuminate\Mail\Markdown($viewFactory);
+        $viewFactory = m::mock(Factory::class);
+        $markdown = new Markdown($viewFactory);
         $viewFactory->shouldReceive('flushFinderCache')->once();
         $viewFactory->shouldReceive('replaceNamespace')->once()->with('mail', $markdown->htmlComponentPaths())->andReturnSelf();
         $viewFactory->shouldReceive('make')->with('view', [])->andReturnSelf();
@@ -28,8 +31,8 @@ class MailMarkdownTest extends TestCase
 
     public function testRenderFunctionReturnsHtmlWithCustomTheme()
     {
-        $viewFactory = \Mockery::mock('Illuminate\View\Factory');
-        $markdown = new \Illuminate\Mail\Markdown($viewFactory);
+        $viewFactory = m::mock(Factory::class);
+        $markdown = new Markdown($viewFactory);
         $markdown->theme('yaz');
         $viewFactory->shouldReceive('flushFinderCache')->once();
         $viewFactory->shouldReceive('replaceNamespace')->once()->with('mail', $markdown->htmlComponentPaths())->andReturnSelf();
@@ -44,8 +47,8 @@ class MailMarkdownTest extends TestCase
 
     public function testRenderTextReturnsText()
     {
-        $viewFactory = \Mockery::mock('Illuminate\View\Factory');
-        $markdown = new \Illuminate\Mail\Markdown($viewFactory);
+        $viewFactory = m::mock(Factory::class);
+        $markdown = new Markdown($viewFactory);
         $viewFactory->shouldReceive('flushFinderCache')->once();
         $viewFactory->shouldReceive('replaceNamespace')->once()->with('mail', $markdown->markdownComponentPaths())->andReturnSelf();
         $viewFactory->shouldReceive('make')->with('view', [])->andReturnSelf();
@@ -58,8 +61,8 @@ class MailMarkdownTest extends TestCase
 
     public function testParseReturnsParsedMarkdown()
     {
-        $viewFactory = \Mockery::mock('Illuminate\View\Factory');
-        $markdown = new \Illuminate\Mail\Markdown($viewFactory);
+        $viewFactory = m::mock(Factory::class);
+        $markdown = new Markdown($viewFactory);
 
         $result = $markdown->parse('# Something');
 

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Mail;
 
+use stdClass;
 use Mockery as m;
 use Illuminate\Mail\Message;
 use PHPUnit\Framework\TestCase;
@@ -98,9 +99,9 @@ class MailMessageTest extends TestCase
 
     public function testBasicAttachment()
     {
-        $swift = m::mock('stdClass');
-        $message = $this->getMockBuilder('Illuminate\Mail\Message')->setMethods(['createAttachmentFromPath'])->setConstructorArgs([$swift])->getMock();
-        $attachment = m::mock('stdClass');
+        $swift = m::mock(stdClass::class);
+        $message = $this->getMockBuilder(Message::class)->setMethods(['createAttachmentFromPath'])->setConstructorArgs([$swift])->getMock();
+        $attachment = m::mock(stdClass::class);
         $message->expects($this->once())->method('createAttachmentFromPath')->with($this->equalTo('foo.jpg'))->will($this->returnValue($attachment));
         $swift->shouldReceive('attach')->once()->with($attachment);
         $attachment->shouldReceive('setContentType')->once()->with('image/jpeg');
@@ -110,9 +111,9 @@ class MailMessageTest extends TestCase
 
     public function testDataAttachment()
     {
-        $swift = m::mock('stdClass');
-        $message = $this->getMockBuilder('Illuminate\Mail\Message')->setMethods(['createAttachmentFromData'])->setConstructorArgs([$swift])->getMock();
-        $attachment = m::mock('stdClass');
+        $swift = m::mock(stdClass::class);
+        $message = $this->getMockBuilder(Message::class)->setMethods(['createAttachmentFromData'])->setConstructorArgs([$swift])->getMock();
+        $attachment = m::mock(stdClass::class);
         $message->expects($this->once())->method('createAttachmentFromData')->with($this->equalTo('foo'), $this->equalTo('name'))->will($this->returnValue($attachment));
         $swift->shouldReceive('attach')->once()->with($attachment);
         $attachment->shouldReceive('setContentType')->once()->with('image/jpeg');

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -3,11 +3,14 @@
 namespace Illuminate\Tests\Mail;
 
 use Mockery as m;
+use Swift_Mailer;
+use Illuminate\Mail\Mailer;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Contracts\View\Factory;
 use Illuminate\Foundation\Application;
 use Illuminate\Mail\SendQueuedMailable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -24,7 +27,7 @@ class MailableQueuedTest extends TestCase
     public function testQueuedMailableSent()
     {
         $queueFake = new QueueFake(new Application);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')
+        $mailer = $this->getMockBuilder(Mailer::class)
             ->setConstructorArgs($this->getMocks())
             ->setMethods(['createMessage', 'to'])
             ->getMock();
@@ -38,7 +41,7 @@ class MailableQueuedTest extends TestCase
     public function testQueuedMailableWithAttachmentSent()
     {
         $queueFake = new QueueFake(new Application);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')
+        $mailer = $this->getMockBuilder(Mailer::class)
             ->setConstructorArgs($this->getMocks())
             ->setMethods(['createMessage'])
             ->getMock();
@@ -67,7 +70,7 @@ class MailableQueuedTest extends TestCase
             return $filesystemFactory;
         });
         $queueFake = new QueueFake($app);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')
+        $mailer = $this->getMockBuilder(Mailer::class)
             ->setConstructorArgs($this->getMocks())
             ->setMethods(['createMessage'])
             ->getMock();
@@ -88,7 +91,7 @@ class MailableQueuedTest extends TestCase
 
     protected function getMocks()
     {
-        return [m::mock('Illuminate\Contracts\View\Factory'), m::mock('Swift_Mailer')];
+        return [m::mock(Factory::class), m::mock(Swift_Mailer::class)];
     }
 }
 

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -2,27 +2,30 @@
 
 namespace Illuminate\Tests\Notifications;
 
-use Mockery;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Notifications\Notification;
 use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Channels\BroadcastChannel;
+use Illuminate\Notifications\Messages\BroadcastMessage;
+use Illuminate\Notifications\Events\BroadcastNotificationCreated;
 
 class NotificationBroadcastChannelTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function testDatabaseChannelCreatesDatabaseRecordWithProperData()
     {
         $notification = new NotificationBroadcastChannelTestNotification;
         $notification->id = 1;
-        $notifiable = Mockery::mock();
+        $notifiable = m::mock();
 
-        $events = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('dispatch')->once()->with(Mockery::type('Illuminate\Notifications\Events\BroadcastNotificationCreated'));
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('dispatch')->once()->with(m::type(BroadcastNotificationCreated::class));
         $channel = new BroadcastChannel($events);
         $channel->send($notifiable, $notification);
     }
@@ -31,9 +34,9 @@ class NotificationBroadcastChannelTest extends TestCase
     {
         $notification = new CustomChannelsTestNotification;
         $notification->id = 1;
-        $notifiable = Mockery::mock();
+        $notifiable = m::mock();
 
-        $event = new \Illuminate\Notifications\Events\BroadcastNotificationCreated(
+        $event = new BroadcastNotificationCreated(
             $notifiable, $notification, $notification->toArray($notifiable)
         );
 
@@ -46,9 +49,9 @@ class NotificationBroadcastChannelTest extends TestCase
     {
         $notification = new CustomEventNameTestNotification;
         $notification->id = 1;
-        $notifiable = Mockery::mock();
+        $notifiable = m::mock();
 
-        $event = new \Illuminate\Notifications\Events\BroadcastNotificationCreated(
+        $event = new BroadcastNotificationCreated(
             $notifiable, $notification, $notification->toArray($notifiable)
         );
 
@@ -61,9 +64,9 @@ class NotificationBroadcastChannelTest extends TestCase
     {
         $notification = new CustomEventNameTestNotification;
         $notification->id = 1;
-        $notifiable = Mockery::mock();
+        $notifiable = m::mock();
 
-        $event = new \Illuminate\Notifications\Events\BroadcastNotificationCreated(
+        $event = new BroadcastNotificationCreated(
             $notifiable, $notification, $notification->toArray($notifiable)
         );
 
@@ -76,10 +79,10 @@ class NotificationBroadcastChannelTest extends TestCase
     {
         $notification = new TestNotificationBroadCastedNow;
         $notification->id = 1;
-        $notifiable = Mockery::mock();
+        $notifiable = m::mock();
 
-        $events = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('dispatch')->once()->with(Mockery::on(function ($event) {
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) {
             return $event->connection == 'sync';
         }));
         $channel = new BroadcastChannel($events);
@@ -130,6 +133,6 @@ class TestNotificationBroadCastedNow extends Notification
 
     public function toBroadcast()
     {
-        return (new \Illuminate\Notifications\Messages\BroadcastMessage([]))->onConnection('sync');
+        return (new BroadcastMessage([]))->onConnection('sync');
     }
 }

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Notifications;
 
-use Mockery;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Channels\DatabaseChannel;
@@ -12,14 +12,14 @@ class NotificationDatabaseChannelTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function testDatabaseChannelCreatesDatabaseRecordWithProperData()
     {
         $notification = new NotificationDatabaseChannelTestNotification;
         $notification->id = 1;
-        $notifiable = Mockery::mock();
+        $notifiable = m::mock();
 
         $notifiable->shouldReceive('routeNotificationFor->create')->with([
             'id' => 1,
@@ -36,7 +36,7 @@ class NotificationDatabaseChannelTest extends TestCase
     {
         $notification = new NotificationDatabaseChannelTestNotification;
         $notification->id = 1;
-        $notifiable = Mockery::mock();
+        $notifiable = m::mock();
 
         $notifiable->shouldReceive('routeNotificationFor->create')->with([
             'id' => 1,

--- a/tests/Notifications/NotificationNexmoChannelTest.php
+++ b/tests/Notifications/NotificationNexmoChannelTest.php
@@ -2,16 +2,18 @@
 
 namespace Illuminate\Tests\Notifications;
 
-use Mockery;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\NexmoMessage;
+use Illuminate\Notifications\Channels\NexmoSmsChannel;
 
 class NotificationNexmoChannelTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function testSmsIsSentViaNexmo()
@@ -19,8 +21,8 @@ class NotificationNexmoChannelTest extends TestCase
         $notification = new NotificationNexmoChannelTestNotification;
         $notifiable = new NotificationNexmoChannelTestNotifiable;
 
-        $channel = new \Illuminate\Notifications\Channels\NexmoSmsChannel(
-            $nexmo = Mockery::mock(\Nexmo\Client::class), '4444444444'
+        $channel = new NexmoSmsChannel(
+            $nexmo = m::mock(\Nexmo\Client::class), '4444444444'
         );
 
         $nexmo->shouldReceive('message->send')->with([
@@ -38,8 +40,8 @@ class NotificationNexmoChannelTest extends TestCase
         $notification = new NotificationNexmoChannelTestCustomFromNotification;
         $notifiable = new NotificationNexmoChannelTestNotifiable;
 
-        $channel = new \Illuminate\Notifications\Channels\NexmoSmsChannel(
-            $nexmo = Mockery::mock(\Nexmo\Client::class), '4444444444'
+        $channel = new NexmoSmsChannel(
+            $nexmo = m::mock(\Nexmo\Client::class), '4444444444'
         );
 
         $nexmo->shouldReceive('message->send')->with([
@@ -55,7 +57,7 @@ class NotificationNexmoChannelTest extends TestCase
 
 class NotificationNexmoChannelTestNotifiable
 {
-    use \Illuminate\Notifications\Notifiable;
+    use Notifiable;
     public $phone_number = '5555555555';
 }
 

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -2,23 +2,24 @@
 
 namespace Illuminate\Tests\Notifications;
 
-use Mockery;
 use stdClass;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
+use Illuminate\Notifications\RoutesNotifications;
 use Illuminate\Contracts\Notifications\Dispatcher;
 
 class NotificationRoutesNotificationsTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function testNotificationCanBeDispatched()
     {
         $container = new Container;
-        $factory = Mockery::mock(Dispatcher::class);
+        $factory = m::mock(Dispatcher::class);
         $container->instance(Dispatcher::class, $factory);
         $notifiable = new RoutesNotificationsTestInstance;
         $instance = new stdClass;
@@ -31,7 +32,7 @@ class NotificationRoutesNotificationsTest extends TestCase
     public function testNotificationCanBeSentNow()
     {
         $container = new Container;
-        $factory = Mockery::mock(Dispatcher::class);
+        $factory = m::mock(Dispatcher::class);
         $container->instance(Dispatcher::class, $factory);
         $notifiable = new RoutesNotificationsTestInstance;
         $instance = new stdClass;
@@ -52,7 +53,7 @@ class NotificationRoutesNotificationsTest extends TestCase
 
 class RoutesNotificationsTestInstance
 {
-    use \Illuminate\Notifications\RoutesNotifications;
+    use RoutesNotifications;
 
     protected $email = 'taylor@laravel.com';
     protected $phone_number = '5555555555';

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -2,21 +2,22 @@
 
 namespace Illuminate\Tests\Notifications;
 
-use Mockery;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\SendQueuedNotifications;
 
 class NotificationSendQueuedNotificationTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function testNotificationsCanBeSent()
     {
         $job = new SendQueuedNotifications('notifiables', 'notification');
-        $manager = Mockery::mock('Illuminate\Notifications\ChannelManager');
+        $manager = m::mock(ChannelManager::class);
         $manager->shouldReceive('sendNow')->once()->with('notifiables', 'notification', null);
         $job->handle($manager);
     }

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -2,9 +2,12 @@
 
 namespace Illuminate\Tests\Notifications;
 
-use Mockery;
+use Mockery as m;
+use GuzzleHttp\Client;
 use Mockery\MockInterface;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Channels\SlackWebhookChannel;
@@ -25,14 +28,14 @@ class NotificationSlackChannelTest extends TestCase
     {
         parent::setUp();
 
-        $this->guzzleHttp = Mockery::mock('GuzzleHttp\Client');
+        $this->guzzleHttp = m::mock(Client::class);
 
         $this->slackChannel = new SlackWebhookChannel($this->guzzleHttp);
     }
 
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     /**
@@ -191,7 +194,7 @@ class NotificationSlackChannelTest extends TestCase
 
 class NotificationSlackChannelTestNotifiable
 {
-    use \Illuminate\Notifications\Notifiable;
+    use Notifiable;
 
     public function routeNotificationForSlack()
     {
@@ -208,7 +211,7 @@ class NotificationSlackChannelTestNotification extends Notification
                     ->to('#ghost-talk')
                     ->content('Content')
                     ->attachment(function ($attachment) {
-                        $timestamp = Mockery::mock(\Illuminate\Support\Carbon::class);
+                        $timestamp = m::mock(Carbon::class);
                         $timestamp->shouldReceive('getTimestamp')->andReturn(1234567890);
                         $attachment->title('Laravel', 'https://laravel.com')
                                    ->content('Attachment Content')
@@ -235,7 +238,7 @@ class NotificationSlackChannelTestNotificationWithImageIcon extends Notification
                     ->to('#ghost-talk')
                     ->content('Content')
                     ->attachment(function ($attachment) {
-                        $timestamp = Mockery::mock(\Illuminate\Support\Carbon::class);
+                        $timestamp = m::mock(Carbon::class);
                         $timestamp->shouldReceive('getTimestamp')->andReturn(1234567890);
                         $attachment->title('Laravel', 'https://laravel.com')
                                    ->content('Attachment Content')

--- a/tests/Pagination/PaginatorLoadMorphTest.php
+++ b/tests/Pagination/PaginatorLoadMorphTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Pagination;
 
-use Mockery;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\AbstractPaginator;
@@ -16,7 +16,7 @@ class PaginatorLoadMorphTest extends TestCase
             'App\\Company' => ['employees', 'calendars'],
         ];
 
-        $items = Mockery::mock(Collection::class);
+        $items = m::mock(Collection::class);
         $items->shouldReceive('loadMorph')->once()->with('parentable', $relations);
 
         $p = (new class extends AbstractPaginator {

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Pipeline;
 
 use PHPUnit\Framework\TestCase;
 use Illuminate\Pipeline\Pipeline;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Responsable;
 
 class PipelineTest extends TestCase
@@ -16,7 +17,7 @@ class PipelineTest extends TestCase
             return $next($piped);
         };
 
-        $result = (new Pipeline(new \Illuminate\Container\Container))
+        $result = (new Pipeline(new Container))
                     ->send('foo')
                     ->through([PipelineTestPipeOne::class, $pipeTwo])
                     ->then(function ($piped) {
@@ -33,7 +34,7 @@ class PipelineTest extends TestCase
 
     public function testPipelineUsageWithObjects()
     {
-        $result = (new Pipeline(new \Illuminate\Container\Container))
+        $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([new PipelineTestPipeOne])
             ->then(function ($piped) {
@@ -48,7 +49,7 @@ class PipelineTest extends TestCase
 
     public function testPipelineUsageWithInvokableObjects()
     {
-        $result = (new Pipeline(new \Illuminate\Container\Container))
+        $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([new PipelineTestPipeTwo])
             ->then(
@@ -65,7 +66,7 @@ class PipelineTest extends TestCase
 
     public function testPipelineUsageWithResponsableObjects()
     {
-        $result = (new Pipeline(new \Illuminate\Container\Container))
+        $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([new PipelineTestPipeResponsable])
             ->then(
@@ -88,7 +89,7 @@ class PipelineTest extends TestCase
             return $next($piped);
         };
 
-        $result = (new Pipeline(new \Illuminate\Container\Container))
+        $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([$function])
             ->then(
@@ -105,7 +106,7 @@ class PipelineTest extends TestCase
 
     public function testPipelineUsageWithInvokableClass()
     {
-        $result = (new Pipeline(new \Illuminate\Container\Container))
+        $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([PipelineTestPipeTwo::class])
             ->then(
@@ -124,7 +125,7 @@ class PipelineTest extends TestCase
     {
         $parameters = ['one', 'two'];
 
-        $result = (new Pipeline(new \Illuminate\Container\Container))
+        $result = (new Pipeline(new Container))
             ->send('foo')
             ->through(PipelineTestParameterPipe::class.':'.implode(',', $parameters))
             ->then(function ($piped) {
@@ -139,7 +140,7 @@ class PipelineTest extends TestCase
 
     public function testPipelineViaChangesTheMethodBeingCalledOnThePipes()
     {
-        $pipelineInstance = new Pipeline(new \Illuminate\Container\Container);
+        $pipelineInstance = new Pipeline(new Container);
         $result = $pipelineInstance->send('data')
             ->through(PipelineTestPipeOne::class)
             ->via('differentMethod')

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -2,8 +2,14 @@
 
 namespace Illuminate\Tests\Queue;
 
+use stdClass;
+use Exception;
 use Mockery as m;
+use Pheanstalk\Job;
+use Pheanstalk\Pheanstalk;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+use Illuminate\Queue\Jobs\BeanstalkdJob;
 
 class QueueBeanstalkdJobTest extends TestCase
 {
@@ -16,7 +22,7 @@ class QueueBeanstalkdJobTest extends TestCase
     {
         $job = $this->getJob();
         $job->getPheanstalkJob()->shouldReceive('getData')->once()->andReturn(json_encode(['job' => 'foo', 'data' => ['data']]));
-        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('stdClass'));
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock(stdClass::class));
         $handler->shouldReceive('fire')->once()->with($job, ['data']);
 
         $job->fire();
@@ -26,10 +32,10 @@ class QueueBeanstalkdJobTest extends TestCase
     {
         $job = $this->getJob();
         $job->getPheanstalkJob()->shouldReceive('getData')->once()->andReturn(json_encode(['job' => 'foo', 'data' => ['data']]));
-        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('Illuminate\Tests\Queue\BeanstalkdJobTestFailedTest'));
-        $handler->shouldReceive('failed')->once()->with(['data'], m::type('Exception'));
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock(BeanstalkdJobTestFailedTest::class));
+        $handler->shouldReceive('failed')->once()->with(['data'], m::type(Exception::class));
 
-        $job->failed(new \Exception);
+        $job->failed(new Exception);
     }
 
     public function testDeleteRemovesTheJobFromBeanstalkd()
@@ -43,7 +49,7 @@ class QueueBeanstalkdJobTest extends TestCase
     public function testReleaseProperlyReleasesJobOntoBeanstalkd()
     {
         $job = $this->getJob();
-        $job->getPheanstalk()->shouldReceive('release')->once()->with($job->getPheanstalkJob(), \Pheanstalk\Pheanstalk::DEFAULT_PRIORITY, 0);
+        $job->getPheanstalk()->shouldReceive('release')->once()->with($job->getPheanstalkJob(), Pheanstalk::DEFAULT_PRIORITY, 0);
 
         $job->release();
     }
@@ -58,10 +64,10 @@ class QueueBeanstalkdJobTest extends TestCase
 
     protected function getJob()
     {
-        return new \Illuminate\Queue\Jobs\BeanstalkdJob(
-            m::mock('Illuminate\Container\Container'),
-            m::mock('Pheanstalk\Pheanstalk'),
-            m::mock('Pheanstalk\Job'),
+        return new BeanstalkdJob(
+            m::mock(Container::class),
+            m::mock(Pheanstalk::class),
+            m::mock(Job::class),
             'connection-name',
             'default'
         );

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -3,7 +3,12 @@
 namespace Illuminate\Tests\Queue;
 
 use Mockery as m;
+use Pheanstalk\Job;
+use Pheanstalk\Pheanstalk;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+use Illuminate\Queue\BeanstalkdQueue;
+use Illuminate\Queue\Jobs\BeanstalkdJob;
 
 class QueueBeanstalkdQueueTest extends TestCase
 {
@@ -14,7 +19,7 @@ class QueueBeanstalkdQueueTest extends TestCase
 
     public function testPushProperlyPushesJobOntoBeanstalkd()
     {
-        $queue = new \Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
+        $queue = new BeanstalkdQueue(m::mock(Pheanstalk::class), 'default', 60);
         $pheanstalk = $queue->getPheanstalk();
         $pheanstalk->shouldReceive('useTube')->once()->with('stack')->andReturn($pheanstalk);
         $pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);
@@ -26,11 +31,11 @@ class QueueBeanstalkdQueueTest extends TestCase
 
     public function testDelayedPushProperlyPushesJobOntoBeanstalkd()
     {
-        $queue = new \Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
+        $queue = new BeanstalkdQueue(m::mock(Pheanstalk::class), 'default', 60);
         $pheanstalk = $queue->getPheanstalk();
         $pheanstalk->shouldReceive('useTube')->once()->with('stack')->andReturn($pheanstalk);
         $pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);
-        $pheanstalk->shouldReceive('put')->twice()->with(json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data']]), \Pheanstalk\Pheanstalk::DEFAULT_PRIORITY, 5, \Pheanstalk\Pheanstalk::DEFAULT_TTR);
+        $pheanstalk->shouldReceive('put')->twice()->with(json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data']]), Pheanstalk::DEFAULT_PRIORITY, 5, Pheanstalk::DEFAULT_TTR);
 
         $queue->later(5, 'foo', ['data'], 'stack');
         $queue->later(5, 'foo', ['data']);
@@ -38,24 +43,24 @@ class QueueBeanstalkdQueueTest extends TestCase
 
     public function testPopProperlyPopsJobOffOfBeanstalkd()
     {
-        $queue = new \Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
-        $queue->setContainer(m::mock('Illuminate\Container\Container'));
+        $queue = new BeanstalkdQueue(m::mock(Pheanstalk::class), 'default', 60);
+        $queue->setContainer(m::mock(Container::class));
         $pheanstalk = $queue->getPheanstalk();
         $pheanstalk->shouldReceive('watchOnly')->once()->with('default')->andReturn($pheanstalk);
-        $job = m::mock('Pheanstalk\Job');
+        $job = m::mock(Job::class);
         $pheanstalk->shouldReceive('reserve')->once()->andReturn($job);
 
         $result = $queue->pop();
 
-        $this->assertInstanceOf('Illuminate\Queue\Jobs\BeanstalkdJob', $result);
+        $this->assertInstanceOf(BeanstalkdJob::class, $result);
     }
 
     public function testDeleteProperlyRemoveJobsOffBeanstalkd()
     {
-        $queue = new \Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
+        $queue = new BeanstalkdQueue(m::mock(Pheanstalk::class), 'default', 60);
         $pheanstalk = $queue->getPheanstalk();
         $pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);
-        $pheanstalk->shouldReceive('delete')->once()->with(m::type('Pheanstalk\Job'));
+        $pheanstalk->shouldReceive('delete')->once()->with(m::type(Job::class));
 
         $queue->deleteMessage('default', 1);
     }

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -5,7 +5,10 @@ namespace Illuminate\Tests\Queue;
 use stdClass;
 use Mockery as m;
 use ReflectionClass;
+use Illuminate\Queue\Queue;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Connection;
+use Illuminate\Queue\DatabaseQueue;
 
 class QueueDatabaseQueueUnitTest extends TestCase
 {
@@ -16,9 +19,9 @@ class QueueDatabaseQueueUnitTest extends TestCase
 
     public function testPushProperlyPushesJobOntoDatabase()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\DatabaseQueue')->setMethods(['currentTime'])->setConstructorArgs([$database = m::mock('Illuminate\Database\Connection'), 'table', 'default'])->getMock();
+        $queue = $this->getMockBuilder(DatabaseQueue::class)->setMethods(['currentTime'])->setConstructorArgs([$database = m::mock(Connection::class), 'table', 'default'])->getMock();
         $queue->expects($this->any())->method('currentTime')->will($this->returnValue('time'));
-        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('stdClass'));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
             $this->assertEquals('default', $array['queue']);
             $this->assertEquals(json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data']]), $array['payload']);
@@ -33,12 +36,12 @@ class QueueDatabaseQueueUnitTest extends TestCase
     public function testDelayedPushProperlyPushesJobOntoDatabase()
     {
         $queue = $this->getMockBuilder(
-            'Illuminate\Queue\DatabaseQueue')->setMethods(
+            DatabaseQueue::class)->setMethods(
             ['currentTime'])->setConstructorArgs(
-            [$database = m::mock('Illuminate\Database\Connection'), 'table', 'default']
+            [$database = m::mock(Connection::class), 'table', 'default']
         )->getMock();
         $queue->expects($this->any())->method('currentTime')->will($this->returnValue('time'));
-        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('stdClass'));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
             $this->assertEquals('default', $array['queue']);
             $this->assertEquals(json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data']]), $array['payload']);
@@ -57,8 +60,8 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $job = new stdClass;
         $job->invalid = "\xc3\x28";
 
-        $queue = $this->getMockForAbstractClass('Illuminate\Queue\Queue');
-        $class = new ReflectionClass('Illuminate\Queue\Queue');
+        $queue = $this->getMockForAbstractClass(Queue::class);
+        $class = new ReflectionClass(Queue::class);
 
         $createPayload = $class->getMethod('createPayload');
         $createPayload->setAccessible(true);
@@ -72,8 +75,8 @@ class QueueDatabaseQueueUnitTest extends TestCase
     {
         $this->expectException('InvalidArgumentException');
 
-        $queue = $this->getMockForAbstractClass('Illuminate\Queue\Queue');
-        $class = new ReflectionClass('Illuminate\Queue\Queue');
+        $queue = $this->getMockForAbstractClass(Queue::class);
+        $class = new ReflectionClass(Queue::class);
 
         $createPayload = $class->getMethod('createPayload');
         $createPayload->setAccessible(true);
@@ -85,11 +88,11 @@ class QueueDatabaseQueueUnitTest extends TestCase
 
     public function testBulkBatchPushesOntoDatabase()
     {
-        $database = m::mock('Illuminate\Database\Connection');
-        $queue = $this->getMockBuilder('Illuminate\Queue\DatabaseQueue')->setMethods(['currentTime', 'availableAt'])->setConstructorArgs([$database, 'table', 'default'])->getMock();
+        $database = m::mock(Connection::class);
+        $queue = $this->getMockBuilder(DatabaseQueue::class)->setMethods(['currentTime', 'availableAt'])->setConstructorArgs([$database, 'table', 'default'])->getMock();
         $queue->expects($this->any())->method('currentTime')->will($this->returnValue('created'));
         $queue->expects($this->any())->method('availableAt')->will($this->returnValue('available'));
-        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('stdClass'));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('insert')->once()->andReturnUsing(function ($records) {
             $this->assertEquals([[
                 'queue' => 'queue',
@@ -113,7 +116,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
 
     public function testBuildDatabaseRecordWithPayloadAtTheEnd()
     {
-        $queue = m::mock('Illuminate\Queue\DatabaseQueue');
+        $queue = m::mock(DatabaseQueue::class);
         $record = $queue->buildDatabaseRecord('queue', 'any_payload', 0);
         $this->assertArrayHasKey('payload', $record);
         $this->assertArrayHasKey('payload', array_slice($record, -1, 1, true));

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -3,7 +3,10 @@
 namespace Illuminate\Tests\Queue;
 
 use Mockery as m;
+use Illuminate\Queue\Listener;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Queue\ListenerOptions;
+use Symfony\Component\Process\Process;
 
 class QueueListenerTest extends TestCase
 {
@@ -14,9 +17,9 @@ class QueueListenerTest extends TestCase
 
     public function testRunProcessCallsProcess()
     {
-        $process = m::mock('Symfony\Component\Process\Process')->makePartial();
+        $process = m::mock(Process::class)->makePartial();
         $process->shouldReceive('run')->once();
-        $listener = m::mock('Illuminate\Queue\Listener')->makePartial();
+        $listener = m::mock(Listener::class)->makePartial();
         $listener->shouldReceive('memoryExceeded')->once()->with(1)->andReturn(false);
 
         $listener->runProcess($process, 1);
@@ -24,9 +27,9 @@ class QueueListenerTest extends TestCase
 
     public function testListenerStopsWhenMemoryIsExceeded()
     {
-        $process = m::mock('Symfony\Component\Process\Process')->makePartial();
+        $process = m::mock(Process::class)->makePartial();
         $process->shouldReceive('run')->once();
-        $listener = m::mock('Illuminate\Queue\Listener')->makePartial();
+        $listener = m::mock(Listener::class)->makePartial();
         $listener->shouldReceive('memoryExceeded')->once()->with(1)->andReturn(true);
         $listener->shouldReceive('stop')->once();
 
@@ -35,15 +38,15 @@ class QueueListenerTest extends TestCase
 
     public function testMakeProcessCorrectlyFormatsCommandLine()
     {
-        $listener = new \Illuminate\Queue\Listener(__DIR__);
-        $options = new \Illuminate\Queue\ListenerOptions;
+        $listener = new Listener(__DIR__);
+        $options = new ListenerOptions;
         $options->delay = 1;
         $options->memory = 2;
         $options->timeout = 3;
         $process = $listener->makeProcess('connection', 'queue', $options);
         $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
 
-        $this->assertInstanceOf('Symfony\Component\Process\Process', $process);
+        $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
         $this->assertEquals($escape.PHP_BINARY.$escape." {$escape}artisan{$escape} queue:work {$escape}connection{$escape} --once --queue={$escape}queue{$escape} --delay=1 --memory=2 --sleep=3 --tries=0", $process->getCommandLine());

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Tests\Queue;
 
+use stdClass;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Queue\QueueManager;
+use Illuminate\Contracts\Encryption\Encrypter;
 
 class QueueManagerTest extends TestCase
 {
@@ -20,12 +22,12 @@ class QueueManagerTest extends TestCase
                 'queue.default' => 'sync',
                 'queue.connections.sync' => ['driver' => 'sync'],
             ],
-            'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+            'encrypter' => $encrypter = m::mock(Encrypter::class),
         ];
 
         $manager = new QueueManager($app);
-        $connector = m::mock('stdClass');
-        $queue = m::mock('stdClass');
+        $connector = m::mock(stdClass::class);
+        $queue = m::mock(stdClass::class);
         $queue->shouldReceive('setConnectionName')->once()->with('sync')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'sync'])->andReturn($queue);
         $manager->addConnector('sync', function () use ($connector) {
@@ -43,12 +45,12 @@ class QueueManagerTest extends TestCase
                 'queue.default' => 'sync',
                 'queue.connections.foo' => ['driver' => 'bar'],
             ],
-            'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+            'encrypter' => $encrypter = m::mock(Encrypter::class),
         ];
 
         $manager = new QueueManager($app);
-        $connector = m::mock('stdClass');
-        $queue = m::mock('stdClass');
+        $connector = m::mock(stdClass::class);
+        $queue = m::mock(stdClass::class);
         $queue->shouldReceive('setConnectionName')->once()->with('foo')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'bar'])->andReturn($queue);
         $manager->addConnector('bar', function () use ($connector) {
@@ -65,12 +67,12 @@ class QueueManagerTest extends TestCase
             'config' => [
                 'queue.default' => 'null',
             ],
-            'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+            'encrypter' => $encrypter = m::mock(Encrypter::class),
         ];
 
         $manager = new QueueManager($app);
-        $connector = m::mock('stdClass');
-        $queue = m::mock('stdClass');
+        $connector = m::mock(stdClass::class);
+        $queue = m::mock(stdClass::class);
         $queue->shouldReceive('setConnectionName')->once()->with('null')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'null'])->andReturn($queue);
         $manager->addConnector('null', function () use ($connector) {

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -2,8 +2,12 @@
 
 namespace Illuminate\Tests\Queue;
 
+use stdClass;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Queue\RedisQueue;
+use Illuminate\Container\Container;
+use Illuminate\Queue\Jobs\RedisJob;
 
 class QueueRedisJobTest extends TestCase
 {
@@ -15,7 +19,7 @@ class QueueRedisJobTest extends TestCase
     public function testFireProperlyCallsTheJobHandler()
     {
         $job = $this->getJob();
-        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('stdClass'));
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock(stdClass::class));
         $handler->shouldReceive('fire')->once()->with($job, ['data']);
 
         $job->fire();
@@ -41,9 +45,9 @@ class QueueRedisJobTest extends TestCase
 
     protected function getJob()
     {
-        return new \Illuminate\Queue\Jobs\RedisJob(
-            m::mock(\Illuminate\Container\Container::class),
-            m::mock(\Illuminate\Queue\RedisQueue::class),
+        return new RedisJob(
+            m::mock(Container::class),
+            m::mock(RedisQueue::class),
             json_encode(['job' => 'foo', 'data' => ['data'], 'attempts' => 1]),
             json_encode(['job' => 'foo', 'data' => ['data'], 'attempts' => 2]),
             'connection-name',

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -4,7 +4,10 @@ namespace Illuminate\Tests\Queue;
 
 use Mockery as m;
 use Illuminate\Queue\Queue;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Queue\RedisQueue;
+use Illuminate\Contracts\Redis\Factory;
 
 class QueueRedisQueueTest extends TestCase
 {
@@ -15,7 +18,7 @@ class QueueRedisQueueTest extends TestCase
 
     public function testPushProperlyPushesJobOntoRedis()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
+        $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]));
@@ -26,7 +29,7 @@ class QueueRedisQueueTest extends TestCase
 
     public function testPushProperlyPushesJobOntoRedisWithCustomPayloadHook()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
+        $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0]));
@@ -43,7 +46,7 @@ class QueueRedisQueueTest extends TestCase
 
     public function testDelayedPushProperlyPushesJobOntoRedis()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
+        $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $queue->expects($this->once())->method('availableAt')->with(1)->will($this->returnValue(2));
 
@@ -60,8 +63,8 @@ class QueueRedisQueueTest extends TestCase
 
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoRedis()
     {
-        $date = \Illuminate\Support\Carbon::now();
-        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
+        $date = Carbon::now();
+        $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $queue->expects($this->once())->method('availableAt')->with($date)->will($this->returnValue(2));
 

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -4,7 +4,12 @@ namespace Illuminate\Tests\Queue;
 
 use Aws\Result;
 use Mockery as m;
+use Aws\Sqs\SqsClient;
+use Illuminate\Queue\SqsQueue;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Queue\Jobs\SqsJob;
+use Illuminate\Container\Container;
 
 class QueueSqsQueueTest extends TestCase
 {
@@ -16,7 +21,7 @@ class QueueSqsQueueTest extends TestCase
     public function setUp()
     {
         // Use Mockery to mock the SqsClient
-        $this->sqs = m::mock('Aws\Sqs\SqsClient');
+        $this->sqs = m::mock(SqsClient::class);
 
         $this->account = '1234567891011';
         $this->queueName = 'emails';
@@ -65,18 +70,18 @@ class QueueSqsQueueTest extends TestCase
 
     public function testPopProperlyPopsJobOffOfSqs()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
-        $queue->setContainer(m::mock('Illuminate\Container\Container'));
+        $queue = $this->getMockBuilder(SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue->setContainer(m::mock(Container::class));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
         $this->sqs->shouldReceive('receiveMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'AttributeNames' => ['ApproximateReceiveCount']])->andReturn($this->mockedReceiveMessageResponseModel);
         $result = $queue->pop($this->queueName);
-        $this->assertInstanceOf('Illuminate\Queue\Jobs\SqsJob', $result);
+        $this->assertInstanceOf(SqsJob::class, $result);
     }
 
     public function testPopProperlyHandlesEmptyMessage()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
-        $queue->setContainer(m::mock('Illuminate\Container\Container'));
+        $queue = $this->getMockBuilder(SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue->setContainer(m::mock(Container::class));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
         $this->sqs->shouldReceive('receiveMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'AttributeNames' => ['ApproximateReceiveCount']])->andReturn($this->mockedReceiveEmptyMessageResponseModel);
         $result = $queue->pop($this->queueName);
@@ -85,8 +90,8 @@ class QueueSqsQueueTest extends TestCase
 
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs()
     {
-        $now = \Illuminate\Support\Carbon::now();
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $now = Carbon::now();
+        $queue = $this->getMockBuilder(SqsQueue::class)->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->queueName, $this->mockedData)->will($this->returnValue($this->mockedPayload));
         $queue->expects($this->once())->method('secondsUntil')->with($now)->will($this->returnValue(5));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
@@ -97,7 +102,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testDelayedPushProperlyPushesJobOntoSqs()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(SqsQueue::class)->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->queueName, $this->mockedData)->will($this->returnValue($this->mockedPayload));
         $queue->expects($this->once())->method('secondsUntil')->with($this->mockedDelay)->will($this->returnValue($this->mockedDelay));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
@@ -108,7 +113,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testPushProperlyPushesJobOntoSqs()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['createPayload', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(SqsQueue::class)->setMethods(['createPayload', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->queueName, $this->mockedData)->will($this->returnValue($this->mockedPayload));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
         $this->sqs->shouldReceive('sendMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload])->andReturn($this->mockedSendMessageResponseModel);
@@ -118,7 +123,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testSizeProperlyReadsSqsQueueSize()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
         $this->sqs->shouldReceive('getQueueAttributes')->once()->with(['QueueUrl' => $this->queueUrl, 'AttributeNames' => ['ApproximateNumberOfMessages']])->andReturn($this->mockedQueueAttributesResponseModel);
         $size = $queue->size($this->queueName);
@@ -127,7 +132,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testGetQueueProperlyResolvesUrlWithPrefix()
     {
-        $queue = new \Illuminate\Queue\SqsQueue($this->sqs, $this->queueName, $this->prefix);
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix);
         $this->assertEquals($this->queueUrl, $queue->getQueue(null));
         $queueUrl = $this->baseUrl.'/'.$this->account.'/test';
         $this->assertEquals($queueUrl, $queue->getQueue('test'));
@@ -135,7 +140,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testGetQueueProperlyResolvesUrlWithoutPrefix()
     {
-        $queue = new \Illuminate\Queue\SqsQueue($this->sqs, $this->queueUrl);
+        $queue = new SqsQueue($this->sqs, $this->queueUrl);
         $this->assertEquals($this->queueUrl, $queue->getQueue(null));
         $queueUrl = $this->baseUrl.'/'.$this->account.'/test';
         $this->assertEquals($queueUrl, $queue->getQueue($queueUrl));

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Tests\Queue;
 
-use Mockery;
+use Mockery as m;
 use RuntimeException;
+use Illuminate\Queue\Worker;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Queue\QueueManager;
 use Illuminate\Container\Container;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Queue\Events\JobFailed;
@@ -23,8 +25,8 @@ class QueueWorkerTest extends TestCase
 
     public function setUp()
     {
-        $this->events = Mockery::spy(Dispatcher::class);
-        $this->exceptionHandler = Mockery::spy(ExceptionHandler::class);
+        $this->events = m::spy(Dispatcher::class);
+        $this->exceptionHandler = m::spy(ExceptionHandler::class);
 
         Container::setInstance($container = new Container);
 
@@ -42,8 +44,8 @@ class QueueWorkerTest extends TestCase
         $worker = $this->getWorker('default', ['queue' => [$job = new WorkerFakeJob]]);
         $worker->runNextJob('default', 'queue', new WorkerOptions);
         $this->assertTrue($job->fired);
-        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobProcessing::class))->once();
-        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobProcessed::class))->once();
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobProcessing::class))->once();
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobProcessed::class))->once();
     }
 
     public function test_worker_can_work_until_queue_is_empty()
@@ -66,9 +68,9 @@ class QueueWorkerTest extends TestCase
 
         $this->assertSame(0, $worker->stoppedWithStatus);
 
-        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobProcessing::class))->twice();
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobProcessing::class))->twice();
 
-        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobProcessed::class))->twice();
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobProcessed::class))->twice();
     }
 
     public function test_job_can_be_fired_based_on_priority()
@@ -124,8 +126,8 @@ class QueueWorkerTest extends TestCase
         $this->assertEquals(10, $job->releaseAfter);
         $this->assertFalse($job->deleted);
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
-        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobExceptionOccurred::class))->once();
-        $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(JobProcessed::class)]);
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobExceptionOccurred::class))->once();
+        $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
     }
 
     public function test_job_is_not_released_if_it_has_exceeded_max_attempts()
@@ -147,9 +149,9 @@ class QueueWorkerTest extends TestCase
         $this->assertTrue($job->deleted);
         $this->assertEquals($e, $job->failedWith);
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
-        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobExceptionOccurred::class))->once();
-        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobFailed::class))->once();
-        $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(JobProcessed::class)]);
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobExceptionOccurred::class))->once();
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobFailed::class))->once();
+        $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
     }
 
     public function test_job_is_not_released_if_it_has_expired()
@@ -178,9 +180,9 @@ class QueueWorkerTest extends TestCase
         $this->assertTrue($job->deleted);
         $this->assertEquals($e, $job->failedWith);
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
-        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobExceptionOccurred::class))->once();
-        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobFailed::class))->once();
-        $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(JobProcessed::class)]);
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobExceptionOccurred::class))->once();
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobFailed::class))->once();
+        $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
     }
 
     public function test_job_is_failed_if_it_has_already_exceeded_max_attempts()
@@ -197,10 +199,10 @@ class QueueWorkerTest extends TestCase
         $this->assertNull($job->releaseAfter);
         $this->assertTrue($job->deleted);
         $this->assertInstanceOf(MaxAttemptsExceededException::class, $job->failedWith);
-        $this->exceptionHandler->shouldHaveReceived('report')->with(Mockery::type(MaxAttemptsExceededException::class));
-        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobExceptionOccurred::class))->once();
-        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobFailed::class))->once();
-        $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(JobProcessed::class)]);
+        $this->exceptionHandler->shouldHaveReceived('report')->with(m::type(MaxAttemptsExceededException::class));
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobExceptionOccurred::class))->once();
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobFailed::class))->once();
+        $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
     }
 
     public function test_job_is_failed_if_it_has_already_expired()
@@ -223,10 +225,10 @@ class QueueWorkerTest extends TestCase
         $this->assertNull($job->releaseAfter);
         $this->assertTrue($job->deleted);
         $this->assertInstanceOf(MaxAttemptsExceededException::class, $job->failedWith);
-        $this->exceptionHandler->shouldHaveReceived('report')->with(Mockery::type(MaxAttemptsExceededException::class));
-        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobExceptionOccurred::class))->once();
-        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobFailed::class))->once();
-        $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(JobProcessed::class)]);
+        $this->exceptionHandler->shouldHaveReceived('report')->with(m::type(MaxAttemptsExceededException::class));
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobExceptionOccurred::class))->once();
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobFailed::class))->once();
+        $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
     }
 
     public function test_job_based_max_retries()
@@ -279,7 +281,7 @@ class QueueWorkerTest extends TestCase
 /**
  * Fakes.
  */
-class InsomniacWorker extends \Illuminate\Queue\Worker
+class InsomniacWorker extends Worker
 {
     public $sleptFor;
 
@@ -301,7 +303,7 @@ class InsomniacWorker extends \Illuminate\Queue\Worker
     }
 }
 
-class WorkerFakeManager extends \Illuminate\Queue\QueueManager
+class WorkerFakeManager extends QueueManager
 {
     public $connections = [];
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -6,6 +6,8 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Redis\RedisManager;
 use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Redis\Connections\Connection;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 
 class RedisConnectionTest extends TestCase
@@ -581,13 +583,13 @@ class RedisConnectionTest extends TestCase
     public function it_dispatches_query_event()
     {
         foreach ($this->connections() as $redis) {
-            $redis->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+            $redis->setEventDispatcher($events = m::mock(Dispatcher::class));
 
             $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) {
                 $this->assertEquals('get', $event->command);
                 $this->assertEquals(['foobar'], $event->parameters);
                 $this->assertEquals('default', $event->connectionName);
-                $this->assertInstanceOf('\Illuminate\Redis\Connections\Connection', $event->connection);
+                $this->assertInstanceOf(Connection::class, $event->connection);
 
                 return true;
             }));

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -122,7 +122,7 @@ class RouteRegistrarTest extends TestCase
     public function testCanRegisterRouteWithControllerAction()
     {
         $this->router->middleware('controller-middleware')
-                     ->get('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub@index');
+                     ->get('users', RouteRegistrarControllerStub::class.'@index');
 
         $this->seeResponse('controller', Request::create('users', 'GET'));
         $this->seeMiddleware('controller-middleware');
@@ -131,7 +131,7 @@ class RouteRegistrarTest extends TestCase
     public function testCanRegisterRouteWithArrayAndControllerAction()
     {
         $this->router->middleware('controller-middleware')->put('users', [
-            'uses' => 'Illuminate\Tests\Routing\RouteRegistrarControllerStub@index',
+            'uses' => RouteRegistrarControllerStub::class.'@index',
         ]);
 
         $this->seeResponse('controller', Request::create('users', 'PUT'));
@@ -224,7 +224,7 @@ class RouteRegistrarTest extends TestCase
     public function testCanRegisterResource()
     {
         $this->router->middleware('resource-middleware')
-                     ->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub');
+                     ->resource('users', RouteRegistrarControllerStub::class);
 
         $this->seeResponse('deleted', Request::create('users/1', 'DELETE'));
         $this->seeMiddleware('resource-middleware');
@@ -298,7 +298,7 @@ class RouteRegistrarTest extends TestCase
     public function testCanAccessRegisteredResourceRoutesAsRouteCollection()
     {
         $resource = $this->router->middleware('resource-middleware')
-                     ->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+                     ->resource('users', RouteRegistrarControllerStub::class)
                      ->register();
 
         $this->assertCount(7, $resource->getRoutes());
@@ -314,7 +314,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanLimitMethodsOnRegisteredResource()
     {
-        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
                      ->only('index', 'show', 'destroy');
 
         $this->assertCount(3, $this->router->getRoutes());
@@ -326,7 +326,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanExcludeMethodsOnRegisteredResource()
     {
-        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
                      ->except(['index', 'create', 'store', 'show', 'edit']);
 
         $this->assertCount(2, $this->router->getRoutes());
@@ -403,7 +403,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testUserCanRegisterApiResource()
     {
-        $this->router->apiResource('users', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class);
+        $this->router->apiResource('users', RouteRegistrarControllerStub::class);
 
         $this->assertCount(5, $this->router->getRoutes());
 
@@ -413,7 +413,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testUserCanRegisterApiResourceWithExceptOption()
     {
-        $this->router->apiResource('users', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class, [
+        $this->router->apiResource('users', RouteRegistrarControllerStub::class, [
             'except' => ['destroy'],
         ]);
 
@@ -426,7 +426,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testUserCanRegisterApiResourceWithOnlyOption()
     {
-        $this->router->apiResource('users', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class, [
+        $this->router->apiResource('users', RouteRegistrarControllerStub::class, [
             'only' => ['index', 'show'],
         ]);
 
@@ -438,16 +438,16 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanNameRoutesOnRegisteredResource()
     {
-        $this->router->resource('comments', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+        $this->router->resource('comments', RouteRegistrarControllerStub::class)
                      ->only('create', 'store')->names('reply');
 
-        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
                      ->only('create', 'store')->names([
                          'create' => 'user.build',
                          'store' => 'user.save',
                      ]);
 
-        $this->router->resource('posts', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+        $this->router->resource('posts', RouteRegistrarControllerStub::class)
                     ->only('create', 'destroy')
                     ->name('create', 'posts.make')
                     ->name('destroy', 'posts.remove');
@@ -462,10 +462,10 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanOverrideParametersOnRegisteredResource()
     {
-        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
                      ->parameters(['users' => 'admin_user']);
 
-        $this->router->resource('posts', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+        $this->router->resource('posts', RouteRegistrarControllerStub::class)
                      ->parameter('posts', 'topic');
 
         $this->assertContains('admin_user', $this->router->getRoutes()->getByName('users.show')->uri);
@@ -474,10 +474,10 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanSetMiddlewareOnRegisteredResource()
     {
-        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
-                     ->middleware('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub');
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+                     ->middleware(RouteRegistrarMiddlewareStub::class);
 
-        $this->seeMiddleware('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub');
+        $this->seeMiddleware(RouteRegistrarMiddlewareStub::class);
     }
 
     public function testCanSetRouteName()

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -3,8 +3,13 @@
 namespace Illuminate\Tests\Routing;
 
 use Mockery as m;
+use Illuminate\Http\Request;
+use Illuminate\Session\Store;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Routing\Redirector;
+use Illuminate\Routing\UrlGenerator;
+use Illuminate\Http\RedirectResponse;
+use Symfony\Component\HttpFoundation\HeaderBag;
 
 class RoutingRedirectorTest extends TestCase
 {
@@ -16,9 +21,9 @@ class RoutingRedirectorTest extends TestCase
 
     public function setUp()
     {
-        $this->headers = m::mock('Symfony\Component\HttpFoundation\HeaderBag');
+        $this->headers = m::mock(HeaderBag::class);
 
-        $this->request = m::mock('Illuminate\Http\Request');
+        $this->request = m::mock(Request::class);
         $this->request->shouldReceive('isMethod')->andReturn(true)->byDefault();
         $this->request->shouldReceive('method')->andReturn('GET')->byDefault();
         $this->request->shouldReceive('route')->andReturn(true)->byDefault();
@@ -26,7 +31,7 @@ class RoutingRedirectorTest extends TestCase
         $this->request->shouldReceive('expectsJson')->andReturn(false)->byDefault();
         $this->request->headers = $this->headers;
 
-        $this->url = m::mock('Illuminate\Routing\UrlGenerator');
+        $this->url = m::mock(UrlGenerator::class);
         $this->url->shouldReceive('getRequest')->andReturn($this->request);
         $this->url->shouldReceive('to')->with('bar', [], null)->andReturn('http://foo.com/bar');
         $this->url->shouldReceive('to')->with('bar', [], true)->andReturn('https://foo.com/bar');
@@ -34,7 +39,7 @@ class RoutingRedirectorTest extends TestCase
         $this->url->shouldReceive('to')->with('http://foo.com/bar', [], null)->andReturn('http://foo.com/bar');
         $this->url->shouldReceive('to')->with('/', [], null)->andReturn('http://foo.com/');
 
-        $this->session = m::mock('Illuminate\Session\Store');
+        $this->session = m::mock(Store::class);
 
         $this->redirect = new Redirector($this->url);
         $this->redirect->setSession($this->session);
@@ -49,7 +54,7 @@ class RoutingRedirectorTest extends TestCase
     {
         $response = $this->redirect->to('bar');
 
-        $this->assertInstanceOf('Illuminate\Http\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals($this->session, $response->getSession());

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -4,7 +4,10 @@ namespace Illuminate\Tests\Session;
 
 use Mockery as m;
 use ReflectionClass;
+use SessionHandlerInterface;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Session\EncryptedStore;
+use Illuminate\Contracts\Encryption\Encrypter;
 
 class EncryptedSessionStoreTest extends TestCase
 {
@@ -43,7 +46,7 @@ class EncryptedSessionStoreTest extends TestCase
 
     public function getSession()
     {
-        $reflection = new ReflectionClass('Illuminate\Session\EncryptedStore');
+        $reflection = new ReflectionClass(EncryptedStore::class);
 
         return $reflection->newInstanceArgs($this->getMocks());
     }
@@ -52,8 +55,8 @@ class EncryptedSessionStoreTest extends TestCase
     {
         return [
             $this->getSessionName(),
-            m::mock('SessionHandlerInterface'),
-            m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+            m::mock(SessionHandlerInterface::class),
+            m::mock(Encrypter::class),
             $this->getSessionId(),
         ];
     }

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -4,7 +4,12 @@ namespace Illuminate\Tests\Session;
 
 use Mockery as m;
 use ReflectionClass;
+use SessionHandlerInterface;
+use Illuminate\Session\Store;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Cookie\CookieJar;
+use Illuminate\Session\CookieSessionHandler;
+use Symfony\Component\HttpFoundation\Request;
 
 class SessionStoreTest extends TestCase
 {
@@ -289,10 +294,10 @@ class SessionStoreTest extends TestCase
         $this->assertFalse($session->handlerNeedsRequest());
         $session->getHandler()->shouldReceive('setRequest')->never();
 
-        $session = new \Illuminate\Session\Store('test', m::mock(new \Illuminate\Session\CookieSessionHandler(new \Illuminate\Cookie\CookieJar, 60)));
+        $session = new Store('test', m::mock(new CookieSessionHandler(new CookieJar, 60)));
         $this->assertTrue($session->handlerNeedsRequest());
         $session->getHandler()->shouldReceive('setRequest')->once();
-        $request = new \Symfony\Component\HttpFoundation\Request;
+        $request = new Request;
         $session->setRequestOnHandler($request);
     }
 
@@ -347,7 +352,7 @@ class SessionStoreTest extends TestCase
 
     public function getSession()
     {
-        $reflection = new ReflectionClass('Illuminate\Session\Store');
+        $reflection = new ReflectionClass(Store::class);
 
         return $reflection->newInstanceArgs($this->getMocks());
     }
@@ -356,7 +361,7 @@ class SessionStoreTest extends TestCase
     {
         return [
             $this->getSessionName(),
-            m::mock('SessionHandlerInterface'),
+            m::mock(SessionHandlerInterface::class),
             $this->getSessionId(),
         ];
     }

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -4,8 +4,13 @@ namespace Illuminate\Tests\Session;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Composer;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Illuminate\Session\Console\SessionTableCommand;
+use Illuminate\Database\Migrations\MigrationCreator;
 
 class SessionTableCommandTest extends TestCase
 {
@@ -17,10 +22,10 @@ class SessionTableCommandTest extends TestCase
     public function testCreateMakesMigration()
     {
         $command = new SessionTableCommandTestStub(
-            $files = m::mock('Illuminate\Filesystem\Filesystem'),
-            $composer = m::mock('Illuminate\Support\Composer')
+            $files = m::mock(Filesystem::class),
+            $composer = m::mock(Composer::class)
         );
-        $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
+        $creator = m::mock(MigrationCreator::class)->shouldIgnoreMissing();
 
         $app = new Application;
         $app->useDatabasePath(__DIR__);
@@ -37,7 +42,7 @@ class SessionTableCommandTest extends TestCase
 
     protected function runCommand($command, $input = [])
     {
-        return $command->run(new \Symfony\Component\Console\Input\ArrayInput($input), new \Symfony\Component\Console\Output\NullOutput);
+        return $command->run(new ArrayInput($input), new NullOutput);
     }
 }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use stdClass;
 use ArrayObject;
 use Illuminate\Support\Arr;
+use InvalidArgumentException;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
@@ -482,19 +483,19 @@ class SupportArrTest extends TestCase
 
         try {
             Arr::random([]);
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             $exceptions++;
         }
 
         try {
             Arr::random([], 1);
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             $exceptions++;
         }
 
         try {
             Arr::random([], 2);
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             $exceptions++;
         }
 

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Tests\Support;
 
 use Mockery as m;
+use Illuminate\Support\Fluent;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Support\Traits\CapsuleManagerTrait;
 
@@ -23,17 +25,17 @@ class SupportCapsuleManagerTraitTest extends TestCase
 
         $this->assertNull($this->setupContainer($app));
         $this->assertEquals($app, $this->getContainer());
-        $this->assertInstanceOf('Illuminate\Support\Fluent', $app['config']);
+        $this->assertInstanceOf(Fluent::class, $app['config']);
     }
 
     public function testSetupContainerForCapsuleWhenConfigIsBound()
     {
         $this->container = null;
         $app = new Container;
-        $app['config'] = m::mock('Illuminate\Config\Repository');
+        $app['config'] = m::mock(Repository::class);
 
         $this->assertNull($this->setupContainer($app));
         $this->assertEquals($app, $this->getContainer());
-        $this->assertInstanceOf('Illuminate\Config\Repository', $app['config']);
+        $this->assertInstanceOf(Repository::class, $app['config']);
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -6,10 +6,13 @@ use stdClass;
 use Exception;
 use ArrayAccess;
 use Mockery as m;
+use ArrayIterator;
+use CachingIterator;
 use ReflectionClass;
 use JsonSerializable;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
+use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
@@ -184,9 +187,9 @@ class SupportCollectionTest extends TestCase
 
     public function testToArrayCallsToArrayOnEachItemInCollection()
     {
-        $item1 = m::mock('Illuminate\Contracts\Support\Arrayable');
+        $item1 = m::mock(Arrayable::class);
         $item1->shouldReceive('toArray')->once()->andReturn('foo.array');
-        $item2 = m::mock('Illuminate\Contracts\Support\Arrayable');
+        $item2 = m::mock(Arrayable::class);
         $item2->shouldReceive('toArray')->once()->andReturn('bar.array');
         $c = new Collection([$item1, $item2]);
         $results = $c->toArray();
@@ -196,9 +199,9 @@ class SupportCollectionTest extends TestCase
 
     public function testJsonSerializeCallsToArrayOrJsonSerializeOnEachItemInCollection()
     {
-        $item1 = m::mock('JsonSerializable');
+        $item1 = m::mock(JsonSerializable::class);
         $item1->shouldReceive('jsonSerialize')->once()->andReturn('foo.json');
-        $item2 = m::mock('Illuminate\Contracts\Support\Arrayable');
+        $item2 = m::mock(Arrayable::class);
         $item2->shouldReceive('toArray')->once()->andReturn('bar.array');
         $c = new Collection([$item1, $item2]);
         $results = $c->jsonSerialize();
@@ -305,14 +308,14 @@ class SupportCollectionTest extends TestCase
     public function testIterable()
     {
         $c = new Collection(['foo']);
-        $this->assertInstanceOf('ArrayIterator', $c->getIterator());
+        $this->assertInstanceOf(ArrayIterator::class, $c->getIterator());
         $this->assertEquals(['foo'], $c->getIterator()->getArrayCopy());
     }
 
     public function testCachingIterator()
     {
         $c = new Collection(['foo']);
-        $this->assertInstanceOf('CachingIterator', $c->getCachingIterator());
+        $this->assertInstanceOf(CachingIterator::class, $c->getCachingIterator());
     }
 
     public function testFilter()
@@ -472,16 +475,16 @@ class SupportCollectionTest extends TestCase
             $c->where('v', '<', null)->values()->all()
         );
 
-        $c = new Collection([['v' => 1], ['v' => new \Illuminate\Support\HtmlString('hello')]]);
+        $c = new Collection([['v' => 1], ['v' => new HtmlString('hello')]]);
         $this->assertEquals(
-            [['v' => new \Illuminate\Support\HtmlString('hello')]],
+            [['v' => new HtmlString('hello')]],
             $c->where('v', 'hello')->values()->all()
         );
 
         $c = new Collection([['v' => 1], ['v' => 'hello']]);
         $this->assertEquals(
             [['v' => 'hello']],
-            $c->where('v', new \Illuminate\Support\HtmlString('hello'))->values()->all()
+            $c->where('v', new HtmlString('hello'))->values()->all()
         );
 
         $c = new Collection([['v' => 1], ['v' => 2], ['v' => null]]);

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -5,13 +5,15 @@ namespace Illuminate\Tests\Support;
 use stdClass;
 use ArrayAccess;
 use Mockery as m;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Facades\Facade;
 
 class SupportFacadeTest extends TestCase
 {
     public function setUp()
     {
-        \Illuminate\Support\Facades\Facade::clearResolvedInstances();
+        Facade::clearResolvedInstances();
         FacadeStub::setFacadeApplication(null);
     }
 
@@ -23,7 +25,7 @@ class SupportFacadeTest extends TestCase
     public function testFacadeCallsUnderlyingApplication()
     {
         $app = new ApplicationStub;
-        $app->setAttributes(['foo' => $mock = m::mock('stdClass')]);
+        $app->setAttributes(['foo' => $mock = m::mock(stdClass::class)]);
         $mock->shouldReceive('bar')->once()->andReturn('baz');
         FacadeStub::setFacadeApplication($app);
         $this->assertEquals('baz', FacadeStub::bar());
@@ -35,7 +37,7 @@ class SupportFacadeTest extends TestCase
         $app->setAttributes(['foo' => new stdClass]);
         FacadeStub::setFacadeApplication($app);
 
-        $this->assertInstanceOf('Mockery\MockInterface', $mock = FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
+        $this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
         $this->assertEquals('baz', $app['foo']->foo('bar'));
     }
 
@@ -45,7 +47,7 @@ class SupportFacadeTest extends TestCase
         $app->setAttributes(['foo' => new stdClass]);
         FacadeStub::setFacadeApplication($app);
 
-        $this->assertInstanceOf(m\MockInterface::class, $spy = FacadeStub::spy());
+        $this->assertInstanceOf(MockInterface::class, $spy = FacadeStub::spy());
 
         FacadeStub::foo();
         $spy->shouldHaveReceived('foo');
@@ -57,8 +59,8 @@ class SupportFacadeTest extends TestCase
         $app->setAttributes(['foo' => new stdClass]);
         FacadeStub::setFacadeApplication($app);
 
-        $this->assertInstanceOf('Mockery\MockInterface', $mock = FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
-        $this->assertInstanceOf('Mockery\MockInterface', $mock = FacadeStub::shouldReceive('foo2')->once()->with('bar2')->andReturn('baz2')->getMock());
+        $this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
+        $this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::shouldReceive('foo2')->once()->with('bar2')->andReturn('baz2')->getMock());
         $this->assertEquals('baz', $app['foo']->foo('bar'));
         $this->assertEquals('baz2', $app['foo']->foo2('bar2'));
     }
@@ -70,7 +72,7 @@ class SupportFacadeTest extends TestCase
     }
 }
 
-class FacadeStub extends \Illuminate\Support\Facades\Facade
+class FacadeStub extends Facade
 {
     protected static function getFacadeAccessor()
     {

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
-use Mockery;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
@@ -19,7 +19,7 @@ class SupportFacadesEventTest extends TestCase
     {
         parent::setUp();
 
-        $this->events = Mockery::spy(Dispatcher::class);
+        $this->events = m::spy(Dispatcher::class);
 
         $container = new Container;
         $container->instance('events', $this->events);
@@ -31,7 +31,7 @@ class SupportFacadesEventTest extends TestCase
     {
         Event::clearResolvedInstances();
 
-        Mockery::close();
+        m::close();
     }
 
     public function testFakeFor()

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use ArrayIterator;
 use ReflectionObject;
 use IteratorAggregate;
 use Illuminate\Support\Fluent;
@@ -81,7 +82,7 @@ class SupportFluentTest extends TestCase
         $this->assertEquals('Taylor', $fluent->name);
         $this->assertTrue($fluent->developer);
         $this->assertEquals(25, $fluent->age);
-        $this->assertInstanceOf('Illuminate\Support\Fluent', $fluent->programmer());
+        $this->assertInstanceOf(Fluent::class, $fluent->programmer());
     }
 
     public function testIssetMagicMethod()
@@ -106,7 +107,7 @@ class SupportFluentTest extends TestCase
 
     public function testToJsonEncodesTheToArrayResult()
     {
-        $fluent = $this->getMockBuilder('Illuminate\Support\Fluent')->setMethods(['toArray'])->getMock();
+        $fluent = $this->getMockBuilder(Fluent::class)->setMethods(['toArray'])->getMock();
         $fluent->expects($this->once())->method('toArray')->will($this->returnValue('foo'));
         $results = $fluent->toJson();
 
@@ -125,6 +126,6 @@ class FluentArrayIteratorStub implements IteratorAggregate
 
     public function getIterator()
     {
-        return new \ArrayIterator($this->items);
+        return new ArrayIterator($this->items);
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Optional;
+use Illuminate\Contracts\Support\Htmlable;
 
 class SupportHelpersTest extends TestCase
 {
@@ -254,7 +255,7 @@ class SupportHelpersTest extends TestCase
     {
         $str = 'A \'quote\' is <b>bold</b>';
         $this->assertEquals('A &#039;quote&#039; is &lt;b&gt;bold&lt;/b&gt;', e($str));
-        $html = m::mock('Illuminate\Contracts\Support\Htmlable');
+        $html = m::mock(Htmlable::class);
         $html->shouldReceive('toHtml')->andReturn($str);
         $this->assertEquals($str, e($html));
     }
@@ -700,17 +701,17 @@ class SupportHelpersTest extends TestCase
     public function testClassUsesRecursiveShouldReturnTraitsOnParentClasses()
     {
         $this->assertSame([
-            'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
-            'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
+            SupportTestTraitTwo::class => SupportTestTraitTwo::class,
+            SupportTestTraitOne::class => SupportTestTraitOne::class,
         ],
-        class_uses_recursive('Illuminate\Tests\Support\SupportTestClassTwo'));
+        class_uses_recursive(SupportTestClassTwo::class));
     }
 
     public function testClassUsesRecursiveAcceptsObject()
     {
         $this->assertSame([
-            'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
-            'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
+            SupportTestTraitTwo::class => SupportTestTraitTwo::class,
+            SupportTestTraitOne::class => SupportTestTraitOne::class,
         ],
         class_uses_recursive(new SupportTestClassTwo));
     }
@@ -718,9 +719,9 @@ class SupportHelpersTest extends TestCase
     public function testClassUsesRecursiveReturnParentTraitsFirst()
     {
         $this->assertSame([
-            'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
-            'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
-            'Illuminate\Tests\Support\SupportTestTraitThree' => 'Illuminate\Tests\Support\SupportTestTraitThree',
+            SupportTestTraitTwo::class => SupportTestTraitTwo::class,
+            SupportTestTraitOne::class => SupportTestTraitOne::class,
+            SupportTestTraitThree::class => SupportTestTraitThree::class,
         ],
         class_uses_recursive(SupportTestClassThree::class));
     }

--- a/tests/Support/SupportNamespacedItemResolverTest.php
+++ b/tests/Support/SupportNamespacedItemResolverTest.php
@@ -19,7 +19,7 @@ class SupportNamespacedItemResolverTest extends TestCase
 
     public function testParsedItemsAreCached()
     {
-        $r = $this->getMockBuilder('Illuminate\Support\NamespacedItemResolver')->setMethods(['parseBasicSegments', 'parseNamespacedSegments'])->getMock();
+        $r = $this->getMockBuilder(NamespacedItemResolver::class)->setMethods(['parseBasicSegments', 'parseNamespacedSegments'])->getMock();
         $r->setParsedKey('foo.bar', ['foo']);
         $r->expects($this->never())->method('parseBasicSegments');
         $r->expects($this->never())->method('parseNamespacedSegments');

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
 class SupportServiceProviderTest extends TestCase
@@ -13,7 +14,7 @@ class SupportServiceProviderTest extends TestCase
         ServiceProvider::$publishes = [];
         ServiceProvider::$publishGroups = [];
 
-        $app = m::mock('Illuminate\\Foundation\\Application')->makePartial();
+        $app = m::mock(Application::class)->makePartial();
         $one = new ServiceProviderForTestingOne($app);
         $one->boot();
         $two = new ServiceProviderForTestingTwo($app);
@@ -29,8 +30,8 @@ class SupportServiceProviderTest extends TestCase
     {
         $toPublish = ServiceProvider::publishableProviders();
         $expected = [
-            'Illuminate\Tests\Support\ServiceProviderForTestingOne',
-            'Illuminate\Tests\Support\ServiceProviderForTestingTwo',
+            ServiceProviderForTestingOne::class,
+            ServiceProviderForTestingTwo::class,
         ];
         $this->assertEquals($expected, $toPublish, 'Publishable service providers do not return expected set of providers.');
     }
@@ -43,7 +44,7 @@ class SupportServiceProviderTest extends TestCase
 
     public function testSimpleAssetsArePublishedCorrectly()
     {
-        $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingOne');
+        $toPublish = ServiceProvider::pathsToPublish(ServiceProviderForTestingOne::class);
         $this->assertArrayHasKey('source/unmarked/one', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertArrayHasKey('source/tagged/one', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertEquals(['source/unmarked/one' => 'destination/unmarked/one', 'source/tagged/one' => 'destination/tagged/one'], $toPublish, 'Service provider does not return expected set of published paths.');
@@ -51,7 +52,7 @@ class SupportServiceProviderTest extends TestCase
 
     public function testMultipleAssetsArePublishedCorrectly()
     {
-        $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingTwo');
+        $toPublish = ServiceProvider::pathsToPublish(ServiceProviderForTestingTwo::class);
         $this->assertArrayHasKey('source/unmarked/two/a', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertArrayHasKey('source/unmarked/two/b', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertArrayHasKey('source/unmarked/two/c', $toPublish, 'Service provider does not return expected published path key.');
@@ -69,7 +70,7 @@ class SupportServiceProviderTest extends TestCase
 
     public function testSimpleTaggedAssetsArePublishedCorrectly()
     {
-        $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingOne', 'some_tag');
+        $toPublish = ServiceProvider::pathsToPublish(ServiceProviderForTestingOne::class, 'some_tag');
         $this->assertArrayNotHasKey('source/tagged/two/a', $toPublish, 'Service provider does return unexpected tagged path key.');
         $this->assertArrayNotHasKey('source/tagged/two/b', $toPublish, 'Service provider does return unexpected tagged path key.');
         $this->assertArrayHasKey('source/tagged/one', $toPublish, 'Service provider does not return expected tagged path key.');
@@ -78,7 +79,7 @@ class SupportServiceProviderTest extends TestCase
 
     public function testMultipleTaggedAssetsArePublishedCorrectly()
     {
-        $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingTwo', 'some_tag');
+        $toPublish = ServiceProvider::pathsToPublish(ServiceProviderForTestingTwo::class, 'some_tag');
         $this->assertArrayHasKey('source/tagged/two/a', $toPublish, 'Service provider does not return expected tagged path key.');
         $this->assertArrayHasKey('source/tagged/two/b', $toPublish, 'Service provider does not return expected tagged path key.');
         $this->assertArrayNotHasKey('source/tagged/one', $toPublish, 'Service provider does return unexpected tagged path key.');

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Closure;
 use stdClass;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -51,7 +52,7 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
         $builder->shouldReceive('where')->with('baz', 'taylor');
         $builder->shouldReceive('where')->with('faz', true);
         $builder->shouldReceive('where')->with('not', '!=', 'admin');
-        $builder->shouldReceive('where')->with(m::type('Closure'))->andReturnUsing(function () use ($builder, $closure) {
+        $builder->shouldReceive('where')->with(m::type(Closure::class))->andReturnUsing(function () use ($builder, $closure) {
             $closure($builder);
         });
         $builder->shouldReceive('where')->with('closure', 1);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\File\File;
 use Illuminate\Contracts\Validation\ImplicitRule;
 use Illuminate\Validation\PresenceVerifierInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 
 class ValidationValidatorTest extends TestCase
 {
@@ -250,7 +251,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, [], ['name' => 'required']);
         $v->setContainer($container = m::mock(Container::class));
         $v->addReplacer('required', 'Foo@bar');
-        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock('stdClass'));
+        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock(stdClass::class));
         $foo->shouldReceive('bar')->once()->andReturn('replaced!');
         $v->passes();
         $v->messages()->setFormat(':message');
@@ -3159,7 +3160,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo']);
         $v->setContainer($container = m::mock(Container::class));
         $v->addExtension('foo', 'Foo@bar');
-        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock('stdClass'));
+        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock(stdClass::class));
         $foo->shouldReceive('bar')->once()->andReturn(false);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
@@ -3173,7 +3174,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo']);
         $v->setContainer($container = m::mock(Container::class));
         $v->addExtension('foo', 'Foo');
-        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock('stdClass'));
+        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock(stdClass::class));
         $foo->shouldReceive('validate')->once()->andReturn(false);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
@@ -4212,7 +4213,7 @@ class ValidationValidatorTest extends TestCase
 
     protected function getTranslator()
     {
-        return m::mock(\Illuminate\Contracts\Translation\Translator::class);
+        return m::mock(TranslatorContract::class);
     }
 
     public function getIlluminateArrayTranslator()

--- a/tests/View/Blade/AbstractBladeTestCase.php
+++ b/tests/View/Blade/AbstractBladeTestCase.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\BladeCompiler;
 
 abstract class AbstractBladeTestCase extends TestCase
@@ -12,7 +13,7 @@ abstract class AbstractBladeTestCase extends TestCase
 
     public function setUp()
     {
-        $this->compiler = new BladeCompiler(m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $this->compiler = new BladeCompiler(m::mock(Filesystem::class), __DIR__);
         parent::setUp();
     }
 

--- a/tests/View/Blade/BladeElseAuthStatementsTest.php
+++ b/tests/View/Blade/BladeElseAuthStatementsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeElseAuthStatementsTest extends TestCase
@@ -47,6 +48,6 @@ wheeze
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeElseGuestStatementsTest.php
+++ b/tests/View/Blade/BladeElseGuestStatementsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeElseGuestStatementsTest extends TestCase
@@ -31,6 +32,6 @@ wheeze
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeIfAuthStatementsTest.php
+++ b/tests/View/Blade/BladeIfAuthStatementsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeIfAuthStatementsTest extends TestCase
@@ -39,6 +40,6 @@ breeze
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeIfGuestStatementsTest.php
+++ b/tests/View/Blade/BladeIfGuestStatementsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeIfGuestStatementsTest extends TestCase
@@ -27,6 +28,6 @@ breeze
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(Filesystem::class);
     }
 }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\View;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\BladeCompiler;
 
 class ViewBladeCompilerTest extends TestCase
@@ -94,6 +95,6 @@ class ViewBladeCompilerTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(Filesystem::class);
     }
 }

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\View;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\View\Engines\CompilerEngine;
+use Illuminate\View\Compilers\CompilerInterface;
 
 class ViewCompilerEngineTest extends TestCase
 {
@@ -39,6 +40,6 @@ class ViewCompilerEngineTest extends TestCase
 
     protected function getEngine()
     {
-        return new CompilerEngine(m::mock('Illuminate\View\Compilers\CompilerInterface'));
+        return new CompilerEngine(m::mock(CompilerInterface::class));
     }
 }

--- a/tests/View/ViewEngineResolverTest.php
+++ b/tests/View/ViewEngineResolverTest.php
@@ -4,12 +4,13 @@ namespace Illuminate\Tests\View;
 
 use stdClass;
 use PHPUnit\Framework\TestCase;
+use Illuminate\View\Engines\EngineResolver;
 
 class ViewEngineResolverTest extends TestCase
 {
     public function testResolversMayBeResolved()
     {
-        $resolver = new \Illuminate\View\Engines\EngineResolver;
+        $resolver = new EngineResolver;
         $resolver->register('foo', function () {
             return new stdClass;
         });
@@ -23,7 +24,7 @@ class ViewEngineResolverTest extends TestCase
      */
     public function testResolverThrowsExceptionOnUnknownEngine()
     {
-        $resolver = new \Illuminate\View\Engines\EngineResolver;
+        $resolver = new EngineResolver;
         $resolver->resolve('foo');
     }
 }

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -4,6 +4,8 @@ namespace Illuminate\Tests\View;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\View\FileViewFinder;
+use Illuminate\Filesystem\Filesystem;
 
 class ViewFileViewFinderTest extends TestCase
 {
@@ -145,6 +147,6 @@ class ViewFileViewFinderTest extends TestCase
 
     protected function getFinder()
     {
-        return new \Illuminate\View\FileViewFinder(m::mock('Illuminate\Filesystem\Filesystem'), [__DIR__]);
+        return new FileViewFinder(m::mock(Filesystem::class), [__DIR__]);
     }
 }

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -2,9 +2,16 @@
 
 namespace Illuminate\Tests\View;
 
+use Closure;
+use ArrayAccess;
 use Mockery as m;
 use Illuminate\View\View;
+use Illuminate\View\Factory;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\MessageBag;
+use Illuminate\Contracts\View\Engine;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Renderable;
 
 class ViewTest extends TestCase
 {
@@ -68,15 +75,15 @@ class ViewTest extends TestCase
 
     public function testRenderSectionsReturnsEnvironmentSections()
     {
-        $view = m::mock('Illuminate\View\View[render]', [
-            m::mock('Illuminate\View\Factory'),
-            m::mock(\Illuminate\Contracts\View\Engine::class),
+        $view = m::mock(View::class.'[render]', [
+            m::mock(Factory::class),
+            m::mock(Engine::class),
             'view',
             'path',
             [],
         ]);
 
-        $view->shouldReceive('render')->with(m::type('Closure'))->once()->andReturn($sections = ['foo' => 'bar']);
+        $view->shouldReceive('render')->with(m::type(Closure::class))->once()->andReturn($sections = ['foo' => 'bar']);
 
         $this->assertEquals($sections, $view->renderSections());
     }
@@ -101,12 +108,12 @@ class ViewTest extends TestCase
         $view->getFactory()->shouldReceive('make')->once()->with('foo', ['data']);
         $result = $view->nest('key', 'foo', ['data']);
 
-        $this->assertInstanceOf('Illuminate\View\View', $result);
+        $this->assertInstanceOf(View::class, $result);
     }
 
     public function testViewAcceptsArrayableImplementations()
     {
-        $arrayable = m::mock('Illuminate\Contracts\Support\Arrayable');
+        $arrayable = m::mock(Arrayable::class);
         $arrayable->shouldReceive('toArray')->once()->andReturn(['foo' => 'bar', 'baz' => ['qux', 'corge']]);
 
         $view = $this->getView($arrayable);
@@ -129,7 +136,7 @@ class ViewTest extends TestCase
     public function testViewArrayAccess()
     {
         $view = $this->getView(['foo' => 'bar']);
-        $this->assertInstanceOf('ArrayAccess', $view);
+        $this->assertInstanceOf(ArrayAccess::class, $view);
         $this->assertTrue($view->offsetExists('foo'));
         $this->assertEquals($view->offsetGet('foo'), 'bar');
         $view->offsetSet('foo', 'baz');
@@ -141,7 +148,7 @@ class ViewTest extends TestCase
     public function testViewConstructedWithObjectData()
     {
         $view = $this->getView(new DataObjectStub);
-        $this->assertInstanceOf('ArrayAccess', $view);
+        $this->assertInstanceOf(ArrayAccess::class, $view);
         $this->assertTrue($view->offsetExists('foo'));
         $this->assertEquals($view->offsetGet('foo'), 'bar');
         $view->offsetSet('foo', 'baz');
@@ -183,7 +190,7 @@ class ViewTest extends TestCase
         $view->getFactory()->shouldReceive('decrementRender')->once()->ordered();
         $view->getFactory()->shouldReceive('flushStateIfDoneRendering')->once();
 
-        $view->renderable = m::mock('Illuminate\Contracts\Support\Renderable');
+        $view->renderable = m::mock(Renderable::class);
         $view->renderable->shouldReceive('render')->once()->andReturn('text');
         $this->assertEquals('contents', $view->render());
     }
@@ -209,13 +216,13 @@ class ViewTest extends TestCase
         $view = $this->getView();
         $errors = ['foo' => 'bar', 'qu' => 'ux'];
         $this->assertSame($view, $view->withErrors($errors));
-        $this->assertInstanceOf('Illuminate\Support\MessageBag', $view->errors);
+        $this->assertInstanceOf(MessageBag::class, $view->errors);
         $foo = $view->errors->get('foo');
         $this->assertEquals($foo[0], 'bar');
         $qu = $view->errors->get('qu');
         $this->assertEquals($qu[0], 'ux');
         $data = ['foo' => 'baz'];
-        $this->assertSame($view, $view->withErrors(new \Illuminate\Support\MessageBag($data)));
+        $this->assertSame($view, $view->withErrors(new MessageBag($data)));
         $foo = $view->errors->get('foo');
         $this->assertEquals($foo[0], 'baz');
     }
@@ -223,8 +230,8 @@ class ViewTest extends TestCase
     protected function getView($data = [])
     {
         return new View(
-            m::mock('Illuminate\View\Factory'),
-            m::mock(\Illuminate\Contracts\View\Engine::class),
+            m::mock(Factory::class),
+            m::mock(Engine::class),
             'view',
             'path',
             $data


### PR DESCRIPTION
Use short ::class notation for following tests
* Auth
* Cache
* Container
* Database
* Events
* Filesystem
* Foundation
* Hashing
* Http
* Integration
* Log
* Mail
* Notifications
* Pagination
* Pipeline
* Queue
* Redis
* Routing
* Session
* Support
* Validation
* View