### PR TITLE
[5.6] hash_equals(): Expected user_string to be a string, null given

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -349,7 +349,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         $signature = hash_hmac('sha256', $original, call_user_func($this->keyResolver));
 
-        return  hash_equals($signature, $request->query('signature', '')) &&
+        return  hash_equals($signature, (string) $request->query('signature', '')) &&
                ! ($expires && Carbon::now()->getTimestamp() > $expires);
     }
 


### PR DESCRIPTION
I am seeing random hash_equals(): Expected user_string to be a string, null given on my monitoring panel (see the log message at the end of this PR).

A user is probably messing with my app signed url, removing the value of the query parameter "signature".

Doing so, with the url `/foo/bar?signature=`, we get `null` for the result of `$request->query('signature', '')` (https://github.com/illuminate/routing/blob/1e05259a8fa573413f8e12c3646a923d188f65c0/UrlGenerator.php#L354)

To be sure to pass a string as the 2nd argument of the function hash_equals, I added a typecast before it.

```json
{  
   "class":"ErrorException",
   "message":"hash_equals(): Expected user_string to be a string, null given",
   "code":0,
   "file":"/var/www/html/xxxxx/releases/20181012090421Z/vendor/laravel/framework/src/Illuminate/Routing/UrlGenerator.php:354",
   "trace":[  
      "{\"function\":\"handleError\",\"class\":\"Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions\",\"type\":\"->\",\"args\":[2,\"hash_equals(): Expected user_string to be a string, null given\",\"/var/www/html/xxxxx/releases/20181012090421Z/vendor/laravel/framework/src/Illuminate/Routing/UrlGenerator.php\",354,{\"request\":\"[object] (Illuminate\\\\Http\\\\Request: GET /files/tmp/20181015054425_b4c2e711-6dd1-45a5-9009-f6fd143971e9?expires=1539582573&signature= HTTP/1.1\\r\\nAccept:          */*\\r\\nAccept-Encoding: gzip, deflate\\r\\nConnection:      Keep-Alive\\r\\nContent-Length:  \\r\\nContent-Type:    \\r\\nHost:            xxxxx\\r\\nUser-Agent:      NSPlayer/12.0.7600.16385 WMFSDK/12.0\\r\\n\\r\\n)\",\"original\":\"https://xxxxx/files/tmp/20181015054425_b4c2e711-6dd1-45a5-9009-f6fd143971e9?expires=1539582573\",\"expires\":\"1539582573\",\"signature\":\"474b6866268ae4cc68f9a279d8157a89ac350d9e1d1d46d1bcf2a65317255232\"}]}",
      "/var/www/html/xxxxx/releases/20181012090421Z/vendor/laravel/framework/src/Illuminate/Routing/UrlGenerator.php:354",
      "/var/www/html/xxxxx/releases/20181012090421Z/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:223",
      "/var/www/html/xxxxx/releases/20181012090421Z/vendor/laravel/framework/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php:53",
      "......"
   ]
}
```

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
