### PR TITLE
[5.5] Ensure auto increment can't accept random values

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -546,6 +546,10 @@ class Blueprint
      */
     public function integer($column, $autoIncrement = false, $unsigned = false)
     {
+        if (! is_bool($autoIncrement)) {
+            $autoIncrement = false;
+        }
+        
         return $this->addColumn('integer', $column, compact('autoIncrement', 'unsigned'));
     }
 
@@ -559,6 +563,10 @@ class Blueprint
      */
     public function tinyInteger($column, $autoIncrement = false, $unsigned = false)
     {
+        if (! is_bool($autoIncrement)) {
+            $autoIncrement = false;
+        }
+        
         return $this->addColumn('tinyInteger', $column, compact('autoIncrement', 'unsigned'));
     }
 
@@ -572,6 +580,10 @@ class Blueprint
      */
     public function smallInteger($column, $autoIncrement = false, $unsigned = false)
     {
+        if (! is_bool($autoIncrement)) {
+            $autoIncrement = false;
+        }
+        
         return $this->addColumn('smallInteger', $column, compact('autoIncrement', 'unsigned'));
     }
 
@@ -585,6 +597,10 @@ class Blueprint
      */
     public function mediumInteger($column, $autoIncrement = false, $unsigned = false)
     {
+        if (! is_bool($autoIncrement)) {
+            $autoIncrement = false;
+        }
+        
         return $this->addColumn('mediumInteger', $column, compact('autoIncrement', 'unsigned'));
     }
 
@@ -598,6 +614,10 @@ class Blueprint
      */
     public function bigInteger($column, $autoIncrement = false, $unsigned = false)
     {
+        if (! is_bool($autoIncrement)) {
+            $autoIncrement = false;
+        }
+        
         return $this->addColumn('bigInteger', $column, compact('autoIncrement', 'unsigned'));
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -549,7 +549,7 @@ class Blueprint
         if (! is_bool($autoIncrement)) {
             $autoIncrement = false;
         }
-        
+
         return $this->addColumn('integer', $column, compact('autoIncrement', 'unsigned'));
     }
 
@@ -566,7 +566,7 @@ class Blueprint
         if (! is_bool($autoIncrement)) {
             $autoIncrement = false;
         }
-        
+
         return $this->addColumn('tinyInteger', $column, compact('autoIncrement', 'unsigned'));
     }
 
@@ -583,7 +583,7 @@ class Blueprint
         if (! is_bool($autoIncrement)) {
             $autoIncrement = false;
         }
-        
+
         return $this->addColumn('smallInteger', $column, compact('autoIncrement', 'unsigned'));
     }
 
@@ -600,7 +600,7 @@ class Blueprint
         if (! is_bool($autoIncrement)) {
             $autoIncrement = false;
         }
-        
+
         return $this->addColumn('mediumInteger', $column, compact('autoIncrement', 'unsigned'));
     }
 
@@ -617,7 +617,7 @@ class Blueprint
         if (! is_bool($autoIncrement)) {
             $autoIncrement = false;
         }
-        
+
         return $this->addColumn('bigInteger', $column, compact('autoIncrement', 'unsigned'));
     }
 

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -97,4 +97,16 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint = clone $base;
         $this->assertEquals(['alter table `users` add `money` decimal(10, 2) unsigned not null'], $blueprint->toSql($connection, new MySqlGrammar));
     }
+
+    public function testIntegerAutoIncrement()
+    {
+        $base = new Blueprint('users', function ($table) {
+            $table->integer('foo', 1)->useCurrent();
+        });
+
+        $connection = m::mock('Illuminate\Database\Connection');
+
+        $blueprint = clone $base;
+        $this->assertEquals(['alter table `users` add `foo` int not null'], $blueprint->toSql($connection, new MySqlGrammar));
+    }
 }


### PR DESCRIPTION
The `integer` methods within Blueprint currently allows values other than a boolean to be used, this update ensures that non-boolean values automatically revert `$autoIncrement` to `false`.

As a fix, the value of `$autoIncrement` is checked and if it fails a boolean test, automatically reverts to `false` to keep consistency between the PHPDoc and the parameters.

This change will prevent cases by which a developer can pass a number for example as the second argument for `integer` and that will cause `$autoIncrement` to pass as `true`.
