### PR TITLE
[5.8] Fix redirect response docblock

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -37,7 +37,7 @@ class RedirectResponse extends BaseRedirectResponse
      *
      * @param  string|array  $key
      * @param  mixed  $value
-     * @return \Illuminate\Http\RedirectResponse
+     * @return $this
      */
     public function with($key, $value = null)
     {
@@ -114,7 +114,7 @@ class RedirectResponse extends BaseRedirectResponse
     /**
      * Flash an array of input to the session.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return $this
      */
     public function exceptInput()
     {
@@ -217,7 +217,7 @@ class RedirectResponse extends BaseRedirectResponse
      *
      * @param  string  $method
      * @param  array  $parameters
-     * @return $this
+     * @return mixed
      *
      * @throws \BadMethodCallException
      */


### PR DESCRIPTION
- Both RedirectResponse::with() and RedirectResponse::exceptInput() return $this.
- The **__call** magic method may return mixed.