### PR TITLE
[5.7] Fix missing index() method phpdoc

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Fluent;
  * @method ColumnDefinition virtualAs(string $expression) Create a virtual generated column (MySQL)
  * @method ColumnDefinition generatedAs($expression) Create a SQL compliant identity column (PostgreSQL)
  * @method ColumnDefinition always() Used as a modifier for generatedAs() (PostgreSQL)
+ * @method ColumnDefinition index() Add an index
  */
 class ColumnDefinition extends Fluent
 {


### PR DESCRIPTION
Adds the method `index()` in `Illuminate\Database\Schema\ColumnDefinition` to help IDEs in handling this method.

Fixes: #26036.