### PR TITLE
[5.7] Make CookieJar macroable

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Cookie;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\InteractsWithTime;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Contracts\Cookie\QueueingFactory as JarContract;
-use Illuminate\Support\Traits\Macroable;
 
 class CookieJar implements JarContract
 {

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -6,10 +6,11 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\InteractsWithTime;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Contracts\Cookie\QueueingFactory as JarContract;
+use Illuminate\Support\Traits\Macroable;
 
 class CookieJar implements JarContract
 {
-    use InteractsWithTime;
+    use InteractsWithTime, Macroable;
 
     /**
      * The default path (if specified).

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -88,6 +88,15 @@ class CookieTest extends TestCase
         $this->assertEmpty($cookie->getQueuedCookies());
     }
 
+    public function testCookieJarIsMacroable()
+    {
+        $cookie = $this->getCreator();
+        $cookie->macro('foo', function () {
+            return 'bar';
+        });
+        $this->assertEquals('bar', $cookie->foo());
+    }
+
     public function getCreator()
     {
         return new CookieJar(Request::create('/foo', 'GET'), [


### PR DESCRIPTION
This PR allows you to do this:
```
Cookie::macro('foo', function() {...});

Cookie::foo();
```

Not sure what the current vibe is on making things Macroable, but this would help me for sure.