### PR TITLE
[5.8] Apply `square bracket syntax for array destructuring assignment` for 5.8

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -60,7 +60,7 @@ class MySqlGrammar extends Grammar
      */
     protected function compileJsonContains($column, $value)
     {
-        list($field, $path) = $this->wrapJsonFieldAndPath($column);
+        [$field, $path] = $this->wrapJsonFieldAndPath($column);
 
         return 'json_contains('.$field.', '.$value.$path.')';
     }
@@ -313,7 +313,7 @@ class MySqlGrammar extends Grammar
      */
     protected function wrapJsonSelector($value)
     {
-        list($field, $path) = $this->wrapJsonFieldAndPath($value);
+        [$field, $path] = $this->wrapJsonFieldAndPath($value);
 
         return 'json_unquote(json_extract('.$field.$path.'))';
     }

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -297,7 +297,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function wrapJsonSelector($value)
     {
-        list($field, $path) = $this->wrapJsonFieldAndPath($value);
+        [$field, $path] = $this->wrapJsonFieldAndPath($value);
 
         $selector = 'json_extract('.$field.$path.')';
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -476,7 +476,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function wrapJsonSelector($value)
     {
-        list($field, $path) = $this->wrapJsonFieldAndPath($value);
+        [$field, $path] = $this->wrapJsonFieldAndPath($value);
 
         return 'json_value('.$field.$path.')';
     }


### PR DESCRIPTION
It is a continuation of https://github.com/laravel/framework/pull/25966. We have some list() method in the master branch which not present on 5.7

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
