### PR TITLE
[5.7] Make PendingResourceRegistration macroable

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Traits\Macroable;
 class PendingResourceRegistration
 {
     use Macroable;
-    
+
     /**
      * The resource registrar.
      *

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -2,8 +2,12 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Support\Traits\Macroable;
+
 class PendingResourceRegistration
 {
+    use Macroable;
+    
     /**
      * The resource registrar.
      *


### PR DESCRIPTION
By making `PendingResourceRegistration` macroable users can define their own helper methods when registering routes.

Here's an example of a macro definition

```php
PendingResourceRegistration::macro('can', function(string $permission) {
   $this->middleware("can:{$permission}");
});
```

and it's usage:


```php
Route::resource('users', UsersController::class)->can('administerUsers');
```


