### PR TITLE
[5.8] Change password min length to 8

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -172,7 +172,7 @@ class PasswordBroker implements PasswordBrokerContract
             $credentials['password_confirmation'],
         ];
 
-        return $password === $confirm && mb_strlen($password) >= 6;
+        return $password === $confirm && mb_strlen($password) >= 8;
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -66,7 +66,7 @@ trait ResetsPasswords
         return [
             'token' => 'required',
             'email' => 'required|email',
-            'password' => 'required|confirmed|min:6',
+            'password' => 'required|confirmed|min:8',
         ];
     }
 

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -90,9 +90,9 @@ class AuthPasswordBrokerTest extends TestCase
         }));
     }
 
-    public function testRedirectReturnedByRemindWhenPasswordsLessThanSixCharacters()
+    public function testRedirectReturnedByRemindWhenPasswordsLessThanEightCharacters()
     {
-        $creds = ['password' => 'abc', 'password_confirmation' => 'abc'];
+        $creds = ['password' => 'abcdefg', 'password_confirmation' => 'abcdefg'];
         $broker = $this->getBroker($mocks = $this->getMocks());
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(CanResetPassword::class));
 


### PR DESCRIPTION
This PR updates the default minimum password length to be 8 (the current default is 6).

⚠️ Note: this requires a companion PR laravel/laravel#4794 in order to update the registration controller and password reset language lines.

Last year, NIST published new standards on memorized secrets (i.e. user passwords), stipulating in [Section 5.1.1.1](https://pages.nist.gov/800-63-3/sp800-63b.html#sec5):

> Memorized secrets SHALL be at least 8 characters in length if chosen by the subscriber.

[Password length](https://pages.nist.gov/800-63-3/sp800-63b.html#appA) is only a part of a security strategy employed by the framework, but the move to an 8-character minimum is long overdue.

Please let me know if there are any questions or comments. Thanks!
