### PR TITLE
[5.7] Fix @param directives for cache store

### DIFF
--- a/src/Illuminate/Contracts/Cache/Store.php
+++ b/src/Illuminate/Contracts/Cache/Store.php
@@ -26,7 +26,7 @@ interface Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  float|int  $minutes
      * @return void
      */
@@ -45,7 +45,7 @@ interface Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function increment($key, $value = 1);
@@ -54,7 +54,7 @@ interface Store
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function decrement($key, $value = 1);
@@ -63,7 +63,7 @@ interface Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value);


### PR DESCRIPTION
Some of this docblocks were using 3 spaces instead of the recommended 2 in the contributions page.
