### PR TITLE
[5.8] Unset relation when calling associate with ID on BelongsTo relationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -222,7 +222,6 @@ class BelongsTo extends Relation
         if ($model instanceof Model) {
             $this->child->setRelation($this->relation, $model);
         } elseif ($this->child->isDirty($this->foreignKey)) {
-            // Relation has changed, so unset the previous relation
             $this->child->unsetRelation($this->relation);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -221,6 +221,9 @@ class BelongsTo extends Relation
 
         if ($model instanceof Model) {
             $this->child->setRelation($this->relation, $model);
+        } elseif ($this->child->isDirty($this->foreignKey)) {
+            // Relation has changed, so unset the previous relation
+            $this->child->unsetRelation($this->relation);
         }
 
         return $this->child;

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -148,6 +148,8 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
         $relation = $this->getRelation($parent);
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
+        $parent->shouldReceive('isDirty')->once()->andReturn(true);
+        $parent->shouldReceive('unsetRelation')->once()->with($relation->getRelation());
         $relation->associate(1);
     }
 

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -47,8 +47,8 @@ class EloquentBelongsToTest extends DatabaseTestCase
 
         $parent->parent()->associate($child);
 
-        $this->assertEquals($parent->parent_id, $child->id);
-        $this->assertEquals($parent->parent->id, $child->id);
+        $this->assertEquals($child->id, $parent->parent_id);
+        $this->assertEquals($child->id, $parent->parent->id);
     }
 
     public function test_associate_with_id()
@@ -58,8 +58,8 @@ class EloquentBelongsToTest extends DatabaseTestCase
 
         $parent->parent()->associate($child->id);
 
-        $this->assertEquals($parent->parent_id, $child->id);
-        $this->assertEquals($parent->parent->id, $child->id);
+        $this->assertEquals($child->id, $parent->parent_id);
+        $this->assertEquals($child->id, $parent->parent->id);
     }
 
     public function test_associate_with_id_unsets_loaded_relation()
@@ -69,7 +69,7 @@ class EloquentBelongsToTest extends DatabaseTestCase
         // Overwrite the (loaded) parent relation
         $child->parent()->associate($child->id);
 
-        $this->assertEquals($child->parent_id, $child->id);
+        $this->assertEquals($child->id, $child->parent_id);
         $this->assertFalse($child->relationLoaded('parent'));
     }
 }

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -62,11 +62,11 @@ class EloquentBelongsToTest extends DatabaseTestCase
         $this->assertEquals($parent->parent->id, $child->id);
     }
 
-    public function test_associate_with_id_unsets_eager_loaded_relation()
+    public function test_associate_with_id_unsets_loaded_relation()
     {
         $child = User::has('parent')->with('parent')->first();
 
-        // Overwrite the (eager loaded) parent relation
+        // Overwrite the (loaded) parent relation
         $child->parent()->associate($child->id);
 
         $this->assertEquals($child->parent_id, $child->id);

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -39,6 +39,39 @@ class EloquentBelongsToTest extends DatabaseTestCase
 
         $this->assertEquals(1, $users->count());
     }
+
+    public function test_associate_with_model()
+    {
+        $parent = User::doesntHave('parent')->first();
+        $child = User::has('parent')->first();
+
+        $parent->parent()->associate($child);
+
+        $this->assertEquals($parent->parent_id, $child->id);
+        $this->assertEquals($parent->parent->id, $child->id);
+    }
+
+    public function test_associate_with_id()
+    {
+        $parent = User::doesntHave('parent')->first();
+        $child = User::has('parent')->first();
+
+        $parent->parent()->associate($child->id);
+
+        $this->assertEquals($parent->parent_id, $child->id);
+        $this->assertEquals($parent->parent->id, $child->id);
+    }
+
+    public function test_associate_with_id_unsets_eager_loaded_relation()
+    {
+        $child = User::has('parent')->with('parent')->first();
+
+        // Overwrite the (eager loaded) parent relation
+        $child->parent()->associate($child->id);
+
+        $this->assertEquals($child->parent_id, $child->id);
+        $this->assertFalse($child->relationLoaded('parent'));
+    }
 }
 
 class User extends Model


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Fixes https://github.com/laravel/framework/issues/26401 (added integration tests)