### PR TITLE
[5.8] Add where between column support query

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1046,6 +1046,67 @@ class Builder
     }
 
     /**
+     * Add a where between column statement to the query.
+     *
+     * @param  mixed   $value
+     * @param  string  $first
+     * @param  string  $second
+     * @param  string  $boolean
+     * @param  bool    $not
+     * @return $this
+     */
+    public function whereBetweenColumn($value, $first, $second, $boolean = 'and', $not = false)
+    {
+        $type = 'betweenColumn';
+
+        $this->wheres[] = compact('type', 'value', 'first', 'second', 'boolean', 'not');
+
+        $this->addBinding($value, 'where');
+
+        return $this;
+    }
+
+    /**
+     * Add an or where between column statement to the query.
+     *
+     * @param  mixed   $value
+     * @param  string  $first
+     * @param  string  $second
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function orWhereBetweenColumn($value, $first, $second)
+    {
+        return $this->whereBetweenColumn($value, $first, $second, 'or');
+    }
+
+    /**
+     * Add a where not between column statement to the query.
+     *
+     * @param  mixed   $value
+     * @param  string  $first
+     * @param  string  $second
+     * @param  string  $boolean
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function whereNotBetweenColumn($value, $first, $second, $boolean = 'and')
+    {
+        return $this->whereBetweenColumn($value, $first, $second, $boolean, true);
+    }
+
+    /**
+     * Add an or where not between column statement to the query.
+     *
+     * @param  mixed   $value
+     * @param  string  $first
+     * @param  string  $second
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function orWhereNotBetweenColumn($value, $first, $second)
+    {
+        return $this->whereNotBetweenColumn($value, $first, $second, 'or');
+    }
+
+    /**
      * Add an "or where not null" clause to the query.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -340,6 +340,22 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "between column" where clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereBetweenColumn(Builder $query, $where)
+    {
+        $between = $where['not'] ? 'not between' : 'between';
+
+        $value = $this->parameter($where['value']);
+
+        return $value.' '.$between.' '.$this->wrap($where['first']).' and '.$this->wrap($where['second']);
+    }
+
+    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -605,6 +605,23 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([], $builder->getBindings());
     }
 
+    public function testWhereBetweenColumns()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereBetweenColumn('2018-10-05', 'start_date', 'end_date');
+        $this->assertEquals('select * from "users" where ? between "start_date" and "end_date"', $builder->toSql());
+        $this->assertEquals([0 => '2018-10-05'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotBetweenColumn('2018-10-05', 'start_date', 'end_date');
+        $this->assertEquals('select * from "users" where ? not between "start_date" and "end_date"', $builder->toSql());
+        $this->assertEquals([0 => '2018-10-05'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereBetweenColumn(new Raw('2018-10-05'), 'start_date', 'end_date');
+        $this->assertEquals('select * from "users" where 2018-10-05 between "start_date" and "end_date"', $builder->toSql());
+    }
+
     public function testBasicOrWheres()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Adds support for `WHERE ? between column_1 AND column_2` queries.  
Not sure about the function name but there is currently `whereBetween()` and `whereColumn()`, so tried to follow the name standard.

Before:
```php
->whereRaw('? between `start_date` and `end_date`', [Carbon::now()]);
```
After:
```php
->whereBetweenColumn(Carbon::now(), 'start_date', 'end_date');
```