### PR TITLE
[5.8] Allow publishing to multiple groups at once in Service Providers

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -134,17 +134,19 @@ abstract class ServiceProvider
      * Register paths to be published by the publish command.
      *
      * @param  array  $paths
-     * @param  string  $group
+     * @param  mixed  $groups
      * @return void
      */
-    protected function publishes(array $paths, $group = null)
+    protected function publishes(array $paths, $groups = null)
     {
         $this->ensurePublishArrayInitialized($class = static::class);
 
         static::$publishes[$class] = array_merge(static::$publishes[$class], $paths);
 
-        if ($group) {
-            $this->addPublishGroup($group, $paths);
+        if (! is_null($groups)) {
+            foreach ((array) $groups as $group) {
+                $this->addPublishGroup($group, $paths);
+            }
         }
     }
 

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -39,7 +39,7 @@ class SupportServiceProviderTest extends TestCase
     public function testPublishableGroups()
     {
         $toPublish = ServiceProvider::publishableGroups();
-        $this->assertEquals(['some_tag'], $toPublish, 'Publishable groups do not return expected set of groups.');
+        $this->assertEquals(['some_tag', 'tag_one', 'tag_two'], $toPublish, 'Publishable groups do not return expected set of groups.');
     }
 
     public function testSimpleAssetsArePublishedCorrectly()
@@ -47,7 +47,7 @@ class SupportServiceProviderTest extends TestCase
         $toPublish = ServiceProvider::pathsToPublish(ServiceProviderForTestingOne::class);
         $this->assertArrayHasKey('source/unmarked/one', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertArrayHasKey('source/tagged/one', $toPublish, 'Service provider does not return expected published path key.');
-        $this->assertEquals(['source/unmarked/one' => 'destination/unmarked/one', 'source/tagged/one' => 'destination/tagged/one'], $toPublish, 'Service provider does not return expected set of published paths.');
+        $this->assertEquals(['source/unmarked/one' => 'destination/unmarked/one', 'source/tagged/one' => 'destination/tagged/one', 'source/tagged/multiple' => 'destination/tagged/multiple'], $toPublish, 'Service provider does not return expected set of published paths.');
     }
 
     public function testMultipleAssetsArePublishedCorrectly()
@@ -118,6 +118,7 @@ class ServiceProviderForTestingOne extends ServiceProvider
     {
         $this->publishes(['source/unmarked/one' => 'destination/unmarked/one']);
         $this->publishes(['source/tagged/one' => 'destination/tagged/one'], 'some_tag');
+        $this->publishes(['source/tagged/multiple' => 'destination/tagged/multiple'], ['tag_one', 'tag_two']);
     }
 }
 


### PR DESCRIPTION
Sometimes bigger applications are split in packages. The app's packages may have multiple types of publishable resources like configs, migrations, email templates, front-end assets and so on.

When deploying or updating the app you will want to publish all the relevant resources by a common tag (or a set of common tags) that would greatly reduce the publishing time and the risk of missing something.

Instead of 

```php
php artisan vendor:publish --tag=package-one-config
php artisan vendor:publish --tag=package-two-config
...
```

you could do 

```php
php artisan vendor:publish --tag=app-config
```

In this case the ability to use an array of groups (tags) when publishing in the service controller can come in handy.

Instead of

```php
$this->publishes(
     [ __DIR__.'/config' => config_path()],
     'some-package-config'
);

$this->publishes(
      [ __DIR__.'/config' => config_path()],
      'app-config'
);
```

you could do

```php
$this->publishes(
      [ __DIR__.'/config' => config_path()],
      ['some-package-config', 'app-config']
);
```