### PR TITLE
[5.8] Add set/get accessors for MigrationCreator stubPath

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -24,6 +24,13 @@ class MigrationCreator
     protected $postCreate = [];
 
     /**
+     * The path to the stubs.
+     *
+     * @var string
+     */
+    protected $stubPath = __DIR__.'/stubs';
+
+    /**
      * Create a new migration creator instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
@@ -92,7 +99,7 @@ class MigrationCreator
     protected function getStub($table, $create)
     {
         if (is_null($table)) {
-            return $this->files->get($this->stubPath().'/blank.stub');
+            return $this->files->get($this->getStubPath().'/blank.stub');
         }
 
         // We also have stubs for creating new tables and modifying existing tables
@@ -100,7 +107,7 @@ class MigrationCreator
         // or modifying existing tables. We'll grab the appropriate stub here.
         $stub = $create ? 'create.stub' : 'update.stub';
 
-        return $this->files->get($this->stubPath()."/{$stub}");
+        return $this->files->get($this->getStubPath()."/{$stub}");
     }
 
     /**
@@ -187,9 +194,20 @@ class MigrationCreator
      *
      * @return string
      */
-    public function stubPath()
+    public function getStubPath()
     {
-        return __DIR__.'/stubs';
+        return $this->stubPath;
+    }
+
+    /**
+     * Set the path to the stubs.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function setStubPath($path)
+    {
+        $this->stubPath = $path;
     }
 
     /**

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -19,7 +19,7 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator = $this->getCreator();
 
         $creator->expects($this->any())->method('getDatePrefix')->will($this->returnValue('foo'));
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/blank.stub')->andReturn('DummyClass');
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->getStubPath().'/blank.stub')->andReturn('DummyClass');
         $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'CreateBar');
 
         $creator->create('create_bar', 'foo');
@@ -36,7 +36,7 @@ class DatabaseMigrationCreatorTest extends TestCase
         });
 
         $creator->expects($this->any())->method('getDatePrefix')->will($this->returnValue('foo'));
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/update.stub')->andReturn('DummyClass DummyTable');
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->getStubPath().'/update.stub')->andReturn('DummyClass DummyTable');
         $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'CreateBar baz');
 
         $creator->create('create_bar', 'foo', $table);
@@ -50,7 +50,7 @@ class DatabaseMigrationCreatorTest extends TestCase
     {
         $creator = $this->getCreator();
         $creator->expects($this->any())->method('getDatePrefix')->will($this->returnValue('foo'));
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/update.stub')->andReturn('DummyClass DummyTable');
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->getStubPath().'/update.stub')->andReturn('DummyClass DummyTable');
         $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'CreateBar baz');
 
         $creator->create('create_bar', 'foo', 'baz');
@@ -60,7 +60,7 @@ class DatabaseMigrationCreatorTest extends TestCase
     {
         $creator = $this->getCreator();
         $creator->expects($this->any())->method('getDatePrefix')->will($this->returnValue('foo'));
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/create.stub')->andReturn('DummyClass DummyTable');
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->getStubPath().'/create.stub')->andReturn('DummyClass DummyTable');
         $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'CreateBar baz');
 
         $creator->create('create_bar', 'foo', 'baz', true);


### PR DESCRIPTION
Very straight-forward, makes the stub path mutable so we can use our own stubs. This is beneficial for those who want different schemas than the defaults with the migration commands. For one example, I want `increments()` over `bigIncrements()` (#26472) without having to change it with each migration

Example usage from a service provider:
```php
$this->app->extend('migration.creator', function ($creator, $app) {
    return tap($creator)->setStubPath(__DIR__.'/../../database/migrations/stubs');
});
```