### PR TITLE
[5.7] Fixed: Can exclude methods on registered ApiResource

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -152,13 +152,17 @@ class ResourceRegistrar
      */
     protected function getResourceMethods($defaults, $options)
     {
+        $methods = $defaults;
+
         if (isset($options['only'])) {
-            return array_intersect($defaults, (array) $options['only']);
-        } elseif (isset($options['except'])) {
-            return array_diff($defaults, (array) $options['except']);
+            $methods = array_intersect($methods, (array) $options['only']);
         }
 
-        return $defaults;
+        if (isset($options['except'])) {
+            $methods = array_diff($methods, (array) $options['except']);
+        }
+
+        return $methods;
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -335,6 +335,17 @@ class RouteRegistrarTest extends TestCase
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
     }
 
+    public function testCanExcludeMethodsOnRegisteredApiResource()
+    {
+        $this->router->apiResource('users', RouteRegistrarControllerStub::class)
+                     ->except(['index', 'show', 'store']);
+
+        $this->assertCount(2, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.update'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
+    }
+
     public function testCanRegisterApiResourcesWithExceptOption()
     {
         $this->router->apiResources([


### PR DESCRIPTION
**Summary**

`Route::apiResource(...)->except(...)` is not working correctly.

**Description**

At this moment we cant exclude methods on registered `ApiResource`, because method `Route::apiResource()` based on `only` option. So if `only` option is present then `except` option is ignored.

**PR**
- `\Illuminate\Tests\Routing\RouteRegistrarTest::testCanExcludeMethodsOnApiRegisteredResource` added.
- `\Illuminate\Routing\ResourceRegistrar::getResourceMethods` fixed.
