### PR TITLE
[5.7] Add sub domain method

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,6 +30,6 @@
       <env name="REDIS_HOST" value="127.0.0.1" />
       <env name="REDIS_PORT" value="6379" />
       -->
-        <env name="APP_URL" value="http://foo.bar" />
+        <env name="APP_URL" value="http://localhost/" />
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,5 +30,6 @@
       <env name="REDIS_HOST" value="127.0.0.1" />
       <env name="REDIS_PORT" value="6379" />
       -->
+        <env name="BASE_NAME" value="foo.bar" />
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,6 +30,5 @@
       <env name="REDIS_HOST" value="127.0.0.1" />
       <env name="REDIS_PORT" value="6379" />
       -->
-        <env name="APP_URL" value="http://localhost/" />
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,6 +30,6 @@
       <env name="REDIS_HOST" value="127.0.0.1" />
       <env name="REDIS_PORT" value="6379" />
       -->
-        <env name="BASE_NAME" value="foo.bar" />
+        <env name="APP_URL" value="http://foo.bar" />
     </php>
 </phpunit>

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -569,7 +569,7 @@ class Route
      */
     public function subDomain($subDomain, $domain = null)
     {
-        $this->action['domain'] = $subDomain.".".($domain ?? env("BASE_NAME"));
+        $this->action['domain'] = $subDomain.'.'.($domain ?? env('BASE_NAME'));
 
         return $this;
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use Closure;
+use Illuminate\Support\Facades\Config;
 use LogicException;
 use ReflectionFunction;
 use Illuminate\Support\Arr;
@@ -570,7 +571,7 @@ class Route
     public function subDomain($subDomain, $domain = null)
     {
         if (is_null($domain)) {
-            $domain = parse_url(env('APP_URL'))['host'];
+            $domain = parse_url(getenv('APP_URL'))['host'];
         }
 
         $this->action['domain'] = $subDomain.'.'.$domain;

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -569,7 +569,11 @@ class Route
      */
     public function subDomain($subDomain, $domain = null)
     {
-        $this->action['domain'] = $subDomain.'.'.($domain ?? env('BASE_NAME'));
+        if (is_null($domain)) {
+            $domain = parse_url(env('APP_URL'))['host'];
+        }
+
+        $this->action['domain'] = $subDomain.'.'.$domain;
 
         return $this;
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Routing;
 
 use Closure;
-use Illuminate\Support\Facades\Config;
 use LogicException;
 use ReflectionFunction;
 use Illuminate\Support\Arr;

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -561,6 +561,20 @@ class Route
     }
 
     /**
+     * Get the sub domain for the route.
+     *
+     * @param string $subDomain
+     * @param string|null $domain
+     * @return $this
+     */
+    public function subDomain($subDomain, $domain = null)
+    {
+        $this->action['domain'] = $subDomain . "." . ( $domain ?? env("BASE_NAME") );
+
+        return $this;
+    }
+
+    /**
      * Get the domain defined for the route.
      *
      * @return string|null

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -569,7 +569,7 @@ class Route
      */
     public function subDomain($subDomain, $domain = null)
     {
-        $this->action['domain'] = $subDomain . "." . ( $domain ?? env("BASE_NAME") );
+        $this->action['domain'] = $subDomain.".".($domain ?? env("BASE_NAME"));
 
         return $this;
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -3,8 +3,6 @@
 namespace Illuminate\Routing;
 
 use Closure;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Config;
 use LogicException;
 use ReflectionFunction;
 use Illuminate\Support\Arr;

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Routing;
 
 use Closure;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
 use LogicException;
 use ReflectionFunction;
 use Illuminate\Support\Arr;
@@ -570,7 +572,7 @@ class Route
     public function subDomain($subDomain, $domain = null)
     {
         if (is_null($domain)) {
-            $domain = parse_url(getenv('APP_URL'))['host'];
+            $domain = parse_url($this->container->make('config')->get('app.url'))['host'];
         }
 
         $this->action['domain'] = $subDomain.'.'.$domain;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Routing;
 
 use DateTime;
+use Illuminate\Config\Repository;
 use stdClass;
 use Exception;
 use Illuminate\Support\Str;
@@ -579,7 +580,7 @@ class RoutingRouteTest extends TestCase
         $router->get('/foo/bar')->subDomain('api')->uses(function () {
             return 'hello';
         });
-        $this->assertEquals('hello', $router->dispatch(Request::create('http://api.localhost/foo/bar', 'GET'))->getContent());
+        $this->assertEquals('hello', $router->dispatch(Request::create('http://api.foo.bar/foo/bar', 'GET'))->getContent());
     }
 
     public function testMatchesMethodAgainstRequests()
@@ -1567,6 +1568,11 @@ class RoutingRouteTest extends TestCase
     protected function getRouter()
     {
         $container = new Container;
+
+        $config = new Repository;
+        $config->set('app.url', 'http://foo.bar/');
+
+        $container->instance('config', $config);
 
         $router = new Router(new Dispatcher, $container);
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -564,6 +564,24 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('hello', $router->dispatch(Request::create('http://api.foo.bar/foo/bar', 'GET'))->getContent());
     }
 
+    public function testRouteSubDomainRegistration()
+    {
+        $router = $this->getRouter();
+        $router->get('/foo/bar')->subDomain('api', 'foo.bar')->uses(function () {
+            return 'hello';
+        });
+        $this->assertEquals('hello', $router->dispatch(Request::create('http://api.foo.bar/foo/bar', 'GET'))->getContent());
+    }
+
+    public function testRouteSubDomainRegistrationWitheoutDomain()
+    {
+        $router = $this->getRouter();
+        $router->get('/foo/bar')->subDomain('api')->uses(function () {
+            return 'hello';
+        });
+        $this->assertEquals('hello', $router->dispatch(Request::create('http://api.foo.bar/foo/bar', 'GET'))->getContent());
+    }
+
     public function testMatchesMethodAgainstRequests()
     {
         /*

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -579,7 +579,7 @@ class RoutingRouteTest extends TestCase
         $router->get('/foo/bar')->subDomain('api')->uses(function () {
             return 'hello';
         });
-        $this->assertEquals('hello', $router->dispatch(Request::create('http://api.foo.bar/foo/bar', 'GET'))->getContent());
+        $this->assertEquals('hello', $router->dispatch(Request::create('http://api.localhost/foo/bar', 'GET'))->getContent());
     }
 
     public function testMatchesMethodAgainstRequests()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Routing;
 
 use DateTime;
-use Illuminate\Config\Repository;
 use stdClass;
 use Exception;
 use Illuminate\Support\Str;
@@ -12,6 +11,7 @@ use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Config\Repository;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;


### PR DESCRIPTION
My old pull request (#26341) was closed because I used the function "env" in the routing component.

This pull request concerns the addition of a method named "subDomain" that will make subdomains easier than the old method that was to write the domain name in the code.

### old method:
```php
use Illuminate\Support\Facades\Route;

Route::domain("sub0.foo.bar")->group(...);
Route::domain("sub1.mydomain.test")->group(...);
Route::domain("sub2.foo.bar")->group(...);
Route::domain("sub3.foo.bar")->group(...);
```

### new method:
```php
use Illuminate\Support\Facades\Route;

// env: APP_URL = http://foo.bar/

Route::subDomain("sub0")->group(...); // domain as sub0.foo.bar
Route::subDomain("sub1", "mydomain.test")->group(...); // domain as sub1.mydomain.test
Route::subDomain("sub2")->group(...); // domain as sub2.foo.bar
Route::subDomain("sub3")->group(...); // domain as sub3.foo.bar
```

The new method is better because the domain name is not versioned, gets the domain name from the environment file ".env".