### PR TITLE
[5.7] Enforce test functions naming consistency

### DIFF
--- a/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
+++ b/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
@@ -29,7 +29,6 @@ class ApiAuthenticationWithEloquentTest extends TestCase
         ]);
     }
 
-    
     public function test_authentication_via_api_with_eloquent_using_wrong_database_credentials_should_not_cause_infinite_loop()
     {
         Route::get('/auth', function () {

--- a/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
+++ b/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
@@ -29,10 +29,8 @@ class ApiAuthenticationWithEloquentTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function authentication_via_api_with_eloquent_using_wrong_database_credentials_should_not_cause_infinite_loop()
+    
+    public function test_authentication_via_api_with_eloquent_using_wrong_database_credentials_should_not_cause_infinite_loop()
     {
         Route::get('/auth', function () {
             return 'success';

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -64,18 +64,14 @@ class AuthenticationTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
-    public function basic_auth_protects_route()
+    
+    public function test_basic_auth_protects_route()
     {
         $this->get('basic')->assertStatus(401);
     }
 
-    /**
-     * @test
-     */
-    public function basic_auth_passes_on_correct_credentials()
+    
+    public function test_basic_auth_passes_on_correct_credentials()
     {
         $response = $this->get('basic', [
             'Authorization' => 'Basic '.base64_encode('email:password'),
@@ -85,10 +81,8 @@ class AuthenticationTest extends TestCase
         $this->assertEquals('email', $response->decodeResponseJson()['email']);
     }
 
-    /**
-     * @test
-     */
-    public function basic_auth_respects_additional_conditions()
+    
+    public function test_basic_auth_respects_additional_conditions()
     {
         AuthenticationTestUser::create([
             'username' => 'username2',
@@ -106,20 +100,16 @@ class AuthenticationTest extends TestCase
         ])->assertStatus(200);
     }
 
-    /**
-     * @test
-     */
-    public function basic_auth_fails_on_wrong_credentials()
+    
+    public function test_basic_auth_fails_on_wrong_credentials()
     {
         $this->get('basic', [
             'Authorization' => 'Basic '.base64_encode('email:wrong_password'),
         ])->assertStatus(401);
     }
 
-    /**
-     * @test
-     */
-    public function logging_in_fails_via_attempt()
+    
+    public function test_logging_in_fails_via_attempt()
     {
         Event::fake();
 
@@ -143,10 +133,8 @@ class AuthenticationTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
-    public function logging_in_succeeds_via_attempt()
+    
+    public function test_logging_in_succeeds_via_attempt()
     {
         Event::fake();
 
@@ -176,9 +164,7 @@ class AuthenticationTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
+    
     public function test_logging_in_using_id()
     {
         $this->app['auth']->loginUsingId(1);
@@ -187,9 +173,7 @@ class AuthenticationTest extends TestCase
         $this->assertFalse($this->app['auth']->loginUsingId(1000));
     }
 
-    /**
-     * @test
-     */
+    
     public function test_logging_out()
     {
         Event::fake();
@@ -207,10 +191,8 @@ class AuthenticationTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
-    public function logging_in_out_via_attempt_remembering()
+    
+    public function test_logging_in_out_via_attempt_remembering()
     {
         $this->assertTrue(
             $this->app['auth']->attempt(['email' => 'email', 'password' => 'password'], true)
@@ -228,10 +210,8 @@ class AuthenticationTest extends TestCase
         $this->assertNotEquals($oldToken, $user->getRememberToken());
     }
 
-    /**
-     * @test
-     */
-    public function auth_via_attempt_remembering()
+    
+    public function test_auth_via_attempt_remembering()
     {
         $provider = new EloquentUserProvider(app('hash'), AuthenticationTestUser::class);
 

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -64,13 +64,11 @@ class AuthenticationTest extends TestCase
         });
     }
 
-    
     public function test_basic_auth_protects_route()
     {
         $this->get('basic')->assertStatus(401);
     }
 
-    
     public function test_basic_auth_passes_on_correct_credentials()
     {
         $response = $this->get('basic', [
@@ -81,7 +79,6 @@ class AuthenticationTest extends TestCase
         $this->assertEquals('email', $response->decodeResponseJson()['email']);
     }
 
-    
     public function test_basic_auth_respects_additional_conditions()
     {
         AuthenticationTestUser::create([
@@ -100,7 +97,6 @@ class AuthenticationTest extends TestCase
         ])->assertStatus(200);
     }
 
-    
     public function test_basic_auth_fails_on_wrong_credentials()
     {
         $this->get('basic', [
@@ -108,7 +104,6 @@ class AuthenticationTest extends TestCase
         ])->assertStatus(401);
     }
 
-    
     public function test_logging_in_fails_via_attempt()
     {
         Event::fake();
@@ -133,7 +128,6 @@ class AuthenticationTest extends TestCase
         });
     }
 
-    
     public function test_logging_in_succeeds_via_attempt()
     {
         Event::fake();
@@ -164,7 +158,6 @@ class AuthenticationTest extends TestCase
         });
     }
 
-    
     public function test_logging_in_using_id()
     {
         $this->app['auth']->loginUsingId(1);
@@ -173,7 +166,6 @@ class AuthenticationTest extends TestCase
         $this->assertFalse($this->app['auth']->loginUsingId(1000));
     }
 
-    
     public function test_logging_out()
     {
         Event::fake();
@@ -191,7 +183,6 @@ class AuthenticationTest extends TestCase
         });
     }
 
-    
     public function test_logging_in_out_via_attempt_remembering()
     {
         $this->assertTrue(
@@ -210,7 +201,6 @@ class AuthenticationTest extends TestCase
         $this->assertNotEquals($oldToken, $user->getRememberToken());
     }
 
-    
     public function test_auth_via_attempt_remembering()
     {
         $provider = new EloquentUserProvider(app('hash'), AuthenticationTestUser::class);

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -41,7 +41,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         Carbon::setTestNow(null);
     }
 
-    
     public function test_basic_create_and_retrieve()
     {
         Carbon::setTestNow(
@@ -81,7 +80,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         );
     }
 
-    
     public function test_refresh_on_other_model_works()
     {
         $post = Post::create(['title' => str_random()]);
@@ -110,7 +108,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals('newName', $post->tags[0]->name);
     }
 
-    
     public function test_custom_pivot_class()
     {
         Carbon::setTestNow(
@@ -140,7 +137,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals(2, CustomPivot::first()->tag_id);
     }
 
-    
     public function test_attach_method()
     {
         $post = Post::create(['title' => str_random()]);
@@ -181,7 +177,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals($tag8->name, $post->tags[7]->name);
     }
 
-    
     public function test_detach_method()
     {
         $post = Post::create(['title' => str_random()]);
@@ -225,7 +220,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertCount(0, $post->tags);
     }
 
-    
     public function test_first_method()
     {
         $post = Post::create(['title' => str_random()]);
@@ -238,7 +232,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     }
 
     /**
-     *
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function test_firstOrFail_method()
@@ -248,7 +241,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tags()->firstOrFail(['id' => 10]);
     }
 
-    
     public function test_find_method()
     {
         $post = Post::create(['title' => str_random()]);
@@ -263,7 +255,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     }
 
     /**
-     *
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function test_findOrFail_method()
@@ -277,7 +268,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tags()->findOrFail(10);
     }
 
-    
     public function test_findOrNew_method()
     {
         $post = Post::create(['title' => str_random()]);
@@ -292,7 +282,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertInstanceOf(Tag::class, $post->tags()->findOrNew('asd'));
     }
 
-    
     public function test_firstOrNew_method()
     {
         $post = Post::create(['title' => str_random()]);
@@ -307,7 +296,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertInstanceOf(Tag::class, $post->tags()->firstOrNew(['id' => 'asd']));
     }
 
-    
     public function test_firstOrCreate_method()
     {
         $post = Post::create(['title' => str_random()]);
@@ -323,7 +311,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertNotNull($new->id);
     }
 
-    
     public function test_updateOrCreate_method()
     {
         $post = Post::create(['title' => str_random()]);
@@ -339,7 +326,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertNotNull($post->tags()->whereName('dives')->first());
     }
 
-    
     public function test_sync_method()
     {
         $post = Post::create(['title' => str_random()]);
@@ -383,7 +369,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals('mohamed', $post->tags[1]->pivot->flag);
     }
 
-    
     public function test_syncWithoutDetaching_method()
     {
         $post = Post::create(['title' => str_random()]);
@@ -406,7 +391,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         );
     }
 
-    
     public function test_toggle_method()
     {
         $post = Post::create(['title' => str_random()]);
@@ -437,7 +421,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals('taylor', $post->tags[0]->pivot->flag);
     }
 
-    
     public function test_touching_parent()
     {
         $post = Post::create(['title' => str_random()]);
@@ -459,7 +442,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
     }
 
-    
     public function test_touching_related_models_on_sync()
     {
         $tag = TouchingTag::create(['name' => str_random()]);
@@ -479,7 +461,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
     }
 
-    
     public function test_no_touching_happens_if_not_configured()
     {
         $tag = Tag::create(['name' => str_random()]);
@@ -499,7 +480,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertNotEquals('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
     }
 
-    
     public function test_can_retrieve_related_ids()
     {
         $post = Post::create(['title' => str_random()]);
@@ -518,7 +498,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals([200, 400], $post->tags()->allRelatedIds()->toArray());
     }
 
-    
     public function test_can_touch_related_models()
     {
         $post = Post::create(['title' => str_random()]);
@@ -547,7 +526,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertNotEquals('2017-10-10 10:10:10', Tag::find(300)->updated_at);
     }
 
-    
     public function test_can_update_existing_pivot()
     {
         $tag = Tag::create(['name' => str_random()]);
@@ -564,7 +542,6 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         }
     }
 
-    
     public function test_can_update_existing_pivot_using_model()
     {
         $tag = Tag::create(['name' => str_random()]);

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -41,10 +41,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         Carbon::setTestNow(null);
     }
 
-    /**
-     * @test
-     */
-    public function basic_create_and_retrieve()
+    
+    public function test_basic_create_and_retrieve()
     {
         Carbon::setTestNow(
             Carbon::createFromFormat('Y-m-d H:i:s', '2017-10-10 10:10:10')
@@ -83,10 +81,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function refresh_on_other_model_works()
+    
+    public function test_refresh_on_other_model_works()
     {
         $post = Post::create(['title' => str_random()]);
         $tag = Tag::create(['name' => $tagName = str_random()]);
@@ -114,10 +110,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals('newName', $post->tags[0]->name);
     }
 
-    /**
-     * @test
-     */
-    public function custom_pivot_class()
+    
+    public function test_custom_pivot_class()
     {
         Carbon::setTestNow(
             Carbon::createFromFormat('Y-m-d H:i:s', '2017-10-10 10:10:10')
@@ -146,10 +140,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals(2, CustomPivot::first()->tag_id);
     }
 
-    /**
-     * @test
-     */
-    public function attach_method()
+    
+    public function test_attach_method()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -189,10 +181,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals($tag8->name, $post->tags[7]->name);
     }
 
-    /**
-     * @test
-     */
-    public function detach_method()
+    
+    public function test_detach_method()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -235,10 +225,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertCount(0, $post->tags);
     }
 
-    /**
-     * @test
-     */
-    public function first_method()
+    
+    public function test_first_method()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -250,20 +238,18 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     }
 
     /**
-     * @test
+     *
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function firstOrFail_method()
+    public function test_firstOrFail_method()
     {
         $post = Post::create(['title' => str_random()]);
 
         $post->tags()->firstOrFail(['id' => 10]);
     }
 
-    /**
-     * @test
-     */
-    public function find_method()
+    
+    public function test_find_method()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -277,10 +263,10 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     }
 
     /**
-     * @test
+     *
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function findOrFail_method()
+    public function test_findOrFail_method()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -291,10 +277,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tags()->findOrFail(10);
     }
 
-    /**
-     * @test
-     */
-    public function findOrNew_method()
+    
+    public function test_findOrNew_method()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -308,10 +292,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertInstanceOf(Tag::class, $post->tags()->findOrNew('asd'));
     }
 
-    /**
-     * @test
-     */
-    public function firstOrNew_method()
+    
+    public function test_firstOrNew_method()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -325,10 +307,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertInstanceOf(Tag::class, $post->tags()->firstOrNew(['id' => 'asd']));
     }
 
-    /**
-     * @test
-     */
-    public function firstOrCreate_method()
+    
+    public function test_firstOrCreate_method()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -343,10 +323,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertNotNull($new->id);
     }
 
-    /**
-     * @test
-     */
-    public function updateOrCreate_method()
+    
+    public function test_updateOrCreate_method()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -361,10 +339,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertNotNull($post->tags()->whereName('dives')->first());
     }
 
-    /**
-     * @test
-     */
-    public function sync_method()
+    
+    public function test_sync_method()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -407,10 +383,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals('mohamed', $post->tags[1]->pivot->flag);
     }
 
-    /**
-     * @test
-     */
-    public function syncWithoutDetaching_method()
+    
+    public function test_syncWithoutDetaching_method()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -432,10 +406,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function toggle_method()
+    
+    public function test_toggle_method()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -465,10 +437,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals('taylor', $post->tags[0]->pivot->flag);
     }
 
-    /**
-     * @test
-     */
-    public function touching_parent()
+    
+    public function test_touching_parent()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -489,10 +459,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
     }
 
