### PR TITLE
[5.7] Add str_wrap string helper function

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -532,6 +532,18 @@ class Str
     }
 
     /**
+     * Begin and end a string with a single instance of a given value.
+     *
+     * @param  string  $value
+     * @param  string  $cap
+     * @return string
+     */
+    public static function wrap($value, $cap)
+    {
+        return static::start(static::finish($value, $cap), $cap);
+    }
+
+    /**
      * Generate a time-ordered UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1011,7 +1011,6 @@ if (! function_exists('str_wrap')) {
     }
 }
 
-
 if (! function_exists('studly_case')) {
     /**
      * Convert a value to studly caps case.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -997,6 +997,21 @@ if (! function_exists('str_start')) {
     }
 }
 
+if (! function_exists('str_wrap')) {
+    /**
+     * Begin and end a string with a single instance of a given value.
+     *
+     * @param  string  $value
+     * @param  string  $cap
+     * @return string
+     */
+    function str_wrap($value, $cap)
+    {
+        return Str::wrap($value, $cap);
+    }
+}
+
+
 if (! function_exists('studly_case')) {
     /**
      * Convert a value to studly caps case.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -298,6 +298,15 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('/test/string', Str::start('//test/string', '/'));
     }
 
+    public function testStrWrap()
+    {
+        $this->assertEquals('/test/string/', Str::wrap('test/string', '/'));
+        $this->assertEquals('/test/string/', Str::wrap('/test/string', '/'));
+        $this->assertEquals('/test/string/', Str::wrap('test/string/', '/'));
+        $this->assertEquals('/test/string/', Str::wrap('/test/string/', '/'));
+        $this->assertEquals('/test/string/', Str::wrap('//test/string/', '/'));
+    }
+
     public function testSnakeCase()
     {
         $this->assertEquals('foo_bar', Str::snake('fooBar'));


### PR DESCRIPTION
We have `str_start` & `str_finish`. I've found the need for `str_wrap` fairly often.

```
str_wrap('foo', '/');
// returns: '/foo/'

str_wrap('/foo', '/');
// returns '/foo/'
```
