### PR TITLE
[5.7] Improve eager loading performance on MySQL

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -81,7 +81,9 @@ abstract class HasOneOrMany extends Relation
      */
     public function addEagerConstraints(array $models)
     {
-        $this->query->whereIn(
+        $whereIn = in_array($this->parent->getKeyType(), ['int', 'integer']) ? 'whereInRaw' : 'whereIn';
+
+        $this->query->$whereIn(
             $this->foreignKey, $this->getKeys($models, $this->localKey)
         );
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -949,6 +949,30 @@ class Builder
     }
 
     /**
+     * Add a "where in raw" clause to the query.
+     *
+     * @param  string  $column
+     * @param  array   $values
+     * @param  string  $boolean
+     * @param  bool    $not
+     * @return $this
+     */
+    public function whereInRaw($column, array $values, $boolean = 'and', $not = false)
+    {
+        $type = $not ? 'NotInRaw' : 'InRaw';
+
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        $values = array_map('intval', $values);
+
+        $this->wheres[] = compact('type', 'column', 'values', 'boolean');
+
+        return $this;
+    }
+
+    /**
      * Add a "where null" clause to the query.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -302,6 +302,22 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where in raw" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereInRaw(Builder $query, $where)
+    {
+        if (! empty($where['values'])) {
+            return $this->wrap($where['column']).' in ('.implode(', ', $where['values']).')';
+        }
+
+        return '0 = 1';
+    }
+
+    /**
      * Compile a "where null" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -200,6 +200,19 @@ class DatabaseEloquentHasManyTest extends TestCase
     public function testEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getRelation();
+        $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
+        $relation->getQuery()->shouldReceive('whereInRaw')->once()->with('table.foreign_key', [1, 2]);
+        $model1 = new EloquentHasManyModelStub;
+        $model1->id = 1;
+        $model2 = new EloquentHasManyModelStub;
+        $model2->id = 2;
+        $relation->addEagerConstraints([$model1, $model2]);
+    }
+
+    public function testEagerConstraintsAreProperlyAddedWithStringKey()
+    {
+        $relation = $this->getRelation();
+        $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('string');
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.foreign_key', [1, 2]);
         $model1 = new EloquentHasManyModelStub;
         $model1->id = 1;

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -163,7 +163,8 @@ class DatabaseEloquentHasOneTest extends TestCase
     public function testEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getRelation();
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.foreign_key', [1, 2]);
+        $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
+        $relation->getQuery()->shouldReceive('whereInRaw')->once()->with('table.foreign_key', [1, 2]);
         $model1 = new EloquentHasOneModelStub;
         $model1->id = 1;
         $model2 = new EloquentHasOneModelStub;

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -28,6 +28,7 @@ class DatabaseEloquentMorphTest extends TestCase
     public function testMorphOneEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getOneRelation();
+        $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('string');
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', [1, 2]);
         $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
 
@@ -50,7 +51,8 @@ class DatabaseEloquentMorphTest extends TestCase
     public function testMorphManyEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getManyRelation();
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', [1, 2]);
+        $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
+        $relation->getQuery()->shouldReceive('whereInRaw')->once()->with('table.morph_id', [1, 2]);
         $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
 
         $model1 = new EloquentMorphResetModelStub;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -693,6 +693,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testWhereInRaw()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereInRaw('id', ['1a', 2]);
+        $this->assertEquals('select * from "users" where "id" in (1, 2)', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+    }
+
     public function testBasicWhereColumn()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
There is an old [bug](https://bugs.php.net/bug.php?id=53458) in the `PDO` implementation for MySQL that slows down larges `WHERE IN` queries. When the query has a few thousand bindings, the time execution time of `fetchAll()` increases non-linearly.

In Laravel, this especially affects eager loading. For models with integer keys, we can fix this by using raw `WHERE IN` clauses. The new `whereInRaw()` method applies `intval()` to all values, so this is as secure as a prepared statement.

It's certainly not a very elegant solution but still worth considering for the core. Since most Laravel sites run on MySQL/MariaDB and most sites use eager loading with integer keys (my assumptions), this would improve the performance on *a lot* of sites – even if they aren't eager loading thousands of records at once. The individual query may only gain a few milliseconds, but over all sites combined, this adds up.

This PR shows a sample implementation for `HasMany` relationships. The same changes would apply to all the other relationships.

Fixes #26051.