### PR TITLE
[5.7] Add missing resource ability

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -105,6 +105,7 @@ trait AuthorizesRequests
     protected function resourceAbilityMap()
     {
         return [
+            'index' => 'index',
             'show' => 'view',
             'create' => 'create',
             'store' => 'create',


### PR DESCRIPTION
Having an index method in a controller will never try to get authenticated when using this trait. As index is present in resourceMethodsWithoutModels I assume it's just missing from the resourceAbilityMap(?). 

Note that this could be a breaking change, as using make:policy does not create the index method per standard, which results in a return null, which results in a 403. But maybe we've misunderstood how to use the trait for default CRUD controllers that one gets when using eg. Route::resource()?
