### PR TITLE
[5.8] Add throws docblock for console kernel

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -242,6 +242,8 @@ class Kernel implements KernelContract
      * @param  array  $parameters
      * @param  \Symfony\Component\Console\Output\OutputInterface  $outputBuffer
      * @return int
+     *
+     * @throws \Symfony\Component\Console\Exception\CommandNotFoundException
      */
     public function call($command, array $parameters = [], $outputBuffer = null)
     {


### PR DESCRIPTION
Illuminate\Console\Application::call() will throws CommandNotFoundException if no command is found and Illuminate\Foundation\Console\Kernel::call() doesn't catch the exception of that method, so it also throws exception sometimes.