### PR TITLE
Add index to ->softDeletes schema by default.

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -413,7 +413,7 @@ class Blueprint
      */
     public function dropSoftDeletes($column = 'deleted_at')
     {
-        $this->dropColumn($column);
+        $this->dropColumn($column)->dropIndex($column);
     }
 
     /**
@@ -424,7 +424,7 @@ class Blueprint
      */
     public function dropSoftDeletesTz($column = 'deleted_at')
     {
-        $this->dropSoftDeletes($column);
+        $this->dropSoftDeletes($column)->dropIndex($column);
     }
 
     /**
@@ -996,7 +996,7 @@ class Blueprint
      */
     public function softDeletes($column = 'deleted_at', $precision = 0)
     {
-        return $this->timestamp($column, $precision)->nullable();
+        return $this->timestamp($column, $precision)->nullable()->index($column);
     }
 
     /**
@@ -1008,7 +1008,7 @@ class Blueprint
      */
     public function softDeletesTz($column = 'deleted_at', $precision = 0)
     {
-        return $this->timestampTz($column, $precision)->nullable();
+        return $this->timestampTz($column, $precision)->nullable()->index($column);
     }
 
     /**


### PR DESCRIPTION
I was kind of surprised to see when adding softDeletes to your tables it doesn't add a index by default.

Would it make sense to have an index on these columns given the fact that `deleted_at` is added to pretty much every query in Eloquent when using soft deletes? Seems to make sense to me to be the default, and if people would like to override the behaviour they can define the deleted_at column manually. 