### PR TITLE
[5.7] Adds throws PHPDoc comment

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -122,8 +122,9 @@ class BoundMethod
     /**
      * Get the proper reflection instance for the given callback.
      *
-     * @param  callable|string  $callback
+     * @param  callable|string $callback
      * @return \ReflectionFunctionAbstract
+     * @throws \ReflectionException
      */
     protected static function getCallReflector($callback)
     {

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -124,6 +124,7 @@ class BoundMethod
      *
      * @param  callable|string $callback
      * @return \ReflectionFunctionAbstract
+     *
      * @throws \ReflectionException
      */
     protected static function getCallReflector($callback)


### PR DESCRIPTION
Looking at the `Container/BoundMethod` class I saw that in the `getCallReflector` method there was no comment on what their exception was, this PR is meant to add the exception comment that the method can throw.