### PR TITLE
[5.7] NotificationFake can assert preferred locale

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Testing\Fakes;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
 use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;
 
@@ -210,7 +211,11 @@ class NotificationFake implements NotificationFactory, NotificationDispatcher
                 'notification' => $notification,
                 'channels' => $notification->via($notifiable),
                 'notifiable' => $notifiable,
-                'locale' => $notification->locale ?? $this->locale,
+                'locale' => $notification->locale ?? $this->locale ?? value(function () use ($notifiable) {
+                    if ($notifiable instanceof HasLocalePreference) {
+                        return $notifiable->preferredLocale();
+                    }
+                }),
             ];
         }
     }

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Testing\Fakes\MailFake;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\Constraint\ExceptionMessage;
+use Illuminate\Contracts\Translation\HasLocalePreference;
 
 class SupportTestingMailFakeTest extends TestCase
 {
@@ -40,6 +41,17 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
         $this->fake->assertSent(MailableStub::class);
+    }
+
+    public function testAssertSentWhenRecipientHasPreferredLocale()
+    {
+        $user = new LocalizedRecipientStub;
+
+        $this->fake->to($user)->send($this->mailable);
+
+        $this->fake->assertSent(MailableStub::class, function ($mail) use ($user) {
+            return $mail->hasTo($user) && $mail->locale === 'au';
+        });
     }
 
     public function testAssertNotSent()
@@ -162,5 +174,15 @@ class QueueableMailableStub extends Mailable implements ShouldQueue
     {
         $this->with('first_name', 'Taylor')
              ->withLastName('Otwell');
+    }
+}
+
+class LocalizedRecipientStub implements HasLocalePreference
+{
+    public $email = 'taylor@laravel.com';
+
+    public function preferredLocale()
+    {
+        return 'au';
     }
 }

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -8,6 +8,7 @@ use Illuminate\Notifications\Notification;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\Constraint\ExceptionMessage;
 use Illuminate\Support\Testing\Fakes\NotificationFake;
+use Illuminate\Contracts\Translation\HasLocalePreference;
 
 class SupportTestingNotificationFakeTest extends TestCase
 {
@@ -94,6 +95,17 @@ class SupportTestingNotificationFakeTest extends TestCase
 
         $this->fake->assertTimesSent(3, NotificationStub::class);
     }
+
+    public function testAssertSentToWhenNotifiableHasPreferredLocale()
+    {
+        $user = new LocalizedUserStub;
+
+        $this->fake->send($user, new NotificationStub);
+
+        $this->fake->assertSentTo($user, NotificationStub::class, function ($notification, $channels, $notifiable, $locale) use ($user) {
+            return $notifiable === $user && $locale === 'au';
+        });
+    }
 }
 
 class NotificationStub extends Notification
@@ -107,4 +119,12 @@ class NotificationStub extends Notification
 class UserStub extends User
 {
     //
+}
+
+class LocalizedUserStub extends User implements HasLocalePreference
+{
+    public function preferredLocale()
+    {
+        return 'au';
+    }
 }


### PR DESCRIPTION
When a notifiable implements the `HasLocalePreference` interface, `NotificationFake` should make the expected locale available for assertions.

e.g.,

```php
Notification::fake();

$user = factory(User::class)->create(['locale' => 'au']);

// Call an artisan console command that invokes:
Notification::send($user, new AFLTrade('Chad Wingard', 'Hawthorn'));

Notification::assertSentTo($user, AFLTrade::class, function ($notification, $channels, $notifiable, $locale) use ($user) {
    return $notification->player === 'Chad Wingard' &&
        $notification->club === 'Hawthorn' &&
        $notifiable->is($user) &&
        $locale === 'au';
});
```

`MailFake` already supports similar locale assertion capabilities so I added a test for that too.
