### PR TITLE
[5.8] Correct param dockblock and description of report helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -697,19 +697,16 @@ if (! function_exists('redirect')) {
 
 if (! function_exists('report')) {
     /**
-     * Report an exception.
+     * Report an exception or throwable error.
      *
-     * @param  \Exception  $exception
+     * @param  \Exception|\Throwable  $e
      * @return void
      */
-    function report($exception)
+    function report($e)
     {
-        if ($exception instanceof Throwable &&
-            ! $exception instanceof Exception) {
-            $exception = new FatalThrowableError($exception);
-        }
-
-        app(ExceptionHandler::class)->report($exception);
+        app(ExceptionHandler::class)->report(
+            $e instanceof Exception ? $e : new FatalThrowableError($e)
+        );
     }
 }
 


### PR DESCRIPTION
Let's see a use-case of report helper below. It also accepts a throwable error.

```php
if (! function_exists('rescue')) {
    /**
     * Catch a potential exception and return a default value.
     *
     * @param  callable  $callback
     * @param  mixed  $rescue
     * @return mixed
     */
    function rescue(callable $callback, $rescue = null)
    {
        try {
            return $callback();
        } catch (Throwable $e) {
            report($e);

            return value($rescue);
        }
    }
}
````