### PR TITLE
Fix uniqueness of macroable objects on grammars

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -2,13 +2,10 @@
 
 namespace Illuminate\Database;
 
-use Illuminate\Support\Traits\Macroable;
 use Illuminate\Database\Query\Expression;
 
 abstract class Grammar
 {
-    use Macroable;
-
     /**
      * The grammar table prefix.
      *

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -5,10 +5,13 @@ namespace Illuminate\Database\Query\Grammars;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Database\Query\JsonExpression;
 
 class MySqlGrammar extends Grammar
 {
+    use Macroable;
+
     /**
      * The grammar specific operators.
      *

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -5,9 +5,12 @@ namespace Illuminate\Database\Query\Grammars;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Traits\Macroable;
 
 class PostgresGrammar extends Grammar
 {
+    use Macroable;
+
     /**
      * All of the available clause operators.
      *

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -5,9 +5,12 @@ namespace Illuminate\Database\Query\Grammars;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Traits\Macroable;
 
 class SQLiteGrammar extends Grammar
 {
+    use Macroable;
+
     /**
      * The components that make up a select clause.
      *

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -4,9 +4,12 @@ namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Support\Arr;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Traits\Macroable;
 
 class SqlServerGrammar extends Grammar
 {
+    use Macroable;
+
     /**
      * All of the available clause operators.
      *

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -4,10 +4,13 @@ namespace Illuminate\Database\Schema\Grammars;
 
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Connection;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Database\Schema\Blueprint;
 
 class MySqlGrammar extends Grammar
 {
+    use Macroable;
+
     /**
      * The possible column modifiers.
      *

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -3,10 +3,13 @@
 namespace Illuminate\Database\Schema\Grammars;
 
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Database\Schema\Blueprint;
 
 class PostgresGrammar extends Grammar
 {
+    use Macroable;
+
     /**
      * If this Grammar supports schema changes wrapped in a transaction.
      *

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -7,10 +7,13 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
 use Doctrine\DBAL\Schema\Index;
 use Illuminate\Database\Connection;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Database\Schema\Blueprint;
 
 class SQLiteGrammar extends Grammar
 {
+    use Macroable;
+
     /**
      * The possible column modifiers.
      *

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -3,10 +3,13 @@
 namespace Illuminate\Database\Schema\Grammars;
 
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Database\Schema\Blueprint;
 
 class SqlServerGrammar extends Grammar
 {
+    use Macroable;
+
     /**
      * If this Grammar supports schema changes wrapped in a transaction.
      *

--- a/tests/Database/DatabaseGrammarTest.php
+++ b/tests/Database/DatabaseGrammarTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Schema\Grammars\SqlServerGrammar as SqlServerSchemaGrammar;
+use Illuminate\Database\Schema\Grammars\PostgresGrammar as PostgresSchemaGrammar;
+use Illuminate\Database\Schema\Grammars\MySqlGrammar as MySqlSchemaGrammar;
+use Illuminate\Database\Schema\Grammars\SQLiteGrammar as SQLiteSchemaGrammar;
+use Illuminate\Database\Query\Grammars\MySqlGrammar as MySqlQueryGrammar;
+use Illuminate\Database\Query\Grammars\SQLiteGrammar as SQLiteQueryGrammar;
+use Illuminate\Database\Query\Grammars\SqlServerGrammar as SqlServerQueryGrammar;
+use Illuminate\Database\Query\Grammars\PostgresGrammar as PostgresQueryGrammar;
+
+class DatabaseGrammarTest extends TestCase
+{
+    public function testMacroableFunctionsAreUniquePerGrammarQueryClass()
+    {
+        // compileReplace macro.
+        MySqlQueryGrammar::macro('compileReplace', function () {
+            return MySqlQueryGrammar::class;
+        });
+
+        SQLiteQueryGrammar::macro('compileReplace', function () {
+            return SQLiteQueryGrammar::class;
+        });
+
+        PostgresQueryGrammar::macro('compileReplace', function () {
+            return PostgresQueryGrammar::class;
+        });
+
+        SqlServerQueryGrammar::macro('compileReplace', function () {
+            return SqlServerQueryGrammar::class;
+        });
+
+        $this->assertSame(MySqlQueryGrammar::class, (new MySqlQueryGrammar())->compileReplace());
+        $this->assertSame(SqlServerQueryGrammar::class, (new SqlServerQueryGrammar())->compileReplace());
+        $this->assertSame(PostgresQueryGrammar::class, (new PostgresQueryGrammar())->compileReplace());
+        $this->assertSame(SQLiteQueryGrammar::class, (new SQLiteQueryGrammar())->compileReplace());
+    }
+
+    public function testMacroableFunctionsAreUniquePerGrammarSchemaClass()
+    {
+        // compileReplace macro.
+        MySqlSchemaGrammar::macro('compileReplace', function () {
+            return MySqlSchemaGrammar::class;
+        });
+
+        SQLiteSchemaGrammar::macro('compileReplace', function () {
+            return SQLiteSchemaGrammar::class;
+        });
+
+        PostgresSchemaGrammar::macro('compileReplace', function () {
+            return PostgresSchemaGrammar::class;
+        });
+
+        SqlServerSchemaGrammar::macro('compileReplace', function () {
+            return SqlServerSchemaGrammar::class;
+        });
+
+        $this->assertSame(MySqlSchemaGrammar::class, (new MySqlSchemaGrammar())->compileReplace());
+        $this->assertSame(SqlServerSchemaGrammar::class, (new SqlServerSchemaGrammar())->compileReplace());
+        $this->assertSame(PostgresSchemaGrammar::class, (new PostgresSchemaGrammar())->compileReplace());
+        $this->assertSame(SQLiteSchemaGrammar::class, (new SQLiteSchemaGrammar())->compileReplace());
+    }
+}


### PR DESCRIPTION
In my pr #24513 i added the macroable trait to the grammars outermost parent class.

But what i didn't realize is that if one where to try to register the same macro name into two different grammars only the last call to the macro method will be used sense the macro property is static and lives in the outmost parent.

So every call to macro would override another one.




