### PR TITLE
[5.7] Deleted unused const

### DIFF
--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -13,13 +13,6 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
     use InteractsWithTime;
 
     /**
-     * The maximum value that can be specified as an expiration delta.
-     *
-     * @var int
-     */
-    const REALTIME_MAXDELTA_IN_MINUTES = 43200;
-
-    /**
      * The Memcached instance.
      *
      * @var \Memcached


### PR DESCRIPTION
 After reverting https://github.com/laravel/framework/pull/25912 we still had a `REALTIME_MAXDELTA_IN_MINUTES` const.
 Usage of this const was deleted in https://github.com/laravel/framework/commit/e5be0dbb4ff2bf2ce9861065f64fc1552a3d59f9 so, this const no needed more

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
