### PR TITLE
[5.7] Delete unneeded return statement

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -919,8 +919,6 @@ class TestResponse
     public function assertSessionHasNoErrors()
     {
         return $this->assertSessionMissing('errors');
-
-        return $this;
     }
 
     /**


### PR DESCRIPTION
 - looks like we had some mistake, since `assertSessionHasNoErrors` have 2 returns one by one

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
