### PR TITLE
[5.8] Fix TrimStrings middleware for excluded array attributes

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
@@ -63,12 +63,17 @@ class TransformsRequest
      * Clean the data in the given array.
      *
      * @param  array  $data
+     * @param  string  $key
      * @return array
      */
-    protected function cleanArray(array $data)
+    protected function cleanArray(array $data, $key = '')
     {
-        return collect($data)->map(function ($value, $key) {
-            return $this->cleanValue($key, $value);
+        return collect($data)->map(function ($arrayValue, $arrayKey) use ($key) {
+            if ($key != '') {
+                $arrayKey = $key;
+            }
+
+            return $this->cleanValue($arrayKey, $arrayValue);
         })->all();
     }
 
@@ -82,9 +87,8 @@ class TransformsRequest
     protected function cleanValue($key, $value)
     {
         if (is_array($value)) {
-            return $this->cleanArray($value);
+            return $this->cleanArray($value, $key);
         }
-
         return $this->transform($key, $value);
     }
 

--- a/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
@@ -63,17 +63,17 @@ class TransformsRequest
      * Clean the data in the given array.
      *
      * @param  array  $data
-     * @param  string  $key
+     * @param  string  $parentKey
      * @return array
      */
-    protected function cleanArray(array $data, $key = '')
+    protected function cleanArray(array $data, $parentKey = '')
     {
-        return collect($data)->map(function ($arrayValue, $arrayKey) use ($key) {
-            if ($key != '') {
-                $arrayKey = $key;
+        return collect($data)->map(function ($value, $key) use ($parentKey) {
+            if (is_numeric($key) && $parentKey != '') {
+                $key = $parentKey;
             }
 
-            return $this->cleanValue($arrayKey, $arrayValue);
+            return $this->cleanValue($key, $value);
         })->all();
     }
 
@@ -89,6 +89,7 @@ class TransformsRequest
         if (is_array($value)) {
             return $this->cleanArray($value, $key);
         }
+
         return $this->transform($key, $value);
     }
 

--- a/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
@@ -69,7 +69,7 @@ class TransformsRequest
     protected function cleanArray(array $data, $parentKey = '')
     {
         return collect($data)->map(function ($value, $key) use ($parentKey) {
-            if (is_numeric($key) && $parentKey != '') {
+            if (is_int($key) && $parentKey != '') {
                 $key = $parentKey;
             }
 

--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -83,6 +83,27 @@ class TrimStringsTest extends TestCase
             $this->assertEquals('  value2  ', $t2[1]);
         });
     }
+
+    public function testTrimNestedArrayFieldsExceptSome()
+    {
+        $middleware = new TrimStringsExcept;
+        $request = new Request(
+            [
+                'nested' => [
+                                [
+                                    'field1' => ' trimmed ',
+                                    'field2' => ' not trimmed ',
+                                ],
+                            ],
+            ]
+        );
+
+        $middleware->handle($request, function (Request $request) {
+            $t = $request->get('nested');
+            $this->assertEquals('trimmed', $t[0]['field1']);
+            $this->assertEquals(' not trimmed ', $t[0]['field2']);
+        });
+    }
 }
 
 class TrimStringsExcept extends TrimStrings

--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Http\Middleware\TrimStrings;
+
+class TrimStringsTest extends TestCase
+{
+    public function testTrimSimpleFields()
+    {
+        $middleware = new TrimStrings;
+        $request = new Request(
+            [
+                'field1' => 'value1',
+                'field2' => '  value2  ',
+            ]
+        );
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals('value1', $request->get('field1'));
+            $this->assertEquals('value2', $request->get('field2'));
+        });
+    }
+
+    /** @test */
+    public function testTrimArrayFields()
+    {
+        $middleware = new TrimStrings;
+        $request = new Request(
+            [
+                'field1' => ['value1', 'value2'],
+                'field2' => ['  value1  ', '  value2  '],
+            ]
+        );
+
+        $middleware->handle($request, function (Request $request) {
+            $t1 = $request->get('field1');
+            $this->assertEquals('value1', $t1[0]);
+            $this->assertEquals('value2', $t1[1]);
+
+            $t2 = $request->get('field2');
+            $this->assertEquals('value1', $t2[0]);
+            $this->assertEquals('value2', $t2[1]);
+        });
+    }
+
+    public function testTrimSimpleFieldsExceptSome()
+    {
+        $middleware = new TrimStringsExcept;
+
+        $request = new Request(
+            [
+                'field1' => 'value1',
+                'field2' => ' value2 ',
+            ]
+        );
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals('value1', $request->get('field1'));
+            $this->assertEquals(' value2 ', $request->get('field2'));
+        });
+    }
+
+    public function testTrimArrayFieldsExceptSome()
+    {
+        $middleware = new TrimStringsExcept;
+        $request = new Request(
+            [
+                'field1' => ['value1', 'value2'],
+                'field2' => ['  value1  ', '  value2  '],
+            ]
+        );
+
+        $middleware->handle($request, function (Request $request) {
+            $t1 = $request->get('field1');
+            $this->assertEquals('value1', $t1[0]);
+            $this->assertEquals('value2', $t1[1]);
+
+            $t2 = $request->get('field2');
+            $this->assertEquals('  value1  ', $t2[0]);
+            $this->assertEquals('  value2  ', $t2[1]);
+        });
+    }
+}
+
+class TrimStringsExcept extends TrimStrings
+{
+    protected $except = [
+        'field2',
+    ];
+}


### PR DESCRIPTION
**Problem**
In TrimStrings (middleware class), array attributes declared in $except are ignored: the array values are trimmed anyway.

**This pull request contains**
- a unit test for TrimStrings including a test for that special case
- a fix

**What the fix does**
In the parent class TransformsRequest.php, the attribute name is passed to the cleanArray() function (as an optional parameter). It's then passed to the cleanValue() function as key. This allows the behaviour with $except to work properly in TrimStrings.

**Notes**
I'm not sure whether it's a proper way to do it, please let me know if there's a better way and feel free to modify this PR or implement a fix differently. Thank you.