### PR TITLE
[5.8] Pass full array key when transforming request value

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
@@ -63,12 +63,13 @@ class TransformsRequest
      * Clean the data in the given array.
      *
      * @param  array  $data
+     * @param  string  $keyPrefix
      * @return array
      */
-    protected function cleanArray(array $data)
+    protected function cleanArray(array $data, $keyPrefix = '')
     {
-        return collect($data)->map(function ($value, $key) {
-            return $this->cleanValue($key, $value);
+        return collect($data)->map(function ($value, $key) use ($keyPrefix) {
+            return $this->cleanValue($keyPrefix.$key, $value);
         })->all();
     }
 
@@ -82,7 +83,7 @@ class TransformsRequest
     protected function cleanValue($key, $value)
     {
         if (is_array($value)) {
-            return $this->cleanArray($value);
+            return $this->cleanArray($value, $key.'.');
         }
 
         return $this->transform($key, $value);

--- a/tests/Foundation/Http/Middleware/TransformsRequestTest.php
+++ b/tests/Foundation/Http/Middleware/TransformsRequestTest.php
@@ -45,6 +45,28 @@ class TransformsRequestTest extends TestCase
         });
     }
 
+    public function testTransformOncePerArrayKeysWhenMethodIsPost()
+    {
+        $middleware = new ManipulateArrayInput;
+        $symfonyRequest = new SymfonyRequest(
+            [
+                'name' => 'Damian',
+                'beers' => [4, 8, 12],
+            ],
+            [
+                'age' => [28, 56, 84]
+            ]
+        );
+        $symfonyRequest->server->set('REQUEST_METHOD', 'POST');
+        $request = Request::createFromBase($symfonyRequest);
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals('Damian', $request->get('name'));
+            $this->assertEquals([27, 55, 83], $request->get('age'));
+            $this->assertEquals([5, 9, 13], $request->get('beers'));
+        });
+    }
+
     public function testTransformOncePerKeyWhenContentTypeIsJson()
     {
         $middleware = new ManipulateInput;
@@ -79,6 +101,21 @@ class ManipulateInput extends TransformsRequest
             $value++;
         }
         if ($key === 'age') {
+            $value--;
+        }
+
+        return $value;
+    }
+}
+
+class ManipulateArrayInput extends TransformsRequest
+{
+    protected function transform($key, $value)
+    {
+        if (str_contains($key, 'beers')) {
+            $value++;
+        }
+        if (str_contains($key, 'age')) {
             $value--;
         }
 

--- a/tests/Foundation/Http/Middleware/TransformsRequestTest.php
+++ b/tests/Foundation/Http/Middleware/TransformsRequestTest.php
@@ -54,7 +54,7 @@ class TransformsRequestTest extends TestCase
                 'beers' => [4, 8, 12],
             ],
             [
-                'age' => [28, 56, 84]
+                'age' => [28, 56, 84],
             ]
         );
         $symfonyRequest->server->set('REQUEST_METHOD', 'POST');


### PR DESCRIPTION
In case in request you have array like this for example:

```
'amount' => [
    800,
    900,
   1000
]
```

once you are in `transform` method as `$key` you will get at the moment 0, 1, 2 what in fact gives you nothing. After update you will get `amount.0`, `amount.1` and `amount.2` what gives you full key and allows to modify value based on key.

I think it should target 5.8 because in probably very rare cases it could break existing applications. And in case anyone needs this in Laravel 5.7, they can override default methods in middleware they implement `transform` method.