### PR TITLE
[5.7] Include null in the return types hints of InteractsWithInput

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -15,7 +15,7 @@ trait InteractsWithInput
      *
      * @param  string  $key
      * @param  string|array|null  $default
-     * @return string|array
+     * @return string|array|null
      */
     public function server($key = null, $default = null)
     {
@@ -38,7 +38,7 @@ trait InteractsWithInput
      *
      * @param  string  $key
      * @param  string|array|null  $default
-     * @return string|array
+     * @return string|array|null
      */
     public function header($key = null, $default = null)
     {
@@ -257,7 +257,7 @@ trait InteractsWithInput
      *
      * @param  string  $key
      * @param  string|array|null  $default
-     * @return string|array
+     * @return string|array|null
      */
     public function query($key = null, $default = null)
     {
@@ -270,7 +270,7 @@ trait InteractsWithInput
      * @param  string  $key
      * @param  string|array|null  $default
      *
-     * @return string|array
+     * @return string|array|null
      */
     public function post($key = null, $default = null)
     {
@@ -293,7 +293,7 @@ trait InteractsWithInput
      *
      * @param  string  $key
      * @param  string|array|null  $default
-     * @return string|array
+     * @return string|array|null
      */
     public function cookie($key = null, $default = null)
     {
@@ -383,7 +383,7 @@ trait InteractsWithInput
      * @param  string  $source
      * @param  string  $key
      * @param  string|array|null  $default
-     * @return string|array
+     * @return string|array|null
      */
     protected function retrieveItem($source, $key, $default)
     {


### PR DESCRIPTION
The return value can be null in a few cases:

* when it return `$default`
* when a middleware converts empty strings to null

This PR is mostly so it stops confusing programs like PHPStan