### PR TITLE
Add ability to ->forceJson() responses on requests

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -7,6 +7,13 @@ use Illuminate\Support\Str;
 trait InteractsWithContentTypes
 {
     /**
+     * Indicates whether to force/expect a json response, regardless of desired content type.
+     *
+     * @var bool
+     */
+    protected $forceJson = false;
+
+    /**
      * Determine if the given content types match.
      *
      * @param  string  $actual
@@ -41,7 +48,7 @@ trait InteractsWithContentTypes
      */
     public function expectsJson()
     {
-        return ($this->ajax() && ! $this->pjax() && $this->acceptsAnyContentType()) || $this->wantsJson();
+        return $this->forceJson || ($this->ajax() && ! $this->pjax() && $this->acceptsAnyContentType()) || $this->wantsJson();
     }
 
     /**
@@ -54,6 +61,18 @@ trait InteractsWithContentTypes
         $acceptable = $this->getAcceptableContentTypes();
 
         return isset($acceptable[0]) && Str::contains($acceptable[0], ['/json', '+json']);
+    }
+
+    /**
+     * Force json response.
+     *
+     * @return $this
+     */
+    public function forceJson()
+    {
+        $this->forceJson = true;
+
+        return $this;
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -598,6 +598,14 @@ class HttpRequestTest extends TestCase
         $this->assertNull(Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*'])->prefers('text/html'));
     }
 
+    public function testCanForceJsonResponse()
+    {
+        $request = Request::create('', 'GET');
+        $this->assertEquals($request, $request->forceJson());
+        $this->assertTrue($request->expectsJson());
+        $this->assertFalse($request->wantsJson());
+    }
+
     public function testAllInputReturnsInputAndFiles()
     {
         $file = $this->getMockBuilder(UploadedFile::class)->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();


### PR DESCRIPTION
This PR allows you to call `$request->forceJson()` in your API to hint to Laravel you expect to send a JSON response where applicable.

The problem with the current approach is:

1. It's difficult to test API-based responses currently in the browser, unless you send content-type headers / use a tool like Postman, which maybe overkill for some to just test basic api
2. If your app only handles JSON-based responses and a non-json response header is sent, your app won't know how to respond with `ValidationException` etcs and will just endlessly redirect. With this PR, it will always send a JSON response of errors, no matter what the client requests.

**tldr;** creates more pleasant testing api's for developers, less exploitable by client requests.
