### PR TITLE
[5.7] Fix(tester): TestResponse assertExactJson does not work for empty JSON objects

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -63,7 +63,7 @@ class TestResponse
      * @param  array $arrayAssoc
      * @return array
      */
-    public static function normalizingArraysObjects (array $arrayStdClass, array $arrayAssoc): array
+    public static function normalizingArraysObjects(array $arrayStdClass, array $arrayAssoc): array
     {
         $merged = $arrayStdClass;
 
@@ -76,7 +76,7 @@ class TestResponse
             }
 
             if (is_array($value)) {
-                $value = self::normalizingArraysObjects((array)$merged[$key], $value);
+                $value = self::normalizingArraysObjects((array) $merged[$key], $value);
             }
 
             $merged[$key] = $value;
@@ -484,7 +484,6 @@ class TestResponse
         $actual = json_encode(Arr::sortRecursive(
             (array) $this->decodeResponseJson()
         ));
-
 
         PHPUnit::assertEquals(json_encode(Arr::sortRecursive($data)), $actual);
 

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -67,6 +67,9 @@ class TestResponse
     {
         $merged = $arrayStdClass;
 
+        // If arrayAssoc key has in $arrayStdClass and value is not empty, replace here.
+        // This converts stdClass to accos array and leaves the empty stdClass
+
         foreach ($arrayAssoc as $k => $v) {
             if (empty($v)) {
                 continue;

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -57,18 +57,25 @@ class TestResponse
         return new static($response);
     }
 
-    public static function mergeAssociateArrayRecursive(array $a, array $b): array
+    /**
+     * Merge stdClass array and assoc array recursively.
+     * @param  array $arrayStdClass
+     * @param  array $arrayAssoc
+     * @return array
+     */
+    public static function mergeAssociateArrayRecursive(array $arrayStdClass, array $arrayAssoc): array
     {
-        $merged = $a;
+        $merged = $arrayStdClass;
 
-        foreach ($b as $k => $v) {
-            if (! empty($v)) {
-                if (is_array($v) && (empty($merged[$k]) || $merged[$k] == (object) [])) {
-                    // k-v map
-                    $merged[$k] = static::mergeAssociateArrayRecursive($merged[$k], $v);
-                } else {
-                    $merged[$k] = $v;
-                }
+        foreach ($arrayAssoc as $k => $v) {
+            if (empty($v)) {
+                continue;
+            }
+            if (is_array($v) && (empty($merged[$k]) || $merged[$k] == (object) [])) {
+                // k-v map
+                $merged[$k] = static::mergeAssociateArrayRecursive($merged[$k], $v);
+            } else {
+                $merged[$k] = $v;
             }
         }
 
@@ -703,8 +710,7 @@ class TestResponse
      */
     public function decodeResponseJson($key = null)
     {
-        $decodedResponseStdClass = (array)json_decode($this->getContent());
-        $decodedResponseAssoc = json_decode($this->getContent(), true);
+        $decodedResponseStdClass = (array) json_decode($this->getContent());
 
         if (is_null($decodedResponseStdClass) || $decodedResponseStdClass === false) {
             if ($this->exception) {
@@ -714,11 +720,11 @@ class TestResponse
             }
         }
 
+        $decodedResponseAssoc = json_decode($this->getContent(), true);
+
         $decodedResponse = static::mergeAssociateArrayRecursive($decodedResponseStdClass, $decodedResponseAssoc);
 
-        $data = data_get($decodedResponse, $key);
-
-        return $data;
+        return data_get($decodedResponse, $key);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -63,23 +63,23 @@ class TestResponse
      * @param  array $arrayAssoc
      * @return array
      */
-    public static function mergeAssociateArrayRecursive(array $arrayStdClass, array $arrayAssoc): array
+    public static function normalizingArraysObjects (array $arrayStdClass, array $arrayAssoc): array
     {
         $merged = $arrayStdClass;
 
         // If arrayAssoc key has in $arrayStdClass and value is not empty, replace here.
         // This converts stdClass to accos array and leaves the empty stdClass
 
-        foreach ($arrayAssoc as $k => $v) {
-            if (empty($v)) {
+        foreach ($arrayAssoc as $key => $value) {
+            if (empty($value)) {
                 continue;
             }
-            if (is_array($v) && (empty($merged[$k]) || $merged[$k] == (object) [])) {
-                // k-v map
-                $merged[$k] = static::mergeAssociateArrayRecursive($merged[$k], $v);
-            } else {
-                $merged[$k] = $v;
+
+            if (is_array($value)) {
+                $value = self::normalizingArraysObjects((array)$merged[$key], $value);
             }
+
+            $merged[$key] = $value;
         }
 
         return $merged;
@@ -485,6 +485,7 @@ class TestResponse
             (array) $this->decodeResponseJson()
         ));
 
+
         PHPUnit::assertEquals(json_encode(Arr::sortRecursive($data)), $actual);
 
         return $this;
@@ -725,7 +726,7 @@ class TestResponse
 
         $decodedResponseAssoc = json_decode($this->getContent(), true);
 
-        $decodedResponse = static::mergeAssociateArrayRecursive($decodedResponseStdClass, $decodedResponseAssoc);
+        $decodedResponse = static::normalizingArraysObjects($decodedResponseStdClass, $decodedResponseAssoc);
 
         return data_get($decodedResponse, $key);
     }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -238,22 +238,43 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonMissing(['id' => 20]);
     }
 
-    public function testAssertEmptyJsonObject()
+    public function testAssertExactJson()
     {
         $response = new TestResponse((new JsonResponse([
             'payload' => (object) [],
+            'a' => [],
+            'b' => (object)[],
+            'status' => 'success',
+            'data' => [
+                'name' => "West Fannieland",
+                'updated_at' => "2018-10-05 20:48:11",
+                'created_at' => "2018-10-05 20:48:11",
+                'id' => 1,
+                'b' => (object)[],
+                'c' => [
+                    'b' => (object)[],
+                    'name' => 'albert'
+                ],
+            ]
         ])));
 
-        $response->assertExactJson(['payload' => (object) []]);
-    }
-
-    public function testAssertEmptyJsonArray()
-    {
-        $response = new TestResponse((new JsonResponse([
-            'payload' => [],
-        ])));
-
-        $response->assertExactJson(['payload' => []]);
+        $response->assertExactJson([
+            'payload' => (object) [],
+            'b' => (object)[],
+            'a' => [],
+            'status' => 'success',
+            'data' => [
+                'name' => "West Fannieland",
+                'created_at' => "2018-10-05 20:48:11",
+                'id' => 1,
+                'b' => (object)[],
+                'c' => [
+                    'b' => (object)[],
+                    'name' => 'albert'
+                ],
+                'updated_at' => "2018-10-05 20:48:11"
+            ]
+        ]);
     }
 
     public function testAssertJsonMissingExact()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use Illuminate\Http\JsonResponse;
 use JsonSerializable;
 use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
@@ -235,6 +236,24 @@ class FoundationTestResponseTest extends TestCase
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
         $response->assertJsonMissing(['id' => 20]);
+    }
+
+    public function testAssertEmptyJsonObject()
+    {
+        $response = new TestResponse((new JsonResponse([
+            'payload' => (object) []
+        ])));
+
+        $response->assertExactJson(['payload' => (object)[]]);
+    }
+
+    public function testAssertEmptyJsonArray()
+    {
+        $response = new TestResponse((new JsonResponse([
+            'payload' => []
+        ])));
+
+        $response->assertExactJson(['payload' => []]);
     }
 
     public function testAssertJsonMissingExact()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Foundation;
 
-use Illuminate\Http\JsonResponse;
 use JsonSerializable;
 use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Contracts\View\View;
 use Illuminate\Filesystem\Filesystem;
 use PHPUnit\Framework\AssertionFailedError;
@@ -241,16 +241,16 @@ class FoundationTestResponseTest extends TestCase
     public function testAssertEmptyJsonObject()
     {
         $response = new TestResponse((new JsonResponse([
-            'payload' => (object) []
+            'payload' => (object) [],
         ])));
 
-        $response->assertExactJson(['payload' => (object)[]]);
+        $response->assertExactJson(['payload' => (object) []]);
     }
 
     public function testAssertEmptyJsonArray()
     {
         $response = new TestResponse((new JsonResponse([
-            'payload' => []
+            'payload' => [],
         ])));
 
         $response->assertExactJson(['payload' => []]);

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -243,37 +243,37 @@ class FoundationTestResponseTest extends TestCase
         $response = new TestResponse((new JsonResponse([
             'payload' => (object) [],
             'a' => [],
-            'b' => (object)[],
+            'b' => (object) [],
             'status' => 'success',
             'data' => [
-                'name' => "West Fannieland",
-                'updated_at' => "2018-10-05 20:48:11",
-                'created_at' => "2018-10-05 20:48:11",
+                'name' => 'West Fannieland',
+                'updated_at' => '2018-10-05 20:48:11',
+                'created_at' => '2018-10-05 20:48:11',
                 'id' => 1,
-                'b' => (object)[],
+                'b' => (object) [],
                 'c' => [
-                    'b' => (object)[],
-                    'name' => 'albert'
+                    'b' => (object) [],
+                    'name' => 'albert',
                 ],
-            ]
+            ],
         ])));
 
         $response->assertExactJson([
             'payload' => (object) [],
-            'b' => (object)[],
+            'b' => (object) [],
             'a' => [],
             'status' => 'success',
             'data' => [
-                'name' => "West Fannieland",
-                'created_at' => "2018-10-05 20:48:11",
+                'name' => 'West Fannieland',
+                'created_at' => '2018-10-05 20:48:11',
                 'id' => 1,
-                'b' => (object)[],
+                'b' => (object) [],
                 'c' => [
-                    'b' => (object)[],
-                    'name' => 'albert'
+                    'b' => (object) [],
+                    'name' => 'albert',
                 ],
-                'updated_at' => "2018-10-05 20:48:11"
-            ]
+                'updated_at' => '2018-10-05 20:48:11',
+            ],
         ]);
     }
 


### PR DESCRIPTION
Solved the problems mentioned in #25960 and #25769.

After the old decodeResponseJson directly operates on the response content json_decode($content, true), it is impossible to tell the difference between empty object and empty array.

```
$data = [
    'a' => new class {}
];

var_dump(json_encode($data)); 
var_dump(json_decode(json_encode($data), true)); 
var_dump(json_decode(json_encode($data)));


result: 

string(8) "{"a":{}}"
array(1) {
  ["a"]=>
  array(0) {
  }
}
object(stdClass)#4313 (1) {
  ["a"]=>
  object(stdClass)#4315 (0) {
  }
}
```
Therefore, if we want to distinguish between empty object and empty array, we need to change the second parameter $assoc to false.
But that's not compatible with the logic that preceded it. The assoc array is resolved to stdclass.
So. for compatibility, I have json_decode($data, true) and json_decode($data, false); Only get json_decode($data, false); The empty object inside is thus compatible with the previous logic, and the bug is fixed.