### PR TITLE
[5.7] Migrator double regexp execution with getMigrationName

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -429,11 +429,9 @@ class Migrator
     {
         return Collection::make($paths)->flatMap(function ($path) {
             return $this->files->glob($path.'/*_*.php');
-        })->filter()->sortBy(function ($file) {
+        })->filter()->values()->keyBy(function ($file) {
             return $this->getMigrationName($file);
-        })->values()->keyBy(function ($file) {
-            return $this->getMigrationName($file);
-        })->all();
+        })->sortKeys()->all();
     }
 
     /**


### PR DESCRIPTION
This pull request fix double execution of getMigrationName in Migrator::getMigrationFiles
Instead of execution of sortBy callback kindly easier to use sortKeys.