### PR TITLE
[5.7] Improve whereInRaw()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -318,7 +318,7 @@ abstract class Relation
     {
         return $model->getKeyName() === last(explode('.', $key))
                     && in_array($model->getKeyType(), ['int', 'integer'])
-                        ? 'whereInRaw'
+                        ? 'whereInRawInt'
                         : 'whereIn';
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -949,15 +949,15 @@ class Builder
     }
 
     /**
-     * Add a "where in raw" clause to the query.
+     * Add a "where in raw" clause for integer values to the query.
      *
      * @param  string  $column
-     * @param  array   $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $values
      * @param  string  $boolean
-     * @param  bool    $not
+     * @param  bool  $not
      * @return $this
      */
-    public function whereInRaw($column, array $values, $boolean = 'and', $not = false)
+    public function whereInRawInt($column, $values, $boolean = 'and', $not = false)
     {
         $type = $not ? 'NotInRaw' : 'InRaw';
 
@@ -965,7 +965,9 @@ class Builder
             $values = $values->toArray();
         }
 
-        $values = array_map('intval', $values);
+        foreach ($values as &$value) {
+            $value = (int) $value;
+        }
 
         $this->wheres[] = compact('type', 'column', 'values', 'boolean');
 

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -81,7 +81,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation = $this->getRelation();
         $relation->getRelated()->shouldReceive('getKeyName')->andReturn('id');
         $relation->getRelated()->shouldReceive('getKeyType')->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereInRaw')->once()->with('relation.id', ['foreign.value', 'foreign.value.two']);
+        $relation->getQuery()->shouldReceive('whereInRawInt')->once()->with('relation.id', ['foreign.value', 'foreign.value.two']);
         $models = [new EloquentBelongsToModelStub, new EloquentBelongsToModelStub, new AnotherEloquentBelongsToModelStub];
         $relation->addEagerConstraints($models);
     }
@@ -91,7 +91,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation = $this->getRelation();
         $relation->getRelated()->shouldReceive('getKeyName')->andReturn('id');
         $relation->getRelated()->shouldReceive('getKeyType')->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereInRaw')->once()->with('relation.id', ['foreign.value', 0]);
+        $relation->getQuery()->shouldReceive('whereInRawInt')->once()->with('relation.id', ['foreign.value', 0]);
         $models = [new EloquentBelongsToModelStub, new EloquentBelongsToModelStubWithZeroId];
         $relation->addEagerConstraints($models);
     }
@@ -160,7 +160,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation = $this->getRelation();
         $relation->getRelated()->shouldReceive('getKeyName')->andReturn('id');
         $relation->getRelated()->shouldReceive('getKeyType')->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereInRaw')->once()->with('relation.id', m::mustBe([null]));
+        $relation->getQuery()->shouldReceive('whereInRawInt')->once()->with('relation.id', m::mustBe([null]));
         $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
         $relation->addEagerConstraints($models);
     }
@@ -178,7 +178,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation = $this->getRelation(null, false);
         $relation->getRelated()->shouldReceive('getKeyName')->andReturn('id');
         $relation->getRelated()->shouldReceive('getKeyType')->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereInRaw')->once()->with('relation.id', m::mustBe([null]));
+        $relation->getQuery()->shouldReceive('whereInRawInt')->once()->with('relation.id', m::mustBe([null]));
         $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
         $relation->addEagerConstraints($models);
     }

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -202,7 +202,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation = $this->getRelation();
         $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
         $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereInRaw')->once()->with('table.foreign_key', [1, 2]);
+        $relation->getQuery()->shouldReceive('whereInRawInt')->once()->with('table.foreign_key', [1, 2]);
         $model1 = new EloquentHasManyModelStub;
         $model1->id = 1;
         $model2 = new EloquentHasManyModelStub;

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -165,7 +165,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $relation = $this->getRelation();
         $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
         $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereInRaw')->once()->with('table.foreign_key', [1, 2]);
+        $relation->getQuery()->shouldReceive('whereInRawInt')->once()->with('table.foreign_key', [1, 2]);
         $model1 = new EloquentHasOneModelStub;
         $model1->id = 1;
         $model2 = new EloquentHasOneModelStub;

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -54,7 +54,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getManyRelation();
         $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
         $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereInRaw')->once()->with('table.morph_id', [1, 2]);
+        $relation->getQuery()->shouldReceive('whereInRawInt')->once()->with('table.morph_id', [1, 2]);
         $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
 
         $model1 = new EloquentMorphResetModelStub;

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -20,7 +20,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation = $this->getRelation();
         $relation->getParent()->shouldReceive('getKeyName')->andReturn('id');
         $relation->getParent()->shouldReceive('getKeyType')->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereInRaw')->once()->with('taggables.taggable_id', [1, 2]);
+        $relation->getQuery()->shouldReceive('whereInRawInt')->once()->with('taggables.taggable_id', [1, 2]);
         $relation->getQuery()->shouldReceive('where')->once()->with('taggables.taggable_type', get_class($relation->getParent()));
         $model1 = new EloquentMorphToManyModelStub;
         $model1->id = 1;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -693,10 +693,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testWhereInRaw()
+    public function testWhereInRawInt()
     {
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereInRaw('id', ['1a', 2]);
+        $builder->select('*')->from('users')->whereInRawInt('id', ['1a', 2]);
         $this->assertEquals('select * from "users" where "id" in (1, 2)', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
     }


### PR DESCRIPTION
The `whereInRaw()` method hasn't been released yet, we can still change it:

- Renames it to `whereInRawInt()` to make its purpose and limitations obvious.
- Removes the `array` type hint to support `Arrayable` values. This is consistent with `whereIn()`.
- Replaces `array_map()` with a `foreach` loop which is considerably faster. Since the whole point of this method is the performance improvement, we shouldn't waste time here.

Thanks to @vlakoff.