### PR TITLE
[5.7] Add support for shouldNotReceive on Facades

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -55,6 +55,22 @@ abstract class Facade
     }
 
     /**
+     * Initiate a mock expectation that a method should not be called on the facade.
+     *
+     * @return \Mockery\Expectation
+     */
+    public static function shouldNotReceive()
+    {
+        $name = static::getFacadeAccessor();
+
+        $mock = static::isMock()
+                    ? static::$resolvedInstance[$name]
+                    : static::createFreshMockInstance();
+
+        return $mock->shouldNotReceive(...func_get_args());
+    }
+
+    /**
      * Create a fresh mock instance for the given class.
      *
      * @return \Mockery\Expectation

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -41,6 +41,15 @@ class SupportFacadeTest extends TestCase
         $this->assertEquals('baz', $app['foo']->foo('bar'));
     }
 
+    public function testShouldNotReceiveReturnsAMockeryMock()
+    {
+        $app = new ApplicationStub;
+        $app->setAttributes(['foo' => new stdClass]);
+        FacadeStub::setFacadeApplication($app);
+
+        $this->assertInstanceOf(MockInterface::class, FacadeStub::shouldNotReceive('foo')->getMock());
+    }
+
     public function testSpyReturnsAMockerySpy()
     {
         $app = new ApplicationStub;


### PR DESCRIPTION
It is already possible to set an expectation on a facade like this:

```php
Cache::shouldReceive('get')->once();
```

This PR adds the ability to also do the opposite, so you can test that a specific method wasn't called on a facade:

```php
Cache::shouldNotReceive('get');
```