### PR TITLE
[5.7] Correct mail localization docblock

### DIFF
--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -17,7 +17,7 @@ class PendingMail
     /**
      * The locale of the message.
      *
-     * @var array
+     * @var string
      */
     protected $locale;
 

--- a/src/Illuminate/Support/Traits/Localizable.php
+++ b/src/Illuminate/Support/Traits/Localizable.php
@@ -11,7 +11,7 @@ trait Localizable
      *
      * @param  string   $locale
      * @param  \Closure $callback
-     * @return bool
+     * @return mixed
      */
     public function withLocale($locale, $callback)
     {


### PR DESCRIPTION
`Localizable@withLocale()` returns the invoked callback result so it may be any value. e.g., In the only two uses within the framework, the return type is `void`.