### PR TITLE
[5.7] Fix ColumnDefinition::default typehint

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Fluent;
  * @method ColumnDefinition charset(string $charset) Specify a character set for the column (MySQL)
  * @method ColumnDefinition collation(string $collation) Specify a collation for the column (MySQL/SQL Server)
  * @method ColumnDefinition comment(string $comment) Add a comment to the column (MySQL)
- * @method ColumnDefinition default(string $value) Specify a "default" value for the column
+ * @method ColumnDefinition default(mixed $value) Specify a "default" value for the column
  * @method ColumnDefinition first(string $column) Place the column "first" in the table (MySQL)
  * @method ColumnDefinition nullable($value = true) Allow NULL values to be inserted into the column
  * @method ColumnDefinition storedAs($expression) Create a stored generated column (MySQL)


### PR DESCRIPTION
It really can be anything as it depends on the column type (e.g. `bool` for boolean, etc.)