### PR TITLE
[5.7] Remove double slashes from hot url in mix() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -586,8 +586,10 @@ if (! function_exists('mix')) {
             $manifestDirectory = "/{$manifestDirectory}";
         }
 
-        if (file_exists(public_path($manifestDirectory.'/hot'))) {
-            $url = rtrim(file_get_contents(public_path($manifestDirectory.'/hot')));
+        $hotFile = public_path($manifestDirectory.'/hot');
+
+        if (file_exists($hotFile)) {
+            $url = rtrim(rtrim(file_get_contents($hotFile)), '/');
 
             if (Str::startsWith($url, ['http://', 'https://'])) {
                 return new HtmlString(Str::after($url, ':').$path);


### PR DESCRIPTION
laravel-mix always adds a slash to the end of the url that is written to the `public/hot` file:
https://github.com/JeffreyWay/laravel-mix/blob/v2.1/src/index.js#L55
```js
new File(path.join(Config.publicPath, 'hot')).write(
    http +
        '://' +
        Config.hmrOptions.host +
        ':' +
        Config.hmrOptions.port +
        '/'
);
```
At the same time, the `mix()` helper always adds a slash at the beginning of the `$path` argument:
```php
if (! Str::startsWith($path, '/')) {
    $path = "/{$path}";
}
```
And after concatenation, the url looks like
```
//localhost:8080//app.js
```
instead of
```
//localhost:8080/app.js
```

This can be solved by adding a slash to an already existing `rtrim`.
