### PR TITLE
[5.7] Adjust mix missing asset exceptions

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -609,10 +609,14 @@ if (! function_exists('mix')) {
         $manifest = $manifests[$manifestPath];
 
         if (! isset($manifest[$path])) {
-            report(new Exception("Unable to locate Mix file: {$path}."));
+            $exception = new Exception("Unable to locate Mix file: {$path}.");
 
             if (! app('config')->get('app.debug')) {
+                report($exception);
+
                 return $path;
+            } else {
+                throw $exception;
             }
         }
 


### PR DESCRIPTION
Sooo...I promise after this I'll stop poking at the mix helper 😅 but while I was adding the tests around it I noticed this code path seemed a little weird.

## Problem

Given this existing snippet:

```php
if (! isset($manifest[$path])) {
    report(new Exception("Unable to locate Mix file: {$path}."));

    if (! app('config')->get('app.debug')) {
        return $path;
    }
}
return new HtmlString($manifestDirectory.$manifest[$path]);
```

If you are in debug mode and have an asset missing the following would occur...

1. Exception is silently reported using the `report()` global helper.
2. An `Undefined index` exception is thrown at `$manifest[$path]` in the following snippet:
```php
return new HtmlString($manifestDirectory.$manifest[$path]);
```

The test added failed previously as it tries to report BOTH the silent `report(new Exception(...))` and the `Undefined index` exception.

## Fix

To remedy this I've made it only report the exception silently in debug mode, otherwise it will throw it. This does 2 things:

1. Only reports 1 exception in both debug and non-debug mode, instead of 1 in non-debug and 2 in debug mode.
2. Gives consistency to the exception message. Instead of undefined index you will get "Unable to locate Mix file: PATH"
 
## Potentially breaking

These changes *only* change behaviour in debug mode. What is more the breaking changes are:

1. It doesn't report 2 exceptions.
2. The exception that is thrown has changed its message.

Which...I can't really see why would be a problem. But if it is, and this fix is wanted, I can push to master.

Bugsnag screenshot showing this duplicate reporting:

<img width="298" alt="screen shot 2018-11-08 at 10 21 32 am" src="https://user-images.githubusercontent.com/24803032/48167562-2bf9bf80-e340-11e8-9c5e-336f4bb66b1d.png">