### PR TITLE
Adding option to use locale when registering authentication routes

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1143,26 +1143,44 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function auth(array $options = [])
     {
+        $login = 'login';
+        $logout = 'logout';
+        $register = 'register';
+        $password = 'password';
+        $reset = 'reset';
+        $email = 'email';
+
+        // Locale translates the routes' names according to configured locale
+        $should_use_locale = $options['locale'] ?? false;
+        if ($should_use_locale) {
+            $login = __('auth.routes.login');
+            $logout = __('auth.routes.logout');
+            $register = __('auth.routes.register');
+            $password = __('auth.routes.password');
+            $reset = __('auth.routes.reset');
+            $email = __('auth.routes.email');
+        }
+
         // Authentication Routes...
-        $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
-        $this->post('login', 'Auth\LoginController@login');
-        $this->post('logout', 'Auth\LoginController@logout')->name('logout');
+        $this->get($login, 'Auth\LoginController@showLoginForm')->name('login');
+        $this->post($login, 'Auth\LoginController@login');
+        $this->post($logout, 'Auth\LoginController@logout')->name('logout');
 
         // Registration Routes...
         if ($options['register'] ?? true) {
-            $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
-            $this->post('register', 'Auth\RegisterController@register');
+            $this->get($register, 'Auth\RegisterController@showRegistrationForm')->name('register');
+            $this->post($register, 'Auth\RegisterController@register');
         }
 
         // Password Reset Routes...
-        $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
-        $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
-        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
-        $this->post('password/reset', 'Auth\ResetPasswordController@reset')->name('password.update');
+        $this->get("$password/$reset", 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
+        $this->post("$password/$email", 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
+        $this->get("$password/$reset/{token}", 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
+        $this->post("$password/$reset", 'Auth\ResetPasswordController@reset')->name('password.update');
 
         // Email Verification Routes...
         if ($options['verify'] ?? false) {
-            $this->emailVerification();
+            $this->emailVerification($should_use_locale);
         }
     }
 
@@ -1171,11 +1189,21 @@ class Router implements RegistrarContract, BindingRegistrar
      *
      * @return void
      */
-    public function emailVerification()
+    public function emailVerification($should_use_locale = false)
     {
-        $this->get('email/verify', 'Auth\VerificationController@show')->name('verification.notice');
-        $this->get('email/verify/{id}', 'Auth\VerificationController@verify')->name('verification.verify');
-        $this->get('email/resend', 'Auth\VerificationController@resend')->name('verification.resend');
+        $email = 'email';
+        $verify = 'verify';
+        $resend = 'resend';
+
+        if ($should_use_locale) {
+            $email = __('auth.routes.email');
+            $verify = __('auth.routes.verify');
+            $resend = __('auth.routes.resend');
+        }
+
+        $this->get("$email/$verify", 'Auth\VerificationController@show')->name('verification.notice');
+        $this->get("$email/$verify/{id}", 'Auth\VerificationController@verify')->name('verification.verify');
+        $this->get("$email/$resend", 'Auth\VerificationController@resend')->name('verification.resend');
     }
 
     /**


### PR DESCRIPTION
I'm from Brazil, often I use the make:auth scaffolding to handle authentication (because it's awesome), however more often than not my customers require that I translate the authentication routes, and I end up losing the power of the Auth::routes method.

Not anymore.

I added a option, 'locale', to the auth and emailVerification methods of the Illuminate\Routing\Router class to allow us to get the routes "words" from the auth.php lang file.

It's 100% backwards compatible, if the option isn't present or isn't "true" the routes fallback to the good old english default; no existing code will have to be modified.

![locale_false](https://user-images.githubusercontent.com/17496707/48103313-c14c6500-e215-11e8-8722-3b639e4b9709.PNG)
![locale_true](https://user-images.githubusercontent.com/17496707/48103314-c14c6500-e215-11e8-9000-e9ef914ece6a.PNG)
