### PR TITLE
[5.7] Add mix helper tests

### DIFF
--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -65,22 +65,175 @@ class FoundationHelpersTest extends TestCase
 
     public function testMixDoesNotIncludeHost()
     {
-        $file = 'unversioned.css';
+        $manifest = $this->makeManifest();
 
+        $result = mix('/unversioned.css');
+
+        $this->assertSame('/versioned.css', $result->toHtml());
+
+        unlink($manifest);
+    }
+
+    public function testMixCachesManifestForSubsequentCalls()
+    {
+        $manifest = $this->makeManifest();
+        mix('unversioned.css');
+        unlink($manifest);
+
+        $result = mix('/unversioned.css');
+
+        $this->assertSame('/versioned.css', $result->toHtml());
+    }
+
+    public function testMixAssetMissingStartingSlashHaveItAdded()
+    {
+        $manifest = $this->makeManifest();
+
+        $result = mix('unversioned.css');
+
+        $this->assertSame('/versioned.css', $result->toHtml());
+
+        unlink($manifest);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage The Mix manifest does not exist.
+     */
+    public function testMixMissingManifestThrowsException()
+    {
+        mix('unversioned.css', 'missing');
+    }
+
+    public function testMixWithManifestDirectory()
+    {
+        mkdir($directory = __DIR__.'/mix');
+        $manifest = $this->makeManifest('mix');
+
+        $result = mix('unversioned.css', 'mix');
+
+        $this->assertSame('/mix/versioned.css', $result->toHtml());
+
+        unlink($manifest);
+        rmdir($directory);
+    }
+
+    public function testMixManifestDirectoryMissingStartingSlashHasItAdded()
+    {
+        mkdir($directory = __DIR__.'/mix');
+        $manifest = $this->makeManifest('/mix');
+
+        $result = mix('unversioned.css', 'mix');
+
+        $this->assertSame('/mix/versioned.css', $result->toHtml());
+
+        unlink($manifest);
+        rmdir($directory);
+    }
+
+    public function testMixHotModuleReloadingGetsUrlFromFileWithHttps()
+    {
+        $path = $this->makeHotModuleReloadFile('https://laravel.com/docs');
+
+        $result = mix('unversioned.css');
+
+        $this->assertSame('//laravel.com/docs/unversioned.css', $result->toHtml());
+
+        unlink($path);
+    }
+
+    public function testMixHotModuleReloadingGetsUrlFromFileWithHttp()
+    {
+        $path = $this->makeHotModuleReloadFile('http://laravel.com/docs');
+
+        $result = mix('unversioned.css');
+
+        $this->assertSame('//laravel.com/docs/unversioned.css', $result->toHtml());
+
+        unlink($path);
+    }
+
+    public function testMixHotModuleReloadingGetsUrlFromFileWithManifestDirectoryAndHttps()
+    {
+        mkdir($directory = __DIR__.'/mix');
+        $path = $this->makeHotModuleReloadFile('https://laravel.com/docs', 'mix');
+
+        $result = mix('unversioned.css', 'mix');
+
+        $this->assertSame('//laravel.com/docs/unversioned.css', $result->toHtml());
+
+        unlink($path);
+        rmdir($directory);
+    }
+
+    public function testMixHotModuleReloadingGetsUrlFromFileWithManifestDirectoryAndHttp()
+    {
+        mkdir($directory = __DIR__.'/mix');
+        $path = $this->makeHotModuleReloadFile('http://laravel.com/docs', 'mix');
+
+        $result = mix('unversioned.css', 'mix');
+
+        $this->assertSame('//laravel.com/docs/unversioned.css', $result->toHtml());
+
+        unlink($path);
+        rmdir($directory);
+    }
+
+    public function testMixHotModuleReloadingUsesLocalhostIfNoHttpScheme()
+    {
+        $path = $this->makeHotModuleReloadFile('');
+
+        $result = mix('unversioned.css');
+
+        $this->assertSame('//localhost:8080/unversioned.css', $result->toHtml());
+
+        unlink($path);
+    }
+
+    public function testMixHotModuleReloadingWithManifestDirectoryUsesLocalhostIfNoHttpScheme()
+    {
+        mkdir($directory = __DIR__.'/mix');
+        $path = $this->makeHotModuleReloadFile('', 'mix');
+
+        $result = mix('unversioned.css', 'mix');
+
+        $this->assertSame('//localhost:8080/unversioned.css', $result->toHtml());
+
+        unlink($path);
+        rmdir($directory);
+    }
+
+    protected function makeHotModuleReloadFile($url, $directory = '')
+    {
         app()->singleton('path.public', function () {
             return __DIR__;
         });
 
-        touch(public_path('mix-manifest.json'));
+        $path = public_path(str_finish($directory, '/').'hot');
 
-        file_put_contents(public_path('mix-manifest.json'), json_encode([
-            '/unversioned.css' => '/versioned.css',
-        ]));
+        // Laravel mix when run 'hot' has a new line after the
+        // url, so for consistency this "\n" is added.
+        file_put_contents($path, "{$url}\n");
 
-        $result = mix($file);
+        return $path;
+    }
 
-        $this->assertEquals('/versioned.css', $result);
+    protected function makeManifest($directory = '')
+    {
+        app()->singleton('path.public', function () {
+            return __DIR__;
+        });
 
-        unlink(public_path('mix-manifest.json'));
+        $path = public_path(str_finish($directory, '/').'mix-manifest.json');
+
+        touch($path);
+
+        // Laravel mix prints JSON pretty and with escaped
+        // slashes, so we are doing that here for consistency.
+        $content = json_encode(['/unversioned.css' => '/versioned.css'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        file_put_contents($path, $content);
+
+        return $path;
     }
 }


### PR DESCRIPTION
Added a bunch of test for the mix helper. I guess these are really just a bunch of happy path tests, but who doesn't love a happy path?!

I believe the only mix code paths that are now not covered by tests are the when the manifest does exist, but the asset does not. Reason being it hits the global `report` function and gets the config off the `app` helper and the tests felt really brittle making it all work with that. However, I'll do up some additional tests (if this kinda thing is wanted) for `5.8` as we should be able to inject the dependencies  as [mix is now bound to the container in 5.8](https://github.com/laravel/framework/pull/26289).

I did make changes to the existing test, but only to use the `makeManifest()` helper that I extracted. It still tests the same thing. If you want this reverted let me know.

I've made the manifest and hot files match what Laravel Mix *actually* outputs, for consistency.

When adding json to the manifest we are pretty printing the JSON, as well as not escaping slashes, so instead of...

```json
{"\/unversioned.css":"\/versioned.css"}
```

it will now output what Mix actually outputs....

```json
{
    "/unversioned.css": "/versioned.css"
}
```

Also, when Mix is run with `nom run hot` it has a new line, so I've also added the new line, again to stay consistent. I assume that is why when getting the file content `rtrim` is used - to remove that new line.