### PR TITLE
[5.8] Add Eloquent HasOneThrough relationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 trait HasRelationships
@@ -75,6 +76,49 @@ trait HasRelationships
     protected function newHasOne(Builder $query, Model $parent, $foreignKey, $localKey)
     {
         return new HasOne($query, $parent, $foreignKey, $localKey);
+    }
+
+    /**
+     * Define a has-one-through relationship.
+     *
+     * @param  string  $related
+     * @param  string  $through
+     * @param  string|null  $firstKey
+     * @param  string|null  $secondKey
+     * @param  string|null  $localKey
+     * @param  string|null  $secondLocalKey
+     * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
+     */
+    public function hasOneThrough($related, $through, $firstKey = null, $secondKey = null, $localKey = null, $secondLocalKey = null)
+    {
+        $through = new $through;
+
+        $firstKey = $firstKey ?: $this->getForeignKey();
+
+        $secondKey = $secondKey ?: $through->getForeignKey();
+
+        return $this->newHasOneThrough(
+            $this->newRelatedInstance($related)->newQuery(), $this, $through,
+            $firstKey, $secondKey, $localKey ?: $this->getKeyName(),
+            $secondLocalKey ?: $through->getKeyName()
+        );
+    }
+
+    /**
+     * Instantiate a new HasOneThrough relationship.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Model  $farParent
+     * @param  \Illuminate\Database\Eloquent\Model  $throughParent
+     * @param  string  $firstKey
+     * @param  string  $secondKey
+     * @param  string  $localKey
+     * @param  string  $secondLocalKey
+     * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
+     */
+    protected function newHasOneThrough(Builder $query, Model $farParent, Model $throughParent, $firstKey, $secondKey, $localKey, $secondLocalKey)
+    {
+        return new HasOneThrough($query, $farParent, $throughParent, $firstKey, $secondKey, $localKey, $secondLocalKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -207,7 +207,7 @@ class HasManyThrough extends Relation
         // relationship as this will allow us to quickly access all of the related
         // models without having to do nested looping which will be quite slow.
         foreach ($results as $result) {
-            $dictionary[$result->laravel_many_through_key][] = $result;
+            $dictionary[$result->laravel_through_key][] = $result;
         }
 
         return $dictionary;
@@ -410,7 +410,7 @@ class HasManyThrough extends Relation
             $columns = [$this->related->getTable().'.*'];
         }
 
-        return array_merge($columns, [$this->getQualifiedFirstKeyName().' as laravel_many_through_key']);
+        return array_merge($columns, [$this->getQualifiedFirstKeyName().' as laravel_through_key']);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
+
+class HasOneThrough extends HasManyThrough
+{
+    use SupportsDefaultModels;
+
+    /**
+     * Get the results of the relationship.
+     *
+     * @return mixed
+     */
+    public function getResults()
+    {
+        return $this->query->first() ?: $this->getDefaultFor($this->farParent);
+    }
+
+    /**
+     * Initialize the relation on a set of models.
+     *
+     * @param  array   $models
+     * @param  string  $relation
+     * @return array
+     */
+    public function initRelation(array $models, $relation)
+    {
+        foreach ($models as $model) {
+            $model->setRelation($relation, $this->getDefaultFor($model));
+        }
+
+        return $models;
+    }
+
+    /**
+     * Match the eagerly loaded results to their parents.
+     *
+     * @param  array   $models
+     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  string  $relation
+     * @return array
+     */
+    public function match(array $models, Collection $results, $relation)
+    {
+        $dictionary = $this->buildDictionary($results);
+
+        // Once we have the dictionary we can simply spin through the parent models to
+        // link them up with their children using the keyed dictionary to make the
+        // matching very convenient and easy work. Then we'll just return them.
+        foreach ($models as $model) {
+            if (isset($dictionary[$key = $model->getAttribute($this->localKey)])) {
+                $value = $dictionary[$key];
+                $model->setRelation(
+                    $relation, reset($value)
+                );
+            }
+        }
+
+        return $models;
+    }
+
+    /**
+     * Make a new related instance for the given model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function newRelatedInstanceFor(Model $parent)
+    {
+        return $this->related->newInstance()->setAttribute(
+            $this->getForeignKeyName(), $parent->{$this->localKey}
+        );
+    }
+
+    /**
+     * Get the plain foreign key.
+     *
+     * @return string
+     */
+    public function getForeignKeyName()
+    {
+        $segments = explode('.', $this->getQualifiedForeignKeyName());
+
+        return end($segments);
+    }
+}

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -163,7 +163,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
             'email',
             'created_at',
             'updated_at',
-            'laravel_many_through_key',
+            'laravel_through_key',
         ], array_keys($post->getAttributes()));
     }
 
