### PR TITLE
[5.8] Add safe way to register route files out of Router scope

### DIFF
--- a/src/Illuminate/Routing/RouteFileRegistrar.php
+++ b/src/Illuminate/Routing/RouteFileRegistrar.php
@@ -27,6 +27,8 @@ class RouteFileRegistrar
      */
     public function register($routes)
     {
+        $router = $this->router;
+
         require $routes;
     }
 }

--- a/src/Illuminate/Routing/RouteFileRegistrar.php
+++ b/src/Illuminate/Routing/RouteFileRegistrar.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Routing;
+
+class RouteFileRegistrar
+{
+    /**
+     * @var \Illuminate\Routing\Router
+     */
+    protected $router;
+
+    /**
+     * RegisterRouteFile constructor.
+     *
+     * @param \Illuminate\Routing\Router $router
+     */
+    public function __construct(Router $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * Register the route file.
+     *
+     * @param  $routes
+     * @return void
+     */
+    public function register($routes)
+    {
+        require $routes;
+    }
+}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -409,9 +409,7 @@ class Router implements RegistrarContract, BindingRegistrar
         if ($routes instanceof Closure) {
             $routes($this);
         } else {
-            $router = $this;
-
-            require $routes;
+            (new RouteFileRegistrar($this))->register($routes);
         }
     }
 


### PR DESCRIPTION
This PR is a concept to fix the problems that #26016 describes.

It breaks the scope of the `Router` when it requires one of the route files so that for example `->prefix('v2')` doesn't call the protected method on the `Router` but passes it to the `RouteRegistrar` as expected.