### PR TITLE
Throw an exception if the programmer is over-writing middleware.

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -883,17 +883,39 @@ class Router implements RegistrarContract, BindingRegistrar
         return $this;
     }
 
-    /**
-     * Add a middleware to the end of a middleware group.
-     *
-     * If the middleware is already in the group, it will not be added again.
-     *
-     * @param  string  $group
-     * @param  string  $middleware
-     * @return $this
-     */
-    public function pushMiddlewareToGroup($group, $middleware)
-    {
+	/**
+	 * Add a middleware to the end of a middleware group.
+	 *
+	 * If the middleware is already in the group, it will not be added again.
+	 * If the group name conflicts with un-grouped names, throw an exception.
+	 *
+	 * @param  string       $group
+	 * @param  string       $middleware
+	 * @param  string|null  $strategy
+	 * @return $this
+	 */
+	public function pushMiddlewareToGroup($group, $middleware, $strategy = null)
+	{
+		if(array_key_exists($group, $this->middleware)){
+			switch(true){
+
+				case ($strategy == 'replace'):
+					// no logical change in framework behaviour
+					break;
+
+				case ($strategy == 'auto-group'):
+					$this->pushMiddlewareToGroup($group, $this->middleware[$group], 'replace');
+					unset($this->middleware[$group]);
+					break;
+
+
+				case (empty($strategy)):
+				default:
+					throw new \LogicException("The middleware key '$group' is already in use, and it is not a group. Choose a different group, or use the 'auto-group' strategy.");
+					break;
+			}
+		}
+
         if (! array_key_exists($group, $this->middlewareGroups)) {
             $this->middlewareGroups[$group] = [];
         }


### PR DESCRIPTION
I was creating a way to ban users.  I added my BanUsersMiddleware::class to the 'auth' group.  However, 'auth' is not a group.  $router->pushMiddlewareToGroup('auth' ...) actually replaced the auth middleware and many things continued to work without any security at all.
