### PR TITLE
[5.7] Cast sqlite foreign key constraints configuration

### DIFF
--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -23,7 +23,7 @@ class SQLiteConnection extends Connection
     {
         parent::__construct($pdo, $database, $tablePrefix, $config);
 
-        if ($this->getForeignKeyConstraintsConfigurationValue() == true) {
+        if ($this->getForeignKeyConstraintsConfigurationValue()) {
             $this->getSchemaBuilder()->enableForeignKeyConstraints();
         }
     }
@@ -85,10 +85,10 @@ class SQLiteConnection extends Connection
     /**
      * Get the database connection foreign key constraints configuration option.
      *
-     * @return bool|null
+     * @return bool
      */
     protected function getForeignKeyConstraintsConfigurationValue()
     {
-        return $this->getConfig('foreign_key_constraints');
+        return (bool) $this->getConfig('foreign_key_constraints');
     }
 }


### PR DESCRIPTION
Instead of delegating the value casting to every caller of this method (which is going to be used for boolean operations), it now handles it itself.

This is a safe refactor because missing configurations are going to return `null` and therefore be casted as `false`.