### PR TITLE
[5.7] Define mix as const in presets

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/react-stubs/webpack.mix.js
+++ b/src/Illuminate/Foundation/Console/Presets/react-stubs/webpack.mix.js
@@ -1,4 +1,4 @@
-let mix = require('laravel-mix');
+const mix = require('laravel-mix');
 
 /*
  |--------------------------------------------------------------------------

--- a/src/Illuminate/Foundation/Console/Presets/vue-stubs/webpack.mix.js
+++ b/src/Illuminate/Foundation/Console/Presets/vue-stubs/webpack.mix.js
@@ -1,4 +1,4 @@
-let mix = require('laravel-mix');
+const mix = require('laravel-mix');
 
 /*
  |--------------------------------------------------------------------------


### PR DESCRIPTION
Since [laravel/laravel#4741](https://github.com/laravel/laravel/pull/4741) the mix variable is `const` but is still defined with `let` in vue and react's webpack config presets files