### PR TITLE
[5.7] Make assertSessionHasNoErrors print the unexpected errors

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -921,7 +921,17 @@ class TestResponse
      */
     public function assertSessionHasNoErrors()
     {
-        return $this->assertSessionMissing('errors');
+        $hasErrors = $this->session()->has('errors');
+
+        $errors = $hasErrors ? $this->session()->get('errors')->all() : [];
+
+        PHPUnit::assertFalse(
+            $hasErrors,
+            'Session has unexpected errors: '.PHP_EOL.
+            json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
When using `assertSessionHasNoErrors()`, it is very tricky to figure out which unexpected errors occurred when the assertion fails:
 
![before](https://user-images.githubusercontent.com/7202674/46727981-0f576280-cc82-11e8-85ec-fe493d7ec2d3.png)

This PR makes the assertion print the error when it fails:
 
![after](https://user-images.githubusercontent.com/7202674/46728002-1a11f780-cc82-11e8-9a52-a4528c7bf022.png)
