### PR TITLE
[5.8] Arr::firstKey

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -162,6 +162,7 @@ class Arr
     public static function first($array, callable $callback = null, $default = null)
     {
         $key = static::firstKey($array, $callback);
+
         return is_null($key) ? $default : static::get($array, $key);
     }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -161,23 +161,36 @@ class Arr
      */
     public static function first($array, callable $callback = null, $default = null)
     {
+        $key = static::firstKey($array, $callback);
+        return is_null($key) ? $default : static::get($array, $key);
+    }
+
+    /**
+     * Return the first key in an array passing a given truth test.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @return mixed
+     */
+    public static function firstKey($array, callable $callback = null)
+    {
         if (is_null($callback)) {
             if (empty($array)) {
-                return value($default);
+                return null;
             }
 
-            foreach ($array as $item) {
-                return $item;
+            foreach ($array as $key => $item) {
+                return $key;
             }
         }
 
         foreach ($array as $key => $value) {
             if (call_user_func($callback, $value, $key)) {
-                return $value;
+                return $key;
             }
         }
 
-        return value($default);
+        return null;
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -137,6 +137,18 @@ class SupportArrTest extends TestCase
         $this->assertEquals(100, Arr::first($array));
     }
 
+    public function testFirstKey()
+    {
+        $array = ['a' => 100, 'b' => 200, 'c' => 300];
+
+        $value = Arr::firstKey($array, function ($value) {
+            return $value >= 150;
+        });
+
+        $this->assertEquals('b', $value);
+        $this->assertEquals('a', Arr::firstKey($array));
+    }
+
     public function testLast()
     {
         $array = [100, 200, 300];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -149,6 +149,17 @@ class SupportArrTest extends TestCase
         $this->assertEquals('a', Arr::firstKey($array));
     }
 
+    public function testFirstKeyReturnsNull()
+    {
+        $array = [100, 200, 300];
+
+        $value = Arr::firstKey($array, function ($value) {
+            return $value >= 400;
+        });
+
+        $this->assertNull($value);
+    }
+
     public function testLast()
     {
         $array = [100, 200, 300];


### PR DESCRIPTION
Currently, `Arr::first()` returns the first value of an array that passes a truth test. 
I've added `Arr::firstKey()` that analogously returns the first key of an array that passes. 
Now `Arr::first()` boils down to `Arr::firstKey()` with `Arr::get()`.

```php
$arr = ['foo' => 100, 'bar' => 200, 'baz' => 300];
Arr::firstKey($arr, function($e){
  return $e > 150;
}); // returns 'bar'
```