### PR TITLE
[5.8] HasAttributes::originalIsEquivalent to public

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1129,7 +1129,7 @@ trait HasAttributes
      * @param  mixed  $current
      * @return bool
      */
-    protected function originalIsEquivalent($key, $current)
+    public function originalIsEquivalent($key, $current)
     {
         if (! array_key_exists($key, $this->original)) {
             return false;


### PR DESCRIPTION
`HasAttributes::originalIsEquivalent` function is great for observers... For example, currently, on `saving()` event:

```php
    public function saving($product) {
        if ($product->stock !== $product->getOriginal('stock')) {
            // do stuff
        }
    }
```

After:
```php
    public function saving($product) {
        if (!$product->originalIsEquivalent('stock')) {
            // do stuff
        }
    }
```

Its possible to change this? Or is there a reason to keep it that way?

Closes #26383, Related with PR #26384