### PR TITLE
[5.7] Fix missing dependency

### DIFF
--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^7.1.3",
         "illuminate/contracts": "5.7.*",
+        "illuminate/support": "5.7.*",
         "psr/container": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
The array class is used in the container and the contextual binding builder. If only the service container is required in another project, `Illuminate\Support\Arr` will not be present after updating or installing Composer dependencies.