### PR TITLE
Don't cycle remember token on logout if not set

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -489,7 +489,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // listening for anytime a user signs out of this application manually.
         $this->clearUserDataFromStorage();
 
-        if (! is_null($this->user)) {
+        if (! is_null($this->user) && ! empty($user->getRememberToken())) {
             $this->cycleRememberToken($user);
         }
 


### PR DESCRIPTION
The remember token was cycled even though the remember functionality was never used and the token set. In the database it looked like all the users had used the functionality, which was confusing. This change stops that and only cycles the token if it is set.
