### PR TITLE
[5.7] Use cascade when truncating table in PostgreSQL

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -360,7 +360,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileTruncate(Builder $query)
     {
-        return ['truncate '.$this->wrapTable($query->from).' restart identity' => []];
+        return ['truncate '.$this->wrapTable($query->from).' restart identity cascade' => []];
     }
 
     /**


### PR DESCRIPTION
**Problem**
PostgreSQL still can't truncate table even we have already disable the foreign key constraints using `Schema::disableForeignKeyConstraints()`.

**Solution**
Use `cascade` parameter when truncating table.