### PR TITLE
[5.8] Feature: user login attempts, multiple decay minutes

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -64,7 +64,7 @@ class RateLimiter
                     $this->cache->increment($key.':step');
                 }
             }
-            $step = $this->cache->get($key.':step', 0);
+            $step = (int) $this->cache->get($key.':step', 0);
             $step = $step < count($decayMinutes) ? $step : count($decayMinutes) - 1;
             $decayMinutes = $decayMinutes[$step];
         }

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -51,11 +51,24 @@ class RateLimiter
      * Increment the counter for a given key for a given decay time.
      *
      * @param  string  $key
-     * @param  float|int  $decayMinutes
+     * @param  float|int|array  $decayMinutes
      * @return int
      */
     public function hit($key, $decayMinutes = 1)
     {
+        if (is_array($decayMinutes)) {
+            if (! $this->cache->has($key.':timer')) {
+                if (! $this->cache->has($key.':step')) {
+                    $this->cache->add($key.':step', 0, 1440);
+                } else {
+                    $this->cache->increment($key.':step');
+                }
+            }
+            $step = $this->cache->get($key.':step', 0);
+            $step = $step < count($decayMinutes) ? $step : count($decayMinutes) - 1;
+            $decayMinutes = $decayMinutes[$step];
+        }
+
         $this->cache->add(
             $key.':timer', $this->availableAt($decayMinutes * 60), $decayMinutes
         );

--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -112,7 +112,7 @@ trait ThrottlesLogins
     /**
      * Get the number of minutes to throttle for.
      *
-     * @return int
+     * @return int|array
      */
     public function decayMinutes()
     {


### PR DESCRIPTION
This feature is allows you to set user login attempts multiple decay minutes.

## For example:

Set `decayMinutes`  a Array `[3, 5, 10]`.

Now start login, and always enter wrong username or password:

First too many attempts, `decayMinutes` is 3 minute;
Second too many attempts, `decayMinutes` is 5 minute;
Third too many attempts, `decayMinutes` is 10 minute;
Fourth too many attempts, `decayMinutes` is 10 minute;
Fifth too many attempts, `decayMinutes` is 10 minute;
And so on....

App\Http\Controllers\Auth\LoginController:
```php
<?php

namespace App\Http\Controllers\Auth;

...

class LoginController extends Controller
{
    ...

    /**
     * The maximum number of attempts to allow.
     *
     * @var integer
     */
    protected $maxAttempts = 1;

    /**
     * The number of minutes to throttle for.
     *
     * @var integer|array
     */
    protected $decayMinutes = [3, 5, 10];
}

```

If this feature is passed,
I hope to add this example to [Laravel's documentation - Authentication](https://laravel.com/docs/5.7/authentication) (rewriting the document).
Thank's.