### PR TITLE
[5.7] Adds clear() method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1242,6 +1242,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Remove all items from the collection.
+     *
+     * @return $this
+     */
+    public function clear()
+    {
+        $this->items = [];
+
+        return $this;
+    }
+
+    /**
      * Push all of the given items onto the collection.
      *
      * @param  \Traversable|array  $source

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2151,6 +2151,15 @@ class SupportCollectionTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
+    public function testClear()
+    {
+        $expected = [];
+
+        $actual = (new Collection(['taylorotwell', 'hivokas']))->clear()->toArray();
+
+        $this->assertSame($expected, $actual);
+    }
+
     public function testConcatWithArray()
     {
         $expected = [


### PR DESCRIPTION
This pull request adds the `clear()` method to the `Collection` class.
I think that this method may be useful in some cases.