### PR TITLE
[5.7] Easily mock and spy object instances in the container

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Closure;
+use Mockery as m;
+
 trait InteractsWithContainer
 {
     /**
@@ -28,5 +31,29 @@ trait InteractsWithContainer
         $this->app->instance($abstract, $instance);
 
         return $instance;
+    }
+
+    /**
+     * Mock an instance of an object in the container.
+     *
+     * @param  string  $abstract
+     * @param  \Closure  $instance
+     * @return object
+     */
+    protected function mock($abstract, Closure $mock)
+    {
+        return $this->instance($abstract, m::mock($abstract, $mock));
+    }
+
+    /**
+     * Spy an instance of an object in the container.
+     *
+     * @param  string  $abstract
+     * @param  \Closure  $instance
+     * @return object
+     */
+    protected function spy($abstract, Closure $mock)
+    {
+        return $this->instance($abstract, m::spy($abstract, $mock));
     }
 }


### PR DESCRIPTION
This adds a simple way to mock and spy object instances in the container.

```php
class ExampleTest extends TestCase
{
    /**
     * A basic test example.
     *
     * @return void
     */
    public function testExample()
    {
        $this->mock(Mailer::class, function ($mock) {
            $mock->shouldReceive('send')->once();
        });


        $this->spy(Dispatcher::class, function ($mock) {
            $mock->shouldReceive('dispatch')->andReturn(false);
        });
    }
}
```

Without this change you have to do something like this:

```php
class ExampleTest extends TestCase
{
    /**
     * A basic test example.
     *
     * @return void
     */
    public function testExample()
    {
        $this->instance(Mailer::class, Mockery::mock(Mailer::class, function ($mock) {
            $mock->shouldReceive('send')->once();
        }));
    }
}
```

obviously this is not a big deal but it cleans up code a bit. :)
