### PR TITLE
[5.7] an array of messages for custom validation rules

### DIFF
--- a/src/Illuminate/Contracts/Validation/Rule.php
+++ b/src/Illuminate/Contracts/Validation/Rule.php
@@ -16,7 +16,7 @@ interface Rule
     /**
      * Get the validation error message.
      *
-     * @return string
+     * @return string|array
      */
     public function message();
 }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -547,9 +547,13 @@ class Validator implements ValidatorContract
         if (! $rule->passes($attribute, $value)) {
             $this->failedRules[$attribute][get_class($rule)] = [];
 
-            $this->messages->add($attribute, $this->makeReplacements(
-                $rule->message(), $attribute, get_class($rule), []
-            ));
+            $messages = (array) $rule->message();
+
+            foreach ($messages as $message){
+                $this->messages->add($attribute, $this->makeReplacements(
+                    $message, $attribute, get_class($rule), []
+                ));
+            }
         }
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -549,7 +549,7 @@ class Validator implements ValidatorContract
 
             $messages = (array) $rule->message();
 
-            foreach ($messages as $message){
+            foreach ($messages as $message) {
                 $this->messages->add($attribute, $this->makeReplacements(
                     $message, $attribute, get_class($rule), []
                 ));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4128,6 +4128,49 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('states.0 must be AR or TX', $v->errors()->get('states.0')[0]);
         $this->assertEquals('states.1 must be AR or TX', $v->errors()->get('states.1')[0]);
         $this->assertEquals('number must be divisible by 4', $v->errors()->get('number')[0]);
+
+        // Test array of messages with failing case...
+        $v = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['name' => 42],
+            ['name' => new class implements Rule {
+                public function passes($attribute, $value)
+                {
+                    return $value === 'taylor';
+                }
+
+                public function message()
+                {
+                    return [':attribute must be taylor', ':attribute must be a first name'];
+                }
+            }]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals('name must be taylor', $v->errors()->get('name')[0]);
+        $this->assertEquals('name must be a first name', $v->errors()->get('name')[1]);
+
+        // Test array of messages with multiple rules for one attribute case...
+        $v = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['name' => 42],
+            ['name' => [new class implements Rule {
+                public function passes($attribute, $value)
+                {
+                    return $value === 'taylor';
+                }
+
+                public function message()
+                {
+                    return [':attribute must be taylor', ':attribute must be a first name'];
+                }
+            }, 'string']]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals('name must be taylor', $v->errors()->get('name')[0]);
+        $this->assertEquals('name must be a first name', $v->errors()->get('name')[1]);
+        $this->assertEquals('validation.string', $v->errors()->get('name')[2]);
     }
 
     public function testImplicitCustomValidationObjects()


### PR DESCRIPTION
At a current project we're working on we have a lot(+200) rules for validating a request. The solution is splitting these rules into separate custom rule classes. Like so

```php
// Before
'units.*.articles.*.date_start' => 'required|date', 
'units.*.articles.*.date_end' => 'required|date',

// After
'units.*.articles' => new UnitArticlesRule,
```

Then in our UnitArticlesRule class we do the following:

```php
class HabitantContractArticlesRule implements Rule
{
    /** @var array */
    protected $messages = [];

    public function passes($attribute, $value)
    {
        foreach ($value as $article){
            $validator = Validator::make($article, $this->rules($article));

            if($validator->fails()){
                $this->messages = array_merge($this->messages, $validator->errors()->all());
            }
        }

        return count($this->messages) === [];
    }

    public function message()
    {
        return $this->messages;
    }

    public function rules(array $article){
        $rules = [
            'date_start' => 'nullable|date',
            'date_end' => 'nullable|date',
        ];

        if($article['date_start'] !== null){
            $rules["date_end"][] = 'after:' . Carbon::make($article['date_start']);
         }

        return $rules;
    }
}

```
As you can see, multiple articles can have validation errors. In the current implementations of custom validation rules we can only return a string. This PR adds the ability to return an array of messages so the example above will work.

The PR won't break any functionality and two tests are added.