### PR TITLE
[5.7] Allow 7.3 to fail for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: setup=lowest
+  allow_failures:
+    - php: 7.3
 
 sudo: false
 


### PR DESCRIPTION
PHP 7.3 builds are failing atm for an unknown reason: https://travis-ci.org/laravel/framework/jobs/454514866

Might be related to the latest RC5 release which was released around the same time the failures started to happen.
