### PR TITLE
[5.7] Add type alias for database notifications

### DIFF
--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -55,7 +55,7 @@ class DatabaseChannel
     {
         return [
             'id' => $notification->id,
-            'type' => $notification->type_alias ?? get_class($notification),
+            'type' => $notification->typeAlias ?? get_class($notification),
             'data' => $this->getData($notifiable, $notification),
             'read_at' => null,
         ];

--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -55,7 +55,7 @@ class DatabaseChannel
     {
         return [
             'id' => $notification->id,
-            'type' => get_class($notification),
+            'type' => $notification->type_alias ?? get_class($notification),
             'data' => $this->getData($notifiable, $notification),
             'read_at' => null,
         ];


### PR DESCRIPTION
Add the ability to choose a custom database notification instead of the class name.

Reason: Class names are long and subject to change (app:name).

Benefit: Categories notifications.

Current method: bind class DatabaseChannel then overwrite buildPayload method