-    /**
-     * @test
-     */
-    public function touching_related_models_on_sync()
+    
+    public function test_touching_related_models_on_sync()
     {
         $tag = TouchingTag::create(['name' => str_random()]);
 
@@ -511,10 +479,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
     }
 
-    /**
-     * @test
-     */
-    public function no_touching_happens_if_not_configured()
+    
+    public function test_no_touching_happens_if_not_configured()
     {
         $tag = Tag::create(['name' => str_random()]);
 
@@ -533,10 +499,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertNotEquals('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
     }
 
-    /**
-     * @test
-     */
-    public function can_retrieve_related_ids()
+    
+    public function test_can_retrieve_related_ids()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -554,10 +518,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals([200, 400], $post->tags()->allRelatedIds()->toArray());
     }
 
-    /**
-     * @test
-     */
-    public function can_touch_related_models()
+    
+    public function test_can_touch_related_models()
     {
         $post = Post::create(['title' => str_random()]);
 
@@ -585,10 +547,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertNotEquals('2017-10-10 10:10:10', Tag::find(300)->updated_at);
     }
 
-    /**
-     * @test
-     */
-    public function can_update_existing_pivot()
+    
+    public function test_can_update_existing_pivot()
     {
         $tag = Tag::create(['name' => str_random()]);
         $post = Post::create(['title' => str_random()]);
@@ -604,10 +564,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function can_update_existing_pivot_using_model()
+    
+    public function test_can_update_existing_pivot_using_model()
     {
         $tag = Tag::create(['name' => str_random()]);
         $post = Post::create(['title' => str_random()]);

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -145,7 +145,6 @@ class EloquentFactoryBuilderTest extends TestCase
         });
     }
 
