### PR TITLE
[5.7] Added CHANGELOG by component for v5.7.8

### DIFF
--- a/src/Illuminate/Container/CHANGELOG-5.7.md
+++ b/src/Illuminate/Container/CHANGELOG-5.7.md
@@ -1,0 +1,6 @@
+# Release Notes for 5.7.x
+
+## [v5.7.8 (2018-10-04)](https://github.com/illuminate/container/compare/v5.7.7...v5.7.8)
+
+### Changed (only realization)
+- Simplify code for contextual binding ([e2476c1](https://github.com/laravel/framework/commit/e2476c1cdfeffd1c4432ec8dc1f733815f70c000))

--- a/src/Illuminate/Database/CHANGELOG-5.7.md
+++ b/src/Illuminate/Database/CHANGELOG-5.7.md
@@ -1,0 +1,11 @@
+# Release Notes for 5.7.x
+
+## [v5.7.8 (2018-10-04)](https://github.com/illuminate/database/compare/v5.7.7...v5.7.8)
+
+### Added
+- Add `--step` to `migrate:fresh` command ([#25897](https://github.com/laravel/framework/pull/25897))
+- Allow `destroy` method in `Model` to accept a collection of ids ([#25878](https://github.com/laravel/framework/pull/25878))
+- Add AsPivot trait ([#25851](https://github.com/laravel/framework/pull/25851))
+
+### Fixed
+- Fixed wrap table for sql server ([#25896](https://github.com/laravel/framework/pull/25896))

--- a/src/Illuminate/Translation/CHANGELOG-5.7.md
+++ b/src/Illuminate/Translation/CHANGELOG-5.7.md
@@ -1,0 +1,6 @@
+# Release Notes for 5.7.x
+
+## [v5.7.8 (2018-10-04)](https://github.com/illuminate/translation/compare/v5.7.7...v5.7.8)
+
+### Changed
+- Revert of "html string support in translator" ([e626ab3](https://github.com/laravel/framework/commit/e626ab32a4afec90f80641fbcd00e6b79d15cd3a))


### PR DESCRIPTION
We had proposition to track changes by components https://github.com/laravel/ideas/issues/1314 for situation when someone used only some components.

In case, if this PR will be accepted then I will add CHANGELOG for v5.7.1-v5.7.7

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
