### PR TITLE
[5.7] Check for model in assertViewHas

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -743,6 +744,8 @@ class TestResponse
             PHPUnit::assertArrayHasKey($key, $this->original->getData());
         } elseif ($value instanceof Closure) {
             PHPUnit::assertTrue($value($this->original->$key));
+        } elseif ($value instanceof Model) {
+            PHPUnit::assertTrue($value->is($this->original->$key));
         } else {
             PHPUnit::assertEquals($value, $this->original->$key);
         }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\View\View;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\AssertionFailedError;
 use Illuminate\Foundation\Testing\TestResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -33,6 +34,25 @@ class FoundationTestResponseTest extends TestCase
         ]);
 
         $response->assertViewHas('foo');
+    }
+
+    public function testAssertViewHasModel()
+    {
+        $model = new class extends Model {
+            public function is($model)
+            {
+                return $this == $model;
+            }
+        };
+
+        $response = $this->makeMockResponse([
+            'render' => 'hello world',
+            'getData' => ['foo' => $model],
+        ]);
+
+        $response->original->foo = $model;
+
+        $response->assertViewHas('foo', $model);
     }
 
     public function testAssertSeeInOrder()


### PR DESCRIPTION
When using `assertViewHas` with a model it can end up comparing class state that the test may not care about, such as `wasRecentlyCreated`, `pivots`, or `relationships`, etc. The way I currently go about this is by passing a callback to `assertviewHas`:

```php
$this->assertViewHas('user', function ($model) use ($user) {
    return $user->is($model);
});
```

I think being able to instead call it with `assertViewHas('user', $user)` would be a nice change, and I don't see any obvious negative consequences to this (unless the user cared about the 'hidden' state).

I'm not too cracked up about the test I added as it requires internal knowledge of `$response`, but I figure it's better than adding no tests. I could get rid of this line, but it would require rewriting `assertViewHas` to not be reliant on `__get`.

Edit: I have a couple custom assertions I would like to PR. They are related to each other, but not to this one - should I submit it as a separate PR or make it part of this one?