### PR TITLE
[5.7] Capitalize the class name in generator commands

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -210,7 +210,7 @@ abstract class GeneratorCommand extends Command
      */
     protected function getNameInput()
     {
-        return trim($this->argument('name'));
+        return ucfirst(trim($this->argument('name')));
     }
 
     /**


### PR DESCRIPTION
This ensures that the classes that are generated with artisan commands are always capitalized, as the PSR standard dictates.