### PR TITLE
[5.8] Call a fully string command line

### DIFF
--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -50,6 +50,26 @@ class ConsoleApplicationTest extends TestCase
         $this->assertEquals($command, $result);
     }
 
+    public function testCallFullyStringCommandLine()
+    {
+        $app = new Application(
+            $app = m::mock(ApplicationContract::class, ['version' => '5.8']),
+            $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            'testing'
+        );
+
+        $outputOfCallArrayInput = $app->call('help', [
+            '--raw' => true,
+            '--format' => 'txt',
+            '--no-interaction' => true,
+            '--env' => 'testing',
+        ]);
+
+        $outputOfCallStringInput = $app->call('help --raw --format=txt --no-interaction --env=testing');
+
+        $this->assertSame($outputOfCallArrayInput, $outputOfCallStringInput);
+    }
+
     protected function getMockConsole(array $methods)
     {
         $app = m::mock(ApplicationContract::class, ['version' => '5.8']);


### PR DESCRIPTION
Symfony supports to parse a console string input. This feature allows us to call a fully string command-line instead of passing an array parameters as the second arguments.

Inside the test I added.
```php
// Normally
$app->call('help', [
    '--raw' => true,
    '--format' => 'txt',
    '--no-interaction' => true,
    '--env' => 'testing',
]);

// A bit Improvement or optional calling (still supports array parameters)
$app->call('help --raw --format=txt --no-interaction --env=testing')
```

Or for some other examples of existing commands:
```php
// Currently
$this->call('db:seed', ['--force' => true]);
// May be called like
$this->call('db:seed --force');
```

```php
// Currently
$this->call(
    'migrate:install', ['--database' => $this->option('database')]
);
// May be called
$this->call("migrate:install --database={$this->option('database')}");
```
