### PR TITLE
Add message to TokenMismatchException

### DIFF
--- a/src/Illuminate/Session/TokenMismatchException.php
+++ b/src/Illuminate/Session/TokenMismatchException.php
@@ -6,5 +6,5 @@ use Exception;
 
 class TokenMismatchException extends Exception
 {
-    //
+    protected $message = 'The page has expired due to inactivity.';
 }


### PR DESCRIPTION
When thrown, TokenMismatchException gives empty message.

If form is submitted async, warning is thrown in console but message is empty and if for example axios interceptor is set to display message, it shows empty.
