### PR TITLE
[5.8] Track abstracts being resolved, fire resolving events once

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1060,7 +1060,7 @@ class Container implements ArrayAccess, ContainerContract
         $results = [];
 
         foreach ($callbacksPerType as $type => $callbacks) {
-            if ($type === $abstract || ($object instanceof $type && ! in_array($type, $this->resolveStack))) {
+            if (! $this->pendingInResolveStack($object) && ($type === $abstract || $object instanceof $type)) {
                 $results = array_merge($results, $callbacks);
             }
         }
@@ -1080,6 +1080,24 @@ class Container implements ArrayAccess, ContainerContract
         foreach ($callbacks as $callback) {
             $callback($object, $this);
         }
+    }
+
+    /**
+     * Check if object or a generalisation is pending in the resolve stack.
+     *
+     * @param   object    $object
+     *
+     * @return  bool
+     */
+    protected function pendingInResolveStack($object)
+    {
+        foreach ($this->resolveStack as $resolving) {
+            if ($resolving !== end($this->resolveStack) && $object instanceof $resolving) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1060,7 +1060,7 @@ class Container implements ArrayAccess, ContainerContract
         $results = [];
 
         foreach ($callbacksPerType as $type => $callbacks) {
-            if (! $this->pendingInResolveStack($object) && ($type === $abstract || $object instanceof $type)) {
+            if (($type === $abstract || $object instanceof $type) && ! $this->pendingInResolveStack($object)) {
                 $results = array_merge($results, $callbacks);
             }
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -653,6 +653,8 @@ class Container implements ArrayAccess, ContainerContract
         // just return an existing instance instead of instantiating new instances
         // so the developer can keep using the same objects instance every time.
         if (isset($this->instances[$abstract]) && ! $needsContextualBuild) {
+            array_pop($this->resolveStack);
+
             return $this->instances[$abstract];
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1058,7 +1058,7 @@ class Container implements ArrayAccess, ContainerContract
         $results = [];
 
         foreach ($callbacksPerType as $type => $callbacks) {
-            if ($type === $abstract || ( $object instanceof $type && !in_array( $type, $this->resolveStack ) ) ) {
+            if ($type === $abstract || ($object instanceof $type && ! in_array($type, $this->resolveStack))) {
                 $results = array_merge($results, $callbacks);
             }
         }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -383,17 +383,17 @@ class ContainerTest extends TestCase
         $resolving_invocations = 0;
         $after_resolving_invocations = 0;
 
-        $container->resolving( IContainerContractStub::class, function( ) use ( &$resolving_invocations ) {
+        $container->resolving(IContainerContractStub::class, function () use (&$resolving_invocations) {
             $resolving_invocations++;
-        } );
-        $container->afterResolving( IContainerContractStub::class, function( ) use ( &$after_resolving_invocations ) {
+        });
+        $container->afterResolving(IContainerContractStub::class, function () use (&$after_resolving_invocations) {
             $after_resolving_invocations++;
-        } );
-        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class );
-        $container->make( IContainerContractStub::class );
+        });
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+        $container->make(IContainerContractStub::class);
 
-        $this->assertEquals( 1, $resolving_invocations );
-        $this->assertEquals( 1, $after_resolving_invocations );
+        $this->assertEquals(1, $resolving_invocations);
+        $this->assertEquals(1, $after_resolving_invocations);
     }
 
     public function testUnsetRemoveBoundInstances()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -377,6 +377,25 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $instance->name);
     }
 
+    public function testResolvingCallbacksAreCalledOnceForImplementations()
+    {
+        $container = new Container;
+        $resolving_invocations = 0;
+        $after_resolving_invocations = 0;
+
+        $container->resolving( IContainerContractStub::class, function( ) use ( &$resolving_invocations ) {
+            $resolving_invocations++;
+        } );
+        $container->afterResolving( IContainerContractStub::class, function( ) use ( &$after_resolving_invocations ) {
+            $after_resolving_invocations++;
+        } );
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class );
+        $container->make( IContainerContractStub::class );
+
+        $this->assertEquals( 1, $resolving_invocations );
+        $this->assertEquals( 1, $after_resolving_invocations );
+    }
+
     public function testUnsetRemoveBoundInstances()
     {
         $container = new Container;


### PR DESCRIPTION
Fixes #23699 by tracking abstracts that are currently being resolved. 
If an object is built that is an `instanceof` of an object that is already on the stack, firing the resolving() callbacks is inhibited. 
These callbacks are fired eventually when the `instanceof` object is resolved. 

This is a continuation of #23701.

I've ran some benchmarks on the adaptions of the `ContainerTest`s that interacts a lot with the `$resolveStack` because of the nested interfaces. 
E.g., for `testResolvingCallbacksAreCalledForNestedDependencies` an adaption that resolves many times:  

```php
$container = new Container;
$resolving_dependency_interface_invocations = 0;
$resolving_dependency_implementation_invocations = 0;
$resolving_dependent_invocations = 0;

$container->bind(IContainerContractStub::class, ContainerImplementationStub::class);

$container->resolving(IContainerContractStub::class, function () use (&$resolving_dependency_interface_invocations) {
    $resolving_dependency_interface_invocations++;
});

$container->resolving(ContainerImplementationStub::class, function () use (&$resolving_dependency_implementation_invocations) {
    $resolving_dependency_implementation_invocations++;
});

$container->resolving(ContainerNestedDependentStubTwo::class, function () use (&$resolving_dependent_invocations) {
    $resolving_dependent_invocations++;
});

for($i = 0; $i < 100; $i++){
    $container->make(ContainerNestedDependentStubTwo::class, compact('i'));
    $container->make(ContainerNestedDependentStubTwo::class, compact('i'));
}
```

I've also adapted and benched:
- `testResolvingCallbacksAreCalledOnceForImplementations`
- `testResolvingCallbacksAreCalledForSpecificAbstracts`

https://github.com/tomlankhorst/framework/tree/resolve-stack-bench
https://github.com/tomlankhorst/framework/pull/1/files

Using PHPBench, 10 revs, 10 its (for a total of 10.000 calls per resolve).
`phpbench run tests/Container/ContainerTest.php --tag=no_resolve_stack --store --retry-threshold=4 --revs=10 --iterations=10`

Comparing this to the current master without the resolve stack (that shows the erroneous behaviour of #23699):
```
phpbench report --uuid=tag:no_resolve_stack --uuid=tag:resolve_stack --report='{extends: compare, compare: tag, cols: ['subject']}'
+-------------------------------------------------------+---------------------------+------------------------+
| subject                                               | tag:no_resolve_stack:mean | tag:resolve_stack:mean |
+-------------------------------------------------------+---------------------------+------------------------+
| testResolvingCallbacksAreCalledForSpecificAbstracts   | 3,879.860μs               | 4,191.810μs            |
| testResolvingCallbacksAreCalledOnceForImplementations | 8,213.690μs               | 9,426.250μs            |
| testResolvingCallbacksAreCalledForNestedDependencies  | 54,412.570μs              | 60,539.490μs           |
+-------------------------------------------------------+---------------------------+------------------------+
```
So, there's an average performance impact of 10% on resolving. I realize this impact is significant but I also realize that the current behaviour is not acceptable.