### PR TITLE
[5.7] Make use of a test listener

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,9 @@
             </exclude>
         </whitelist>
     </filter>
+    <listeners>
+        <listener class="Illuminate\Tests\TestListener" file="./tests/TestListener.php"/>
+    </listeners>
     <php>
       <!--
       <env name="REDIS_HOST" value="127.0.0.1" />

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -24,7 +24,6 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         parent::tearDown();
 
-        m::close();
         Carbon::setTestNow(null);
     }
 

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -12,11 +12,6 @@ use Illuminate\Contracts\Auth\Authenticatable;
 
 class AuthDatabaseUserProviderTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testRetrieveByIDReturnsUserWhenUserIsFound()
     {
         $conn = m::mock(Connection::class);

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -12,11 +12,6 @@ use Illuminate\Contracts\Auth\Authenticatable;
 
 class AuthEloquentUserProviderTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testRetrieveByIDReturnsUser()
     {
         $provider = $this->getProviderMock();

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -21,11 +21,6 @@ use Illuminate\Contracts\Encryption\Encrypter;
 
 class AuthGuardTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBasicReturnsNullOnValidAttempt()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -14,11 +14,6 @@ use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
 
 class AuthPasswordBrokerTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testIfUserIsNotFoundErrorRedirectIsReturned()
     {
         $mocks = $this->getMocks();

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -10,11 +10,6 @@ use Illuminate\Contracts\Auth\UserProvider;
 
 class AuthTokenGuardTest extends TestCase
 {
-    protected function tearDown()
-    {
-        m::close();
-    }
-
     public function testUserCanBeRetrievedByQueryStringVariable()
     {
         $provider = m::mock(UserProvider::class);

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -18,11 +18,6 @@ class AuthenticateMiddlewareTest extends TestCase
 {
     protected $auth;
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function setUp()
     {
         $container = Container::setInstance(new Container);

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -22,11 +22,6 @@ class AuthorizeMiddlewareTest extends TestCase
     protected $user;
     protected $router;
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -9,11 +9,6 @@ use Illuminate\Contracts\Broadcasting\Broadcaster;
 
 class BroadcastEventTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBasicEventBroadcastParameterFormatting()
     {
         $broadcaster = m::mock(Broadcaster::class);

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -11,11 +11,6 @@ use Illuminate\Broadcasting\Broadcasters\Broadcaster;
 
 class BroadcasterTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testExtractingParametersWhileCheckingForUserAccess()
     {
         $broadcaster = new FakeBroadcaster;

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -15,11 +15,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 
 class BusDispatcherTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testCommandsThatShouldQueueIsQueued()
     {
         $container = new Container;

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -13,11 +13,6 @@ use Illuminate\Database\PostgresConnection;
 
 class CacheDatabaseStoreTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testNullIsReturnedWhenItemNotFound()
     {
         $store = $this->getStore();

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -14,11 +14,6 @@ use Illuminate\Cache\Events\KeyForgotten;
 
 class CacheEventsTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testHasTriggersEvents()
     {
         $dispatcher = $this->getDispatcher();

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -2,17 +2,11 @@
 
 namespace Illuminate\Tests\Cache;
 
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\CacheManager;
 
 class CacheManagerTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testCustomDriverClosureBoundObjectIsCacheManager()
     {
         $cacheManager = new CacheManager([

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -9,11 +9,6 @@ use Illuminate\Cache\MemcachedConnector;
 
 class CacheMemcachedConnectorTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testServersAreAddedCorrectly()
     {
         $memcached = $this->memcachedMockWithAddServer();

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -9,11 +9,6 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 
 class CacheRateLimiterTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testTooManyAttemptsReturnTrueIfAlreadyLockedOut()
     {
         $cache = m::mock(Cache::class);

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -9,11 +9,6 @@ use Illuminate\Contracts\Redis\Factory;
 
 class CacheRedisStoreTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testGetReturnsNullWhenNotFound()
     {
         $redis = $this->getRedis();

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -19,7 +19,6 @@ class CacheRepositoryTest extends TestCase
 {
     protected function tearDown()
     {
-        m::close();
         Carbon::setTestNow();
     }
 

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -14,11 +14,6 @@ use Illuminate\Database\Migrations\MigrationCreator;
 
 class CacheTableCommandTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testCreateMakesMigration()
     {
         $command = new CacheTableCommandTestStub(

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -14,11 +14,6 @@ use Illuminate\Cache\RedisTaggedCache;
 
 class CacheTaggedCacheTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testCacheCanBeSavedWithMultipleTags()
     {
         $store = new ArrayStore;

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -52,11 +52,6 @@ class ClearCommandTest extends TestCase
         $this->command->setLaravel($app);
     }
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testClearWithNoStoreArgument()
     {
         $this->files->shouldReceive('exists')->andReturn(true);

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Cache;
 
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\RedisStore;
 use Illuminate\Cache\Repository;
@@ -21,7 +20,6 @@ class RedisCacheIntegrationTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        m::close();
         $this->tearDownRedis();
     }
 

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -12,11 +12,6 @@ use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
 class ConsoleApplicationTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testAddSetsLaravelInstance()
     {
         $app = $this->getMockConsole(['addToParent']);

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -32,11 +32,6 @@ class ConsoleEventSchedulerTest extends TestCase
         $container->instance(Schedule::class, $this->schedule = new Schedule(m::mock(EventMutex::class)));
     }
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testMutexCanReceiveCustomStore()
     {
         Container::getInstance()->make(EventMutex::class)->shouldReceive('useStore')->once()->with('test');

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -28,7 +28,6 @@ class ConsoleScheduledEventTest extends TestCase
     {
         date_default_timezone_set($this->defaultTimezone);
         Carbon::setTestNow(null);
-        m::close();
     }
 
     public function testBasicCronCompilation()

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -9,11 +9,6 @@ use Illuminate\Console\Scheduling\EventMutex;
 
 class EventTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBuildCommand()
     {
         $isWindows = DIRECTORY_SEPARATOR == '\\';

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Cookie;
 
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Cookie\CookieJar;
 use Symfony\Component\HttpFoundation\Cookie;
@@ -10,11 +9,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class CookieTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testCookiesAreCreatedWithProperOptions()
     {
         $cookie = $this->getCreator();

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -36,11 +36,6 @@ class DatabaseConnectionFactoryTest extends TestCase
         $this->db->setAsGlobal();
     }
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testConnectionCanBeCreated()
     {
         $this->assertInstanceOf(PDO::class, $this->db->connection()->getPdo());

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -25,11 +25,6 @@ use Illuminate\Database\Query\Builder as BaseBuilder;
 
 class DatabaseConnectionTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testSettingDefaultCallsGetDefaultGrammar()
     {
         $connection = $this->getMockConnection();

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -13,11 +13,6 @@ use Illuminate\Database\Connectors\SqlServerConnector;
 
 class DatabaseConnectorTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testOptionResolution()
     {
         $connector = new Connector;

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -10,11 +10,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testwithPivotValueMethodSetsWhereConditionsForFetching()
     {
         $relation = $this->getMockBuilder(BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -15,11 +15,6 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     protected $related;
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBelongsToWithDefault()
     {
         $relation = $this->getRelation()->withDefault(); //belongsTo relationships

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -19,11 +19,6 @@ use Illuminate\Database\Query\Builder as BaseBuilder;
 
 class DatabaseEloquentBuilderTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testFindMethod()
     {
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -10,11 +10,6 @@ use Illuminate\Support\Collection as BaseCollection;
 
 class DatabaseEloquentCollectionTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testAddingItemsToCollection()
     {
         $c = new Collection(['foo']);

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Database;
 
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
@@ -23,8 +22,6 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
 
     public function tearDown()
     {
-        m::close();
-
         Model::unsetConnectionResolver();
     }
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -12,11 +12,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class DatabaseEloquentHasManyTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testMakeMethodDoesNotSaveNewModel()
     {
         $relation = $this->getRelation();

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -19,11 +19,6 @@ class DatabaseEloquentHasOneTest extends TestCase
 
     protected $parent;
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testHasOneWithDefault()
     {
         $relation = $this->getRelation()->withDefault();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -39,7 +39,6 @@ class DatabaseEloquentModelTest extends TestCase
     {
         parent::tearDown();
 
-        m::close();
         Carbon::setTestNow(null);
 
         Model::unsetEventDispatcher();

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -16,8 +16,6 @@ class DatabaseEloquentMorphTest extends TestCase
     public function tearDown()
     {
         Relation::morphMap([], false);
-
-        m::close();
     }
 
     public function testMorphOneSetsProperConstraints()

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -10,11 +10,6 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 class DatabaseEloquentMorphToManyTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getRelation();

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -14,11 +14,6 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     protected $related;
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testLookupDictionaryIsProperlyConstructed()
     {
         $relation = $this->getRelation();

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -9,11 +9,6 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class DatabaseEloquentPivotTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testPropertiesAreSetCorrectly()
     {
         $parent = m::mock(Model::class.'[getConnectionName]');

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -14,11 +14,6 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 
 class DatabaseEloquentRelationTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testSetRelationFail()
     {
         $parent = new EloquentRelationResetModelStub;

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -9,11 +9,6 @@ use Illuminate\Database\Migrations\MigrationCreator;
 
 class DatabaseMigrationCreatorTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBasicCreateMethodStoresMigrationFile()
     {
         $creator = $this->getCreator();

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -12,11 +12,6 @@ use Illuminate\Database\Migrations\MigrationRepositoryInterface;
 
 class DatabaseMigrationInstallCommandTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testFireCallsRepositoryToInstall()
     {
         $command = new InstallCommand($repo = m::mock(MigrationRepositoryInterface::class));

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -13,11 +13,6 @@ use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
 
 class DatabaseMigrationMakeCommandTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBasicCreateDumpsAutoload()
     {
         $command = new MigrateMakeCommand(

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -12,11 +12,6 @@ use Illuminate\Database\Console\Migrations\MigrateCommand;
 
 class DatabaseMigrationMigrateCommandTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBasicMigrationsCallMigratorWithProperArguments()
     {
         $command = new MigrateCommand($migrator = m::mock(Migrator::class));

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Console\Application as ConsoleApplication;
 
 class DatabaseMigrationRefreshCommandTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testRefreshCommandCallsCommandsWithProperArguments()
     {
         $command = new RefreshCommand($migrator = m::mock(Migrator::class));

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -13,11 +13,6 @@ use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 
 class DatabaseMigrationRepositoryTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testGetRanMigrationsListMigrationsByPackage()
     {
         $repo = $this->getRepository();

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -12,11 +12,6 @@ use Illuminate\Database\Console\Migrations\ResetCommand;
 
 class DatabaseMigrationResetCommandTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testResetCommandCallsMigratorWithProperArguments()
     {
         $command = new ResetCommand($migrator = m::mock(Migrator::class));

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -12,11 +12,6 @@ use Illuminate\Database\Console\Migrations\RollbackCommand;
 
 class DatabaseMigrationRollbackCommandTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testRollbackCommandCallsMigratorWithProperArguments()
     {
         $command = new RollbackCommand($migrator = m::mock(Migrator::class));

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -11,11 +11,6 @@ use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 
 class DatabaseMySqlSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBasicCreateTable()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -10,11 +10,6 @@ use Illuminate\Database\Schema\Grammars\PostgresGrammar;
 
 class DatabasePostgresSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBasicCreateTable()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -11,11 +11,6 @@ use Illuminate\Database\Query\Processors\Processor;
 
 class DatabaseProcessorTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testInsertGetIdProcessing()
     {
         $pdo = $this->createMock(ProcessorTestPDOStub::class);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -22,11 +22,6 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class DatabaseQueryBuilderTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBasicSelect()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -12,11 +12,6 @@ use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
 
 class DatabaseSQLiteSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBasicCreateTable()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -13,11 +13,6 @@ use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 
 class DatabaseSchemaBlueprintTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testToSqlRunsCommandsFromBlueprint()
     {
         $conn = m::mock(Connection::class);

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -10,11 +10,6 @@ use Illuminate\Database\Schema\Builder;
 
 class DatabaseSchemaBuilderTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testHasTableCorrectlyCallsGrammar()
     {
         $connection = m::mock(Connection::class);

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -28,11 +28,6 @@ class TestDepsSeeder extends Seeder
 
 class DatabaseSeederTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testCallResolveTheClassAndCallsRun()
     {
         $seeder = new TestSeeder;

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -15,11 +15,6 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class DatabaseSoftDeletingScopeTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testApplyingScopeToABuilder()
     {
         $scope = m::mock(SoftDeletingScope::class.'[extend]');

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -9,11 +9,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class DatabaseSoftDeletingTraitTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testDeleteSetsSoftDeletedColumn()
     {
         $model = m::mock(DatabaseSoftDeletingTraitStub::class);

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -10,11 +10,6 @@ use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 
 class DatabaseSqlServerSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBasicCreateTable()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -44,9 +44,4 @@ class SeedCommandTest extends TestCase
 
         $container->shouldHaveReceived('call')->with([$command, 'handle']);
     }
-
-    protected function tearDown()
-    {
-        m::close();
-    }
 }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -14,11 +14,6 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 class EventsDispatcherTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBasicEventExecution()
     {
         unset($_SERVER['__event.test']);

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -22,8 +22,6 @@ class FilesystemTest extends TestCase
 
     public function tearDown()
     {
-        m::close();
-
         $files = new Filesystem;
         $files->deleteDirectory($this->tempDir);
     }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -12,11 +12,6 @@ use Illuminate\Foundation\Bootstrap\RegisterFacades;
 
 class FoundationApplicationTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testSetLocaleSetsLocaleAndFiresLocaleChangedEvent()
     {
         $app = new Application;

--- a/tests/Foundation/FoundationAuthenticationTest.php
+++ b/tests/Foundation/FoundationAuthenticationTest.php
@@ -49,11 +49,6 @@ class FoundationAuthenticationTest extends TestCase
         return $guard;
     }
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testAssertAuthenticated()
     {
         $this->mockGuard()

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -9,11 +9,6 @@ use Illuminate\Filesystem\Filesystem;
 
 class FoundationComposerTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testDumpAutoloadRunsTheCorrectCommand()
     {
         $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -2,17 +2,11 @@
 
 namespace Illuminate\Tests\Foundation;
 
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\EnvironmentDetector;
 
 class FoundationEnvironmentDetectorTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testClosureCanBeUsedForCustomEnvironmentDetection()
     {
         $env = new EnvironmentDetector;

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -51,11 +51,6 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->handler = new Handler($this->container);
     }
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testHandlerReportsExceptionAsContext()
     {
         $logger = m::mock(LoggerInterface::class);

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -20,8 +20,6 @@ class FoundationFormRequestTest extends TestCase
 
     public function tearDown()
     {
-        m::close();
-
         $this->mocks = [];
     }
 

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -9,11 +9,6 @@ use Illuminate\Foundation\Application;
 
 class FoundationHelpersTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testCache()
     {
         $app = new Application;

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -23,11 +23,6 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->connection = m::mock(Connection::class);
     }
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testSeeInDatabaseFindsResults()
     {
         $this->mockCountBuilder(1);

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -12,11 +12,6 @@ use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
 class FoundationProviderRepositoryTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testServicesAreRegisteredWhenManifestIsNotRecompiled()
     {
         $app = m::mock(Application::class);

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -14,11 +14,6 @@ use Illuminate\Contracts\Support\MessageProvider;
 
 class HttpRedirectResponseTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testHeaderOnRedirect()
     {
         $response = new RedirectResponse('foo.bar');

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -13,11 +13,6 @@ use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 
 class HttpRequestTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testInstanceMethod()
     {
         $request = Request::create('', 'GET');

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -21,11 +21,6 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class HttpResponseTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testJsonResponsesAreConvertedAndHeadersAreSet()
     {
         $response = new Response(new ArrayableStub);

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Mail;
 
-use Mockery as m;
 use Illuminate\Mail\Mailable;
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
@@ -21,8 +20,6 @@ class SendingMailWithLocaleTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-
-        m::close();
     }
 
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -26,8 +26,6 @@ class SendingMailNotificationsTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-
-        m::close();
     }
 
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -20,8 +20,6 @@ class CallQueuedHandlerTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-
-        m::close();
     }
 
     public function test_job_can_be_dispatched()

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -12,11 +12,6 @@ use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
 class LogLoggerTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testMethodsPassErrorAdditionsToMonolog()
     {
         $writer = new Logger($monolog = m::mock(Monolog::class));

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -18,11 +18,6 @@ use Illuminate\Contracts\Events\Dispatcher;
 
 class MailMailerTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testMailerSendSendsMessageWithProperViewContent()
     {
         unset($_SERVER['__mailer.test']);

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -9,11 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 class MailMarkdownTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testRenderFunctionReturnsHtml()
     {
         $viewFactory = m::mock(Factory::class);

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -27,11 +27,6 @@ class MailMessageTest extends TestCase
         $this->message = new Message($this->swift);
     }
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testFromMethod()
     {
         $this->swift->shouldReceive('setFrom')->once()->with('foo@bar.baz', 'Foo');

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -19,11 +19,6 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
 
 class MailableQueuedTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testQueuedMailableSent()
     {
         $queueFake = new QueueFake(new Application);

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -13,11 +13,6 @@ use Illuminate\Notifications\Events\BroadcastNotificationCreated;
 
 class NotificationBroadcastChannelTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testDatabaseChannelCreatesDatabaseRecordWithProperData()
     {
         $notification = new NotificationBroadcastChannelTestNotification;

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -18,11 +18,6 @@ use Illuminate\Notifications\Events\NotificationSending;
 
 class NotificationChannelManagerTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testNotificationCanBeDispatchedToDriver()
     {
         $container = new Container;

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -10,11 +10,6 @@ use Illuminate\Notifications\Messages\DatabaseMessage;
 
 class NotificationDatabaseChannelTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testDatabaseChannelCreatesDatabaseRecordWithProperData()
     {
         $notification = new NotificationDatabaseChannelTestNotification;

--- a/tests/Notifications/NotificationNexmoChannelTest.php
+++ b/tests/Notifications/NotificationNexmoChannelTest.php
@@ -11,11 +11,6 @@ use Illuminate\Notifications\Channels\NexmoSmsChannel;
 
 class NotificationNexmoChannelTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testSmsIsSentViaNexmo()
     {
         $notification = new NotificationNexmoChannelTestNotification;

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -11,11 +11,6 @@ use Illuminate\Contracts\Notifications\Dispatcher;
 
 class NotificationRoutesNotificationsTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testNotificationCanBeDispatched()
     {
         $container = new Container;

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -9,11 +9,6 @@ use Illuminate\Notifications\SendQueuedNotifications;
 
 class NotificationSendQueuedNotificationTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testNotificationsCanBeSent()
     {
         $job = new SendQueuedNotifications('notifiables', 'notification');

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -33,11 +33,6 @@ class NotificationSlackChannelTest extends TestCase
         $this->slackChannel = new SlackWebhookChannel($this->guzzleHttp);
     }
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     /**
      * @dataProvider payloadDataProvider
      * @param Notification $notification

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -13,11 +13,6 @@ use Illuminate\Queue\Jobs\BeanstalkdJob;
 
 class QueueBeanstalkdJobTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testFireProperlyCallsTheJobHandler()
     {
         $job = $this->getJob();

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -12,11 +12,6 @@ use Illuminate\Queue\Jobs\BeanstalkdJob;
 
 class QueueBeanstalkdQueueTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testPushProperlyPushesJobOntoBeanstalkd()
     {
         $queue = new BeanstalkdQueue(m::mock(Pheanstalk::class), 'default', 60);

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -12,11 +12,6 @@ use Illuminate\Queue\DatabaseQueue;
 
 class QueueDatabaseQueueUnitTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testPushProperlyPushesJobOntoDatabase()
     {
         $queue = $this->getMockBuilder(DatabaseQueue::class)->setMethods(['currentTime'])->setConstructorArgs([$database = m::mock(Connection::class), 'table', 'default'])->getMock();

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -10,11 +10,6 @@ use Symfony\Component\Process\Process;
 
 class QueueListenerTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testRunProcessCallsProcess()
     {
         $process = m::mock(Process::class)->makePartial();

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -10,11 +10,6 @@ use Illuminate\Contracts\Encryption\Encrypter;
 
 class QueueManagerTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testDefaultConnectionCanBeResolved()
     {
         $app = [

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -11,11 +11,6 @@ use Illuminate\Queue\Jobs\RedisJob;
 
 class QueueRedisJobTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testFireProperlyCallsTheJobHandler()
     {
         $job = $this->getJob();

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -11,11 +11,6 @@ use Illuminate\Contracts\Redis\Factory;
 
 class QueueRedisQueueTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testPushProperlyPushesJobOntoRedis()
     {
         $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -50,11 +50,6 @@ class QueueSqsJobTest extends TestCase
         ];
     }
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testFireProperlyCallsTheJobHandler()
     {
         $job = $this->getJob();

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -13,11 +13,6 @@ use Illuminate\Container\Container;
 
 class QueueSqsQueueTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function setUp()
     {
         // Use Mockery to mock the SqsClient

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -13,11 +13,6 @@ use Illuminate\Contracts\Queue\QueueableEntity;
 
 class QueueSyncQueueTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testPushShouldFireJobInstantly()
     {
         unset($_SERVER['__sync.test']);

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -32,7 +32,6 @@ class RedisQueueIntegrationTest extends TestCase
         Carbon::setTestNow(null);
         parent::tearDown();
         $this->tearDownRedis();
-        m::close();
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -23,11 +23,6 @@ class RouteRegistrarTest extends TestCase
         $this->router = new Router(m::mock(Dispatcher::class), Container::getInstance());
     }
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testMiddlewareFluentRegistration()
     {
         $this->router->middleware(['one', 'two'])->get('users', function () {

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -45,11 +45,6 @@ class RoutingRedirectorTest extends TestCase
         $this->redirect->setSession($this->session);
     }
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBasicRedirectTo()
     {
         $response = $this->redirect->to('bar');

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -11,11 +11,6 @@ use Illuminate\Contracts\Encryption\Encrypter;
 
 class EncryptedSessionStoreTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testSessionIsProperlyEncrypted()
     {
         $session = $this->getSession();

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -13,11 +13,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SessionStoreTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testSessionIsLoadedFromHandler()
     {
         $session = $this->getSession();

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -14,11 +14,6 @@ use Illuminate\Database\Migrations\MigrationCreator;
 
 class SessionTableCommandTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testCreateMakesMigration()
     {
         $command = new SessionTableCommandTestStub(

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -13,11 +13,6 @@ class SupportCapsuleManagerTraitTest extends TestCase
 {
     use CapsuleManagerTrait;
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testSetupContainerForCapsule()
     {
         $this->container = null;

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -17,11 +17,6 @@ class SupportFacadeTest extends TestCase
         FacadeStub::setFacadeApplication(null);
     }
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testFacadeCallsUnderlyingApplication()
     {
         $app = new ApplicationStub;

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -30,8 +30,6 @@ class SupportFacadesEventTest extends TestCase
     public function tearDown()
     {
         Event::clearResolvedInstances();
-
-        m::close();
     }
 
     public function testFakeFor()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -14,11 +14,6 @@ use Illuminate\Contracts\Support\Htmlable;
 
 class SupportHelpersTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testArrayDot()
     {
         $array = Arr::dot(['name' => 'taylor', 'languages' => ['php' => true]]);

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -2,18 +2,12 @@
 
 namespace Illuminate\Tests\Support;
 
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 use Illuminate\Support\MessageBag;
 
 class SupportMessageBagTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testUniqueness()
     {
         $container = new MessageBag;

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -21,11 +21,6 @@ class SupportServiceProviderTest extends TestCase
         $two->boot();
     }
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testPublishableServiceProviders()
     {
         $toPublish = ServiceProvider::publishableProviders();

--- a/tests/TestListener.php
+++ b/tests/TestListener.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests;
+
+use Mockery as m;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestListener as BaseTestListener;
+use PHPUnit\Framework\TestListenerDefaultImplementation;
+
+class TestListener implements BaseTestListener
+{
+    use TestListenerDefaultImplementation;
+
+    public function endTest(Test $test, float $time): void
+    {
+        m::close();
+    }
+}

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -9,11 +9,6 @@ use Illuminate\Translation\FileLoader;
 
 class TranslationFileLoaderTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testLoadMethodWithoutNamespacesProperlyCallsLoader()
     {
         $loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -11,11 +11,6 @@ use Illuminate\Contracts\Translation\Loader;
 
 class TranslationTranslatorTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
     {
         $t = $this->getMockBuilder(Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -11,11 +11,6 @@ use Illuminate\Database\ConnectionResolverInterface;
 
 class ValidationDatabasePresenceVerifierTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBasicCount()
     {
         $verifier = new DatabasePresenceVerifier($db = m::mock(ConnectionResolverInterface::class));

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -11,11 +11,6 @@ use Illuminate\Contracts\Translation\Translator as TranslatorInterface;
 
 class ValidationFactoryTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testMakeMethodCreatesValidValidator()
     {
         $translator = m::mock(TranslatorInterface::class);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -27,7 +27,6 @@ class ValidationValidatorTest extends TestCase
     public function tearDown()
     {
         Carbon::setTestNow();
-        m::close();
     }
 
     public function testSometimesWorksOnNestedArrays()

--- a/tests/View/Blade/AbstractBladeTestCase.php
+++ b/tests/View/Blade/AbstractBladeTestCase.php
@@ -16,11 +16,4 @@ abstract class AbstractBladeTestCase extends TestCase
         $this->compiler = new BladeCompiler(m::mock(Filesystem::class), __DIR__);
         parent::setUp();
     }
-
-    public function tearDown()
-    {
-        m::close();
-
-        parent::tearDown();
-    }
 }

--- a/tests/View/Blade/BladeElseAuthStatementsTest.php
+++ b/tests/View/Blade/BladeElseAuthStatementsTest.php
@@ -9,11 +9,6 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeElseAuthStatementsTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testElseAuthStatementsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/Blade/BladeElseGuestStatementsTest.php
+++ b/tests/View/Blade/BladeElseGuestStatementsTest.php
@@ -9,11 +9,6 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeElseGuestStatementsTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testIfStatementsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/Blade/BladeIfAuthStatementsTest.php
+++ b/tests/View/Blade/BladeIfAuthStatementsTest.php
@@ -9,11 +9,6 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeIfAuthStatementsTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testIfStatementsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/Blade/BladeIfGuestStatementsTest.php
+++ b/tests/View/Blade/BladeIfGuestStatementsTest.php
@@ -9,11 +9,6 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeIfGuestStatementsTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testIfStatementsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -9,11 +9,6 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class ViewBladeCompilerTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testIsExpiredReturnsTrueIfCompiledFileDoesntExist()
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -9,11 +9,6 @@ use Illuminate\View\Compilers\CompilerInterface;
 
 class ViewCompilerEngineTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testViewsMayBeRecompiledAndRendered()
     {
         $engine = $this->getEngine();

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -22,11 +22,6 @@ use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
 class ViewFactoryTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testMakeCreatesNewViewInstanceWithProperPathAndEngine()
     {
         unset($_SERVER['__test.view']);

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -9,11 +9,6 @@ use Illuminate\Filesystem\Filesystem;
 
 class ViewFileViewFinderTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testBasicViewFinding()
     {
         $finder = $this->getFinder();

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -2,17 +2,11 @@
 
 namespace Illuminate\Tests\View;
 
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\View\Engines\PhpEngine;
 
 class ViewPhpEngineTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testViewsMayBeProperlyRendered()
     {
         $engine = new PhpEngine;

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -15,11 +15,6 @@ use Illuminate\Contracts\Support\Renderable;
 
 class ViewTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testDataCanBeSetOnView()
     {
         $view = $this->getView();


### PR DESCRIPTION
Use a test listener instead of `m::close()` in every test