### PR TITLE
[5.7] whereInRaw PHPDoc: fix method name and tweak sentence

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -304,7 +304,7 @@ class Grammar extends BaseGrammar
     /**
      * Compile a "where in raw" clause.
      *
-     * For safety, this method is only used with integer values as whereInRaw utilizes "intval".
+     * For safety, whereIntegerInRaw ensures this method is only used with integer values.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $where


### PR DESCRIPTION
Follow-up to [`d10b0a5`](https://github.com/laravel/framework/commit/d10b0a57ce0f09163310e0f7d378e929f31e3cea#diff-cc3d43e01028390141596ae0da939930) and https://github.com/laravel/framework/commit/a3738cf4e133a4475c56b51f521a12db78e2ecbb.

Doing my best so that the sentence doesn't become too long while keeping its meaning, I have actually shortened it :)