### PR TITLE
[5.7] Change broadcast event name from within a notification

### DIFF
--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -103,4 +103,17 @@ class BroadcastNotificationCreated implements ShouldBroadcast
                     ? $this->notification->broadcastType()
                     : get_class($this->notification);
     }
+    
+    /**
+     * Get the type of the broadcasted event.
+     *
+     * @return string
+     */
+    public function broadcastAs()
+    {
+        if (method_exists($this->notification, 'broadcastAs')) {
+            return $this->notification->broadcastAs();
+        }
+         return static::class;
+    }
 }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -114,7 +114,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
         if (method_exists($this->notification, 'broadcastAs')) {
             return $this->notification->broadcastAs();
         }
-        
-         return static::class;
+
+        return static:class;
     }
 }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -115,6 +115,6 @@ class BroadcastNotificationCreated implements ShouldBroadcast
             return $this->notification->broadcastAs();
         }
 
-        return static:class;
+        return static::class;
     }
 }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -103,9 +103,9 @@ class BroadcastNotificationCreated implements ShouldBroadcast
                     ? $this->notification->broadcastType()
                     : get_class($this->notification);
     }
-    
+
     /**
-     * Get the type of the broadcasted event.
+     * Get the event name for the broadcasted event.
      *
      * @return string
      */
@@ -114,6 +114,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
         if (method_exists($this->notification, 'broadcastAs')) {
             return $this->notification->broadcastAs();
         }
+        
          return static::class;
     }
 }


### PR DESCRIPTION
We currently have support for changing the type and channel that a notifications broadcasts but we can't change the the eventname itself. This pull request does just that. 
Please merge in next (patch) version if possible. I need it for one of my projects.
