### PR TITLE
Update auth controllers to use with api rest

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -124,7 +124,7 @@ trait AuthenticatesUsers
             return response()->json([
                 'status' => trans('auth.authenticated'),
                 'user' => $user,
-                'token' => $token
+                'token' => $token,
             ]);
         }
 
@@ -183,7 +183,7 @@ trait AuthenticatesUsers
     {
         if ($request->expectsJson()) {
             return response()->json([
-                'status' => trans('auth.logout')
+                'status' => trans('auth.logout'),
             ]);
         }
 

--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -13,7 +13,7 @@ trait RegistersUsers
     /**
      * Show the application registration form.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\View\View
      */
     public function showRegistrationForm()
     {
@@ -24,7 +24,7 @@ trait RegistersUsers
      * Handle a registration request for the application.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\Response|\Illuminate\Http\JsonResponse
      */
     public function register(Request $request)
     {
@@ -32,10 +32,9 @@ trait RegistersUsers
 
         event(new Registered($user = $this->create($request->all())));
 
-        $this->guard()->login($user);
+        $token = $this->guard()->login($user);
 
-        return $this->registered($request, $user)
-                        ?: redirect($this->redirectPath());
+        return $this->registered($request, $user, $token);
     }
 
     /**
@@ -53,10 +52,19 @@ trait RegistersUsers
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  mixed  $user
-     * @return mixed
+     * @param  mixed  $token
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\Response|\Illuminate\Http\JsonResponse
      */
-    protected function registered(Request $request, $user)
+    protected function registered(Request $request, $user, $token = null)
     {
-        //
+        if ($request->expectsJson()) {
+            return response()->json([
+                'status' => trans('auth.registered'),
+                'user' => $user,
+                'token' => $token
+            ], 201);
+        }
+
+        return redirect($this->redirectPath());
     }
 }

--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -61,7 +61,7 @@ trait RegistersUsers
             return response()->json([
                 'status' => trans('auth.registered'),
                 'user' => $user,
-                'token' => $token
+                'token' => $token,
             ], 201);
         }
 

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -137,7 +137,7 @@ trait ResetsPasswords
             return response()->json([
                 'status' => trans($response),
                 'user' => $user,
-                'token' => $token
+                'token' => $token,
             ], 202);
         }
 
@@ -156,7 +156,7 @@ trait ResetsPasswords
     protected function sendResetFailedResponse(Request $request, $response)
     {
         throw ValidationException::withMessages([
-            'email' => trans($response)
+            'email' => trans($response),
         ]);
     }
 

--- a/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
+++ b/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
@@ -4,13 +4,14 @@ namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Validation\ValidationException;
 
 trait SendsPasswordResetEmails
 {
     /**
      * Display the form to request a password reset link.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\View\View
      */
     public function showLinkRequestForm()
     {
@@ -21,7 +22,9 @@ trait SendsPasswordResetEmails
      * Send a reset link to the given user.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+     *
+     * @throws \Illuminate\Validation\ValidationException
      */
     public function sendResetLinkEmail(Request $request)
     {
@@ -55,10 +58,14 @@ trait SendsPasswordResetEmails
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  string  $response
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\Response|\Illuminate\Http\JsonResponse
      */
     protected function sendResetLinkResponse(Request $request, $response)
     {
+        if ($request->expectsJson()) {
+            return response()->json(['status' => trans($response)]);
+        }
+
         return back()->with('status', trans($response));
     }
 
@@ -67,13 +74,15 @@ trait SendsPasswordResetEmails
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  string  $response
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @throws \Illuminate\Validation\ValidationException
      */
     protected function sendResetLinkFailedResponse(Request $request, $response)
     {
-        return back()
-                ->withInput($request->only('email'))
-                ->withErrors(['email' => trans($response)]);
+        throw ValidationException::withMessages([
+            'email' => trans($response)
+        ]);
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
+++ b/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
@@ -81,7 +81,7 @@ trait SendsPasswordResetEmails
     protected function sendResetLinkFailedResponse(Request $request, $response)
     {
         throw ValidationException::withMessages([
-            'email' => trans($response)
+            'email' => trans($response),
         ]);
     }
 


### PR DESCRIPTION
The laravel authentication controls are very useful on a day to day basis, but they do not fall into place when we are making an api with authentication.

With this PR for example the `login` method in `Illuminate\Foundation\Auth\AuthenticatesUsers` checks whether to redirect or return a json, in case of success add a token in your response.

These enhancements would further facilitate the creation of an api rest with authentication.