### PR TITLE
[5.7] Added loadCount method to eloquent collections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -63,6 +63,32 @@ class Collection extends BaseCollection implements QueueableCollection
         return $this;
     }
 
+     /**
+     * Load a set of relationship counts onto the collection.
+     *
+     * @param  array|string  $relations
+     * @return $this
+     */
+    public function loadCount($relations)
+    {
+        if ($this->isEmpty()) {
+            return $this;
+        }
+
+        $query = $this->first()->newModelQuery()
+            ->whereKey($this->modelKeys())
+            ->select($this->first()->getKeyName())
+            ->withCount(...func_get_args());
+
+        $query->get()->each(function ($model) {
+            $this->find($model->getKey())->forceFill(
+                Arr::except($model->getAttributes(), $model->getKeyName())
+            );
+        });
+
+        return $this;
+    }
+
     /**
      * Load a set of relationships onto the collection if they are not already eager loaded.
      *

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -63,7 +63,7 @@ class Collection extends BaseCollection implements QueueableCollection
         return $this;
     }
 
-     /**
+    /**
      * Load a set of relationship counts onto the collection.
      *
      * @param  array|string  $relations

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -167,6 +167,36 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(['results'], $c->all());
     }
 
+    public function testLoadCountMethodEagerLoadsGivenRelationshipCounts()
+    {
+        $mockQuery = m::mock(stdClass::class);
+        $mockExistingModel = m::mock(stdClass::class);
+        $mockRetrieveModel = m::mock(stdClass::class);
+        $c = $this->getMockBuilder(Collection::class)->setMethods(['first', 'find'])->setConstructorArgs([[$mockExistingModel]])->getMock();
+        $c->expects($this->exactly(2))->method('first')->will($this->returnValue($mockExistingModel));
+        $c->expects($this->once())->method('find')->with('model_key_value')->will($this->returnValue($mockExistingModel));
+        $mockQuery->shouldReceive('whereKey')->once()->with(['model_key_value'])->andReturn($mockQuery);
+        $mockQuery->shouldReceive('select')->once()->with('model_key_name')->andReturn($mockQuery);
+        $mockQuery->shouldReceive('withCount')->once()->with(['bar', 'baz'])->andReturn($mockQuery);
+        $mockQuery->shouldReceive('get')->once()->andReturn($mockQuery);
+        $mockQuery->shouldReceive('each')->once()->with(m::on(function ($value) use ($mockRetrieveModel) {
+            if (! is_callable($value)) {
+                return false;
+            }
+            $value($mockRetrieveModel);
+
+            return true;
+        }));
+        $mockExistingModel->shouldReceive('getKey')->once()->andReturn('model_key_value');
+        $mockExistingModel->shouldReceive('newModelQuery')->once()->andReturn($mockQuery);
+        $mockExistingModel->shouldReceive('getKeyName')->once()->andReturn('model_key_name');
+        $mockExistingModel->shouldReceive('forceFill')->once()->with(['bar_count' => 1, 'baz_count' => 2]);
+        $mockRetrieveModel->shouldReceive('getKey')->once()->andReturn('model_key_value');
+        $mockRetrieveModel->shouldReceive('getAttributes')->once()->andReturn(['model_key_name' => 'model_key_value', 'bar_count' => 1, 'baz_count' => 2]);
+        $mockRetrieveModel->shouldReceive('getKeyName')->once()->andReturn('model_key_name');
+        $c->loadCount(['bar', 'baz']);
+    }
+
     public function testCollectionDictionaryReturnsModelKeys()
     {
         $one = m::mock(Model::class);

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Integration\Database;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentCollectionLoadCountTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('some_default_value');
+            $table->softDeletes();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('post_id');
+        });
+
+        Schema::create('likes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('post_id');
+        });
+
+        $post = Post::create();
+        $post->comments()->saveMany([new Comment, new Comment]);
+
+        $post->likes()->save(new Like);
+
+        Post::create();
+    }
+
+    public function testLoadCount()
+    {
+        $posts = Post::all();
+
+        DB::enableQueryLog();
+
+        $posts->loadCount('comments');
+
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertSame('2', $posts[0]->comments_count);
+        $this->assertSame('0', $posts[1]->comments_count);
+    }
+
+    public function testLoadCountOnDeletedModels()
+    {
+        $posts = Post::all()->each->delete();
+
+        DB::enableQueryLog();
+
+        $posts->loadCount('comments');
+
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertSame('2', $posts[0]->comments_count);
+        $this->assertSame('0', $posts[1]->comments_count);
+    }
+
+    public function testLoadCountWithArrayOfRelations()
+    {
+        $posts = Post::all();
+
+        DB::enableQueryLog();
+
+        $posts->loadCount(['comments', 'likes']);
+
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertSame('2', $posts[0]->comments_count);
+        $this->assertSame('1', $posts[0]->likes_count);
+        $this->assertSame('0', $posts[1]->comments_count);
+        $this->assertSame('0', $posts[1]->likes_count);
+    }
+
+    public function testLoadCountDoesNotOverrideAttributesWithDefaultValue()
+    {
+        $post = Post::first();
+        $post->some_default_value = 200;
+
+        Collection::make([$post])->loadCount('comments');
+
+        $this->assertSame(200, $post->some_default_value);
+        $this->assertSame('2', $post->comments_count);
+    }
+}
+
+class Post extends Model
+{
+    use SoftDeletes;
+
+    protected $attributes = [
+        'some_default_value' => 100,
+    ];
+
+    public $timestamps = false;
+
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
+
+    public function likes()
+    {
+        return $this->hasMany(Like::class);
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+}
+
+class Like extends Model
+{
+    public $timestamps = false;
+}


### PR DESCRIPTION
This PR introduces the ability to load relationship counts on an `Eloquent\Collection`. With the query builder you can `$query->with($relations)` and also `$query->withCount($relations)`, but on the eloquent collection we can only `$collection->load($relations)`. This introduces the ability to `$collection->loadCount($relations)`.

Usually, of course, you would want to be loading these counts when you are retrieving the models from the DB in the first place, i.e. with the query builder as shown above, however in certain circumstances that is not possible. One example is when the model you are retrieving has a polymorphic relation on which you need to dynamically load counts based on the class type.

A real world example of how I would use this in my current app...

I am tracking certain events. An event is something like "Post created" or "Comment created". Each event has an `eventable` relation that is polymorphic, i.e. it might be a `Post` or a `Comment`

```php
class Event extends Eloquent
{
    public function eventable()
    {
        return $this->morphTo();
    }
}
```

On my events endpoint, I want to show each event and some information about the eventable. The information shown for each eventable item can vary. For a `Post` it might be the number of comments it has recieved and for a `Comment` it might be the number of hearts it has received.

Show me the code!

```php
$events = Event::latest()->with('eventable')->paginate();

$groups = $events->map(function ($event) {
    return $event->eventable;
})->groupBy(function ($eventable) {
    return get_class($eventable);
});

$groups[Post::class]->loadCount('comments');
$groups[Comment::class]->loadCount('hearts');

return new EventIndexResponse($events);
```

Not sure if this was the best example of its use, but it is a real one. Hopefully it would be useful in other situations also.

~Under the hood the query is having `each` called on it, causing the db hits to be chunked. Only the model primary key and relation counts are being retrieved from the DB to keep the payloads and memory impact as low as possible. It is defaulting the the 1000 chunk count.~

Some places where this idea has been discussed / requested:

- https://github.com/laravel/framework/issues/17845
- https://github.com/laravel/ideas/issues/110

---

If a few people could do a once over of the test I've introduced that would be awesome - not used to mocking soooo many things 😅

Also, if there is anyway to optimise the way I'm doing this, I'm all ears 👂