### PR TITLE
[5.7] Extract setting intended url to public method

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -89,7 +89,7 @@ class Redirector
                         : $this->generator->previous();
 
         if ($intended) {
-            $this->session->put('url.intended', $intended);
+            $this->setIntendedUrl($intended);
         }
 
         return $this->to($path, $status, $headers, $secure);
@@ -109,6 +109,18 @@ class Redirector
         $path = $this->session->pull('url.intended', $default);
 
         return $this->to($path, $status, $headers, $secure);
+    }
+
+    /**
+     * Set intended url.
+     *
+     * @param  string  $url
+     *
+     * @return void
+     */
+    public function setIntendedUrl($url)
+    {
+        $this->session->put('url.intended', $url);
     }
 
     /**

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -112,10 +112,9 @@ class Redirector
     }
 
     /**
-     * Set intended url.
+     * Set the intended url.
      *
      * @param  string  $url
-     *
      * @return void
      */
     public function setIntendedUrl($url)

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -160,4 +160,12 @@ class RoutingRedirectorTest extends TestCase
         $response = $this->redirect->home();
         $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
     }
+
+    public function testItSetsValidIntendedUrl()
+    {
+        $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
+
+        $result = $this->redirect->setIntendedUrl('http://foo.com/bar');
+        $this->assertNull($result);
+    }
 }


### PR DESCRIPTION
It just extracts setting intended url to public method that could be reused in application. 

Of course anyone can in app just use:

```
session(['url.intended' => $intended])
```

instead of

```
app('redirect')->setIntendedUrl($intended);
```

but it's better to not expose framework implementation details to app.