### PR TITLE
[5.7] Allow migration table name to be guessed without `_table` suffix

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -22,13 +22,13 @@ class TableGuesser
      */
     public static function guess($migration)
     {
-        foreach(self::CREATE_PATTERNS as $pattern) {
+        foreach (self::CREATE_PATTERNS as $pattern) {
             if (preg_match($pattern, $migration, $matches)) {
                 return [$matches[1], $create = true];
             }
         }
 
-        foreach(self::CHANGE_PATTERNS as $pattern) {
+        foreach (self::CHANGE_PATTERNS as $pattern) {
             if (preg_match($pattern, $migration, $matches)) {
                 return [$matches[2], $create = false];
             }

--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -4,6 +4,16 @@ namespace Illuminate\Database\Console\Migrations;
 
 class TableGuesser
 {
+    const CREATE_PATTERNS = [
+        '/^create_(\w+)_table$/',
+        '/^create_(\w+)$/',
+    ];
+
+    const CHANGE_PATTERNS = [
+        '/_(to|from|in)_(\w+)_table$/',
+        '/_(to|from|in)_(\w+)$/',
+    ];
+
     /**
      * Attempt to guess the table name and "creation" status of the given migration.
      *
@@ -12,12 +22,16 @@ class TableGuesser
      */
     public static function guess($migration)
     {
-        if (preg_match('/^create_(\w+)_table$/', $migration, $matches)) {
-            return [$matches[1], $create = true];
+        foreach(self::CREATE_PATTERNS as $pattern) {
+            if (preg_match($pattern, $migration, $matches)) {
+                return [$matches[1], $create = true];
+            }
         }
 
-        if (preg_match('/_(to|from|in)_(\w+)_table$/', $migration, $matches)) {
-            return [$matches[2], $create = false];
+        foreach(self::CHANGE_PATTERNS as $pattern) {
+            if (preg_match($pattern, $migration, $matches)) {
+                return [$matches[2], $create = false];
+            }
         }
     }
 }

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -27,7 +27,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app = new Application;
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
-        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', null, false);
+        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true);
         $composer->shouldReceive('dumpAutoloads')->once();
 
         $this->runCommand($command, ['name' => 'create_foo']);
@@ -42,7 +42,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app = new Application;
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
-        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', null, false);
+        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true);
 
         $this->runCommand($command, ['name' => 'create_foo']);
     }
@@ -56,7 +56,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app = new Application;
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
-        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', null, false);
+        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true);
 
         $this->runCommand($command, ['name' => 'CreateFoo']);
     }

--- a/tests/Database/TableGuesserTest.php
+++ b/tests/Database/TableGuesserTest.php
@@ -25,4 +25,23 @@ class TableGuesserTest extends TestCase
         $this->assertEquals('users', $table);
         $this->assertFalse($create);
     }
+
+    public function test_migration_is_properly_parsed_without_table_suffix()
+    {
+        [$table, $create] = TableGuesser::guess('create_users');
+        $this->assertEquals('users', $table);
+        $this->assertTrue($create);
+
+        [$table, $create] = TableGuesser::guess('add_status_column_to_users');
+        $this->assertEquals('users', $table);
+        $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('change_status_column_in_users');
+        $this->assertEquals('users', $table);
+        $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('drop_status_column_from_users');
+        $this->assertEquals('users', $table);
+        $this->assertFalse($create);
+    }
 }

--- a/tests/Database/TableGuesserTest.php
+++ b/tests/Database/TableGuesserTest.php
@@ -17,6 +17,10 @@ class TableGuesserTest extends TestCase
         $this->assertEquals('users', $table);
         $this->assertFalse($create);
 
+        [$table, $create] = TableGuesser::guess('change_status_column_in_users_table');
+        $this->assertEquals('users', $table);
+        $this->assertFalse($create);
+
         [$table, $create] = TableGuesser::guess('drop_status_column_from_users_table');
         $this->assertEquals('users', $table);
         $this->assertFalse($create);


### PR DESCRIPTION
This PR modifies the `TableGuesser` class to allow the table name to be parsed from migrations that do not have the `_table` suffix.

This will allow devs to create migrations with shorter names and still have them pre-populated with the relevant creation or change boilerplate content. See the following examples.

```bash
# This longer migration name:
php artisan make:migration create_users_table

# Can now be just:
php artisan make:migration create_users

# And, this longer migration name:
php artisan make:migration add_status_column_to_users_table

# Can now be just:
php artisan make:migration add_status_column_to_users
```

Original functionality (longer migration names) still works fine. The original regex pattern is checked first, prior to checking the new regex pattern.

Even though this is a minor change, it should help speed up and make migration creation just a tiny bit more intuitive. This change was actually inspired by a colleague who recently accidentally missed out the `_table` prefix from their `artisan` command and asked me why the boilerplate content was not added.

This PR also adds a test which was missing from the `TableGuesser` class tests, to ensure migrations in created in the format `foo_in_bar_table` are parsed correctly.