### PR TITLE
[5.7] Fix nested whereDoesntHave()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -74,6 +74,13 @@ trait QueriesRelationships
     {
         $relations = explode('.', $relations);
 
+        $doesntHave = $operator === '<' && $count === 1;
+
+        if ($doesntHave) {
+            $operator = '>=';
+            $count = 1;
+        }
+
         $closure = function ($q) use (&$closure, &$relations, $operator, $count, $callback) {
             // In order to nest "has", we need to add count relation constraints on the
             // callback Closure. We'll do this by simply passing the Closure its own
@@ -83,7 +90,7 @@ trait QueriesRelationships
                 : $q->has(array_shift($relations), $operator, $count, 'and', $callback);
         };
 
-        return $this->has(array_shift($relations), '>=', 1, $boolean, $closure);
+        return $this->has(array_shift($relations), $doesntHave ? '<' : '>=', 1, $boolean, $closure);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -876,6 +876,15 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where not exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id")', $builder->toSql());
     }
 
+    public function testDoesntHaveNested()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->doesntHave('foo.bar');
+
+        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where not exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id"))', $builder->toSql());
+    }
+
     public function testOrDoesntHave()
     {
         $model = new EloquentBuilderTestModelParentStub;

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -526,6 +526,14 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertCount(1, $users);
     }
 
+    public function testWhereDoesntHaveWithNestedDeletedRelationship()
+    {
+        $this->createUsers();
+
+        $users = SoftDeletesTestUser::doesntHave('posts.comments')->get();
+        $this->assertCount(1, $users);
+    }
+
     public function testWhereHasWithNestedDeletedRelationshipAndWithTrashedCondition()
     {
         $this->createUsers();


### PR DESCRIPTION
`doesntHave()` and `whereDoesntHave()` don't work properly with nested relationships:

```php
User::whereDoesntHave('posts.comments', function ($query) {
    $query->where('spam', true);
})->get());
```

Eloquent applies the `not exists` clause to the innermost relationship instead of the outermost:

```sql
select * from "users" where exists (
  select * from "posts" where "users"."id" = "posts"."user_id" and not exists (
    select * from "comments" where "posts"."id" = "comments"."post_id" and "spam" = 1
  )
)
```

This causes incorrect results ([fiddle](https://www.db-fiddle.com/f/j8LwAZ2Gc4PEv412EUYkBB/0)):

- It returns users that have posts with spam comments and posts without spam comments (user 1).
- It doesn't return users that don't have any posts at all (user 2).


You get the correct query when you nest the closures yourself:

```php
User::whereDoesntHave('posts', function ($query) {
    $query->whereHas('comments', function ($query) {
        $query->where('spam', true);
    });
})->get();
```

```sql
select * from "users" where not exists (
  select * from "posts" where "users"."id" = "posts"."user_id" and exists (
    select * from "comments" where "posts"."id" = "comments"."post_id" and "spam" = 1
  )
)
```

Fixes #26222.