### PR TITLE
[5.8] Fix return dockblock for BoundMethod

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -145,7 +145,7 @@ class BoundMethod
      * @param  \ReflectionParameter  $parameter
      * @param  array  $parameters
      * @param  array  $dependencies
-     * @return mixed
+     * @return void
      */
     protected static function addDependencyForCallParameter($container, $parameter,
                                                             array &$parameters, &$dependencies)


### PR DESCRIPTION
BoundMethod::addDependencyForCallParameter() returns void instead of mixed value.
