### PR TITLE
[5.7] add `test_path`

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -281,6 +281,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $this->instance('path', $this->path());
         $this->instance('path.base', $this->basePath());
         $this->instance('path.lang', $this->langPath());
+        $this->instance('path.tests', $this->testPath());
         $this->instance('path.config', $this->configPath());
         $this->instance('path.public', $this->publicPath());
         $this->instance('path.storage', $this->storagePath());
@@ -402,6 +403,17 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $this->instance('path.storage', $path);
 
         return $this;
+    }
+
+    /**
+     * Get the path to the tests directory.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function testPath($path = '')
+    {
+        return $this->basePath.DIRECTORY_SEPARATOR.'tests'.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -883,6 +883,19 @@ if (! function_exists('storage_path')) {
     }
 }
 
+if (! function_exists('test_path')) {
+    /**
+     * Get the path to the tests folder.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function test_path($path = '')
+    {
+        return app()->testPath($path);
+    }
+}
+
 if (! function_exists('today')) {
     /**
      * Create a new Carbon instance for the current date.


### PR DESCRIPTION
similar to all the other path helpers.

It may be uncommon, but I have a need to access the `tests` directory path, and figured since all the other ones exist, we'll add this for consistency.