### PR TITLE
[5.7] Insufficient permissions on packages.php

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -152,6 +152,8 @@ class Filesystem
         }
 
         $tempPath = tempnam($dirName, basename($path));
+        // Remove tempPath because it will be created with incorrect permissions
+        unlink($tempPath);
 
         file_put_contents($tempPath, $content);
 


### PR DESCRIPTION
Fix for #26230 

`tempnam()` creates files with permissions set to 600, so we fix it by
just removing the temp file created by `tempnam()`.

The alternative is to change permissions after creating the file, but that might not always be possible and also means we would have to figure out what the current `umask()` is to do it consistent with the umask.