### PR TITLE
[5.7] Eloquent Trait Get and Set Attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -178,7 +178,7 @@ trait HasAttributes
         if (! empty(static::$traitGetAttributes[static::class])) {
             foreach (static::$traitGetAttributes[static::class] as $method) {
                 foreach ($attributes as $key => $value) {
-                    if (!in_array($key, $mutatedAttributes)) {
+                    if (! in_array($key, $mutatedAttributes)) {
                         $attributes[$key] = $this->{$method}($key, $value);
                     }
                 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -128,6 +128,20 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected static $traitInitializers = [];
 
     /**
+     * The array of trait get attributes that will be called on each get attributes.
+     *
+     * @var array
+     */
+    protected static $traitGetAttributes = [];
+
+    /**
+     * The array of trait set attributes that will be called on each set attributes.
+     *
+     * @var array
+     */
+    protected static $traitSetAttributes = [];
+
+    /**
      * The array of global scopes on the model.
      *
      * @var array
@@ -222,12 +236,20 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                 $booted[] = $method;
             }
 
-            if (method_exists($class, $method = 'initialize'.class_basename($trait))) {
-                static::$traitInitializers[$class][] = $method;
+            $checkers = [
+                'initialize' => 'traitInitializers',
+                'getAttribute' => 'traitGetAttributes',
+                'setAttribute' => 'traitSetAttributes'
+            ];
 
-                static::$traitInitializers[$class] = array_unique(
-                    static::$traitInitializers[$class]
-                );
+            foreach ($checkers as $methodName => $staticName) {
+                if (method_exists($class, $method = $methodName.class_basename($trait))) {
+                    static::${$staticName}[$class][] = $method;
+
+                    static::${$staticName}[$class] = array_unique(
+                        static::${$staticName}[$class]
+                    );
+                }
             }
         }
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -239,7 +239,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $checkers = [
                 'initialize' => 'traitInitializers',
                 'getAttribute' => 'traitGetAttributes',
-                'setAttribute' => 'traitSetAttributes'
+                'setAttribute' => 'traitSetAttributes',
             ];
 
             foreach ($checkers as $methodName => $staticName) {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1396,6 +1396,26 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->fooBarIsInitialized);
     }
 
+    public function testModelsTraitSetters()
+    {
+        $model = new EloquentModelStubWithTrait;
+        $model->test = 8;
+        $this->assertSame(16, $model->getTestValue());
+    }
+
+    public function testModelsTraitGetters()
+    {
+        $model = new EloquentModelStubWithTrait;
+        $model->test = 8;
+        $this->assertSame(4, $model->test);
+
+        // Test mutated attributes don't go through the traits getter and setters
+        $model->test_mutated = 8;
+        $this->assertSame(8, $model->test_mutated);
+
+        $this->assertSame(['test' => 4, 'test_mutated' => 8], $model->attributesToArray());
+    }
+
     public function testAppendingOfAttributes()
     {
         $model = new EloquentModelAppendsStub;
@@ -1945,6 +1965,31 @@ trait FooBarTrait
     public function initializeFooBarTrait()
     {
         $this->fooBarIsInitialized = true;
+    }
+
+    public function getAttributeFooBarTrait($key, $value)
+    {
+        return $value / 4;
+    }
+
+    public function setAttributeFooBarTrait($key, $value)
+    {
+        return $value * 2;
+    }
+
+    public function getTestMutatedAttribute($value)
+    {
+        return $value;
+    }
+
+    public function setTestMutatedAttribute($value)
+    {
+        return $this->attributes['test_mutated'] = $value;
+    }
+
+    public function getTestValue()
+    {
+        return $this->attributes['test'];
     }
 }
 


### PR DESCRIPTION
Lately I have been using traits to add functionality to my eloquent models and have run into an issue when multiple traits need to override `setAttribute` and `getAttribute`. There is a workaround to this where your model can define these methods and then call the trait methods but this doesn't seem right. 

This pull request solves this by storing if the trait has the getters or setters much like how the boot trait method works. So if you have a trait called `FooBar` you can defined the methods `getAttributeFooBar` and `setAttributeFooBar`.

This will be very useful for traits wanting to add custom functionally for example an Encryption Trait.

If the main model has an overriding get or set mutator the trait versions will not be called. This keeps it inline with how Eloquent currently works.