### PR TITLE
[5.8] changed default 401 img from `403.svg` to `401.svg`

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/401.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/401.blade.php
@@ -4,7 +4,7 @@
 @section('title', __('Unauthorized'))
 
 @section('image')
-<div style="background-image: url('/svg/403.svg');" class="absolute pin bg-cover bg-no-repeat md:bg-left lg:bg-center">
+<div style="background-image: url('/svg/401.svg');" class="absolute pin bg-cover bg-no-repeat md:bg-left lg:bg-center">
 </div>
 @endsection
 


### PR DESCRIPTION
 - changed default 401 error img from `403.svg` to `401.svg`. 

The 401.img is added in https://github.com/laravel/laravel/pull/4814
Documentation updated - https://github.com/laravel/docs/pull/4639
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
