### PR TITLE
[5.7] Add an sqlite config option to enable foreign key constraints

### DIFF
--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -11,6 +11,23 @@ use Illuminate\Database\Schema\Grammars\SQLiteGrammar as SchemaGrammar;
 class SQLiteConnection extends Connection
 {
     /**
+     * Create a new database connection instance.
+     *
+     * @param  \PDO|\Closure     $pdo
+     * @param  string   $database
+     * @param  string   $tablePrefix
+     * @param  array    $config
+     * @return void
+     */
+    public function __construct($pdo, $database = '', $tablePrefix = '', array $config = [])
+    {
+        parent::__construct($pdo, $database, $tablePrefix, $config);
+
+        if ($this->getForeignKeyConstraintsSetting() == true) {
+            $this->getSchemaBuilder()->enableForeignKeyConstraints();
+        }
+    }
+    /**
      * Get the default query grammar instance.
      *
      * @return \Illuminate\Database\Query\Grammars\SQLiteGrammar
@@ -62,5 +79,15 @@ class SQLiteConnection extends Connection
     protected function getDoctrineDriver()
     {
         return new DoctrineDriver;
+    }
+
+    /**
+     * Get the database connection foreign_key_constraints setting.
+     *
+     * @return boolean|null
+     */
+    protected function getForeignKeyConstraintsSetting()
+    {
+        return $this->getConfig('foreign_key_constraints');
     }
 }

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -102,4 +102,17 @@ class DatabaseConnectionFactoryTest extends TestCase
 
         $this->assertEquals('connector', $factory->createConnector(['driver' => 'foo']));
     }
+
+    public function testSqliteForeignKeyConstraints()
+    {
+        $this->db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'foreign_key_constraints' => true,
+        ], 'constraints_set');
+
+        $this->assertEquals(0, $this->db->connection()->select('PRAGMA foreign_keys')[0]->foreign_keys);
+
+        $this->assertEquals(1, $this->db->connection('constraints_set')->select('PRAGMA foreign_keys')[0]->foreign_keys);
+    }
 }


### PR DESCRIPTION
For Sqlite, foreign key constraints need to be explicitly enabled for every database connection. So enabling them in the migrations (as suggestednby the documentation) does not work.

This PR enables the contraints for every connection to an sqlite database that has the config option `foreign_key_constraints` set to `true`.

If the option is not set, nothing changes, so no breaking change is introduced.

As foreign key constraints are the default behavior for all other databases I suggest switching this around for the next release and enable foreign keys unless this is set to `false`.

If this is accepted I'll submit two more PRs for documentation and laravel/laravel.