### PR TITLE
[5.7] Add message to TokenMismatchException

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -43,6 +43,13 @@ class VerifyCsrfToken
     protected $addHttpCookie = true;
 
     /**
+     * The message that is passed to exception.
+     *
+     * @var string
+     */
+    protected $message = '';
+
+    /**
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Foundation\Application  $app
@@ -79,9 +86,7 @@ class VerifyCsrfToken
             });
         }
 
-        $message = __('Sorry, your session has expired. Please refresh and try again.');
-
-        throw new TokenMismatchException($message);
+        throw new TokenMismatchException($this->message);
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -79,7 +79,9 @@ class VerifyCsrfToken
             });
         }
 
-        throw new TokenMismatchException;
+        $message = __('Sorry, your session has expired. Please refresh and try again.');
+
+        throw new TokenMismatchException($message);
     }
 
     /**


### PR DESCRIPTION
When thrown, TokenMismatchException gives empty message.

If form is submitted async, warning is thrown in console but message is empty and if for example axios interceptor is set to display message, it shows empty.

Fixed #26215 