### PR TITLE
[5.7] Add `missing()` method to the Cache

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -71,6 +71,17 @@ class Repository implements CacheContract, ArrayAccess
     }
 
     /**
+     * Determine if an item doesn't exist in the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function missing($key)
+    {
+        return ! $this->has($key);
+    }
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -16,6 +16,14 @@ interface Repository extends CacheInterface
     public function has($key);
 
     /**
+     * Determine if an item doesn't exist in the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function missing($key);
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -16,14 +16,6 @@ interface Repository extends CacheInterface
     public function has($key);
 
     /**
-     * Determine if an item doesn't exist in the cache.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    public function missing($key);
-
-    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Facades;
 /**
  * @method static \Illuminate\Contracts\Cache\Repository  store(string|null $name = null)
  * @method static bool has(string $key)
+ * @method static bool missing(string $key)
  * @method static mixed get(string $key, mixed $default = null)
  * @method static mixed pull(string $key, mixed $default = null)
  * @method static void put(string $key, $value, \DateTimeInterface|\DateInterval|float|int $minutes)

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -71,6 +71,16 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($repo->has('foo'));
     }
 
+    public function testMissingMethod()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
+        $repo->getStore()->shouldReceive('get')->once()->with('bar')->andReturn('bar');
+
+        $this->assertTrue($repo->missing('foo'));
+        $this->assertFalse($repo->missing('bar'));
+    }
+
     public function testRememberMethodCallsPutAndReturnsDefault()
     {
         $repo = $this->getRepository();


### PR DESCRIPTION
The `missing()` method  would be useful to avoid the negative conditions.

For example, I have an array of keys. Some of them are present in cache, some not.

If I want to get only those which are not (for the further caching), I have to use `! has()` condition.
