### PR TITLE
[5.8] Allow DatabaseManager to make extension connections

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -97,6 +97,8 @@ class DatabaseManager implements ConnectionResolverInterface
      *
      * @param  string  $name
      * @return \Illuminate\Database\Connection
+     *
+     * @throws \InvalidArgumentException
      */
     protected function makeConnection($name)
     {
@@ -107,6 +109,10 @@ class DatabaseManager implements ConnectionResolverInterface
         // Closure and pass it the config allowing it to resolve the connection.
         if (isset($this->extensions[$name])) {
             return call_user_func($this->extensions[$name], $config, $name);
+        }
+
+        if (is_null($config)) {
+            throw new InvalidArgumentException("Database [{$name}] not configured.");
         }
 
         // Next we will check to see if an extension has been registered for a driver
@@ -123,9 +129,7 @@ class DatabaseManager implements ConnectionResolverInterface
      * Get the configuration for a connection.
      *
      * @param  string  $name
-     * @return array
-     *
-     * @throws \InvalidArgumentException
+     * @return array|null
      */
     protected function configuration($name)
     {
@@ -136,11 +140,7 @@ class DatabaseManager implements ConnectionResolverInterface
         // If the configuration doesn't exist, we'll throw an exception and bail.
         $connections = $this->app['config']['database.connections'];
 
-        if (is_null($config = Arr::get($connections, $name))) {
-            throw new InvalidArgumentException("Database [{$name}] not configured.");
-        }
-
-        return $config;
+        return Arr::get($connections, $name);
     }
 
     /**

--- a/tests/Database/DatabaseManagerTest.php
+++ b/tests/Database/DatabaseManagerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Connection;
+use Illuminate\Foundation\Application;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\Connectors\ConnectionFactory;
+
+class DatabaseManagerTest extends TestCase
+{
+    public function testMakeConnectionUsingExtensionWithoutHavingPredefinedConnectionName()
+    {
+        $connectionName = 'connection-name';
+        $connection = $this->createMock(Connection::class);
+        $app = $this->createMock(Application::class);
+        $connectionFactory = $this->createMock(connectionFactory::class);
+
+        $databaseManager = new DatabaseManager($app, $connectionFactory);
+
+        $databaseManager->extend($connectionName, function () use ($connection) {
+            return $connection;
+        });
+
+        $this->assertSame($connection, $databaseManager->connection($connectionName));
+    }
+}


### PR DESCRIPTION
When there is no Laravel connection name defined is not possible to create a extension connection.

This allows extension connections resolution without depend on predefined connections name and allows the developer to add an extension to `DatabaseManager` decoupled from configuration from `illuminate/config`.

The potential for breaking change is minimal, however it's possible that somebody extended the class and relies on `configuration` throwing the exception. I moved the exception to `makeConnection` to give the `extensions` a chance to resolve the connection.