### PR TITLE
[5.7] Fix whereHas() and $withCount bindings

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -43,7 +43,7 @@ trait QueriesRelationships
                         : 'getRelationExistenceCountQuery';
 
         $hasQuery = $relation->{$method}(
-            $relation->getRelated()->newQuery(), $this
+            $relation->getRelated()->newQueryWithoutRelationships(), $this
         );
 
         // Next we will call any given callback as an "anonymous" scope so they can get the

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -960,9 +960,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function newQueryWithoutRelationships()
     {
-        return $this->registerGlobalScopes(
-            $this->newEloquentBuilder($this->newBaseQueryBuilder())->setModel($this)
-        );
+        return $this->registerGlobalScopes($this->newModelQuery());
     }
 
     /**

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentWhereHasTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentWhereHasTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id');
+            $table->boolean('public');
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('commentable_type');
+            $table->integer('commentable_id');
+        });
+
+        $user = User::create();
+        $post = tap((new Post(['public' => true]))->user()->associate($user))->save();
+        (new Comment)->commentable()->associate($post)->save();
+
+        $user = User::create();
+        $post = tap((new Post(['public' => false]))->user()->associate($user))->save();
+        (new Comment)->commentable()->associate($post)->save();
+    }
+
+    public function test_with_count()
+    {
+        $users = User::whereHas('posts', function ($query) {
+            $query->where('public', true);
+        })->get();
+
+        $this->assertEquals([1], $users->pluck('id')->all());
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Post extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $withCount = ['comments'];
+
+    public function comments()
+    {
+        return $this->morphMany(Comment::class, 'commentable');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}
+
+class User extends Model
+{
+    public $timestamps = false;
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
+}


### PR DESCRIPTION
Another case where `$withCount` and bindings from polymorphic relationships break queries:

```php
class Post extends Model {
    protected $withCount = ['comments'];

    public function comments() {
        return $this->morphMany(Comment::class, 'commentable');
    }
}

class User extends Model {
    public function posts() {
        return $this->hasMany(Post::class);
    }
}

User::whereHas('posts', function ($query) {
    $query->where('public', true);
})->get();
```

```sql
select * from "users" where exists (
    select * from "posts" where "users"."id" = "posts"."user_id" and "public" = App\Post
)
```

We can also simplify `newQueryWithoutRelationships()`, it shares most of its code with `newModelQuery()`.

Fixes #26141.