### PR TITLE
[5.8] Add terminate method to the console kernel contract

### DIFF
--- a/src/Illuminate/Contracts/Console/Kernel.php
+++ b/src/Illuminate/Contracts/Console/Kernel.php
@@ -45,4 +45,13 @@ interface Kernel
      * @return string
      */
     public function output();
+
+    /**
+     * Terminate the application.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  int  $status
+     * @return void
+     */
+    public function terminate($input, $status);
 }


### PR DESCRIPTION
Artisan calls the `terminate` method -> https://github.com/laravel/laravel/blob/master/artisan#L51

But that method isn't on the console Kernel contract which means that for any other contract implementation Artisan would break which shouldn't happen.