-    
     public function test_creating_factory_models()
     {
         $user = factory(FactoryBuildableUser::class)->create();
@@ -155,7 +154,6 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertTrue($user->is($dbUser));
     }
 
-    
     public function test_creating_factory_models_overriding_attributes()
     {
         $user = factory(FactoryBuildableUser::class)->create(['name' => 'Zain']);
@@ -163,7 +161,6 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertEquals('Zain', $user->name);
     }
 
-    
     public function test_creating_collection_of_models()
     {
         $users = factory(FactoryBuildableUser::class, 3)->create();
@@ -178,7 +175,6 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertCount(0, FactoryBuildableUser::find($instances->pluck('id')->toArray()));
     }
 
-    
     public function test_creating_models_with_callable_state()
     {
         $server = factory(FactoryBuildableServer::class)->create();
@@ -190,7 +186,6 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertEquals('callable', $callableServer->status);
     }
 
-    
     public function test_creating_models_with_inline_state()
     {
         $server = factory(FactoryBuildableServer::class)->create();
@@ -201,7 +196,6 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertEquals('inline', $inlineServer->status);
     }
 
-    
     public function test_creating_models_with_relationships()
     {
         factory(FactoryBuildableUser::class, 2)
@@ -214,7 +208,6 @@ class EloquentFactoryBuilderTest extends TestCase
             });
     }
 
-    
     public function test_creating_models_on_custom_connection()
     {
         $user = factory(FactoryBuildableUser::class)
@@ -227,7 +220,6 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertTrue($user->is($dbUser));
     }
 
-    
     public function test_creating_models_with_after_callback()
     {
         $team = factory(FactoryBuildableTeam::class)->create();
@@ -235,7 +227,6 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertTrue($team->users->contains($team->owner));
     }
 
