### PR TITLE
[5.7] Correct type doc on collection that uses pluck

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -172,7 +172,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the median of a given key.
      *
-     * @param  null $key
+     * @param  string|array|null $key
      * @return mixed
      */
     public function median($key = null)
@@ -202,7 +202,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the mode of a given key.
      *
-     * @param  mixed  $key
+     * @param  string|array|null  $key
      * @return array|null
      */
     public function mode($key = null)


### PR DESCRIPTION
**What?**
Functions in Collection that utilizes Arr::pluck is wrongly type hinted in the PHPDoc block.

**Why fix this?**
As statically analytics tools become more and more popular as phpstan, this will provide a headache towards fixing the inconsistencies. It will also provide a correct documentation.

**Note**
Contributing guide says to target it towards LTS, but recent hotfixes, where all targeted towards 5.7, so i will continue that.