### PR TITLE
[5.7] Add support for proper decimal casting if using php-decimal

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -732,12 +732,16 @@ trait HasAttributes
     /**
      * Return a decimal as string.
      *
-     * @param  float  $value
-     * @param  int  $decimals
+     * @param  mixed $value
+     * @param  int   $decimals
      * @return string
      */
     protected function asDecimal($value, $decimals)
     {
+        if ($value instanceof \Decimal\Decimal) {
+            return $value->toFixed($decimals, false, PHP_ROUND_HALF_UP);
+        }
+
         return number_format($value, $decimals, '.', '');
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -738,6 +738,9 @@ trait HasAttributes
      */
     protected function asDecimal($value, $decimals)
     {
+        /**
+         * @see http://php-decimal.io/#toFixed
+         */
         if ($value instanceof \Decimal\Decimal) {
             return $value->toFixed($decimals, false, PHP_ROUND_HALF_UP);
         }


### PR DESCRIPTION
Adds support for smarter decimal casting, if the extension is installed.

This shouldn't break anything or affect those who won't have the extension installed. The `instanceof` call doesn't attempt to autoload so there is zero-cost here. The alternative is for me to create a separate package with a trait that overrides `asDecimal`. I'm happy to do that but this seems way nicer.

See: http://php-decimal.io