-    
     public function test_creating_models_with_after_callback_state()
     {
         $user = factory(FactoryBuildableUser::class)->state('with_callable_server')->create();
@@ -244,7 +235,6 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertNotNull($user->servers->where('status', 'callable')->first());
     }
 
-    
     public function test_making_models_with_a_custom_connection()
     {
         $user = factory(FactoryBuildableUser::class)
@@ -254,7 +244,6 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertEquals('alternative-connection', $user->getConnectionName());
     }
 
-    
     public function test_making_models_with_after_callback()
     {
         $user = factory(FactoryBuildableUser::class)->make();
@@ -262,7 +251,6 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertNotNull($user->profile);
     }
 
-    
     public function test_making_models_with_after_callback_state()
     {
         $user = factory(FactoryBuildableUser::class)->state('with_callable_server')->make();

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -145,10 +145,8 @@ class EloquentFactoryBuilderTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
-    public function creating_factory_models()
+    
+    public function test_creating_factory_models()
     {
         $user = factory(FactoryBuildableUser::class)->create();
 
@@ -157,20 +155,16 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertTrue($user->is($dbUser));
     }
 
-    /**
-     * @test
-     */
-    public function creating_factory_models_overriding_attributes()
+    
+    public function test_creating_factory_models_overriding_attributes()
     {
         $user = factory(FactoryBuildableUser::class)->create(['name' => 'Zain']);
 
         $this->assertEquals('Zain', $user->name);
     }
 
-    /**
-     * @test
-     */
-    public function creating_collection_of_models()
+    
+    public function test_creating_collection_of_models()
     {
         $users = factory(FactoryBuildableUser::class, 3)->create();
 
@@ -184,10 +178,8 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertCount(0, FactoryBuildableUser::find($instances->pluck('id')->toArray()));
     }
 
-    /**
-     * @test
-     */
-    public function creating_models_with_callable_state()
+    
+    public function test_creating_models_with_callable_state()
     {
         $server = factory(FactoryBuildableServer::class)->create();
 
@@ -198,10 +190,8 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertEquals('callable', $callableServer->status);
     }
 
-    /**
-     * @test
-     */
-    public function creating_models_with_inline_state()
+    
+    public function test_creating_models_with_inline_state()
     {
         $server = factory(FactoryBuildableServer::class)->create();
 
@@ -211,10 +201,8 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertEquals('inline', $inlineServer->status);
     }
 
-    /**
-     * @test
-     */
-    public function creating_models_with_relationships()
+    
+    public function test_creating_models_with_relationships()
     {
         factory(FactoryBuildableUser::class, 2)
             ->create()
@@ -226,10 +214,8 @@ class EloquentFactoryBuilderTest extends TestCase
             });
     }
 
-    /**
-     * @test
-     */
-    public function creating_models_on_custom_connection()
+    
+    public function test_creating_models_on_custom_connection()
     {
         $user = factory(FactoryBuildableUser::class)
             ->connection('alternative-connection')
@@ -241,16 +227,16 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertTrue($user->is($dbUser));
     }
 
-    /** @test **/
-    public function creating_models_with_after_callback()
+    
+    public function test_creating_models_with_after_callback()
     {
         $team = factory(FactoryBuildableTeam::class)->create();
 
         $this->assertTrue($team->users->contains($team->owner));
     }
 
-    /** @test **/
-    public function creating_models_with_after_callback_state()
+    
+    public function test_creating_models_with_after_callback_state()
     {
         $user = factory(FactoryBuildableUser::class)->state('with_callable_server')->create();
 
@@ -258,8 +244,8 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertNotNull($user->servers->where('status', 'callable')->first());
     }
 
-    /** @test */
-    public function making_models_with_a_custom_connection()
+    
+    public function test_making_models_with_a_custom_connection()
     {
         $user = factory(FactoryBuildableUser::class)
             ->connection('alternative-connection')
@@ -268,16 +254,16 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertEquals('alternative-connection', $user->getConnectionName());
     }
 
-    /** @test **/
-    public function making_models_with_after_callback()
+    
+    public function test_making_models_with_after_callback()
     {
         $user = factory(FactoryBuildableUser::class)->make();
 
         $this->assertNotNull($user->profile);
     }
 
-    /** @test **/
-    public function making_models_with_after_callback_state()
+    
+    public function test_making_models_with_after_callback_state()
     {
         $user = factory(FactoryBuildableUser::class)->state('with_callable_server')->make();
 

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -29,10 +29,8 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         });
     }
 
-    /**
-     * @test
-     */
-    public function basic_create_and_retrieve()
+    
+    public function test_basic_create_and_retrieve()
     {
         $user = User::create(['name' => str_random()]);
 

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -29,7 +29,6 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         });
     }
 
-    
     public function test_basic_create_and_retrieve()
     {
         $user = User::create(['name' => str_random()]);

--- a/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
@@ -31,7 +31,6 @@ class EloquentLazyEagerLoadingTest extends DatabaseTestCase
         });
     }
 
-    
     public function test_it_basic()
     {
         $one = Model1::create();

--- a/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
@@ -31,10 +31,8 @@ class EloquentLazyEagerLoadingTest extends DatabaseTestCase
         });
     }
 
-    /**
-     * @test
-     */
-    public function it_basic()
+    
+    public function test_it_basic()
     {
         $one = Model1::create();
         $one->twos()->create();

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -25,20 +25,16 @@ class EloquentModelRefreshTest extends DatabaseTestCase
         });
     }
 
