### PR TITLE
[5.7] Cache distinct validation rule data

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -580,7 +580,7 @@ trait ValidatesAttributes
     {
         $attributeName = $this->getPrimaryAttribute($attribute);
 
-        if(! property_exists($this, 'distinctValues')){
+        if (! property_exists($this, 'distinctValues')){
             return $this->extractDistinctValues($attributeName);
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -580,7 +580,7 @@ trait ValidatesAttributes
     {
         $attributeName = $this->getPrimaryAttribute($attribute);
 
-        if (! property_exists($this, 'distinctValues')){
+        if (! property_exists($this, 'distinctValues')) {
             return $this->extractDistinctValues($attributeName);
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -574,7 +574,7 @@ trait ValidatesAttributes
             return empty(preg_grep('/^' . preg_quote($value, '/') . '$/iu', $data));
         }
 
-        return !in_array($value, array_values($data));
+        return ! in_array($value, array_values($data));
     }
 
     /**
@@ -587,7 +587,7 @@ trait ValidatesAttributes
     {
         $attributeName = $this->getPrimaryAttribute($attribute);
 
-        if (!array_key_exists($attributeName, $this->distinctValues)) {
+        if (! array_key_exists($attributeName, $this->distinctValues)) {
             $attributeData = ValidationData::extractDataFromPath(
                 ValidationData::getLeadingExplicitAttributePath($attributeName), $this->data
             );
@@ -595,7 +595,7 @@ trait ValidatesAttributes
             $pattern = str_replace('\*', '[^.]+', preg_quote($attributeName, '#'));
 
             $this->distinctValues[$attributeName] = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($attribute, $pattern) {
-                return (bool)preg_match('#^' . $pattern . '\z#u', $key);
+                return (bool) preg_match('#^'.$pattern.'\z#u', $key);
             });
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -571,7 +571,7 @@ trait ValidatesAttributes
         $data = $this->getDistinctValues($attribute);
 
         if (in_array('ignore_case', $parameters)) {
-            return empty(preg_grep('/^' . preg_quote($value, '/') . '$/iu', $data));
+            return empty(preg_grep('/^'.preg_quote($value, '/').'$/iu', $data));
         }
 
         return ! in_array($value, array_values($data));

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -98,6 +98,13 @@ class Validator implements ValidatorContract
     protected $after = [];
 
     /**
+     * The cached data for distinct rules.
+     *
+     * @var array
+     */
+    protected $distinctValues = [];
+
+    /**
      * The array of custom error messages.
      *
      * @var array

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -257,6 +257,7 @@ class Validator implements ValidatorContract
     public function passes()
     {
         $this->messages = new MessageBag;
+        $this->distinctValues = [];
 
         // We'll spin through each rule, validating the attributes attached to that
         // rule. Any error messages will be added to the containers with each of

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1798,7 +1798,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $this->assertCount(4, $v->messages());
 
-        $v = new Validator($trans, ['foo' => ['foo', 'bar'], 'bar' => ['foo', 'bar']], ['foo.*' => 'distinct', 'bar.*' => 'distinct']);
+        $v->setData(['foo' => ['foo', 'bar'], 'bar' => ['foo', 'bar']]);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => ['foo', 'foo']], ['foo.*' => 'distinct'], ['foo.*.distinct' => 'There is a duplication!']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1790,6 +1790,17 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['cat' => ['sub' => [['prod' => [['id' => 2]]], ['prod' => [['id' => 2]]]]]], ['cat.sub.*.prod.*.id' => 'distinct']);
         $this->assertFalse($v->passes());
 
+        $v = new Validator($trans, ['foo' => ['foo', 'foo'], 'bar' => ['bar', 'baz']], ['foo.*' => 'distinct', 'bar.*' => 'distinct']);
+        $this->assertFalse($v->passes());
+        $this->assertCount(2, $v->messages());
+
+        $v = new Validator($trans, ['foo' => ['foo', 'foo'], 'bar' => ['bar', 'bar']], ['foo.*' => 'distinct', 'bar.*' => 'distinct']);
+        $this->assertFalse($v->passes());
+        $this->assertCount(4, $v->messages());
+
+        $v = new Validator($trans, ['foo' => ['foo', 'bar'], 'bar' => ['foo', 'bar']], ['foo.*' => 'distinct', 'bar.*' => 'distinct']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => ['foo', 'foo']], ['foo.*' => 'distinct'], ['foo.*.distinct' => 'There is a duplication!']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');


### PR DESCRIPTION
While validating 1000 records with the distinct rule I encountered some impact on performance for this rule. When performing this validation the same 'distinct data set' is created every time. We're creating 1000 times an array of 999 items with almost identical data.

Because data is not being changed during validation I think we should be able to 'cache' this data for the first record and reuse it for all following records.

It will be a huge improvement on performance while validating bigger datasets:

| #items  | Without caching | With caching | Improvement |
| :--- | :--- | :--- | :--- |
| 10 | 5ms | 5ms | same |
| 100 | 21ms | 7ms | 3x |
| 1000 | 7200s | 80ms | 90x |

> _test results on my local machine_

Optionally if you're not feeling comfortable with this being the default behaviour we could maybe implement this as being configurable with a `cached` parameter?