### PR TITLE
[5.8] updating migration rollback command for accepting step parameter as n…

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -63,6 +63,8 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     {
         $query = $this->table()->where('batch', '>=', '1');
 
+        $steps = $steps < 0 ? $query->count() + $steps : $steps;  
+
         return $query->orderBy('batch', 'desc')
                      ->orderBy('migration', 'desc')
                      ->take($steps)->get()->all();

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -218,7 +218,8 @@ class Migrator
      */
     protected function getMigrationsForRollback(array $options)
     {
-        if (($steps = $options['step'] ?? 0) > 0) {
+        $steps = $options['step'] ?? 0;
+        if ($steps != 0) {
             return $this->repository->getMigrations($steps);
         }
 


### PR DESCRIPTION
**Description** 
This request will enable support of negative value for **_step_** parameter in migration rollback command. Earlier we couldn't use negative value. 

**Usage** 
Now using  `php artisan migrate:rollback --step=-10` will rollback migration except the initial 10 migrations.


- It will add one extra feature to existing command.
- Won't break any existing functionality. 

