### PR TITLE
[5.8] Add throws docblock for DateFactory::use() method

### DIFF
--- a/src/Illuminate/Support/DateFactory.php
+++ b/src/Illuminate/Support/DateFactory.php
@@ -115,6 +115,8 @@ class DateFactory
      * Use the given handler when generating dates (class name, callable, or factory).
      *
      * @param  mixed  $handler
+     *
+     * @throws \InvalidArgumentException
      */
     public static function use($handler)
     {


### PR DESCRIPTION
DateFactory::use() method may throw an InvalidArgumentException if the given handler is invalid.
