### PR TITLE
[5.8] Fix render exception description

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -354,7 +354,7 @@ class Kernel implements KernelContract
     }
 
     /**
-     * Report the exception to the exception handler.
+     * Render the exception to the exception handler.
      *
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @param  \Exception  $e


### PR DESCRIPTION
It was seem a mistake of a "copy & paste" action.