### PR TITLE
[5.7] Fix an issue where the worker process would not be killed by the listener when the timeout is exceeded

### DIFF
--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -105,7 +105,9 @@ class Listener
         // options available for the command. This will produce the final command
         // line array that we will pass into a Symfony process object for processing.
         $command = $this->createCommand(
-            $connection, $queue, $options
+            $connection,
+            $queue,
+            $options
         );
 
         // If the environment is set, we will append it to the command array so the
@@ -116,7 +118,11 @@ class Listener
         }
 
         return new Process(
-            $command, $this->commandPath, null, null, $options->timeout
+            $command,
+            $this->commandPath,
+            null,
+            null,
+            $options->timeout
         );
     }
 
@@ -142,7 +148,7 @@ class Listener
      */
     protected function createCommand($connection, $queue, ListenerOptions $options)
     {
-        return [
+        return array_filter([
             $this->phpBinary(),
             $this->artisanBinary(),
             'queue:work',
@@ -153,7 +159,7 @@ class Listener
             "--memory={$options->memory}",
             "--sleep={$options->sleep}",
             "--tries={$options->maxTries}",
-        ];
+        ]);
     }
 
     /**

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Queue;
 
 use Closure;
-use Illuminate\Support\ProcessUtils;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\PhpExecutableFinder;
 
@@ -38,13 +37,6 @@ class Listener
     protected $maxTries = 0;
 
     /**
-     * The queue worker command line.
-     *
-     * @var string
-     */
-    protected $workerCommand;
-
-    /**
      * The output handler callback.
      *
      * @var \Closure|null
@@ -60,19 +52,6 @@ class Listener
     public function __construct($commandPath)
     {
         $this->commandPath = $commandPath;
-        $this->workerCommand = $this->buildCommandTemplate();
-    }
-
-    /**
-     * Build the environment specific worker command.
-     *
-     * @return string
-     */
-    protected function buildCommandTemplate()
-    {
-        $command = 'queue:work %s --once --queue=%s --delay=%s --memory=%s --sleep=%s --tries=%s';
-
-        return "{$this->phpBinary()} {$this->artisanBinary()} {$command}";
     }
 
     /**
@@ -82,9 +61,7 @@ class Listener
      */
     protected function phpBinary()
     {
-        return ProcessUtils::escapeArgument(
-            (new PhpExecutableFinder)->find(false)
-        );
+        return (new PhpExecutableFinder)->find(false);
     }
 
     /**
@@ -94,9 +71,7 @@ class Listener
      */
     protected function artisanBinary()
     {
-        return defined('ARTISAN_BINARY')
-                        ? ProcessUtils::escapeArgument(ARTISAN_BINARY)
-                        : ProcessUtils::escapeArgument('artisan');
+        return defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan';
     }
 
     /**
@@ -126,21 +101,19 @@ class Listener
      */
     public function makeProcess($connection, $queue, ListenerOptions $options)
     {
-        $command = $this->workerCommand;
+        // First, we will just create the worker commands with all of the various
+        // options available for the command. This will produce the final command
+        // line array that we will pass into a Symfony process object for processing.
+        $command = $this->createCommand(
+            $connection, $queue, $options
+        );
 
-        // If the environment is set, we will append it to the command string so the
+        // If the environment is set, we will append it to the command array so the
         // workers will run under the specified environment. Otherwise, they will
         // just run under the production environment which is not always right.
         if (isset($options->environment)) {
             $command = $this->addEnvironment($command, $options);
         }
-
-        // Next, we will just format out the worker commands with all of the various
-        // options available for the command. This will produce the final command
-        // line that we will pass into a Symfony process object for processing.
-        $command = $this->formatCommand(
-            $command, $connection, $queue, $options
-        );
 
         return new Process(
             $command, $this->commandPath, null, null, $options->timeout
@@ -152,31 +125,35 @@ class Listener
      *
      * @param  string  $command
      * @param  \Illuminate\Queue\ListenerOptions  $options
-     * @return string
+     * @return array
      */
     protected function addEnvironment($command, ListenerOptions $options)
     {
-        return $command.' --env='.ProcessUtils::escapeArgument($options->environment);
+        return array_merge($command, ["--env={$options->environment}"]);
     }
 
     /**
-     * Format the given command with the listener options.
+     * Create the command with the listener options.
      *
-     * @param  string  $command
      * @param  string  $connection
      * @param  string  $queue
      * @param  \Illuminate\Queue\ListenerOptions  $options
      * @return string
      */
-    protected function formatCommand($command, $connection, $queue, ListenerOptions $options)
+    protected function createCommand($connection, $queue, ListenerOptions $options)
     {
-        return sprintf(
-            $command,
-            ProcessUtils::escapeArgument($connection),
-            ProcessUtils::escapeArgument($queue),
-            $options->delay, $options->memory,
-            $options->sleep, $options->maxTries
-        );
+        return [
+            $this->phpBinary(),
+            $this->artisanBinary(),
+            'queue:work',
+            $connection,
+            '--once',
+            "--queue={$queue}",
+            "--delay={$options->delay}",
+            "--memory={$options->memory}",
+            "--sleep={$options->sleep}",
+            "--tries={$options->maxTries}",
+        ];
     }
 
     /**

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -159,7 +159,9 @@ class Listener
             "--memory={$options->memory}",
             "--sleep={$options->sleep}",
             "--tries={$options->maxTries}",
-        ]);
+        ], function ($value) {
+            return ! is_null($value);
+        });
     }
 
     /**

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -49,6 +49,22 @@ class QueueListenerTest extends TestCase
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals($escape.PHP_BINARY.$escape." {$escape}artisan{$escape} queue:work {$escape}connection{$escape} --once --queue={$escape}queue{$escape} --delay=1 --memory=2 --sleep=3 --tries=0", $process->getCommandLine());
+        $this->assertEquals($escape.PHP_BINARY.$escape." {$escape}artisan{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--queue=queue{$escape} {$escape}--delay=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=0{$escape}", $process->getCommandLine());
+    }
+
+    public function testMakeProcessCorrectlyFormatsCommandLineWithAnEnvironmentSpecified()
+    {
+        $listener = new Listener(__DIR__);
+        $options = new ListenerOptions('test');
+        $options->delay = 1;
+        $options->memory = 2;
+        $options->timeout = 3;
+        $process = $listener->makeProcess('connection', 'queue', $options);
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
+
+        $this->assertInstanceOf(Process::class, $process);
+        $this->assertEquals(__DIR__, $process->getWorkingDirectory());
+        $this->assertEquals(3, $process->getTimeout());
+        $this->assertEquals($escape.PHP_BINARY.$escape." {$escape}artisan{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--queue=queue{$escape} {$escape}--delay=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=0{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
     }
 }

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -67,4 +67,20 @@ class QueueListenerTest extends TestCase
         $this->assertEquals(3, $process->getTimeout());
         $this->assertEquals($escape.PHP_BINARY.$escape." {$escape}artisan{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--queue=queue{$escape} {$escape}--delay=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=0{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
     }
+
+    public function testMakeProcessCorrectlyFormatsCommandLineWhenTheConnectionIsNotSpecified()
+    {
+        $listener = new Listener(__DIR__);
+        $options = new ListenerOptions('test');
+        $options->delay = 1;
+        $options->memory = 2;
+        $options->timeout = 3;
+        $process = $listener->makeProcess(null, 'queue', $options);
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
+
+        $this->assertInstanceOf(Process::class, $process);
+        $this->assertEquals(__DIR__, $process->getWorkingDirectory());
+        $this->assertEquals(3, $process->getTimeout());
+        $this->assertEquals($escape.PHP_BINARY.$escape." {$escape}artisan{$escape} {$escape}queue:work{$escape} {$escape}--once{$escape} {$escape}--queue=queue{$escape} {$escape}--delay=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=0{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
+    }
 }


### PR DESCRIPTION
Refer to #25980 for the issue.

This PR fixes the issue by passing an array into the Process constructor rather than the formatted stripe. Refer to https://github.com/symfony/symfony/pull/21474 for the reason for passing an array in.

Here are some test cases that I've tried to show how they differ. I ran `php artisan queue:listen database --timeout 10` on the 5.7 branch and on my branch. Then I ran `ps -ef | grep "[q]ueue"`. The results from that second command are as follows:

On the 5.7 branch, on Mac:
```
$ ps -ef | grep "[q]ueue"
  501 13085 12444   0  1:16am ttys007    0:00.11 php artisan queue:listen database --timeout 10
  501 13089 13085   0  1:16am ttys007    0:00.12 /usr/local/Cellar/php/7.2.1_12/bin/php artisan queue:work database --once --queue=default --delay=0 --memory=128 --sleep=3 --tries=0
```

On the 5.7 branch, on Linux:
```
$ ps -ef | grep "[q]ueue"
vagrant   5512  5485 46 05:21 pts/1    00:00:00 php artisan queue:listen database --timeout 10
vagrant   5521  5512  0 05:21 pts/1    00:00:00 sh -c '/usr/bin/php7.2' 'artisan' queue:work 'database' --once --queue='default' --delay=0 --memory=128 --sleep=3 --tries=0
vagrant   5522  5521  0 05:21 pts/1    00:00:00 /usr/bin/php7.2 artisan queue:work database --once --queue=default --delay=0 --memory=128 --sleep=3 --tries=0
```

On the my branch, on Mac:
```
$ ps -ef | grep "[q]ueue"
  501 13818  9815   0  1:22am ttys001    0:00.14 php artisan queue:listen database --timeout 10
  501 13846 13818   0  1:22am ttys001    0:00.13 /usr/local/Cellar/php/7.2.1_12/bin/php artisan queue:work database --once --queue=default --delay=0 --memory=128 --sleep=3 --tries=0
```

On the my branch, on Linux:
```
$ ps -ef | grep "[q]ueue"
vagrant   5536  5485 46 05:21 pts/1    00:00:00 php artisan queue:listen database --timeout 10
vagrant   5540  5536  0 05:21 pts/1    00:00:00 /usr/bin/php7.2 artisan queue:work database --once --queue=default --delay=0 --memory=128 --sleep=3 --tries=0
```

As you can see, on my branch the listener correctly forks the worker command, which will allow the SIGTERM signal to terminate the correct process.

Let me know what you think about this approach, and if you know any issues with this.
