### PR TITLE
[5.8] Normalize view paths within FileViewFinder

### DIFF
--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -53,7 +53,7 @@ class FileViewFinder implements ViewFinderInterface
     public function __construct(Filesystem $files, array $paths, array $extensions = null)
     {
         $this->files = $files;
-        $this->paths = $paths;
+        $this->paths = array_map([$this, 'normalizePath'], $paths);
 
         if (isset($extensions)) {
             $this->extensions = $extensions;
@@ -158,7 +158,7 @@ class FileViewFinder implements ViewFinderInterface
      */
     public function addLocation($location)
     {
-        $this->paths[] = $location;
+        $this->paths[] = $this->normalizePath($location);
     }
 
     /**
@@ -169,7 +169,7 @@ class FileViewFinder implements ViewFinderInterface
      */
     public function prependLocation($location)
     {
-        array_unshift($this->paths, $location);
+        array_unshift($this->paths, $this->normalizePath($location));
     }
 
     /**
@@ -294,5 +294,16 @@ class FileViewFinder implements ViewFinderInterface
     public function getExtensions()
     {
         return $this->extensions;
+    }
+
+    /**
+     * Replace unnecessary relative fragments from the absolute view path.
+     *
+     * @param string $path
+     * @return string
+     */
+    protected function normalizePath($path)
+    {
+        return realpath($path) ?: $path;
     }
 }

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -145,6 +145,24 @@ class ViewFileViewFinderTest extends TestCase
         $this->assertFalse($finder->hasHintInformation('::foo.bar'));
     }
 
+    public function pathsProvider()
+    {
+        return [
+            ['incorrect_path', 'incorrect_path'],
+        ];
+    }
+
+    /**
+     * @dataProvider pathsProvider
+     */
+    public function testNormalizedPaths($originalPath, $exceptedPath)
+    {
+        $finder = $this->getFinder();
+        $finder->prependLocation($originalPath);
+        $normalizedPath = $finder->getPaths()[0];
+        $this->assertSame($exceptedPath, $normalizedPath);
+    }
+
     protected function getFinder()
     {
         return new FileViewFinder(m::mock(Filesystem::class), [__DIR__]);


### PR DESCRIPTION
Normalize view paths within FileViewFinder.

Third attempt. Targeting master as @X-Coder264 advised me.

See https://github.com/laravel/framework/pull/26362 and https://github.com/laravel/framework/issues/26357 for more details.