### PR TITLE
[5.7] Allow MorphTo relations to specify select columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -126,8 +126,7 @@ class MorphTo extends BelongsTo
                             ->mergeConstraintsFrom($this->getQuery())
                             ->with($this->getQuery()->getEagerLoads());
 
-        if ($columns = $this->getQuery()->getQuery()->columns)
-        {
+        if ($columns = $this->getQuery()->getQuery()->columns) {
             $query->select($columns);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -126,6 +126,11 @@ class MorphTo extends BelongsTo
                             ->mergeConstraintsFrom($this->getQuery())
                             ->with($this->getQuery()->getEagerLoads());
 
+        if ($columns = $this->getQuery()->getQuery()->columns)
+        {
+            $query->select($columns);
+        }
+
         return $query->whereIn(
             $instance->getTable().'.'.$ownerKey, $this->gatherKeysByType($type)
         )->get();


### PR DESCRIPTION
When eager loading relations with the `with` function, one can alter the query used to retrieve the related models with a closure. With normal relations you can select the columns which will be retrieved from the database, but with MorphTo relationships you can not. 

My small change only allows column selection in eager loading MorphTo relations.