### PR TITLE
[5.7] Add missing annotations for exceptions

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -87,6 +87,7 @@ trait ManagesTransactions
      * @return void
      *
      * @throws \Exception
+     * @throws \Throwable
      */
     public function beginTransaction()
     {
@@ -101,6 +102,9 @@ trait ManagesTransactions
      * Create a transaction within the database.
      *
      * @return void
+     *
+     * @throws \Exception
+     * @throws \Throwable
      */
     protected function createTransaction()
     {
@@ -134,6 +138,7 @@ trait ManagesTransactions
      * @return void
      *
      * @throws \Exception
+     * @throws \Throwable
      */
     protected function handleBeginTransactionException($e)
     {


### PR DESCRIPTION
While working on the DB transactions found that some of the exceptions were thrown but not mentioned on the doc-block. This PR adds those missing doc blocks for exceptions and throwable.