### PR TITLE
[5.7] Remove size argument from Testing/File constructor

### DIFF
--- a/src/Illuminate/Http/Testing/File.php
+++ b/src/Illuminate/Http/Testing/File.php
@@ -41,7 +41,7 @@ class File extends UploadedFile
 
         parent::__construct(
             $this->tempFilePath(), $name, $this->getMimeType(),
-            filesize($this->tempFilePath()), null, true
+            null, true
         );
     }
 


### PR DESCRIPTION
Remove 4th argument from constructor because ErrorException: Passing a size as 4th argument to the constructor is deprecated since 4.1

fixes #26040 