### PR TITLE
[5.7] Allow arrays in route redirect methods

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -229,30 +229,34 @@ class Router implements RegistrarContract, BindingRegistrar
     }
 
     /**
-     * Create a redirect from one URI to another.
+     * Create a redirect from one or more URIs to another.
      *
-     * @param  string  $uri
+     * @param  array|string  $uri
      * @param  string  $destination
      * @param  int  $status
      * @return \Illuminate\Routing\Route
      */
     public function redirect($uri, $destination, $status = 302)
     {
-        return $this->any($uri, '\Illuminate\Routing\RedirectController')
-                ->defaults('destination', $destination)
-                ->defaults('status', $status);
+        return collect($uri)->map(function ($item) use ($destination, $status) {
+            return $this->any($item, '\Illuminate\Routing\RedirectController')
+                    ->defaults('destination', $destination)
+                    ->defaults('status', $status);
+        });
     }
 
     /**
-     * Create a permanent redirect from one URI to another.
+     * Create a permanent redirect from one or more URIs to another.
      *
-     * @param  string  $uri
+     * @param  array|string  $uri
      * @param  string  $destination
      * @return \Illuminate\Routing\Route
      */
     public function permanentRedirect($uri, $destination)
     {
-        return $this->redirect($uri, $destination, 301);
+        return collect($uri)->map(function ($item) use ($destination) {
+            return $this->redirect($item, $destination, 301);
+        });
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1529,12 +1529,12 @@ class RoutingRouteTest extends TestCase
         $router->get('message_us', function () {
             throw new Exception('Route B should not be reachable.');
         });
-        $router->redirect(['contact_us', 'message_us'], 'route_c');
+        $router->redirect(['contact_us', 'message_us'], 'contact');
 
         $responseA = $router->dispatch(Request::create('contact_us', 'GET'));
         $responseB = $router->dispatch(Request::create('message_us', 'GET'));
-        $this->assertTrue($responseA->isRedirect('route_c'));
-        $this->assertTrue($responseB->isRedirect('route_c'));
+        $this->assertTrue($responseA->isRedirect('contact'));
+        $this->assertTrue($responseB->isRedirect('contact'));
         $this->assertEquals(302, $responseA->getStatusCode());
         $this->assertEquals(302, $responseB->getStatusCode());
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1520,6 +1520,25 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(302, $response->getStatusCode());
     }
 
+    public function testMultipleRouteRedirects()
+    {
+        $router = $this->getRouter();
+        $router->get('contact_us', function () {
+            throw new Exception('Route A should not be reachable.');
+        });
+        $router->get('message_us', function () {
+            throw new Exception('Route B should not be reachable.');
+        });
+        $router->redirect(['contact_us', 'message_us'], 'route_c');
+
+        $responseA = $router->dispatch(Request::create('contact_us', 'GET'));
+        $responseB = $router->dispatch(Request::create('message_us', 'GET'));
+        $this->assertTrue($responseA->isRedirect('route_c'));
+        $this->assertTrue($responseB->isRedirect('route_c'));
+        $this->assertEquals(302, $responseA->getStatusCode());
+        $this->assertEquals(302, $responseB->getStatusCode());
+    }
+
     public function testRouteRedirectWithCustomStatus()
     {
         $router = $this->getRouter();
@@ -1533,6 +1552,25 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(301, $response->getStatusCode());
     }
 
+    public function testMultipleRouteRedirectsWithCustomStatuses()
+    {
+        $router = $this->getRouter();
+        $router->get('contact_us', function () {
+            throw new Exception('Route A should not be reachable.');
+        });
+        $router->get('message_us', function () {
+            throw new Exception('Route B should not be reachable.');
+        });
+        $router->redirect(['contact_us', 'message_us'], 'contact', 301);
+
+        $responseA = $router->dispatch(Request::create('contact_us', 'GET'));
+        $responseB = $router->dispatch(Request::create('message_us', 'GET'));
+        $this->assertTrue($responseA->isRedirect('contact'));
+        $this->assertTrue($responseB->isRedirect('contact'));
+        $this->assertEquals(301, $responseA->getStatusCode());
+        $this->assertEquals(301, $responseB->getStatusCode());
+    }
+
     public function testRoutePermanentRedirect()
     {
         $router = $this->getRouter();
@@ -1544,6 +1582,25 @@ class RoutingRouteTest extends TestCase
         $response = $router->dispatch(Request::create('contact_us', 'GET'));
         $this->assertTrue($response->isRedirect('contact'));
         $this->assertEquals(301, $response->getStatusCode());
+    }
+
+    public function testMultipleRoutePermanentRedirects()
+    {
+        $router = $this->getRouter();
+        $router->get('contact_us', function () {
+            throw new Exception('Route A should not be reachable.');
+        });
+        $router->get('message_us', function () {
+            throw new Exception('Route B should not be reachable.');
+        });
+        $router->permanentRedirect(['contact_us', 'message_us'], 'contact');
+
+        $responseA = $router->dispatch(Request::create('contact_us', 'GET'));
+        $responseB = $router->dispatch(Request::create('message_us', 'GET'));
+        $this->assertTrue($responseA->isRedirect('contact'));
+        $this->assertTrue($responseB->isRedirect('contact'));
+        $this->assertEquals(301, $responseA->getStatusCode());
+        $this->assertEquals(301, $responseB->getStatusCode());
     }
 
     protected function getRouter()


### PR DESCRIPTION
A previous commit in Laravel 5.5 (https://github.com/laravel/framework/pull/19794) added an awesome `Route::redirect('here', 'there')` method. This PR allows for arrays to be entered into said method, allowing for the clean and convenient redirection of multiple URIs.

For example:

```php
Route::redirect(['/home', '/me'], '/dashboard');
```

I also included tests for simple redirection as shown above, as well as using custom statuses and the `Route::permanentRedirect('/here', '/there')` method:

```php
Route::redirect(['/home', '/me'], '/dashboard', 302);

Route::permanentRedirect(['/home', '/me'], '/dashboard');
```