### PR TITLE
[5.6] fixed @return type for phpstan

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -456,7 +456,7 @@ class Mailer implements MailerContract, MailQueueContract
      * Send a Swift Message instance.
      *
      * @param  \Swift_Message  $message
-     * @return void | int
+     * @return void|int
      */
     protected function sendSwiftMessage($message)
     {

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -456,7 +456,7 @@ class Mailer implements MailerContract, MailQueueContract
      * Send a Swift Message instance.
      *
      * @param  \Swift_Message  $message
-     * @return void|int
+     * @return int|null
      */
     protected function sendSwiftMessage($message)
     {

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -456,7 +456,7 @@ class Mailer implements MailerContract, MailQueueContract
      * Send a Swift Message instance.
      *
      * @param  \Swift_Message  $message
-     * @return void
+     * @return void | int
      */
     protected function sendSwiftMessage($message)
     {


### PR DESCRIPTION
I order to resolve phpstan error:

Result of method Illuminate\\Mail\\Mailer::sendSwiftMessage\(\) \(void\) is used

need Mailer @return annotation be extended with int 