@@ -175,7 +175,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertEquals([
             'title',
             'body',
-            'laravel_many_through_key',
+            'laravel_through_key',
         ], array_keys($post->getAttributes()));
     }
 
@@ -195,7 +195,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
                 'email',
                 'created_at',
                 'updated_at',
-                'laravel_many_through_key', ], array_keys($post->getAttributes()));
+                'laravel_through_key', ], array_keys($post->getAttributes()));
         });
     }
 
@@ -216,7 +216,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
                 'email',
                 'created_at',
                 'updated_at',
-                'laravel_many_through_key', ], array_keys($post->getAttributes()));
+                'laravel_through_key', ], array_keys($post->getAttributes()));
         }
     }
 
@@ -235,7 +235,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
                 'email',
                 'created_at',
                 'updated_at',
-                'laravel_many_through_key', ], array_keys($post->getAttributes()));
+                'laravel_through_key', ], array_keys($post->getAttributes()));
         });
     }
 

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -159,7 +159,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
             'email',
             'created_at',
             'updated_at',
-            'position_id',
+            'laravel_through_key',
         ], array_keys($contract->getAttributes()));
     }
 
@@ -171,7 +171,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         $this->assertEquals([
             'title',
             'body',
-            'position_id',
+            'laravel_through_key',
         ], array_keys($contract->getAttributes()));
     }
 
@@ -191,7 +191,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
                 'email',
                 'created_at',
                 'updated_at',
-                'position_id', ], array_keys($contract->getAttributes()));
+                'laravel_through_key', ], array_keys($contract->getAttributes()));
         });
     }
 
@@ -212,7 +212,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
                 'email',
                 'created_at',
                 'updated_at',
-                'position_id', ], array_keys($contract->getAttributes()));
+                'laravel_through_key', ], array_keys($contract->getAttributes()));
         }
     }
 
@@ -231,7 +231,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
                 'email',
                 'created_at',
                 'updated_at',