-    /**
-     * @test
-     */
-    public function it_refreshes_model_excluded_by_global_scope()
+    
+    public function test_it_refreshes_model_excluded_by_global_scope()
     {
         $post = Post::create(['title' => 'mohamed']);
 
         $post->refresh();
     }
 
-    /**
-     * @test
-     */
-    public function it_refreshes_a_soft_deleted_model()
+    
+    public function test_it_refreshes_a_soft_deleted_model()
     {
         $post = Post::create(['title' => 'said']);
 
@@ -51,10 +47,8 @@ class EloquentModelRefreshTest extends DatabaseTestCase
         $this->assertTrue($post->trashed());
     }
 
-    /**
-     * @test
-     */
-    public function it_syncs_original_on_refresh()
+    
+    public function test_it_syncs_original_on_refresh()
     {
         $post = Post::create(['title' => 'pat']);
 

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -25,7 +25,6 @@ class EloquentModelRefreshTest extends DatabaseTestCase
         });
     }
 
-    
     public function test_it_refreshes_model_excluded_by_global_scope()
     {
         $post = Post::create(['title' => 'mohamed']);
@@ -33,7 +32,6 @@ class EloquentModelRefreshTest extends DatabaseTestCase
         $post->refresh();
     }
 
-    
     public function test_it_refreshes_a_soft_deleted_model()
     {
         $post = Post::create(['title' => 'said']);
@@ -47,7 +45,6 @@ class EloquentModelRefreshTest extends DatabaseTestCase
         $this->assertTrue($post->trashed());
     }
 
-    
     public function test_it_syncs_original_on_refresh()
     {
         $post = Post::create(['title' => 'pat']);

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -33,10 +33,8 @@ class EloquentMorphManyTest extends DatabaseTestCase
         Carbon::setTestNow(null);
     }
 
-    /**
-     * @test
-     */
-    public function update_model_with_default_withCount()
+    
+    public function test_update_model_with_default_withCount()
     {
         $post = Post::create(['title' => str_random()]);
 

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -33,7 +33,6 @@ class EloquentMorphManyTest extends DatabaseTestCase
         Carbon::setTestNow(null);
     }
 
-    
     public function test_update_model_with_default_withCount()
     {
         $post = Post::create(['title' => str_random()]);

--- a/tests/Integration/Database/EloquentRelationshipsTest.php
+++ b/tests/Integration/Database/EloquentRelationshipsTest.php
@@ -20,10 +20,8 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
  */
 class EloquentRelationshipsTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function standard_relationships()
+    
+    public function test_standard_relationships()
     {
         $post = new Post;
 
@@ -38,10 +36,8 @@ class EloquentRelationshipsTest extends TestCase
         $this->assertInstanceOf(MorphTo::class, $post->postable());
     }
 
-    /**
-     * @test
-     */
-    public function overridden_relationships()
+    
+    public function test_overridden_relationships()
     {
         $post = new CustomPost;
 

--- a/tests/Integration/Database/EloquentRelationshipsTest.php
+++ b/tests/Integration/Database/EloquentRelationshipsTest.php
@@ -20,7 +20,6 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
  */
 class EloquentRelationshipsTest extends TestCase
 {
-    
     public function test_standard_relationships()
     {
         $post = new Post;
@@ -36,7 +35,6 @@ class EloquentRelationshipsTest extends TestCase
         $this->assertInstanceOf(MorphTo::class, $post->postable());
     }
 
-    
     public function test_overridden_relationships()
     {
         $post = new CustomPost;

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -32,10 +32,8 @@ class EloquentTouchParentWithGlobalScopeTest extends DatabaseTestCase
         Carbon::setTestNow(null);
     }
 
-    /**
-     * @test
-     */
-    public function basic_create_and_retrieve()
+    
+    public function test_basic_create_and_retrieve()
     {
         $post = Post::create(['title' => str_random(), 'updated_at' => '2016-10-10 10:10:10']);
 

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -32,7 +32,6 @@ class EloquentTouchParentWithGlobalScopeTest extends DatabaseTestCase
         Carbon::setTestNow(null);
     }
 
-    
     public function test_basic_create_and_retrieve()
     {
         $post = Post::create(['title' => str_random(), 'updated_at' => '2016-10-10 10:10:10']);

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -35,7 +35,6 @@ class EloquentWithCountTest extends DatabaseTestCase
         });
     }
 
-    
     public function test_it_basic()
     {
         $one = Model1::create();

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -35,10 +35,8 @@ class EloquentWithCountTest extends DatabaseTestCase
         });
     }
 
-    /**
-     * @test
-     */
-    public function it_basic()
+    
+    public function test_it_basic()
     {
         $one = Model1::create();
         $two = $one->twos()->Create();

--- a/tests/Integration/Encryption/EncryptionTest.php
+++ b/tests/Integration/Encryption/EncryptionTest.php
@@ -19,13 +19,11 @@ class EncryptionTest extends TestCase
         return [EncryptionServiceProvider::class];
     }
 
-    
     public function test_encryption_provider_bind()
     {
         self::assertInstanceOf(Encrypter::class, $this->app->make('encrypter'));
     }
 
-    
     public function test_encryption_will_not_be_instantiable_when_missing_app_key()
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Integration/Encryption/EncryptionTest.php
+++ b/tests/Integration/Encryption/EncryptionTest.php
@@ -19,18 +19,14 @@ class EncryptionTest extends TestCase
         return [EncryptionServiceProvider::class];
     }
 
-    /**
-     * @test
-     */
-    public function encryption_provider_bind()
+    
+    public function test_encryption_provider_bind()
     {
         self::assertInstanceOf(Encrypter::class, $this->app->make('encrypter'));
     }
 
