### PR TITLE
[5.8] Use a library for email validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "ext-openssl": "*",
         "doctrine/inflector": "^1.1",
         "dragonmantank/cron-expression": "^2.0",
+        "egulias/email-validator": "~2.0",
         "erusev/parsedown": "^1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "^1.12",

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -16,7 +16,9 @@ use Illuminate\Support\Facades\Date;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Validation\ValidationData;
+use Egulias\EmailValidator\EmailValidator;
 use Symfony\Component\HttpFoundation\File\File;
+use Egulias\EmailValidator\Validation\RFCValidation;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 trait ValidatesAttributes
@@ -590,7 +592,7 @@ trait ValidatesAttributes
      */
     public function validateEmail($attribute, $value)
     {
-        return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
+        return (new EmailValidator)->isValid($value, new RFCValidation);
     }
 
     /**

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
+        "egulias/email-validator": "~2.0",
         "illuminate/container": "5.8.*",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*",

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -386,10 +386,10 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.email' => ':input is not a valid email'], 'en');
-        $v = new Validator($trans, ['email' => 'a@s'], ['email' => 'email']);
+        $v = new Validator($trans, ['email' => 'a@@s'], ['email' => 'email']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('a@s is not a valid email', $v->messages()->first('email'));
+        $this->assertEquals('a@@s is not a valid email', $v->messages()->first('email'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.email' => ':input is not a valid email'], 'en');
@@ -1966,6 +1966,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['x' => 'foo@gmail.com'], ['x' => 'Email']);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testValidateEmailWithInternationalCharacters()
+    {
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'foo@gmäil.com'], ['x' => 'email']);
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
### Summary

This PR aims to resolve https://github.com/laravel/framework/issues/13215 and similar problems users may experience when trying to send emails with non-ascii characters. The current version of Laravel is dependent on Swiftmailer ^6.0, which added support for [RFC5630](https://tools.ietf.org/html/rfc6530) email addresses. However, the `email` validation rule in the current version of Laravel relies on PHP's built-in email validation, which is based on the 1982 [RFC822 ](https://tools.ietf.org/html/rfc822) according to [the official documentation](http://php.net/manual/en/filter.filters.validate.php).

Thus, the aim here is just to bring the framework's validation inline with what we support in terms of SMTP sending (through Swiftmailer).

### Breaking Changes

This PR will result in a breaking change – emails that (incorrectly) were considered invalid will now be considered valid. e.g hej@bär.se. Any applications that have been relying on the strict RFC822 validation will thus need updating (e.g users that run their own antiquated email servers).

**Impact:** Low

### Notes

- Note that the included dependency is already required by Swiftmailer.
- Using `new EmailValidator` rather than `$this->container->make()` was a conscious decision to reduce backwards compatibility issues, as `$this->container` is only defined if the validator factory is used