### PR TITLE
[5.7] Allows for custom formatter when using Slack Log driver

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -273,7 +273,7 @@ class LogManager implements LoggerInterface
                 $this->level($config),
                 $config['bubble'] ?? true,
                 $config['exclude_fields'] ?? []
-            )),
+            ), $config),
         ]);
     }
 


### PR DESCRIPTION
## Use case
Allow for a custom formatter defined in `logging.php` config file, when using the Slack Log driver.

## More info
Looking at the source code of LogManager, it allows for using a custom formatter if defined in the `logging.php` config file. However the method of LogManager that creates the Slack driver does not pass on the `$config` array to the appropriate method. This PR addresses this by passing the missing configuration array to the `prepareHandler()` method. This is a non breaking change as the existing implementation will fallback to the default formatter if none defined in the `logging.php` config file.