### PR TITLE
[5.7] Add "some" method to Collection as an alias to "contains"

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -262,6 +262,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Alias for the "contains" method.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function any($key, $operator = null, $value = null)
+    {
+        return $this->contains($key, $operator, $value);
+    }
+
+    /**
      * Determine if an item exists in the collection using strict comparison.
      *
      * @param  mixed  $key

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -269,7 +269,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  mixed  $value
      * @return bool
      */
-    public function any($key, $operator = null, $value = null)
+    public function some($key, $operator = null, $value = null)
     {
         return $this->contains($key, $operator, $value);
     }


### PR DESCRIPTION
After going through the Collections [documentation](https://laravel.com/docs/5.7/collections), I couldn't find an `any` method, especially after observing that an `every` method does exist! 

After quite a long code walkthrough, I found that `contains` would the equivalent of `any`. However, it's not quite apparent especially from a predicate callback perspective. I think adding `any` as an alias to `contains` would be very helpful. Since this is an additional method, there are no breaking changes.