### PR TITLE
Allow users, in JSON API, define localized message for ValidationException

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -53,7 +53,7 @@ class ValidationException extends Exception
      */
     public function __construct($validator, $response = null, $errorBag = 'default')
     {
-        parent::__construct(trans('validation.failed'));
+        parent::__construct(__('validation.failed'));
 
         $this->response = $response;
         $this->errorBag = $errorBag;

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -53,7 +53,7 @@ class ValidationException extends Exception
      */
     public function __construct($validator, $response = null, $errorBag = 'default')
     {
-        parent::__construct('The given data was invalid.');
+        parent::__construct(trans('validation.failed'));
 
         $this->response = $response;
         $this->errorBag = $errorBag;


### PR DESCRIPTION
Currently, in JSON APIs, when we throw a ValidationException, the result JSON is something like this below:

```json
{
  "message": "The given data was invalid.",
  "errors": [
    "field_1": ["....."]
  ]
}
```

After this change, It will be possible to return localized message, like this (in Portuguese, for example), without have to modify source code of Laravel:

```json
{
  "message": "Os dados preenchidos estão inválidos.",
  "errors": [
    "field_1": ["....."]
  ]
}
```