### PR TITLE
[5.7] Revert breaking filesystem changes

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Filesystem;
 
-use Exception;
 use ErrorException;
 use FilesystemIterator;
 use Symfony\Component\Finder\Finder;
@@ -121,41 +120,6 @@ class Filesystem
     public function put($path, $contents, $lock = false)
     {
         return file_put_contents($path, $contents, $lock ? LOCK_EX : 0);
-    }
-
-    /**
-     * Write the contents of a file, replacing it atomically if it already exists.
-     *
-     * This will also replace the target file permissions.
-     *
-     * @param  string  $path
-     * @param  string  $content
-     * @return void
-     *
-     * @throws \Exception
-     */
-    public function replace($path, $content)
-    {
-        // If the path already exists and is a symlink, make sure we get the real path...
-        clearstatcache(true, $path);
-
-        $realPath = realpath($path);
-
-        if ($realPath) {
-            $path = $realPath;
-        }
-
-        $dirName = dirname($path);
-
-        if (! is_writable($dirName)) {
-            throw new Exception("Replacing [{$path}] requires that its parent directory is writable.");
-        }
-
-        $tempPath = tempnam($dirName, basename($path));
-
-        file_put_contents($tempPath, $content);
-
-        rename($tempPath, $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation;
 
+use Exception;
 use Illuminate\Filesystem\Filesystem;
 
 class PackageManifest
@@ -96,7 +97,7 @@ class PackageManifest
             $this->build();
         }
 
-        $this->files->get($this->manifestPath);
+        $this->files->get($this->manifestPath, true);
 
         return $this->manifest = file_exists($this->manifestPath) ?
             $this->files->getRequire($this->manifestPath) : [];
@@ -163,9 +164,13 @@ class PackageManifest
      */
     protected function write(array $manifest)
     {
-        $this->files->replace(
-            $this->manifestPath,
-            '<?php return '.var_export($manifest, true).';'
+        if (! is_writable(dirname($this->manifestPath))) {
+            throw new Exception('The '.dirname($this->manifestPath).' directory must be present and writable.');
+        }
+
+        $this->files->put(
+            $this->manifestPath, '<?php return '.var_export($manifest, true).';',
+            true
         );
     }
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -42,16 +42,6 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello World');
     }
 
-    public function testReplaceStoresFiles()
-    {
-        $files = new Filesystem;
-        $files->replace($this->tempDir.'/file.txt', 'Hello World');
-        $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello World');
-
-        $files->replace($this->tempDir.'/file.txt', 'Something Else');
-        $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Something Else');
-    }
-
     public function testSetChmod()
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');


### PR DESCRIPTION
This is to revert PR https://github.com/laravel/framework/pull/26010

Although the PR was merged 16 days ago, it was only "tagged" 18 hours ago. We already have 3x reported issues of people experiencing file system permissions issues, which all of them mention that reverting to `5.7.9` solves their problems: https://github.com/laravel/framework/issues/26230, https://github.com/laravel/framework/issues/26229 and at the bottom of the PR https://github.com/laravel/framework/pull/26010

Arguably the problem is not the PR itself, but incorrect file permissions on existing projects.

The issue is as more people start running `composer update` we are likely to see an increase in reported tickets. And these problems might not appear until the application is pushed to production, which is even worse.

So I suggest the PR perhaps should be targetted to `5.8` and listed as part of the upgrade checklist.

Of course, reverting the PR re-introduces the original edge case bug that it solved - but that seemed to be less of an issue. 🤷‍♂️ 

_p.s. I couldnt create an automatic PR to "revert" the changes, as there have been formatting changes since. So if people could cross check this PR with the original to make sure it's a correct revert - that would be helpful._