### PR TITLE
[5.7] Update CacheManager::driver @return directive

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -62,7 +62,7 @@ class CacheManager implements FactoryContract
      * Get a cache driver instance.
      *
      * @param  string|null  $driver
-     * @return mixed
+     * @return \Illuminate\Contracts\Cache\Repository
      */
     public function driver($driver = null)
     {


### PR DESCRIPTION
The driver method only calls the store method which return type is `\Illuminate\Contracts\Cache\Repository`, so this should be the same one.