### PR TITLE
4.2.23

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.2-dev"
+            "master": "4.2.23"
         }
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravel/framework",
+    "name": "web-engineer/framework",
     "description": "The Laravel Framework.",
     "keywords": ["framework", "laravel"],
     "license": "MIT",

--- a/src/Illuminate/Foundation/changes.json
+++ b/src/Illuminate/Foundation/changes.json
@@ -1,5 +1,8 @@
 {
-	"4.2.*": [
+		"4.3.*": [
+		{"message": "Session fixation backported from 270991219.", "backport": null}
+	],
+		"4.2.*": [
 		{"message": "View and Pagination 'Environment' classes renamed to 'Factory'.", "backport": null},
 		{"message": "Configurable encryption for Iron.io queue messages.", "backport": null},
 		{"message": "Make FrameGuard middleware opt-in.", "backport": null},

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Connection;
 use Carbon\Carbon;
 use Illuminate\Database\QueryException;
+use Illuminate\Support\Arr;
 
 class DatabaseSessionHandler implements \SessionHandlerInterface, ExistenceAwareInterface {
 


### PR DESCRIPTION
I've back ported a fix in 5 to solve the session fixation issue.

This is the issue discissed here - 
https://github.com/laravel/framework/issues/9251#issuecomment-270991219 
and fixed later in laravel 5 on commit d9e0a6a03891d16ed6a71151354445fbdc9e6f50 

Hoping that this helps others stuck on a 4.2 codebase experiencing the problem.

This manifests itself in the laravel logs as -

local.ERROR: 500 exception 'PDOException' with message 'SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'xxxxxxxxxx' for key 'sessions_id_unique'' in vendor/laravel/framework/src/Illuminate/Database/Connection.php:369