### PR TITLE
[5.7] Remove unecessary ternary

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -299,7 +299,7 @@ class AuthAccessGateTest extends TestCase
         $gate = $this->getBasicGate();
 
         $gate->after(function ($user, $ability, $result) {
-            return $ability == 'allow' ? true : false;
+            return $ability == 'allow';
         });
 
         $gate->after(function ($user, $ability, $result) {


### PR DESCRIPTION
The result of a `==` comparison is always `true` or `false`, so there's no needed for the ternary.