### PR TITLE
[5.7] Mailable render() respects Mailable@locale

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -208,11 +208,13 @@ class Mailable implements MailableContract, Renderable
      */
     public function render()
     {
-        Container::getInstance()->call([$this, 'build']);
+        return $this->withLocale($this->locale, function () {
+            Container::getInstance()->call([$this, 'build']);
 
-        return Container::getInstance()->make('mailer')->render(
-            $this->buildView(), $this->buildViewData()
-        );
+            return Container::getInstance()->make('mailer')->render(
+                $this->buildView(), $this->buildViewData()
+            );
+        });
     }
 
     /**

--- a/tests/Integration/Mail/RenderingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/RenderingMailWithLocaleTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Mail;
+
+use Illuminate\Mail\Mailable;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\View;
+
+/**
+ * @group integration
+ */
+class RenderingMailWithLocaleTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.locale', 'en');
+
+        View::addLocation(__DIR__.'/Fixtures');
+
+        app('translator')->setLoaded([
+            '*' => [
+                '*' => [
+                    'en' => ['nom' => 'name'],
+                    'es' => ['nom' => 'nombre'],
+                ],
+            ],
+        ]);
+    }
+
+    public function testMailableRendersInDefaultLocale()
+    {
+        $mail = new RenderedTestMail;
+
+        $this->assertEquals("name\n", $mail->render());
+    }
+
+    public function testMailableRendersInSelectedLocale()
+    {
+        $mail = (new RenderedTestMail)->locale('es');
+
+        $this->assertEquals("nombre\n", $mail->render());
+    }
+
+    public function testMailableRendersInAppSelectedLocale()
+    {
+        $this->app->setLocale('es');
+
+        $mail = new RenderedTestMail;
+
+        $this->assertEquals("nombre\n", $mail->render());
+    }
+}
+
+class RenderedTestMail extends Mailable
+{
+    public function build()
+    {
+        return $this->view('view');
+    }
+}


### PR DESCRIPTION
https://github.com/laravel/ideas/issues/1318

When testing mailables in the browser or calling `Mailable@render()` in production (e.g., to store the HTML string in the database), this will render in `Mailable@locale` when it is filled.

Testing example:

```php
$mail = new App\Mail\OrderConfirmation(App\Order::first());
$translatedHtml = $mail->locale('es')->render();
```

Production example:

```php
$mail = new OrderConfirmation($order);
Mail::to($user)->queue($mail);

// this would be in $user->preferredLocale()
$translatedHtml = $mail->render();
```