### PR TITLE
[5.7] Make getAllTables a public method

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -216,7 +216,7 @@ class Builder
     }
 
     /**
-     * Drop all views from the database.
+     * Get all of the table names for the database.
      *
      * @return void
      *

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -216,6 +216,18 @@ class Builder
     }
 
     /**
+     * Drop all views from the database.
+     *
+     * @return void
+     *
+     * @throws \LogicException
+     */
+    public function getAllTables()
+    {
+        throw new LogicException('This database driver does not support getting all tables.');
+    }
+
+    /**
      * Rename a table on the schema.
      *
      * @param  string  $from

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -93,7 +93,7 @@ class MySqlBuilder extends Builder
      *
      * @return array
      */
-    protected function getAllTables()
+    public function getAllTables()
     {
         return $this->connection->select(
             $this->grammar->compileGetAllTables()

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -80,7 +80,7 @@ class PostgresBuilder extends Builder
      *
      * @return array
      */
-    protected function getAllTables()
+    public function getAllTables()
     {
         return $this->connection->select(
             $this->grammar->compileGetAllTables($this->connection->getConfig('schema'))


### PR DESCRIPTION
Currently i'm building a SPA using Vue.js and I'm writing e2e tests using Cypress. I want to truncate all tables except Laravel passport `oauth` tables to cleaning up the state. Making `getAllTables` method public i can get all the tables of the database.
