### PR TITLE
[5.7] Allow multiple create payload callbacks on queues.

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -213,7 +213,7 @@ abstract class Queue
      */
     protected function withCreatePayloadHooks($queue, array $payload)
     {
-        if (!empty(static::$createPayloadCallback)) {
+        if (! empty(static::$createPayloadCallback)) {
             foreach (static::$createPayloadCallback as $callback) {
                 $payload = array_merge($payload, call_user_func(
                     $callback, $this->getConnectionName(), $queue, $payload

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -27,9 +27,9 @@ abstract class Queue
     /**
      * The create payload callback.
      *
-     * @var callable|null
+     * @var callable[]
      */
-    protected static $createPayloadCallback;
+    protected static $createPayloadCallback = [];
 
     /**
      * Push a new job onto the queue.
@@ -197,7 +197,11 @@ abstract class Queue
      */
     public static function createPayloadUsing($callback)
     {
-        static::$createPayloadCallback = $callback;
+        if (is_null($callback)) {
+            static::$createPayloadCallback = [];
+        } else {
+            static::$createPayloadCallback[] = $callback;
+        }
     }
 
     /**
@@ -209,10 +213,12 @@ abstract class Queue
      */
     protected function withCreatePayloadHooks($queue, array $payload)
     {
-        if (static::$createPayloadCallback) {
-            return array_merge($payload, call_user_func(
-                static::$createPayloadCallback, $this->getConnectionName(), $queue, $payload
-            ));
+        if (!empty(static::$createPayloadCallback)) {
+            foreach (static::$createPayloadCallback as $callback) {
+                $payload = array_merge($payload, call_user_func(
+                    $callback, $this->getConnectionName(), $queue, $payload
+                ));
+            }
         }
 
         return $payload;


### PR DESCRIPTION
The `createPayloadUsing` was added in 5.7.7 and is an excellent feature that I started using on one of my projects.

Telescope was released as a beta this week and started using this feature and stop my application from working as intended due to it using this same feature.

This pull request makes it possible to define multiple payload callbacks and is completely backwards compatible. This will mean anyone using Telescope can still use this feature.

This feature could also be used in the future to support share data between all queues.
