### PR TITLE
[5.8] Decode quotes from content when testing text

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -368,7 +368,7 @@ class TestResponse
      */
     public function assertSeeText($value)
     {
-        PHPUnit::assertContains((string) $value, strip_tags($this->getContent()));
+        PHPUnit::assertContains((string) $value, html_entity_decode(strip_tags($this->getContent()), ENT_QUOTES));
 
         return $this;
     }
@@ -381,7 +381,7 @@ class TestResponse
      */
     public function assertSeeTextInOrder(array $values)
     {
-        PHPUnit::assertThat($values, new SeeInOrder(strip_tags($this->getContent())));
+        PHPUnit::assertThat($values, new SeeInOrder(html_entity_decode(strip_tags($this->getContent()), ENT_QUOTES)));
 
         return $this;
     }
@@ -407,7 +407,7 @@ class TestResponse
      */
     public function assertDontSeeText($value)
     {
-        PHPUnit::assertNotContains((string) $value, strip_tags($this->getContent()));
+        PHPUnit::assertNotContains((string) $value, html_entity_decode(strip_tags($this->getContent()), ENT_QUOTES));
 
         return $this;
     }


### PR DESCRIPTION
I have treated this as a breaking change because it alters the behaviour of a test assertion. Also as it is a change to a test assertion I have not included a test.

Currently when using blade templates all strings are sent through `htmlspecialchars` by default. This means that all quotes get encoded. For example `"Brian O'Driscoll"` becomes `"Brian O&#039;Driscoll"`.

However when we try testing to see if the text `"Brian O'Driscoll"` is included in the response we get a test failure because the strings `"Brian O'Driscoll"` and `"Brian O&#039;Driscoll"` don't match.

Route
```php
Route::get('/test', function () {
    $name = "Brian O'Driscoll";

    return view('test', compact('name'));
});
```

Template
```blade
{{ $name }}
```

Test
```php
public function testSeeText()
{
    $response = $this->get('/test');
    $response->assertSeeText("Brian O'Driscoll");
}
```

I've encountered this issue several times when writing tests and using Faker to generate names, it seems to like generating names with apostrophise .

I propose decoding HTML entities in the test assertion before running the comparison. I believe this will give a more accurate outcome when using `assertSeeText `, `assertSeeTextInOrder `, and `assertDontSeeText `.