### PR TITLE
[5.8] Fix HasOneThrough lazy loading and default attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -17,7 +17,7 @@ class HasOneThrough extends HasManyThrough
      */
     public function getResults()
     {
-        return $this->query->first() ?: $this->getDefaultFor($this->farParent);
+        return $this->first() ?: $this->getDefaultFor($this->farParent);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -71,20 +71,6 @@ class HasOneThrough extends HasManyThrough
      */
     public function newRelatedInstanceFor(Model $parent)
     {
-        return $this->related->newInstance()->setAttribute(
-            $this->getForeignKeyName(), $parent->{$this->localKey}
-        );
-    }
-
-    /**
-     * Get the plain foreign key.
-     *
-     * @return string
-     */
-    public function getForeignKeyName()
-    {
-        $segments = explode('.', $this->getQualifiedForeignKeyName());
-
-        return end($segments);
+        return $this->related->newInstance();
     }
 }

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -84,6 +84,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
 
         $contract = HasOneThroughDefaultTestPosition::first()->contract;
         $this->assertEquals('A title', $contract->title);
+        $this->assertArrayNotHasKey('email', $contract->getAttributes());
 
         $this->resetDefault();
     }


### PR DESCRIPTION
**Fixes lazy loading:**

```php
class User extends Model
    public function comment() {
        return $this->hasOneThrough(Comment::class, Post::class);
    }
}

$user->comment;
```
The relationship doesn't limit the selected columns, so `posts` columns override `comments` columns:

```sql
select * from "comments" inner join "posts" on "posts"."id" = "comments"."post_id"
where "posts"."user_id" = 1 limit 1
```

**Fixes default attributes:**

`newRelatedInstanceFor()` was taken from the `HasOne` relationship, but doesn't work here:

```php
class User extends Model
    public function comment() {
        return $this->hasOneThrough(Comment::class, Post::class)
            ->withDefault(['foo' => 'bar']);
    }
}

dump($userWithoutComment->comment->getAttributes());
["post_id" => /* $userWithoutComment->id */, "foo" => "bar"]
```

 We can't set the foreign key on the related model (`comments.post_id`) because that would be the *intermediate* model's primary key (`posts.id`). We can't possibly know this value.
