### PR TITLE
[5.7] Allow passing a model instance directly to assertSoftDeleted

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\Constraints\HasInDatabase;
 use PHPUnit\Framework\Constraint\LogicalNot as ReverseConstraint;
 use Illuminate\Foundation\Testing\Constraints\SoftDeletedInDatabase;
@@ -47,13 +48,17 @@ trait InteractsWithDatabase
     /**
      * Assert the given record has been deleted.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Database\Eloquent\Model  $table
      * @param  array  $data
      * @param  string  $connection
      * @return $this
      */
-    protected function assertSoftDeleted($table, array $data, $connection = null)
+    protected function assertSoftDeleted($table, array $data = [], $connection = null)
     {
+        if ($table instanceof Model) {
+            return $this->assertSoftDeleted($table->getTable(), [$table->getKeyName() => $table->getKey()]);
+        }
+
         $this->assertThat(
             $table, new SoftDeletedInDatabase($this->getConnection($connection), $data)
         );

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase;
 
 class FoundationInteractsWithDatabaseTest extends TestCase
@@ -100,7 +101,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseMissing($this->table, $this->data);
     }
 
-    public function testSeeSoftDeletedInDatabaseFindsResults()
+    public function testAssertSoftDeletedInDatabaseFindsResults()
     {
         $this->mockCountBuilder(1);
 
@@ -111,13 +112,28 @@ class FoundationInteractsWithDatabaseTest extends TestCase
      * @expectedException \PHPUnit\Framework\ExpectationFailedException
      * @expectedExceptionMessage The table is empty.
      */
-    public function testSeeSoftDeletedInDatabaseDoesNotFindResults()
+    public function testAssertSoftDeletedInDatabaseDoesNotFindResults()
     {
         $builder = $this->mockCountBuilder(0);
 
         $builder->shouldReceive('get')->andReturn(collect());
 
         $this->assertSoftDeleted($this->table, $this->data);
+    }
+
+    /**
+     * @expectedException \PHPUnit\Framework\ExpectationFailedException
+     * @expectedExceptionMessage The table is empty.
+     */
+    public function testAssertSoftDeletedInDatabaseDoesNotFindModelResults()
+    {
+        $this->data = ['id' => 1];
+
+        $builder = $this->mockCountBuilder(0);
+
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $this->assertSoftDeleted(new ProductStub($this->data));
     }
 
     protected function mockCountBuilder($countResult)
@@ -141,4 +157,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     {
         return $this->connection;
     }
+}
+
+class ProductStub extends Model
+{
+    protected $table = 'products';
+
+    protected $guarded = [];
 }


### PR DESCRIPTION
This is a simple change that makes it a little nicer to confirm that an Eloquent model is soft deleted. I found that quite often I was doing something like this...

```php
$this->assertSoftDeleted('users', ['id' => $user->id]);
```

Which felt a little unnecessary - if soft deleting is a feature of Eloquent and I have the model instance handy surely I should be able to just pass it in. This PR allows this to happen instead...

```php
$this->assertSoftDeleted($user);
```
