### PR TITLE
[5.7] Require ext-json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "php": "^7.1.3",
         "ext-mbstring": "*",
         "ext-openssl": "*",
+        "ext-json": "*",
         "doctrine/inflector": "^1.1",
         "dragonmantank/cron-expression": "^2.0",
         "erusev/parsedown": "^1.7",


### PR DESCRIPTION
Require `ext-json` in `composer.json` to strictly define required PHP extensions.