### PR TITLE
[5.8] Tag RedisStore as implementing LockProvider

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Cache;
 
 use Illuminate\Contracts\Redis\Factory as Redis;
+use Illuminate\Contracts\Cache\LockProvider;
 
-class RedisStore extends TaggableStore
+class RedisStore extends TaggableStore implements LockProvider
 {
     /**
      * The Redis factory implementation.

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Cache;
 
-use Illuminate\Contracts\Redis\Factory as Redis;
 use Illuminate\Contracts\Cache\LockProvider;
+use Illuminate\Contracts\Redis\Factory as Redis;
 
 class RedisStore extends TaggableStore implements LockProvider
 {


### PR DESCRIPTION
This follows `MemcachedStore` and was missed in https://github.com/laravel/framework/commit/4e6b2e4ecbbec5a4b265f4d5a57ad1399227cf12#diff-2264a8010d8f05fa1e9b160c1b9431f4.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
