### PR TITLE
[5.7] fix $middlewares is empty but $priorityMap is not empty return empty …

### DIFF
--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -33,6 +33,11 @@ class SortedMiddleware extends Collection
      */
     protected function sortMiddleware($priorityMap, $middlewares)
     {
+        // fix bug : $middlewares is empty but $priorityMap is not empty return empty array
+        if (empty($middlewares)) {
+            return $priorityMap;
+        }
+
         $lastIndex = 0;
 
         foreach ($middlewares as $index => $middleware) {


### PR DESCRIPTION
When the middleware of the route is an empty array, the `$middlewarePriority($router->middlewarePriority)` in the Kernel kernel cannot be loaded.