### PR TITLE
[5.7] Check that a specific error is missing

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -887,9 +887,20 @@ class TestResponse
      *
      * @return $this
      */
-    public function assertSessionHasNoErrors()
+    public function assertSessionHasNoErrors($keys = [], $errorBag = 'default')
     {
-        $this->assertSessionMissing('errors');
+        $keys = (array) $keys;
+
+        if ( empty($keys) )
+        {
+            return $this->assertSessionMissing('errors');
+        }
+
+        $errors = $this->session()->get('errors')->getBag($errorBag);
+
+        foreach ($keys as $key) {
+            PHPUnit::assertFalse($errors->has($key), "Session has an unexpected error: $key");
+        }
 
         return $this;
     }


### PR DESCRIPTION
This will allow to check that a specific field has no error in tests.
My use case is the following.

I have a form with these fields

`Label`, `With uploads`, `Upload label`, `Upload deadline`

The `Upload label` and `Upload deadline` fields are only required when the `With uploads` checkbox is checked.

I have a test where i check that the required field validation is correct.

I'm checking that when the `With uploads` is not checked i should have no errors for `Upload label`, `Upload deadline`

```php
        $response->assertSessionHasErrors(['label']);
        $response->assertSessionHasNoErrors(['presentation_label', 'presentation_upload_deadline']);
```

Of course this update does not introduce any breaking changes, if the `$keys` argument is empty we will just assert that there is no errors at all.

Also, i checked the `FoundationTestResponseTest` and found no existing tests about session error assertions. If you would like i can make another PR to add tests for all session assertions.