### PR TITLE
[5.7] Detect for oracles ORA-03114 'not connect to' error

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -35,7 +35,7 @@ trait DetectsLostConnections
             'Physical connection is not usable',
             'TCP Provider: Error code 0x68',
             'Name or service not known',
-            'ORA-03114'
+            'ORA-03114',
         ]);
     }
 }

--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -35,6 +35,7 @@ trait DetectsLostConnections
             'Physical connection is not usable',
             'TCP Provider: Error code 0x68',
             'Name or service not known',
+            'ORA-03114'
         ]);
     }
 }


### PR DESCRIPTION
Similar to #24566 , this ensures queue workers handle dropped connections when using Oracle as the database.

Full oracle error message is 'ORA-03114: not connected to', but code should be sufficient