### PR TITLE
[5.7] Adds missing logging options to slack log driver

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -270,7 +270,9 @@ class LogManager implements LoggerInterface
                 $config['emoji'] ?? ':boom:',
                 $config['short'] ?? false,
                 $config['context'] ?? true,
-                $this->level($config)
+                $this->level($config),
+                $config['bubble'] ?? true,
+                $config['excludeFields'] ?? []
             )),
         ]);
     }

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -272,7 +272,7 @@ class LogManager implements LoggerInterface
                 $config['context'] ?? true,
                 $this->level($config),
                 $config['bubble'] ?? true,
-                $config['excludeFields'] ?? []
+                $config['exclude_fields'] ?? []
             )),
         ]);
     }


### PR DESCRIPTION
## Usecase
Hide some fields from the Slack message (eg. PII), when Slack is used as a Log driver.

## More info
While you can define a property `excludeFields` in your `logging.php` config file, this is not taken into account when Slack is used as a log driver. The method of `LogManager` that creates the Slack driver does not pass this information to SlackWebhookHandler even though the later can support it. This PR addresses this by adding the missing fields.

## Note
The default values have been set to match the ones found at the constructor of SlackWebhookHandler.
