### PR TITLE
[5.8] Test for TrimStrings middleware

### DIFF
--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Http\Middleware\TrimStrings;
+
+class TrimStringsTest extends TestCase
+{
+    public function testTrimSimpleFields()
+    {
+        $middleware = new TrimStrings;
+        $request = new Request(
+            [
+                'field1' => 'value1',
+                'field2' => '  value2  ',
+            ]
+        );
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals('value1', $request->get('field1'));
+            $this->assertEquals('value2', $request->get('field2'));
+        });
+    }
+
+    /** @test */
+    public function testTrimArrayFields()
+    {
+        $middleware = new TrimStrings;
+        $request = new Request(
+            [
+                'field1' => ['value1', 'value2'],
+                'field2' => ['  value1  ', '  value2  '],
+            ]
+        );
+
+        $middleware->handle($request, function (Request $request) {
+            $t1 = $request->get('field1');
+            $this->assertEquals('value1', $t1[0]);
+            $this->assertEquals('value2', $t1[1]);
+
+            $t2 = $request->get('field2');
+            $this->assertEquals('value1', $t2[0]);
+            $this->assertEquals('value2', $t2[1]);
+        });
+    }
+
+    public function testTrimSimpleFieldsExceptSome()
+    {
+        $middleware = new TrimStringsExcept;
+
+        $request = new Request(
+            [
+                'field1' => 'value1',
+                'field2' => ' value2 ',
+            ]
+        );
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals('value1', $request->get('field1'));
+            $this->assertEquals(' value2 ', $request->get('field2'));
+        });
+    }
+
+    public function testTrimArrayFieldsExceptSome()
+    {
+        $middleware = new TrimStringsExcept;
+        $request = new Request(
+            [
+                'field1' => ['value1', 'value2'],
+                'field2' => ['  value1  ', '  value2  '],
+            ]
+        );
+
+        $middleware->handle($request, function (Request $request) {
+            $t1 = $request->get('field1');
+            $this->assertEquals('value1', $t1[0]);
+            $this->assertEquals('value2', $t1[1]);
+
+            $t2 = $request->get('field2');
+            $this->assertEquals('  value1  ', $t2[0]);
+            $this->assertEquals('  value2  ', $t2[1]);
+        });
+    }
+}
+
+class TrimStringsExcept extends TrimStrings
+{
+    protected $except = [
+        'field2',
+    ];
+}


### PR DESCRIPTION
This test is a bug report for the TrimStrings middleware class. The test fails because array parameters declared in $except are ignored: the array values are trimmed anyway. 

I proposed a fix yesterday:
https://github.com/laravel/framework/pull/26301/files

This is one of my first pull requests, sorry if I missed something.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
