### PR TITLE
[5.7] Revert email lang template changes

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -51,12 +51,12 @@
 @component('mail::subcopy')
 @lang(
     "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
-    'into your web browser: ',
+    'into your web browser: [:actionURL](:actionURL)',
     [
-        'actionText' => $actionText
+        'actionText' => $actionText,
+        'actionUrl' => $actionUrl
     ]
 )
-[{{ $actionUrl }}]({!! $actionUrl !!})
 @endcomponent
 @endisset
 @endcomponent


### PR DESCRIPTION
Reverts my original PR https://github.com/laravel/framework/pull/25723 - because all the `lang` changes have been reverted, so we should revert this as well.