### PR TITLE
[5.7] Get table improvement

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1278,7 +1278,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function getTable()
     {
         if (! isset($this->table)) {
-            return str_replace(
+            return $this->table = str_replace(
                 '\\', '', Str::snake(Str::plural(class_basename($this)))
             );
         }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Database;
 
 use DateTime;
-use Illuminate\Support\Str;
 use stdClass;
 use Exception;
 use Mockery as m;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use DateTime;
+use Illuminate\Support\Str;
 use stdClass;
 use Exception;
 use Mockery as m;
@@ -690,6 +691,16 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('stub', $model->getTable());
         $model->setTable('foo');
         $this->assertEquals('foo', $model->getTable());
+    }
+
+    public function testGetTableOnlyExecutedOnce()
+    {
+        $model = new EloquentModelStub;
+        $model->setTableRaw(null);
+
+        $this->assertEquals(null, $model->getTableRaw());
+        $model->getTable();
+        $this->assertEquals('eloquent_model_stubs', $model->getTableRaw());
     }
 
     public function testGetKeyReturnsValueOfPrimaryKey()
@@ -1935,6 +1946,16 @@ class EloquentModelStub extends Model
     public function scopeFramework(Builder $builder, $framework, $version)
     {
         $this->scopesCalled['framework'] = [$framework, $version];
+    }
+
+    public function getTableRaw()
+    {
+        return $this->table;
+    }
+
+    public function setTableRaw($table)
+    {
+        $this->table = $table;
     }
 }
 


### PR DESCRIPTION
When the `getTable` method is called multiple times, the method will make the table property from scratch every time. I don't think this is necessary. By setting the property in the `getTable()` method when it doesn't exist yet, we can prevent that. I also added a test for this case.

I am not sure if this could be a breaking change. For my projects it isn't. Feel free to close this PR if it is a breaking change.