### PR TITLE
[5.8] Fix container contract violations

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -120,17 +120,17 @@ class AuthManager implements FactoryContract
     {
         $provider = $this->createUserProvider($config['provider'] ?? null);
 
-        $guard = new SessionGuard($name, $provider, $this->app['session.store']);
+        $guard = new SessionGuard($name, $provider, $this->app->make('session.store'));
 
         // When using the remember me functionality of the authentication services we
         // will need to be set the encryption instance of the guard, which allows
         // secure, encrypted cookie values to get generated for those cookies.
         if (method_exists($guard, 'setCookieJar')) {
-            $guard->setCookieJar($this->app['cookie']);
+            $guard->setCookieJar($this->app->make('cookie'));
         }
 
         if (method_exists($guard, 'setDispatcher')) {
-            $guard->setDispatcher($this->app['events']);
+            $guard->setDispatcher($this->app->make('events'));
         }
 
         if (method_exists($guard, 'setRequest')) {
@@ -154,7 +154,7 @@ class AuthManager implements FactoryContract
         // user in the database or another persistence layer where users are.
         $guard = new TokenGuard(
             $this->createUserProvider($config['provider'] ?? null),
-            $this->app['request']
+            $this->app->make('request')
         );
 
         $this->app->refresh('request', $guard, 'setRequest');
@@ -170,7 +170,7 @@ class AuthManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        return $this->app['config']["auth.guards.{$name}"];
+        return $this->app->make('config')->get("auth.guards.{$name}");
     }
 
     /**
@@ -180,7 +180,7 @@ class AuthManager implements FactoryContract
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['auth.defaults.guard'];
+        return $this->app->make('config')->get('auth.defaults.guard');
     }
 
     /**
@@ -208,7 +208,7 @@ class AuthManager implements FactoryContract
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['auth.defaults.guard'] = $name;
+        $this->app->make('config')->set('auth.defaults.guard', $name);
     }
 
     /**
@@ -221,7 +221,7 @@ class AuthManager implements FactoryContract
     public function viaRequest($driver, callable $callback)
     {
         return $this->extend($driver, function () use ($callback) {
-            $guard = new RequestGuard($callback, $this->app['request'], $this->createUserProvider());
+            $guard = new RequestGuard($callback, $this->app->make('request'), $this->createUserProvider());
 
             $this->app->refresh('request', $guard, 'setRequest');
 

--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Auth;
 
+use Illuminate\Http\Request;
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 
@@ -32,17 +34,19 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerAuthenticator()
     {
-        $this->app->singleton('auth', function ($app) {
+        $this->app->singleton('auth', function (Application $app) {
             // Once the authentication service has actually been requested by the developer
             // we will set a variable in the application indicating such. This helps us
             // know that we need to set any queued cookies in the after event later.
-            $app['auth.loaded'] = true;
+            $app->bind('auth.loaded', function () {
+                return true;
+            });
 
             return new AuthManager($app);
         });
 
-        $this->app->singleton('auth.driver', function ($app) {
-            return $app['auth']->guard();
+        $this->app->singleton('auth.driver', function (Application $app) {
+            return $app->make('auth')->guard();
         });
     }
 
@@ -54,8 +58,8 @@ class AuthServiceProvider extends ServiceProvider
     protected function registerUserResolver()
     {
         $this->app->bind(
-            AuthenticatableContract::class, function ($app) {
-                return call_user_func($app['auth']->userResolver());
+            AuthenticatableContract::class, function (Application $app) {
+                return call_user_func($app->make('auth')->userResolver());
             }
         );
     }
@@ -67,9 +71,9 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerAccessGate()
     {
-        $this->app->singleton(GateContract::class, function ($app) {
+        $this->app->singleton(GateContract::class, function (Application $app) {
             return new Gate($app, function () use ($app) {
-                return call_user_func($app['auth']->userResolver());
+                return call_user_func($app->make('auth')->userResolver());
             });
         });
     }
@@ -81,9 +85,9 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerRequestRebindHandler()
     {
-        $this->app->rebinding('request', function ($app, $request) {
+        $this->app->rebinding('request', function (Application $app, Request $request) {
             $request->setUserResolver(function ($guard = null) use ($app) {
-                return call_user_func($app['auth']->userResolver(), $guard);
+                return call_user_func($app->make('auth')->userResolver(), $guard);
             });
         });
     }

--- a/src/Illuminate/Auth/Console/ClearResetsCommand.php
+++ b/src/Illuminate/Auth/Console/ClearResetsCommand.php
@@ -27,7 +27,7 @@ class ClearResetsCommand extends Command
      */
     public function handle()
     {
-        $this->laravel['auth.password']->broker($this->argument('name'))->getRepository()->deleteExpired();
+        $this->laravel->make('auth.password')->broker($this->argument('name'))->getRepository()->deleteExpired();
 
         $this->info('Expired reset tokens cleared!');
     }

--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -54,7 +54,7 @@ trait CreatesUserProviders
     protected function getProviderConfiguration($provider)
     {
         if ($provider = $provider ?: $this->getDefaultUserProvider()) {
-            return $this->app['config']['auth.providers.'.$provider];
+            return $this->app->make('config')->get('auth.providers.'.$provider);
         }
     }
 
@@ -66,9 +66,9 @@ trait CreatesUserProviders
      */
     protected function createDatabaseProvider($config)
     {
-        $connection = $this->app['db']->connection();
+        $connection = $this->app->make('db')->connection();
 
-        return new DatabaseUserProvider($connection, $this->app['hash'], $config['table']);
+        return new DatabaseUserProvider($connection, $this->app->make('hash'), $config['table']);
     }
 
     /**
@@ -79,7 +79,7 @@ trait CreatesUserProviders
      */
     protected function createEloquentProvider($config)
     {
-        return new EloquentUserProvider($this->app['hash'], $config['model']);
+        return new EloquentUserProvider($this->app->make('hash'), $config['model']);
     }
 
     /**
@@ -89,6 +89,6 @@ trait CreatesUserProviders
      */
     public function getDefaultUserProvider()
     {
-        return $this->app['config']['auth.defaults.provider'];
+        return $this->app->make('config')->get('auth.defaults.provider');
     }
 }

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -72,7 +72,7 @@ class PasswordBrokerManager implements FactoryContract
         // aggregate service of sorts providing a convenient interface for resets.
         return new PasswordBroker(
             $this->createTokenRepository($config),
-            $this->app['auth']->createUserProvider($config['provider'] ?? null)
+            $this->app->make('auth')->createUserProvider($config['provider'] ?? null)
         );
     }
 
