### PR TITLE
[5.7] Changed return type in PhpDoc from mixed to void

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -64,7 +64,7 @@ abstract class Queue
      * @param  array   $jobs
      * @param  mixed   $data
      * @param  string  $queue
-     * @return mixed
+     * @return void
      */
     public function bulk($jobs, $data = '', $queue = null)
     {


### PR DESCRIPTION
 - changed return type in PhpDoc from `mixed` to `void` since method to not return anything:
 ```PHP
     public function bulk($jobs, $data = '', $queue = null)
     {
         foreach ((array) $jobs as $job) {
             $this->push($job, $data, $queue);
         }
     }
 ```

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
