### PR TITLE
Avoid multiple questions in `migrate:refresh`

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -107,7 +107,7 @@ class FreshCommand extends Command
         $this->call('db:seed', [
             '--database' => $database,
             '--class' => $this->option('seeder') ?: 'DatabaseSeeder',
-            '--force' => $this->option('force'),
+            '--force' => true,
         ]);
     }
 

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -86,7 +86,7 @@ class RefreshCommand extends Command
             '--path' => $path,
             '--realpath' => $this->input->getOption('realpath'),
             '--step' => $step,
-            '--force' => $force,
+            '--force' => true,
         ]);
     }
 
@@ -104,7 +104,7 @@ class RefreshCommand extends Command
             '--database' => $database,
             '--path' => $path,
             '--realpath' => $this->input->getOption('realpath'),
-            '--force' => $force,
+            '--force' => true,
         ]);
     }
 
@@ -129,7 +129,7 @@ class RefreshCommand extends Command
         $this->call('db:seed', [
             '--database' => $database,
             '--class' => $this->option('seeder') ?: 'DatabaseSeeder',
-            '--force' => $this->option('force'),
+            '--force' => true,
         ]);
     }
 


### PR DESCRIPTION
Currently if you perform `migrate:refresh` or `migrate:fresh` in production environment it will ask to confirm operation multiple times.
Each question does not add any information about what step it relates to, so currently the extra copies are pointless.

This pull request modifies `migrate:refresh` and `migrate:fresh` so that after the initial question will pass, each subcommand will be called with `--force=true` making their behavior similar to `migrate` command that already is passing `--force=true`.
