### PR TITLE
[5.7] Add forget cache method

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -279,6 +279,25 @@ class CacheManager implements FactoryContract
     }
 
     /**
+     * Unset the given disk instances.
+     *
+     * @param  array|string|null  $disk
+     * @return $this
+     */
+    public function forgetCache($name = null)
+    {
+        $name = $name ?? $this->getDefaultDriver();
+
+        foreach ((array) $name as $cacheName) {
+            if (isset($this->stores[$cacheName])) {
+                unset($this->stores[$cacheName]);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Register a custom driver creator Closure.
      *
      * @param  string    $driver

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Cache;
 
-use Illuminate\Cache\ArrayStore;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\CacheManager;
 
 class CacheManagerTest extends TestCase
@@ -63,7 +63,7 @@ class CacheManagerTest extends TestCase
                 ],
             ],
         ]);
-        $cacheManager->extend('forget', function() {
+        $cacheManager->extend('forget', function () {
             return new ArrayStore();
         });
 

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Cache;
 
+use Illuminate\Cache\ArrayStore;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\CacheManager;
@@ -27,5 +28,48 @@ class CacheManagerTest extends TestCase
         };
         $cacheManager->extend(__CLASS__, $driver);
         $this->assertEquals($cacheManager, $cacheManager->store(__CLASS__));
+    }
+
+    public function testForgetCache()
+    {
+        $cacheManager = m::mock(CacheManager::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+
+        $cacheManager->shouldReceive('resolve')
+            ->withArgs(['array'])
+            ->times(4)
+            ->andReturn(new ArrayStore());
+
+        $cacheManager->shouldReceive('getDefaultDriver')
+            ->once()
+            ->andReturn('array');
+
+        foreach (['array', ['array'], null] as $option) {
+            $cacheManager->store('array');
+            $cacheManager->store('array');
+            $cacheManager->forgetCache($option);
+            $cacheManager->store('array');
+            $cacheManager->store('array');
+        }
+    }
+
+    public function testForgetCacheForgets()
+    {
+        $cacheManager = new CacheManager([
+            'config' => [
+                'cache.stores.forget' => [
+                    'driver' => 'forget',
+                ],
+            ],
+        ]);
+        $cacheManager->extend('forget', function() {
+            return new ArrayStore();
+        });
+
+        $cacheManager->store('forget')->forever('foo', 'bar');
+        $this->assertSame('bar', $cacheManager->store('forget')->get('foo'));
+        $cacheManager->forgetCache('forget');
+        $this->assertNull($cacheManager->store('forget')->get('foo'));
     }
 }


### PR DESCRIPTION
This method allows you to drop a connection already opened by the cache manager. This is handy if you want to force the connection to reconnect or you change some config options and want to create the connection again using these configs.

A similar method was added to the FilesystemManager earlier this year called `forgetDisk`.

There is no breaking changes from this as it is a completely new method.