### PR TITLE
[5.7] Correct Collection@firstWhere() return docblock

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -677,7 +677,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return static
+     * @return mixed
      */
     public function firstWhere($key, $operator, $value = null)
     {


### PR DESCRIPTION
Like `Collection@first()`, this [method](https://github.com/laravel/framework/pull/22261) will return an item in the collection (or null), not necessarily an instance of that collection.