### PR TITLE
Adds str_wrap and stringify helper methods

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -993,6 +993,35 @@ if (! function_exists('str_start')) {
     }
 }
 
+if (! function_exists('str_wrap')) {
+    /**
+     * Wraps string with single instance of given value.
+     *
+     * @param  string  $value
+     * @param  string  $wrap
+     * @return string
+     */
+    function str_wrap($value, $wrap)
+    {
+        return Str::finish(Str::start($value, $wrap), $wrap);
+    }
+}
+
+if (! function_exists('stringify')) {
+    /**
+     * Stringify given scalar value.
+     * E.g. true -> 'true', 0 -> '0', null -> 'null', 10.0 -> '10.0' etc.
+     * Note: It does not work for octal represented integers etc, i.e. 0123 (Octal 83) will get stringified to '83' instead of '0123'.
+     *
+     * @param  mixed       $value
+     * @return string|null
+     */
+    function stringify($value)
+    {
+        return is_scalar($value) ? (is_string($value) ? $value : var_export($value, true)) : null;
+    }
+}
+
 if (! function_exists('studly_case')) {
     /**
      * Convert a value to studly caps case.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -297,6 +297,23 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('/test/string', Str::start('//test/string', '/'));
     }
 
+    public function testStrWrap()
+    {
+        $this->assertSame('/test/string/', str_wrap('test/string', '/'));
+        $this->assertSame('/test/string/', str_wrap('/test/string', '/'));
+        $this->assertSame('/test/string/', str_wrap('//test/string/', '/'));
+    }
+
+    public function testStringify()
+    {
+        $this->assertSame('true', stringify(true));
+        $this->assertSame('false', stringify(false));
+        $this->assertSame('123', stringify(123));
+        $this->assertSame('-123', stringify(-123));
+        $this->assertSame('1.234', stringify(1.234));
+        $this->assertSame('string', stringify('string'));
+    }
+
     public function testSnakeCase()
     {
         $this->assertEquals('foo_bar', Str::snake('fooBar'));


### PR DESCRIPTION
__Description__

Adds 2 new string helper methods:
- str_wrap(), which interally usage str_start() and str_finish() - wrap string with single instance of given value.
- stringify() - returns string representation of given scalar value.
  It is different from strval() or (string) $x as illustrated below.

    ```php
    >>> (string) null
    => ""
    >>> stringify(null)
    => "null"
    >>> (string) false
    => ""
    >>> stringify(false)
    => "false"
    >>> (string) true
    => "1"
    >>> stringify(true)
    => "true"
    ```

__Backward compatibility__

It is a new helper method and hence is backward compatible.


