### PR TITLE
[5.7] Use the model connection

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -56,7 +56,7 @@ trait InteractsWithDatabase
     protected function assertSoftDeleted($table, array $data = [], $connection = null)
     {
         if ($table instanceof Model) {
-            return $this->assertSoftDeleted($table->getTable(), [$table->getKeyName() => $table->getKey()]);
+            return $this->assertSoftDeleted($table->getTable(), [$table->getKeyName() => $table->getKey()], $table->getConnectionName());
         }
 
         $this->assertThat(


### PR DESCRIPTION
This merged PR https://github.com/laravel/framework/pull/26133 allows the following method `assertSoftDeleted()` to make an assertion using a model.

Since it is making the assertion using the model, the model database connection should also be used in the assertion so we do not need to do this when the model has a database connection other then the default one

```php
// Avoid this, by passing the model connection
$this->assertSoftDeleted($model, [], 'customConnection');
```