### PR TITLE
[5.7] Update documentation to reflect true behaviour

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -84,9 +84,9 @@ abstract class Manager
      */
     protected function createDriver($driver)
     {
-        // We'll check to see if a creator method exists for the given driver. If not we
-        // will check for a custom driver creator, which allows developers to create
+        // We'll check for a custom driver creator, which allows developers to create
         // drivers using their own customized driver creator Closure to create it.
+        // If not we will check to see if a creator method exists for the given driver.
         if (isset($this->customCreators[$driver])) {
             return $this->callCustomCreator($driver);
         } else {


### PR DESCRIPTION
The comments in the `createDriver()` method are the incorrect way around. This change flips it to reflect the true behaviour.

Looks like it has been like this since the first commit. https://github.com/laravel/framework/commit/de69bb287c5017d1acb7d47a6db1dedf578036d6#diff-e10df0cf984701aece6ffd81877713a1R66