### PR TITLE
[5.7] Late bindings by routes.

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -120,6 +120,13 @@ class Route
     public static $validators;
 
     /**
+     * Registered potential bindings to the action's parameters.
+     *
+     * @var array
+     */
+    protected $lateBindings = [];
+
+    /**
      * Create a new Route instance.
      *
      * @param  array|string  $methods
@@ -301,6 +308,31 @@ class Route
                         ->parameters($request);
 
         return $this;
+    }
+
+    /**
+     * Register a potential binding.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @param  bool  $shared
+     * @return $this
+     */
+    public function lateBind($abstract, $concrete = null, $shared = false)
+    {
+        $this->lateBindings[$abstract] = compact('concrete', 'shared');
+
+        return $this;
+    }
+
+    /**
+     * Returns the lateBindings array.
+     *
+     * @return array
+     */
+    public function lateBindings()
+    {
+        return $this->lateBindings;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -70,6 +70,17 @@ trait RouteDependencyResolverTrait
     {
         $class = $parameter->getClass();
 
+        if ($this instanceof Route) {
+            $bindings = $this->lateBindings();
+            foreach ($bindings as $abstract => $value) {
+                $this->container->bind(
+                    $abstract,
+                    $value['concrete'],
+                    $value['shared']
+                );
+            }
+        }
+
         // If the parameter has a type-hinted class, we will check to see if it is already in
         // the list of parameters. If it is we will just skip it as it is probably a model
         // binding and we do not want to mess with those; otherwise, we resolve it here.

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1469,6 +1469,25 @@ class RoutingRouteTest extends TestCase
         $router->dispatch(Request::create('foo/baz', 'GET'))->getContent();
     }
 
+    public function testLateParameterBind()
+    {
+        $router = $this->getRouter();
+        $exampleModel = new TestLateParameter();
+        $exampleModel->testProperty = 'testValue' . random_int(1, 6543);
+        $currentRoute = $router->get('foo', function (TestLateParameter $m) use ($exampleModel) {
+            $this->assertEquals($exampleModel, $m);
+        });
+
+        $currentRoute->lateBind(
+            TestLateParameter::class,
+            function () use($exampleModel) {
+                return $exampleModel;
+            }
+        );
+
+        $router->dispatch(Request::create('foo'), 'GET');
+    }
+
     public function testDispatchingCallableActionClasses()
     {
         $router = $this->getRouter();
@@ -1558,6 +1577,11 @@ class RoutingRouteTest extends TestCase
 
         return $router;
     }
+}
+
+class TestLateParameter
+{
+    public $testProperty = '';
 }
 
 class RouteTestControllerStub extends Controller

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1473,14 +1473,14 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
         $exampleModel = new TestLateParameter();
-        $exampleModel->testProperty = 'testValue' . random_int(1, 6543);
+        $exampleModel->testProperty = 'testValue'.random_int(1, 6543);
         $currentRoute = $router->get('foo', function (TestLateParameter $m) use ($exampleModel) {
             $this->assertEquals($exampleModel, $m);
         });
 
         $currentRoute->lateBind(
             TestLateParameter::class,
-            function () use($exampleModel) {
+            function () use ($exampleModel) {
                 return $exampleModel;
             }
         );


### PR DESCRIPTION
I used contextual binding to initialize my request handlers properly. At one point I wanted to use it for the __invoke method. But the Container::build method only cares about the constructor's parameters of the given concrete class which is reasonable.
So in this case, the binding depends on the chosen action which is defined by adding a new route to the router. That's why the Route should contain these possible bindings.

Basic usage:
```
class ExampleRequestHandler
{
    public function __invoke(A $a)
    {
        //some code
    }
}

Route::get('foo', ExampleRequestHandler::class)->lateBind(
    A::class,
    function () {
        $a = new A();
        //some code

        return $a;
    }
);
```

When the RouteDependencyResolverTrait resolves the method's parameter it tries to bind the lateBindings of the route.