### PR TITLE
Adds epoch() and millitime() helper methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "erusev/parsedown": "^1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "^1.12",
-        "nesbot/carbon": "^1.26.3",
+        "nesbot/carbon": "^2.3.0",
         "opis/closure": "^3.1",
         "psr/container": "^1.0",
         "psr/simple-cache": "^1.0",

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -633,6 +633,32 @@ if (! function_exists('now')) {
     }
 }
 
+if (! function_exists('epoch')) {
+    /**
+     * Returns current Unix epoch time.
+     *
+     * @param  \DateTimeZone|string|null $tz
+     * @return int
+     */
+    function epoch($tz = null)
+    {
+        return now($tz)->unix();
+    }
+}
+
+if (! function_exists('millitime')) {
+    /**
+     * Return current Unix timestamp with milliseconds.
+     *
+     * @param  \DateTimeZone|string|null $tz
+     * @return int
+     */
+    function millitime($tz = null)
+    {
+        return (int) now($tz)->getPreciseTimestamp(3);
+    }
+}
+
 if (! function_exists('old')) {
     /**
      * Retrieve an old input item.

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation;
 
 use Mockery as m;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 
@@ -81,5 +82,13 @@ class FoundationHelpersTest extends TestCase
         $this->assertEquals('/versioned.css', $result);
 
         unlink(public_path('mix-manifest.json'));
+    }
+
+    public function testEpochAndMillitime()
+    {
+        Carbon::setTestNow(Carbon::create(2018, 10, 5, 19, 14, 45));
+
+        $this->assertSame(1538766885, epoch());
+        $this->assertSame(1538766885000, millitime());
     }
 }


### PR DESCRIPTION

__Description__

Adds 2 new time related helper methods:
- epoch() - returns current unix epoch timestamp(seconds).
- millitime() - similar to php's microtime() but instead returns milliseconds.
- Additionally, updates nesbot/carbon dependency to ^2.3.0. I checked change logs and didn't find any backward incompatible changes even though it moves from 1.* to 2.* .

__Backward compatibility__

It is a new helper method and hence is backward compatible.

__Reason__

Many a times in code one quickly needs current epoch time or milliseconds, e.g. instrumenting code to measure runtime metrics, or storing epoch in database columns etc.
