### PR TITLE
[5.8] Fix contextual var docblock

### DIFF
--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -17,7 +17,7 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
     /**
      * The concrete instance.
      *
-     * @var string
+     * @var string|array
      */
     protected $concrete;
 


### PR DESCRIPTION
ContextualBindingBuilder::$concrete may also be an array.

Let's see the creation of ContextualBindingBuilder inside the Container class.
```php
/**
 * Define a contextual binding.
 *
 * @param  array|string  $concrete
 * @return \Illuminate\Contracts\Container\ContextualBindingBuilder
 */
public function when($concrete)
{
    $aliases = [];

    foreach (Arr::wrap($concrete) as $c) {
        $aliases[] = $this->getAlias($c);
    }

    return new ContextualBindingBuilder($this, $aliases);
}
```