### PR TITLE
[5.6] Revert email lang template changes.

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -56,7 +56,7 @@
     'into your web browser: [:actionURL](:actionURL)',
     [
         'actionText' => $actionText,
-        'actionURL' => $actionUrl
+        'actionURL' => $actionUrl,
     ]
 )
 @endcomponent

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -53,12 +53,12 @@
 @component('mail::subcopy')
 @lang(
     "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
-    'into your web browser: ',
+    'into your web browser: [:actionURL](:actionURL)',
     [
-        'actionText' => $actionText
+        'actionText' => $actionText,
+        'actionURL' => $actionUrl
     ]
 )
-[{{ $actionUrl }}]({!! $actionUrl !!})
 @endcomponent
 @endisset
 @endcomponent


### PR DESCRIPTION
I`m not sure, but probably we also should reverting `email lang template` ([#25734](https://github.com/laravel/framework/pull/25734)) changes in 5.6 version

Since in prev 5.6 release we also had:
 - Fixed translation escaping ([#25858](https://github.com/laravel/framework/pull/25858), [4c46500](https://github.com/laravel/framework/commit/4c465007bbf51d7f269871cd76b6d99de7df90bb))


The same revert was in 5.7 (https://github.com/laravel/framework/pull/25963)

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
