### PR TITLE
Fix wrong Eloquent pagination count using distinct

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -742,7 +742,7 @@ class Builder
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = ($total = $this->toBase()->getCountForPagination())
+        $results = ($total = $this->toBase()->getCountForPagination($columns))
                                     ? $this->forPage($page, $perPage)->get($columns)
                                     : $this->model->newCollection();
 


### PR DESCRIPTION
The Eloquent paginate method doesn't pass to the getCountForPagination method the columns parameter.

This can results in a wrong total number of results, for example when using the paginator with joins and distinct and using the solution proposed here (https://github.com/laravel/framework/issues/15600#issuecomment-250563710).

The paginate method of the Query Builder already passes the parameter correctly.
