### PR TITLE
[5.8] Fix timestampTz() without precision on SQL Server

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -581,13 +581,9 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTimestampTz(Fluent $column)
     {
-        if ($column->useCurrent) {
-            $columnType = $column->precision ? "datetimeoffset($column->precision)" : 'datetimeoffset';
+        $columnType = $column->precision ? "datetimeoffset($column->precision)" : 'datetimeoffset';
 
-            return "$columnType default CURRENT_TIMESTAMP";
-        }
-
-        return "datetimeoffset($column->precision)";
+        return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
     }
 
     /**

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -610,7 +610,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetimeoffset(0) not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetimeoffset not null', $statements[0]);
     }
 
     public function testAddingTimestampTzWithPrecision()
@@ -637,7 +637,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestampsTz();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetimeoffset(0) null, "updated_at" datetimeoffset(0) null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetimeoffset null, "updated_at" datetimeoffset null', $statements[0]);
     }
 
     public function testAddingRememberToken()


### PR DESCRIPTION
The behavior of `timestampTz()` is inconsistent with `dateTimeTz()` when the user doesn't specify a precision:

```php
Schema::create('users', function (Blueprint $table) {
    $table->timestampTz('created_at');
});
Schema::create('users', function (Blueprint $table) {
    $table->dateTimeTz('created_at');
});
```

```sql
create table "users" ("created_at" datetimeoffset(0) not null)
create table "users" ("created_at" datetimeoffset not null)
```

`datetimeoffset(0)` and `datetimeoffset` are different:
https://docs.microsoft.com/en-us/sql/t-sql/data-types/datetimeoffset-transact-sql

`dateTime()` and `timestamp()` both don't append `(0)`, so `datetimeoffset` should be the expected result.