### PR TITLE
Fix issue that prevents manipulation of overloaded Eloquent model JSON columns

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "doctrine/inflector": "^1.1",
         "dragonmantank/cron-expression": "^2.0",
         "erusev/parsedown": "^1.7",
+        "judahnator/json-manipulator": "^1.2",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "^1.12",
         "nesbot/carbon": "^1.26.3",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/inflector": "^1.1",
         "dragonmantank/cron-expression": "^2.0",
         "erusev/parsedown": "^1.7",
-        "judahnator/json-manipulator": "^1.2",
+        "judahnator/json-manipulator": "^2.0",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "^1.12",
         "nesbot/carbon": "^1.26.3",

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use function judahnator\JsonManipulator\load_json;
 use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
@@ -489,6 +490,12 @@ trait HasAttributes
             case 'array':
             case 'json':
                 return $this->fromJson($value);
+            case 'json_object':
+                $value ?: $this->attributes[$key] = '{}';
+                return load_json($this->attributes[$key]);
+            case 'json_array':
+                $value ?: $this->attributes[$key] = '[]';
+                return load_json($this->attributes[$key]);
             case 'collection':
                 return new BaseCollection($this->fromJson($value));
             case 'date':
@@ -901,7 +908,7 @@ trait HasAttributes
      */
     protected function isJsonCastable($key)
     {
-        return $this->hasCast($key, ['array', 'json', 'object', 'collection']);
+        return $this->hasCast($key, ['array', 'json', 'json_array', 'json_object', 'object', 'collection']);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,13 +2,13 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use function judahnator\JsonManipulator\load_json;
 use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
+use function judahnator\JsonManipulator\load_json;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\JsonEncodingException;
@@ -492,9 +492,11 @@ trait HasAttributes
                 return $this->fromJson($value);
             case 'json_object':
                 $value ?: $this->attributes[$key] = '{}';
+
                 return load_json($this->attributes[$key]);
             case 'json_array':
                 $value ?: $this->attributes[$key] = '[]';
+
                 return load_json($this->attributes[$key]);
             case 'collection':
                 return new BaseCollection($this->fromJson($value));

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -18,7 +18,8 @@
         "php": "^7.1.3",
         "illuminate/container": "5.7.*",
         "illuminate/contracts": "5.7.*",
-        "illuminate/support": "5.7.*"
+        "illuminate/support": "5.7.*",
+        "judahnator/json-manipulator": "^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -19,7 +19,7 @@
         "illuminate/container": "5.7.*",
         "illuminate/contracts": "5.7.*",
         "illuminate/support": "5.7.*",
-        "judahnator/json-manipulator": "^1.2"
+        "judahnator/json-manipulator": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
+++ b/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
@@ -2,10 +2,9 @@
 
 namespace Illuminate\Tests\Database;
 
+use PHPUnit\Framework\TestCase;
 use judahnator\JsonManipulator\JsonArray;
 use judahnator\JsonManipulator\JsonObject;
-use function judahnator\JsonManipulator\load_json;
-use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
@@ -156,6 +155,6 @@ class TableForCasting extends Eloquent
         'json_attributes' => 'json',
         'object_attributes' => 'object',
         'json_array_attributes' => 'json_array',
-        'json_object_attributes' => 'json_object'
+        'json_object_attributes' => 'json_object',
     ];
 }

--- a/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
+++ b/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
@@ -80,9 +80,16 @@ class DatabaseEloquentCastsDatabaseStringTest extends TestCase
         $this->assertSame('["value1","value2"]', $model->getOriginal('json_array_attributes'));
         $this->assertSame('value1', $model->getAttribute('json_array_attributes')[0]);
         $this->assertSame('value2', $model->getAttribute('json_array_attributes')[1]);
+        $model->getAttribute('json_array_attributes')[1] = 'value2-edited';
+        $this->assertSame('value2-edited', $model->getAttribute('json_array_attributes')[1]);
 
         $this->assertSame('{"key1":"value1"}', $model->getOriginal('json_object_attributes'));
         $this->assertSame('value1', $model->getAttribute('json_object_attributes')->key1);
+        $model->getAttribute('json_object_attributes')->key1 = 'value1-edited';
+        $model->getAttribute('json_object_attributes')->newkey = 'new-value';
+        $this->assertSame('value1-edited', $model->getAttribute('json_object_attributes')->key1);
+        $this->assertSame('new-value', $model->getAttribute('json_object_attributes')->newkey);
+
     }
 
     public function testSavingCastedEmptyAttributesToDatabase()

