### PR TITLE
[5.8] Allow tuple notation when defining Gates

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -102,14 +102,17 @@ class Gate implements GateContract
      * Define a new ability.
      *
      * @param  string  $ability
-     * @param  callable|string  $callback
+     * @param  callable|string|array  $callback
      * @return $this
      *
      * @throws \InvalidArgumentException
      */
     public function define($ability, $callback)
     {
-        if (is_callable($callback)) {
+        if (is_array($callback)) {
+            $callback = implode('@', $callback);
+            $this->abilities[$ability] = $this->buildAbilityCallback($ability, $callback);
+        } elseif (is_callable($callback)) {
             $this->abilities[$ability] = $callback;
         } elseif (is_string($callback)) {
             $this->abilities[$ability] = $this->buildAbilityCallback($ability, $callback);

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -364,6 +364,15 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('foo'));
     }
 
+    public function test_arrays_can_be_defined_as_callbacks_using_tuple_notation()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->define('foo', [AccessGateTestClass::class, 'foo']);
+
+        $this->assertTrue($gate->check('foo'));
+    }
+
     public function test_invokable_classes_can_be_defined()
     {
         $gate = $this->getBasicGate();
@@ -480,7 +489,7 @@ class AuthAccessGateTest extends TestCase
      * @dataProvider notCallableDataProvider
      * @expectedException \InvalidArgumentException
      */
-    public function test_define_second_parametter_should_be_string_or_callable($callback)
+    public function test_define_second_parameter_should_be_string_or_callable_or_array($callback)
     {
         $gate = $this->getBasicGate();
 
@@ -495,7 +504,6 @@ class AuthAccessGateTest extends TestCase
         return [
             [1],
             [new stdClass],
-            [[]],
             [1.1],
         ];
     }


### PR DESCRIPTION
This PR allows Gates to be defined using tuple notation.

The idea here is similar to tuple notation used when generating action urls.