### PR TITLE
[5.7] withPivotValue also accepts an array

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -360,8 +360,8 @@ class BelongsToMany extends Relation
      *
      * In addition, new pivot records will receive this value.
      *
-     * @param  string  $column
-     * @param  mixed  $value
+     * @param  string|array $column
+     * @param  mixed        $value
      * @return $this
      */
     public function withPivotValue($column, $value = null)


### PR DESCRIPTION
I want to do the following:
$printer->shops()->withPivotValue(['format' => $printerData['format']])->exists();
This is allowed according to the code, but not according to the phpdocs.
