### PR TITLE
[5.7] Fixes issue: #26058, Adds setTable($this->getTable()) to newInstance

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -394,6 +394,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $this->getConnectionName()
         );
 
+        $model->setTable(
+            $this->getTable()
+        );
+
         return $model;
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -168,6 +168,15 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('taylor', $instance->name);
     }
 
+    public function testNewInstanceReturnsNewInstanceWithTableSet()
+    {
+        $model = new EloquentModelStub;
+        $model->setTable('test');
+        $newInstance = $model->newInstance();
+
+        $this->assertEquals('test', $newInstance->getTable());
+    }
+
     public function testCreateMethodSavesNewModel()
     {
         $_SERVER['__eloquent.saved'] = false;


### PR DESCRIPTION
Sets the name of the current table to the new instance being generated by the newInstance() method call, adds the test as well.