### PR TITLE
[5.7] Remove unecessary cast

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -507,7 +507,7 @@ trait InteractsWithPivotTable
      */
     protected function castKeys(array $keys)
     {
-        return (array) array_map(function ($v) {
+        return array_map(function ($v) {
             return $this->castKey($v);
         }, $keys);
     }

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -121,7 +121,7 @@ class FluentArrayIteratorStub implements IteratorAggregate
 
     public function __construct(array $items = [])
     {
-        $this->items = (array) $items;
+        $this->items = $items;
     }
 
     public function getIterator()


### PR DESCRIPTION
`array_map` always returns an array, even when the passed one was empty: https://3v4l.org/K8IdL