### PR TITLE
[5.7] Add uuid validation rule to validator

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -5,6 +5,7 @@ namespace Illuminate\Validation\Concerns;
 use DateTime;
 use Countable;
 use Exception;
+use Ramsey\Uuid\Uuid;
 use Throwable;
 use DateTimeZone;
 use DateTimeInterface;
@@ -1541,6 +1542,22 @@ trait ValidatesAttributes
         $~ixu';
 
         return preg_match($pattern, $value) > 0;
+    }
+
+    /**
+     * Validate that an attribute is a valid UUID.
+     *
+     * @param  string $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateUuid($attribute, $value)
+    {
+        if (!is_string($value)) {
+            return false;
+        }
+
+        return Uuid::isValid($value);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1556,10 +1556,6 @@ trait ValidatesAttributes
             return false;
         }
 
-        if ($value === '00000000-0000-0000-0000-000000000000') {
-            return true;
-        }
-
         return preg_match('/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/D', $value);
     }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1556,7 +1556,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return preg_match('/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/D', $value);
+        return preg_match('/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iD', $value);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1556,7 +1556,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return preg_match('/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iD', $value);
+        return preg_match('/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iD', $value) > 0;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1546,7 +1546,7 @@ trait ValidatesAttributes
     /**
      * Validate that an attribute is a valid UUID.
      *
-     * @param  string $attribute
+     * @param  string  $attribute
      * @param  mixed  $value
      * @return bool
      */

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -7,7 +7,6 @@ use Countable;
 use Exception;
 use Throwable;
 use DateTimeZone;
-use Ramsey\Uuid\Uuid;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -1557,7 +1556,11 @@ trait ValidatesAttributes
             return false;
         }
 
-        return Uuid::isValid($value);
+        if ($value === '00000000-0000-0000-0000-000000000000') {
+            return true;
+        }
+
+        return preg_match('/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/D', $value);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -5,9 +5,9 @@ namespace Illuminate\Validation\Concerns;
 use DateTime;
 use Countable;
 use Exception;
-use Ramsey\Uuid\Uuid;
 use Throwable;
 use DateTimeZone;
+use Ramsey\Uuid\Uuid;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -1553,7 +1553,7 @@ trait ValidatesAttributes
      */
     public function validateUuid($attribute, $value)
     {
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             return false;
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3,24 +3,24 @@
 namespace Illuminate\Tests\Validation;
 
 use DateTime;
+use Mockery as m;
 use DateTimeImmutable;
-use Illuminate\Container\Container;
-use Illuminate\Contracts\Translation\Translator as TranslatorContract;
-use Illuminate\Contracts\Validation\ImplicitRule;
-use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
-use Illuminate\Translation\ArrayLoader;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+use Illuminate\Validation\Validator;
 use Illuminate\Translation\Translator;
-use Illuminate\Validation\PresenceVerifierInterface;
+use Illuminate\Translation\ArrayLoader;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
+use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Validation\ValidationData;
-use Illuminate\Validation\Validator;
-use Mockery as m;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\File\File;
+use Illuminate\Contracts\Validation\ImplicitRule;
+use Illuminate\Validation\PresenceVerifierInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 
 class ValidationValidatorTest extends TestCase
 {
@@ -4252,7 +4252,7 @@ class ValidationValidatorTest extends TestCase
         return [
             ['not a valid uuid so we can test this'],
             ['zf6f8cb0-c57d-11e1-9b21-0800200c9a66'],
-            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1' . PHP_EOL],
+            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'.PHP_EOL],
             ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1 '],
             [' 145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'],
             ['145a1e72-d11d-11e8-a8d5-f2z01f1b9fd1'],

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4211,6 +4211,55 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['nested' => [['bar' => 'baz'], ['bar' => 'baz2']]], $data);
     }
 
+    /**
+     * @dataProvider validUuidList
+     */
+    public function testValidateWithValidUuid($uuid)
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => $uuid], ['foo' => 'uuid']);
+        $this->assertTrue($v->passes());
+    }
+
+    /**
+     * @dataProvider invalidUuidList
+     */
+    public function testValidateWithInvalidUuid($uuid)
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => $uuid], ['foo' => 'uuid']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function validUuidList()
+    {
+        return [
+            ['a0a2a2d2-0b87-4a18-83f2-2529882be2de'],
+            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'],
+            ['00000000-0000-0000-0000-000000000000'],
+            ['e60d3f48-95d7-4d8d-aad0-856f29a27da2'],
+            ['ff6f8cb0-c57d-11e1-9b21-0800200c9a66'],
+            ['ff6f8cb0-c57d-21e1-9b21-0800200c9a66'],
+            ['ff6f8cb0-c57d-31e1-9b21-0800200c9a66'],
+            ['ff6f8cb0-c57d-41e1-9b21-0800200c9a66'],
+            ['ff6f8cb0-c57d-51e1-9b21-0800200c9a66'],
+            ['FF6F8CB0-C57D-11E1-9B21-0800200C9A66'],
+        ];
+    }
+
+    public function invalidUuidList()
+    {
+        return [
+            ['not a valid uuid so we can test this'],
+            ['zf6f8cb0-c57d-11e1-9b21-0800200c9a66'],
+            ['145a1e72-d11d-11e8-a8d5-f2z01f1b9fd1'],
+            ['3f6f8cb0-c57d-11e1-9b21-0800200c9a6'],
+            ['af6f8cb-c57d-11e1-9b21-0800200c9a66'],
+            ['af6f8cb0c57d11e19b210800200c9a66'],
+            ['ff6f8cb0-c57da-51e1-9b21-0800200c9a66'],
+        ];
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3,24 +3,24 @@
 namespace Illuminate\Tests\Validation;
 
 use DateTime;
-use Mockery as m;
 use DateTimeImmutable;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Translation\Translator as TranslatorContract;
+use Illuminate\Contracts\Validation\ImplicitRule;
+use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
-use PHPUnit\Framework\TestCase;
-use Illuminate\Container\Container;
-use Illuminate\Validation\Validator;
-use Illuminate\Translation\Translator;
 use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\PresenceVerifierInterface;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
-use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Validation\ValidationData;
+use Illuminate\Validation\Validator;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\File\File;
-use Illuminate\Contracts\Validation\ImplicitRule;
-use Illuminate\Validation\PresenceVerifierInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 
 class ValidationValidatorTest extends TestCase
 {
@@ -4252,6 +4252,9 @@ class ValidationValidatorTest extends TestCase
         return [
             ['not a valid uuid so we can test this'],
             ['zf6f8cb0-c57d-11e1-9b21-0800200c9a66'],
+            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1' . PHP_EOL],
+            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1 '],
+            [' 145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'],
             ['145a1e72-d11d-11e8-a8d5-f2z01f1b9fd1'],
             ['3f6f8cb0-c57d-11e1-9b21-0800200c9a6'],
             ['af6f8cb-c57d-11e1-9b21-0800200c9a66'],


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Often there is the need to extend the Validator to add a uuid validation rule like this below.

```php
Validator::extend('uuid', function ($attribute, $value, $parameters, $validator) {
    return \Ramsey\Uuid\Uuid::isValid($value);
});
```

Since Laravel already depends on `ramsey/uuid`,  I think this would be a nice little addition to Laravel's validation ruleset.

Let me know what you think

