### PR TITLE
Builder toggle function

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2632,6 +2632,21 @@ class Builder
     }
 
     /**
+     * Toggle a boolean column's value.
+     *
+     * @param  string  $column
+     * @return int
+     */
+    public function toggle($column)
+    {
+        $wrapped = $this->grammar->wrap($column);
+
+        $columns = array_merge([$column => $this->raw("!$wrapped")]);
+
+        return $this->update($columns);
+    }
+
+    /**
      * Delete a record from the database.
      *
      * @param  mixed  $id


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

A quick and painless function to toggle boolean column's value from true to false and vise versa. Equivalent to this example SQL code:

```
Update `posts` set `active` = !`active`;
```

This function prevents the need to loop through records and update them one by one. So instead of writing this:

```
foreach (Posts::all() as $post) {
  $post->active = !$post->active;
}
```

We can write this:

```
Posts::toggle('active');
```