### PR TITLE
[5.7] Fix distinct pagination on the Eloquent query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -742,9 +742,11 @@ class Builder
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = ($total = $this->toBase()->getCountForPagination($columns))
-                                    ? $this->forPage($page, $perPage)->get($columns)
-                                    : $this->model->newCollection();
+        $query = $this->toBase();
+
+        $results = ($total = $query->getCountForPagination($query->distinct ? [$this->model->getQualifiedKeyName()] : ['*']))
+            ? $this->forPage($page, $perPage)->get($columns)
+            : $this->model->newCollection();
 
         return $this->paginator($results, $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -742,7 +742,7 @@ class Builder
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = ($total = $this->toBase()->getCountForPagination())
+        $results = ($total = $this->toBase()->getCountForPagination($columns))
                                     ? $this->forPage($page, $perPage)->get($columns)
                                     : $this->model->newCollection();
 

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -20,6 +20,14 @@ class EloquentPaginateTest extends DatabaseTestCase
             $table->string('title')->nullable();
             $table->timestamps();
         });
+        Schema::create('post_comments', function ($table) {
+            $table->increments('id');
+            $table->unsignedInteger('post_id');
+            $table->foreign('post_id')->references('id')->on('posts');
+            $table->string('text')->nullable();
+            $table->unsignedInteger('likes')->default(0);
+            $table->timestamps();
+        });
     }
 
     public function test_pagination_on_top_of_columns()
@@ -32,9 +40,40 @@ class EloquentPaginateTest extends DatabaseTestCase
 
         $this->assertCount(15, Post::paginate(15, ['id', 'title']));
     }
+
+    public function test_pagination_with_distinct()
+    {
+        for ($i = 1; $i <= 25; $i++) {
+            $post = Post::create([
+                'title' => 'Title '.$i,
+            ]);
+
+            for ($j = 1; $j <= 5; $j++) {
+                PostComment::create([
+                    'post_id' => $post->id,
+                    'text'    => 'Comment '.$j,
+                    'likes'   => $i + $j,
+                ]);
+            }
+        }
+
+        $paginator = Post::join('post_comments', 'post_comments.post_id', '=', 'posts.id')
+                         ->where('likes', '>', 10)
+                         ->distinct()
+                         ->select('posts.*')
+                         ->paginate(15);
+
+        $this->assertCount(15, $paginator);
+        $this->assertEquals(20, $paginator->total());
+    }
 }
 
 class Post extends Model
+{
+    protected $guarded = [];
+}
+
+class PostComment extends Model
 {
     protected $guarded = [];
 }


### PR DESCRIPTION
When doing a `distinct` query I tried to make the paginator also use a distinct query. The only way to do this seems to be to pass the columns to the paginator so it in turn should build a correct count query.

```php
$query->paginate(10, ['table.id']);
```

However it seems that the columns are never passed to the `getCountForPagination` in the Eloquent builder. It does in the "regular" query Builder. This corrects that.

This seems to be the way since the initial refactor 2 years ago and thus possible longer, maybe this should also be backported to earlier version.

----

Edit: I missed the `EloquentPaginateTest`, seeing that now I can see why this is done. However this means a paginate on a distinct query will not work when using the Eloquent builder. 

Possibly passing the model's primary key as a distinction column is the way to go... however I'm not too sure about it... it works for my use case but not sure if correct and/or covers most cases.

(also the test is not how you would use this but I tried to keep the query and test to a minimum to prevent overcomplicated queries clouding the purpose of the test)

----

Edit 2: This is discussed already a few times but never fixed: #21242 (PR's: #21891 #21899)

I hope this can be reconsidered for 5.7 or possibly 5.8 since pagination is just plain broken when using a distinct.