### PR TITLE
[5.8] Make `Illuminate\Queue\Queue` implement `QueueContract`

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -5,9 +5,8 @@ namespace Illuminate\Queue;
 use Pheanstalk\Pheanstalk;
 use Pheanstalk\Job as PheanstalkJob;
 use Illuminate\Queue\Jobs\BeanstalkdJob;
-use Illuminate\Contracts\Queue\Queue as QueueContract;
 
-class BeanstalkdQueue extends Queue implements QueueContract
+class BeanstalkdQueue extends Queue
 {
     /**
      * The Pheanstalk instance.

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -6,9 +6,8 @@ use Illuminate\Support\Carbon;
 use Illuminate\Database\Connection;
 use Illuminate\Queue\Jobs\DatabaseJob;
 use Illuminate\Queue\Jobs\DatabaseJobRecord;
-use Illuminate\Contracts\Queue\Queue as QueueContract;
 
-class DatabaseQueue extends Queue implements QueueContract
+class DatabaseQueue extends Queue
 {
     /**
      * The database connection instance.

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Queue;
 
-use Illuminate\Contracts\Queue\Queue as QueueContract;
-
-class NullQueue extends Queue implements QueueContract
+class NullQueue extends Queue
 {
     /**
      * Get the size of the queue.

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -5,8 +5,9 @@ namespace Illuminate\Queue;
 use DateTimeInterface;
 use Illuminate\Container\Container;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Contracts\Queue\Queue as QueueContract;
 
-abstract class Queue
+abstract class Queue implements QueueContract
 {
     use InteractsWithTime;
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -5,9 +5,8 @@ namespace Illuminate\Queue;
 use Illuminate\Support\Str;
 use Illuminate\Queue\Jobs\RedisJob;
 use Illuminate\Contracts\Redis\Factory as Redis;
-use Illuminate\Contracts\Queue\Queue as QueueContract;
 
-class RedisQueue extends Queue implements QueueContract
+class RedisQueue extends Queue
 {
     /**
      * The Redis factory implementation.

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -4,9 +4,8 @@ namespace Illuminate\Queue;
 
 use Aws\Sqs\SqsClient;
 use Illuminate\Queue\Jobs\SqsJob;
-use Illuminate\Contracts\Queue\Queue as QueueContract;
 
-class SqsQueue extends Queue implements QueueContract
+class SqsQueue extends Queue
 {
     /**
      * The Amazon SQS instance.

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -6,10 +6,9 @@ use Exception;
 use Throwable;
 use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Contracts\Queue\Job;
-use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
 
-class SyncQueue extends Queue implements QueueContract
+class SyncQueue extends Queue
 {
     /**
      * Get the size of the queue.


### PR DESCRIPTION
made `Illuminate\Queue\Queue` implement `QueueContract`,
since `pushOn` method used `push` which not implemented in abstract class, but declared on interface;
```PHP
    public function pushOn($queue, $job, $data = '')
    {
        return $this->push($job, $data, $queue);
    }
```

also `laterOn` is used method which not present on abstract class

```PHP
    public function laterOn($queue, $delay, $job, $data = '')
    {
        return $this->later($delay, $job, $data, $queue);
    }
```

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
