### PR TITLE
[5.7] Make View Factory macroable

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -5,6 +5,7 @@ namespace Illuminate\View;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\View\Engines\EngineResolver;
@@ -13,7 +14,8 @@ use Illuminate\Contracts\View\Factory as FactoryContract;
 
 class Factory implements FactoryContract
 {
-    use Concerns\ManagesComponents,
+    use Macroable,
+        Concerns\ManagesComponents,
         Concerns\ManagesEvents,
         Concerns\ManagesLayouts,
         Concerns\ManagesLoops,

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -653,6 +653,15 @@ class ViewFactoryTest extends TestCase
         $this->assertNull($factory->getLoopStack()[0]['last']);
     }
 
+    public function testMacro()
+    {
+        $factory = $this->getFactory();
+        $factory->macro('getFoo', function () {
+            return 'Hello World';
+        });
+        $this->assertEquals('Hello World', $factory->getFoo());
+    }
+
     protected function getFactory()
     {
         return new Factory(


### PR DESCRIPTION
I recently wanted to add a macro to the View Factory class, but realized I couldn't. This makes that possible.

```php
View::macro('getFoo', function () {
    return 'Hello World';
});
```