### PR TITLE
[5.7] Create getter for the http middleware groups

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -335,4 +335,14 @@ class Kernel implements KernelContract
     {
         return $this->app;
     }
+
+    /**
+     * Get the application's route middleware groups.
+     *
+     * @return array
+     */
+    public function getMiddlewareGroups()
+    {
+        return $this->middlewareGroups;
+    }
 }

--- a/tests/Foundation/Http/KernelTest.php
+++ b/tests/Foundation/Http/KernelTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http;
+
+use Illuminate\Routing\Router;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Http\Kernel;
+
+class KernelTest extends TestCase
+{
+    public function testGetMiddlewareGroups()
+    {
+        $kernel = new Kernel($this->getApplication(), $this->getRouter());
+
+        $this->assertEquals([], $kernel->getMiddlewareGroups());
+    }
+
+    /**
+     * @return \Illuminate\Foundation\Application
+     */
+    protected function getApplication()
+    {
+        return new Application;
+    }
+
+    /**
+     * @return \Illuminate\Routing\Router
+     */
+    protected function getRouter()
+    {
+        return new Router(new Dispatcher);
+    }
+}


### PR DESCRIPTION
This getter allows to create tests for the route middleware groups, which is currently not possible because the property is protected.

For example, if you want to ensure that the web group is using a middleware to track utm campaigns, with this getter you can write:

```php
/** @test */
public function it_registers_the_track_utm_middleware_in_the_web_group()
{
    $groups = resolve(\App\Http\Kernel::class)->getMiddlewareGroups();

    $this->assertContains(\App\Http\Middleware\TrackUTM::class, $groups['web']);
}
```