### PR TITLE
Improve `$request->is()` method

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -184,13 +184,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function is(...$patterns)
     {
-        foreach ($patterns as $pattern) {
-            if (Str::is($pattern, $this->decodedPath())) {
-                return true;
-            }
-        }
-
-        return false;
+        return Str::is($patterns, $this->decodedPath());
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -654,13 +654,7 @@ class Route
             return false;
         }
 
-        foreach ($patterns as $pattern) {
-            if (Str::is($pattern, $routeName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return Str::is($patterns, $routeName);
     }
 
     /**


### PR DESCRIPTION
I removed the foreach loops in these two methods. This still works because the `Str::is` method accepts arrays.  This also will work slightly faster. (Not something you will notice directly but still *yay*)