### PR TITLE
[5.7] Fix filesystem locking hangs in PackageManifest::build() (#25898)

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -127,16 +127,17 @@ class Filesystem
      *
      * This will replace the target file permissions. It also resolves symlinks to replace the symlink's target file.
      *
-     * @param string $path
-     * @param string $content
+     * @param  string  $path
+     * @param  string  $content
+     * @return void
      */
     public function replace($path, $content)
     {
-        // Just in case path already exists and is a symlink, we want to make sure we get the real path.
+        // If the path already exists and is a symlink, make sure we get the real path...
         clearstatcache(true, $path);
+
         $path = realpath($path) ?: $path;
 
-        // Write out the contents to a temp file, so we then can rename the file atomically.
         $tempPath = tempnam(dirname($path), basename($path));
 
         // Fix permissions of tempPath because `tempnam()` creates it with permissions set to 0600.

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -97,7 +97,7 @@ class PackageManifest
             $this->build();
         }
 
-        $this->files->get($this->manifestPath, true);
+        $this->files->get($this->manifestPath);
 
         return $this->manifest = file_exists($this->manifestPath) ?
             $this->files->getRequire($this->manifestPath) : [];
@@ -168,9 +168,8 @@ class PackageManifest
             throw new Exception('The '.dirname($this->manifestPath).' directory must be present and writable.');
         }
 
-        $this->files->put(
-            $this->manifestPath, '<?php return '.var_export($manifest, true).';',
-            true
+        $this->files->replace(
+            $this->manifestPath, '<?php return '.var_export($manifest, true).';'
         );
     }
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -42,6 +42,45 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello World');
     }
 
+    public function testReplaceStoresFiles()
+    {
+        $tempFile   = "{$this->tempDir}/file.txt";
+        $symlinkDir = "{$this->tempDir}/symlink_dir";
+        $symlink    = "{$symlinkDir}/symlink.txt";
+
+        mkdir($symlinkDir);
+        symlink($tempFile, $symlink);
+
+        // Prevent changes to symlink_dir
+        chmod($symlinkDir, 0555);
+
+        // Test with a weird non-standard umask.
+        $umask         = 0131;
+        $originalUmask = umask($umask);
+
+        $filesystem = new Filesystem;
+
+        // Test replacing non-existent file.
+        $filesystem->replace($tempFile, 'Hello World');
+        $this->assertStringEqualsFile($tempFile, 'Hello World');
+        $this->assertEquals($umask, 0777 - $this->getFilePermissions($tempFile));
+
+        // Test replacing existing file.
+        $filesystem->replace($tempFile, 'Something Else');
+        $this->assertStringEqualsFile($tempFile, 'Something Else');
+        $this->assertEquals($umask, 0777 - $this->getFilePermissions($tempFile));
+
+        // Test replacing symlinked file.
+        $filesystem->replace($symlink, 'Yet Something Else Again');
+        $this->assertStringEqualsFile($tempFile, 'Yet Something Else Again');
+        $this->assertEquals($umask, 0777 - $this->getFilePermissions($tempFile));
+
+        umask($originalUmask);
+
+        // Reset changes to symlink_dir
+        chmod($symlinkDir, 0777 - $originalUmask);
+    }
+
     public function testSetChmod()
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');
@@ -495,5 +534,17 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $filesystem = new Filesystem;
         $this->assertEquals('acbd18db4cc2f85cedef654fccc4a4d8', $filesystem->hash($this->tempDir.'/foo.txt'));
+    }
+
+    /**
+     * @param string $file
+     * @return int
+     */
+    private function getFilePermissions($file)
+    {
+        $filePerms = fileperms($file);
+        $filePerms = substr(sprintf('%o', $filePerms), -3);
+
+        return (int) base_convert($filePerms, 8, 10);
     }
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -44,9 +44,9 @@ class FilesystemTest extends TestCase
 
     public function testReplaceStoresFiles()
     {
-        $tempFile   = "{$this->tempDir}/file.txt";
+        $tempFile = "{$this->tempDir}/file.txt";
         $symlinkDir = "{$this->tempDir}/symlink_dir";
-        $symlink    = "{$symlinkDir}/symlink.txt";
+        $symlink = "{$symlinkDir}/symlink.txt";
 
         mkdir($symlinkDir);
         symlink($tempFile, $symlink);
@@ -55,7 +55,7 @@ class FilesystemTest extends TestCase
         chmod($symlinkDir, 0555);
 
         // Test with a weird non-standard umask.
-        $umask         = 0131;
+        $umask = 0131;
         $originalUmask = umask($umask);
 
         $filesystem = new Filesystem;


### PR DESCRIPTION
So, for what it's worth, here is my updated fix for #25898, the NFS file locking issue.

I cleaned it up some more and included a fix that prevents #26232. I also included that case in the unit test, among with some other cases.

  - Filesystem.php

     1. Created a new `Filesystem::replace()` method that atomically replaces a file if it already exists.

  - PackageManifest.php

     1. The Filesystem::get() call in PackageManifest::getManifest() no longer has to use an exclusive lock because the packages.php manifest file will always be replaced atomically.

     2. Use the new Filesystem::replace() method in PackageManifest::write()