### PR TITLE
[5.7] Add panel component to the MailMessage

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -64,6 +64,13 @@ class SimpleMessage
     public $actionUrl;
 
     /**
+     * The text / label for the panel.
+     *
+     * @var string
+     */
+    public $panelText;
+
+    /**
      * Indicate that the notification gives information about a successful operation.
      *
      * @return $this
@@ -160,7 +167,7 @@ class SimpleMessage
     {
         if ($line instanceof Action) {
             $this->action($line->text, $line->url);
-        } elseif (! $this->actionText) {
+        } elseif (! $this->actionText && ! $this->panelText) {
             $this->introLines[] = $this->formatLine($line);
         } else {
             $this->outroLines[] = $this->formatLine($line);
@@ -204,6 +211,19 @@ class SimpleMessage
     }
 
     /**
+     * Configure the panel block.
+     *
+     * @param  string  $text
+     * @return $this
+     */
+    public function panel($text)
+    {
+        $this->panelText = $text;
+
+        return $this;
+    }
+
+    /**
      * Get an array representation of the message.
      *
      * @return array
@@ -219,6 +239,7 @@ class SimpleMessage
             'outroLines' => $this->outroLines,
             'actionText' => $this->actionText,
             'actionUrl' => $this->actionUrl,
+            'panelText' => $this->panelText,
         ];
     }
 }

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -33,6 +33,13 @@
 @endcomponent
 @endisset
 
+{{-- Panel --}}
+@isset($panelText)
+@component('mail::panel')
+{{ $panelText }}
+@endcomponent
+@endisset
+
 {{-- Outro Lines --}}
 @foreach ($outroLines as $line)
 {{ $line }}


### PR DESCRIPTION
In some scenarios like Steam login confirmation (some text code is sent to the user's email), a panel component would be more convenient than a simple text line and may be an alternative to the action button.

![2018-10-16 19 23 08](https://user-images.githubusercontent.com/839349/47013288-3b3e8080-d179-11e8-8eec-abb40073fb40.png)
