### PR TITLE
[5.8] Fix ambiguous UPDATED_AT columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -857,9 +857,11 @@ class Builder
             return $values;
         }
 
-        return Arr::add(
-            $values, $this->model->getUpdatedAtColumn(),
-            $this->model->freshTimestampString()
+        $column = $this->qualifyColumn($this->model->getUpdatedAtColumn());
+
+        return array_merge(
+            [$column => $this->model->freshTimestampString()],
+            $values
         );
     }
 

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -173,7 +173,7 @@ class PostgresGrammar extends Grammar
         // Each one of the columns in the update statements needs to be wrapped in the
         // keyword identifiers, also a place-holder needs to be created for each of
         // the values in the list of bindings so we can make the sets statements.
-        $columns = $this->compileUpdateColumns($values);
+        $columns = $this->compileUpdateColumns($query, $values);
 
         $from = $this->compileUpdateFrom($query);
 
@@ -185,20 +185,23 @@ class PostgresGrammar extends Grammar
     /**
      * Compile the columns for the update statement.
      *
+     * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array   $values
      * @return string
      */
-    protected function compileUpdateColumns($values)
+    protected function compileUpdateColumns($query, $values)
     {
         // When gathering the columns for an update statement, we'll wrap each of the
         // columns and convert it to a parameter value. Then we will concatenate a
         // list of the columns that can be added into this update query clauses.
-        return collect($values)->map(function ($value, $key) {
+        return collect($values)->map(function ($value, $key) use ($query) {
+            $column = Str::after($key, $query->from.'.');
+
             if ($this->isJsonSelector($key)) {
-                return $this->compileJsonUpdateColumn($key, $value);
+                return $this->compileJsonUpdateColumn($column, $value);
             }
 
-            return $this->wrap($key).' = '.$this->parameter($value);
+            return $this->wrap($column).' = '.$this->parameter($value);
         })->implode(', ');
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Closure;
 use stdClass;
 use Mockery as m;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
@@ -1049,6 +1050,24 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->oldest('foo');
     }
 
+    public function testUpdate()
+    {
+        Carbon::setTestNow($now = '2017-10-10 10:10:10');
+
+        $query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));
+        $builder = new Builder($query);
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, '');
+        $builder->setModel($model);
+        $builder->getConnection()->shouldReceive('update')->once()
+            ->with('update "table" set "table"."updated_at" = ?, "foo" = ?', [$now, 'bar'])->andReturn(1);
+
+        $result = $builder->update(['foo' => 'bar']);
+        $this->assertEquals(1, $result);
+
+        Carbon::setTestNow(null);
+    }
+
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';
@@ -1083,6 +1102,11 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         return $query;
     }
+}
+
+class EloquentBuilderTestStub extends Model
+{
+    protected $table = 'table';
 }
 
 class EloquentBuilderTestScopeStub extends Model

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1801,7 +1801,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "id" = ?', ['foo', 'bar', 1])->andReturn(1);
-        $result = $builder->from('users')->where('id', '=', 1)->update(['email' => 'foo', 'name' => 'bar']);
+        $result = $builder->from('users')->where('id', '=', 1)->update(['users.email' => 'foo', 'name' => 'bar']);
         $this->assertEquals(1, $result);
     }
 
@@ -2042,7 +2042,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')
             ->with('update "users" set "options" = jsonb_set("options"::jsonb, \'{"name","first_name"}\', ?)', ['"John"']);
-        $builder->from('users')->update(['options->name->first_name' => 'John']);
+        $builder->from('users')->update(['users.options->name->first_name' => 'John']);
 
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')


### PR DESCRIPTION
#13519 attempted to fix ambiguous `UPDATED_AT` columns in `JOIN` queries:

```php
class Country extends Model {
    public function posts() {
        return $this->hasManyThrough(Post::class, User::class);
    }
}

$country->posts()->update(['foo' => 'bar']);
```

```sql
update `posts` inner join `users` on `users`.`id` = `posts`.`user_id`
set `foo` = bar, `updated_at` = 2018-10-10 01:56:14
where `users`.`country_id` = 1
```

If both tables have an `updated_at` column, you get an "ambiguous column name" error (on MySQL).

To fix this, the previous PR qualified the column with the table name. This didn't work because PostgreSQL and SQLite don't allow qualified columns in `UPDATE` queries (#13707).

#22366 updated the `SQLiteGrammar` to remove the table name from qualified columns when an `UPDATE` query is compiled. This PR applies the same behavior to the `PostgresGrammar`.

We can now safely qualify the column on all platforms. We have to replace `Arr::add()` with `array_merge()` because the former interprets a qualified column as a nested key. `$values` is the second argument so that the users can override the `updated_at` value (as they can now).

Fixes #13909.