### PR TITLE
[5.7] Added the loop variable to the @each directive

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -196,9 +196,11 @@ class Factory implements FactoryContract
         // an instance of the partial view to the final result HTML passing in the
         // iterated value of this data array, allowing the views to access them.
         if (count($data) > 0) {
+        	$this->addLoop($data);
             foreach ($data as $key => $value) {
+            	$this->incrementLoopIndices();
                 $result .= $this->make(
-                    $view, ['key' => $key, $iterator => $value]
+                    $view, ['key' => $key, $iterator => $value, 'loop' => $this->getLastLoop()]
                 )->render();
             }
         }

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -198,13 +198,12 @@ class Factory implements FactoryContract
         if (count($data) > 0) {
         	$this->addLoop($data);
             foreach ($data as $key => $value) {
-            	$this->incrementLoopIndices();
                 $result .= $this->make(
                     $view, ['key' => $key, $iterator => $value, 'loop' => $this->getLastLoop()]
                 )->render();
+                $this->incrementLoopIndices();
             }
         }
-
         // If there is no data in the array, we will render the contents of the empty
         // view. Alternatively, the "empty view" could be a raw string that begins
         // with "raw|" for convenience and to let this know that it is a string.

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -196,7 +196,7 @@ class Factory implements FactoryContract
         // an instance of the partial view to the final result HTML passing in the
         // iterated value of this data array, allowing the views to access them.
         if (count($data) > 0) {
-        	$this->addLoop($data);
+            $this->addLoop($data);
             foreach ($data as $key => $value) {
                 $result .= $this->make(
                     $view, ['key' => $key, $iterator => $value, 'loop' => $this->getLastLoop()]

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -97,11 +97,13 @@ class ViewFactoryTest extends TestCase
     public function testRenderEachCreatesViewForEachItemInArray()
     {
         $factory = m::mock(Factory::class.'[make]', $this->getFactoryArgs());
-        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'bar', 'value' => 'baz'])->andReturn($mockView1 = m::mock(stdClass::class));
-        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'breeze', 'value' => 'boom'])->andReturn($mockView2 = m::mock(stdClass::class));
+        $loopFactory = $this->getFactory();
+        $loopFactory->addLoop(['bar' => 'baz', 'breeze' => 'boom']);
+        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'bar', 'value' => 'baz', 'loop' => $loopFactory->getLastLoop()])->andReturn($mockView1 = m::mock(stdClass::class));
+        $loopFactory->incrementLoopIndices();
+        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'breeze', 'value' => 'boom', 'loop' => $loopFactory->getLastLoop()])->andReturn($mockView2 = m::mock(stdClass::class));
         $mockView1->shouldReceive('render')->once()->andReturn('dayle');
         $mockView2->shouldReceive('render')->once()->andReturn('rees');
-
         $result = $factory->renderEach('foo', ['bar' => 'baz', 'breeze' => 'boom'], 'value');
 
         $this->assertEquals('daylerees', $result);


### PR DESCRIPTION
Made it so that the `$loop` variable is available inside of an `@each` directive the view file. 

This makes it more consistent with the documentation, where it states: "When looping, a $loop variable will be available inside of your loop. "

Feature request: [https://github.com/laravel/framework/pull/26183](https://github.com/laravel/ideas/issues/597)