### PR TITLE
[5.8] Allow tuple notation when defining Gates

### DIFF
--- a/CHANGELOG-5.7.md
+++ b/CHANGELOG-5.7.md
@@ -1,12 +1,14 @@
 # Release Notes for 5.7.x
 
-## Unreleased
+## [v5.7.13 (2018-11-07)](https://github.com/laravel/framework/compare/v5.7.12...v5.7.13)
 
 ### Added
 - Added ability to return an array of messages in a custom validation rule ([#26327](https://github.com/laravel/framework/pull/26327))
 - Added `whenEmpty`/ `whenNotEmpty` / `unlessEmpty` / `unlessNotEmpty` methods to `Collection` ([#26345](https://github.com/laravel/framework/pull/26345))
+- Added `Illuminate\Support\Collection::some` method ([#26376](https://github.com/laravel/framework/pull/26376), [8f7e647](https://github.com/laravel/framework/commit/8f7e647dcee5fe13d7fc33a1e0e1ce531ea9f49e))
 - Added `Illuminate\Cache\Repository::missing` method ([#26351](https://github.com/laravel/framework/pull/26351)) 
 - Added `Macroable` trait to `Illuminate\View\Factory` ([#26361](https://github.com/laravel/framework/pull/26361))
+- Added support for UNION aggregate queries ([#26365](https://github.com/laravel/framework/pull/26365))
 
 ### Changed
 - Updated `AbstractPaginator::appends` to handle null ([#26326](https://github.com/laravel/framework/pull/26326))
@@ -14,6 +16,8 @@
 - Showed exception message on 403 error page when message is available ([#26356](https://github.com/laravel/framework/pull/26356))
 - Don't run TransformsRequest twice on ?query= parameters ([#26366](https://github.com/laravel/framework/pull/26366))
 - Added missing logging options to slack log driver ([#26360](https://github.com/laravel/framework/pull/26360))
+- Use cascade when truncating table in PostgreSQL ([#26389](https://github.com/laravel/framework/pull/26389))
+- Allowed pass absolute parameter in has valid signature request macro ([#26397](https://github.com/laravel/framework/pull/26397))
 
 ### Changed realization
 - Used `Request::validate` macro in Auth traits ([#26314](https://github.com/laravel/framework/pull/26314))

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -102,14 +102,17 @@ class Gate implements GateContract
      * Define a new ability.
      *
      * @param  string  $ability
-     * @param  callable|string  $callback
+     * @param  callable|string|array  $callback
      * @return $this
      *
      * @throws \InvalidArgumentException
      */
     public function define($ability, $callback)
     {
-        if (is_callable($callback)) {
+        if (is_array($callback)) {
+            $callback = implode('@', $callback);
+            $this->abilities[$ability] = $this->buildAbilityCallback($ability, $callback);
+        } elseif (is_callable($callback)) {
             $this->abilities[$ability] = $callback;
         } elseif (is_string($callback)) {
             $this->abilities[$ability] = $this->buildAbilityCallback($ability, $callback);

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -29,7 +29,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.7.12';
+    const VERSION = '5.7.13';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -609,10 +609,14 @@ if (! function_exists('mix')) {
         $manifest = $manifests[$manifestPath];
 
         if (! isset($manifest[$path])) {
-            report(new Exception("Unable to locate Mix file: {$path}."));
+            $exception = new Exception("Unable to locate Mix file: {$path}.");
 
             if (! app('config')->get('app.debug')) {
+                report($exception);
+
                 return $path;
+            } else {
+                throw $exception;
             }
         }
 

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -364,6 +364,15 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('foo'));
     }
 
+    public function test_arrays_can_be_defined_as_callbacks_using_tuple_notation()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->define('foo', [AccessGateTestClass::class, 'foo']);
+
+        $this->assertTrue($gate->check('foo'));
+    }
+
     public function test_invokable_classes_can_be_defined()
     {
         $gate = $this->getBasicGate();
@@ -480,7 +489,7 @@ class AuthAccessGateTest extends TestCase
      * @dataProvider notCallableDataProvider
      * @expectedException \InvalidArgumentException
      */
-    public function test_define_second_parametter_should_be_string_or_callable($callback)
+    public function test_define_second_parameter_should_be_string_or_callable_or_array($callback)
     {
         $gate = $this->getBasicGate();
 
@@ -495,7 +504,6 @@ class AuthAccessGateTest extends TestCase
         return [
             [1],
             [new stdClass],
-            [[]],
             [1.1],
         ];
     }

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Foundation;
 
 use Exception;
 use Orchestra\Testbench\TestCase;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 
 /**
  * @group integration
@@ -36,5 +37,78 @@ class FoundationHelpersTest extends TestCase
         $this->assertEquals(rescue(function () use ($testClass) {
             $testClass->test([]);
         }, 'rescued!'), 'rescued!');
+    }
+
+    public function testMixReportsExceptionWhenAssetIsMissingFromManifest()
+    {
+        $handler = new FakeHandler;
+        $this->app->instance(ExceptionHandler::class, $handler);
+        $manifest = $this->makeManifest();
+
+        mix('missing.js');
+
+        $this->assertInstanceOf(Exception::class, $handler->reported);
+        $this->assertSame('Unable to locate Mix file: /missing.js.', $handler->reported->getMessage());
+
+        unlink($manifest);
+    }
+
+    public function testMixSilentlyFailsWhenAssetIsMissingFromManifestWhenNotInDebugMode()
+    {
+        $this->app['config']->set('app.debug', false);
+        $manifest = $this->makeManifest();
+
+        $path = mix('missing.js');
+
+        $this->assertSame('/missing.js', $path);
+
+        unlink($manifest);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Undefined index: /missing.js
+     */
+    public function testMixThrowsExceptionWhenAssetIsMissingFromManifestWhenInDebugMode()
+    {
+        $this->app['config']->set('app.debug', true);
+        $manifest = $this->makeManifest();
+
+        try {
+            mix('missing.js');
+        } catch (\Exception $e) {
+            throw $e;
+        } finally { // make sure we can cleanup the file
+            unlink($manifest);
+        }
+    }
+
+    protected function makeManifest($directory = '')
+    {
+        $this->app->singleton('path.public', function () {
+            return __DIR__;
+        });
+
+        $path = public_path(str_finish($directory, '/').'mix-manifest.json');
+
+        touch($path);
+
+        // Laravel mix prints JSON pretty and with escaped
+        // slashes, so we are doing that here for consistency.
+        $content = json_encode(['/unversioned.css' => '/versioned.css'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        file_put_contents($path, $content);
+
+        return $path;
+    }
+}
+
+class FakeHandler
+{
+    public $reported;
+
+    public function report($exception)
+    {
+        $this->reported = $exception;
     }
 }


### PR DESCRIPTION
This PR allows Gates to be defined using tuple notation.

The idea here is similar to tuple notation used when generating action urls.