### PR TITLE
[5.8] Uses composer default version constraint ^ (caret)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-openssl": "*",
         "doctrine/inflector": "^1.1",
         "dragonmantank/cron-expression": "^2.0",
-        "egulias/email-validator": "~2.0",
+        "egulias/email-validator": "^2.0",
         "erusev/parsedown": "^1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "^1.12",


### PR DESCRIPTION
Uses composer default version constraint ^ (caret) in the new package `egulias/email-validator`.