--- a/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
+++ b/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
@@ -89,7 +89,6 @@ class DatabaseEloquentCastsDatabaseStringTest extends TestCase
         $model->getAttribute('json_object_attributes')->newkey = 'new-value';
         $this->assertSame('value1-edited', $model->getAttribute('json_object_attributes')->key1);
         $this->assertSame('new-value', $model->getAttribute('json_object_attributes')->newkey);
-
     }
 
     public function testSavingCastedEmptyAttributesToDatabase()

--- a/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
+++ b/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Tests\Database;
 
+use judahnator\JsonManipulator\JsonArray;
+use judahnator\JsonManipulator\JsonObject;
+use function judahnator\JsonManipulator\load_json;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
@@ -35,6 +38,8 @@ class DatabaseEloquentCastsDatabaseStringTest extends TestCase
             $table->string('array_attributes');
             $table->string('json_attributes');
             $table->string('object_attributes');
+            $table->string('json_array_attributes');
+            $table->string('json_object_attributes');
             $table->timestamps();
         });
     }
@@ -59,6 +64,8 @@ class DatabaseEloquentCastsDatabaseStringTest extends TestCase
             'array_attributes' => ['key1'=>'value1'],
             'json_attributes' => ['json_key'=>'json_value'],
             'object_attributes' => ['json_key'=>'json_value'],
+            'json_array_attributes' => ['value1', 'value2'],
+            'json_object_attributes' => ['key1' => 'value1'],
         ]);
         $this->assertSame('{"key1":"value1"}', $model->getOriginal('array_attributes'));
         $this->assertSame(['key1'=>'value1'], $model->getAttribute('array_attributes'));
@@ -70,6 +77,13 @@ class DatabaseEloquentCastsDatabaseStringTest extends TestCase
         $stdClass = new \stdClass();
         $stdClass->json_key = 'json_value';
         $this->assertEquals($stdClass, $model->getAttribute('object_attributes'));
+
+        $this->assertSame('["value1","value2"]', $model->getOriginal('json_array_attributes'));
+        $this->assertSame('value1', $model->getAttribute('json_array_attributes')[0]);
+        $this->assertSame('value2', $model->getAttribute('json_array_attributes')[1]);
+
+        $this->assertSame('{"key1":"value1"}', $model->getOriginal('json_object_attributes'));
+        $this->assertSame('value1', $model->getAttribute('json_object_attributes')->key1);
     }
 
     public function testSavingCastedEmptyAttributesToDatabase()
@@ -79,6 +93,8 @@ class DatabaseEloquentCastsDatabaseStringTest extends TestCase
             'array_attributes' => [],
             'json_attributes' => [],
             'object_attributes' => [],
+            'json_array_attributes' => [],
+            'json_object_attributes' => new \stdClass(),
         ]);
         $this->assertSame('[]', $model->getOriginal('array_attributes'));
         $this->assertSame([], $model->getAttribute('array_attributes'));
@@ -88,6 +104,12 @@ class DatabaseEloquentCastsDatabaseStringTest extends TestCase
 
         $this->assertSame('[]', $model->getOriginal('object_attributes'));
         $this->assertSame([], $model->getAttribute('object_attributes'));
+
+        $this->assertSame('[]', $model->getOriginal('json_array_attributes'));
+        $this->assertInstanceOf(JsonArray::class, $model->getAttribute('json_array_attributes'));
+
+        $this->assertSame('{}', $model->getOriginal('json_object_attributes'));
+        $this->assertInstanceOf(JsonObject::class, $model->getAttribute('json_object_attributes'));
     }
 
     /**
@@ -133,5 +155,7 @@ class TableForCasting extends Eloquent
         'array_attributes' => 'array',
         'json_attributes' => 'json',
         'object_attributes' => 'object',
+        'json_array_attributes' => 'json_array',
+        'json_object_attributes' => 'json_object'
     ];
 }


### PR DESCRIPTION
Hello Laravel Team!

This is a follow up to my previous pull request, #25854. Some of the fine folks in the ShiftyCoders slack channel said not to get discouraged and to give it another shot, so here I am!

There was a valid concern about the memory usage in the library, which I have addressed. I have included those changes in this pull request and would like to reopen a discussion about solving this problem.

I wont copy/paste all the details of the former pull request as everything was pretty well documented there, but here is the gist of it:

Lets say you have this code:
```php
$myModel = MyModel::find($n);
$myModel->json_column->some_key = 'some value';
```
Before this pull request you will get this result:
```php
// PHP Notice:  Indirect modification of overloaded property App/MyModel::$json_column has no effect in...
```
With this pull request, that operation is perfectly valid and will modify that column as if it were a native PHP object or array.

I look forward to the discussion on this!