### PR TITLE
[5.7] Command to create custom filesystem links

### DIFF
--- a/src/Illuminate/Foundation/Console/GenerateLinksCommand.php
+++ b/src/Illuminate/Foundation/Console/GenerateLinksCommand.php
@@ -32,17 +32,13 @@ class GenerateLinksCommand extends Command
 
                 if (file_exists($link)) {
                     $this->error("The [$link] directory already exists.");
-                }
-
-                else {
+                } else {
                     $this->laravel->make('files')->link($target, $link);
 
                     $this->info("The [$link] directory has been linked to [$target].");
                 }
             }
-        }
-
-        else {
+        } else {
             $this->warn('No links defined in filesystem configuration.');
         }
     }

--- a/src/Illuminate/Foundation/Console/GenerateLinksCommand.php
+++ b/src/Illuminate/Foundation/Console/GenerateLinksCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+
+class GenerateLinksCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'links:generate';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create links';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if ($links = $this->laravel['config']['filesystems.links']) {
+            foreach ($links as $link => $target) {
+
+                if (file_exists($link)) {
+                    $this->error("The [$link] directory already exists.");
+                }
+
+                else {
+                    $this->laravel->make('files')->link($target, $link);
+
+                    $this->info("The [$link] directory has been linked to [$target].");
+                }
+            }
+        }
+
+        else {
+            $this->warn('No links defined in filesystem configuration.');
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Console/GenerateLinksCommand.php
+++ b/src/Illuminate/Foundation/Console/GenerateLinksCommand.php
@@ -29,7 +29,6 @@ class GenerateLinksCommand extends Command
     {
         if ($links = $this->laravel['config']['filesystems.links']) {
             foreach ($links as $link => $target) {
-
                 if (file_exists($link)) {
                     $this->error("The [$link] directory already exists.");
                 } else {


### PR DESCRIPTION
Currently we have the ability to generate a filesystem link from `/public/storage` to `/storage/app/public` using the `storage:link` artisan command.  AFAIK, any other links would need to be created with a manual process, or a custom script.

This PR gives the programmer the ability to define all the links they would like created in their application programmatically. Links and their targets are defined in the `config/filesystems.php` file.

```php
'links' => [
    public_path('storage') => storage_path('app/public'),
    public_path('images') => storage_path('app/images'),
],
```

These links will be generated using the new `links:generate` command, which the programmer can make a part of their deployment process.

This change is better for the user because it gives them full control over the generation of links, rather than being stuck with only the default `public_path('storage') => storage_path('app/public')`.  Also, for better or worse, the user can opt to use relative links over absolute links if they so choose (`'public/storage' => 'storage/app/public'`).

Originally I was going to adapt the `StorageLinkCommand` for these changes, but I felt the naming would not appropriately reflect what it now does, so I opted for a completely new command.  Also, this allows us to add it to 5.7 instead of 5.8, because we will not affect current users.  My intention is the `StorageLinkCommand` will be removed in 5.8 in favor of this.

Obviously open to changing any naming.

If this PR is accepted, I would like to go back and add an option to force the deletion and recreation of the link, in case an existing link is updated to point to a new target. Something like:

```sh
php artisan links:generate --force
```
