### PR TITLE
[5.7] Remove double slashes from hot url in mix() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -586,8 +586,10 @@ if (! function_exists('mix')) {
             $manifestDirectory = "/{$manifestDirectory}";
         }
 
-        if (file_exists(public_path($manifestDirectory.'/hot'))) {
-            $url = rtrim(file_get_contents(public_path($manifestDirectory.'/hot')));
+        $hotFile = public_path($manifestDirectory.'/hot');
+
+        if (file_exists($hotFile)) {
+            $url = rtrim(rtrim(file_get_contents($hotFile)), '/');
 
             if (Str::startsWith($url, ['http://', 'https://'])) {
                 return new HtmlString(Str::after($url, ':').$path);

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -83,4 +83,29 @@ class FoundationHelpersTest extends TestCase
 
         unlink(public_path('mix-manifest.json'));
     }
+
+    public function testMixReturnsHotUrl()
+    {
+        app()->singleton('path.public', function () {
+            return __DIR__;
+        });
+
+        $hotFile = public_path('hot');
+
+        try {
+            file_put_contents($hotFile, 'http://localhost:8080/');
+
+            $this->assertEquals('//localhost:8080/app.css', mix('app.css'));
+
+            file_put_contents($hotFile, "http://localhost:8081\n");
+
+            $this->assertEquals('//localhost:8081/app.css', mix('app.css'));
+
+            file_put_contents($hotFile, 'invalid-url');
+
+            $this->assertEquals('//localhost:8080/app.css', mix('app.css'));
+        } finally {
+            unlink($hotFile);
+        }
+    }
 }


### PR DESCRIPTION
https://github.com/laravel/framework/pull/26117 + tests