### PR TITLE
[5.8] open generated files in IDE

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Console;
 use Illuminate\Support\Str;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 abstract class GeneratorCommand extends Command
 {
@@ -33,6 +34,13 @@ abstract class GeneratorCommand extends Command
         parent::__construct();
 
         $this->files = $files;
+
+        $this->addOption(
+            'open',
+            'o',
+            InputOption::VALUE_NONE,
+            'Launch the generated file in your .php editor'
+        );
     }
 
     /**
@@ -73,7 +81,9 @@ abstract class GeneratorCommand extends Command
 
         $this->info($this->type.' created successfully.');
 
-        $this->launchInEditor($path);
+        if ($this->input->getOption('open')) {
+            $this->launchInEditor($path);
+        }
     }
 
     /**
@@ -263,7 +273,7 @@ abstract class GeneratorCommand extends Command
             '/usr/bin/open',
             '/usr/bin/xdg-open',
         ]);
-        
+
         foreach ($editors as $editor) {
             if (file_exists($editor)) {
                 shell_exec("$editor $path");

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -72,6 +72,8 @@ abstract class GeneratorCommand extends Command
         $this->files->put($path, $this->buildClass($name));
 
         $this->info($this->type.' created successfully.');
+
+        $this->launchInEditor($path);
     }
 
     /**
@@ -247,5 +249,24 @@ abstract class GeneratorCommand extends Command
         return [
             ['name', InputArgument::REQUIRED, 'The name of the class'],
         ];
+    }
+
+    /**
+     * Takes the newly generated file, and attempts to launch in the OS's default editor
+     * for .php files
+     * @param $path
+     */
+    protected function launchInEditor($path)
+    {
+        $editors = [
+            '/usr/bin/open',
+            '/usr/bin/xdg-open',
+        ];
+
+        foreach ($editors as $editor) {
+            if (file_exists($editor)) {
+                `$editor $path`;
+            }
+        }
     }
 }

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -258,14 +258,16 @@ abstract class GeneratorCommand extends Command
      */
     protected function launchInEditor($path)
     {
-        $editors = [
+        $editors = array_filter([
+            env('ARTISAN_LAUNCHER_PATH'),
             '/usr/bin/open',
             '/usr/bin/xdg-open',
-        ];
-
+        ]);
+        
         foreach ($editors as $editor) {
             if (file_exists($editor)) {
-                `$editor $path`;
+                shell_exec("$editor $path");
+                return;
             }
         }
     }

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -275,6 +275,10 @@ abstract class GeneratorCommand extends Command
                 return;
             }
         }
+
+        if (windows_os()) {
+            shell_exec("start $path");
+        }
     }
 
     /**

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -35,12 +35,7 @@ abstract class GeneratorCommand extends Command
 
         $this->files = $files;
 
-        $this->addOption(
-            'open',
-            'o',
-            InputOption::VALUE_NONE,
-            'Launch the generated file in your .php editor'
-        );
+        $this->addOpenOption();
     }
 
     /**
@@ -280,5 +275,18 @@ abstract class GeneratorCommand extends Command
                 return;
             }
         }
+    }
+
+    /**
+     * Defines the command option to launch generated files
+     */
+    protected function addOpenOption()
+    {
+        $this->addOption(
+            'open',
+            'o',
+            InputOption::VALUE_NONE,
+            'Launch the generated file in your .php editor'
+        );
     }
 }

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -4,8 +4,8 @@ namespace Illuminate\Console;
 
 use Illuminate\Support\Str;
 use Illuminate\Filesystem\Filesystem;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
 
 abstract class GeneratorCommand extends Command
 {
@@ -258,7 +258,7 @@ abstract class GeneratorCommand extends Command
 
     /**
      * Takes the newly generated file, and attempts to launch in the OS's default editor
-     * for .php files
+     * for .php files.
      * @param $path
      */
     protected function launchInEditor($path)
@@ -272,6 +272,7 @@ abstract class GeneratorCommand extends Command
         foreach ($editors as $editor) {
             if (file_exists($editor)) {
                 shell_exec("$editor $path");
+
                 return;
             }
         }
@@ -282,7 +283,7 @@ abstract class GeneratorCommand extends Command
     }
 
     /**
-     * Defines the command option to launch generated files
+     * Defines the command option to launch generated files.
      */
     protected function addOpenOption()
     {


### PR DESCRIPTION
This PR adds an `--open` option to `artisan make` commands to launch the newly generated file in your editor.

```
php artisan make:controller ExampleController --open
```

(The short-hand for this option is `-o`)

This PR has Linux, macOS and Windows support by leveraging OS command line launchers. Whichever program you have associated with `.php` files will be used.

There is also an `ARTISAN_LAUNCHER_PATH` environment variable available if you're using a different launcher, or you want to set an override e.g. `/usr/local/bin/pstorm`.

Proposal here: https://github.com/laravel/ideas/issues/1330