### PR TITLE
Fix pagination slider when it's too close to the end

### DIFF
--- a/src/Illuminate/Pagination/UrlWindow.php
+++ b/src/Illuminate/Pagination/UrlWindow.php
@@ -123,7 +123,7 @@ class UrlWindow
     protected function getSliderTooCloseToEnding($window)
     {
         $last = $this->paginator->getUrlRange(
-            $this->lastPage() - ($window + 2),
+            $this->lastPage() - ($window + 1),
             $this->lastPage()
         );
 

--- a/tests/Pagination/UrlWindowTest.php
+++ b/tests/Pagination/UrlWindowTest.php
@@ -43,7 +43,7 @@ class UrlWindowTest extends TestCase
         $p = new LengthAwarePaginator($array, count($array), 1, 8);
         $window = new UrlWindow($p);
         $last = [];
-        for ($i = 5; $i <= 13; $i++) {
+        for ($i = 6; $i <= 13; $i++) {
             $last[$i] = '/?page='.$i;
         }
 


### PR DESCRIPTION
Make the number of pages that are shown close to the end, equal to
the number of pages that are shown close to the beginning.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
