### PR TITLE
[5.7] PackageManifest::build() hangs on filesystems that don't support exclusive file locks

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Filesystem;
 
 use ErrorException;
+use Exception;
 use FilesystemIterator;
 use Symfony\Component\Finder\Finder;
 use Illuminate\Support\Traits\Macroable;
@@ -55,14 +56,21 @@ class Filesystem
 
         if ($handle) {
             try {
-                if (flock($handle, LOCK_SH)) {
-                    clearstatcache(true, $path);
+                // First we try a non-block lock to prevent deadlocks on filesystems that don't support locks.
+                $lockSuccessful = flock($handle, LOCK_SH | LOCK_NB, $wouldBlock);
 
-                    $contents = fread($handle, $this->size($path) ?: 1);
+                // If there is no lock but it's because the lock would block, do a blocking lock to wait for the lock.
+                if (! $lockSuccessful && $wouldBlock) {
+                    $lockSuccessful = flock($handle, LOCK_SH, $wouldBlock);
+                }
 
+                clearstatcache(true, $path);
+                $contents = fread($handle, $this->size($path) ?: 1);
+            } finally {
+                if ($lockSuccessful) {
                     flock($handle, LOCK_UN);
                 }
-            } finally {
+
                 fclose($handle);
             }
         }
@@ -119,7 +127,72 @@ class Filesystem
      */
     public function put($path, $contents, $lock = false)
     {
-        return file_put_contents($path, $contents, $lock ? LOCK_EX : 0);
+        $bytesWritten = false;
+
+        // Opening the file for writing without truncating.
+        $handle = fopen($path, 'cb');
+        if ($handle) {
+            $lockSuccessful = false;
+
+            try {
+                if ($lock) {
+                    // First we try a non-blocking lock to prevent deadlocks on filesystems that don't support locks.
+                    $lockSuccessful = flock($handle, LOCK_EX | LOCK_NB, $wouldBlock);
+
+                    // If there is no lock because the lock would block, do a blocking lock to wait for the lock.
+                    if (! $lockSuccessful && $wouldBlock) {
+                        $lockSuccessful = flock($handle, LOCK_EX, $wouldBlock);
+                    }
+                }
+
+                // We manually truncate the file because we opened the file with 'cb' earlier.
+                ftruncate($handle, 0);
+                $bytesWritten = fwrite($handle, $contents);
+            } finally {
+                if ($lockSuccessful) {
+                    flock($handle, LOCK_UN);
+                }
+
+                fclose($handle);
+            }
+        }
+
+        return $bytesWritten;
+    }
+
+    /**
+     * Write the contents of a file, replacing it atomically if it already exists.
+     *
+     * @param string $path
+     * @param string $content
+     * @throws Exception
+     */
+    public function replace($path, $content)
+    {
+        // Just in case path already exists and is a symlink, we want to make sure we get the real path.
+        clearstatcache(true, $path);
+        $realPath = realpath($path);
+        if ($realPath) {
+            $path = $realPath;
+        }
+
+        $dirName = dirname($path);
+        if (! is_writable($dirName)) {
+            throw new Exception("Replacing $path requires it's parent directory to be writable.");
+        }
+
+        // Write out the contents to a temp file, so we can rename the file atomically.
+        $tempPath = tempnam($dirName, basename($path));
+        $this->put($tempPath, $content);
+
+        if (file_exists($path)) {
+            // Copy over the permissions and owner from the original file.
+            chmod($tempPath, $this->permissions($path));
+            chown($tempPath, $this->owner($path));
+            chgrp($tempPath, $this->group($path));
+        }
+
+        rename($tempPath, $path);
     }
 
     /**
@@ -581,5 +654,58 @@ class Filesystem
     public function cleanDirectory($directory)
     {
         return $this->deleteDirectory($directory, true);
+    }
+
+    /**
+     * Return permissions in a format that can be used by chmod().
+     *
+     * This function only returns the lowest 12 bytes (or last 3 octal digits) for compatibility.
+     *
+     * @param string $path Path to the file.
+     * @return int
+     * @throws FileNotFoundException
+     */
+    public function permissions(string $path): int
+    {
+        if (! file_exists($path)) {
+            throw new FileNotFoundException("File does not exist at path {$path}");
+        }
+
+        $perms = fileperms($path);
+
+        // Convert perms to octal so we only grab the last three digits
+        $perms = substr((string) decoct($perms), -3);
+
+        return (int) base_convert($perms, 8, 10);
+    }
+
+    /**
+     * Get the owner of a file.
+     *
+     * @param string $path Path to the file.
+     * @return int The user ID in numerical format.
+     * @throws FileNotFoundException
+     */
+    public function owner(string $path)
+    {
+        if (! file_exists($path)) {
+            throw new FileNotFoundException("File does not exist at path {$path}");
+        }
+
+        return fileowner($path);
+    }
+
+    /**
+     * @param string $path
+     * @return int The group ID in numerical format.
+     * @throws FileNotFoundException
+     */
+    public function group(string $path)
+    {
+        if (! file_exists($path)) {
+            throw new FileNotFoundException("File does not exist at path {$path}");
+        }
+
+        return filegroup($path);
     }
 }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Filesystem;
 
