### PR TITLE
[5.7] Don't run TransformsRequest twice on ?query= parameters

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
@@ -43,7 +43,7 @@ class TransformsRequest
 
         if ($request->isJson()) {
             $this->cleanParameterBag($request->json());
-        } else {
+        } elseif ($request->request !== $request->query) {
             $this->cleanParameterBag($request->request);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/19920
A similar fix was already made on the request JSON `ParameterBag`: https://github.com/laravel/framework/pull/18840

`Illuminate\Http\Request::createFromBase()` modifies the base Symfony request:

https://github.com/laravel/framework/blob/231119b846aa975988d39707b5d404d36be710f2/src/Illuminate/Http/Request.php#L351

which makes `$request->query === $request->request` for GET/HEAD requests. HTTP middleware extending `TransformsRequest`  (`TrimStrings`, `ConvertEmptyStringsToNull`, and user-land extensions) will recursively traverse ?query= parameters _twice_.

The existing unit tests were naive (not setting HTTP method nor initializing each `ParameterBag`) so I corrected their setup to reproduce how Laravel's request lifecycle handles middleware. Test data and assertions for those two tests remain unchanged.