### PR TITLE
[5.7] Created Request::obscure() method

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -253,6 +253,25 @@ trait InteractsWithInput
     }
 
     /**
+     * Get all of the input except obscure the value for a specified array of items.
+     *
+     * @param  array|mixed  $keys
+     * @return array
+     */
+    public function obscure($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $results = $this->all();
+
+        foreach ($this->only($keys) as $key => $value) {
+            Arr::set($results, $key, str_repeat('*', strlen($value)));
+        }
+
+        return $results;
+    }
+
+    /**
      * Retrieve a query string item from the request.
      *
      * @param  string  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -983,4 +983,22 @@ class HttpRequestTest extends TestCase
         $request->setLaravelSession($session);
         $request->flashExcept(['email']);
     }
+
+    public function testHttpRequestCanObscureParameters()
+    {
+        // Email to be obscured
+        $email = 'example@example.com';
+
+        // Simulates request with query string parameters
+        $request = Request::create('/', 'GET', [
+            'email' => $email,
+            'foo' => 'bar',
+        ]);
+
+        $result = $request->obscure('email');
+
+        // Ensure parameter we want obscured is indeed obscured, and remaining parameter is left unchanged
+        $this->assertNotEquals($email, $result['email']);
+        $this->assertEquals('bar', $result['foo']);
+    }
 }


### PR DESCRIPTION
When dumping entire requests using `Illuminate\Http\Request::all()` to log files, they can often include Personally identifiable information (PII) - such as email addresses and names.

This PR creates a new method called `obscure()` which, like `only()` and `except()` takes an argument(s) of keys, and will then return the same as `all()` would, but with the relevant keys obscured:

```php

$request = Illuminate\Http\Request::create('/', 'GET', [
    'email' => $email,
    'foo' => 'bar',
]);

$result = $request->all();

/*
array:2 [
  "email" => "example@example.com"
  "foo" => "bar"
]
*/

$result = $request->obscure('email');

/*
array:2 [
  "email" => "*******************"
  "foo" => "bar"
]
*/

```