### PR TITLE
[5.8] Collection->pullFirst($callback)

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -162,6 +162,7 @@ class Arr
     public static function first($array, callable $callback = null, $default = null)
     {
         $key = static::firstKey($array, $callback);
+
         return is_null($key) ? $default : static::get($array, $key);
     }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -161,23 +161,36 @@ class Arr
      */
     public static function first($array, callable $callback = null, $default = null)
     {
+        $key = static::firstKey($array, $callback);
+        return is_null($key) ? $default : static::get($array, $key);
+    }
+
+    /**
+     * Return the first key in an array passing a given truth test.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @return mixed
+     */
+    public static function firstKey($array, callable $callback = null)
+    {
         if (is_null($callback)) {
             if (empty($array)) {
-                return value($default);
+                return null;
             }
 
-            foreach ($array as $item) {
-                return $item;
+            foreach ($array as $key => $item) {
+                return $key;
             }
         }
 
         foreach ($array as $key => $value) {
             if (call_user_func($callback, $value, $key)) {
-                return $value;
+                return $key;
             }
         }
 
-        return value($default);
+        return null;
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -672,6 +672,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the first key from the collection.
+     *
+     * @param  callable|null  $callback
+     * @return mixed
+     */
+    public function firstKey(callable $callback = null)
+    {
+        return Arr::firstKey($this->items, $callback);
+    }
+
+    /**
      * Get the first item by the given key value pair.
      *
      * @param  string  $key
@@ -1293,7 +1304,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function pullFirst($callback, $default = null)
     {
-        $key = Arr::firstKey($this->items, $callback);
+        $key = $this->firstKey($callback);
+
         return is_null($key) ? $default : Arr::pull($this->items, $key);
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1285,6 +1285,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get and remove an item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function pullFirst($callback, $default = null)
+    {
+        $key = Arr::firstKey($this->items, $callback);
+        return is_null($key) ? $default : Arr::pull($this->items, $key);
+    }
+
+    /**
      * Put an item in the collection by key.
      *
      * @param  mixed  $key

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -137,6 +137,18 @@ class SupportArrTest extends TestCase
         $this->assertEquals(100, Arr::first($array));
     }
 
+    public function testFirstKey()
+    {
+        $array = ['a' => 100, 'b' => 200, 'c' => 300];
+
+        $value = Arr::firstKey($array, function ($value) {
+            return $value >= 150;
+        });
+
+        $this->assertEquals('b', $value);
+        $this->assertEquals('a', Arr::firstKey($array));
+    }
+
     public function testLast()
     {
         $array = [100, 200, 300];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -149,6 +149,17 @@ class SupportArrTest extends TestCase
         $this->assertEquals('a', Arr::firstKey($array));
     }
 
+    public function testFirstKeyReturnsNull()
+    {
+        $array = [100, 200, 300];
+
+        $value = Arr::firstKey($array, function ($value) {
+            return $value >= 400;
+        });
+
+        $this->assertNull($value);
+    }
+
     public function testLast()
     {
         $array = [100, 200, 300];

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1936,6 +1936,34 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('foo', $value);
     }
 
+    public function testPullFirstRemovesItemFromCollection()
+    {
+        $c = new Collection(['foo', 'bar', 'baz']);
+        $e = $c->pullFirst(function($e){
+            return $e == 'bar';
+        });
+        $this->assertEquals([0 => 'foo', 2 => 'baz'], $c->all());
+    }
+
+    public function testPullFirstRetrievesItemFromCollection()
+    {
+        $c = new Collection(['foo', 'bar', 'baz']);
+        $e = $c->pullFirst(function($e){
+            return $e == 'bar';
+        });
+        $this->assertEquals('bar', $e);
+    }
+
+    public function testPullFirstReturnsDefault()
+    {
+        $c = new Collection(['foo', 'bar']);
+        $e = $c->pullFirst(function($e){
+            return false;
+        }, 'baz');
+        $this->assertEquals(['foo', 'bar'], $c->all());
+        $this->assertEquals('baz', $e);
+    }
+
     public function testRejectRemovesElementsPassingTruthTest()
     {
         $c = new Collection(['foo', 'bar']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -50,6 +50,21 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('default', $result);
     }
 
+    public function testFirstKeyReturnsFirstItemInCollection()
+    {
+        $c = new Collection(['a' => 'foo', 'b' => 'bar']);
+        $this->assertEquals('a', $c->firstKey());
+    }
+
+    public function testFirstKeyWithCallback()
+    {
+        $data = new Collection(['foo', 'bar', 'baz']);
+        $result = $data->firstKey(function ($value) {
+            return $value === 'bar';
+        });
+        $this->assertEquals(1, $result);
+    }
+
     public function testFirstWhere()
     {
         $data = new Collection([
@@ -1939,7 +1954,7 @@ class SupportCollectionTest extends TestCase
     public function testPullFirstRemovesItemFromCollection()
     {
         $c = new Collection(['foo', 'bar', 'baz']);
-        $e = $c->pullFirst(function($e){
+        $e = $c->pullFirst(function ($e) {
             return $e == 'bar';
         });
         $this->assertEquals([0 => 'foo', 2 => 'baz'], $c->all());
@@ -1948,7 +1963,7 @@ class SupportCollectionTest extends TestCase
     public function testPullFirstRetrievesItemFromCollection()
     {
         $c = new Collection(['foo', 'bar', 'baz']);
-        $e = $c->pullFirst(function($e){
+        $e = $c->pullFirst(function ($e) {
             return $e == 'bar';
         });
         $this->assertEquals('bar', $e);
@@ -1957,7 +1972,7 @@ class SupportCollectionTest extends TestCase
     public function testPullFirstReturnsDefault()
     {
         $c = new Collection(['foo', 'bar']);
-        $e = $c->pullFirst(function($e){
+        $e = $c->pullFirst(function ($e) {
             return false;
         }, 'baz');
         $this->assertEquals(['foo', 'bar'], $c->all());


### PR DESCRIPTION
I am missing a function to pull the first item from a collection that passes a truth test. 
So, I've implemented this with some supporting functions.

Currently, `Collection->pull($key)` returns and removes an item from a collection by key. 
I've added `Collection->pullFirst($callback)` that returns and removes the first item from a collection that passes a truth test. 

This builds upon #26100

The functionality of `pullFirst()` comes in handy when trying to find the first element from a collection and subsequently remove it. This might speed up later calls to `first` and provides a way to avoid `first` returning the same value twice. 