### PR TITLE
[5.8] `BelongsTo` method name consistency refactoring

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -311,6 +311,16 @@ class BelongsTo extends Relation
     }
 
     /**
+     * Get the child of the relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function getChild()
+    {
+        return $this->child;
+    }
+
+    /**
      * Get the foreign key of the relationship.
      *
      * @return string

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -253,7 +253,7 @@ class BelongsTo extends Relation
         }
 
         return $query->select($columns)->whereColumn(
-            $this->getQualifiedForeignKey(), '=', $query->qualifyColumn($this->ownerKey)
+            $this->getQualifiedForeignKeyName(), '=', $query->qualifyColumn($this->ownerKey)
         );
     }
 
@@ -274,7 +274,7 @@ class BelongsTo extends Relation
         $query->getModel()->setTable($hash);
 
         return $query->whereColumn(
-            $hash.'.'.$this->ownerKey, '=', $this->getQualifiedForeignKey()
+            $hash.'.'.$this->ownerKey, '=', $this->getQualifiedForeignKeyName()
         );
     }
 
@@ -325,7 +325,7 @@ class BelongsTo extends Relation
      *
      * @return string
      */
-    public function getForeignKey()
+    public function getForeignKeyName()
     {
         return $this->foreignKey;
     }
@@ -335,7 +335,7 @@ class BelongsTo extends Relation
      *
      * @return string
      */
-    public function getQualifiedForeignKey()
+    public function getQualifiedForeignKeyName()
     {
         return $this->child->qualifyColumn($this->foreignKey);
     }
@@ -345,7 +345,7 @@ class BelongsTo extends Relation
      *
      * @return string
      */
-    public function getOwnerKey()
+    public function getOwnerKeyName()
     {
         return $this->ownerKey;
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1071,14 +1071,14 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->belongsToStub();
-        $this->assertEquals('belongs_to_stub_id', $relation->getForeignKey());
+        $this->assertEquals('belongs_to_stub_id', $relation->getForeignKeyName());
         $this->assertSame($model, $relation->getParent());
         $this->assertInstanceOf(EloquentModelSaveStub::class, $relation->getQuery()->getModel());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->belongsToExplicitKeyStub();
-        $this->assertEquals('foo', $relation->getForeignKey());
+        $this->assertEquals('foo', $relation->getForeignKeyName());
     }
 
     public function testMorphToCreatesProperRelation()
@@ -1088,7 +1088,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         // $this->morphTo();
         $relation = $model->morphToStub();
-        $this->assertEquals('morph_to_stub_id', $relation->getForeignKey());
+        $this->assertEquals('morph_to_stub_id', $relation->getForeignKeyName());
         $this->assertEquals('morph_to_stub_type', $relation->getMorphType());
         $this->assertEquals('morphToStub', $relation->getRelation());
         $this->assertSame($model, $relation->getParent());
@@ -1096,19 +1096,19 @@ class DatabaseEloquentModelTest extends TestCase
 
         // $this->morphTo(null, 'type', 'id');
         $relation2 = $model->morphToStubWithKeys();
-        $this->assertEquals('id', $relation2->getForeignKey());
+        $this->assertEquals('id', $relation2->getForeignKeyName());
         $this->assertEquals('type', $relation2->getMorphType());
         $this->assertEquals('morphToStubWithKeys', $relation2->getRelation());
 
         // $this->morphTo('someName');
         $relation3 = $model->morphToStubWithName();
-        $this->assertEquals('some_name_id', $relation3->getForeignKey());
+        $this->assertEquals('some_name_id', $relation3->getForeignKeyName());
         $this->assertEquals('some_name_type', $relation3->getMorphType());
         $this->assertEquals('someName', $relation3->getRelation());
 
         // $this->morphTo('someName', 'type', 'id');
         $relation4 = $model->morphToStubWithNameAndKeys();
-        $this->assertEquals('id', $relation4->getForeignKey());
+        $this->assertEquals('id', $relation4->getForeignKeyName());
         $this->assertEquals('type', $relation4->getMorphType());
         $this->assertEquals('someName', $relation4->getRelation());
     }


### PR DESCRIPTION
Added `Name` as the suffix to clarify that it's the "key" but not the "value" of the "key".
Such a naming convention appears around all other places:

https://github.com/laravel/framework/blob/5.7/src/Illuminate/Database/Eloquent/Model.php#L1307-L1310

https://github.com/laravel/framework/blob/5.7/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php#L984-L1027

https://github.com/laravel/framework/blob/5.7/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php#L126-L130

https://github.com/laravel/framework/blob/5.7/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php#L397-L422

This will be confused with:

https://github.com/laravel/framework/blob/5.7/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php#L387-L390

https://github.com/laravel/framework/blob/5.7/src/Illuminate/Database/Eloquent/Model.php#L1386-L1389

Also added the `getChild` alias method for `getParent` method for better readability as described in:

https://github.com/laravel/framework/blob/5.7/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php#L66-L68