### PR TITLE
[5.7] Add make:class command to artisan

### DIFF
--- a/src/Illuminate/Foundation/Console/ClassMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ClassMakeCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+
+class ClassMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:class';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Class';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/class.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace;
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/class.stub
+++ b/src/Illuminate/Foundation/Console/stubs/class.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace DummyNamespace;
+
+class DummyClass
+{
+    //
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -19,6 +19,7 @@ use Illuminate\Foundation\Console\MailMakeCommand;
 use Illuminate\Foundation\Console\OptimizeCommand;
 use Illuminate\Foundation\Console\RuleMakeCommand;
 use Illuminate\Foundation\Console\TestMakeCommand;
+use Illuminate\Foundation\Console\ClassMakeCommand;
 use Illuminate\Foundation\Console\EventMakeCommand;
 use Illuminate\Foundation\Console\ModelMakeCommand;
 use Illuminate\Foundation\Console\RouteListCommand;
@@ -136,6 +137,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'AuthMake' => 'command.auth.make',
         'CacheTable' => 'command.cache.table',
         'ChannelMake' => 'command.channel.make',
+        'ClassMake' => 'command.class.make',
         'ConsoleMake' => 'command.console.make',
         'ControllerMake' => 'command.controller.make',
         'EventGenerate' => 'command.event.generate',
@@ -261,6 +263,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.channel.make', function ($app) {
             return new ChannelMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerClassMakeCommand()
+    {
+        $this->app->singleton('command.class.make', function ($app) {
+            return new ClassMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
Sometimes I just need to create a plain class from artisan. Often I just make a model and back out Eloquent. (Apologies if this has been rejected/submitted before - I didn't find anything when searching).