### PR TITLE
[5.7] Removed index from AuthorizeRequests

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -121,6 +121,6 @@ trait AuthorizesRequests
      */
     protected function resourceMethodsWithoutModels()
     {
-        return ['index', 'create', 'store'];
+        return ['create', 'store'];
     }
 }


### PR DESCRIPTION
In a previous commit you removed index method from authorizeResource() so there is no use to keep mention of it in the AuthorizeRequests trait ?