### PR TITLE
[5.7] Allow updateExistingPivot to receive an arrayable item

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -427,7 +427,7 @@ trait InteractsWithPivotTable
      */
     public function newPivotStatementForId($id)
     {
-        return $this->newPivotQuery()->where($this->relatedPivotKey, $id);
+        return $this->newPivotQuery()->whereIn($this->relatedPivotKey, $this->parseIds($id));
     }
 
     /**

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -542,6 +542,26 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         }
     }
 
+    public function test_can_update_existing_pivot_using_arrayable_of_ids()
+    {
+        $tags = new Collection([
+            $tag1 = Tag::create(['name' => str_random()]),
+            $tag2 = Tag::create(['name' => str_random()]),
+        ]);
+        $post = Post::create(['title' => str_random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag1->id, 'flag' => 'empty'],
+            ['post_id' => $post->id, 'tag_id' => $tag2->id, 'flag' => 'empty'],
+        ]);
+
+        $post->tagsWithExtraPivot()->updateExistingPivot($tags, ['flag' => 'exclude']);
+
+        foreach ($post->tagsWithExtraPivot as $tag) {
+            $this->assertEquals('exclude', $tag->pivot->flag);
+        }
+    }
+
     public function test_can_update_existing_pivot_using_model()
     {
         $tag = Tag::create(['name' => str_random()]);


### PR DESCRIPTION
This PR allows to pass an arrayable item to `updateExistingPivot`.

Currently there is a little bug which method `updateExistingPivot` allows to pass an array of ids, but the query built is with an equal operator. This causes that the rest of the passed ids are ignored, without breaking the code but causing weird behaviour in the database.

Don't know if this is on purpose. Just tell me if that is the case.