### PR TITLE
[5.8] Add return type for router run or dispatch

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -587,7 +587,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * Return the response returned by the given route.
      *
      * @param  string  $name
-     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
     public function respondWithRoute($name)
     {
@@ -600,7 +600,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * Dispatch the request to the application.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
     public function dispatch(Request $request)
     {
@@ -613,7 +613,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * Dispatch the request to a route and return the response.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
     public function dispatchToRoute(Request $request)
     {
@@ -640,7 +640,7 @@ class Router implements RegistrarContract, BindingRegistrar
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Routing\Route  $route
-     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
     protected function runRoute(Request $request, Route $route)
     {
@@ -710,7 +710,7 @@ class Router implements RegistrarContract, BindingRegistrar
      *
      * @param  \Symfony\Component\HttpFoundation\Request  $request
      * @param  mixed  $response
-     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
     public function prepareResponse($request, $response)
     {
@@ -722,7 +722,7 @@ class Router implements RegistrarContract, BindingRegistrar
      *
      * @param  \Symfony\Component\HttpFoundation\Request  $request
      * @param  mixed  $response
-     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
     public static function toResponse($request, $response)
     {


### PR DESCRIPTION
Illuminate\Routing\Router::toResponse() sometimes returns an instanceof Symfony\Component\HttpFoundation\Response. Let's see this sample code for more details.

```php

use Illuminate\Http\Request;
use Illuminate\Http\Response;
use Illuminate\Routing\Router;
use Illuminate\Http\JsonResponse;
use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
use Symfony\Component\HttpFoundation\JsonResponse as JsonSymfonyResponse;
use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;

$request = Request::create('/');

// Try to transform SymfonyRedirectResponse.
$transformed = Router::toResponse($request, $original = new SymfonyRedirectResponse('/'));
var_dump($transformed === $original); // true
var_dump($transformed instanceof SymfonyResponse); // true
var_dump($transformed instanceof Response); // false
var_dump($transformed instanceof JsonResponse); // false

// Try to transform JsonSymfonyResponse.
$transformed = Router::toResponse($request, $original = new JsonSymfonyResponse([]));
var_dump($transformed === $original); // true
var_dump($transformed instanceof SymfonyResponse); // true
var_dump($transformed instanceof Response); // false
var_dump($transformed instanceof JsonResponse); // false

// Try to transform SymfonyResponse.
$transformed = Router::toResponse($request, $original = new SymfonyResponse(''));
var_dump($transformed === $original); // true
var_dump($transformed instanceof SymfonyResponse); // true
var_dump($transformed instanceof Response); // false
var_dump($transformed instanceof JsonResponse); // false
```

Therefore, it's reasonable to add SymfonyResponse as a return type to router run or dispatch methods.