### PR TITLE
[5.7] Support UNION aggregate queries

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -43,6 +43,10 @@ class MySqlGrammar extends Grammar
      */
     public function compileSelect(Builder $query)
     {
+        if ($query->unions && $query->aggregate) {
+            return $this->compileUnionAggregate($query);
+        }
+
         $sql = parent::compileSelect($query);
 
         if ($query->unions) {

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -46,6 +46,10 @@ class SQLiteGrammar extends Grammar
      */
     public function compileSelect(Builder $query)
     {
+        if ($query->unions && $query->aggregate) {
+            return $this->compileUnionAggregate($query);
+        }
+
         $sql = parent::compileSelect($query);
 
         if ($query->unions) {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -827,6 +827,33 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('(select * from `users`) union (select * from `dogs`) limit 10 offset 5', $builder->toSql());
     }
 
+    public function testUnionAggregate()
+    {
+        $expected = 'select count(*) as aggregate from ((select * from `posts`) union (select * from `videos`)) as `temp_table`';
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with($expected, [], true);
+        $builder->getProcessor()->shouldReceive('processSelect')->once();
+        $builder->from('posts')->union($this->getMySqlBuilder()->from('videos'))->count();
+
+        $expected = 'select count(*) as aggregate from (select * from "posts" union select * from "videos") as "temp_table"';
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with($expected, [], true);
+        $builder->getProcessor()->shouldReceive('processSelect')->once();
+        $builder->from('posts')->union($this->getPostgresBuilder()->from('videos'))->count();
+
+        $expected = 'select count(*) as aggregate from (select * from (select * from "posts") union select * from (select * from "videos")) as "temp_table"';
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with($expected, [], true);
+        $builder->getProcessor()->shouldReceive('processSelect')->once();
+        $builder->from('posts')->union($this->getSQLiteBuilder()->from('videos'))->count();
+
+        $expected = 'select count(*) as aggregate from (select * from [posts] union select * from [videos]) as [temp_table]';
+        $builder = $this->getSqlServerBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with($expected, [], true);
+        $builder->getProcessor()->shouldReceive('processSelect')->once();
+        $builder->from('posts')->union($this->getSqlServerBuilder()->from('videos'))->count();
+    }
+
     public function testSubSelectWhereIns()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Adds support for `UNION` aggregate queries:

```php
DB::table('posts')->union(DB::table('videos'))->count();
```

```sql
select count(*) as aggregate from (
    (select * from `posts`) union (select * from `videos`)
) as `temp_table`
```

This allows the pagination of `UNION` queries:

```php
DB::table('posts')->union(DB::table('videos'))->orderBy('title')->paginate();
```

Simple queries like the first example work on SQL Server, pagination doesn't. SQL Server's `OFFSET` implementation makes this more compIex. I will leave that for another day.

Fixes #24941 and #2968.