### PR TITLE
[5.7] Prefer @expectedException docblocks.

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -866,13 +866,14 @@ class ContainerTest extends TestCase
         $this->assertEquals($container->getAlias('foo'), 'ConcreteStub');
     }
 
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage [name] is aliased to itself.
+     */
     public function testItThrowsExceptionWhenAbstractIsSameAsAlias()
     {
         $container = new Container;
         $container->alias('name', 'name');
-
-        $this->expectException('LogicException');
-        $this->expectExceptionMessage('[name] is aliased to itself.');
 
         $container->getAlias('name');
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2730,11 +2730,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([1], $builder->getBindings());
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The number of columns must match the number of values
+     */
     public function testWhereRowValuesArityMismatch()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The number of columns must match the number of values');
-
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->whereRowValues(['last_update'], '<', [1, 2]);
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Database;
 
 use stdClass;
 use Mockery as m;
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\ConnectionInterface;

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -2,14 +2,11 @@
 
 namespace Illuminate\Tests\Filesystem;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Adapter\Local;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Illuminate\Contracts\Filesystem\FileExistsException;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class FilesystemAdapterTest extends TestCase
 {

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -73,10 +73,12 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals('Hello World', $filesystemAdapter->get('file.txt'));
     }
 
+    /**
+     * @expectedException \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
     public function testGetFileNotFound()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
-        $this->expectException(FileNotFoundException::class);
         $filesystemAdapter->get('file.txt');
     }
 
@@ -168,9 +170,11 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($original_content, $secondFilesystemAdapter->get('copy.txt'));
     }
 
+    /**
+     * @expectedException \Illuminate\Contracts\Filesystem\FileExistsException
+     */
     public function testStreamToExistingFileThrows()
     {
-        $this->expectException(FileExistsException::class);
         $this->filesystem->write('file.txt', 'Hello World');
         $this->filesystem->write('existing.txt', 'Dear Kate');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
@@ -178,16 +182,20 @@ class FilesystemAdapterTest extends TestCase
         $filesystemAdapter->writeStream('existing.txt', $readStream);
     }
 
+    /**
+     * @expectedException \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
     public function testReadStreamNonExistentFileThrows()
     {
-        $this->expectException(FileNotFoundException::class);
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $filesystemAdapter->readStream('nonexistent.txt');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testStreamInvalidResourceThrows()
     {
-        $this->expectException(InvalidArgumentException::class);
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $filesystemAdapter->writeStream('file.txt', 'foo bar');
     }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -66,9 +66,11 @@ class FoundationTestResponseTest extends TestCase
         $response->assertSeeInOrder(['foo', 'bar', 'baz', 'foo']);
     }
 
+    /**
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
+     */
     public function testAssertSeeInOrderCanFail()
     {
-        $this->expectException(AssertionFailedError::class);
 
         $response = $this->makeMockResponse([
             'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
@@ -77,9 +79,11 @@ class FoundationTestResponseTest extends TestCase
         $response->assertSeeInOrder(['baz', 'bar', 'foo']);
     }
 
+    /**
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
+     */
     public function testAssertSeeInOrderCanFail2()
     {
-        $this->expectException(AssertionFailedError::class);
 
         $response = $this->makeMockResponse([
             'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
@@ -108,9 +112,11 @@ class FoundationTestResponseTest extends TestCase
         $response->assertSeeTextInOrder(['foobar', 'baz', 'foo']);
     }
 
+    /**
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
+     */
     public function testAssertSeeTextInOrderCanFail()
     {
-        $this->expectException(AssertionFailedError::class);
 
         $response = $this->makeMockResponse([
             'render' => 'foo<strong>bar</strong> baz <strong>foo</strong>',
@@ -119,9 +125,11 @@ class FoundationTestResponseTest extends TestCase
         $response->assertSeeTextInOrder(['baz', 'foobar']);
     }
 
+    /**
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
+     */
     public function testAssertSeeTextInOrderCanFail2()
     {
-        $this->expectException(AssertionFailedError::class);
 
         $response = $this->makeMockResponse([
             'render' => 'foo<strong>bar</strong> baz <strong>foo</strong>',
@@ -130,9 +138,11 @@ class FoundationTestResponseTest extends TestCase
         $response->assertSeeTextInOrder(['foobar', 'qux', 'baz']);
     }
 
+    /**
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
+     */
     public function testAssertHeader()
     {
-        $this->expectException(AssertionFailedError::class);
 
         $baseResponse = tap(new Response, function ($response) {
             $response->header('Location', '/foo');
@@ -199,9 +209,11 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonFragment(['id' => 10]);
     }
 
+    /**
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
+     */
     public function testAssertJsonFragmentCanFail()
     {
-        $this->expectException(AssertionFailedError::class);
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
@@ -249,9 +261,11 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonCount(4);
     }
 
+    /**
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
+     */
     public function testAssertJsonMissing()
     {
-        $this->expectException(AssertionFailedError::class);
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
@@ -268,18 +282,22 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonMissingExact(['id' => 20, 'foo' => 'baz']);
     }
 
+    /**
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
+     */
     public function testAssertJsonMissingExactCanFail()
     {
-        $this->expectException(AssertionFailedError::class);
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
         $response->assertJsonMissingExact(['id' => 20]);
     }
 
+    /**
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
+     */
     public function testAssertJsonMissingExactCanFail2()
     {
-        $this->expectException(AssertionFailedError::class);
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
@@ -308,9 +326,11 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonMissingValidationErrors('foo');
     }
 
+    /**
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
+     */
     public function testAssertJsonMissingValidationErrorsCanFail()
     {
-        $this->expectException(AssertionFailedError::class);
 
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(json_encode(['errors' => [
@@ -325,9 +345,11 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonMissingValidationErrors('foo');
     }
 
+    /**
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
+     */
     public function testAssertJsonMissingValidationErrorsCanFail2()
     {
-        $this->expectException(AssertionFailedError::class);
 
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(json_encode(['errors' => [

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\View\View;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Database\Eloquent\Model;
-use PHPUnit\Framework\AssertionFailedError;
 use Illuminate\Foundation\Testing\TestResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
@@ -71,7 +70,6 @@ class FoundationTestResponseTest extends TestCase
      */
     public function testAssertSeeInOrderCanFail()
     {
-
         $response = $this->makeMockResponse([
             'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
         ]);
@@ -84,7 +82,6 @@ class FoundationTestResponseTest extends TestCase
      */
     public function testAssertSeeInOrderCanFail2()
     {
-
         $response = $this->makeMockResponse([
             'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
         ]);
@@ -117,7 +114,6 @@ class FoundationTestResponseTest extends TestCase
      */
     public function testAssertSeeTextInOrderCanFail()
     {
-
         $response = $this->makeMockResponse([
             'render' => 'foo<strong>bar</strong> baz <strong>foo</strong>',
         ]);
@@ -130,7 +126,6 @@ class FoundationTestResponseTest extends TestCase
      */
     public function testAssertSeeTextInOrderCanFail2()
     {
-
         $response = $this->makeMockResponse([
             'render' => 'foo<strong>bar</strong> baz <strong>foo</strong>',
         ]);
@@ -143,7 +138,6 @@ class FoundationTestResponseTest extends TestCase
      */
     public function testAssertHeader()
     {
-
         $baseResponse = tap(new Response, function ($response) {
             $response->header('Location', '/foo');
         });
@@ -214,7 +208,6 @@ class FoundationTestResponseTest extends TestCase
      */
     public function testAssertJsonFragmentCanFail()
     {
-
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
         $response->assertJsonFragment(['id' => 1]);
@@ -266,7 +259,6 @@ class FoundationTestResponseTest extends TestCase
      */
     public function testAssertJsonMissing()
     {
-
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
         $response->assertJsonMissing(['id' => 20]);
@@ -287,7 +279,6 @@ class FoundationTestResponseTest extends TestCase
      */
     public function testAssertJsonMissingExactCanFail()
     {
-
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
         $response->assertJsonMissingExact(['id' => 20]);
@@ -298,7 +289,6 @@ class FoundationTestResponseTest extends TestCase
      */
     public function testAssertJsonMissingExactCanFail2()
     {
-
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
         $response->assertJsonMissingExact(['id' => 20, 'foo' => 'bar']);
@@ -331,7 +321,6 @@ class FoundationTestResponseTest extends TestCase
      */
     public function testAssertJsonMissingValidationErrorsCanFail()
     {
-
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(json_encode(['errors' => [
                     'foo' => [],
@@ -350,7 +339,6 @@ class FoundationTestResponseTest extends TestCase
      */
     public function testAssertJsonMissingValidationErrorsCanFail2()
     {
-
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(json_encode(['errors' => [
                     'foo' => [],

--- a/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
+++ b/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Integration\Auth\ApiAuthenticationWithEloquentTest;
 
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Database\QueryException;
 
 class ApiAuthenticationWithEloquentTest extends TestCase
 {

--- a/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
+++ b/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
@@ -31,16 +31,14 @@ class ApiAuthenticationWithEloquentTest extends TestCase
 
     /**
      * @test
+     * @expectedException \Illuminate\Database\QueryException
+     * @expectedExceptionMessage SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: YES) (SQL: select * from `users` where `api_token` = whatever limit 1)
      */
     public function authentication_via_api_with_eloquent_using_wrong_database_credentials_should_not_cause_infinite_loop()
     {
         Route::get('/auth', function () {
             return 'success';
         })->middleware('auth:api');
-
-        $this->expectException(QueryException::class);
-
-        $this->expectExceptionMessage("SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: YES) (SQL: select * from `users` where `api_token` = whatever limit 1)");
 
         $this->withoutExceptionHandling()->get('/auth', ['Authorization' => 'Bearer whatever']);
     }

--- a/tests/Integration/Encryption/EncryptionTest.php
+++ b/tests/Integration/Encryption/EncryptionTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Encryption;
 
-use RuntimeException;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Encryption\EncryptionServiceProvider;

--- a/tests/Integration/Encryption/EncryptionTest.php
+++ b/tests/Integration/Encryption/EncryptionTest.php
@@ -29,11 +29,10 @@ class EncryptionTest extends TestCase
 
     /**
      * @test
+     * @expectedException \RuntimeException
      */
     public function encryption_will_not_be_instantiable_when_missing_app_key()
     {
-        $this->expectException(RuntimeException::class);
-
         $this->app['config']->set('app.key', null);
 
         $this->app->make('encrypter');

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -53,10 +53,11 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $queue->later(10, 'foo', ['data']);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testFailureToCreatePayloadFromObject()
     {
-        $this->expectException('InvalidArgumentException');
-
         $job = new stdClass;
         $job->invalid = "\xc3\x28";
 
@@ -71,10 +72,11 @@ class QueueDatabaseQueueUnitTest extends TestCase
         ]);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testFailureToCreatePayloadFromArray()
     {
-        $this->expectException('InvalidArgumentException');
-
         $queue = $this->getMockForAbstractClass(Queue::class);
         $class = new ReflectionClass(Queue::class);
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -48,6 +48,9 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldHaveReceived('dispatch')->with(m::type(JobProcessed::class))->once();
     }
 
+    /**
+     * @expectedException \Illuminate\Tests\Queue\LoopBreakerException
+     */
     public function test_worker_can_work_until_queue_is_empty()
     {
         $workerOptions = new WorkerOptions;
@@ -57,8 +60,6 @@ class QueueWorkerTest extends TestCase
             $firstJob = new WorkerFakeJob,
             $secondJob = new WorkerFakeJob,
         ]]);
-
-        $this->expectException(LoopBreakerException::class);
 
         $worker->daemon('default', 'queue', $workerOptions);
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Support;
 
 use stdClass;
-use Exception;
 use ArrayAccess;
 use ArrayObject;
 use Mockery as m;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2746,11 +2746,13 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['foo' => 3, 'bar' => ['nested' => 'two']], $collection->toArray());
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Property [foo] does not exist on this collection instance.
+     */
     public function testItThrowsExceptionWhenTryingToAccessNoProxyProperty()
     {
         $collection = new Collection;
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Property [foo] does not exist on this collection instance.');
         $collection->foo;
     }
 


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Staty consistant and always use `@expectedException` docblocks.