### PR TITLE
HasAttributes::originalIsEquivalent is public now

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1127,7 +1127,7 @@ trait HasAttributes
      * @param  mixed  $current
      * @return bool
      */
-    protected function originalIsEquivalent($key, $current)
+    public function originalIsEquivalent($key, $current)
     {
         if (! array_key_exists($key, $this->original)) {
             return false;


### PR DESCRIPTION
This function is great for observers... For example on `saving()` event:

Closes #26383 
