### PR TITLE
[5.8] Add encrypter throws docblock

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -114,6 +114,8 @@ class Encrypter implements EncrypterContract
      *
      * @param  string  $value
      * @return string
+     *
+     * @throws \Illuminate\Contracts\Encryption\EncryptException
      */
     public function encryptString($value)
     {
@@ -154,6 +156,8 @@ class Encrypter implements EncrypterContract
      *
      * @param  string  $payload
      * @return string
+     *
+     * @throws \Illuminate\Contracts\Encryption\DecryptException
      */
     public function decryptString($payload)
     {


### PR DESCRIPTION
- Encrypter::encryptString() method may throw an EncryptException that comes from Encrypter::encrypt() method.

- Encrypter::decryptString() method may throw a DecryptException that comes from Encrypter:decrypt() method.