### PR TITLE
[5.7] Update docblock on Job contract's "release" method

### DIFF
--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -29,7 +29,7 @@ interface Job
      * Release the job back into the queue.
      *
      * @param  int   $delay
-     * @return mixed
+     * @return void
      */
     public function release($delay = 0);
 

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -52,7 +52,7 @@ trait InteractsWithQueue
      * Release the job back into the queue.
      *
      * @param  int   $delay
-     * @return mixed
+     * @return void
      */
     public function release($delay = 0)
     {

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -52,7 +52,7 @@ trait InteractsWithQueue
      * Release the job back into the queue.
      *
      * @param  int   $delay
-     * @return void
+     * @return mixed
      */
     public function release($delay = 0)
     {


### PR DESCRIPTION
As seen in [`Illuminate\Queue\Jobs\Job`](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Queue/Jobs/Job.php#L112), this method returns `void`, and not `mixed` as previously indicated in the `Illuminate\Contracts\Queue\Job` contract.

Fixes #25915.