### PR TITLE
[5.7] Allow disabling sqlite foreign keys

### DIFF
--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -22,9 +22,16 @@ class SQLiteConnection extends Connection
     public function __construct($pdo, $database = '', $tablePrefix = '', array $config = [])
     {
         parent::__construct($pdo, $database, $tablePrefix, $config);
+        
+        $enableForeignKeyConstraints = $this->getForeignKeyConstraintsConfigurationValue();
 
-        if ($this->getForeignKeyConstraintsConfigurationValue() == true) {
-            $this->getSchemaBuilder()->enableForeignKeyConstraints();
+        if ($enableForeignKeyConstraints === null) {
+            return;
+        }
+
+        $enableForeignKeyConstraints
+            ? $this->getSchemaBuilder()->enableForeignKeyConstraints()
+            : $this->getSchemaBuilder()->disableForeignKeyConstraints();
         }
     }
 

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -22,7 +22,7 @@ class SQLiteConnection extends Connection
     public function __construct($pdo, $database = '', $tablePrefix = '', array $config = [])
     {
         parent::__construct($pdo, $database, $tablePrefix, $config);
-        
+
         $enableForeignKeyConstraints = $this->getForeignKeyConstraintsConfigurationValue();
 
         if ($enableForeignKeyConstraints === null) {

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -32,7 +32,6 @@ class SQLiteConnection extends Connection
         $enableForeignKeyConstraints
             ? $this->getSchemaBuilder()->enableForeignKeyConstraints()
             : $this->getSchemaBuilder()->disableForeignKeyConstraints();
-        }
     }
 
     /**


### PR DESCRIPTION
https://github.com/laravel/framework/pull/26298 added the ability to enable foreign key constraints for sqlite datbase connections using a config value. This PR allows you to disable foreign key constraints by setting the config value to `false`.