### PR TITLE
[5.8] Fix http kernel return docblock

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -319,7 +319,7 @@ class Kernel implements KernelContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception  $e
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response
      */
     protected function renderException($request, Exception $e)
     {


### PR DESCRIPTION
The Illuminate\Foundation\Http\Kernel::handle() method has to return an Illuminate\Http\Response instance as which type it is hinted.

The Illuminate\Foundation\Http\Kernel::renderException() method also has to return the same type because it's called inside the handle block and it's result may be returned from handle on catching an exception.

