### PR TITLE
[5.8] Pass guards to redirectTo method in Authenticate middleware

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -65,7 +65,7 @@ class Authenticate
         }
 
         throw new AuthenticationException(
-            'Unauthenticated.', $guards, $this->redirectTo($request)
+            'Unauthenticated.', $guards, $this->redirectTo($request, $guards)
         );
     }
 
@@ -73,9 +73,10 @@ class Authenticate
      * Get the path the user should be redirected to when they are not authenticated.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  array  $guards
      * @return string
      */
-    protected function redirectTo($request)
+    protected function redirectTo($request, array $guards)
     {
         //
     }


### PR DESCRIPTION
closes https://github.com/laravel/framework/issues/26292

After merging this, we will be able to use `guards` in `Authenticate` middleware
```php
<?php

namespace App\Http\Middleware;

use Illuminate\Auth\Middleware\Authenticate as Middleware;
use Illuminate\Support\Facades\Route;

class Authenticate extends Middleware
{
    /**
     * Get the path the user should be redirected to when they are not authenticated.
     *
     * @param  \Illuminate\Http\Request $request
     * @param  array  $guards
     * @return string
     */
    protected function redirectTo($request, $guards)
    {
        if (!$request->expectsJson()) {
            // do something with $guards array here
        }
    }
}
```

* [PR](https://github.com/laravel/laravel/pull/4849) to https://github.com/laravel/laravel to make it compatible with v5.8
* [PR](https://github.com/orchestral/testbench-core/pull/14) to https://github.com/orchestral/testbench to make test pass