### PR TITLE
[5.7] Refactoring tests

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -392,7 +392,7 @@ class ContainerTest extends TestCase
         $container->instance('object', new stdClass);
         $container->alias('object', 'alias');
 
-        $this->assertArrayHasKey('object' ,$container);
+        $this->assertArrayHasKey('object', $container);
         $this->assertArrayHasKey('alias', $container);
     }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -117,10 +117,10 @@ class ContainerTest extends TestCase
         $container['something'] = function () {
             return 'foo';
         };
-        $this->assertTrue(isset($container['something']));
+        $this->assertArrayHasKey('something', $container);
         $this->assertEquals('foo', $container['something']);
         unset($container['something']);
-        $this->assertFalse(isset($container['something']));
+        $this->assertArrayNotHasKey('something', $container);
     }
 
     public function testAliases()
@@ -392,8 +392,8 @@ class ContainerTest extends TestCase
         $container->instance('object', new stdClass);
         $container->alias('object', 'alias');
 
-        $this->assertTrue(isset($container['object']));
-        $this->assertTrue(isset($container['alias']));
+        $this->assertArrayHasKey('object' ,$container);
+        $this->assertArrayHasKey('alias', $container);
     }
 
     public function testReboundListeners()
@@ -1056,9 +1056,11 @@ class ContainerTest extends TestCase
     public function testContainerCanDynamicallySetService()
     {
         $container = new Container;
-        $this->assertFalse(isset($container['name']));
+        $this->assertArrayNotHasKey('name', $container);
         $container['name'] = 'Taylor';
-        $this->assertTrue(isset($container['name']));
+
+        $this->assertArrayHasKey('name', $container);
+
         $this->assertSame('Taylor', $container['name']);
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -138,13 +138,13 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub(['attributes' => 1, 'connection' => 2, 'table' => 3]);
         unset($model['table']);
 
-        $this->assertTrue(isset($model['attributes']));
+        $this->assertArrayHasKey('attributes', $model);
         $this->assertEquals($model['attributes'], 1);
-        $this->assertTrue(isset($model['connection']));
+        $this->assertArrayHasKey('connection', $model);
         $this->assertEquals($model['connection'], 2);
-        $this->assertFalse(isset($model['table']));
+        $this->assertArrayNotHasKey('table', $model);
         $this->assertEquals($model['table'], null);
-        $this->assertFalse(isset($model['with']));
+        $this->assertArrayNotHasKey('with', $model);
     }
 
     public function testOnly()
@@ -727,7 +727,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('abby', $array['partner']['name']);
         $this->assertNull($array['group']);
         $this->assertEquals([], $array['multi']);
-        $this->assertFalse(isset($array['password']));
+        $this->assertArrayNotHasKey('password', $array);
 
         $model->setAppends(['appendable']);
         $array = $model->toArray();

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -37,13 +37,13 @@ class LogLoggerTest extends TestCase
         });
 
         $writer->error('foo');
-        $this->assertTrue(isset($_SERVER['__log.level']));
+        $this->assertArrayHasKey('__log.level', $_SERVER);
         $this->assertEquals('error', $_SERVER['__log.level']);
         unset($_SERVER['__log.level']);
-        $this->assertTrue(isset($_SERVER['__log.message']));
+        $this->assertArrayHasKey('__log.message', $_SERVER);
         $this->assertEquals('foo', $_SERVER['__log.message']);
         unset($_SERVER['__log.message']);
-        $this->assertTrue(isset($_SERVER['__log.context']));
+        $this->assertArrayHasKey('__log.context', $_SERVER);
         $this->assertEquals([], $_SERVER['__log.context']);
         unset($_SERVER['__log.context']);
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1310,7 +1310,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(Response::class, $_SERVER['route.test.controller.middleware.class']);
         $this->assertEquals(0, $_SERVER['route.test.controller.middleware.parameters.one']);
         $this->assertEquals(['foo', 'bar'], $_SERVER['route.test.controller.middleware.parameters.two']);
-        $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
+        $this->assertArrayNotHasKey('route.test.controller.except.middleware', $_SERVER);
     }
 
     public function testControllerRoutingArrayCallable()
@@ -1330,7 +1330,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(Response::class, $_SERVER['route.test.controller.middleware.class']);
         $this->assertEquals(0, $_SERVER['route.test.controller.middleware.parameters.one']);
         $this->assertEquals(['foo', 'bar'], $_SERVER['route.test.controller.middleware.parameters.two']);
-        $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
+        $this->assertArrayNotHasKey('route.test.controller.except.middleware', $_SERVER);
         $action = $router->getRoutes()->getRoutes()[0]->getAction()['controller'];
         $this->assertEquals(RouteTestControllerStub::class.'@index', $action);
     }


### PR DESCRIPTION
Looking at some tests I saw that they can be refactored for better understanding, either from the one who reads the tests or when a test fails and show a error message.

Some tests were refactoring using:

`assertArrayHasKey`, `assertArrayNotHasKey` instead of isset function;