### PR TITLE
[5.7] Make the channel for `log` mail driver configurable

### DIFF
--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -160,7 +160,11 @@ class TransportManager extends Manager
      */
     protected function createLogDriver()
     {
-        return new LogTransport($this->app->make(LoggerInterface::class));
+        $channel = $this->app['config']['mail.log_channel'];
+
+        return new LogTransport(
+            $this->app->make(LoggerInterface::class)->channel($channel)
+        );
     }
 
     /**

--- a/tests/Mail/MailLogTransportTest.php
+++ b/tests/Mail/MailLogTransportTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Illuminate\Tests\Mail;
+
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
+use Orchestra\Testbench\TestCase;
+use Monolog\Handler\StreamHandler;
+use Monolog\Handler\RotatingFileHandler;
+use Illuminate\Mail\Transport\LogTransport;
+
+class MailLogTransportTest extends TestCase
+{
+    public function testGetLogTransportWithDefaultChannel()
+    {
+        $manager = $this->app['swift.transport'];
+
+        $transport = $manager->driver('log');
+        $this->assertInstanceOf(LogTransport::class, $transport);
+
+        $logger = $this->readAttribute($transport, 'logger');
+        $this->assertInstanceOf(LoggerInterface::class, $logger);
+
+        $this->assertInstanceOf(Logger::class, $monolog = $logger->getLogger());
+        $this->assertCount(1, $handlers = $monolog->getHandlers());
+        $this->assertInstanceOf(RotatingFileHandler::class, $handlers[0]);
+    }
+
+    public function testGetLogTransportWithConfiguredChannel()
+    {
+        $this->app['config']->set('mail.log_channel', 'mail');
+        $this->app['config']->set('logging.channels.mail', [
+            'driver' => 'single',
+            'path' => 'mail.log',
+        ]);
+
+        $manager = $this->app['swift.transport'];
+
+        $transport = $manager->driver('log');
+        $this->assertInstanceOf(LogTransport::class, $transport);
+
+        $logger = $this->readAttribute($transport, 'logger');
+        $this->assertInstanceOf(LoggerInterface::class, $logger);
+
+        $this->assertInstanceOf(Logger::class, $monolog = $logger->getLogger());
+        $this->assertCount(1, $handlers = $monolog->getHandlers());
+        $this->assertInstanceOf(StreamHandler::class, $handler = $handlers[0]);
+        $this->assertEquals('mail.log', $handler->getUrl());
+    }
+}


### PR DESCRIPTION
Allows users to configure the channel for logging the emails when using the `log` mail driver.

By default the mails are logged to the `default` channel in `config/logging.php`, but users can configure a custom channel in the `channels` array. That would be handy because mail logs are often huge and messy, and it's not easy to debug along with stack traces and other log messages.

For example in `config/logging.php `

```php
'channels' => [
    // ...

    'mail' => [
        'driver' => 'daily',
        'path' => storage_path('logs/mail.log'),
        'level' => 'debug',
        'days' => 14,
    ],
],
```

To specify the mailer to use a specific log channel instead of the default, users can set the `log_channel` key in `config/mail.php`.

```php
'log_channel' => 'mail',
```
