### PR TITLE
[5.7] Add str_match alias to str_is helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -238,6 +238,18 @@ class Str
     }
 
     /**
+     * Determine if a given string matches a given pattern.
+     *
+     * @param  string|array  $pattern
+     * @param  string  $value
+     * @return bool
+     */
+    public static function match($pattern, $value)
+    {
+        return static::is($pattern, $value);
+    }
+
+    /**
      * Limit the number of words in a string.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -891,7 +891,7 @@ if (! function_exists('str_match')) {
      */
     function str_match($pattern, $value)
     {
-        return Str::is($pattern, $value);
+        return Str::match($pattern, $value);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -881,6 +881,20 @@ if (! function_exists('str_limit')) {
     }
 }
 
+if (! function_exists('str_match')) {
+    /**
+     * Determine if a given string matches a given pattern.
+     *
+     * @param  string|array  $pattern
+     * @param  string  $value
+     * @return bool
+     */
+    function str_match($pattern, $value)
+    {
+        return Str::is($pattern, $value);
+    }
+}
+
 if (! function_exists('str_plural')) {
     /**
      * Get the plural form of an English word.


### PR DESCRIPTION
`str_is` is not intuitive to me (I really like it, it's just not what I would anticipate it be called).

I personally would search for the word "match" for anything comparing a string to a regex pattern.

This PR just adds an alias called `str_match` and `Str::match()` that points to `str_is` and `Str::is`

I hope you'll accept this string helper offering ;)