### PR TITLE
[5.8] Changed Collection::firstWhere signature to be the same as Collection::where

### DIFF
--- a/CHANGELOG-5.7.md
+++ b/CHANGELOG-5.7.md
@@ -1,5 +1,20 @@
 # Release Notes for 5.7.x
 
+## [v5.7.11 (2018-10-24)](https://github.com/laravel/framework/compare/v5.7.10...v5.7.11)
+
+### Added
+- Added `decimal:<num>` cast to Model ([#26173](https://github.com/laravel/framework/pull/26173))
+- Allowed updateExistingPivot to receive an arrayable item ([#26167](https://github.com/laravel/framework/pull/26167))
+- Added `setIntendedUrl` method to `Routing/Redirector.php` ([#26227](https://github.com/laravel/framework/pull/26227))
+- Added `ORA-03114` string to `DetectsLostConnections` trait ([#26233](https://github.com/laravel/framework/pull/26233))
+
+### Fixed
+- Fixed an issue where the worker process would not be killed by the listener when the timeout is exceeded ([#25981](https://github.com/laravel/framework/pull/25981))
+
+### Changed
+- Reverted filesystem changes which were done in [#26010](https://github.com/laravel/framework/pull/26010) ([#26231](https://github.com/laravel/framework/pull/26231))
+
+
 ## [v5.7.10 (2018-10-23)](https://github.com/laravel/framework/compare/v5.7.9...v5.7.10)
 
 ### Added

--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -35,6 +35,7 @@ trait DetectsLostConnections
             'Physical connection is not usable',
             'TCP Provider: Error code 0x68',
             'Name or service not known',
+            'ORA-03114',
         ]);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -698,6 +698,18 @@ trait HasAttributes
     }
 
     /**
+     * Decode the given JSON back into an array or object.
+     *
+     * @param  string  $value
+     * @param  bool  $asObject
+     * @return mixed
+     */
+    public function fromJson($value, $asObject = false)
+    {
+        return json_decode($value, ! $asObject);
+    }
+
+    /**
      * Decode the given float.
      *
      * @param  mixed  $value
@@ -727,18 +739,6 @@ trait HasAttributes
     protected function asDecimal($value, $decimals)
     {
         return number_format($value, $decimals, '.', '');
-    }
-
-    /**
-     * Decode the given JSON back into an array or object.
-     *
-     * @param  string  $value
-     * @param  bool  $asObject
-     * @return mixed
-     */
-    public function fromJson($value, $asObject = false)
-    {
-        return json_decode($value, ! $asObject);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -479,6 +479,8 @@ trait HasAttributes
             case 'float':
             case 'double':
                 return $this->fromFloat($value);
+            case 'decimal':
+                return $this->asDecimal($value, explode(':', $this->getCasts()[$key], 2)[1]);
             case 'string':
                 return (string) $value;
             case 'bool':
@@ -515,6 +517,10 @@ trait HasAttributes
             return 'custom_datetime';
         }
 
+        if ($this->isDecimalCast($this->getCasts()[$key])) {
+            return 'decimal';
+        }
+
         return trim(strtolower($this->getCasts()[$key]));
     }
 
@@ -528,6 +534,17 @@ trait HasAttributes
     {
         return strncmp($cast, 'date:', 5) === 0 ||
                strncmp($cast, 'datetime:', 9) === 0;
+    }
+
+    /**
+     * Determine if the cast type is a decimal cast.
+     *
+     * @param  string  $cast
+     * @return bool
+     */
+    protected function isDecimalCast($cast)
+    {
+        return strncmp($cast, 'decimal:', 8) === 0;
     }
 
     /**
@@ -698,6 +715,18 @@ trait HasAttributes
             default:
                 return (float) $value;
         }
+    }
+
+    /**
+     * Return a decimal as string.
+     *
+     * @param  float  $value
+     * @param  int  $value
+     * @return string
+     */
+    protected function asDecimal($value, $decimals)
+    {
+        return number_format($value, $decimals, '.', '');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -721,7 +721,7 @@ trait HasAttributes
      * Return a decimal as string.
      *
      * @param  float  $value
-     * @param  int  $value
+     * @param  int  $decimals
      * @return string
      */
     protected function asDecimal($value, $decimals)

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -360,7 +360,7 @@ class BelongsToMany extends Relation
      *
      * In addition, new pivot records will receive this value.
      *
-     * @param  string  $column
+     * @param  string|array  $column
      * @param  mixed  $value
      * @return $this
      */

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Filesystem;
 
-use Exception;
 use ErrorException;
 use FilesystemIterator;
 use Symfony\Component\Finder\Finder;
@@ -121,41 +120,6 @@ class Filesystem
     public function put($path, $contents, $lock = false)
     {
         return file_put_contents($path, $contents, $lock ? LOCK_EX : 0);
-    }
-
-    /**
-     * Write the contents of a file, replacing it atomically if it already exists.
-     *
-     * This will also replace the target file permissions.
-     *
-     * @param  string  $path
-     * @param  string  $content
-     * @return void
-     *
-     * @throws \Exception
-     */
-    public function replace($path, $content)
-    {
-        // If the path already exists and is a symlink, make sure we get the real path...
-        clearstatcache(true, $path);
-
-        $realPath = realpath($path);
-
-        if ($realPath) {
-            $path = $realPath;
-        }
-
-        $dirName = dirname($path);
-
-        if (! is_writable($dirName)) {
-            throw new Exception("Replacing [{$path}] requires that its parent directory is writable.");
-        }
-
-        $tempPath = tempnam($dirName, basename($path));
-
-        file_put_contents($tempPath, $content);
-
-        rename($tempPath, $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -29,7 +29,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.7.10';
+    const VERSION = '5.7.11';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Console/Presets/None.php
+++ b/src/Illuminate/Foundation/Console/Presets/None.php
@@ -55,5 +55,6 @@ class None extends Preset
     {
         file_put_contents(resource_path('sass/app.scss'), ''.PHP_EOL);
         copy(__DIR__.'/none-stubs/app.js', resource_path('js/app.js'));
+        copy(__DIR__.'/none-stubs/bootstrap.js', resource_path('js/bootstrap.js'));
     }
 }

--- a/src/Illuminate/Foundation/Console/Presets/Vue.php
+++ b/src/Illuminate/Foundation/Console/Presets/Vue.php
@@ -30,7 +30,7 @@ class Vue extends Preset
      */
     protected static function updatePackageArray(array $packages)
     {
-        return ['vue' => '^2.5.7'] + Arr::except($packages, [
+        return ['vue' => '^2.5.17'] + Arr::except($packages, [
             'babel-preset-react',
             'react',
             'react-dom',

--- a/src/Illuminate/Foundation/Console/Presets/none-stubs/bootstrap.js
+++ b/src/Illuminate/Foundation/Console/Presets/none-stubs/bootstrap.js
@@ -1,0 +1,43 @@
+
+window._ = require('lodash');
+
+/**
+ * We'll load the axios HTTP library which allows us to easily issue requests
+ * to our Laravel back-end. This library automatically handles sending the
+ * CSRF token as a header based on the value of the "XSRF" token cookie.
+ */
+
+window.axios = require('axios');
+
+window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
+/**
+ * Next we will register the CSRF Token as a common header with Axios so that
+ * all outgoing HTTP requests automatically have it attached. This is just
+ * a simple convenience so we don't have to attach every token manually.
+ */
+
+let token = document.head.querySelector('meta[name="csrf-token"]');
+
+if (token) {
+    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
+} else {
+    console.error('CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token');
+}
+
+/**
+ * Echo exposes an expressive API for subscribing to channels and listening
+ * for events that are broadcast by Laravel. Echo and event broadcasting
+ * allows your team to easily build robust real-time web applications.
+ */
+
+// import Echo from 'laravel-echo'
+
+// window.Pusher = require('pusher-js');
+
+// window.Echo = new Echo({
+//     broadcaster: 'pusher',
+//     key: process.env.MIX_PUSHER_APP_KEY,
+//     cluster: process.env.MIX_PUSHER_APP_CLUSTER,
+//     encrypted: true
+// });

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation;
 
+use Exception;
 use Illuminate\Filesystem\Filesystem;
 
 class PackageManifest
@@ -96,7 +97,7 @@ class PackageManifest
             $this->build();
         }
 
-        $this->files->get($this->manifestPath);
+        $this->files->get($this->manifestPath, true);
 
         return $this->manifest = file_exists($this->manifestPath) ?
             $this->files->getRequire($this->manifestPath) : [];
@@ -163,9 +164,13 @@ class PackageManifest
      */
     protected function write(array $manifest)
     {
-        $this->files->replace(
-            $this->manifestPath,
-            '<?php return '.var_export($manifest, true).';'
+        if (! is_writable(dirname($this->manifestPath))) {
+            throw new Exception('The '.dirname($this->manifestPath).' directory must be present and writable.');
+        }
+
+        $this->files->put(
+            $this->manifestPath, '<?php return '.var_export($manifest, true).';',
+            true
         );
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -37,23 +37,23 @@ trait InteractsWithContainer
      * Mock an instance of an object in the container.
      *
      * @param  string  $abstract
-     * @param  \Closure  $instance
+     * @param  \Closure|null  $instance
      * @return object
      */
-    protected function mock($abstract, Closure $mock)
+    protected function mock($abstract, Closure $mock = null)
     {
-        return $this->instance($abstract, Mockery::mock($abstract, $mock));
+        return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args())));
     }
 
     /**
      * Spy an instance of an object in the container.
      *
      * @param  string  $abstract
-     * @param  \Closure  $instance
+     * @param  \Closure|null  $instance
      * @return object
      */
-    protected function spy($abstract, Closure $mock)
+    protected function spy($abstract, Closure $mock = null)
     {
-        return $this->instance($abstract, Mockery::spy($abstract, $mock));
+        return $this->instance($abstract, Mockery::spy(...array_filter(func_get_args())));
     }
 }

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -213,7 +213,7 @@ abstract class Queue
      */
     protected function withCreatePayloadHooks($queue, array $payload)
     {
-        if (!empty(static::$createPayloadCallback)) {
+        if (! empty(static::$createPayloadCallback)) {
             foreach (static::$createPayloadCallback as $callback) {
                 $payload = array_merge($payload, call_user_func(
                     $callback, $this->getConnectionName(), $queue, $payload

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -27,9 +27,9 @@ abstract class Queue
     /**
      * The create payload callback.
      *
-     * @var callable|null
+     * @var callable[]
      */
-    protected static $createPayloadCallback;
+    protected static $createPayloadCallback = [];
 
     /**
      * Push a new job onto the queue.
@@ -197,7 +197,11 @@ abstract class Queue
      */
     public static function createPayloadUsing($callback)
     {
-        static::$createPayloadCallback = $callback;
+        if (is_null($callback)) {
+            static::$createPayloadCallback = [];
+        } else {
+            static::$createPayloadCallback[] = $callback;
+        }
     }
 
     /**
@@ -209,10 +213,12 @@ abstract class Queue
      */
     protected function withCreatePayloadHooks($queue, array $payload)
     {
-        if (static::$createPayloadCallback) {
-            return array_merge($payload, call_user_func(
-                static::$createPayloadCallback, $this->getConnectionName(), $queue, $payload
-            ));
+        if (!empty(static::$createPayloadCallback)) {
+            foreach (static::$createPayloadCallback as $callback) {
+                $payload = array_merge($payload, call_user_func(
+                    $callback, $this->getConnectionName(), $queue, $payload
+                ));
+            }
         }
 
         return $payload;

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -25,11 +25,11 @@ abstract class Queue
     protected $connectionName;
 
     /**
-     * The create payload callback.
+     * The create payload callbacks.
      *
      * @var callable[]
      */
-    protected static $createPayloadCallback = [];
+    protected static $createPayloadCallbacks = [];
 
     /**
      * Push a new job onto the queue.
@@ -198,9 +198,9 @@ abstract class Queue
     public static function createPayloadUsing($callback)
     {
         if (is_null($callback)) {
-            static::$createPayloadCallback = [];
+            static::$createPayloadCallbacks = [];
         } else {
-            static::$createPayloadCallback[] = $callback;
+            static::$createPayloadCallbacks[] = $callback;
         }
     }
 
@@ -213,8 +213,8 @@ abstract class Queue
      */
     protected function withCreatePayloadHooks($queue, array $payload)
     {
-        if (! empty(static::$createPayloadCallback)) {
-            foreach (static::$createPayloadCallback as $callback) {
+        if (! empty(static::$createPayloadCallbacks)) {
+            foreach (static::$createPayloadCallbacks as $callback) {
                 $payload = array_merge($payload, call_user_func(
                     $callback, $this->getConnectionName(), $queue, $payload
                 ));

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -89,7 +89,7 @@ class Redirector
                         : $this->generator->previous();
 
         if ($intended) {
-            $this->session->put('url.intended', $intended);
+            $this->setIntendedUrl($intended);
         }
 
         return $this->to($path, $status, $headers, $secure);
@@ -109,6 +109,18 @@ class Redirector
         $path = $this->session->pull('url.intended', $default);
 
         return $this->to($path, $status, $headers, $secure);
+    }
+
+    /**
+     * Set intended url.
+     *
+     * @param  string  $url
+     *
+     * @return void
+     */
+    public function setIntendedUrl($url)
+    {
+        $this->session->put('url.intended', $url);
     }
 
     /**

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -112,10 +112,9 @@ class Redirector
     }
 
     /**
-     * Set intended url.
+     * Set the intended url.
      *
      * @param  string  $url
-     *
      * @return void
      */
     public function setIntendedUrl($url)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -679,7 +679,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  mixed  $value
      * @return mixed
      */
-    public function firstWhere($key, $operator, $value = null)
+    public function firstWhere($key, $operator = null, $value = null)
     {
         return $this->first($this->operatorForWhere(...func_get_args()));
     }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -42,16 +42,6 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello World');
     }
 
-    public function testReplaceStoresFiles()
-    {
-        $files = new Filesystem;
-        $files->replace($this->tempDir.'/file.txt', 'Hello World');
-        $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello World');
-
-        $files->replace($this->tempDir.'/file.txt', 'Something Else');
-        $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Something Else');
-    }
-
     public function testSetChmod()
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');

--- a/tests/Integration/Database/EloquentModelDecimalCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDecimalCastingTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelDecimalCastingTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentModelDecimalCastingTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('test_model1', function ($table) {
+            $table->increments('id');
+            $table->decimal('decimal_field_2', 8, 2)->nullable();
+            $table->decimal('decimal_field_4', 8, 4)->nullable();
+        });
+    }
+
+    public function test_decimals_are_castable()
+    {
+        $user = TestModel1::create([
+            'decimal_field_2' => '12',
+            'decimal_field_4' => '1234',
+        ]);
+
+        $this->assertEquals('12.00', $user->toArray()['decimal_field_2']);
+        $this->assertEquals('1234.0000', $user->toArray()['decimal_field_4']);
+
+        $user->decimal_field_2 = 12;
+        $user->decimal_field_4 = '1234';
+
+        $this->assertEquals('12.00', $user->toArray()['decimal_field_2']);
+        $this->assertEquals('1234.0000', $user->toArray()['decimal_field_4']);
+
+        $this->assertFalse($user->isDirty());
+
+        $user->decimal_field_4 = '1234.1234';
+        $this->assertTrue($user->isDirty());
+    }
+}
+
+class TestModel1 extends Model
+{
+    public $table = 'test_model1';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+
+    public $casts = [
+        'decimal_field_2' => 'decimal:2',
+        'decimal_field_4' => 'decimal:4',
+    ];
+}

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -160,4 +160,12 @@ class RoutingRedirectorTest extends TestCase
         $response = $this->redirect->home();
         $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
     }
+
+    public function testItSetsValidIntendedUrl()
+    {
+        $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
+
+        $result = $this->redirect->setIntendedUrl('http://foo.com/bar');
+        $this->assertNull($result);
+    }
 }


### PR DESCRIPTION
This small PR makes the collection convenience method `firstWhere` work the same way as the `where` function does by making the second parameter optional.

Image we have a Post model with a boolean property published, if we wanted to retrieve the first published post we could do this
```php
$collection->where('published')->first()
```
But if we use the convenience method `firstWhere`
```php
# We have to pass true here, because the second argument is required
$collection->firstWhere('published', true)
```
With this PR the second argument to `firstWhere` is no longer required and boolean checks can be performed the same way as with the `where` function. (This PR shouldn't create any breaking changes because all it does is make one parameter optional)
