### PR TITLE
[5.7] Fix CacheManager's forgetDriver method docblock

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -281,7 +281,7 @@ class CacheManager implements FactoryContract
     /**
      * Unset the given driver instances.
      *
-     * @param  array|string|null  $driver
+     * @param  array|string|null  $name
      * @return $this
      */
     public function forgetDriver($name = null)


### PR DESCRIPTION
It should be `$name` instead of `$driver`