### PR TITLE
[5.7] Add message to TokenMismatchException

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -78,8 +78,10 @@ class VerifyCsrfToken
                 }
             });
         }
+        
+        $message = __('Sorry, your session has expired. Please refresh and try again.');
 
-        throw new TokenMismatchException;
+        throw new TokenMismatchException($message);
     }
 
     /**


### PR DESCRIPTION
When thrown, TokenMismatchException gives empty message.

If form is submitted async, warning is thrown in console but message is empty and if for example axios interceptor is set to display message, it shows empty.

Fixed #26215 