### PR TITLE
[5.7] Fix #22951 permanently: Using shouldIgnoreMissing on dispatcher mock

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -175,7 +175,7 @@ trait MocksApplicationServices
      */
     protected function withoutJobs()
     {
-        $mock = Mockery::mock(BusDispatcherContract::class);
+        $mock = Mockery::mock(BusDispatcherContract::class)->shouldIgnoreMissing();
 
         $mock->shouldReceive('dispatch', 'dispatchNow')->andReturnUsing(function ($dispatched) {
             $this->dispatchedJobs[] = $dispatched;


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
#22951 was "fixed" by adding methods to the dispatcher contract, which is great, but Mockery will still fail if you haven't set up expectations for the methods that get called.

In my particular case, the getCommandHandler method was being called but it hadn't been defined. So I see 2 potential resolutions to this issue:
1) Define the mock method I'm having issues with to something that makes sense.
2) Add shouldIgnoreMissing to the mock definition which has the benefit of not having the particular error happen again but could potentially be bad if you want it to fail if a mocked method isn't defined.

Since the dispatch and dispatchNow command are mocked, the command handler isn't really used and is fine with being set to null (as best as I can tell) so I went with option 2. I also don't think the con is super bad either with that method.