### PR TITLE
[5.4] Fix collection min() on objects with null value

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -844,8 +844,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $callback = $this->valueRetriever($callback);
 
-        return $this->filter(function ($value) {
-            return ! is_null($value);
+        return $this->filter(function ($value) use ($callback) {
+            return ! is_null($callback($value));
         })->reduce(function ($result, $item) use ($callback) {
             $value = $callback($item);
 
@@ -896,8 +896,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $callback = $this->valueRetriever($callback);
 
-        return $this->filter(function ($value) {
-            return ! is_null($value);
+        return $this->filter(function ($value) use ($callback) {
+            return ! is_null($callback($value));
         })->reduce(function ($result, $item) use ($callback) {
             $value = $callback($item);
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1667,13 +1667,13 @@ class SupportCollectionTest extends TestCase
 
     public function testGettingMaxItemsFromCollection()
     {
-        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
+        $c = new Collection([(object) ['foo' => 20], (object) ['foo' => null], (object) ['foo' => 10]]);
         $this->assertEquals(20, $c->max(function ($item) {
             return $item->foo;
         }));
         $this->assertEquals(20, $c->max('foo'));
 
-        $c = new Collection([['foo' => 10], ['foo' => 20]]);
+        $c = new Collection([['foo' => 20], ['foo' => null], ['foo' => 10]]);
         $this->assertEquals(20, $c->max('foo'));
 
         $c = new Collection([1, 2, 3, 4, 5]);
@@ -1685,13 +1685,13 @@ class SupportCollectionTest extends TestCase
 
     public function testGettingMinItemsFromCollection()
     {
-        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
+        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => null], (object) ['foo' => 20]]);
         $this->assertEquals(10, $c->min(function ($item) {
             return $item->foo;
         }));
         $this->assertEquals(10, $c->min('foo'));
 
-        $c = new Collection([['foo' => 10], ['foo' => 20]]);
+        $c = new Collection([['foo' => 10], ['foo' => null], ['foo' => 20]]);
         $this->assertEquals(10, $c->min('foo'));
 
         $c = new Collection([1, 2, 3, 4, 5]);


### PR DESCRIPTION
Collections of objects or arrays containing a key with a null value
resets min() reduce loop so already seen lower values are forgotten.

This change ensures null values are filtered out before reducing on both
min and max for consistency although max() is not affected by this bug.