@@ -84,7 +84,7 @@ class PasswordBrokerManager implements FactoryContract
      */
     protected function createTokenRepository(array $config)
     {
-        $key = $this->app['config']['app.key'];
+        $key = $this->app->make('config')->get('app.key');
 
         if (Str::startsWith($key, 'base64:')) {
             $key = base64_decode(substr($key, 7));
@@ -93,8 +93,8 @@ class PasswordBrokerManager implements FactoryContract
         $connection = $config['connection'] ?? null;
 
         return new DatabaseTokenRepository(
-            $this->app['db']->connection($connection),
-            $this->app['hash'],
+            $this->app->make('db')->connection($connection),
+            $this->app->make('hash'),
             $config['table'],
             $key,
             $config['expire']
@@ -109,7 +109,7 @@ class PasswordBrokerManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        return $this->app['config']["auth.passwords.{$name}"];
+        return $this->app->make('config')->get("auth.passwords.{$name}");
     }
 
     /**
@@ -119,7 +119,7 @@ class PasswordBrokerManager implements FactoryContract
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['auth.defaults.passwords'];
+        return $this->app->make('config')->get('auth.defaults.passwords');
     }
 
     /**
@@ -130,7 +130,7 @@ class PasswordBrokerManager implements FactoryContract
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['auth.defaults.passwords'] = $name;
+        $this->app->make('config')->set('auth.defaults.passwords', $name);
     }
 
     /**

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -64,7 +64,7 @@ class BroadcastManager implements FactoryContract
 
         $attributes = $attributes ?: ['middleware' => ['web']];
 
-        $this->app['router']->group($attributes, function ($router) {
+        $this->app->make('router')->group($attributes, function ($router) {
             $router->match(
                 ['get', 'post'], '/broadcasting/auth',
                 '\\'.BroadcastController::class.'@authenticate'
@@ -84,7 +84,7 @@ class BroadcastManager implements FactoryContract
             return;
         }
 
-        $request = $request ?: $this->app['request'];
+        $request = $request ?: $this->app->make('request');
 
         return $request->header('X-Socket-ID');
     }
@@ -269,7 +269,7 @@ class BroadcastManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        return $this->app['config']["broadcasting.connections.{$name}"];
+        return $this->app->make('config')->get("broadcasting.connections.{$name}");
     }
 
     /**
@@ -279,7 +279,7 @@ class BroadcastManager implements FactoryContract
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['broadcasting.default'];
+        return $this->app->make('config')->get('broadcasting.default');
     }
 
     /**
@@ -290,7 +290,7 @@ class BroadcastManager implements FactoryContract
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['broadcasting.default'] = $name;
+        $this->app->make('config')->set('broadcasting.default', $name);
     }
 
     /**

--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Bus;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
 use Illuminate\Contracts\Queue\Factory as QueueFactoryContract;
 use Illuminate\Contracts\Bus\QueueingDispatcher as QueueingDispatcherContract;
@@ -23,9 +24,9 @@ class BusServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(Dispatcher::class, function ($app) {
+        $this->app->singleton(Dispatcher::class, function (Application $app) {
             return new Dispatcher($app, function ($connection = null) use ($app) {
-                return $app[QueueFactoryContract::class]->connection($connection);
+                return $app->make(QueueFactoryContract::class)->connection($connection);
             });
         });
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -151,7 +151,7 @@ class CacheManager implements FactoryContract
      */
     protected function createFileDriver(array $config)
     {
-        return $this->repository(new FileStore($this->app['files'], $config['path']));
+        return $this->repository(new FileStore($this->app->make('files'), $config['path']));
     }
 
     /**
@@ -164,7 +164,7 @@ class CacheManager implements FactoryContract
     {
         $prefix = $this->getPrefix($config);
 
-        $memcached = $this->app['memcached.connector']->connect(
+        $memcached = $this->app->make('memcached.connector')->connect(
             $config['servers'],
             $config['persistent_id'] ?? null,
             $config['options'] ?? [],
@@ -192,7 +192,7 @@ class CacheManager implements FactoryContract
      */
     protected function createRedisDriver(array $config)
     {
-        $redis = $this->app['redis'];
+        $redis = $this->app->make('redis');
 
         $connection = $config['connection'] ?? 'default';
 
@@ -207,7 +207,7 @@ class CacheManager implements FactoryContract
      */
     protected function createDatabaseDriver(array $config)
     {
-        $connection = $this->app['db']->connection($config['connection'] ?? null);
+        $connection = $this->app->make('db')->connection($config['connection'] ?? null);
 
         return $this->repository(
             new DatabaseStore(
@@ -228,7 +228,7 @@ class CacheManager implements FactoryContract
 
         if ($this->app->bound(DispatcherContract::class)) {
             $repository->setEventDispatcher(
-                $this->app[DispatcherContract::class]
+                $this->app->make(DispatcherContract::class)
             );
         }
 
@@ -243,7 +243,7 @@ class CacheManager implements FactoryContract
      */
     protected function getPrefix(array $config)
     {
-        return $config['prefix'] ?? $this->app['config']['cache.prefix'];
+        return $config['prefix'] ?? $this->app->make('config')->get('cache.prefix');
     }
 
     /**
@@ -254,7 +254,7 @@ class CacheManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        return $this->app['config']["cache.stores.{$name}"];
+        return $this->app->make('config')->get("cache.stores.{$name}");
     }
 
     /**
@@ -264,7 +264,7 @@ class CacheManager implements FactoryContract
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['cache.default'];
+        return $this->app->make('config')->get('cache.default');
     }
 
     /**
@@ -275,7 +275,7 @@ class CacheManager implements FactoryContract
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['cache.default'] = $name;
+        $this->app->make('config')->set('cache.default', $name);
     }
 
     /**

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Cache;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Foundation\Application;
 
 class CacheServiceProvider extends ServiceProvider
 {
@@ -20,12 +21,12 @@ class CacheServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('cache', function ($app) {
+        $this->app->singleton('cache', function (Application $app) {
             return new CacheManager($app);
         });
 
-        $this->app->singleton('cache.store', function ($app) {
-            return $app['cache']->driver();
+        $this->app->singleton('cache.store', function (Application $app) {
+            return $app->make('cache')->driver();
         });
 
         $this->app->singleton('memcached.connector', function () {

--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -76,6 +76,6 @@ class CacheTableCommand extends Command
 
         $path = $this->laravel->databasePath().'/migrations';
 
-        return $this->laravel['migration.creator']->create($name, $path);
+        return $this->laravel->make('migration.creator')->create($name, $path);
     }
 }

--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -60,7 +60,7 @@ class ClearCommand extends Command
      */
     public function handle()
     {
-        $this->laravel['events']->fire(
+        $this->laravel->make('events')->dispatch(
             'cache:clearing', [$this->argument('store'), $this->tags()]
         );
 
@@ -72,7 +72,7 @@ class ClearCommand extends Command
             return $this->error('Failed to clear cache. Make sure you have the appropriate permissions.');
         }
 
-        $this->laravel['events']->fire(
+        $this->laravel->make('events')->dispatch(
             'cache:cleared', [$this->argument('store'), $this->tags()]
         );
 

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -129,7 +129,7 @@ abstract class GeneratorCommand extends Command
     {
         $name = Str::replaceFirst($this->rootNamespace(), '', $name);
 
-        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->make('path').'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -68,7 +68,7 @@ class FreshCommand extends Command
      */
     protected function dropAllTables($database)
     {
-        $this->laravel['db']->connection($database)
+        $this->laravel->make('db')->connection($database)
                     ->getSchemaBuilder()
                     ->dropAllTables();
     }
@@ -81,7 +81,7 @@ class FreshCommand extends Command
      */
     protected function dropAllViews($database)
     {
-        $this->laravel['db']->connection($database)
+        $this->laravel->make('db')->connection($database)
                     ->getSchemaBuilder()
                     ->dropAllViews();
     }

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -87,7 +87,7 @@ class SeedCommand extends Command
     {
         $database = $this->input->getOption('database');
 
-        return $database ?: $this->laravel['config']['database.default'];
+        return $database ?: $this->laravel->make('config')->get('database.default');
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -134,7 +134,7 @@ class DatabaseManager implements ConnectionResolverInterface
         // To get the database connection configuration, we will just pull each of the
         // connection configurations and get the configurations for the given name.
         // If the configuration doesn't exist, we'll throw an exception and bail.
-        $connections = $this->app['config']['database.connections'];
+        $connections = $this->app->make('config')->get('database.connections');
 
         if (is_null($config = Arr::get($connections, $name))) {
             throw new InvalidArgumentException("Database [{$name}] not configured.");
@@ -158,7 +158,7 @@ class DatabaseManager implements ConnectionResolverInterface
         // connection. This method basically just configures and prepares it to get
         // used by the application. Once we're finished we'll return it back out.
         if ($this->app->bound('events')) {
-            $connection->setEventDispatcher($this->app['events']);
+            $connection->setEventDispatcher($this->app->make('events'));
         }
 
         // Here we'll set a reconnector callback. This reconnector can be any callable
@@ -256,7 +256,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function getDefaultConnection()
     {
-        return $this->app['config']['database.default'];
+        return $this->app->make('config')->get('database.default');
     }
 
     /**
@@ -267,7 +267,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function setDefaultConnection($name)
     {
-        $this->app['config']['database.default'] = $name;
+        $this->app->make('config')->set('database.default', $name);
     }
 
     /**

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 
@@ -37,10 +38,10 @@ class MigrationServiceProvider extends ServiceProvider
      */
     protected function registerRepository()
     {
-        $this->app->singleton('migration.repository', function ($app) {
-            $table = $app['config']['database.migrations'];
+        $this->app->singleton('migration.repository', function (Application $app) {
+            $table = $app->make('config')->get('database.migrations');
 
-            return new DatabaseMigrationRepository($app['db'], $table);
+            return new DatabaseMigrationRepository($app->make('db'), $table);
         });
     }
 
@@ -54,10 +55,10 @@ class MigrationServiceProvider extends ServiceProvider
         // The migrator is responsible for actually running and rollback the migration
         // files in the application. We'll pass in our database connection resolver
         // so the migrator can resolve any of these connections when it needs to.
-        $this->app->singleton('migrator', function ($app) {
-            $repository = $app['migration.repository'];
+        $this->app->singleton('migrator', function (Application $app) {
+            $repository = $app->make('migration.repository');
 
-            return new Migrator($repository, $app['db'], $app['files']);
+            return new Migrator($repository, $app->make('db'), $app->make('files'));
         });
     }
 
@@ -68,8 +69,8 @@ class MigrationServiceProvider extends ServiceProvider
      */
     protected function registerCreator()
     {
-        $this->app->singleton('migration.creator', function ($app) {
-            return new MigrationCreator($app['files']);
+        $this->app->singleton('migration.creator', function (Application $app) {
+            return new MigrationCreator($app->make('files'));
         });
     }
 

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -296,7 +296,7 @@ class FilesystemManager implements FactoryContract
         }
 
         return new Cache(
-            $this->app['cache']->store($config['store']),
+            $this->app->make('cache')->store($config['store']),
             $config['prefix'] ?? 'flysystem',
             $config['expire'] ?? null
         );
@@ -335,7 +335,7 @@ class FilesystemManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        return $this->app['config']["filesystems.disks.{$name}"];
+        return $this->app->make('config')->get("filesystems.disks.{$name}");
     }
 
     /**
@@ -345,7 +345,7 @@ class FilesystemManager implements FactoryContract
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['filesystems.default'];
+        return $this->app->make('config')->get('filesystems.default');
     }
 
     /**
@@ -355,7 +355,7 @@ class FilesystemManager implements FactoryContract
      */
     public function getDefaultCloudDriver()
     {
-        return $this->app['config']['filesystems.cloud'];
+        return $this->app->make('config')->get('filesystems.cloud');
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -40,11 +40,11 @@ class FilesystemServiceProvider extends ServiceProvider
         $this->registerManager();
 
         $this->app->singleton('filesystem.disk', function () {
-            return $this->app['filesystem']->disk($this->getDefaultDriver());
+            return $this->app->make('filesystem')->disk($this->getDefaultDriver());
         });
 
         $this->app->singleton('filesystem.cloud', function () {
-            return $this->app['filesystem']->disk($this->getCloudDriver());
+            return $this->app->make('filesystem')->disk($this->getCloudDriver());
         });
     }
 
@@ -67,7 +67,7 @@ class FilesystemServiceProvider extends ServiceProvider
      */
     protected function getDefaultDriver()
     {
-        return $this->app['config']['filesystems.default'];
+        return $this->app->make('config')->get('filesystems.default');
     }
 
     /**
@@ -77,6 +77,6 @@ class FilesystemServiceProvider extends ServiceProvider
      */
     protected function getCloudDriver()
     {
-        return $this->app['config']['filesystems.cloud'];
+        return $this->app->make('config')->get('filesystems.cloud');
     }
 }

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -109,7 +109,7 @@ class HandleExceptions
      */
     protected function renderHttpResponse(Exception $e)
     {
-        $this->getExceptionHandler()->render($this->app['request'], $e)->send();
+        $this->getExceptionHandler()->render($this->app->make('request'), $e)->send();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -90,7 +90,7 @@ class AppNameCommand extends Command
     protected function setAppDirectoryNamespace()
     {
         $files = Finder::create()
-                            ->in($this->laravel['path'])
+                            ->in($this->laravel->make('path'))
                             ->contains($this->currentRoot)
                             ->name('*.php');
 
@@ -279,7 +279,7 @@ class AppNameCommand extends Command
      */
     protected function getConfigPath($name)
     {
-        return $this->laravel['path.config'].'/'.$name.'.php';
+        return $this->laravel->make('path.config').'/'.$name.'.php';
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -82,6 +82,6 @@ class ConfigCacheCommand extends Command
 
         $app->make(ConsoleKernelContract::class)->bootstrap();
 
-        return $app['config']->all();
+        return $app->make('config')->all();
     }
 }

--- a/src/Illuminate/Foundation/Console/EnvironmentCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentCommand.php
@@ -27,6 +27,6 @@ class EnvironmentCommand extends Command
      */
     public function handle()
     {
-        $this->line('<info>Current application environment:</info> <comment>'.$this->laravel['env'].'</comment>');
+        $this->line('<info>Current application environment:</info> <comment>'.$this->laravel->make('env').'</comment>');
     }
 }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -352,7 +352,7 @@ class Kernel implements KernelContract
      */
     protected function reportException(Exception $e)
     {
-        $this->app[ExceptionHandler::class]->report($e);
+        $this->app->make(ExceptionHandler::class)->report($e);
     }
 
     /**
@@ -364,6 +364,6 @@ class Kernel implements KernelContract
      */
     protected function renderException($output, Exception $e)
     {
-        $this->app[ExceptionHandler::class]->renderForConsole($output, $e);
+        $this->app->make(ExceptionHandler::class)->renderForConsole($output, $e);
     }
 }

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -46,7 +46,7 @@ class KeyGenerateCommand extends Command
             return;
         }
 
-        $this->laravel['config']['app.key'] = $key;
+        $this->laravel->make('config')->set('app.key', $key);
 
         $this->info('Application key set successfully.');
     }
@@ -59,7 +59,7 @@ class KeyGenerateCommand extends Command
     protected function generateRandomKey()
     {
         return 'base64:'.base64_encode(
-            Encrypter::generateKey($this->laravel['config']['app.cipher'])
+            Encrypter::generateKey($this->laravel->make('config')->get('app.cipher'))
         );
     }
 
@@ -71,7 +71,7 @@ class KeyGenerateCommand extends Command
      */
     protected function setKeyInEnvironmentFile($key)
     {
-        $currentKey = $this->laravel['config']['app.key'];
+        $currentKey = $this->laravel->make('config')->get('app.key');
 
         if (strlen($currentKey) !== 0 && (! $this->confirmToProceed())) {
             return false;
@@ -104,7 +104,7 @@ class KeyGenerateCommand extends Command
      */
     protected function keyReplacementPattern()
     {
-        $escaped = preg_quote('='.$this->laravel['config']['app.key'], '/');
+        $escaped = preg_quote('='.$this->laravel->make('config')->get('app.key'), '/');
 
         return "/^APP_KEY{$escaped}/m";
     }

--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -45,7 +45,7 @@ class ViewCacheCommand extends Command
      */
     protected function compileViews(Collection $views)
     {
-        $compiler = $this->laravel['view']->getEngineResolver()->resolve('blade')->getCompiler();
+        $compiler = $this->laravel->make('view')->getEngineResolver()->resolve('blade')->getCompiler();
 
         $views->map(function (SplFileInfo $file) use ($compiler) {
             $compiler->compile($file->getRealPath());
@@ -76,7 +76,7 @@ class ViewCacheCommand extends Command
      */
     protected function paths()
     {
-        $finder = $this->laravel['view']->getFinder();
+        $finder = $this->laravel->make('view')->getFinder();
 
         return collect($finder->getPaths())->merge(
             collect($finder->getHints())->flatten()

--- a/src/Illuminate/Foundation/Console/ViewClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewClearCommand.php
@@ -51,7 +51,7 @@ class ViewClearCommand extends Command
      */
     public function handle()
     {
-        $path = $this->laravel['config']['view.compiled'];
+        $path = $this->laravel->make('config')->get('view.compiled');
 
         if (! $path) {
             throw new RuntimeException('View path not found.');

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -124,7 +124,7 @@ class Kernel implements KernelContract
             $response = $this->renderException($request, $e);
         }
 
-        $this->app['events']->dispatch(
+        $this->app->make('events')->dispatch(
             new Events\RequestHandled($request, $response)
         );
 
@@ -311,7 +311,7 @@ class Kernel implements KernelContract
      */
     protected function reportException(Exception $e)
     {
-        $this->app[ExceptionHandler::class]->report($e);
+        $this->app->make(ExceptionHandler::class)->report($e);
     }
 
     /**
@@ -323,7 +323,7 @@ class Kernel implements KernelContract
      */
     protected function renderException($request, Exception $e)
     {
-        return $this->app[ExceptionHandler::class]->render($request, $e);
+        return $this->app->make(ExceptionHandler::class)->render($request, $e);
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Foundation\Console\ServeCommand;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Console\PresetCommand;
 use Illuminate\Queue\Console\FailedTableCommand;
 use Illuminate\Foundation\Console\AppNameCommand;
@@ -199,8 +200,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerAppNameCommand()
     {
-        $this->app->singleton('command.app.name', function ($app) {
-            return new AppNameCommand($app['composer'], $app['files']);
+        $this->app->singleton('command.app.name', function (Application $app) {
+            return new AppNameCommand($app->make('composer'), $app->make('files'));
         });
     }
 
@@ -223,8 +224,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerCacheClearCommand()
     {
-        $this->app->singleton('command.cache.clear', function ($app) {
-            return new CacheClearCommand($app['cache'], $app['files']);
+        $this->app->singleton('command.cache.clear', function (Application $app) {
+            return new CacheClearCommand($app->make('cache'), $app->make('files'));
         });
     }
 
@@ -235,8 +236,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerCacheForgetCommand()
     {
-        $this->app->singleton('command.cache.forget', function ($app) {
-            return new CacheForgetCommand($app['cache']);
+        $this->app->singleton('command.cache.forget', function (Application $app) {
+            return new CacheForgetCommand($app->make('cache'));
         });
     }
 
@@ -247,8 +248,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerCacheTableCommand()
     {
-        $this->app->singleton('command.cache.table', function ($app) {
-            return new CacheTableCommand($app['files'], $app['composer']);
+        $this->app->singleton('command.cache.table', function (Application $app) {
+            return new CacheTableCommand($app->make('files'), $app->make('composer'));
         });
     }
 
@@ -259,8 +260,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerChannelMakeCommand()
     {
-        $this->app->singleton('command.channel.make', function ($app) {
-            return new ChannelMakeCommand($app['files']);
+        $this->app->singleton('command.channel.make', function (Application $app) {
+            return new ChannelMakeCommand($app->make('files'));
         });
     }
 
@@ -295,8 +296,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerConfigCacheCommand()
     {
-        $this->app->singleton('command.config.cache', function ($app) {
-            return new ConfigCacheCommand($app['files']);
+        $this->app->singleton('command.config.cache', function (Application $app) {
+            return new ConfigCacheCommand($app->make('files'));
         });
     }
 
@@ -307,8 +308,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerConfigClearCommand()
     {
-        $this->app->singleton('command.config.clear', function ($app) {
-            return new ConfigClearCommand($app['files']);
+        $this->app->singleton('command.config.clear', function (Application $app) {
+            return new ConfigClearCommand($app->make('files'));
         });
     }
 
@@ -319,8 +320,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerConsoleMakeCommand()
     {
-        $this->app->singleton('command.console.make', function ($app) {
-            return new ConsoleMakeCommand($app['files']);
+        $this->app->singleton('command.console.make', function (Application $app) {
+            return new ConsoleMakeCommand($app->make('files'));
         });
     }
 
@@ -331,8 +332,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerControllerMakeCommand()
     {
-        $this->app->singleton('command.controller.make', function ($app) {
-            return new ControllerMakeCommand($app['files']);
+        $this->app->singleton('command.controller.make', function (Application $app) {
+            return new ControllerMakeCommand($app->make('files'));
         });
     }
 
@@ -355,8 +356,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerEventMakeCommand()
     {
-        $this->app->singleton('command.event.make', function ($app) {
-            return new EventMakeCommand($app['files']);
+        $this->app->singleton('command.event.make', function (Application $app) {
+            return new EventMakeCommand($app->make('files'));
         });
     }
 
@@ -367,8 +368,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerExceptionMakeCommand()
     {
-        $this->app->singleton('command.exception.make', function ($app) {
-            return new ExceptionMakeCommand($app['files']);
+        $this->app->singleton('command.exception.make', function (Application $app) {
+            return new ExceptionMakeCommand($app->make('files'));
         });
     }
 
@@ -379,8 +380,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerFactoryMakeCommand()
     {
-        $this->app->singleton('command.factory.make', function ($app) {
-            return new FactoryMakeCommand($app['files']);
+        $this->app->singleton('command.factory.make', function (Application $app) {
+            return new FactoryMakeCommand($app->make('files'));
         });
     }
 
@@ -415,8 +416,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerJobMakeCommand()
     {
-        $this->app->singleton('command.job.make', function ($app) {
-            return new JobMakeCommand($app['files']);
+        $this->app->singleton('command.job.make', function (Application $app) {
+            return new JobMakeCommand($app->make('files'));
         });
     }
 
@@ -439,8 +440,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerListenerMakeCommand()
     {
-        $this->app->singleton('command.listener.make', function ($app) {
-            return new ListenerMakeCommand($app['files']);
+        $this->app->singleton('command.listener.make', function (Application $app) {
+            return new ListenerMakeCommand($app->make('files'));
         });
     }
 
@@ -451,8 +452,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerMailMakeCommand()
     {
-        $this->app->singleton('command.mail.make', function ($app) {
-            return new MailMakeCommand($app['files']);
+        $this->app->singleton('command.mail.make', function (Application $app) {
+            return new MailMakeCommand($app->make('files'));
         });
     }
 
@@ -463,8 +464,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerMiddlewareMakeCommand()
     {
-        $this->app->singleton('command.middleware.make', function ($app) {
-            return new MiddlewareMakeCommand($app['files']);
+        $this->app->singleton('command.middleware.make', function (Application $app) {
+            return new MiddlewareMakeCommand($app->make('files'));
         });
     }
 
@@ -475,8 +476,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerMigrateCommand()
     {
-        $this->app->singleton('command.migrate', function ($app) {
-            return new MigrateCommand($app['migrator']);
+        $this->app->singleton('command.migrate', function (Application $app) {
+            return new MigrateCommand($app->make('migrator'));
         });
     }
 
@@ -499,8 +500,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerMigrateInstallCommand()
     {
-        $this->app->singleton('command.migrate.install', function ($app) {
-            return new MigrateInstallCommand($app['migration.repository']);
+        $this->app->singleton('command.migrate.install', function (Application $app) {
+            return new MigrateInstallCommand($app->make('migration.repository'));
         });
     }
 
@@ -511,13 +512,13 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerMigrateMakeCommand()
     {
-        $this->app->singleton('command.migrate.make', function ($app) {
+        $this->app->singleton('command.migrate.make', function (Application $app) {
             // Once we have the migration creator registered, we will create the command
             // and inject the creator. The creator is responsible for the actual file
             // creation of the migrations, and may be extended by these developers.
-            $creator = $app['migration.creator'];
+            $creator = $app->make('migration.creator');
 
-            $composer = $app['composer'];
+            $composer = $app->make('composer');
 
             return new MigrateMakeCommand($creator, $composer);
         });
@@ -542,8 +543,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerMigrateResetCommand()
     {
-        $this->app->singleton('command.migrate.reset', function ($app) {
-            return new MigrateResetCommand($app['migrator']);
+        $this->app->singleton('command.migrate.reset', function (Application $app) {
+            return new MigrateResetCommand($app->make('migrator'));
         });
     }
 
@@ -554,8 +555,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerMigrateRollbackCommand()
     {
-        $this->app->singleton('command.migrate.rollback', function ($app) {
-            return new MigrateRollbackCommand($app['migrator']);
+        $this->app->singleton('command.migrate.rollback', function (Application $app) {
+            return new MigrateRollbackCommand($app->make('migrator'));
         });
     }
 
@@ -566,8 +567,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerMigrateStatusCommand()
     {
-        $this->app->singleton('command.migrate.status', function ($app) {
-            return new MigrateStatusCommand($app['migrator']);
+        $this->app->singleton('command.migrate.status', function (Application $app) {
+            return new MigrateStatusCommand($app->make('migrator'));
         });
     }
 
@@ -578,8 +579,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerModelMakeCommand()
     {
-        $this->app->singleton('command.model.make', function ($app) {
-            return new ModelMakeCommand($app['files']);
+        $this->app->singleton('command.model.make', function (Application $app) {
+            return new ModelMakeCommand($app->make('files'));
         });
     }
 
@@ -590,8 +591,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerNotificationMakeCommand()
     {
-        $this->app->singleton('command.notification.make', function ($app) {
-            return new NotificationMakeCommand($app['files']);
+        $this->app->singleton('command.notification.make', function (Application $app) {
+            return new NotificationMakeCommand($app->make('files'));
         });
     }
 
@@ -602,8 +603,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerNotificationTableCommand()
     {
-        $this->app->singleton('command.notification.table', function ($app) {
-            return new NotificationTableCommand($app['files'], $app['composer']);
+        $this->app->singleton('command.notification.table', function (Application $app) {
+            return new NotificationTableCommand($app->make('files'), $app->make('composer'));
         });
     }
 
@@ -626,8 +627,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerObserverMakeCommand()
     {
-        $this->app->singleton('command.observer.make', function ($app) {
-            return new ObserverMakeCommand($app['files']);
+        $this->app->singleton('command.observer.make', function (Application $app) {
+            return new ObserverMakeCommand($app->make('files'));
         });
     }
 
@@ -662,8 +663,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerPolicyMakeCommand()
     {
-        $this->app->singleton('command.policy.make', function ($app) {
-            return new PolicyMakeCommand($app['files']);
+        $this->app->singleton('command.policy.make', function (Application $app) {
+            return new PolicyMakeCommand($app->make('files'));
         });
     }
 
@@ -686,8 +687,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerProviderMakeCommand()
     {
-        $this->app->singleton('command.provider.make', function ($app) {
-            return new ProviderMakeCommand($app['files']);
+        $this->app->singleton('command.provider.make', function (Application $app) {
+            return new ProviderMakeCommand($app->make('files'));
         });
     }
 
@@ -734,8 +735,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerQueueListenCommand()
     {
-        $this->app->singleton('command.queue.listen', function ($app) {
-            return new QueueListenCommand($app['queue.listener']);
+        $this->app->singleton('command.queue.listen', function (Application $app) {
+            return new QueueListenCommand($app->make('queue.listener'));
         });
     }
 
@@ -770,8 +771,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerQueueWorkCommand()
     {
-        $this->app->singleton('command.queue.work', function ($app) {
-            return new QueueWorkCommand($app['queue.worker']);
+        $this->app->singleton('command.queue.work', function (Application $app) {
+            return new QueueWorkCommand($app->make('queue.worker'));
         });
     }
 
@@ -782,8 +783,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerQueueFailedTableCommand()
     {
-        $this->app->singleton('command.queue.failed-table', function ($app) {
-            return new FailedTableCommand($app['files'], $app['composer']);
+        $this->app->singleton('command.queue.failed-table', function (Application $app) {
+            return new FailedTableCommand($app->make('files'), $app->make('composer'));
         });
     }
 
@@ -794,8 +795,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerQueueTableCommand()
     {
-        $this->app->singleton('command.queue.table', function ($app) {
-            return new TableCommand($app['files'], $app['composer']);
+        $this->app->singleton('command.queue.table', function (Application $app) {
+            return new TableCommand($app->make('files'), $app->make('composer'));
         });
     }
 
@@ -806,8 +807,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerRequestMakeCommand()
     {
-        $this->app->singleton('command.request.make', function ($app) {
-            return new RequestMakeCommand($app['files']);
+        $this->app->singleton('command.request.make', function (Application $app) {
+            return new RequestMakeCommand($app->make('files'));
         });
     }
 
@@ -818,8 +819,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerResourceMakeCommand()
     {
-        $this->app->singleton('command.resource.make', function ($app) {
-            return new ResourceMakeCommand($app['files']);
+        $this->app->singleton('command.resource.make', function (Application $app) {
+            return new ResourceMakeCommand($app->make('files'));
         });
     }
 
@@ -830,8 +831,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerRuleMakeCommand()
     {
-        $this->app->singleton('command.rule.make', function ($app) {
-            return new RuleMakeCommand($app['files']);
+        $this->app->singleton('command.rule.make', function (Application $app) {
+            return new RuleMakeCommand($app->make('files'));
         });
     }
 
@@ -842,8 +843,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerSeederMakeCommand()
     {
-        $this->app->singleton('command.seeder.make', function ($app) {
-            return new SeederMakeCommand($app['files'], $app['composer']);
+        $this->app->singleton('command.seeder.make', function (Application $app) {
+            return new SeederMakeCommand($app->make('files'), $app->make('composer'));
         });
     }
 
@@ -854,8 +855,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerSessionTableCommand()
     {
-        $this->app->singleton('command.session.table', function ($app) {
-            return new SessionTableCommand($app['files'], $app['composer']);
+        $this->app->singleton('command.session.table', function (Application $app) {
+            return new SessionTableCommand($app->make('files'), $app->make('composer'));
         });
     }
 
@@ -878,8 +879,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerRouteCacheCommand()
     {
-        $this->app->singleton('command.route.cache', function ($app) {
-            return new RouteCacheCommand($app['files']);
+        $this->app->singleton('command.route.cache', function (Application $app) {
+            return new RouteCacheCommand($app->make('files'));
         });
     }
 
@@ -890,8 +891,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerRouteClearCommand()
     {
-        $this->app->singleton('command.route.clear', function ($app) {
-            return new RouteClearCommand($app['files']);
+        $this->app->singleton('command.route.clear', function (Application $app) {
+            return new RouteClearCommand($app->make('files'));
         });
     }
 
@@ -902,8 +903,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerRouteListCommand()
     {
-        $this->app->singleton('command.route.list', function ($app) {
-            return new RouteListCommand($app['router']);
+        $this->app->singleton('command.route.list', function (Application $app) {
+            return new RouteListCommand($app->make('router'));
         });
     }
 
@@ -914,8 +915,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerSeedCommand()
     {
-        $this->app->singleton('command.seed', function ($app) {
-            return new SeedCommand($app['db']);
+        $this->app->singleton('command.seed', function (Application $app) {
+            return new SeedCommand($app->make('db'));
         });
     }
 
@@ -958,8 +959,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerTestMakeCommand()
     {
-        $this->app->singleton('command.test.make', function ($app) {
-            return new TestMakeCommand($app['files']);
+        $this->app->singleton('command.test.make', function (Application $app) {
+            return new TestMakeCommand($app->make('files'));
         });
     }
 
@@ -982,8 +983,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerVendorPublishCommand()
     {
-        $this->app->singleton('command.vendor.publish', function ($app) {
-            return new VendorPublishCommand($app['files']);
+        $this->app->singleton('command.vendor.publish', function (Application $app) {
+            return new VendorPublishCommand($app->make('files'));
         });
     }
 
@@ -1006,8 +1007,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerViewClearCommand()
     {
-        $this->app->singleton('command.view.clear', function ($app) {
-            return new ViewClearCommand($app['files']);
+        $this->app->singleton('command.view.clear', function (Application $app) {
+            return new ViewClearCommand($app->make('files'));
         });
     }
 

--- a/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Providers;
 
 use Illuminate\Support\Composer;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Foundation\Application;
 
 class ComposerServiceProvider extends ServiceProvider
 {
@@ -21,8 +22,8 @@ class ComposerServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('composer', function ($app) {
-            return new Composer($app['files'], $app->basePath());
+        $this->app->singleton('composer', function (Application $app) {
+            return new Composer($app->make('files'), $app->basePath());
         });
     }
 

--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Providers;
 use Illuminate\Routing\Redirector;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 
 class FormRequestServiceProvider extends ServiceProvider
@@ -30,8 +31,8 @@ class FormRequestServiceProvider extends ServiceProvider
             $resolved->validateResolved();
         });
 
-        $this->app->resolving(FormRequest::class, function ($request, $app) {
-            $request = FormRequest::createFrom($app['request'], $request);
+        $this->app->resolving(FormRequest::class, function ($request, Application $app) {
+            $request = FormRequest::createFrom($app->make('request'), $request);
 
             $request->setContainer($app)->setRedirector($app->make(Redirector::class));
         });

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -36,8 +36,8 @@ class RouteServiceProvider extends ServiceProvider
             $this->loadRoutes();
 
             $this->app->booted(function () {
-                $this->app['router']->getRoutes()->refreshNameLookups();
-                $this->app['router']->getRoutes()->refreshActionLookups();
+                $this->app->make('router')->getRoutes()->refreshNameLookups();
+                $this->app->make('router')->getRoutes()->refreshActionLookups();
             });
         }
     }
@@ -50,7 +50,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function setRootControllerNamespace()
     {
         if (! is_null($this->namespace)) {
-            $this->app[UrlGenerator::class]->setRootControllerNamespace($this->namespace);
+            $this->app->make(UrlGenerator::class)->setRootControllerNamespace($this->namespace);
         }
     }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -31,9 +31,9 @@ trait InteractsWithAuthentication
             $user->wasRecentlyCreated = false;
         }
 
-        $this->app['auth']->guard($driver)->setUser($user);
+        $this->app->make('auth')->guard($driver)->setUser($user);
 
-        $this->app['auth']->shouldUse($driver);
+        $this->app->make('auth')->shouldUse($driver);
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -39,7 +39,7 @@ trait InteractsWithConsole
     public function artisan($command, $parameters = [])
     {
         if (! $this->mockConsoleOutput) {
-            return $this->app[Kernel::class]->call($command, $parameters);
+            return $this->app->make(Kernel::class)->call($command, $parameters);
         }
 
         $this->beforeApplicationDestroyed(function () {

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithSession.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithSession.php
@@ -28,7 +28,7 @@ trait InteractsWithSession
         $this->startSession();
 
         foreach ($data as $key => $value) {
-            $this->app['session']->put($key, $value);
+            $this->app->make('session')->put($key, $value);
         }
 
         return $this;
@@ -41,8 +41,8 @@ trait InteractsWithSession
      */
     protected function startSession()
     {
-        if (! $this->app['session']->isStarted()) {
-            $this->app['session']->start();
+        if (! $this->app->make('session')->isStarted()) {
+            $this->app->make('session')->start();
         }
 
         return $this;
@@ -57,7 +57,7 @@ trait InteractsWithSession
     {
         $this->startSession();
 
-        $this->app['session']->flush();
+        $this->app->make('session')->flush();
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
@@ -15,7 +15,7 @@ trait DatabaseMigrations
     {
         $this->artisan('migrate:fresh');
 
-        $this->app[Kernel::class]->setArtisan(null);
+        $this->app->make(Kernel::class)->setArtisan(null);
 
         $this->beforeApplicationDestroyed(function () {
             $this->artisan('migrate:rollback');

--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -133,7 +133,7 @@ class PendingCommand
         $this->mockConsoleOutput();
 
         try {
-            $exitCode = $this->app[Kernel::class]->call($this->command, $this->parameters);
+            $exitCode = $this->app->make(Kernel::class)->call($this->command, $this->parameters);
         } catch (NoMatchingExpectationException $e) {
             if ($e->getMethodName() === 'askQuestion') {
                 $this->test->fail('Unexpected question "'.$e->getActualArguments()[0]->getQuestion().'" was asked.');

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -39,7 +39,7 @@ trait RefreshDatabase
     {
         $this->artisan('migrate');
 
-        $this->app[Kernel::class]->setArtisan(null);
+        $this->app->make(Kernel::class)->setArtisan(null);
     }
 
     /**
@@ -54,7 +54,7 @@ trait RefreshDatabase
                 '--drop-views' => true,
             ] : []);
 
-            $this->app[Kernel::class]->setArtisan(null);
+            $this->app->make(Kernel::class)->setArtisan(null);
 
             RefreshDatabaseState::$migrated = true;
         }

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -77,7 +77,7 @@ abstract class TestCase extends BaseTestCase
 
         Facade::clearResolvedInstances();
 
-        Model::setEventDispatcher($this->app['events']);
+        Model::setEventDispatcher($this->app->make('events'));
 
         $this->setUpHasRun = true;
     }

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -14,7 +14,7 @@ class HashManager extends Manager implements Hasher
      */
     public function createBcryptDriver()
     {
-        return new BcryptHasher($this->app['config']['hashing.bcrypt'] ?? []);
+        return new BcryptHasher($this->app->make('config')->get('hashing.bcrypt') ?? []);
     }
 
     /**
@@ -24,7 +24,7 @@ class HashManager extends Manager implements Hasher
      */
     public function createArgonDriver()
     {
-        return new ArgonHasher($this->app['config']['hashing.argon'] ?? []);
+        return new ArgonHasher($this->app->make('config')->get('hashing.argon') ?? []);
     }
 
     /**
@@ -34,7 +34,7 @@ class HashManager extends Manager implements Hasher
      */
     public function createArgon2idDriver()
     {
-        return new Argon2IdHasher($this->app['config']['hashing.argon'] ?? []);
+        return new Argon2IdHasher($this->app->make('config')->get('hashing.argon') ?? []);
     }
 
     /**
@@ -92,6 +92,6 @@ class HashManager extends Manager implements Hasher
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['hashing.driver'] ?? 'bcrypt';
+        return $this->app->make('config')->get('hashing.driver') ?? 'bcrypt';
     }
 }

--- a/src/Illuminate/Hashing/HashServiceProvider.php
+++ b/src/Illuminate/Hashing/HashServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Hashing;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Foundation\Application;
 
 class HashServiceProvider extends ServiceProvider
 {
@@ -20,12 +21,12 @@ class HashServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('hash', function ($app) {
+        $this->app->singleton('hash', function (Application $app) {
             return new HashManager($app);
         });
 
-        $this->app->singleton('hash.driver', function ($app) {
-            return $app['hash']->driver();
+        $this->app->singleton('hash.driver', function (Application $app) {
+            return $app->make('hash')->driver();
         });
     }
 

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -63,7 +63,7 @@ class LogManager implements LoggerInterface
     {
         return new Logger(
             $this->createStackDriver(compact('channels', 'channel')),
-            $this->app['events']
+            $this->app->make('events')
         );
     }
 
@@ -99,7 +99,7 @@ class LogManager implements LoggerInterface
     {
         try {
             return $this->channels[$name] ?? with($this->resolve($name), function ($logger) use ($name) {
-                return $this->channels[$name] = $this->tap($name, new Logger($logger, $this->app['events']));
+                return $this->channels[$name] = $this->tap($name, new Logger($logger, $this->app->make('events')));
             });
         } catch (Throwable $e) {
             return tap($this->createEmergencyLogger(), function ($logger) use ($e) {
@@ -148,7 +148,7 @@ class LogManager implements LoggerInterface
     {
         return new Logger(new Monolog('laravel', $this->prepareHandlers([new StreamHandler(
                 $this->app->storagePath().'/logs/laravel.log', $this->level(['level' => 'debug'])
-        )])), $this->app['events']);
+        )])), $this->app->make('events'));
     }
 
     /**
@@ -285,7 +285,7 @@ class LogManager implements LoggerInterface
     {
         return new Monolog($this->parseChannel($config), [
             $this->prepareHandler(new SyslogHandler(
-                Str::snake($this->app['config']['app.name'], '-'), $config['facility'] ?? LOG_USER, $this->level($config))
+                Str::snake($this->app->make('config')->get('app.name'), '-'), $config['facility'] ?? LOG_USER, $this->level($config))
             ),
         ]);
     }
@@ -392,7 +392,7 @@ class LogManager implements LoggerInterface
      */
     protected function configurationFor($name)
     {
-        return $this->app['config']["logging.channels.{$name}"];
+        return $this->app->make('config')->get("logging.channels.{$name}");
     }
 
     /**
@@ -402,7 +402,7 @@ class LogManager implements LoggerInterface
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['logging.default'];
+        return $this->app->make('config')->get('logging.default');
     }
 
     /**
@@ -413,7 +413,7 @@ class LogManager implements LoggerInterface
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['logging.default'] = $name;
+        $this->app->make('config')->set('logging.default', $name);
     }
 
     /**

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -63,7 +63,7 @@ class TransportManager extends Manager
      */
     protected function createSendmailDriver()
     {
-        return new SendmailTransport($this->app['config']['mail']['sendmail']);
+        return new SendmailTransport($this->app->make('config')->get('mail.sendmail'));
     }
 
     /**
@@ -73,7 +73,7 @@ class TransportManager extends Manager
      */
     protected function createSesDriver()
     {
-        $config = array_merge($this->app['config']->get('services.ses', []), [
+        $config = array_merge($this->app->make('config')->get('services.ses', []), [
             'version' => 'latest', 'service' => 'email',
         ]);
 
@@ -115,7 +115,7 @@ class TransportManager extends Manager
      */
     protected function createMailgunDriver()
     {
-        $config = $this->app['config']->get('services.mailgun', []);
+        $config = $this->app->make('config')->get('services.mailgun', []);
 
         return new MailgunTransport(
             $this->guzzle($config),
@@ -132,7 +132,7 @@ class TransportManager extends Manager
      */
     protected function createMandrillDriver()
     {
-        $config = $this->app['config']->get('services.mandrill', []);
+        $config = $this->app->make('config')->get('services.mandrill', []);
 
         return new MandrillTransport(
             $this->guzzle($config), $config['secret']
@@ -146,7 +146,7 @@ class TransportManager extends Manager
      */
     protected function createSparkPostDriver()
     {
-        $config = $this->app['config']->get('services.sparkpost', []);
+        $config = $this->app->make('config')->get('services.sparkpost', []);
 
         return new SparkPostTransport(
             $this->guzzle($config), $config['secret'], $config['options'] ?? []
@@ -193,7 +193,7 @@ class TransportManager extends Manager
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['mail.driver'];
+        return $this->app->make('config')->get('mail.driver');
     }
 
     /**
@@ -204,6 +204,6 @@ class TransportManager extends Manager
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['mail.driver'] = $name;
+        $this->app->make('config')->set('mail.driver', $name);
     }
 }

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -107,10 +107,10 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     {
         return new Channels\NexmoSmsChannel(
             new NexmoClient(new NexmoCredentials(
-                $this->app['config']['services.nexmo.key'],
-                $this->app['config']['services.nexmo.secret']
+                $this->app->make('config')->get('services.nexmo.key'),
+                $this->app->make('config')->get('services.nexmo.secret')
             )),
-            $this->app['config']['services.nexmo.sms_from']
+            $this->app->make('config')->get('services.nexmo.sms_from')
         );
     }
 

--- a/src/Illuminate/Notifications/Console/NotificationTableCommand.php
+++ b/src/Illuminate/Notifications/Console/NotificationTableCommand.php
@@ -76,6 +76,6 @@ class NotificationTableCommand extends Command
 
         $path = $this->laravel->databasePath().'/migrations';
 
-        return $this->laravel['migration.creator']->create($name, $path);
+        return $this->laravel->make('migration.creator')->create($name, $path);
     }
 }

--- a/src/Illuminate/Pagination/PaginationServiceProvider.php
+++ b/src/Illuminate/Pagination/PaginationServiceProvider.php
@@ -30,15 +30,15 @@ class PaginationServiceProvider extends ServiceProvider
     public function register()
     {
         Paginator::viewFactoryResolver(function () {
-            return $this->app['view'];
+            return $this->app->make('view');
         });
 
         Paginator::currentPathResolver(function () {
-            return $this->app['request']->url();
+            return $this->app->make('request')->url();
         });
 
         Paginator::currentPageResolver(function ($pageName = 'page') {
-            $page = $this->app['request']->input($pageName);
+            $page = $this->app->make('request')->input($pageName);
 
             if (filter_var($page, FILTER_VALIDATE_INT) !== false && (int) $page >= 1) {
                 return (int) $page;

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -57,7 +57,7 @@ class FailedTableCommand extends Command
      */
     public function handle()
     {
-        $table = $this->laravel['config']['queue.failed.table'];
+        $table = $this->laravel->make('config')->get('queue.failed.table');
 
         $this->replaceMigration(
             $this->createBaseMigration($table), $table, Str::studly($table)
@@ -76,7 +76,7 @@ class FailedTableCommand extends Command
      */
     protected function createBaseMigration($table = 'failed_jobs')
     {
-        return $this->laravel['migration.creator']->create(
+        return $this->laravel->make('migration.creator')->create(
             'create_'.$table.'_table', $this->laravel->databasePath().'/migrations'
         );
     }

--- a/src/Illuminate/Queue/Console/FlushFailedCommand.php
+++ b/src/Illuminate/Queue/Console/FlushFailedCommand.php
@@ -27,7 +27,7 @@ class FlushFailedCommand extends Command
      */
     public function handle()
     {
-        $this->laravel['queue.failer']->flush();
+        $this->laravel->make('queue.failer')->flush();
 
         $this->info('All failed jobs deleted successfully!');
     }

--- a/src/Illuminate/Queue/Console/ForgetFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ForgetFailedCommand.php
@@ -27,7 +27,7 @@ class ForgetFailedCommand extends Command
      */
     public function handle()
     {
-        if ($this->laravel['queue.failer']->forget($this->argument('id'))) {
+        if ($this->laravel->make('queue.failer')->forget($this->argument('id'))) {
             $this->info('Failed job deleted successfully!');
         } else {
             $this->error('No failed job matches the given ID.');

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -49,7 +49,7 @@ class ListFailedCommand extends Command
      */
     protected function getFailedJobs()
     {
-        $failed = $this->laravel['queue.failer']->all();
+        $failed = $this->laravel->make('queue.failer')->all();
 
         return collect($failed)->map(function ($failed) {
             return $this->parseFailedJob((array) $failed);

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -77,9 +77,9 @@ class ListenCommand extends Command
      */
     protected function getQueue($connection)
     {
-        $connection = $connection ?: $this->laravel['config']['queue.default'];
+        $connection = $connection ?: $this->laravel->make('config')->get('queue.default');
 
-        return $this->input->getOption('queue') ?: $this->laravel['config']->get(
+        return $this->input->getOption('queue') ?: $this->laravel->make('config')->get(
             "queue.connections.{$connection}.queue", 'default'
         );
     }

--- a/src/Illuminate/Queue/Console/RestartCommand.php
+++ b/src/Illuminate/Queue/Console/RestartCommand.php
@@ -30,7 +30,7 @@ class RestartCommand extends Command
      */
     public function handle()
     {
-        $this->laravel['cache']->forever('illuminate:queue:restart', $this->currentTime());
+        $this->laravel->make('cache')->forever('illuminate:queue:restart', $this->currentTime());
 
         $this->info('Broadcasting queue restart signal.');
     }

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -29,7 +29,7 @@ class RetryCommand extends Command
     public function handle()
     {
         foreach ($this->getJobIds() as $id) {
-            $job = $this->laravel['queue.failer']->find($id);
+            $job = $this->laravel->make('queue.failer')->find($id);
 
             if (is_null($job)) {
                 $this->error("Unable to find failed job with ID [{$id}].");
@@ -38,7 +38,7 @@ class RetryCommand extends Command
 
                 $this->info("The failed job [{$id}] has been pushed back onto the queue!");
 
-                $this->laravel['queue.failer']->forget($id);
+                $this->laravel->make('queue.failer')->forget($id);
             }
         }
     }
@@ -53,7 +53,7 @@ class RetryCommand extends Command
         $ids = (array) $this->argument('id');
 
         if (count($ids) === 1 && $ids[0] === 'all') {
-            $ids = Arr::pluck($this->laravel['queue.failer']->all(), 'id');
+            $ids = Arr::pluck($this->laravel->make('queue.failer')->all(), 'id');
         }
 
         return $ids;
@@ -67,7 +67,7 @@ class RetryCommand extends Command
      */
     protected function retryJob($job)
     {
-        $this->laravel['queue']->connection($job->connection)->pushRaw(
+        $this->laravel->make('queue')->connection($job->connection)->pushRaw(
             $this->resetAttempts($job->payload), $job->queue
         );
     }

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -57,7 +57,7 @@ class TableCommand extends Command
      */
     public function handle()
     {
-        $table = $this->laravel['config']['queue.connections.database.table'];
+        $table = $this->laravel->make('config')->get('queue.connections.database.table');
 
         $this->replaceMigration(
             $this->createBaseMigration($table), $table, Str::studly($table)
@@ -76,7 +76,7 @@ class TableCommand extends Command
      */
     protected function createBaseMigration($table = 'jobs')
     {
-        return $this->laravel['migration.creator']->create(
+        return $this->laravel->make('migration.creator')->create(
             'create_'.$table.'_table', $this->laravel->databasePath().'/migrations'
         );
     }

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -75,7 +75,7 @@ class WorkCommand extends Command
         $this->listenForEvents();
 
         $connection = $this->argument('connection')
-                        ?: $this->laravel['config']['queue.default'];
+                        ?: $this->laravel->make('config')->get('queue.default');
 
         // We need to get the right queue for the connection which is set in the queue
         // configuration file for the application. We will pull it based on the set
@@ -96,7 +96,7 @@ class WorkCommand extends Command
      */
     protected function runWorker($connection, $queue)
     {
-        $this->worker->setCache($this->laravel['cache']->driver());
+        $this->worker->setCache($this->laravel->make('cache')->driver());
 
         return $this->worker->{$this->option('once') ? 'runNextJob' : 'daemon'}(
             $connection, $queue, $this->gatherWorkerOptions()
@@ -125,15 +125,15 @@ class WorkCommand extends Command
      */
     protected function listenForEvents()
     {
-        $this->laravel['events']->listen(JobProcessing::class, function ($event) {
+        $this->laravel->make('events')->listen(JobProcessing::class, function ($event) {
             $this->writeOutput($event->job, 'starting');
         });
 
-        $this->laravel['events']->listen(JobProcessed::class, function ($event) {
+        $this->laravel->make('events')->listen(JobProcessed::class, function ($event) {
             $this->writeOutput($event->job, 'success');
         });
 
-        $this->laravel['events']->listen(JobFailed::class, function ($event) {
+        $this->laravel->make('events')->listen(JobFailed::class, function ($event) {
             $this->writeOutput($event->job, 'failed');
 
             $this->logFailedJob($event);
@@ -185,7 +185,7 @@ class WorkCommand extends Command
      */
     protected function logFailedJob(JobFailed $event)
     {
-        $this->laravel['queue.failer']->log(
+        $this->laravel->make('queue.failer')->log(
             $event->connectionName, $event->job->getQueue(),
             $event->job->getRawBody(), $event->exception
         );
@@ -199,7 +199,7 @@ class WorkCommand extends Command
      */
     protected function getQueue($connection)
     {
-        return $this->option('queue') ?: $this->laravel['config']->get(
+        return $this->option('queue') ?: $this->laravel->make('config')->get(
             "queue.connections.{$connection}.queue", 'default'
         );
     }

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -52,7 +52,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function before($callback)
     {
-        $this->app['events']->listen(Events\JobProcessing::class, $callback);
+        $this->app->make('events')->listen(Events\JobProcessing::class, $callback);
     }
 
     /**
@@ -63,7 +63,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function after($callback)
     {
-        $this->app['events']->listen(Events\JobProcessed::class, $callback);
+        $this->app->make('events')->listen(Events\JobProcessed::class, $callback);
     }
 
     /**
@@ -74,7 +74,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function exceptionOccurred($callback)
     {
-        $this->app['events']->listen(Events\JobExceptionOccurred::class, $callback);
+        $this->app->make('events')->listen(Events\JobExceptionOccurred::class, $callback);
     }
 
     /**
@@ -85,7 +85,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function looping($callback)
     {
-        $this->app['events']->listen(Events\Looping::class, $callback);
+        $this->app->make('events')->listen(Events\Looping::class, $callback);
     }
 
     /**
@@ -96,7 +96,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function failing($callback)
     {
-        $this->app['events']->listen(Events\JobFailed::class, $callback);
+        $this->app->make('events')->listen(Events\JobFailed::class, $callback);
     }
 
     /**
@@ -107,7 +107,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function stopping($callback)
     {
-        $this->app['events']->listen(Events\WorkerStopping::class, $callback);
+        $this->app->make('events')->listen(Events\WorkerStopping::class, $callback);
     }
 
     /**
@@ -208,7 +208,7 @@ class QueueManager implements FactoryContract, MonitorContract
     protected function getConfig($name)
     {
         if (! is_null($name) && $name !== 'null') {
-            return $this->app['config']["queue.connections.{$name}"];
+            return $this->app->make('config')->get("queue.connections.{$name}");
         }
 
         return ['driver' => 'null'];
@@ -221,7 +221,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['queue.default'];
+        return $this->app->make('config')->get('queue.default');
     }
 
     /**
@@ -232,7 +232,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['queue.default'] = $name;
+        $this->app->make('config')->set('queue.default', $name);
     }
 
     /**

--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Redis;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Foundation\Application;
 
 class RedisServiceProvider extends ServiceProvider
 {
@@ -21,14 +22,14 @@ class RedisServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('redis', function ($app) {
+        $this->app->singleton('redis', function (Application $app) {
             $config = $app->make('config')->get('database.redis', []);
 
             return new RedisManager($app, Arr::pull($config, 'client', 'predis'), $config);
         });
 
-        $this->app->bind('redis.connection', function ($app) {
-            return $app['redis']->connection();
+        $this->app->bind('redis.connection', function (Application $app) {
+            return $app->make('redis')->connection();
         });
     }
 

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\ServiceProvider;
 use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Response as PsrResponse;
 use Psr\Http\Message\ServerRequestInterface;
+use Illuminate\Contracts\Foundation\Application;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Illuminate\Contracts\View\Factory as ViewFactoryContract;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
@@ -36,8 +38,8 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerRouter()
     {
-        $this->app->singleton('router', function ($app) {
-            return new Router($app['events'], $app);
+        $this->app->singleton('router', function (Application $app) {
+            return new Router($app->make('events'), $app);
         });
     }
 
@@ -48,8 +50,8 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerUrlGenerator()
     {
-        $this->app->singleton('url', function ($app) {
-            $routes = $app['router']->getRoutes();
+        $this->app->singleton('url', function (Application $app) {
+            $routes = $app->make('router')->getRoutes();
 
             // The URL generator needs the route collection that exists on the router.
             // Keep in mind this is an object, so we're passing by references here
@@ -66,7 +68,7 @@ class RoutingServiceProvider extends ServiceProvider
             // get the information it needs to function. This just provides some of
             // the convenience features to this URL generator like "signed" URLs.
             $url->setSessionResolver(function () {
-                return $this->app['session'];
+                return $this->app->make('session');
             });
 
             $url->setKeyResolver(function () {
@@ -76,8 +78,8 @@ class RoutingServiceProvider extends ServiceProvider
             // If the route collection is "rebound", for example, when the routes stay
             // cached for the application, we will need to rebind the routes on the
             // URL generator instance so it has the latest version of the routes.
-            $app->rebinding('routes', function ($app, $routes) {
-                $app['url']->setRoutes($routes);
+            $app->rebinding('routes', function (Application $app, RouteCollection $routes) {
+                $app->make('url')->setRoutes($routes);
             });
 
             return $url;
@@ -91,8 +93,8 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function requestRebinder()
     {
-        return function ($app, $request) {
-            $app['url']->setRequest($request);
+        return function (Application $app, Request $request) {
+            $app->make('url')->setRequest($request);
         };
     }
 
@@ -103,14 +105,14 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerRedirector()
     {
-        $this->app->singleton('redirect', function ($app) {
-            $redirector = new Redirector($app['url']);
+        $this->app->singleton('redirect', function (Application $app) {
+            $redirector = new Redirector($app->make('url'));
 
             // If the session is set on the application instance, we'll inject it into
             // the redirector instance. This allows the redirect responses to allow
             // for the quite convenient "with" methods that flash to the session.
-            if (isset($app['session.store'])) {
-                $redirector->setSession($app['session.store']);
+            if ($app->bound('session.store')) {
+                $redirector->setSession($app->make('session.store'));
             }
 
             return $redirector;
@@ -124,7 +126,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerPsrRequest()
     {
-        $this->app->bind(ServerRequestInterface::class, function ($app) {
+        $this->app->bind(ServerRequestInterface::class, function (Application $app) {
             return (new DiactorosFactory)->createRequest($app->make('request'));
         });
     }
@@ -148,8 +150,8 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerResponseFactory()
     {
-        $this->app->singleton(ResponseFactoryContract::class, function ($app) {
-            return new ResponseFactory($app[ViewFactoryContract::class], $app['redirect']);
+        $this->app->singleton(ResponseFactoryContract::class, function (Application $app) {
+            return new ResponseFactory($app->make(ViewFactoryContract::class), $app->make('redirect'));
         });
     }
 
@@ -160,7 +162,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerControllerDispatcher()
     {
-        $this->app->singleton(ControllerDispatcherContract::class, function ($app) {
+        $this->app->singleton(ControllerDispatcherContract::class, function (Application $app) {
             return new ControllerDispatcher($app);
         });
     }

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -76,6 +76,6 @@ class SessionTableCommand extends Command
 
         $path = $this->laravel->databasePath().'/migrations';
 
-        return $this->laravel['migration.creator']->create($name, $path);
+        return $this->laravel->make('migration.creator')->create($name, $path);
     }
 }

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -35,7 +35,7 @@ class SessionManager extends Manager
     protected function createCookieDriver()
     {
         return $this->buildSession(new CookieSessionHandler(
-            $this->app['cookie'], $this->app['config']['session.lifetime']
+            $this->app->make('cookie'), $this->app->make('config')->get('session.lifetime')
         ));
     }
 
@@ -56,10 +56,10 @@ class SessionManager extends Manager
      */
     protected function createNativeDriver()
     {
-        $lifetime = $this->app['config']['session.lifetime'];
+        $lifetime = $this->app->make('config')->get('session.lifetime');
 
         return $this->buildSession(new FileSessionHandler(
-            $this->app['files'], $this->app['config']['session.files'], $lifetime
+            $this->app->make('files'), $this->app->make('config')->get('session.files'), $lifetime
         ));
     }
 
@@ -70,9 +70,9 @@ class SessionManager extends Manager
      */
     protected function createDatabaseDriver()
     {
-        $table = $this->app['config']['session.table'];
+        $table = $this->app->make('config')->get('session.table');
 
-        $lifetime = $this->app['config']['session.lifetime'];
+        $lifetime = $this->app->make('config')->get('session.lifetime');
 
         return $this->buildSession(new DatabaseSessionHandler(
             $this->getDatabaseConnection(), $table, $lifetime, $this->app
@@ -86,9 +86,9 @@ class SessionManager extends Manager
      */
     protected function getDatabaseConnection()
     {
-        $connection = $this->app['config']['session.connection'];
+        $connection = $this->app->make('config')->get('session.connection');
 
-        return $this->app['db']->connection($connection);
+        return $this->app->make('db')->connection($connection);
     }
 
     /**
@@ -121,7 +121,7 @@ class SessionManager extends Manager
         $handler = $this->createCacheHandler('redis');
 
         $handler->getCache()->getStore()->setConnection(
-            $this->app['config']['session.connection']
+            $this->app->make('config')->get('session.connection')
         );
 
         return $this->buildSession($handler);
@@ -146,11 +146,11 @@ class SessionManager extends Manager
      */
     protected function createCacheHandler($driver)
     {
-        $store = $this->app['config']->get('session.store') ?: $driver;
+        $store = $this->app->make('config')->get('session.store') ?: $driver;
 
         return new CacheBasedSessionHandler(
-            clone $this->app['cache']->store($store),
-            $this->app['config']['session.lifetime']
+            clone $this->app->make('cache')->store($store),
+            $this->app->make('config')->get('session.lifetime')
         );
     }
 
@@ -162,11 +162,11 @@ class SessionManager extends Manager
      */
     protected function buildSession($handler)
     {
-        if ($this->app['config']['session.encrypt']) {
+        if ($this->app->make('config')->get('session.encrypt')) {
             return $this->buildEncryptedSession($handler);
         }
 
-        return new Store($this->app['config']['session.cookie'], $handler);
+        return new Store($this->app->make('config')->get('session.cookie'), $handler);
     }
 
     /**
@@ -178,7 +178,7 @@ class SessionManager extends Manager
     protected function buildEncryptedSession($handler)
     {
         return new EncryptedStore(
-            $this->app['config']['session.cookie'], $handler, $this->app['encrypter']
+            $this->app->make('config')->get('session.cookie'), $handler, $this->app->make('encrypter')
         );
     }
 
@@ -189,7 +189,7 @@ class SessionManager extends Manager
      */
     public function getSessionConfig()
     {
-        return $this->app['config']['session'];
+        return $this->app->make('config')->get('session');
     }
 
     /**
@@ -199,7 +199,7 @@ class SessionManager extends Manager
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['session.driver'];
+        return $this->app->make('config')->get('session.driver');
     }
 
     /**
@@ -210,6 +210,6 @@ class SessionManager extends Manager
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['session.driver'] = $name;
+        $this->app->make('config')->set('session.driver', $name);
     }
 }

--- a/src/Illuminate/Support/Facades/Cookie.php
+++ b/src/Illuminate/Support/Facades/Cookie.php
@@ -19,7 +19,7 @@ class Cookie extends Facade
      */
     public static function has($key)
     {
-        return ! is_null(static::$app['request']->cookie($key, null));
+        return ! is_null(static::$app->make('request')->cookie($key, null));
     }
 
     /**
@@ -31,7 +31,7 @@ class Cookie extends Facade
      */
     public static function get($key = null, $default = null)
     {
-        return static::$app['request']->cookie($key, $default);
+        return static::$app->make('request')->cookie($key, $default);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Date.php
+++ b/src/Illuminate/Support/Facades/Date.php
@@ -104,7 +104,7 @@ class Date extends Facade
      */
     protected static function resolveFacadeInstance($name)
     {
-        if (! isset(static::$resolvedInstance[$name]) && ! isset(static::$app, static::$app[$name])) {
+        if (! isset(static::$resolvedInstance[$name]) && ! (isset(static::$app) && static::$app->bound($name))) {
             $class = static::DEFAULT_FACADE;
 
             static::swap(new $class);

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -154,7 +154,11 @@ abstract class Facade
             return static::$resolvedInstance[$name];
         }
 
-        return static::$resolvedInstance[$name] = static::$app[$name];
+        if (! isset(static::$app)) {
+            return static::$resolvedInstance[$name] = null;
+        }
+
+        return static::$resolvedInstance[$name] = static::$app->make($name);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Input.php
+++ b/src/Illuminate/Support/Facades/Input.php
@@ -57,7 +57,7 @@ class Input extends Facade
      */
     public static function get($key = null, $default = null)
     {
-        return static::$app['request']->input($key, $default);
+        return static::$app->make('request')->input($key, $default);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -21,7 +21,7 @@ class Schema extends Facade
      */
     public static function connection($name)
     {
-        return static::$app['db']->connection($name)->getSchemaBuilder();
+        return static::$app->make('db')->connection($name)->getSchemaBuilder();
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -20,7 +20,7 @@ class Storage extends Facade
      */
     public static function fake($disk = null)
     {
-        $disk = $disk ?: self::$app['config']->get('filesystems.default');
+        $disk = $disk ?: self::$app->make('config')->get('filesystems.default');
 
         (new Filesystem)->cleanDirectory(
             $root = storage_path('framework/testing/disks/'.$disk)
@@ -37,7 +37,7 @@ class Storage extends Facade
      */
     public static function persistentFake($disk = null)
     {
-        $disk = $disk ?: self::$app['config']->get('filesystems.default');
+        $disk = $disk ?: self::$app->make('config')->get('filesystems.default');
 
         static::set($disk, self::createLocalDriver([
             'root' => storage_path('framework/testing/disks/'.$disk),

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -54,9 +54,9 @@ abstract class ServiceProvider
      */
     protected function mergeConfigFrom($path, $key)
     {
-        $config = $this->app['config']->get($key, []);
+        $config = $this->app->make('config')->get($key, []);
 
-        $this->app['config']->set($key, array_merge(require $path, $config));
+        $this->app->make('config')->set($key, array_merge(require $path, $config));
     }
 
     /**
@@ -81,15 +81,15 @@ abstract class ServiceProvider
      */
     protected function loadViewsFrom($path, $namespace)
     {
-        if (is_array($this->app->config['view']['paths'])) {
-            foreach ($this->app->config['view']['paths'] as $viewPath) {
+        if (is_array($this->app->make('config')->get('view.paths'))) {
+            foreach ($this->app->make('config')->get('view.paths') as $viewPath) {
                 if (is_dir($appPath = $viewPath.'/vendor/'.$namespace)) {
-                    $this->app['view']->addNamespace($namespace, $appPath);
+                    $this->app->make('view')->addNamespace($namespace, $appPath);
                 }
             }
         }
 
-        $this->app['view']->addNamespace($namespace, $path);
+        $this->app->make('view')->addNamespace($namespace, $path);
     }
 
     /**
@@ -101,7 +101,7 @@ abstract class ServiceProvider
      */
     protected function loadTranslationsFrom($path, $namespace)
     {
-        $this->app['translator']->addNamespace($namespace, $path);
+        $this->app->make('translator')->addNamespace($namespace, $path);
     }
 
     /**
@@ -112,7 +112,7 @@ abstract class ServiceProvider
      */
     protected function loadJsonTranslationsFrom($path)
     {
-        $this->app['translator']->addJsonPath($path);
+        $this->app->make('translator')->addJsonPath($path);
     }
 
     /**

--- a/src/Illuminate/Translation/TranslationServiceProvider.php
+++ b/src/Illuminate/Translation/TranslationServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Translation;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Foundation\Application;
 
 class TranslationServiceProvider extends ServiceProvider
 {
@@ -22,17 +23,17 @@ class TranslationServiceProvider extends ServiceProvider
     {
         $this->registerLoader();
 
-        $this->app->singleton('translator', function ($app) {
-            $loader = $app['translation.loader'];
+        $this->app->singleton('translator', function (Application $app) {
+            $loader = $app->make('translation.loader');
 
             // When registering the translator component, we'll need to set the default
             // locale as well as the fallback locale. So, we'll grab the application
             // configuration so we can easily get both of these values from there.
-            $locale = $app['config']['app.locale'];
+            $locale = $app->make('config')->get('app.locale');
 
             $trans = new Translator($loader, $locale);
 
-            $trans->setFallback($app['config']['app.fallback_locale']);
+            $trans->setFallback($app->make('config')->get('app.fallback_locale'));
 
             return $trans;
         });
@@ -45,8 +46,8 @@ class TranslationServiceProvider extends ServiceProvider
      */
     protected function registerLoader()
     {
-        $this->app->singleton('translation.loader', function ($app) {
-            return new FileLoader($app['files'], $app['path.lang']);
+        $this->app->singleton('translation.loader', function (Application $app) {
+            return new FileLoader($app->make('files'), $app->make('path.lang'));
         });
     }
 

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Foundation\Application;
 
 class ValidationServiceProvider extends ServiceProvider
 {
@@ -32,14 +33,14 @@ class ValidationServiceProvider extends ServiceProvider
      */
     protected function registerValidationFactory()
     {
-        $this->app->singleton('validator', function ($app) {
-            $validator = new Factory($app['translator'], $app);
+        $this->app->singleton('validator', function (Application $app) {
+            $validator = new Factory($app->make('translator'), $app);
 
             // The validation presence verifier is responsible for determining the existence of
             // values in a given data collection which is typically a relational database or
             // other persistent data stores. It is used to check for "uniqueness" as well.
-            if (isset($app['db'], $app['validation.presence'])) {
-                $validator->setPresenceVerifier($app['validation.presence']);
+            if ($app->bound('db') && $app->bound('validation.presence')) {
+                $validator->setPresenceVerifier($app->make('validation.presence'));
             }
 
             return $validator;
@@ -53,8 +54,8 @@ class ValidationServiceProvider extends ServiceProvider
      */
     protected function registerPresenceVerifier()
     {
-        $this->app->singleton('validation.presence', function ($app) {
-            return new DatabasePresenceVerifier($app['db']);
+        $this->app->singleton('validation.presence', function (Application $app) {
+            return new DatabasePresenceVerifier($app->make('db'));
         });
     }
 

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\View\Engines\FileEngine;
 use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Compilers\BladeCompiler;
+use Illuminate\Contracts\Foundation\Application;
 
 class ViewServiceProvider extends ServiceProvider
 {
@@ -32,15 +33,15 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerFactory()
     {
-        $this->app->singleton('view', function ($app) {
+        $this->app->singleton('view', function (Application $app) {
             // Next we need to grab the engine resolver instance that will be used by the
             // environment. The resolver will be used by an environment to get each of
             // the various engine implementations such as plain PHP or Blade engine.
-            $resolver = $app['view.engine.resolver'];
+            $resolver = $app->make('view.engine.resolver');
 
-            $finder = $app['view.finder'];
+            $finder = $app->make('view.finder');
 
-            $factory = $this->createFactory($resolver, $finder, $app['events']);
+            $factory = $this->createFactory($resolver, $finder, $app->make('events'));
 
             // We will also set the container instance on this view environment since the
             // view composers may be classes registered in the container, which allows
@@ -73,8 +74,8 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerViewFinder()
     {
-        $this->app->bind('view.finder', function ($app) {
-            return new FileViewFinder($app['files'], $app['config']['view.paths']);
+        $this->app->bind('view.finder', function (Application $app) {
+            return new FileViewFinder($app->make('files'), $app->make('config')->get('view.paths'));
         });
     }
 
@@ -138,12 +139,12 @@ class ViewServiceProvider extends ServiceProvider
         // instance to pass into the engine so it can compile the views properly.
         $this->app->singleton('blade.compiler', function () {
             return new BladeCompiler(
-                $this->app['files'], $this->app['config']['view.compiled']
+                $this->app->make('files'), $this->app->make('config')->get('view.compiled')
             );
         });
 
         $resolver->register('blade', function () {
-            return new CompilerEngine($this->app['blade.compiler']);
+            return new CompilerEngine($this->app->make('blade.compiler'));
         });
     }
 }

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -5,7 +5,9 @@ namespace Illuminate\Tests\Cache;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\ArrayStore;
+use Illuminate\Config\Repository;
 use Illuminate\Cache\CacheManager;
+use Illuminate\Foundation\Application;
 
 class CacheManagerTest extends TestCase
 {
@@ -16,13 +18,14 @@ class CacheManagerTest extends TestCase
 
     public function testCustomDriverClosureBoundObjectIsCacheManager()
     {
-        $cacheManager = new CacheManager([
-            'config' => [
-                'cache.stores.'.__CLASS__ => [
-                    'driver' => __CLASS__,
-                ],
-            ],
+        $app = new Application();
+        $config = new Repository();
+        $config->set('cache.stores.'.__CLASS__, [
+            'driver' => __CLASS__,
         ]);
+
+        $app->instance('config', $config);
+        $cacheManager = new CacheManager($app);
         $driver = function () {
             return $this;
         };
@@ -56,13 +59,15 @@ class CacheManagerTest extends TestCase
 
     public function testForgetDriverForgets()
     {
-        $cacheManager = new CacheManager([
-            'config' => [
-                'cache.stores.forget' => [
-                    'driver' => 'forget',
-                ],
-            ],
+        $app = new Application();
+        $config = new Repository();
+        $config->set('cache.stores.forget', [
+            'driver' => 'forget',
         ]);
+
+        $app->instance('config', $config);
+
+        $cacheManager = new CacheManager($app);
         $cacheManager->extend('forget', function () {
             return new ArrayStore();
         });

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -174,9 +174,13 @@ class FoundationApplicationTest extends TestCase
     public function testEnvironment()
     {
         $app = new Application;
-        $app['env'] = 'foo';
+        $app['env'] = 'bar';
 
-        $this->assertEquals('foo', $app->environment());
+        $this->assertEquals('bar', $app->environment());
+
+        $app->bind('env', function () {
+            return 'foo';
+        });
 
         $this->assertTrue($app->environment('foo'));
         $this->assertTrue($app->environment('f*'));
@@ -187,6 +191,11 @@ class FoundationApplicationTest extends TestCase
         $this->assertFalse($app->environment('q*'));
         $this->assertFalse($app->environment('qux', 'bar'));
         $this->assertFalse($app->environment(['qux', 'bar']));
+
+        $app['env'] = 'local';
+        $this->assertTrue($app->isLocal());
+        $app['env'] = 'dev';
+        $this->assertFalse($app->isLocal());
     }
 
     public function testMethodAfterLoadingEnvironmentAddsClosure()

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -6,7 +6,7 @@ use Swift_Message;
 use Aws\Ses\SesClient;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Support\Collection;
+use Illuminate\Config\Repository;
 use Illuminate\Mail\TransportManager;
 use Illuminate\Foundation\Application;
 use Illuminate\Mail\Transport\SesTransport;
@@ -15,16 +15,15 @@ class MailSesTransportTest extends TestCase
 {
     public function testGetTransport()
     {
-        /** @var Application $app */
-        $app = [
-            'config' => new Collection([
-                'services.ses' => [
-                    'key'    => 'foo',
-                    'secret' => 'bar',
-                    'region' => 'us-east-1',
-                ],
-            ]),
-        ];
+        $app = new Application();
+        $config = new Repository();
+        $config->set('services.ses', [
+            'key'    => 'foo',
+            'secret' => 'bar',
+            'region' => 'us-east-1',
+        ]);
+
+        $app->instance('config', $config);
 
         $manager = new TransportManager($app);
 

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -5,7 +5,9 @@ namespace Illuminate\Tests\Queue;
 use stdClass;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Config\Repository;
 use Illuminate\Queue\QueueManager;
+use Illuminate\Foundation\Application;
 use Illuminate\Contracts\Encryption\Encrypter;
 
 class QueueManagerTest extends TestCase
@@ -17,13 +19,14 @@ class QueueManagerTest extends TestCase
 
     public function testDefaultConnectionCanBeResolved()
     {
-        $app = [
-            'config' => [
-                'queue.default' => 'sync',
-                'queue.connections.sync' => ['driver' => 'sync'],
-            ],
-            'encrypter' => $encrypter = m::mock(Encrypter::class),
-        ];
+        $app = new Application();
+
+        $config = new Repository();
+        $config->set('queue.default', 'sync');
+        $config->set('queue.connections.sync', ['driver' => 'sync']);
+
+        $app->instance('config', $config);
+        $app->instance('encrypter', $encrypter = m::mock(Encrypter::class));
 
         $manager = new QueueManager($app);
         $connector = m::mock(stdClass::class);
@@ -40,13 +43,14 @@ class QueueManagerTest extends TestCase
 
     public function testOtherConnectionCanBeResolved()
     {
-        $app = [
-            'config' => [
-                'queue.default' => 'sync',
-                'queue.connections.foo' => ['driver' => 'bar'],
-            ],
-            'encrypter' => $encrypter = m::mock(Encrypter::class),
-        ];
+        $app = new Application();
+
+        $config = new Repository();
+        $config->set('queue.default', 'sync');
+        $config->set('queue.connections.foo', ['driver' => 'bar']);
+
+        $app->instance('config', $config);
+        $app->instance('encrypter', $encrypter = m::mock(Encrypter::class));
 
         $manager = new QueueManager($app);
         $connector = m::mock(stdClass::class);

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -99,6 +99,11 @@ class ApplicationStub implements ArrayAccess
         return isset($this->attributes[$offset]);
     }
 
+    public function make($key)
+    {
+        return $this->attributes[$key];
+    }
+
     public function offsetGet($key)
     {
         return $this->attributes[$key];


### PR DESCRIPTION
The Container contract concrete implementation also implements `ArrayAccess` (it uses the methods which are on the contract to implement `ArrayAccess`). As the Container contract itself doesn't extend `ArrayAccess` we cannot use `ArrayAccess` when resolving services from the container as a `Illuminate\Contracts\Container\Container` contract implementation isn't forced to implement it and would break when we'd attempt to resolve the services from it that way. Some parts of the framework are using `ArrayAccess` which is a clear violation of the contract while on some other places the proper contract methods are used so not only is the contract violated in a lot of places, the entire code is pretty inconsistent. This PR aims to fix that. I also added some type-hints for better IDE auto-completion in Closures.