### PR TITLE
[5.7] Use the time function for test performance

### DIFF
--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -31,7 +31,7 @@ class CacheTaggedCacheTest extends TestCase
     {
         $store = new ArrayStore;
         $tags = ['bop', 'zap'];
-        $duration = new DateTime;
+        $duration = time();
         $duration->add(new DateInterval('PT10M'));
         $store->tags($tags)->put('foo', 'bar', $duration);
         $this->assertEquals('bar', $store->tags($tags)->get('foo'));

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1432,8 +1432,8 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $model->id = 'id';
         $model->foo = 'bar';
-        $model->created_at = new DateTime;
-        $model->updated_at = new DateTime;
+        $model->created_at = time();
+        $model->updated_at = time();
         $replicated = $model->replicate();
 
         $this->assertNull($replicated->id);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -163,7 +163,7 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
         $router->get('test', function () {
-            return (new SymfonyResponse('test', 304, ['foo' => 'bar']))->setLastModified(new DateTime);
+            return (new SymfonyResponse('test', 304, ['foo' => 'bar']))->setLastModified(time());
         });
 
         $response = $router->dispatch(Request::create('test', 'GET'));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2643,7 +2643,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => ['Not', 'a', 'date']], ['x' => 'date']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['x' => new DateTime], ['x' => 'date']);
+        $v = new Validator($trans, ['x' => time()], ['x' => 'date']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => new DateTimeImmutable], ['x' => 'date']);


### PR DESCRIPTION
Benchmark: 
```php
<?php

$microtime = microtime(true);

for ($i = 1; $i < 5000000; ++$i) {
    time();
}

var_dump(microtime(true) - $microtime);


$microtime = microtime(true);

for ($i = 1; $i < 5000000; ++$i) {
    new DateTime();
}

var_dump(microtime(true) - $microtime);
```

Results
```
new DateTime() (50000x): 0.62s
time() (50000x): 0.00s

new DateTime() (500000x): 5.89s
time() (500000x): 0.04s

new DateTime() (5000000x): 62.66s
time() (5000000x): 0.45s
```