### PR TITLE
[5.7] Remove HandlesAuthorization trait from Policy stubs

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
@@ -3,11 +3,9 @@
 namespace DummyNamespace;
 
 use NamespacedDummyUserModel;
-use Illuminate\Auth\Access\HandlesAuthorization;
 
 class DummyClass
 {
-    use HandlesAuthorization;
 
     /**
      * Create a new policy instance.

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -4,11 +4,9 @@ namespace DummyNamespace;
 
 use NamespacedDummyUserModel;
 use NamespacedDummyModel;
-use Illuminate\Auth\Access\HandlesAuthorization;
 
 class DummyClass
 {
-    use HandlesAuthorization;
 
     /**
      * Determine whether the user can view the DocDummyModel.


### PR DESCRIPTION
This PR removes the use of the HandlesAuthorization trait from the policy stubs.

The `HandlesAuthorization` trait is only used by `Illuminate\Auth\Access\Gate` on line 296, and is not called when used in a policy.

I came across this as I wanted to override the behaviour of the `deny` method. For guest users I want to throw an `AuthenticationException` instead of an `AuthorizationException`, so redirecting users to the login page. This sadly didn't work as expected. By browsing through the source code I found out these methods are never called, so they should be removed from the stub.

As an alternative, I used the `after` method of the `Gate` facade to redirect unauthorized guests to the login page:
````php
Gate::after(
    function ($user = null, $ability, $result, $arguments) {
        if ($user === null && $result === false) {
            throw new AuthenticationException();
        }
    }
);
````