### PR TITLE
[5.7] Bind mix helper to the container to allow swapping in tests

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -7,6 +7,7 @@ use RuntimeException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
+use Illuminate\Foundation\Mix;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
@@ -140,6 +141,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         if ($basePath) {
             $this->setBasePath($basePath);
         }
+
+        $this->registerMixBinding();
 
         $this->registerBaseBindings();
 
@@ -287,6 +290,20 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $this->instance('path.database', $this->databasePath());
         $this->instance('path.resources', $this->resourcePath());
         $this->instance('path.bootstrap', $this->bootstrapPath());
+    }
+
+    /**
+     * Register the mix class binding.
+     *
+     * @return $this
+     */
+    public function registerMixBinding()
+    {
+        $this->singleton('mix', function () {
+            return new Mix;
+        });
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Illuminate\Foundation;
+
+use Exception;
+use Illuminate\Support\Str;
+use Illuminate\Support\HtmlString;
+
+class Mix
+{
+    /**
+     * Get the path to a versioned Mix file.
+     *
+     * @param  string  $path
+     * @param  string  $manifestDirectory
+     * @return \Illuminate\Support\HtmlString|string
+     *
+     * @throws \Exception
+     */
+    public function __invoke($path, $manifestDirectory = '')
+    {
+        static $manifests = [];
+
+        if (! Str::startsWith($path, '/')) {
+            $path = "/{$path}";
+        }
+
+        if ($manifestDirectory && ! Str::startsWith($manifestDirectory, '/')) {
+            $manifestDirectory = "/{$manifestDirectory}";
+        }
+
+        if (file_exists(public_path($manifestDirectory.'/hot'))) {
+            $url = rtrim(file_get_contents(public_path($manifestDirectory.'/hot')));
+
+            if (Str::startsWith($url, ['http://', 'https://'])) {
+                return new HtmlString(Str::after($url, ':').$path);
+            }
+
+            return new HtmlString("//localhost:8080{$path}");
+        }
+
+        $manifestPath = public_path($manifestDirectory.'/mix-manifest.json');
+
+        if (! isset($manifests[$manifestPath])) {
+            if (! file_exists($manifestPath)) {
+                throw new Exception('The Mix manifest does not exist.');
+            }
+
+            $manifests[$manifestPath] = json_decode(file_get_contents($manifestPath), true);
+        }
+
+        $manifest = $manifests[$manifestPath];
+
+        if (! isset($manifest[$path])) {
+            report(new Exception("Unable to locate Mix file: {$path}."));
+
+            if (! app('config')->get('app.debug')) {
+                return $path;
+            }
+        }
+
+        return new HtmlString($manifestDirectory.$manifest[$path]);
+    }
+}

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -576,47 +576,7 @@ if (! function_exists('mix')) {
      */
     function mix($path, $manifestDirectory = '')
     {
-        static $manifests = [];
-
-        if (! Str::startsWith($path, '/')) {
-            $path = "/{$path}";
-        }
-
-        if ($manifestDirectory && ! Str::startsWith($manifestDirectory, '/')) {
-            $manifestDirectory = "/{$manifestDirectory}";
-        }
-
-        if (file_exists(public_path($manifestDirectory.'/hot'))) {
-            $url = rtrim(file_get_contents(public_path($manifestDirectory.'/hot')));
-
-            if (Str::startsWith($url, ['http://', 'https://'])) {
-                return new HtmlString(Str::after($url, ':').$path);
-            }
-
-            return new HtmlString("//localhost:8080{$path}");
-        }
-
-        $manifestPath = public_path($manifestDirectory.'/mix-manifest.json');
-
-        if (! isset($manifests[$manifestPath])) {
-            if (! file_exists($manifestPath)) {
-                throw new Exception('The Mix manifest does not exist.');
-            }
-
-            $manifests[$manifestPath] = json_decode(file_get_contents($manifestPath), true);
-        }
-
-        $manifest = $manifests[$manifestPath];
-
-        if (! isset($manifest[$path])) {
-            report(new Exception("Unable to locate Mix file: {$path}."));
-
-            if (! app('config')->get('app.debug')) {
-                return $path;
-            }
-        }
-
-        return new HtmlString($manifestDirectory.$manifest[$path]);
+        return app('mix')(...func_get_args());
     }
 }
 

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -67,7 +67,7 @@ class FoundationHelpersTest extends TestCase
     {
         $file = 'unversioned.css';
 
-        app()->singleton('path.public', function () {
+        (new Application)->singleton('path.public', function () {
             return __DIR__;
         });
 
@@ -82,5 +82,15 @@ class FoundationHelpersTest extends TestCase
         $this->assertEquals('/versioned.css', $result);
 
         unlink(public_path('mix-manifest.json'));
+    }
+
+    public function testMixIsSwappableForTests()
+    {
+        $app = new Application;
+        $app->instance('mix', function () {
+            return 'expected';
+        });
+
+        $this->assertSame('expected', mix('asset.png'));
     }
 }


### PR DESCRIPTION
This PR binds the mix helper functionality to the container to allow it to be swapped easily during testing.

## Why is this even needed?

If a view is using the mix helper to retrieve an asset, and the key passed to the mix helper is created dynamically  i.e. related to a model attribute, you need to:

1. Create the manifest in the public directory, or wherever you have specified it goes in the `webpack.mix.js`
2. Add the file as a key value pair in the manifest.
3. Cleanup the file after the test has run.

## Example

You have a `Business` class. The class has a `resource_key` that relates to assets, such as a background image. This key is generated, in your tests, using `Faker`.

```php
{{ mix("backgrounds/{$business->resource_key}.png") }}
```

In order for me to be able to test this view I would need to do something like this...

```php
touch(public_path('mix-manifest.json'));

file_put_contents(public_path('mix-manifest.json'), json_encode([
    '/backgrounds/amazon.png' => '/backgrounds/amazon.png',
]));

// test some stuff that hits the mix helper as show above...

unlink(public_path('mix-manifest.json'));
```

With it bound to the container we can essentially "fake" the mix method:

```php
$this->app->instance('mix', function () { });

// test some stuff...
```

To keep the PR focused on what is actually happening I have not made *any* changes to the helpers code, but moving it to a dedicated class will mean that, if you wanted, we could also: 

- Remove the static variable and make it a class property (because it is registered as a singleton).
- Make a bunch of class helper methods to make what is happening a bit clearer in the conditionals / code blocks.