### PR TITLE
[5.7] Updating AbstractPaginator::appends to handle null

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -191,12 +191,16 @@ abstract class AbstractPaginator implements Htmlable
     /**
      * Add a set of query string values to the paginator.
      *
-     * @param  array|string  $key
+     * @param  array|string|null  $key
      * @param  string|null  $value
      * @return $this
      */
     public function appends($key, $value = null)
     {
+        if (is_null($key)) {
+            return $this;
+        }
+        
         if (is_array($key)) {
             return $this->appendArray($key);
         }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -200,7 +200,7 @@ abstract class AbstractPaginator implements Htmlable
         if (is_null($key)) {
             return $this;
         }
-        
+
         if (is_array($key)) {
             return $this->appendArray($key);
         }


### PR DESCRIPTION
This method is most commonly used with `$request->query()` which recently changed docblock [1] also to return `null`. Same as original commit, this is to make PHPStan happy.

```
$events = $query->paginate($perPage);
$events->appends($request->query());
```

[1] https://github.com/laravel/framework/pull/25954
