### PR TITLE
[5.7] Allow for explicit text parameters on Authorize middleware

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -72,7 +72,12 @@ class Authorize
      */
     protected function getModel($request, $model)
     {
-        return $this->isClassName($model) ? trim($model) : $request->route($model, $model);
+        if ($this->isClassName($model)) {
+            return trim($model);
+        } else {
+            return $request->route($model,null) ?:
+                ((preg_match("/^['\"](.*)['\"]$/", trim($model), $matches)) ? $matches[1] : null);
+        }
     }
 
     /**

--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -75,7 +75,7 @@ class Authorize
         if ($this->isClassName($model)) {
             return trim($model);
         } else {
-            return $request->route($model,null) ?:
+            return $request->route($model, null) ?:
                 ((preg_match("/^['\"](.*)['\"]$/", trim($model), $matches)) ? $matches[1] : null);
         }
     }

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -91,11 +91,11 @@ class AuthorizeMiddlewareTest extends TestCase
     public function testSimpleAbilityWithStringParameter()
     {
         $this->gate()->define('view-dashboard', function ($user, $param) {
-            return $param === 'true';
+            return $param === 'some string';
         });
 
         $this->router->get('dashboard', [
-            'middleware' => Authorize::class.':view-dashboard,true',
+            'middleware' => Authorize::class.':view-dashboard,"some string"',
             'uses' => function () {
                 return 'success';
             },
@@ -104,6 +104,58 @@ class AuthorizeMiddlewareTest extends TestCase
         $response = $this->router->dispatch(Request::create('dashboard', 'GET'));
 
         $this->assertEquals($response->content(), 'success');
+    }
+
+    public function testSimpleAbilityWithNullParameter()
+    {
+        $this->gate()->define('view-dashboard', function ($user, $param = null) {
+            $this->assertNull($param);
+            return true;
+        });
+
+        $this->router->get('dashboard', [
+            'middleware' => Authorize::class.':view-dashboard,null',
+            'uses' => function () {
+                return 'success';
+            },
+        ]);
+
+        $this->router->dispatch(Request::create('dashboard', 'GET'));
+    }
+
+    public function testSimpleAbilityWithOptionalParameter()
+    {
+        $post = new stdClass;
+
+        $this->router->bind('post', function () use ($post) {
+            return $post;
+        });
+
+        $this->gate()->define('view-comments', function ($user, $model = null) use ($post) {
+            return true;
+        });
+
+        $middleware = [SubstituteBindings::class, Authorize::class.':view-comments,post'];
+
+        $this->router->get('comments', [
+            'middleware' => $middleware,
+            'uses' => function () {
+                return 'success';
+            },
+        ]);
+        $this->router->get('posts/{post}/comments', [
+            'middleware' => $middleware,
+            'uses' => function () {
+                return 'success';
+            },
+        ]);
+
+        $response = $this->router->dispatch(Request::create('posts/1/comments', 'GET'));
+        $this->assertEquals($response->content(), 'success');
+
+        $response = $this->router->dispatch(Request::create('comments', 'GET'));
+        $this->assertEquals($response->content(), 'success');
+
     }
 
     public function testSimpleAbilityWithStringParameterFromRouteParameter()

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -110,6 +110,7 @@ class AuthorizeMiddlewareTest extends TestCase
     {
         $this->gate()->define('view-dashboard', function ($user, $param = null) {
             $this->assertNull($param);
+
             return true;
         });
 
@@ -155,7 +156,6 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('comments', 'GET'));
         $this->assertEquals($response->content(), 'success');
-
     }
 
     public function testSimpleAbilityWithStringParameterFromRouteParameter()


### PR DESCRIPTION
Pull Request #25763 broke some non documented functionality (explained here #26422) related to the Authorize middleware.

The previous implementation would allow to set an Authorize for a Gate with an optional parameter. That could be useful when the 'can' middleware is attached directly into the controller method (instead of a route) and thus act on multiple routes that access such method.

The current (master) implementation sends a string with the value of the Authorize argument if it's not a route parameter. This is behave ambiguous as any argument on the middleware can mean either a parameter of the request named after it or it's own name depending of the conditions a layer of abstraction up.

This PR solves this issue while still allowing the Authorize middleware to send string values to Gates by explicitly defining them as string using single or double quoted values on it's arguments, thus removing the ambiguity:
````php
    // this should only send and route parameter to the gate or null if not available
    Route::middleware('can:ability,model');
````
````php
    // This will send a string to the gate
    Route::middleware('can:ability,"some text"');
````

TL;DR; This reverts the default bahaviour to prior PR #25763, while still allowing string parameters.
