### PR TITLE
[5.8][WIP] Support eager loading with limit

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -920,6 +920,34 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Alias to set the "limit" value of the query.
+     *
+     * @param  int  $value
+     * @return $this
+     */
+    public function take($value)
+    {
+        return $this->limit($value);
+    }
+
+    /**
+     * Set the "limit" value of the query.
+     *
+     * @param  int  $value
+     * @return $this
+     */
+    public function limit($value)
+    {
+        if ($this->parent->exists) {
+            $this->query->limit($value);
+        } else {
+            $this->query->partitionLimit($value, $this->getQualifiedForeignPivotKeyName());
+        }
+
+        return $this;
+    }
+
+    /**
      * Get the key for comparing against the parent key in "has" query.
      *
      * @return string

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -515,6 +515,34 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Alias to set the "limit" value of the query.
+     *
+     * @param  int  $value
+     * @return $this
+     */
+    public function take($value)
+    {
+        return $this->limit($value);
+    }
+
+    /**
+     * Set the "limit" value of the query.
+     *
+     * @param  int  $value
+     * @return $this
+     */
+    public function limit($value)
+    {
+        if ($this->farParent->exists) {
+            $this->query->limit($value);
+        } else {
+            $this->query->partitionLimit($value, $this->getQualifiedFirstKeyName());
+        }
+
+        return $this;
+    }
+
+    /**
      * Get a relationship join table hash.
      *
      * @return string

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -360,6 +360,34 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Alias to set the "limit" value of the query.
+     *
+     * @param  int  $value
+     * @return $this
+     */
+    public function take($value)
+    {
+        return $this->limit($value);
+    }
+
+    /**
+     * Set the "limit" value of the query.
+     *
+     * @param  int  $value
+     * @return $this
+     */
+    public function limit($value)
+    {
+        if ($this->parent->exists) {
+            $this->query->limit($value);
+        } else {
+            $this->query->partitionLimit($value, $this->getQualifiedForeignKeyName());
+        }
+
+        return $this;
+    }
+
+    /**
      * Get a relationship join table hash.
      *
      * @return string

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -132,6 +132,13 @@ class Builder
     public $limit;
 
     /**
+     * The maximum number of records to return per partition.
+     *
+     * @var array
+     */
+    public $partitionLimit;
+
+    /**
      * The number of records to skip.
      *
      * @var int
@@ -1898,6 +1905,22 @@ class Builder
                         return isset($order['column'])
                                ? $order['column'] === $column : false;
                     })->values()->all();
+    }
+
+    /**
+     * Add a "partition limit" clause to the query.
+     *
+     * @param  int  $value
+     * @param  string  $column
+     * @return $this
+     */
+    public function partitionLimit($value, $column)
+    {
+        if ($value >= 0) {
+            $this->partitionLimit = compact('value', 'column');
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
+use PDO;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Database\Query\Builder;
@@ -53,6 +54,25 @@ class SQLiteGrammar extends Grammar
         }
 
         return $sql;
+    }
+
+    /**
+     * Compile a partition limit clause for the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    protected function compilePartitionLimit(Builder $query)
+    {
+        $version = $query->getConnection()->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+
+        if (version_compare($version, '3.25.0') >= 0) {
+            return parent::compilePartitionLimit($query);
+        }
+
+        $query->partitionLimit = null;
+
+        return $this->compileSelect($query);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -258,6 +258,18 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals($colin, $instances[1]);
     }
 
+    public function testLimit()
+    {
+        $relation = $this->getRelation();
+        $relation->getQuery()->shouldReceive('partitionLimit')->once()->with(10, 'table.foreign_key');
+        $relation->limit(10);
+
+        $relation = $this->getRelation();
+        $relation->getParent()->exists = true;
+        $relation->getQuery()->shouldReceive('limit')->once()->with(10);
+        $relation->limit(10);
+    }
+
     protected function getRelation()
     {
         $builder = m::mock(Builder::class);


### PR DESCRIPTION
There is currently no way to limit eager loading results *per parent*:

```php
class User extends Model {
    public function posts() {
        return $this->hasMany(Post::class)->latest()->limit(5);
    }
}

User::with('posts')->get(); 
```

```sql
# Loads 5 posts for all users combined.
select * from "posts" where "posts"."user_id" in (1, 2, 3) order by "created_at" desc limit 5
```

There are multiple issues about this (#16217, #4835, #18014) and it also comes up regularly on StackOverflow etc.

We can support this feature with a [window function](https://en.wikipedia.org/wiki/SQL_window_function) (we are already using this technique to implement `OFFSET` queries on SQL Server):

```sql
select * from (
  select *, row_number() over (partition by "user_id" order by "created_at" desc) as row_num
  from "posts"
  where "posts"."user_id" in (1, 2, 3)
) as temp_table
where row_num <= 5
order by row_num
```

The query is supported by all four databases, but requires very recent versions of MySQL and SQLite:

 - MySQL 8.0 (2018-07-27): We could support older versions with [this](https://softonsofa.com/tweaking-eloquent-relations-how-to-get-n-related-models-per-parent/) workaround.
 - PostgreSQL 9.3 (2013)
 - SQLite 3.25 (2018-09-15)
 - SQL Server 2008

I wrote a sample implementation for PostgreSQL because it's the only supported database in Homestead at the moment.

The relationships override the query builder's `limit()` and call the new `partitionLimit()` method. By checking the parent model's `exists` property, we can detect eager loading. This is necessary to support lazy loading (`$user->posts`). The window function would also work for lazy loading but the database might not support it.

Before I implement the other databases: Would you consider this for the core?
