### PR TITLE
[5.7] Tidy up for artisan preset command

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/None.php
+++ b/src/Illuminate/Foundation/Console/Presets/None.php
@@ -55,5 +55,6 @@ class None extends Preset
     {
         file_put_contents(resource_path('sass/app.scss'), ''.PHP_EOL);
         copy(__DIR__.'/none-stubs/app.js', resource_path('js/app.js'));
+        copy(__DIR__.'/none-stubs/bootstrap.js', resource_path('js/bootstrap.js'));
     }
 }

--- a/src/Illuminate/Foundation/Console/Presets/Vue.php
+++ b/src/Illuminate/Foundation/Console/Presets/Vue.php
@@ -30,7 +30,7 @@ class Vue extends Preset
      */
     protected static function updatePackageArray(array $packages)
     {
-        return ['vue' => '^2.5.7'] + Arr::except($packages, [
+        return ['vue' => '^2.5.17'] + Arr::except($packages, [
             'babel-preset-react',
             'react',
             'react-dom',

--- a/src/Illuminate/Foundation/Console/Presets/none-stubs/bootstrap.js
+++ b/src/Illuminate/Foundation/Console/Presets/none-stubs/bootstrap.js
@@ -1,0 +1,43 @@
+
+window._ = require('lodash');
+
+/**
+ * We'll load the axios HTTP library which allows us to easily issue requests
+ * to our Laravel back-end. This library automatically handles sending the
+ * CSRF token as a header based on the value of the "XSRF" token cookie.
+ */
+
+window.axios = require('axios');
+
+window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
+/**
+ * Next we will register the CSRF Token as a common header with Axios so that
+ * all outgoing HTTP requests automatically have it attached. This is just
+ * a simple convenience so we don't have to attach every token manually.
+ */
+
+let token = document.head.querySelector('meta[name="csrf-token"]');
+
+if (token) {
+    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
+} else {
+    console.error('CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token');
+}
+
+/**
+ * Echo exposes an expressive API for subscribing to channels and listening
+ * for events that are broadcast by Laravel. Echo and event broadcasting
+ * allows your team to easily build robust real-time web applications.
+ */
+
+// import Echo from 'laravel-echo'
+
+// window.Pusher = require('pusher-js');
+
+// window.Echo = new Echo({
+//     broadcaster: 'pusher',
+//     key: process.env.MIX_PUSHER_APP_KEY,
+//     cluster: process.env.MIX_PUSHER_APP_CLUSTER,
+//     encrypted: true
+// });


### PR DESCRIPTION
Sorry for 2 different commits for one pull request, I thought I was working on a different branch.

## First commit
version bump for vue, package.json updated in on the Laravel repo - https://github.com/laravel/laravel/pull/4831 however I had forgotten about the artisan preset command.

fix potential xss vulnerability in ssr (2.5.17)
fix v-for alias deconstruct regression (2.5.8)

## Second commit
After running `php artisan preset none` and then trying to build your resources (after re running npm install or yarn) you get the following errors.

```
WARNING in ./resources/js/bootstrap.js
Module not found: Error: Can't resolve 'bootstrap' in 'resources/js'
 @ ./resources/js/bootstrap.js 14:2-22
 @ ./resources/js/app.js
 @ multi ./resources/js/app.js ./resources/sass/app.scss

WARNING in ./resources/js/bootstrap.js
Module not found: Error: Can't resolve 'jquery' in 'resources/js'
 @ ./resources/js/bootstrap.js 12:29-46
 @ ./resources/js/app.js
 @ multi ./resources/js/app.js ./resources/sass/app.scss

WARNING in ./resources/js/bootstrap.js
Module not found: Error: Can't resolve 'popper.js' in 'resources/js'
 @ ./resources/js/bootstrap.js 11:18-38
 @ ./resources/js/app.js
 @ multi ./resources/js/app.js ./resources/sass/app.scss

```

This is due to the file `resources/js/bootstrap.js` still running a try catch on requiring them.

I know its nothing big, I have removed the try catch.