### PR TITLE
[5.8] Fix whereIn() with global scopes

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -274,30 +274,6 @@ class Grammar extends BaseGrammar
     }
 
     /**
-     * Compile a where in sub-select clause.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $where
-     * @return string
-     */
-    protected function whereInSub(Builder $query, $where)
-    {
-        return $this->wrap($where['column']).' in ('.$this->compileSelect($where['query']).')';
-    }
-
-    /**
-     * Compile a where not in sub-select clause.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $where
-     * @return string
-     */
-    protected function whereNotInSub(Builder $query, $where)
-    {
-        return $this->wrap($where['column']).' not in ('.$this->compileSelect($where['query']).')';
-    }
-
-    /**
      * Compile a "where null" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -56,7 +56,7 @@ class JoinClause extends Builder
      *
      * will produce the following SQL:
      *
-     * on `contacts`.`user_id` = `users`.`id`  and `contacts`.`info_id` = `info`.`id`
+     * on `contacts`.`user_id` = `users`.`id` and `contacts`.`info_id` = `info`.`id`
      *
      * @param  \Closure|string  $first
      * @param  string|null  $operator

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -989,6 +989,15 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->whereKeyNot($collection);
     }
 
+    public function testWhereIn()
+    {
+        $model = new EloquentBuilderTestNestedStub;
+        $this->mockConnectionForModel($model, '');
+        $query = $model->newQuery()->withoutGlobalScopes()->whereIn('foo', $model->newQuery()->select('id'));
+        $expected = 'select * from "table" where "foo" in (select "id" from "table" where "table"."deleted_at" is null)';
+        $this->assertEquals($expected, $query->toSql());
+    }
+
     public function testLatestWithoutColumnWithCreatedAt()
     {
         $model = $this->getMockModel();


### PR DESCRIPTION
`whereIn()` accidentally removes global scopes from subqueries:

```php
class Post extends Model {
    use SoftDeletes;
}

User::whereIn('id', Post::select('user_id'))->get();
```

```sql
# expected
 select * from "users" where "id" in (
  select "user_id" from "posts" where "posts"."deleted_at" is null
)

# actual
select * from "users" where "id" in (
  select "user_id" from "posts"
)
```

The fix requires breaking changes, so I used the opportunity to simplify the whole `whereIn()` code.

Fixes #26198.