### PR TITLE
[5.7] Add UTF-8 slug without explicit language code

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -412,12 +412,12 @@ class Str
      *
      * @param  string  $title
      * @param  string  $separator
-     * @param  string  $language
+     * @param  string|null  $language
      * @return string
      */
     public static function slug($title, $separator = '-', $language = 'en')
     {
-        $title = static::ascii($title, $language);
+        $title = $language ? static::ascii($title, $language) : $title;
 
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -142,6 +142,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('hello-world', Str::slug('hello_world'));
         $this->assertEquals('hello_world', Str::slug('hello_world', '_'));
         $this->assertEquals('user-at-host', Str::slug('user@host'));
+        $this->assertEquals('سلام-دنیا', Str::slug('سلام دنیا', '-', null));
     }
 
     public function testFinish()


### PR DESCRIPTION
This commit helps slug to remain UTF-8 if the language parameter set to `null`, default output is not perfect for user or search engines, this keeps the slug in the same input language.

for example:
```php
\Illuminate\Support\Str::slug('سلام دنیا', '-', null); // سلام-دنیا
\Illuminate\Support\Str::slug('سلام دنیا'); // slam-dnia
```

second output is more like a random output in my language (Persian).
This does not break the default behaviour of the `slug` method.