### PR TITLE
add dropColumns Feature

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -294,12 +294,23 @@ class Blueprint
     }
 
     /**
+     * Indicate that the given column should be dropped.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function dropColumn($column)
+    {
+        return $this->dropColumns($column);
+    }
+
+    /**
      * Indicate that the given columns should be dropped.
      *
      * @param  array|mixed  $columns
      * @return \Illuminate\Support\Fluent
      */
-    public function dropColumn($columns)
+    public function dropColumns($columns)
     {
         $columns = is_array($columns) ? $columns : func_get_args();
 


### PR DESCRIPTION
add `dropColumns` function

Instead of doing that
```php
Schema::table('users', function (Blueprint $table) {
    $table->dropColumn('votes');
});

Schema::table('users', function (Blueprint $table) {
    $table->dropColumn(['votes', 'avatar', 'location']);
});
```

we can do 

```php
Schema::table('users', function (Blueprint $table) {
    $table->dropColumn('votes');
});

Schema::table('users', function (Blueprint $table) {
    $table->dropColumns(['votes', 'avatar', 'location']);
});
```