### PR TITLE
[5.7] Cookie::get() doc block fixed.

### DIFF
--- a/src/Illuminate/Support/Facades/Cookie.php
+++ b/src/Illuminate/Support/Facades/Cookie.php
@@ -27,7 +27,7 @@ class Cookie extends Facade
      *
      * @param  string  $key
      * @param  mixed   $default
-     * @return string
+     * @return string|array|null
      */
     public static function get($key = null, $default = null)
     {


### PR DESCRIPTION
`Cookie::get()` returns not only the `string`, but also the `array` and `null`, as the underlying `Http\Request` does.

```php
$array = Cookie::get();
```

```php
$null = Cookie::get('foo');
```