### PR TITLE
[5.8] Changed Collection::firstWhere signature to be the same as Collection::where

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -679,7 +679,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  mixed  $value
      * @return mixed
      */
-    public function firstWhere($key, $operator, $value = null)
+    public function firstWhere($key, $operator = null, $value = null)
     {
         return $this->first($this->operatorForWhere(...func_get_args()));
     }


### PR DESCRIPTION
This small PR makes the collection convenience method `firstWhere` work the same way as the `where` function does by making the second parameter optional.

Image we have a Post model with a boolean property published, if we wanted to retrieve the first published post we could do this
```php
$collection->where('published')->first()
```
But if we use the convenience method `firstWhere`
```php
# We have to pass true here, because the second argument is required
$collection->firstWhere('published', true)
```
With this PR the second argument to `firstWhere` is no longer required and boolean checks can be performed the same way as with the `where` function.

This PR is the same as #26260, but targets and branches from the correct branch.