### PR TITLE
[5.7] Make expectation closure optional for mock and spy instances

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -37,23 +37,23 @@ trait InteractsWithContainer
      * Mock an instance of an object in the container.
      *
      * @param  string  $abstract
-     * @param  \Closure  $instance
+     * @param  \Closure|null  $instance
      * @return object
      */
-    protected function mock($abstract, Closure $mock)
+    protected function mock($abstract, Closure $mock = null)
     {
-        return $this->instance($abstract, Mockery::mock($abstract, $mock));
+        return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args())));
     }
 
     /**
      * Spy an instance of an object in the container.
      *
      * @param  string  $abstract
-     * @param  \Closure  $instance
+     * @param  \Closure|null  $instance
      * @return object
      */
-    protected function spy($abstract, Closure $mock)
+    protected function spy($abstract, Closure $mock = null)
     {
-        return $this->instance($abstract, Mockery::spy($abstract, $mock));
+        return $this->instance($abstract, Mockery::spy(...array_filter(func_get_args())));
     }
 }


### PR DESCRIPTION
#26171 introduced the ability to more conveniently add mock and spy instances to the container in a test. These methods require a closure as the second argument.

Passing the closure is perfectly valid, and is the example given in the blog announcement. However, examples of the use of this closure is rare. In fact, AFAIK it's completely undocumented by Laravel and Mockery. Also, requiring the closure is inconvenient where no expectations are desired.

This PR makes the second argument optional.

Before:
```php
class ExampleTest extends TestCase
{
    /**
     * A basic test example.
     *
     * @return void
     */
    public function testExample()
    {
        $mailer = $this->spy(Mailer::class, function ($mock) {
            $mock->shouldReceive('send')->andReturn(true);
        });

        // SUT here

        $mailer->shouldHaveReceived('send');
    }
}
```

After:
```php
class ExampleTest extends TestCase
{
    /**
     * A basic test example.
     *
     * @return void
     */
    public function testExample()
    {
        $mailer = $this->spy(Mailer::class);
        $mailer->shouldReceive('send')->andReturn(true);

        // SUT here

        $mailer->shouldHaveReceived('send');
    }
}
```