### PR TITLE
[5.8] Move clientExtension()

### DIFF
--- a/src/Illuminate/Http/FileHelpers.php
+++ b/src/Illuminate/Http/FileHelpers.php
@@ -34,16 +34,6 @@ trait FileHelpers
     }
 
     /**
-     * Get the file's extension supplied by the client.
-     *
-     * @return string
-     */
-    public function clientExtension()
-    {
-        return $this->guessClientExtension();
-    }
-
-    /**
      * Get a filename for the file.
      *
      * @param  string  $path

--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -24,6 +24,16 @@ class UploadedFile extends SymfonyUploadedFile
     }
 
     /**
+     * Get the file's extension supplied by the client.
+     *
+     * @return string
+     */
+    public function clientExtension()
+    {
+        return $this->guessClientExtension();
+    }
+
+    /**
      * Store the uploaded file on a filesystem disk.
      *
      * @param  string  $path


### PR DESCRIPTION
The `FileHelpers` trait is used in `File` and `UploadedFile`, but `clientExtension()` only works (and makes sense) in `UploadedFile`. The method calls `guessClientExtension()` which is coming from Symfony's `UploadedFile`.

Fixes #26188.