### PR TITLE
[5.8] Fix pluralizing model names ending in words with an irregular plural

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -529,7 +529,7 @@ trait HasRelationships
         // the relationship instances for this relation. This relations will set
         // appropriate query constraints then entirely manages the hydrations.
         if (! $table) {
-            $words = preg_split('/(_)/', $name, -1, PREG_SPLIT_DELIM_CAPTURE);
+            $words = preg_split('/(_)/u', $name, -1, PREG_SPLIT_DELIM_CAPTURE);
 
             $lastWord = array_pop($words);
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -528,7 +528,13 @@ trait HasRelationships
         // Now we're ready to create a new query builder for this related model and
         // the relationship instances for this relation. This relations will set
         // appropriate query constraints then entirely manages the hydrations.
-        $table = $table ?: Str::plural($name);
+        if (! $table) {
+            $words = preg_split('/(_)/', $name, -1, PREG_SPLIT_DELIM_CAPTURE);
+
+            $lastWord = array_pop($words);
+
+            $table = implode('', $words).Str::plural($lastWord);
+        }
 
         return $this->newMorphToMany(
             $instance->newQuery(), $this, $name, $table,

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1277,13 +1277,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getTable()
     {
-        if (! isset($this->table)) {
-            return str_replace(
-                '\\', '', Str::snake(Str::plural(class_basename($this)))
-            );
-        }
-
-        return $this->table;
+        return isset($this->table)
+            ? $this->table
+            : Str::snake(Str::pluralStudly(class_basename($this)));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -766,7 +766,7 @@ class BelongsToMany extends Relation
      */
     protected function guessInverseRelation()
     {
-        return Str::camel(Str::plural(class_basename($this->getParent())));
+        return Str::camel(Str::pluralStudly(class_basename($this->getParent())));
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -82,7 +82,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function createMigration()
     {
-        $table = Str::plural(Str::snake(class_basename($this->argument('name'))));
+        $table = Str::snake(Str::pluralStudly(class_basename($this->argument('name'))));
 
         if ($this->option('pivot')) {
             $table = Str::singular($table);

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -104,7 +104,7 @@ class PolicyMakeCommand extends GeneratorCommand
 
         $stub = str_replace('DummyUser', $dummyUser, $stub);
 
-        return str_replace('DocDummyPluralModel', Str::snake(Str::plural($dummyModel), ' '), $stub);
+        return str_replace('DocDummyPluralModel', Str::snake(Str::pluralStudly($dummyModel), ' '), $stub);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -281,6 +281,22 @@ class Str
     }
 
     /**
+     * Pluralize the last word of an English, studly caps case string.
+     *
+     * @param  string  $value
+     * @param  int     $count
+     * @return string
+     */
+    public static function pluralStudly($value, $count = 2)
+    {
+        $parts = preg_split('/(.)(?=[A-Z])/u', $value, -1, PREG_SPLIT_DELIM_CAPTURE);
+
+        $lastWord = array_pop($parts);
+
+        return implode('', $parts).self::plural($lastWord, $count);
+    }
+
+    /**
      * Generate a more truly "random" alpha-numeric string.
      *
      * @param  int  $length

--- a/tests/Database/DatabaseEloquentIrregularPluralTest.php
+++ b/tests/Database/DatabaseEloquentIrregularPluralTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Capsule\Manager as DB;
+
+class DatabaseEloquentIrregularPluralTest extends TestCase
+{
+    public function setUp()
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+        $this->createSchema();
+    }
+
+    public function createSchema()
+    {
+        $this->schema()->create('irregular_plural_humans', function ($table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('irregular_plural_tokens', function ($table) {
+            $table->increments('id');
+            $table->string('title');
+        });
+
+        $this->schema()->create('irregular_plural_human_irregular_plural_token', function ($table) {
+            $table->integer('irregular_plural_human_id')->unsigned();
+            $table->integer('irregular_plural_token_id')->unsigned();
+        });
+    }
+
+    public function tearDown()
+    {
+        $this->schema()->drop('irregular_plural_tokens');
+        $this->schema()->drop('irregular_plural_humans');
+        $this->schema()->drop('irregular_plural_human_irregular_plural_token');
+    }
+
+    protected function schema()
+    {
+        $connection = Model::getConnectionResolver()->connection();
+
+        return $connection->getSchemaBuilder();
+    }
+
+    /** @test */
+    function it_pluralizes_the_table_name()
+    {
+        $model = new IrregularPluralHuman();
+
+        $this->assertSame('irregular_plural_humans', $model->getTable());
+    }
+
+    /** @test */
+    function it_touches_the_parent_with_an_irregular_plural()
+    {
+        Carbon::setTestNow('2018-05-01 12:13:14');
+
+        IrregularPluralHuman::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+
+        IrregularPluralToken::insert([
+            ['title' => 'The title'],
+        ]);
+
+        $human = IrregularPluralHuman::query()->first();
+
+        $tokenIds = IrregularPluralToken::pluck('id');
+
+        Carbon::setTestNow('2018-05-01 15:16:17');
+
+        $human->irregularPluralTokens()->sync($tokenIds);
+
+        $human->refresh();
+
+        $this->assertSame('2018-05-01 12:13:14', (string) $human->created_at);
+        $this->assertSame('2018-05-01 15:16:17', (string) $human->updated_at);
+    }
+}
+
+class IrregularPluralHuman extends Model
+{
+    protected $guarded = [];
+
+    public function irregularPluralTokens()
+    {
+        return $this->belongsToMany(
+            IrregularPluralToken::class,
+            'irregular_plural_human_irregular_plural_token',
+            'irregular_plural_token_id',
+            'irregular_plural_human_id'
+        );
+    }
+}
+
+class IrregularPluralToken extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    protected $touches = [
+        'irregularPluralHumans',
+    ];
+}

--- a/tests/Database/DatabaseEloquentIrregularPluralTest.php
+++ b/tests/Database/DatabaseEloquentIrregularPluralTest.php
@@ -57,7 +57,7 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
     }
 
     /** @test */
-    function it_pluralizes_the_table_name()
+    public function it_pluralizes_the_table_name()
     {
         $model = new IrregularPluralHuman();
 
@@ -65,7 +65,7 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
     }
 
     /** @test */
-    function it_touches_the_parent_with_an_irregular_plural()
+    public function it_touches_the_parent_with_an_irregular_plural()
     {
         Carbon::setTestNow('2018-05-01 12:13:14');
 

--- a/tests/Database/DatabaseEloquentIrregularPluralTest.php
+++ b/tests/Database/DatabaseEloquentIrregularPluralTest.php
@@ -40,6 +40,17 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
             $table->integer('irregular_plural_human_id')->unsigned();
             $table->integer('irregular_plural_token_id')->unsigned();
         });
+
+        $this->schema()->create('irregular_plural_mottoes', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        $this->schema()->create('cool_mottoes', function ($table) {
+            $table->integer('irregular_plural_motto_id');
+            $table->integer('cool_motto_id');
+            $table->string('cool_motto_type');
+        });
     }
 
     public function tearDown()
@@ -69,7 +80,7 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
     {
         Carbon::setTestNow('2018-05-01 12:13:14');
 
-        IrregularPluralHuman::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        IrregularPluralHuman::create(['email' => 'taylorotwell@gmail.com']);
 
         IrregularPluralToken::insert([
             ['title' => 'The title'],
@@ -88,6 +99,18 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
         $this->assertSame('2018-05-01 12:13:14', (string) $human->created_at);
         $this->assertSame('2018-05-01 15:16:17', (string) $human->updated_at);
     }
+
+    /** @test */
+    public function it_pluralizes_morph_to_many_relationships()
+    {
+        $human = IrregularPluralHuman::create(['email' => 'bobby@example.com']);
+
+        $human->mottoes()->create(['name' => 'Real eyes realize real lies']);
+
+        $motto = IrregularPluralMotto::query()->first();
+
+        $this->assertSame('Real eyes realize real lies', $motto->name);
+    }
 }
 
 class IrregularPluralHuman extends Model
@@ -103,6 +126,11 @@ class IrregularPluralHuman extends Model
             'irregular_plural_human_id'
         );
     }
