### PR TITLE
[5.7] Reverse ternary condition to make it clearer

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -629,6 +629,6 @@ class Arr
             return [];
         }
 
-        return ! is_array($value) ? [$value] : $value;
+        return is_array($value) ? $value : [$value];
     }
 }


### PR DESCRIPTION
This change makes the code more readable by removing the overhead of thinking in the unnecessary negation.
