### PR TITLE
[5.7] Postgres connector set names

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -59,9 +59,11 @@ class PostgresConnector extends Connector implements ConnectorInterface
      */
     protected function configureEncoding($connection, $config)
     {
-        $charset = $config['charset'];
+        if (! isset($config['charset'])) {
+            return;
+        }
 
-        $connection->prepare("set names '$charset'")->execute();
+        $connection->prepare("set names '{$config['charset']}'")->execute();
     }
 
     /**


### PR DESCRIPTION
After analizing database queries using pg_stat_statements i found that query 
`set names 'utf-8'` running too much times.
`SHOW SERVER_ENCODING` already returns 'UTF8' and no needs to change it every launch.
Code was implemented from [MysqlConnector](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Database/Connectors/MySqlConnector.php#L49)
So if you remove charset option in database config file where will no any `set names` queries