### PR TITLE
[5.7] Fix UNION aggregate queries with columns

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2130,8 +2130,10 @@ class Builder
      */
     protected function runPaginationCountQuery($columns = ['*'])
     {
-        return $this->cloneWithout(['columns', 'orders', 'limit', 'offset'])
-                    ->cloneWithoutBindings(['select', 'order'])
+        $without = $this->unions ? ['orders', 'limit', 'offset'] : ['columns', 'orders', 'limit', 'offset'];
+
+        return $this->cloneWithout($without)
+                    ->cloneWithoutBindings($this->unions ? ['order'] : ['select', 'order'])
                     ->setAggregate('count', $this->withoutSelectAliases($columns))
                     ->get()->all();
     }
@@ -2444,8 +2446,8 @@ class Builder
      */
     public function aggregate($function, $columns = ['*'])
     {
-        $results = $this->cloneWithout(['columns'])
-                        ->cloneWithoutBindings(['select'])
+        $results = $this->cloneWithout($this->unions ? [] : ['columns'])
+                        ->cloneWithoutBindings($this->unions ? [] : ['select'])
                         ->setAggregate($function, $columns)
                         ->get($columns);
 


### PR DESCRIPTION
`UNION` aggregate queries don't apply the selected columns to the base query:

```php
DB::table('posts')->select('id')->union(
  DB::table('videos')->select('id')
)->count()
```

```sql
# expected
select count(*) as aggregate from (
  (select `id` from `posts`) union (select `id` from `videos`)
) as `temp_table`

# actual
select count(*) as aggregate from (
  (select * from `posts`) union (select `id` from `videos`)
          ^
) as `temp_table`
```

The selected columns are irrelevant for the result, but the `UNION` query doesn't work with different numbers of columns ("cardinality violation").

This also affects pagination queries.

Fixes #26444.