### PR TITLE
[5.7] add `explode` to collection support

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -846,17 +846,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
 
     /**
-     * Concatenate values of a given key as a string.
+     * splitting values by a string delimiter.
      *
      * @param  string  $value
-     * @param  string  $glue
-     * @return string
+     * @param  string  $delimiter
+     * @return array
      */
-    public function explode($glue = null, $value = null)
+    public function explode($delimiter = null, $value = null)
     {
         $first = $this->first();
 
-        if(is_null($glue))
+        if(is_null($delimiter))
         {
             return $this->toArray();
         }
@@ -864,17 +864,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         if(is_array($first) || is_object($first))
         {
             if(! is_null($value)) {
-                return $this->pluck($value)->map(function($item) use($glue) {
-                    return explode($glue, $item);
+                return $this->pluck($value)->map(function($item) use($delimiter) {
+                    return explode($delimiter, $item);
                 })->toArray();
             }
 
-            return $this->flatten()->values()->map(function($item) use($glue) {
-                return explode($glue, $item);
+            return $this->flatten()->values()->map(function($item) use($delimiter) {
+                return explode($delimiter, $item);
             })->toArray();
         }
 
-        return explode($glue, $first);
+        return explode($delimiter, $first);
     }
 
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -844,6 +844,40 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         return implode($value, $this->items);
     }
 
+
+    /**
+     * Concatenate values of a given key as a string.
+     *
+     * @param  string  $value
+     * @param  string  $glue
+     * @return string
+     */
+    public function explode($glue = null, $value = null)
+    {
+        $first = $this->first();
+
+        if(is_null($glue))
+        {
+            return $this->toArray();
+        }
+
+        if(is_array($first) || is_object($first))
+        {
+            if(! is_null($value)) {
+                return $this->pluck($value)->map(function($item) use($glue) {
+                    return explode($glue, $item);
+                })->toArray();
+            }
+
+            return $this->flatten()->values()->map(function($item) use($glue) {
+                return explode($glue, $item);
+            })->toArray();
+        }
+
+        return explode($glue, $first);
+    }
+
+
     /**
      * Intersect the collection with the given items.
      *

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1109,6 +1109,31 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('taylor,dayle', $data->implode(','));
     }
 
+    public function testExplode()
+    {
+        $data = new Collection('taylor:mohamed');
+        $this->assertEquals(['taylor', 'mohamed'], $data->explode(':'));
+        $this->assertEquals(['taylor:mohamed'], $data->explode());
+
+        $data = new Collection(['taylor:mohamed']);
+        $this->assertEquals(['taylor', 'mohamed'], $data->explode(':'));
+        $this->assertEquals(['taylor:mohamed'], $data->explode());
+
+        $data = new Collection([['taylor/mohamed'],['taylor/mohamed']]);
+        $this->assertEquals([['taylor','mohamed'],['taylor', 'mohamed']], $data->explode('/'));
+        $this->assertEquals([['taylor/mohamed'],['taylor/mohamed']], $data->explode());
+
+        $data = new Collection([['taylor/mohamed'], ['taylor/mohamed'], ['taylor/mohamed']]);
+        $this->assertEquals([['taylor','mohamed'], ['taylor', 'mohamed'], ['taylor', 'mohamed']], $data->explode('/'));
+        $this->assertEquals([['taylor/mohamed'], ['taylor/mohamed'], ['taylor/mohamed']], $data->explode());
+
+        $data = new Collection([['name' => 'taylor/bar', 'email' => 'taylor/foo'], ['name' => 'mohamed/bar', 'email' => 'mohamed/foo']]);
+        $this->assertEquals([['taylor','foo'], ['mohamed', 'foo']], $data->explode('/', 'email'));
+        $this->assertEquals([['taylor','bar'], ['mohamed', 'bar']], $data->explode('/', 'name'));
+        $this->assertEquals([['name' => 'taylor/bar', 'email' => 'taylor/foo'], ['name' => 'mohamed/bar', 'email' => 'mohamed/foo']], $data->explode());
+
+    }
+
     public function testTake()
     {
         $data = new Collection(['taylor', 'dayle', 'shawn']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1131,7 +1131,6 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([['taylor','foo'], ['mohamed', 'foo']], $data->explode('/', 'email'));
         $this->assertEquals([['taylor','bar'], ['mohamed', 'bar']], $data->explode('/', 'name'));
         $this->assertEquals([['name' => 'taylor/bar', 'email' => 'taylor/foo'], ['name' => 'mohamed/bar', 'email' => 'mohamed/foo']], $data->explode());
-
     }
 
     public function testTake()


### PR DESCRIPTION
Add `explode` helper to Collection Support

```php
new Collection(['taylor:mohamed'])->explode(':');
output => ['taylor', 'mohamed']

new Collection([['taylor/mohamed'],['taylor/mohamed']])->explode('/');
output => [['taylor','mohamed'],['taylor', 'mohamed']]
```
it is been so many times when im working with collection and i needed to `explode` the strings so i had to this for example
```collect(explode('/', collect($array))->last()```