### PR TITLE
[5.7] Added findIndex to the Collection class

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -496,6 +496,25 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Find the index of the first passing callback.
+     *
+     * @param  callable|null  $callback
+     * @return integer|boolean
+     */
+    public function findIndex(callable $callback = null)
+    {
+        if($callback) {
+            foreach ($this->items as $key => $value) {
+                if ($callback($value)) {
+                    return $key;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Apply the callback if the value is truthy.
      *
      * @param  bool  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -335,6 +335,27 @@ class SupportCollectionTest extends TestCase
         })->all());
     }
 
+    public function testFindIndex() {
+
+        $c = new Collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);
+        $this->assertEquals(1, $c->findIndex(function($item) {
+            return $item['name'] === 'World';
+        }));
+
+        $c = new Collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);
+        $this->assertEquals(false, $c->findIndex(function($item) {
+            return $item['name'] === 'Worlds';
+        }));
+
+        $c = new Collection(['Hello', 'world', 'find', 'the', 'correct', 'index']);
+        $this->assertEquals(4, $c->findIndex(function($item) {
+            return $item === 'correct';
+        }));
+
+        $this->assertEquals(false, $c->findIndex());
+
+    }
+
     public function testHigherOrderKeyBy()
     {
         $c = new Collection([


### PR DESCRIPTION
I've added the findIndex method to the Collection class. It's similar to the findIndex method on arrays in Javascript. You can give it any array and find the correct index. 

I've been in the situation a lot where I needed to find the index of a specific item in an array and had to write another method that takes an array or collection and find the index that way. This feature solves that problem by having an internal findIndex. 

This is fully backward compatible, it doesn't change any other Collection methods, and is not chainable. This method resolves to two different return values: an integer (the index) or a boolean (false, the collection doesn't contain an item that matches the provided callback, or no callback is supplied).