### PR TITLE
[5.7] Router middleware pushing and appending

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1276,6 +1276,7 @@ class Router implements RegistrarContract, BindingRegistrar
 	 *
 	 * @param $group
 	 * @param $strategy
+	 * @param $caller
 	 */
 	private function ensureGroupNameIsAvailable($group, $strategy, $caller){
 		if(array_key_exists($group, $this->middleware)){

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -883,17 +883,39 @@ class Router implements RegistrarContract, BindingRegistrar
         return $this;
     }
 
-    /**
-     * Add a middleware to the end of a middleware group.
-     *
-     * If the middleware is already in the group, it will not be added again.
-     *
-     * @param  string  $group
-     * @param  string  $middleware
-     * @return $this
-     */
-    public function pushMiddlewareToGroup($group, $middleware)
-    {
+	/**
+	 * Add a middleware to the end of a middleware group.
+	 *
+	 * If the middleware is already in the group, it will not be added again.
+	 * If the group name conflicts with un-grouped names, throw an exception.
+	 *
+	 * @param  string       $group
+	 * @param  string       $middleware
+	 * @param  string|null  $strategy
+	 * @return $this
+	 */
+	public function pushMiddlewareToGroup($group, $middleware, $strategy = null)
+	{
+		if(array_key_exists($group, $this->middleware)){
+			switch(true){
+
+				case ($strategy == 'replace'):
+					// no logical change in framework behaviour
+					break;
+
+				case ($strategy == 'auto-group'):
+					$this->pushMiddlewareToGroup($group, $this->middleware[$group], 'replace');
+					unset($this->middleware[$group]);
+					break;
+
+
+				case (empty($strategy)):
+				default:
+					throw new \LogicException("The middleware key '$group' is already in use, and it is not a group. Choose a different group, or use the 'auto-group' strategy.");
+					break;
+			}
+		}
+
         if (! array_key_exists($group, $this->middlewareGroups)) {
             $this->middlewareGroups[$group] = [];
         }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -869,13 +869,35 @@ class Router implements RegistrarContract, BindingRegistrar
      * Add a middleware to the beginning of a middleware group.
      *
      * If the middleware is already in the group, it will not be added again.
+     * If the group name conflicts with un-grouped names, throw an exception.
      *
-     * @param  string  $group
-     * @param  string  $middleware
+     * @param  string       $group
+     * @param  string       $middleware
+     * @param  string|null  $strategy
      * @return $this
      */
-    public function prependMiddlewareToGroup($group, $middleware)
+    public function prependMiddlewareToGroup($group, $middleware, $strategy = null)
     {
+	    if(array_key_exists($group, $this->middleware)){
+		    switch(true){
+
+			    case ($strategy == 'replace'):
+				    // no logical change in framework behaviour
+				    break;
+
+			    case ($strategy == 'auto-group'):
+				    $this->prependMiddlewareToGroup($group, $this->middleware[$group], 'replace');
+				    unset($this->middleware[$group]);
+				    break;
+
+
+			    case (empty($strategy)):
+			    default:
+				    throw new \LogicException("The middleware key '$group' is already in use, and it is not a group. Choose a different group, or use the 'auto-group' strategy.");
+				    break;
+		    }
+	    }
+
 	    if (! array_key_exists($group, $this->middlewareGroups)) {
 		    $this->middlewareGroups[$group] = [];
 	    }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -876,6 +876,10 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function prependMiddlewareToGroup($group, $middleware)
     {
+	    if (! array_key_exists($group, $this->middlewareGroups)) {
+		    $this->middlewareGroups[$group] = [];
+	    }K
+
         if (isset($this->middlewareGroups[$group]) && ! in_array($middleware, $this->middlewareGroups[$group])) {
             array_unshift($this->middlewareGroups[$group], $middleware);
         }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -878,7 +878,7 @@ class Router implements RegistrarContract, BindingRegistrar
     {
 	    if (! array_key_exists($group, $this->middlewareGroups)) {
 		    $this->middlewareGroups[$group] = [];
-	    }K
+	    }
 
         if (isset($this->middlewareGroups[$group]) && ! in_array($middleware, $this->middlewareGroups[$group])) {
             array_unshift($this->middlewareGroups[$group], $middleware);

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -878,25 +878,7 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function prependMiddlewareToGroup($group, $middleware, $strategy = null)
     {
-	    if(array_key_exists($group, $this->middleware)){
-		    switch(true){
-
-			    case ($strategy == 'replace'):
-				    // no logical change in framework behaviour
-				    break;
-
-			    case ($strategy == 'auto-group'):
-				    $this->prependMiddlewareToGroup($group, $this->middleware[$group], 'replace');
-				    unset($this->middleware[$group]);
-				    break;
-
-
-			    case (empty($strategy)):
-			    default:
-				    throw new \LogicException("The middleware key '$group' is already in use, and it is not a group. Choose a different group, or use the 'auto-group' strategy.");
-				    break;
-		    }
-	    }
+	    $this->ensureGroupNameIsAvailable($group, $strategy, __FUNCTION__);
 
 	    if (! array_key_exists($group, $this->middlewareGroups)) {
 		    $this->middlewareGroups[$group] = [];
@@ -922,25 +904,7 @@ class Router implements RegistrarContract, BindingRegistrar
 	 */
 	public function pushMiddlewareToGroup($group, $middleware, $strategy = null)
 	{
-		if(array_key_exists($group, $this->middleware)){
-			switch(true){
-
-				case ($strategy == 'replace'):
-					// no logical change in framework behaviour
-					break;
-
-				case ($strategy == 'auto-group'):
-					$this->pushMiddlewareToGroup($group, $this->middleware[$group], 'replace');
-					unset($this->middleware[$group]);
-					break;
-
-
-				case (empty($strategy)):
-				default:
-					throw new \LogicException("The middleware key '$group' is already in use, and it is not a group. Choose a different group, or use the 'auto-group' strategy.");
-					break;
-			}
-		}
+		$this->ensureGroupNameIsAvailable($group, $strategy, __FUNCTION__);
 
         if (! array_key_exists($group, $this->middlewareGroups)) {
             $this->middlewareGroups[$group] = [];
@@ -1305,4 +1269,33 @@ class Router implements RegistrarContract, BindingRegistrar
 
         return (new RouteRegistrar($this))->attribute($method, $parameters[0]);
     }
+
+	/**
+	 * Check that the programmer is not over writing a middleware
+	 * by creating a middleware group with the same named key.
+	 *
+	 * @param $group
+	 * @param $strategy
+	 */
+	private function ensureGroupNameIsAvailable($group, $strategy, $caller){
+		if(array_key_exists($group, $this->middleware)){
+			switch(true){
+
+				case ($strategy == 'replace'):
+					// no logical change in framework behaviour
+					break;
+
+				case ($strategy == 'auto-group'):
+					$this->$caller($group, $this->middleware[$group], 'replace');
+					unset($this->middleware[$group]);
+					break;
+
+
+				case (empty($strategy)):
+				default:
+					throw new \LogicException("The middleware key '$group' is already in use, and it is not a group. Choose a different group, or use the 'auto-group' strategy.");
+					break;
+			}
+		}
+	}
 }


### PR DESCRIPTION
I was trying to add middleware to BanUsers, however I used $router->pushMiddlewareToGroup('auth' ...) and it was a very bad situation because 'auth' is not a group.  This method call replaced the auth middleware with my much more basic check - and people were passing right thru.