### PR TITLE
[5.7] Add `decimal:<num>` cast to Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -479,6 +479,8 @@ trait HasAttributes
             case 'float':
             case 'double':
                 return $this->fromFloat($value);
+            case 'decimal':
+                return $this->asDecimal($value, explode(':', $this->getCasts()[$key], 2)[1]);
             case 'string':
                 return (string) $value;
             case 'bool':
@@ -515,6 +517,10 @@ trait HasAttributes
             return 'custom_datetime';
         }
 
+        if ($this->isDecimalCast($this->getCasts()[$key])) {
+            return 'decimal';
+        }
+
         return trim(strtolower($this->getCasts()[$key]));
     }
 
@@ -528,6 +534,17 @@ trait HasAttributes
     {
         return strncmp($cast, 'date:', 5) === 0 ||
                strncmp($cast, 'datetime:', 9) === 0;
+    }
+
+    /**
+     * Determine if the cast type is a decimal cast.
+     *
+     * @param  string  $cast
+     * @return bool
+     */
+    protected function isDecimalCast($cast)
+    {
+        return strncmp($cast, 'decimal:', 8) === 0;
     }
 
     /**
@@ -698,6 +715,18 @@ trait HasAttributes
             default:
                 return (float) $value;
         }
+    }
+
+    /**
+     * Return a decimal as string.
+     *
+     * @param  float  $value
+     * @param  int  $value
+     * @return string
+     */
+    protected function asDecimal($value, $decimals)
+    {
+        return number_format($value, $decimals, '.', '');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -721,7 +721,7 @@ trait HasAttributes
      * Return a decimal as string.
      *
      * @param  float  $value
-     * @param  int  $value
+     * @param  int  $decimals
      * @return string
      */
     protected function asDecimal($value, $decimals)

--- a/tests/Integration/Database/EloquentModelDecimalCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDecimalCastingTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelDecimalCastingTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentModelDecimalCastingTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('test_model1', function ($table) {
+            $table->increments('id');
+            $table->decimal('decimal_field_2', 8, 2)->nullable();
+            $table->decimal('decimal_field_4', 8, 4)->nullable();
+        });
+    }
+
+    public function test_decimals_are_castable()
+    {
+        $user = TestModel1::create([
+            'decimal_field_2' => '12',
+            'decimal_field_4' => '1234',
+        ]);
+
+        $this->assertEquals('12.00', $user->toArray()['decimal_field_2']);
+        $this->assertEquals('1234.0000', $user->toArray()['decimal_field_4']);
+
+        $user->decimal_field_2 = 12;
+        $user->decimal_field_4 = '1234';
+
+        $this->assertEquals('12.00', $user->toArray()['decimal_field_2']);
+        $this->assertEquals('1234.0000', $user->toArray()['decimal_field_4']);
+
+        $this->assertFalse($user->isDirty());
+
+        $user->decimal_field_4 = '1234.1234';
+        $this->assertTrue($user->isDirty());
+    }
+}
+
+class TestModel1 extends Model
+{
+    public $table = 'test_model1';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+
+    public $casts = [
+        'decimal_field_2' => 'decimal:2',
+        'decimal_field_4' => 'decimal:4',
+    ];
+}


### PR DESCRIPTION
Adds a `decimal` cast, to cast to a string with a set number of decimals. This makes it easier to preserve the type when updating the value and makes the `isDirty()` check work.
A `decimal` field is already returned as string when getting it from the database. Simplified example:

Old behavior:
```php
$item = Item::first();
var_dump($item->amount); // (string) "2.00";
$item->amount = 2; 
var_dump($item->amount); // (int) 2;
var_dump($item->isDirty()); // true
$item->save();
$item->refresh();
var_dump($item->amount); // (string) "2.00"
```

This will allow to add this cast to the model:

```php
    protected $casts = [
        'amount' => 'decimal:2',
    ];
```
In the example it will now always output `(string) "2.00"` and is no longer dirty.

Fixes https://github.com/laravel/framework/issues/13742 
