### PR TITLE
[5.7] Fix filesystem locking hangs in PackageManifest::build()

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -151,7 +151,6 @@ class Filesystem
         if (file_exists($path)) {
             // Copy over the permissions and owner from the original file.
             chmod($tempPath, (int) base_convert(substr((string) decoct(fileperms($path)), -3), 8, 10));
-            chown($tempPath, fileowner($path));
             chgrp($tempPath, filegroup($path));
         }
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -126,6 +126,8 @@ class Filesystem
     /**
      * Write the contents of a file, replacing it atomically if it already exists.
      *
+     * This will also replace the target file permissions.
+     *
      * @param string $path
      * @param string $content
      * @throws Exception
@@ -144,15 +146,9 @@ class Filesystem
             throw new Exception("Replacing $path requires it's parent directory to be writable.");
         }
 
-        // Write out the contents to a temp file, so we can rename the file atomically.
+        // Write out the contents to a temp file, so we then can rename the file atomically.
         $tempPath = tempnam($dirName, basename($path));
-        $this->put($tempPath, $content);
-
-        if (file_exists($path)) {
-            // Copy over the permissions and owner from the original file.
-            chmod($tempPath, (int) base_convert(substr((string) decoct(fileperms($path)), -3), 8, 10));
-            chgrp($tempPath, filegroup($path));
-        }
+        file_put_contents($tempPath, $content);
 
         rename($tempPath, $path);
     }

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation;
 
-use Exception;
 use Illuminate\Filesystem\Filesystem;
 
 class PackageManifest
@@ -97,7 +96,7 @@ class PackageManifest
             $this->build();
         }
 
-        $this->files->get($this->manifestPath, true);
+        $this->files->get($this->manifestPath);
 
         return $this->manifest = file_exists($this->manifestPath) ?
             $this->files->getRequire($this->manifestPath) : [];
@@ -164,13 +163,6 @@ class PackageManifest
      */
     protected function write(array $manifest)
     {
-        if (! is_writable(dirname($this->manifestPath))) {
-            throw new Exception('The '.dirname($this->manifestPath).' directory must be present and writable.');
-        }
-
-        $this->files->put(
-            $this->manifestPath, '<?php return '.var_export($manifest, true).';',
-            true
-        );
+        $this->files->replace($this->manifestPath, '<?php return '.var_export($manifest, true).';');
     }
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -42,6 +42,16 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello World');
     }
 
+    public function testReplaceStoresFiles()
+    {
+        $files = new Filesystem;
+        $files->replace($this->tempDir.'/file.txt', 'Hello World');
+        $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello World');
+
+        $files->replace($this->tempDir.'/file.txt', 'Something Else');
+        $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Something Else');
+    }
+
     public function testSetChmod()
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');


### PR DESCRIPTION
(this time with less code)

See #25898 PackageManifest::build() hangs on filesystems that don't support exclusive file locks

  - Filesystem.php

     1. Created a new `Filesystem::replace()` method that atomically
        replaces a file if it already exists.

  - PackageManifest.php

     1. The Filesystem::get() call in PackageManifest::getManifest() no
        longer has to use an exclusive lock because the packages.php
        manifest file will always be replaced atomically.

     2. Use the new Filesystem::replace() method in
        PackageManifest::write()