+
+    public function mottoes()
+    {
+        return $this->morphToMany(IrregularPluralMotto::class, 'cool_motto');
+    }
 }
 
 class IrregularPluralToken extends Model
@@ -114,4 +142,16 @@ class IrregularPluralToken extends Model
     protected $touches = [
         'irregularPluralHumans',
     ];
+}
+
+class IrregularPluralMotto extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function irregularPluralHumans()
+    {
+        return $this->morphedByMany(IrregularPluralHuman::class, 'cool_motto');
+    }
 }

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -38,6 +38,9 @@ class SupportPluralizerTest extends TestCase
         $this->assertEquals('MatrixFields', Str::plural('MatrixField'));
         $this->assertEquals('IndexFields', Str::plural('IndexField'));
         $this->assertEquals('VertexFields', Str::plural('VertexField'));
+
+        // This is expected behavior, use "Str::pluralStudly" instead.
+        $this->assertSame('RealHumen', Str::plural('RealHuman'));
     }
 
     public function testPluralWithNegativeCount()
@@ -46,5 +49,26 @@ class SupportPluralizerTest extends TestCase
         $this->assertEquals('tests', Str::plural('test', 2));
         $this->assertEquals('test', Str::plural('test', -1));
         $this->assertEquals('tests', Str::plural('test', -2));
+    }
+
+    public function testPluralStudly()
+    {
+        $this->assertPluralStudly('RealHumans', 'RealHuman');
+        $this->assertPluralStudly('Models', 'Model');
+        $this->assertPluralStudly('VortexFields', 'VortexField');
+        $this->assertPluralStudly('MultipleWordsInOneStrings', 'MultipleWordsInOneString');
+    }
+
+    public function testPluralStudlyWithCount()
+    {
+        $this->assertPluralStudly('RealHuman', 'RealHuman', 1);
+        $this->assertPluralStudly('RealHumans', 'RealHuman', 2);
+        $this->assertPluralStudly('RealHuman', 'RealHuman', -1);
+        $this->assertPluralStudly('RealHumans', 'RealHuman', -2);
+    }
+
+    private function assertPluralStudly($expected, $value, $count = 2)
+    {
+        $this->assertSame($expected, Str::pluralStudly($value, $count));
     }
 }


### PR DESCRIPTION
Currently, running `artisan make:model RealHuman -m` gives you a migration called `2018_11_07_133204_create_real_humen_table` and a table called `real_humen`. This happens because it tries to pluralize the word RealHuman, and since that word isn't in the list of irregular plurals the [Doctrine  Inflector](https://github.com/doctrine/inflector/blob/1.3.x/lib/Doctrine/Common/Inflector/Inflector.php) applies the normal (in this case incorrect) rules to pluralize the word.

This PR adds a `Str::pluralStudly` helper that pluralizes only the last word of a studly caps case string. This helper is used throughout the framework to correctly generate plurals of model names.

~~The old `Str::plural` is still being used in the [`morphToMany`](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php#L487) method. If this PR gets merged that should also be fixed and tested.~~

Edit:
turns out someone had this issue before: https://github.com/doctrine/inflector/pull/35