-    /**
-     * @test
-     */
-    public function encryption_will_not_be_instantiable_when_missing_app_key()
+    
+    public function test_encryption_will_not_be_instantiable_when_missing_app_key()
     {
         $this->expectException(RuntimeException::class);
 

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -19,7 +19,6 @@ class MigratorTest extends TestCase
         ]);
     }
 
-    
     public function test_dont_display_output_when_output_object_is_not_available()
     {
         $migrator = $this->app->make('migrator');

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -19,10 +19,8 @@ class MigratorTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function dont_display_output_when_output_object_is_not_available()
+    
+    public function test_dont_display_output_when_output_object_is_not_available()
     {
         $migrator = $this->app->make('migrator');
 

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -61,7 +61,6 @@ class ModelSerializationTest extends TestCase
         });
     }
 
-    
     public function test_it_serialize_user_on_default_connection()
     {
         $user = ModelSerializationTestUser::create([
@@ -89,7 +88,6 @@ class ModelSerializationTest extends TestCase
         $this->assertEquals('taylor@laravel.com', $unSerialized->user[1]->email);
     }
 
-    
     public function test_it_serialize_user_on_different_connection()
     {
         $user = ModelSerializationTestUser::on('custom')->create([
@@ -118,7 +116,6 @@ class ModelSerializationTest extends TestCase
     }
 
     /**
-     *
      * @expectedException \LogicException
      * @expectedExceptionMessage  Queueing collections with multiple model connections is not supported.
      */
@@ -139,7 +136,6 @@ class ModelSerializationTest extends TestCase
         unserialize($serialized);
     }
 
-    
     public function test_it_reloads_relationships()
     {
         $order = tap(Order::create(), function (Order $order) {
@@ -160,7 +156,6 @@ class ModelSerializationTest extends TestCase
         $this->assertEquals($unSerialized->order->getRelations(), $order->getRelations());
     }
 
-    
     public function test_it_reloads_nested_relationships()
     {
         $order = tap(Order::create(), function (Order $order) {
@@ -181,7 +176,6 @@ class ModelSerializationTest extends TestCase
         $this->assertEquals($nestedUnSerialized->order->getRelations(), $order->getRelations());
     }
 
-    
     public function test_it_serializes_an_empty_collection()
     {
         $serialized = serialize(new ModelSerializationTestClass(

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -61,10 +61,8 @@ class ModelSerializationTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
-    public function it_serialize_user_on_default_connection()
+    
+    public function test_it_serialize_user_on_default_connection()
     {
         $user = ModelSerializationTestUser::create([
             'email' => 'mohamed@laravel.com',
@@ -91,10 +89,8 @@ class ModelSerializationTest extends TestCase
         $this->assertEquals('taylor@laravel.com', $unSerialized->user[1]->email);
     }
 
-    /**
-     * @test
-     */
-    public function it_serialize_user_on_different_connection()
+    
+    public function test_it_serialize_user_on_different_connection()
     {
         $user = ModelSerializationTestUser::on('custom')->create([
             'email' => 'mohamed@laravel.com',
@@ -122,11 +118,11 @@ class ModelSerializationTest extends TestCase
     }
 
     /**
-     * @test
+     *
      * @expectedException \LogicException
      * @expectedExceptionMessage  Queueing collections with multiple model connections is not supported.
      */
-    public function it_fails_if_models_on_multi_connections()
+    public function test_it_fails_if_models_on_multi_connections()
     {
         $user = ModelSerializationTestUser::on('custom')->create([
             'email' => 'mohamed@laravel.com',
@@ -143,10 +139,8 @@ class ModelSerializationTest extends TestCase
         unserialize($serialized);
     }
 
-    /**
-     * @test
-     */
-    public function it_reloads_relationships()
+    
+    public function test_it_reloads_relationships()
     {
         $order = tap(Order::create(), function (Order $order) {
             $order->wasRecentlyCreated = false;
@@ -166,10 +160,8 @@ class ModelSerializationTest extends TestCase
         $this->assertEquals($unSerialized->order->getRelations(), $order->getRelations());
     }
 
-    /**
-     * @test
-     */
-    public function it_reloads_nested_relationships()
+    
+    public function test_it_reloads_nested_relationships()
     {
         $order = tap(Order::create(), function (Order $order) {
             $order->wasRecentlyCreated = false;
@@ -189,8 +181,8 @@ class ModelSerializationTest extends TestCase
         $this->assertEquals($nestedUnSerialized->order->getRelations(), $order->getRelations());
     }
 
-    /** @test */
-    public function it_serializes_an_empty_collection()
+    
+    public function test_it_serializes_an_empty_collection()
     {
         $serialized = serialize(new ModelSerializationTestClass(
             new Collection([])

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -22,10 +22,8 @@ class ConcurrentLimiterTest extends TestCase
         $this->setUpRedis();
     }
 
-    /**
-     * @test
-     */
-    public function it_locks_tasks_when_no_slot_available()
+    
+    public function test_it_locks_tasks_when_no_slot_available()
     {
         $store = [];
 
@@ -50,10 +48,8 @@ class ConcurrentLimiterTest extends TestCase
         $this->assertEquals([1, 2, 4], $store);
     }
 
-    /**
-     * @test
-     */
-    public function it_releases_lock_after_task_finishes()
+    
+    public function test_it_releases_lock_after_task_finishes()
     {
         $store = [];
 
@@ -66,10 +62,8 @@ class ConcurrentLimiterTest extends TestCase
         $this->assertEquals([1, 2, 3, 4], $store);
     }
 
-    /**
-     * @test
-     */
-    public function it_releases_lock_if_task_took_too_long()
+    
+    public function test_it_releases_lock_if_task_took_too_long()
     {
         $store = [];
 
@@ -96,10 +90,8 @@ class ConcurrentLimiterTest extends TestCase
         $this->assertEquals([1, 3], $store);
     }
 
-    /**
-     * @test
-     */
-    public function it_fails_immediately_or_retries_for_a_while_based_on_a_given_timeout()
+    
+    public function test_it_fails_immediately_or_retries_for_a_while_based_on_a_given_timeout()
     {
         $store = [];
 
@@ -124,10 +116,8 @@ class ConcurrentLimiterTest extends TestCase
         $this->assertEquals([1, 3], $store);
     }
 
-    /**
-     * @test
-     */
-    public function it_fails_after_retry_timeout()
+    
+    public function test_it_fails_after_retry_timeout()
     {
         $store = [];
 

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -22,7 +22,6 @@ class ConcurrentLimiterTest extends TestCase
         $this->setUpRedis();
     }
 
-    
     public function test_it_locks_tasks_when_no_slot_available()
     {
         $store = [];
@@ -48,7 +47,6 @@ class ConcurrentLimiterTest extends TestCase
         $this->assertEquals([1, 2, 4], $store);
     }
 
-    
     public function test_it_releases_lock_after_task_finishes()
     {
         $store = [];
@@ -62,7 +60,6 @@ class ConcurrentLimiterTest extends TestCase
         $this->assertEquals([1, 2, 3, 4], $store);
     }
 
-    
     public function test_it_releases_lock_if_task_took_too_long()
     {
         $store = [];
@@ -90,7 +87,6 @@ class ConcurrentLimiterTest extends TestCase
         $this->assertEquals([1, 3], $store);
     }
 
-    
     public function test_it_fails_immediately_or_retries_for_a_while_based_on_a_given_timeout()
     {
         $store = [];
@@ -116,7 +112,6 @@ class ConcurrentLimiterTest extends TestCase
         $this->assertEquals([1, 3], $store);
     }
 
-    
     public function test_it_fails_after_retry_timeout()
     {
         $store = [];

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -22,7 +22,6 @@ class DurationLimiterTest extends TestCase
         $this->setUpRedis();
     }
 
-    
     public function test_it_locks_tasks_when_no_slot_available()
     {
         $store = [];
@@ -54,7 +53,6 @@ class DurationLimiterTest extends TestCase
         $this->assertEquals([1, 2, 3], $store);
     }
 
-    
     public function test_it_fails_immediately_or_retries_for_a_while_based_on_a_given_timeout()
     {
         $store = [];

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -22,10 +22,8 @@ class DurationLimiterTest extends TestCase
         $this->setUpRedis();
     }
 
-    /**
-     * @test
-     */
-    public function it_locks_tasks_when_no_slot_available()
+    
+    public function test_it_locks_tasks_when_no_slot_available()
     {
         $store = [];
 
@@ -56,10 +54,8 @@ class DurationLimiterTest extends TestCase
         $this->assertEquals([1, 2, 3], $store);
     }
 
-    /**
-     * @test
-     */
-    public function it_fails_immediately_or_retries_for_a_while_based_on_a_given_timeout()
+    
+    public function test_it_fails_immediately_or_retries_for_a_while_based_on_a_given_timeout()
     {
         $store = [];
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -34,10 +34,8 @@ class RedisConnectionTest extends TestCase
         $this->tearDownRedis();
     }
 
-    /**
-     * @test
-     */
-    public function it_sets_values_with_expiry()
+    
+    public function test_it_sets_values_with_expiry()
     {
         foreach ($this->connections() as $redis) {
             $redis->set('one', 'mohamed', 'EX', 5, 'NX');
@@ -65,10 +63,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_deletes_keys()
+    
+    public function test_it_deletes_keys()
     {
         foreach ($this->connections() as $redis) {
             $redis->set('one', 'mohamed');
@@ -88,10 +84,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_checks_for_existence()
+    
+    public function test_it_checks_for_existence()
     {
         foreach ($this->connections() as $redis) {
             $redis->set('one', 'mohamed');
@@ -106,10 +100,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_expires_keys()
+    
+    public function test_it_expires_keys()
     {
         foreach ($this->connections() as $redis) {
             $redis->set('one', 'mohamed');
@@ -130,10 +122,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_renames_keys()
+    
+    public function test_it_renames_keys()
     {
         foreach ($this->connections() as $redis) {
             $redis->set('one', 'mohamed');
@@ -155,10 +145,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_adds_members_to_sorted_set()
+    
+    public function test_it_adds_members_to_sorted_set()
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', 1, 'mohamed');
@@ -189,10 +177,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_counts_members_in_sorted_set()
+    
+    public function test_it_counts_members_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
@@ -205,10 +191,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_increments_score_of_sorted_set()
+    
+    public function test_it_increments_score_of_sorted_set()
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
@@ -219,10 +203,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_sets_key_if_not_exists()
+    
+    public function test_it_sets_key_if_not_exists()
     {
         foreach ($this->connections() as $redis) {
             $redis->set('name', 'mohamed');
@@ -237,10 +219,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_sets_hash_field_if_not_exists()
+    
+    public function test_it_sets_hash_field_if_not_exists()
     {
         foreach ($this->connections() as $redis) {
             $redis->hset('person', 'name', 'mohamed');
@@ -255,10 +235,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_calculates_intersection_of_sorted_sets_and_stores()
+    
+    public function test_it_calculates_intersection_of_sorted_sets_and_stores()
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
@@ -287,10 +265,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_calculates_union_of_sorted_sets_and_stores()
+    
+    public function test_it_calculates_union_of_sorted_sets_and_stores()
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
@@ -322,10 +298,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_returns_range_in_sorted_set()
+    
+    public function test_it_returns_range_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
@@ -338,10 +312,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_returns_rev_range_in_sorted_set()
+    
+    public function test_it_returns_rev_range_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
@@ -354,10 +326,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_returns_range_by_score_in_sorted_set()
+    
+    public function test_it_returns_range_by_score_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
@@ -374,10 +344,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_returns_rev_range_by_score_in_sorted_set()
+    
+    public function test_it_returns_rev_range_by_score_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
@@ -394,10 +362,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_returns_rank_in_sorted_set()
+    
+    public function test_it_returns_rank_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
@@ -409,10 +375,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_returns_score_in_sorted_set()
+    
+    public function test_it_returns_score_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
@@ -424,10 +388,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_removes_members_in_sorted_set()
+    
+    public function test_it_removes_members_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
@@ -442,10 +404,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_removes_members_by_score_in_sorted_set()
+    
+    public function test_it_removes_members_by_score_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
@@ -456,10 +416,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_removes_members_by_rank_in_sorted_set()
+    
+    public function test_it_removes_members_by_rank_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
@@ -470,10 +428,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_sets_multiple_hash_fields()
+    
+    public function test_it_sets_multiple_hash_fields()
     {
         foreach ($this->connections() as $redis) {
             $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
@@ -486,10 +442,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_gets_multiple_hash_fields()
+    
+    public function test_it_gets_multiple_hash_fields()
     {
         foreach ($this->connections() as $redis) {
             $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
@@ -506,10 +460,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_runs_eval()
+    
+    public function test_it_runs_eval()
     {
         foreach ($this->connections() as $redis) {
             $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', 'mohamed');
@@ -519,10 +471,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_runs_pipes()
+    
+    public function test_it_runs_pipes()
     {
         foreach ($this->connections() as $redis) {
             $result = $redis->pipeline(function ($pipe) {
@@ -540,10 +490,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_runs_transactions()
+    
+    public function test_it_runs_transactions()
     {
         foreach ($this->connections() as $redis) {
             $result = $redis->transaction(function ($pipe) {
@@ -561,10 +509,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_runs_raw_command()
+    
+    public function test_it_runs_raw_command()
     {
         foreach ($this->connections() as $redis) {
             $redis->executeRaw(['SET', 'test:raw:1', '1']);
@@ -577,10 +523,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_dispatches_query_event()
+    
+    public function test_it_dispatches_query_event()
     {
         foreach ($this->connections() as $redis) {
             $redis->setEventDispatcher($events = m::mock(Dispatcher::class));
@@ -600,10 +544,8 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_persists_connection()
+    
+    public function test_it_persists_connection()
     {
         if (PHP_ZTS) {
             $this->markTestSkipped('PhpRedis does not support persistent connections with PHP_ZTS enabled.');

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -34,7 +34,6 @@ class RedisConnectionTest extends TestCase
         $this->tearDownRedis();
     }
 
-    
     public function test_it_sets_values_with_expiry()
     {
         foreach ($this->connections() as $redis) {
@@ -63,7 +62,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_deletes_keys()
     {
         foreach ($this->connections() as $redis) {
@@ -84,7 +82,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_checks_for_existence()
     {
         foreach ($this->connections() as $redis) {
@@ -100,7 +97,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_expires_keys()
     {
         foreach ($this->connections() as $redis) {
@@ -122,7 +118,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_renames_keys()
     {
         foreach ($this->connections() as $redis) {
@@ -145,7 +140,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_adds_members_to_sorted_set()
     {
         foreach ($this->connections() as $redis) {
@@ -177,7 +171,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_counts_members_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
@@ -191,7 +184,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_increments_score_of_sorted_set()
     {
         foreach ($this->connections() as $redis) {
@@ -203,7 +195,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_sets_key_if_not_exists()
     {
         foreach ($this->connections() as $redis) {
@@ -219,7 +210,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_sets_hash_field_if_not_exists()
     {
         foreach ($this->connections() as $redis) {
@@ -235,7 +225,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_calculates_intersection_of_sorted_sets_and_stores()
     {
         foreach ($this->connections() as $redis) {
@@ -265,7 +254,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_calculates_union_of_sorted_sets_and_stores()
     {
         foreach ($this->connections() as $redis) {
@@ -298,7 +286,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_returns_range_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
@@ -312,7 +299,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_returns_rev_range_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
@@ -326,7 +312,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_returns_range_by_score_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
@@ -344,7 +329,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_returns_rev_range_by_score_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
@@ -362,7 +346,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_returns_rank_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
@@ -375,7 +358,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_returns_score_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
@@ -388,7 +370,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_removes_members_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
@@ -404,7 +385,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_removes_members_by_score_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
@@ -416,7 +396,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_removes_members_by_rank_in_sorted_set()
     {
         foreach ($this->connections() as $redis) {
@@ -428,7 +407,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_sets_multiple_hash_fields()
     {
         foreach ($this->connections() as $redis) {
@@ -442,7 +420,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_gets_multiple_hash_fields()
     {
         foreach ($this->connections() as $redis) {
@@ -460,7 +437,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_runs_eval()
     {
         foreach ($this->connections() as $redis) {
@@ -471,7 +447,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_runs_pipes()
     {
         foreach ($this->connections() as $redis) {
@@ -490,7 +465,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_runs_transactions()
     {
         foreach ($this->connections() as $redis) {
@@ -509,7 +483,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_runs_raw_command()
     {
         foreach ($this->connections() as $redis) {
@@ -523,7 +496,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_dispatches_query_event()
     {
         foreach ($this->connections() as $redis) {
@@ -544,7 +516,6 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    
     public function test_it_persists_connection()
     {
         if (PHP_ZTS) {


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Enforce test functions naming consistency.