### PR TITLE
[5.8] Fixes session attributes persistence

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -41,9 +41,6 @@ class StartSession
     public function handle($request, Closure $next)
     {
         if ($this->sessionConfigured()) {
-            // First of all, we need to start the session here so that the data
-            // is ready for an application. Note that the Laravel sessions do not
-            // make use of PHP "native" sessions in any way since they are crappy.
             $request->setLaravelSession(
                 $session = $this->startSession($request)
             );
@@ -54,12 +51,8 @@ class StartSession
 
             $response = $next($request);
 
-            // Then we need to add the session identifier cookie
-            // to the application response headers.
             $this->addCookieToResponse($response, $session);
 
-            // And finally we need to persist the session attributes
-            // to some storage medium.
             $this->manager->driver()->save();
         }
 


### PR DESCRIPTION
### Prehistory
We have been using database as session driver on our project. We had no problems. Until one day... Since that day some strange things had been happening (displaying of flash/validation messages and authorization hadn't been working very often).
We have been investigating this problem so much time and finally have understood the essence.

### Current state
Now the session attributes persistence logic is in the `terminate()` method of the `StartSession` middleware. For most cases it's okay. But not for all!

### Essence
Every day the amount of entries in the `sessions` table has been increasing. When there were ~50k (I can't say the exact amount) entries in this table we didn't have any problems. Because session attributes persistence query was pretty fast. But when we reached ~100k we faced the problems described above. But why? Because the query has became slower.

Now let's put it all together.

During the request handling some attributes are added to the session. 
Then response is sent to the browser. And then (!) session attributes are persisted to the database. But sometimes there is not enough time for attributes persistence before start of the next request handling (because query is slower). And as a result, we retrieve irrelevant attributes in the beginning of the next request handling.

### Solution
Move attributes persistence logic from `terminate()` to `handle()` method.