### PR TITLE
[5.7] Re-add mixins for models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -18,6 +18,10 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
+/**
+ * @mixin \Illuminate\Database\Eloquent\Builder
+ * @mixin \Illuminate\Database\Query\Builder
+ */
 abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
     use Concerns\HasAttributes,


### PR DESCRIPTION
Re-add the mixins for the Model abstract to facilitate IDEs code inspections and autocompletion.

They were originally deleted by commit 6f518a8a534702da9166ef2fc5e297a06ed5cc18. 

Without these mixins, the following occurs:
![screen shot 2018-10-12 at 21 27 00](https://user-images.githubusercontent.com/2458289/46899771-957fce80-ce65-11e8-907b-48e20bcca578.png)

With the mixins:
![screen shot 2018-10-12 at 21 29 04](https://user-images.githubusercontent.com/2458289/46899790-e099e180-ce65-11e8-9d78-ef5a17ec4c95.png)

As you can see, it reduces the code inspection error and also facilitates auto-competing the methods.