### PR TITLE
[5.8] Test router returns original symfony response

### DIFF
--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -25,6 +25,8 @@ use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpFoundation\JsonResponse as SymfonyJsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;
 
 class RoutingRouteTest extends TestCase
 {
@@ -1544,6 +1546,29 @@ class RoutingRouteTest extends TestCase
         $response = $router->dispatch(Request::create('contact_us', 'GET'));
         $this->assertTrue($response->isRedirect('contact'));
         $this->assertEquals(301, $response->getStatusCode());
+    }
+
+    /**
+     * @dataProvider originalSymfonyResponseProvider
+     */
+    public function testReturnOrignalSymfonyResponse(SymfonyResponse $response)
+    {
+        $router = $this->getRouter();
+
+        $router->get('/', function () use ($response) {
+            return $response;
+        });
+
+        $this->assertSame($response, $router->dispatch(Request::create('/')));
+    }
+
+    public function originalSymfonyResponseProvider()
+    {
+        return [
+            [new SymfonyResponse('A symfony response')],
+            [new SymfonyJsonResponse('A symfony json response')],
+            [new SymfonyRedirectResponse('A symfony json response')],
+        ];
     }
 
     protected function getRouter()


### PR DESCRIPTION
Normally the router also returns an original symfony response. That means if a controller returns a symfony response, the router won't transform it into an illuminate response. Let's make some tests to ensure that this behavior will be controlled if any future changes.

Please take a look at the tests for more details!

Anyway, I think it's better to fix returns docblock of Router::dispatch() and some related methods because they don't always return an illuminate response. For me, this is more suitable.

https://github.com/laravel/framework/pull/26097

```php
/**
 * Dispatch the request to the application.
 *
 * @param  \Illuminate\Http\Request  $request
 * @return \Symfony\Component\HttpFoundation\Response
 */
public function dispatch(Request $request)
```