### PR TITLE
Pass request parameter name instead or numeric array key to cleanValu…

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
@@ -65,10 +65,13 @@ class TransformsRequest
      * @param  array  $data
      * @return array
      */
-    protected function cleanArray(array $data)
+    protected function cleanArray(array $data, $key = '')
     {
-        return collect($data)->map(function ($value, $key) {
-            return $this->cleanValue($key, $value);
+        return collect($data)->map(function ($arrayValue, $arrayKey) use ($key) {
+            if ($key != '') {
+                $arrayKey = $key;
+            }
+            return $this->cleanValue($arrayKey, $arrayValue);
         })->all();
     }
 
@@ -82,7 +85,7 @@ class TransformsRequest
     protected function cleanValue($key, $value)
     {
         if (is_array($value)) {
-            return $this->cleanArray($value);
+            return $this->cleanArray($value, $key);
         }
 
         return $this->transform($key, $value);


### PR DESCRIPTION
…e() in TransformsRequest

<!--
Adding array attributes to $except in TrimStrings middleware wasn't working because in TransformsRequest, the attribute name was not passed to cleanArray().

This is an attempt to fix that. Note: this my first pull request ever, so sorry for any inconvenience.
-->
