### PR TITLE
[5.7] Code improvements for TestResponse::parseJsonWhilePreservingEmptyObjects

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -727,11 +727,13 @@ class TestResponse
     protected function parseJsonWhilePreservingEmptyObjects($payload)
     {
         if (is_object($payload)) {
-            $arrayPayload = (array) $payload;
+            $originalPayload = $payload;
 
-            return ! empty($arrayPayload)
-                ? $this->parseJsonWhilePreservingEmptyObjects($arrayPayload)
-                : $payload;
+            $payload = (array) $payload;
+
+            if (empty($payload)) {
+                return $originalPayload;
+            }
         }
 
         foreach ($payload as $key => $item) {

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -727,8 +727,10 @@ class TestResponse
     protected function parseJsonWhilePreservingEmptyObjects($payload)
     {
         if (is_object($payload)) {
-            return ! empty((array) $payload)
-                ? $this->parseJsonWhilePreservingEmptyObjects((array) $payload)
+            $arrayPayload = (array) $payload;
+
+            return ! empty($arrayPayload)
+                ? $this->parseJsonWhilePreservingEmptyObjects($arrayPayload)
                 : $payload;
         }
 


### PR DESCRIPTION
Follow-up to #26353 (and e6ebc8d239e53e6daf16c869de3897ffbce6c751).

* Avoids doing the object-to-array cast twice (such cast can be somewhat costly)
* Avoids the nested method call, mainly for simplification, and also for performance