-use ErrorException;
 use Exception;
+use ErrorException;
 use FilesystemIterator;
 use Symfony\Component\Finder\Finder;
 use Illuminate\Support\Traits\Macroable;

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation;
 
-use Exception;
 use Illuminate\Filesystem\Filesystem;
 
 class PackageManifest
@@ -163,6 +162,6 @@ class PackageManifest
      */
     protected function write(array $manifest)
     {
-        $this->files->replace($this->manifestPath, '<?php return ' . var_export($manifest, true) . ';');
+        $this->files->replace($this->manifestPath, '<?php return '.var_export($manifest, true).';');
     }
 }

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -97,7 +97,7 @@ class PackageManifest
             $this->build();
         }
 
-        $this->files->get($this->manifestPath, true);
+        $this->files->get($this->manifestPath);
 
         return $this->manifest = file_exists($this->manifestPath) ?
             $this->files->getRequire($this->manifestPath) : [];
@@ -163,13 +163,6 @@ class PackageManifest
      */
     protected function write(array $manifest)
     {
-        if (! is_writable(dirname($this->manifestPath))) {
-            throw new Exception('The '.dirname($this->manifestPath).' directory must be present and writable.');
-        }
-
-        $this->files->put(
-            $this->manifestPath, '<?php return '.var_export($manifest, true).';',
-            true
-        );
+        $this->files->replace($this->manifestPath, '<?php return ' . var_export($manifest, true) . ';');
     }
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -41,6 +41,16 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello World');
     }
 
+    public function testReplaceStoresFiles()
+    {
+        $files = new Filesystem;
+        $files->replace($this->tempDir.'/file.txt', 'Hello World');
+        $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello World');
+
+        $files->replace($this->tempDir.'/file.txt', 'Something Else');
+        $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Something Else');
+    }
+
     public function testSetChmod()
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');
@@ -495,5 +505,34 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $filesystem = new Filesystem;
         $this->assertEquals('acbd18db4cc2f85cedef654fccc4a4d8', $filesystem->hash($this->tempDir.'/foo.txt'));
+    }
+
+    public function testPermissions()
+    {
+        file_put_contents($this->tempDir.'/foo.txt', 'foo');
+        chmod($this->tempDir.'/foo.txt', 0123);
+
+        $filesystem = new Filesystem;
+        $this->assertEquals(0123, $filesystem->permissions($this->tempDir.'/foo.txt'));
+    }
+
+    public function testOwner()
+    {
+        $uid = posix_geteuid();
+        file_put_contents($this->tempDir.'/foo.txt', 'foo');
+        chown($this->tempDir.'/foo.txt', $uid);
+
+        $filesystem = new Filesystem;
+        $this->assertEquals($uid, $filesystem->owner($this->tempDir.'/foo.txt'));
+    }
+
+    public function testGroup()
+    {
+        $gid = posix_getegid();
+        file_put_contents($this->tempDir.'/foo.txt', 'foo');
+        chown($this->tempDir.'/foo.txt', $gid);
+
+        $filesystem = new Filesystem;
+        $this->assertEquals($gid, $filesystem->group($this->tempDir.'/foo.txt'));
     }
 }


### PR DESCRIPTION
  - Filesystem.php

     1. Created a safer way to write data that won't cause deadlocks on
        NFS

     2. The above, even though it prevents deadlocks, still can cause
        12 second hangs. So created a new `Filesystem::replace()` method
        that atomically replaces a file if it already exists.

     3. Also added `Filesystem::permissions()`, `Filesystem::owner()`
        and `Filesystem::group()` methods because they were needed.

  - PackageManifest.php

     1. The Filesystem::get() call in PackageManifest::getManifest() no
        longer has to use an exclusive lock because the packages.php
        manifest file will always be replaced atomically.

     2. Use the new Filesystem::replace() method in
        PackageManifest::write()