### PR TITLE
[5.7] Fixes for Carbon serialization

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -842,11 +842,11 @@ trait HasAttributes
     protected function serializeDate(DateTimeInterface $date)
     {
         if ($this->dateFormat) {
-            return $date->format($this->dateFormat);
+            return $date->format($this->getDateFormat());
         } elseif (Carbon::getSerializer()) {
             return $date->serialize();
         } else {
-            return $date->format($this->getConnection()->getQueryGrammar()->getDateFormat());
+            return $date->format($this->getDateFormat());
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -841,7 +841,13 @@ trait HasAttributes
      */
     protected function serializeDate(DateTimeInterface $date)
     {
-        return $date->format($this->getDateFormat());
+        if ($this->dateFormat){
+            return $date->format($this->dateFormat);
+        } elseif (Carbon::getSerializer()) {
+            return $date->serialize();
+        } else {
+            return $date->format($this->getConnection()->getQueryGrammar()->getDateFormat());
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -841,7 +841,7 @@ trait HasAttributes
      */
     protected function serializeDate(DateTimeInterface $date)
     {
-        if ($this->dateFormat){
+        if ($this->dateFormat) {
             return $date->format($this->dateFormat);
         } elseif (Carbon::getSerializer()) {
             return $date->serialize();

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -6,17 +6,17 @@ use Carbon\Carbon as BaseCarbon;
 
 class Carbon extends BaseCarbon
 {
-     /**
+    /**
      * Return protected value $serializer.
      *
      * @return callable|null
      */
-    public static function getSerializer ()
+    public static function getSerializer()
     {
         return static::$serializer;
     }
-    
-     /**
+
+    /**
      * Return a serialized string of the instance.
      *
      * @return string
@@ -26,6 +26,7 @@ class Carbon extends BaseCarbon
         if (static::$serializer) {
             return call_user_func(static::$serializer, $this);
         }
+
         return serialize($this);
     }
 }

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -6,5 +6,26 @@ use Carbon\Carbon as BaseCarbon;
 
 class Carbon extends BaseCarbon
 {
-    //
+     /**
+     * Return protected value $serializer.
+     *
+     * @return callable|null
+     */
+    public static function getSerializer ()
+    {
+        return static::$serializer;
+    }
+    
+     /**
+     * Return a serialized string of the instance.
+     *
+     * @return string
+     */
+    public function serialize()
+    {
+        if (static::$serializer) {
+            return call_user_func(static::$serializer, $this);
+        }
+        return serialize($this);
+    }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -447,6 +447,21 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(Carbon::class, $model->created_at);
     }
 
+    public function testSerializeDate()
+    {
+        $model = new EloquentDateModelStub;
+        $model->created_at = '2018-11-05 09:26:00';
+        $this->assertEquals($model->attributesToArray()['created_at'], '2018-11-05 09:26:00');
+        Carbon::serializeUsing(function ($carbon) {
+            return intval($carbon->format('U'));
+        });
+        $this->assertEquals($model->attributesToArray()['created_at'], 1541409960);
+        $model->setDateFormat('Y-m-d H:i');
+        $model->created_at = '2018-11-05 09:26';
+        $this->assertEquals($model->attributesToArray()['created_at'], '2018-11-05 09:26');
+
+    }
+
     public function testFromDateTime()
     {
         $model = new EloquentModelStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -459,6 +459,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setDateFormat('Y-m-d H:i');
         $model->created_at = '2018-11-05 09:26';
         $this->assertEquals($model->attributesToArray()['created_at'], '2018-11-05 09:26');
+        Carbon::serializeUsing(null);
     }
 
     public function testFromDateTime()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -451,14 +451,14 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentDateModelStub;
         $model->created_at = '2018-11-05 09:26:00';
-        $this->assertEquals($model->attributesToArray()['created_at'], '2018-11-05 09:26:00');
+        $this->assertSame('2018-11-05 09:26:00', $model->attributesToArray()['created_at']);
         Carbon::serializeUsing(function ($carbon) {
-            return intval($carbon->format('U'));
+            return (int) $carbon->format('U');
         });
-        $this->assertEquals($model->attributesToArray()['created_at'], 1541409960);
+        $this->assertSame(1541409960, $model->attributesToArray()['created_at']);
         $model->setDateFormat('Y-m-d H:i');
         $model->created_at = '2018-11-05 09:26';
-        $this->assertEquals($model->attributesToArray()['created_at'], '2018-11-05 09:26');
+        $this->assertSame('2018-11-05 09:26', $model->attributesToArray()['created_at']);
         Carbon::serializeUsing(null);
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -459,7 +459,6 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setDateFormat('Y-m-d H:i');
         $model->created_at = '2018-11-05 09:26';
         $this->assertEquals($model->attributesToArray()['created_at'], '2018-11-05 09:26');
-
     }
 
     public function testFromDateTime()


### PR DESCRIPTION
Regarding #21703

From what I see, the current implementation of `Carbon::serializeUsing` is only applied in `$carbon->jsonSerialize()`, and should have been called `Carbon::jsonSerializeUsing`.

We could change `HasAttributes->serializeDate()` to use `$date->serialize()`, but if `Carbon::$serializer` is not set, that will serialize the whole object while we just want to format the time. That is probably why `HasAttributes->serializeDate()` has been avoiding it.

This fix will fallback to the current behaviour if `Carbon::$serializer` is not set.
