### PR TITLE
Bug relation mutators on to array

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -265,6 +265,10 @@ trait HasAttributes
             unset($relation);
         }
 
+        $attributes = $this->addMutatedAttributesToArray(
+            $attributes, $this->getMutatedAttributes()
+        );
+
         return $attributes;
     }
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -37,7 +37,8 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertFalse($parent->relationLoaded('foo'));
     }
 
-    public function testRelationshipMutatorOnToArray() {
+    public function testRelationshipMutatorOnToArray()
+    {
         $parent = new EloquentRelationMutatorModelStub;
         $relation = new EloquentRelationResetModelStub;
         $parent->setRelation('foo', $relation);
@@ -268,13 +269,13 @@ class EloquentRelationResetModelStub extends Model
     }
 }
 
-class EloquentRelationMutatorModelStub extends Model {
+class EloquentRelationMutatorModelStub extends Model
+{
     public function getFooAttribute($value)
     {
         return 'Mutated';
     }
 }
-
 
 class EloquentRelationStub extends Relation
 {

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -37,6 +37,14 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertFalse($parent->relationLoaded('foo'));
     }
 
+    public function testRelationshipMutatorOnToArray() {
+        $parent = new EloquentRelationMutatorModelStub;
+        $relation = new EloquentRelationResetModelStub;
+        $parent->setRelation('foo', $relation);
+
+        $this->assertEquals(['foo' => 'Mutated'], $parent->toArray());
+    }
+
     public function testTouchMethodUpdatesRelatedTimestamps()
     {
         $builder = m::mock(Builder::class);
@@ -259,6 +267,14 @@ class EloquentRelationResetModelStub extends Model
         return $this->newQuery()->getQuery();
     }
 }
+
+class EloquentRelationMutatorModelStub extends Model {
+    public function getFooAttribute($value)
+    {
+        return 'Mutated';
+    }
+}
+
 
 class EloquentRelationStub extends Relation
 {


### PR DESCRIPTION
Resolves #26404 

Not sure if `relationsToArray` was the best place to fix this, I think it is because it is also used in the `attributesToArray` method. (Both are used in the `toArray()` method.)