### PR TITLE
[4.2] Fix errors issues filp/whoops with PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "classpreloader/classpreloader": "~1.0.2",
         "d11wtq/boris": "~1.0",
         "ircmaxell/password-compat": "~1.0",
-        "filp/whoops": "1.1.*",
+        "filp/whoops": "2.3.*",
         "jeremeamia/superclosure": "~1.0.1",
         "monolog/monolog": "~1.6",
         "nesbot/carbon": "~1.0",


### PR DESCRIPTION
This fix correct this message:
Error: Type error: Argument 1 passed to Whoops\Exception\Inspector::__construct()
In Version Laravel 4.2.22 with PHP 7.2
