### PR TITLE
[5.8] Add custom messages to all $response->assertX methods

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -61,13 +61,17 @@ class TestResponse
     /**
      * Assert that the response has a successful status code.
      *
+     * @param  string  $message
      * @return $this
      */
-    public function assertSuccessful()
+    public function assertSuccessful(string $message = '')
     {
         PHPUnit::assertTrue(
             $this->isSuccessful(),
-            'Response status code ['.$this->getStatusCode().'] is not a successful status code.'
+            $this->prependMessage(
+                'Response status code ['.$this->getStatusCode().'] is not a successful status code.',
+                $message
+            )
         );
 
         return $this;
@@ -76,13 +80,17 @@ class TestResponse
     /**
      * Assert that the response has a 200 status code.
      *
+     * @param  string  $message
      * @return $this
      */
-    public function assertOk()
+    public function assertOk(string $message = '')
     {
         PHPUnit::assertTrue(
             $this->isOk(),
-            'Response status code ['.$this->getStatusCode().'] does not match expected 200 status code.'
+            $this->prependMessage(
+                'Response status code ['.$this->getStatusCode().'] does not match expected 200 status code.',
+                $message
+            )
         );
 
         return $this;
@@ -91,13 +99,17 @@ class TestResponse
     /**
      * Assert that the response has a not found status code.
      *
+     * @param  string  $message
      * @return $this
      */
-    public function assertNotFound()
+    public function assertNotFound(string $message = '')
     {
         PHPUnit::assertTrue(
             $this->isNotFound(),
-            'Response status code ['.$this->getStatusCode().'] is not a not found status code.'
+            $this->prependMessage(
+                'Response status code ['.$this->getStatusCode().'] is not a not found status code.',
+                $message
+            )
         );
 
         return $this;
@@ -106,13 +118,17 @@ class TestResponse
     /**
      * Assert that the response has a forbidden status code.
      *
+     * @param  string  $message
      * @return $this
      */
-    public function assertForbidden()
+    public function assertForbidden(string $message = '')
     {
         PHPUnit::assertTrue(
             $this->isForbidden(),
-            'Response status code ['.$this->getStatusCode().'] is not a forbidden status code.'
+            $this->prependMessage(
+                'Response status code ['.$this->getStatusCode().'] is not a forbidden status code.',
+                $message
+            )
         );
 
         return $this;
@@ -122,15 +138,16 @@ class TestResponse
      * Assert that the response has the given status code.
      *
      * @param  int  $status
+     * @param  string  $message
      * @return $this
      */
-    public function assertStatus($status)
+    public function assertStatus($status, string $message = '')
     {
         $actual = $this->getStatusCode();
 
         PHPUnit::assertTrue(
             $actual === $status,
-            "Expected status code {$status} but received {$actual}."
+            $this->prependMessage("Expected status code {$status} but received {$actual}.", $message)
         );
 
         return $this;
@@ -140,12 +157,17 @@ class TestResponse
      * Assert whether the response is redirecting to a given URI.
      *
      * @param  string  $uri
+     * @param  string  $message
      * @return $this
      */
-    public function assertRedirect($uri = null)
+    public function assertRedirect($uri = null, string $message = '')
     {
         PHPUnit::assertTrue(
-            $this->isRedirect(), 'Response status code ['.$this->getStatusCode().'] is not a redirect status code.'
+            $this->isRedirect(),
+            $this->prependMessage(
+                'Response status code ['.$this->getStatusCode().'] is not a redirect status code.',
+                $message
+            )
         );
 
         if (! is_null($uri)) {
@@ -160,12 +182,14 @@ class TestResponse
      *
      * @param  string  $headerName
      * @param  mixed  $value
+     * @param  string  $message
      * @return $this
      */
-    public function assertHeader($headerName, $value = null)
+    public function assertHeader($headerName, $value = null, string $message = '')
     {
         PHPUnit::assertTrue(
-            $this->headers->has($headerName), "Header [{$headerName}] not present on response."
+            $this->headers->has($headerName),
+            $this->prependMessage("Header [{$headerName}] not present on response.", $message)
         );
 
         $actual = $this->headers->get($headerName);
@@ -173,7 +197,10 @@ class TestResponse
         if (! is_null($value)) {
             PHPUnit::assertEquals(
                 $value, $this->headers->get($headerName),
-                "Header [{$headerName}] was found, but value [{$actual}] does not match [{$value}]."
+                $this->prependMessage(
+                    "Header [{$headerName}] was found, but value [{$actual}] does not match [{$value}].",
+                    $message
+                )
             );
         }
 
@@ -184,12 +211,14 @@ class TestResponse
      * Asserts that the response does not contains the given header.
      *
      * @param  string  $headerName
+     * @param  string  $message
      * @return $this
      */
-    public function assertHeaderMissing($headerName)
+    public function assertHeaderMissing($headerName, string $message = '')
     {
         PHPUnit::assertFalse(
-            $this->headers->has($headerName), "Unexpected header [{$headerName}] is present on response."
+            $this->headers->has($headerName),
+            $this->prependMessage("Unexpected header [{$headerName}] is present on response.", $message)
         );
 
         return $this;
@@ -199,12 +228,13 @@ class TestResponse
      * Assert that the current location header matches the given URI.
      *
      * @param  string  $uri
+     * @param  string  $message
      * @return $this
      */
-    public function assertLocation($uri)
+    public function assertLocation($uri, string $message = '')
     {
         PHPUnit::assertEquals(
-            app('url')->to($uri), app('url')->to($this->headers->get('Location'))
+            app('url')->to($uri), app('url')->to($this->headers->get('Location'), $message)
         );
 
         return $this;
@@ -215,11 +245,12 @@ class TestResponse
      *
      * @param  string  $cookieName
      * @param  mixed  $value
+     * @param  string  $message
      * @return $this
      */
-    public function assertPlainCookie($cookieName, $value = null)
+    public function assertPlainCookie($cookieName, $value = null, string $message = '')
     {
-        $this->assertCookie($cookieName, $value, false);
+        $this->assertCookie($cookieName, $value, false, false, $message);
 
         return $this;
     }
@@ -231,13 +262,18 @@ class TestResponse
      * @param  mixed  $value
      * @param  bool  $encrypted
      * @param  bool  $unserialize
+     * @param  string  $message
      * @return $this
      */
-    public function assertCookie($cookieName, $value = null, $encrypted = true, $unserialize = false)
+    public function assertCookie($cookieName,
+                                 $value = null,
+                                 $encrypted = true,
+                                 $unserialize = false,
+                                 string $message = '')
     {
         PHPUnit::assertNotNull(
             $cookie = $this->getCookie($cookieName),
-            "Cookie [{$cookieName}] not present on response."
+            $this->prependMessage("Cookie [{$cookieName}] not present on response.", $message)
         );
 
         if (! $cookie || is_null($value)) {
@@ -251,7 +287,10 @@ class TestResponse
 
         PHPUnit::assertEquals(
             $value, $actual,
-            "Cookie [{$cookieName}] was found, but value [{$actual}] does not match [{$value}]."
+            $this->prependMessage(
+                "Cookie [{$cookieName}] was found, but value [{$actual}] does not match [{$value}].",
+                $message
+            )
         );
 
         return $this;
@@ -261,13 +300,14 @@ class TestResponse
      * Asserts that the response contains the given cookie and is expired.
      *
      * @param  string  $cookieName
+     * @param  string  $message
      * @return $this
      */
-    public function assertCookieExpired($cookieName)
+    public function assertCookieExpired($cookieName, string $message)
     {
         PHPUnit::assertNotNull(
             $cookie = $this->getCookie($cookieName),
-            "Cookie [{$cookieName}] not present on response."
+            $this->prependMessage("Cookie [{$cookieName}] not present on response.", $message)
         );
 
         $expiresAt = Carbon::createFromTimestamp($cookie->getExpiresTime());
@@ -284,20 +324,21 @@ class TestResponse
      * Asserts that the response contains the given cookie and is not expired.
      *
      * @param  string  $cookieName
+     * @param  string  $message
      * @return $this
      */
-    public function assertCookieNotExpired($cookieName)
+    public function assertCookieNotExpired($cookieName, string $message)
     {
         PHPUnit::assertNotNull(
             $cookie = $this->getCookie($cookieName),
-            "Cookie [{$cookieName}] not present on response."
+            $this->prependMessage("Cookie [{$cookieName}] not present on response.", $message)
         );
 
         $expiresAt = Carbon::createFromTimestamp($cookie->getExpiresTime());
 
         PHPUnit::assertTrue(
             $expiresAt->greaterThan(Carbon::now()),
-            "Cookie [{$cookieName}] is expired, it expired at [{$expiresAt}]."
+            $this->prependMessage("Cookie [{$cookieName}] is expired, it expired at [{$expiresAt}].", $message)
         );
 
         return $this;
@@ -307,13 +348,14 @@ class TestResponse
      * Asserts that the response does not contains the given cookie.
      *
      * @param  string  $cookieName
+     * @param  string  $message
      * @return $this
      */
-    public function assertCookieMissing($cookieName)
+    public function assertCookieMissing($cookieName, string $message = '')
     {
         PHPUnit::assertNull(
             $this->getCookie($cookieName),
-            "Cookie [{$cookieName}] is present on response."
+            $this->prependMessage("Cookie [{$cookieName}] is present on response.", $message)
         );
 
         return $this;
@@ -338,11 +380,12 @@ class TestResponse
      * Assert that the given string is contained within the response.
      *
      * @param  string  $value
+     * @param  string  $message
      * @return $this
      */
-    public function assertSee($value)
+    public function assertSee($value, string $message = '')
     {
-        PHPUnit::assertContains((string) $value, $this->getContent());
+        PHPUnit::assertContains((string) $value, $this->getContent(), $message);
 
         return $this;
     }
@@ -351,11 +394,12 @@ class TestResponse
      * Assert that the given strings are contained in order within the response.
      *
      * @param  array  $values
+     * @param  string  $message
      * @return $this
      */
-    public function assertSeeInOrder(array $values)
+    public function assertSeeInOrder(array $values, string $message = '')
     {
-        PHPUnit::assertThat($values, new SeeInOrder($this->getContent()));
+        PHPUnit::assertThat($values, new SeeInOrder($this->getContent()), $message);
 
         return $this;
     }
@@ -364,11 +408,12 @@ class TestResponse
      * Assert that the given string is contained within the response text.
      *
      * @param  string  $value
+     * @param  string  $message
      * @return $this
      */
-    public function assertSeeText($value)
+    public function assertSeeText($value, string $message = '')
     {
-        PHPUnit::assertContains((string) $value, strip_tags($this->getContent()));
+        PHPUnit::assertContains((string) $value, strip_tags($this->getContent()), $message);
 
         return $this;
     }
@@ -377,11 +422,12 @@ class TestResponse
      * Assert that the given strings are contained in order within the response text.
      *
      * @param  array  $values
+     * @param  string  $message
      * @return $this
      */
-    public function assertSeeTextInOrder(array $values)
+    public function assertSeeTextInOrder(array $values, string $message = '')
     {
-        PHPUnit::assertThat($values, new SeeInOrder(strip_tags($this->getContent())));
+        PHPUnit::assertThat($values, new SeeInOrder(strip_tags($this->getContent())), $message);
 
         return $this;
     }
@@ -390,11 +436,12 @@ class TestResponse
      * Assert that the given string is not contained within the response.
      *
      * @param  string  $value
+     * @param  string  $message
      * @return $this
      */
-    public function assertDontSee($value)
+    public function assertDontSee($value, string $message = '')
     {
-        PHPUnit::assertNotContains((string) $value, $this->getContent());
+        PHPUnit::assertNotContains((string) $value, $this->getContent(), $message);
 
         return $this;
     }
@@ -403,11 +450,12 @@ class TestResponse
      * Assert that the given string is not contained within the response text.
      *
      * @param  string  $value
+     * @param  string  $message
      * @return $this
      */
-    public function assertDontSeeText($value)
+    public function assertDontSeeText($value, string $message = '')
     {
-        PHPUnit::assertNotContains((string) $value, strip_tags($this->getContent()));
+        PHPUnit::assertNotContains((string) $value, strip_tags($this->getContent()), $message);
 
         return $this;
     }
@@ -417,12 +465,13 @@ class TestResponse
      *
      * @param  array  $data
      * @param  bool  $strict
+     * @param  string  $message
      * @return $this
      */
-    public function assertJson(array $data, $strict = false)
+    public function assertJson(array $data, $strict = false, string $message = '')
     {
         PHPUnit::assertArraySubset(
-            $data, $this->decodeResponseJson(), $strict, $this->assertJsonMessage($data)
+            $data, $this->decodeResponseJson(), $strict, $this->assertJsonMessage($data, $message)
         );
 
         return $this;
@@ -432,33 +481,38 @@ class TestResponse
      * Get the assertion message for assertJson.
      *
      * @param  array  $data
+     * @param  string  $message
      * @return string
      */
-    protected function assertJsonMessage(array $data)
+    protected function assertJsonMessage(array $data, string $message = '')
     {
         $expected = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
         $actual = json_encode($this->decodeResponseJson(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
-        return 'Unable to find JSON: '.PHP_EOL.PHP_EOL.
+        return $this->prependMessage(
+            'Unable to find JSON: '.PHP_EOL.PHP_EOL.
             "[{$expected}]".PHP_EOL.PHP_EOL.
             'within response JSON:'.PHP_EOL.PHP_EOL.
-            "[{$actual}].".PHP_EOL.PHP_EOL;
+            "[{$actual}].".PHP_EOL.PHP_EOL,
+            $message
+        );
     }
 
     /**
      * Assert that the response has the exact given JSON.
      *
      * @param  array  $data
+     * @param  string  $message
      * @return $this
      */
-    public function assertExactJson(array $data)
+    public function assertExactJson(array $data, string $message = '')
     {
         $actual = json_encode(Arr::sortRecursive(
             (array) $this->decodeResponseJson()
         ));
 
-        PHPUnit::assertEquals(json_encode(Arr::sortRecursive($data)), $actual);
+        PHPUnit::assertEquals(json_encode(Arr::sortRecursive($data)), $actual, $message);
 
         return $this;
     }
@@ -467,9 +521,10 @@ class TestResponse
      * Assert that the response contains the given JSON fragment.
      *
      * @param  array  $data
+     * @param  string  $message
      * @return $this
      */
-    public function assertJsonFragment(array $data)
+    public function assertJsonFragment(array $data, string $message = '')
     {
         $actual = json_encode(Arr::sortRecursive(
             (array) $this->decodeResponseJson()
@@ -480,10 +535,13 @@ class TestResponse
 
             PHPUnit::assertTrue(
                 Str::contains($actual, $expected),
-                'Unable to find JSON fragment: '.PHP_EOL.PHP_EOL.
-                '['.json_encode([$key => $value]).']'.PHP_EOL.PHP_EOL.
-                'within'.PHP_EOL.PHP_EOL.
-                "[{$actual}]."
+                $this->prependMessage(
+                    'Unable to find JSON fragment: '.PHP_EOL.PHP_EOL.
+                    '['.json_encode([$key => $value]).']'.PHP_EOL.PHP_EOL.
+                    'within'.PHP_EOL.PHP_EOL.
+                    "[{$actual}].",
+                    $message
+                )
             );
         }
 
@@ -495,12 +553,13 @@ class TestResponse
      *
      * @param  array  $data
      * @param  bool   $exact
+     * @param  string  $message
      * @return $this
      */
-    public function assertJsonMissing(array $data, $exact = false)
+    public function assertJsonMissing(array $data, $exact = false, string $message = '')
     {
         if ($exact) {
-            return $this->assertJsonMissingExact($data);
+            return $this->assertJsonMissingExact($data, $message);
         }
 
         $actual = json_encode(Arr::sortRecursive(
@@ -512,10 +571,13 @@ class TestResponse
 
             PHPUnit::assertFalse(
                 Str::contains($actual, $unexpected),
-                'Found unexpected JSON fragment: '.PHP_EOL.PHP_EOL.
-                '['.json_encode([$key => $value]).']'.PHP_EOL.PHP_EOL.
-                'within'.PHP_EOL.PHP_EOL.
-                "[{$actual}]."
+                $this->prependMessage(
+                    'Found unexpected JSON fragment: '.PHP_EOL.PHP_EOL.
+                    '['.json_encode([$key => $value]).']'.PHP_EOL.PHP_EOL.
+                    'within'.PHP_EOL.PHP_EOL.
+                    "[{$actual}].",
+                    $message
+                )
             );
         }
 
@@ -526,9 +588,10 @@ class TestResponse
      * Assert that the response does not contain the exact JSON fragment.
      *
      * @param  array  $data
+     * @param  string  $message
      * @return $this
      */
-    public function assertJsonMissingExact(array $data)
+    public function assertJsonMissingExact(array $data, string $message = '')
     {
         $actual = json_encode(Arr::sortRecursive(
             (array) $this->decodeResponseJson()
@@ -543,10 +606,13 @@ class TestResponse
         }
 
         PHPUnit::fail(
-            'Found unexpected JSON fragment: '.PHP_EOL.PHP_EOL.
-            '['.json_encode($data).']'.PHP_EOL.PHP_EOL.
-            'within'.PHP_EOL.PHP_EOL.
-            "[{$actual}]."
+            $this->prependMessage(
+                'Found unexpected JSON fragment: '.PHP_EOL.PHP_EOL.
+                '['.json_encode($data).']'.PHP_EOL.PHP_EOL.
+                'within'.PHP_EOL.PHP_EOL.
+                "[{$actual}].",
+                $message
+            )
         );
     }
 
@@ -573,9 +639,10 @@ class TestResponse
      *
      * @param  array|null  $structure
      * @param  array|null  $responseData
+     * @param  string  $message
      * @return $this
      */
-    public function assertJsonStructure(array $structure = null, $responseData = null)
+    public function assertJsonStructure(array $structure = null, $responseData = null, string $message = '')
     {
         if (is_null($structure)) {
             return $this->assertExactJson($this->json());
@@ -587,17 +654,17 @@ class TestResponse
 
         foreach ($structure as $key => $value) {
             if (is_array($value) && $key === '*') {
-                PHPUnit::assertInternalType('array', $responseData);
+                PHPUnit::assertInternalType('array', $responseData, $message);
 
                 foreach ($responseData as $responseDataItem) {
-                    $this->assertJsonStructure($structure['*'], $responseDataItem);
+                    $this->assertJsonStructure($structure['*'], $responseDataItem, $message);
                 }
             } elseif (is_array($value)) {
                 PHPUnit::assertArrayHasKey($key, $responseData);
 
-                $this->assertJsonStructure($structure[$key], $responseData[$key]);
+                $this->assertJsonStructure($structure[$key], $responseData[$key], $message);
             } else {
-                PHPUnit::assertArrayHasKey($value, $responseData);
+                PHPUnit::assertArrayHasKey($value, $responseData, $message);
             }
         }
 
@@ -609,14 +676,18 @@ class TestResponse
      *
      * @param  int  $count
      * @param  string|null  $key
+     * @param  string  $message
      * @return $this
      */
-    public function assertJsonCount(int $count, $key = null)
+    public function assertJsonCount(int $count, $key = null, string $message = '')
     {
         if ($key) {
             PHPUnit::assertCount(
                 $count, data_get($this->json(), $key),
-                "Failed to assert that the response count matched the expected {$count}"
+                $this->prependMessage(
+                    "Failed to assert that the response count matched the expected {$count}",
+                    $message
+                )
             );
 
             return $this;
@@ -624,7 +695,10 @@ class TestResponse
 
         PHPUnit::assertCount($count,
             $this->json(),
-            "Failed to assert that the response count matched the expected {$count}"
+            $this->prependMessage(
+                "Failed to assert that the response count matched the expected {$count}",
+                $message
+            )
         );
 
         return $this;
@@ -634,16 +708,20 @@ class TestResponse
      * Assert that the response has the given JSON validation errors for the given keys.
      *
      * @param  string|array  $keys
+     * @param  string  $message
      * @return $this
      */
-    public function assertJsonValidationErrors($keys)
+    public function assertJsonValidationErrors($keys, string $message = '')
     {
         $errors = $this->json()['errors'];
 
         foreach (Arr::wrap($keys) as $key) {
             PHPUnit::assertTrue(
                 isset($errors[$key]),
-                "Failed to find a validation error in the response for key: '{$key}'"
+                $this->prependMessage(
+                    "Failed to find a validation error in the response for key: '{$key}'",
+                    $message
+                )
             );
         }
 
@@ -654,14 +732,15 @@ class TestResponse
      * Assert that the response has no JSON validation errors for the given keys.
      *
      * @param  string|array  $keys
+     * @param  string  $message
      * @return $this
      */
-    public function assertJsonMissingValidationErrors($keys)
+    public function assertJsonMissingValidationErrors($keys, string $message = '')
     {
         $json = $this->json();
 
         if (! array_key_exists('errors', $json)) {
-            PHPUnit::assertArrayNotHasKey('errors', $json);
+            PHPUnit::assertArrayNotHasKey('errors', $json, $message);
 
             return $this;
         }
@@ -671,7 +750,10 @@ class TestResponse
         foreach (Arr::wrap($keys) as $key) {
             PHPUnit::assertFalse(
                 isset($errors[$key]),
-                "Found unexpected validation error for key: '{$key}'"
+                $this->prependMessage(
+                    "Found unexpected validation error for key: '{$key}'",
+                    $message
+                )
             );
         }
 
@@ -714,13 +796,14 @@ class TestResponse
      * Assert that the response view equals the given value.
      *
      * @param  string $value
+     * @param  string  $message
      * @return $this
      */
-    public function assertViewIs($value)
+    public function assertViewIs($value, string $message = '')
     {
         $this->ensureResponseHasView();
 
-        PHPUnit::assertEquals($value, $this->original->getName());
+        PHPUnit::assertEquals($value, $this->original->getName(), $message);
 
         return $this;
     }
@@ -730,24 +813,25 @@ class TestResponse
      *
      * @param  string|array  $key
      * @param  mixed  $value
+     * @param  string  $message
      * @return $this
      */
-    public function assertViewHas($key, $value = null)
+    public function assertViewHas($key, $value = null, string $message = '')
     {
         if (is_array($key)) {
-            return $this->assertViewHasAll($key);
+            return $this->assertViewHasAll($key, $message);
         }
 
         $this->ensureResponseHasView();
 
         if (is_null($value)) {
-            PHPUnit::assertArrayHasKey($key, $this->original->getData());
+            PHPUnit::assertArrayHasKey($key, $this->original->getData(), $message);
         } elseif ($value instanceof Closure) {
-            PHPUnit::assertTrue($value($this->original->$key));
+            PHPUnit::assertTrue($value($this->original->$key), $message);
         } elseif ($value instanceof Model) {
-            PHPUnit::assertTrue($value->is($this->original->$key));
+            PHPUnit::assertTrue($value->is($this->original->$key), $message);
         } else {
-            PHPUnit::assertEquals($value, $this->original->$key);
+            PHPUnit::assertEquals($value, $this->original->$key, $message);
         }
 
         return $this;
@@ -757,15 +841,16 @@ class TestResponse
      * Assert that the response view has a given list of bound data.
      *
      * @param  array  $bindings
+     * @param  string  $message
      * @return $this
      */
-    public function assertViewHasAll(array $bindings)
+    public function assertViewHasAll(array $bindings, string $message = '')
     {
         foreach ($bindings as $key => $value) {
             if (is_int($key)) {
-                $this->assertViewHas($value);
+                $this->assertViewHas($value, $message);
             } else {
-                $this->assertViewHas($key, $value);
+                $this->assertViewHas($key, $value, $message);
             }
         }
 
@@ -789,13 +874,14 @@ class TestResponse
      * Assert that the response view is missing a piece of bound data.
      *
      * @param  string  $key
+     * @param  string  $message
      * @return $this
      */
-    public function assertViewMissing($key)
+    public function assertViewMissing($key, string $message = '')
     {
         $this->ensureResponseHasView();
 
-        PHPUnit::assertArrayNotHasKey($key, $this->original->getData());
+        PHPUnit::assertArrayNotHasKey($key, $this->original->getData(), $message);
 
         return $this;
     }
@@ -819,9 +905,10 @@ class TestResponse
      *
      * @param  string|array  $key
      * @param  mixed  $value
+     * @param  string  $message
      * @return $this
      */
-    public function assertSessionHas($key, $value = null)
+    public function assertSessionHas($key, $value = null, string $message = '')
     {
         if (is_array($key)) {
             return $this->assertSessionHasAll($key);
@@ -830,7 +917,7 @@ class TestResponse
         if (is_null($value)) {
             PHPUnit::assertTrue(
                 $this->session()->has($key),
-                "Session is missing expected key [{$key}]."
+                $this->prependMessage("Session is missing expected key [{$key}].", $message)
             );
         } else {
             PHPUnit::assertEquals($value, $this->session()->get($key));
@@ -843,15 +930,16 @@ class TestResponse
      * Assert that the session has a given list of values.
      *
      * @param  array  $bindings
+     * @param  string  $message
      * @return $this
      */
-    public function assertSessionHasAll(array $bindings)
+    public function assertSessionHasAll(array $bindings, string $message = '')
     {
         foreach ($bindings as $key => $value) {
             if (is_int($key)) {
-                $this->assertSessionHas($value);
+                $this->assertSessionHas($value, $message);
             } else {
-                $this->assertSessionHas($key, $value);
+                $this->assertSessionHas($key, $value, $message);
             }
         }
 
@@ -864,9 +952,10 @@ class TestResponse
      * @param  string|array  $keys
      * @param  mixed  $format
      * @param  string  $errorBag
+     * @param  string  $message
      * @return $this
      */
-    public function assertSessionHasErrors($keys = [], $format = null, $errorBag = 'default')
+    public function assertSessionHasErrors($keys = [], $format = null, $errorBag = 'default', string $message = '')
     {
         $this->assertSessionHas('errors');
 
@@ -876,9 +965,12 @@ class TestResponse
 
         foreach ($keys as $key => $value) {
             if (is_int($key)) {
-                PHPUnit::assertTrue($errors->has($value), "Session missing error: $value");
+                PHPUnit::assertTrue(
+                    $errors->has($value),
+                    $this->prependMessage("Session missing error: $value", $message)
+                );
             } else {
-                PHPUnit::assertContains($value, $errors->get($key, $format));
+                PHPUnit::assertContains($value, $errors->get($key, $format), $message);
             }
         }
 
@@ -891,9 +983,13 @@ class TestResponse
      * @param  string|array  $keys
      * @param  string  $format
      * @param  string  $errorBag
+     * @param  string  $message
      * @return $this
      */
-    public function assertSessionDoesntHaveErrors($keys = [], $format = null, $errorBag = 'default')
+    public function assertSessionDoesntHaveErrors($keys = [],
+                                                  $format = null,
+                                                  $errorBag = 'default',
+                                                  string $message = '')
     {
         $keys = (array) $keys;
 
@@ -905,9 +1001,12 @@ class TestResponse
 
         foreach ($keys as $key => $value) {
             if (is_int($key)) {
-                PHPUnit::assertFalse($errors->has($value), "Session has unexpected error: $value");
+                PHPUnit::assertFalse(
+                    $errors->has($value),
+                    $this->prependMessage("Session has unexpected error: $value", $message)
+                );
             } else {
-                PHPUnit::assertNotContains($value, $errors->get($key, $format));
+                PHPUnit::assertNotContains($value, $errors->get($key, $format), $message);
             }
         }
 
@@ -917,9 +1016,10 @@ class TestResponse
     /**
      * Assert that the session has no errors.
      *
+     * @param  string  $message
      * @return $this
      */
-    public function assertSessionHasNoErrors()
+    public function assertSessionHasNoErrors(string $message = '')
     {
         $hasErrors = $this->session()->has('errors');
 
@@ -927,8 +1027,11 @@ class TestResponse
 
         PHPUnit::assertFalse(
             $hasErrors,
-            'Session has unexpected errors: '.PHP_EOL.PHP_EOL.
-            json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+            $this->prependMessage(
+                'Session has unexpected errors: '.PHP_EOL.PHP_EOL.
+                json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+                $message
+            )
         );
 
         return $this;
@@ -940,29 +1043,31 @@ class TestResponse
      * @param  string  $errorBag
      * @param  string|array  $keys
      * @param  mixed  $format
+     * @param  string  $message
      * @return $this
      */
-    public function assertSessionHasErrorsIn($errorBag, $keys = [], $format = null)
+    public function assertSessionHasErrorsIn($errorBag, $keys = [], $format = null, string $message = '')
     {
-        return $this->assertSessionHasErrors($keys, $format, $errorBag);
+        return $this->assertSessionHasErrors($keys, $format, $errorBag, $message);
     }
 
     /**
      * Assert that the session does not have a given key.
      *
      * @param  string|array  $key
+     * @param  string  $message
      * @return $this
      */
-    public function assertSessionMissing($key)
+    public function assertSessionMissing($key, string $message = '')
     {
         if (is_array($key)) {
             foreach ($key as $value) {
-                $this->assertSessionMissing($value);
+                $this->assertSessionMissing($value, $message);
             }
         } else {
             PHPUnit::assertFalse(
                 $this->session()->has($key),
-                "Session has unexpected key [{$key}]."
+                $this->prependMessage("Session has unexpected key [{$key}].", $message)
             );
         }
 
@@ -1055,5 +1160,18 @@ class TestResponse
         }
 
         return $this->baseResponse->{$method}(...$args);
+    }
+
+    /**
+     * Prepend a message to the default one if its not empty.
+     *
+     * @param string $defaultMessage
+     * @param string $message
+     *
+     * @return string
+     */
+    protected function prependMessage(string $defaultMessage, string $message): string
+    {
+        return ($message !== '' ? $message.PHP_EOL : '').$defaultMessage;
     }
 }


### PR DESCRIPTION
This will preserve the current message but add the the custom one above, same behavior as PHPUnit's core asserts

This is particularly useful for assert like `assertSee` which print all the page's HTML and can be hard to track when they fail.

I don't think that behavior warrant any additional tests, but I can implement them if I'm wrong.