### PR TITLE
[5.7] Delete unneeded type check, since it will never be `true`

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -93,7 +93,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
 
         if (is_array($data)) {
             $data = $data;
-        } elseif ($data instanceof Arrayable || $data instanceof Collection) {
+        } elseif ($data instanceof Arrayable) {
             $data = $data->toArray();
         } elseif ($data instanceof JsonSerializable) {
             $data = $data->jsonSerialize();


### PR DESCRIPTION
Actually, we should not check the `$data instanceof Collection`, since Collection implements an `Arrayable` which checked before this.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