-                'position_id', ], array_keys($contract->getAttributes()));
+                'laravel_through_key', ], array_keys($contract->getAttributes()));
         });
     }
 

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -1,0 +1,489 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
+{
+    public function setUp()
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+            $table->unsignedInteger('position_id')->unique()->nullable();
+            $table->string('position_short');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        $this->schema()->create('contracts', function ($table) {
+            $table->increments('id');
+            $table->integer('user_id')->unique();
+            $table->string('title');
+            $table->text('body');
+            $table->string('email');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('positions', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('shortname');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('contracts');
+        $this->schema()->drop('positions');
+    }
+
+    public function testItLoadsAHasOneThroughRelationWithCustomKeys()
+    {
+        $this->seedData();
+        $contract = HasOneThroughTestPosition::first()->contract;
+
+        $this->assertEquals('A title', $contract->title);
+    }
+
+    public function testItLoadsADefaultHasOneThroughRelation()
+    {
+        $this->migrateDefault();
+        $this->seedDefaultData();
+
+        $contract = HasOneThroughDefaultTestPosition::first()->contract;
+        $this->assertEquals('A title', $contract->title);
+
+        $this->resetDefault();
+    }
+
+    public function testItLoadsARelationWithCustomIntermediateAndLocalKey()
+    {
+        $this->seedData();
+        $contract = HasOneThroughIntermediateTestPosition::first()->contract;
+
+        $this->assertEquals('A title', $contract->title);
+    }
+
+    public function testEagerLoadingARelationWithCustomIntermediateAndLocalKey()
+    {
+        $this->seedData();
+        $contract = HasOneThroughIntermediateTestPosition::with('contract')->first()->contract;
+
+        $this->assertEquals('A title', $contract->title);
+    }
+
+    public function testWhereHasOnARelationWithCustomIntermediateAndLocalKey()
+    {
+        $this->seedData();
+        $position = HasOneThroughIntermediateTestPosition::whereHas('contract', function ($query) {
+            $query->where('title', 'A title');
+        })->get();
+
+        $this->assertCount(1, $position);
+    }
+
+    /**
+     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasOneThroughTestContract].
+     */
+    public function testFirstOrFailThrowsAnException()
+    {
+        HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
+            ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);
+
+        HasOneThroughTestPosition::first()->contract()->firstOrFail();
+    }
+
+    /**
+     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasOneThroughTestContract].
+     */
+    public function testFindOrFailThrowsAnException()
+    {
+        HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
+            ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);
+
+        HasOneThroughTestPosition::first()->contract()->findOrFail(1);
+    }
+
+    public function testFirstRetrievesFirstRecord()
+    {
+        $this->seedData();
+        $contract = HasOneThroughTestPosition::first()->contract()->first();
+
+        $this->assertNotNull($contract);
+        $this->assertEquals('A title', $contract->title);
+    }
+
+    public function testAllColumnsAreRetrievedByDefault()
+    {
+        $this->seedData();
+        $contract = HasOneThroughTestPosition::first()->contract()->first();
+        $this->assertEquals([
+            'id',
+            'user_id',
+            'title',
+            'body',
+            'email',
+            'created_at',
+            'updated_at',
+            'position_id',
+        ], array_keys($contract->getAttributes()));
+    }
+
+    public function testOnlyProperColumnsAreSelectedIfProvided()
+    {
+        $this->seedData();
+        $contract = HasOneThroughTestPosition::first()->contract()->first(['title', 'body']);
+
+        $this->assertEquals([
+            'title',
+            'body',
+            'position_id',
+        ], array_keys($contract->getAttributes()));
+    }
+
+    public function testChunkReturnsCorrectModels()
+    {
+        $this->seedData();
+        $this->seedDataExtended();
+        $position = HasOneThroughTestPosition::find(1);
+
+        $position->contract()->chunk(10, function ($contractsChunk) {
+            $contract = $contractsChunk->first();
+            $this->assertEquals([
+                'id',
+                'user_id',
+                'title',
+                'body',
+                'email',
+                'created_at',
+                'updated_at',
+                'position_id', ], array_keys($contract->getAttributes()));
+        });
+    }
+
+    public function testCursorReturnsCorrectModels()
+    {
+        $this->seedData();
+        $this->seedDataExtended();
+        $position = HasOneThroughTestPosition::find(1);
+
+        $contracts = $position->contract()->cursor();
+
+        foreach ($contracts as $contract) {
+            $this->assertEquals([
+                'id',
+                'user_id',
+                'title',
+                'body',
+                'email',
+                'created_at',
+                'updated_at',
+                'position_id', ], array_keys($contract->getAttributes()));
+        }
+    }
+
+    public function testEachReturnsCorrectModels()
+    {
+        $this->seedData();
+        $this->seedDataExtended();
+        $position = HasOneThroughTestPosition::find(1);
+
+        $position->contract()->each(function ($contract) {
+            $this->assertEquals([
+                'id',
+                'user_id',
+                'title',
+                'body',
+                'email',
+                'created_at',
+                'updated_at',
+                'position_id', ], array_keys($contract->getAttributes()));
+        });
+    }
+
+    public function testIntermediateSoftDeletesAreIgnored()
+    {
+        $this->seedData();
+        HasOneThroughSoftDeletesTestUser::first()->delete();
+
+        $contract = HasOneThroughSoftDeletesTestPosition::first()->contract;
+
+        $this->assertEquals('A title', $contract->title);
+    }
+
+    public function testEagerLoadingLoadsRelatedModelsCorrectly()
+    {
+        $this->seedData();
+        $position = HasOneThroughSoftDeletesTestPosition::with('contract')->first();
+
+        $this->assertEquals('ps', $position->shortname);
+        $this->assertEquals('A title', $position->contract->title);
+    }
+
+    /**
+     * Helpers...
+     */
+    protected function seedData()
+    {
+        HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
+            ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps'])
+            ->contract()->create(['title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
+    }
+
+    protected function seedDataExtended()
+    {
+        $position = HasOneThroughTestPosition::create(['id' => 2, 'name' => 'Vice President', 'shortname' => 'vp']);
+        $position->user()->create(['id' => 2, 'email' => 'example1@gmail.com', 'position_short' => 'vp'])
+            ->contract()->create(
+                ['title' => 'Example1 title1', 'body' => 'Example1 body1', 'email' => 'example1contract1@gmail.com']
+            );
+    }
+
+    /**
+     * Seed data for a default HasOneThrough setup.
+     */
+    protected function seedDefaultData()
+    {
+        HasOneThroughDefaultTestPosition::create(['id' => 1, 'name' => 'President'])
+            ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com'])
+            ->contract()->create(['title' => 'A title', 'body' => 'A body']);
+    }
+
+    /**
+     * Drop the default tables.
+     */
+    protected function resetDefault()
+    {
+        $this->schema()->drop('users_default');
+        $this->schema()->drop('contracts_default');
+        $this->schema()->drop('positions_default');
+    }
+
+    /**
+     * Migrate tables for classes with a Laravel "default" HasOneThrough setup.
+     */
+    protected function migrateDefault()
+    {
+        $this->schema()->create('users_default', function ($table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+            $table->unsignedInteger('has_one_through_default_test_position_id')->unique()->nullable();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('contracts_default', function ($table) {
+            $table->increments('id');
+            $table->integer('has_one_through_default_test_user_id')->unique();
+            $table->string('title');
+            $table->text('body');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('positions_default', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class HasOneThroughTestUser extends Eloquent
+{
+    protected $table = 'users';
+    protected $guarded = [];
+
+    public function contract()
+    {
+        return $this->hasOne(HasOneThroughTestContract::class, 'user_id');
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class HasOneThroughTestContract extends Eloquent
+{
+    protected $table = 'contracts';
+    protected $guarded = [];
+
+    public function owner()
+    {
+        return $this->belongsTo(HasOneThroughTestUser::class, 'user_id');
+    }
+}
+
+class HasOneThroughTestPosition extends Eloquent
+{
+    protected $table = 'positions';
+    protected $guarded = [];
+
+    public function contract()
+    {
+        return $this->hasOneThrough(HasOneThroughTestContract::class, HasOneThroughTestUser::class, 'position_id', 'user_id');
+    }
+
+    public function user()
+    {
+        return $this->hasOne(HasOneThroughTestUser::class, 'position_id');
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class HasOneThroughDefaultTestUser extends Eloquent
+{
+    protected $table = 'users_default';
+    protected $guarded = [];
+
+    public function contract()
+    {
+        return $this->hasOne(HasOneThroughDefaultTestContract::class);
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class HasOneThroughDefaultTestContract extends Eloquent
+{
+    protected $table = 'contracts_default';
+    protected $guarded = [];
+
+    public function owner()
+    {
+        return $this->belongsTo(HasOneThroughDefaultTestUser::class);
+    }
+}
+
+class HasOneThroughDefaultTestPosition extends Eloquent
+{
+    protected $table = 'positions_default';
+    protected $guarded = [];
+
+    public function contract()
+    {
+        return $this->hasOneThrough(HasOneThroughDefaultTestContract::class, HasOneThroughDefaultTestUser::class);
+    }
+
+    public function user()
+    {
+        return $this->hasOne(HasOneThroughDefaultTestUser::class);
+    }
+}
+
+class HasOneThroughIntermediateTestPosition extends Eloquent
+{
+    protected $table = 'positions';
+    protected $guarded = [];
+
+    public function contract()
+    {
+        return $this->hasOneThrough(HasOneThroughTestContract::class, HasOneThroughTestUser::class, 'position_short', 'email', 'shortname', 'email');
+    }
+
+    public function user()
+    {
+        return $this->hasOne(HasOneThroughTestUser::class, 'position_id');
+    }
+}
+
+class HasOneThroughSoftDeletesTestUser extends Eloquent
+{
+    use SoftDeletes;
+
+    protected $table = 'users';
+    protected $guarded = [];
+
+    public function contract()
+    {
+        return $this->hasOne(HasOneThroughSoftDeletesTestContract::class, 'user_id');
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class HasOneThroughSoftDeletesTestContract extends Eloquent
+{
+    protected $table = 'contracts';
+    protected $guarded = [];
+
+    public function owner()
+    {
+        return $this->belongsTo(HasOneThroughSoftDeletesTestUser::class, 'user_id');
+    }
+}
+
+class HasOneThroughSoftDeletesTestPosition extends Eloquent
+{
+    protected $table = 'positions';
+    protected $guarded = [];
+
+    public function contract()
+    {
+        return $this->hasOneThrough(HasOneThroughSoftDeletesTestContract::class, HasOneThroughTestUser::class, 'position_id', 'user_id');
+    }
+
+    public function user()
+    {
+        return $this->hasOne(HasOneThroughSoftDeletesTestUser::class, 'position_id');
+    }
+}

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -58,7 +58,7 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
 
         $teamMates = $user->teamMatesWithGlobalScope;
 
-        $this->assertEquals(['id' => 2, 'laravel_many_through_key' => 1], $teamMates[0]->getAttributes());
+        $this->assertEquals(['id' => 2, 'laravel_through_key' => 1], $teamMates[0]->getAttributes());
     }
 
     public function test_has_self()

--- a/tests/Integration/Database/EloquentRelationshipsTest.php
+++ b/tests/Integration/Database/EloquentRelationshipsTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentRelationshipsTest;
 
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
@@ -34,6 +35,7 @@ class EloquentRelationshipsTest extends TestCase
         $this->assertInstanceOf(MorphMany::class, $post->likes());
         $this->assertInstanceOf(BelongsToMany::class, $post->viewers());
         $this->assertInstanceOf(HasManyThrough::class, $post->lovers());
+        $this->assertInstanceOf(HasOneThrough::class, $post->contract());
         $this->assertInstanceOf(MorphToMany::class, $post->tags());
         $this->assertInstanceOf(MorphTo::class, $post->postable());
     }
@@ -52,6 +54,7 @@ class EloquentRelationshipsTest extends TestCase
         $this->assertInstanceOf(CustomMorphMany::class, $post->likes());
         $this->assertInstanceOf(CustomBelongsToMany::class, $post->viewers());
         $this->assertInstanceOf(CustomHasManyThrough::class, $post->lovers());
+        $this->assertInstanceOf(CustomHasOneThrough::class, $post->contract());
         $this->assertInstanceOf(CustomMorphToMany::class, $post->tags());
         $this->assertInstanceOf(CustomMorphTo::class, $post->postable());
     }
@@ -96,6 +99,11 @@ class Post extends Model
     public function lovers()
     {
         return $this->hasManyThrough(FakeRelationship::class, FakeRelationship::class);
+    }
+
+    public function contract()
+    {
+        return $this->hasOneThrough(FakeRelationship::class, FakeRelationship::class);
     }
 
     public function tags()
@@ -148,6 +156,12 @@ class CustomPost extends Post
         return new CustomHasManyThrough($query, $farParent, $throughParent, $firstKey, $secondKey, $localKey, $secondLocalKey);
     }
 
+    protected function newHasOneThrough(Builder $query, Model $farParent, Model $throughParent, $firstKey,
+        $secondKey, $localKey, $secondLocalKey
+    ) {
+        return new CustomHasOneThrough($query, $farParent, $throughParent, $firstKey, $secondKey, $localKey, $secondLocalKey);
+    }
+
     protected function newMorphToMany(Builder $query, Model $parent, $name, $table, $foreignPivotKey,
         $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $inverse = false)
     {
@@ -186,6 +200,10 @@ class CustomBelongsToMany extends BelongsToMany
 }
 
 class CustomHasManyThrough extends HasManyThrough
+{
+}
+
+class CustomHasOneThrough extends HasOneThrough
 {
 }
 

--- a/tests/Integration/Database/EloquentRelationshipsTest.php
+++ b/tests/Integration/Database/EloquentRelationshipsTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentRelationshipsTest;
 
-use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
@@ -14,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 /**


### PR DESCRIPTION
This commit adds the Eloquent HasOneThrough relationship. This will allow for easy linking to deeper nested models and easy eager loading of them.

Many thanks to @frdteknikelektro and his original PR which really was most of the work: https://github.com/laravel/framework/pull/25083
