### PR TITLE
[5.7] @throws tag is missing in docblocks

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -203,6 +203,8 @@ class Mailable implements MailableContract, Renderable
      * Render the mailable into a view.
      *
      * @return \Illuminate\View\View
+     *
+     * @throws \ReflectionException
      */
     public function render()
     {
@@ -217,6 +219,8 @@ class Mailable implements MailableContract, Renderable
      * Build the view for the message.
      *
      * @return array|string
+     *
+     * @throws \ReflectionException
      */
     protected function buildView()
     {
@@ -244,6 +248,8 @@ class Mailable implements MailableContract, Renderable
      * Build the Markdown view for the message.
      *
      * @return array
+     *
+     * @throws \ReflectionException
      */
     protected function buildMarkdownView()
     {
@@ -265,6 +271,8 @@ class Mailable implements MailableContract, Renderable
      * Build the view data for the message.
      *
      * @return array
+     *
+     * @throws \ReflectionException
      */
     public function buildViewData()
     {


### PR DESCRIPTION
This PR adds missing docblock for `\ReflectionException`