### PR TITLE
Fixed typo in actionURL parameter

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -51,7 +51,7 @@
 @component('mail::subcopy')
 @lang(
     "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
-    'into your web browser: [:actionURL](:actionURL)',
+    'into your web browser: [:actionUrl](:actionUrl)',
     [
         'actionText' => $actionText,
         'actionUrl' => $actionUrl


### PR DESCRIPTION
The placeholder has not been replaced because the spelling is case-sensitive.