### PR TITLE
[5.7] isChainOfObjects: No need to create 2 collections.

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -146,10 +146,9 @@ class QueueFake extends QueueManager implements Queue
      */
     protected function isChainOfObjects($chain)
     {
-        return collect($chain)->count() == collect($chain)
-                    ->filter(function ($job) {
-                        return is_object($job);
-                    })->count();
+        return ! collect($chain)->contains(function ($job) {
+            return ! is_object($job);
+        });
     }
 
     /**


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

No need to create 2 collections to ensure that the collection only contains objects.