### PR TITLE
fix followRedirects return type (Response instead of TestResponse)

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -439,7 +439,8 @@ trait MakesHttpRequests
     protected function followRedirects($response)
     {
         while ($response->isRedirect()) {
-            $response = $this->get($response->headers->get('Location'));
+            $testResponse = $this->get($response->headers->get('Location'));
+            $response = $testResponse->baseResponse;
         }
 
         $this->followRedirects = false;


### PR DESCRIPTION
followRedirects returns a wrong object (TestResponse) instead of Response stated in phpDoc.

this pull request make it returns a Response as expected