### PR TITLE
[5.7] Remove Duplicated Code

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -381,7 +381,7 @@ class Router implements RegistrarContract, BindingRegistrar
     protected function updateGroupStack(array $attributes)
     {
         if (! empty($this->groupStack)) {
-            $attributes = RouteGroup::merge($attributes, end($this->groupStack));
+            $attributes = $this->mergeWithLastGroup(...func_get_args());
         }
 
         $this->groupStack[] = $attributes;


### PR DESCRIPTION
this logic is duplicated on mergeWithLastGroup function
```php 
RouteGroup::merge($attributes, end($this->groupStack)); 

public function mergeWithLastGroup($new)
{
   return RouteGroup::merge($new, end($this->groupStack));
}
```
so it will need to be changed to

```php
$this->mergeWithLastGroup(...func_get_args());

```

