### PR TITLE
[5.8] Added option for preserving keys of the collection in reverse function

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1414,11 +1414,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Reverse items order.
      *
+     * @param  bool  $preserveKeys
      * @return static
      */
-    public function reverse()
+    public function reverse($preserveKeys = true)
     {
-        return new static(array_reverse($this->items, true));
+        return new static(array_reverse($this->items, $preserveKeys));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -986,6 +986,14 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['framework' => 'laravel', 'name' => 'taylor'], $reversed->all());
     }
 
+    public function testReverseWithoutPreservingKeys()
+    {
+        $data = new Collection(['zaeed', 'alan']);
+        $reversed = $data->reverse(false);
+
+        $this->assertSame([0 => 'alan', 1 => 'zaeed'], $reversed->all());
+    }
+
     public function testFlip()
     {
         $data = new Collection(['name' => 'taylor', 'framework' => 'laravel']);


### PR DESCRIPTION
This PR brings back the option to not preserve keys in the `reverse()` function for the collections. 

> There are previous PR's where others already tried to get this option back, see [here](https://github.com/laravel/framework/pull/20924).