### PR TITLE
[5.7] Allow adding additional $manyMethods when extending the model class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -41,7 +41,6 @@ trait HasRelationships
      */
     public static $manyMethods = [
         'belongsToMany', 'morphToMany', 'morphedByMany',
-        'guessBelongsToManyRelation', 'findFirstMethodThatIsntRelation',
     ];
 
     /**
@@ -546,14 +545,19 @@ trait HasRelationships
     }
 
     /**
-     * Get the relationship name of the belongs to many.
+     * Get the relationship name of the belongsToMany.
      *
-     * @return string
+     * @return string|null
      */
     protected function guessBelongsToManyRelation()
     {
+        // Search the call stack for the name of the relationship defined in the model
         $caller = Arr::first(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), function ($trace) {
-            return ! in_array($trace['function'], Model::$manyMethods);
+            // Exclude names of the relationship methods and this method itself
+            return ! in_array(
+                $trace['function'],
+                array_merge(static::$manyMethods, ['guessBelongsToManyRelation'])
+            );
         });
 
         return ! is_null($caller) ? $caller['function'] : null;


### PR DESCRIPTION
## Motivation

This allows adding additional $manyMethods when extending the model class
and still receive a correct guess for the relationship name.

I have to overwrite the `BelongsToMany` relationship class in my application.
To return such a relationship, i also extended the `Model` class with a custom
method that returns an instance of my particular relationship clas.

## Changes

Access the $manyMethods property through `static::$manyMethods` instead of
`Model::$manyMethods`. This both reduces coupling between the trait and the Model
class and allows for extensibility.

Removed the name of guessBelongsToManyRelation from the list but still consider
it when analyzing the call stack. This makes $manyMethods more slim and easier
to override.

Removed findFirstMethodThatIsntRelation from $hasMany array, since it does not
appear anywhere in the code and seems to have been forgotten there.
It is also not really a name for a many-relationship method, so if it is needed,
i think there might be a better place for it.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
