### PR TITLE
[5.7] Use Request::validate() macro in Auth traits

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -63,7 +63,7 @@ trait AuthenticatesUsers
      */
     protected function validateLogin(Request $request)
     {
-        $this->validate($request, [
+        $request->validate([
             $this->username() => 'required|string',
             'password' => 'required|string',
         ]);

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -37,7 +37,7 @@ trait ResetsPasswords
      */
     public function reset(Request $request)
     {
-        $this->validate($request, $this->rules(), $this->validationErrorMessages());
+        $request->validate($this->rules(), $this->validationErrorMessages());
 
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the

--- a/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
+++ b/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
@@ -47,7 +47,7 @@ trait SendsPasswordResetEmails
      */
     protected function validateEmail(Request $request)
     {
-        $this->validate($request, ['email' => 'required|email']);
+        $request->validate(['email' => 'required|email']);
     }
 
     /**


### PR DESCRIPTION
The traits `AuthenticatesUsers`, `ResetsPasswords`, and `SendsPasswordResetEmails` currently call `ValidatesRequests::validate()` in order to validate request data. However, `ValidatesRequests` is not listed as a dependency of these traits and even though the base controller of the default Laravel installation includes this trait, it is technically optional.

This PR uses the `Request::validate()` function that is macroed in `FoundationServiceProvider` since 5.5 (#19063) because that is more likely to be available.

This is technically a breaking change because it's possible for an installation not to include `FoundationServiceProvider`. However, all examples of validation in the Laravel documentation use this method instead and it is much more likely that a developer would remove the `ValidatesRequests` trait from the base controller for disuse than for the `FoundationServiceProvider` to be removed, especially considering that there is no mention of `FoundationServiceProvider` or of removing the framework service providers in `config/app.php` in the documentation. Still, I'm willing to resubmit this for 5.8.