### PR TITLE
[5.7] Simplify condition for `__laravel_notification_queued` meta data key in MailChanel

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -109,9 +109,7 @@ class MailChannel
     {
         return [
             '__laravel_notification' => get_class($notification),
-            '__laravel_notification_queued' => in_array(
-                ShouldQueue::class, class_implements($notification)
-            ),
+            '__laravel_notification_queued' => $notification instanceof ShouldQueue,
         ];
     }
 


### PR DESCRIPTION

```PHP
          in_array(ShouldQueue::class, class_implements($notification)),
```
Will return the same result as 
```PHP
$notification instanceof ShouldQueue
```

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
