### PR TITLE
[5.7] Add callable docblock to route registrar methods

### DIFF
--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -8,7 +8,7 @@ interface Registrar
      * Register a new GET route with the router.
      *
      * @param  string  $uri
-     * @param  \Closure|array|string  $action
+     * @param  \Closure|array|string|callable  $action
      * @return \Illuminate\Routing\Route
      */
     public function get($uri, $action);
@@ -17,7 +17,7 @@ interface Registrar
      * Register a new POST route with the router.
      *
      * @param  string  $uri
-     * @param  \Closure|array|string  $action
+     * @param  \Closure|array|string|callable  $action
      * @return \Illuminate\Routing\Route
      */
     public function post($uri, $action);
@@ -26,7 +26,7 @@ interface Registrar
      * Register a new PUT route with the router.
      *
      * @param  string  $uri
-     * @param  \Closure|array|string  $action
+     * @param  \Closure|array|string|callable  $action
      * @return \Illuminate\Routing\Route
      */
     public function put($uri, $action);
@@ -35,7 +35,7 @@ interface Registrar
      * Register a new DELETE route with the router.
      *
      * @param  string  $uri
-     * @param  \Closure|array|string  $action
+     * @param  \Closure|array|string|callable  $action
      * @return \Illuminate\Routing\Route
      */
     public function delete($uri, $action);
@@ -44,7 +44,7 @@ interface Registrar
      * Register a new PATCH route with the router.
      *
      * @param  string  $uri
-     * @param  \Closure|array|string  $action
+     * @param  \Closure|array|string|callable  $action
      * @return \Illuminate\Routing\Route
      */
     public function patch($uri, $action);
@@ -53,7 +53,7 @@ interface Registrar
      * Register a new OPTIONS route with the router.
      *
      * @param  string  $uri
-     * @param  \Closure|array|string  $action
+     * @param  \Closure|array|string|callable  $action
      * @return \Illuminate\Routing\Route
      */
     public function options($uri, $action);
@@ -63,7 +63,7 @@ interface Registrar
      *
      * @param  array|string  $methods
      * @param  string  $uri
-     * @param  \Closure|array|string  $action
+     * @param  \Closure|array|string|callable  $action
      * @return \Illuminate\Routing\Route
      */
     public function match($methods, $uri, $action);

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -133,7 +133,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * Register a new GET route with the router.
      *
      * @param  string  $uri
-     * @param  \Closure|array|string|null  $action
+     * @param  \Closure|array|string|callable|null  $action
      * @return \Illuminate\Routing\Route
      */
     public function get($uri, $action = null)
@@ -145,7 +145,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * Register a new POST route with the router.
      *
      * @param  string  $uri
-     * @param  \Closure|array|string|null  $action
+     * @param  \Closure|array|string|callable|null  $action
      * @return \Illuminate\Routing\Route
      */
     public function post($uri, $action = null)
@@ -157,7 +157,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * Register a new PUT route with the router.
      *
      * @param  string  $uri
-     * @param  \Closure|array|string|null  $action
+     * @param  \Closure|array|string|callable|null  $action
      * @return \Illuminate\Routing\Route
      */
     public function put($uri, $action = null)
@@ -169,7 +169,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * Register a new PATCH route with the router.
      *
      * @param  string  $uri
-     * @param  \Closure|array|string|null  $action
+     * @param  \Closure|array|string|callable|null  $action
      * @return \Illuminate\Routing\Route
      */
     public function patch($uri, $action = null)
@@ -181,7 +181,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * Register a new DELETE route with the router.
      *
      * @param  string  $uri
-     * @param  \Closure|array|string|null  $action
+     * @param  \Closure|array|string|callable|null  $action
      * @return \Illuminate\Routing\Route
      */
     public function delete($uri, $action = null)
@@ -193,7 +193,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * Register a new OPTIONS route with the router.
      *
      * @param  string  $uri
-     * @param  \Closure|array|string|null  $action
+     * @param  \Closure|array|string|callable|null  $action
      * @return \Illuminate\Routing\Route
      */
     public function options($uri, $action = null)
@@ -205,7 +205,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * Register a new route responding to all verbs.
      *
      * @param  string  $uri
-     * @param  \Closure|array|string|null  $action
+     * @param  \Closure|array|string|callable|null  $action
      * @return \Illuminate\Routing\Route
      */
     public function any($uri, $action = null)
@@ -216,7 +216,7 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Register a new Fallback route with the router.
      *
-     * @param  \Closure|array|string|null  $action
+     * @param  \Closure|array|string|callable|null  $action
      * @return \Illuminate\Routing\Route
      */
     public function fallback($action)
@@ -275,7 +275,7 @@ class Router implements RegistrarContract, BindingRegistrar
      *
      * @param  array|string  $methods
      * @param  string  $uri
-     * @param  \Closure|array|string|null  $action
+     * @param  \Closure|array|string|callable|null  $action
      * @return \Illuminate\Routing\Route
      */
     public function match($methods, $uri, $action = null)
@@ -436,7 +436,7 @@ class Router implements RegistrarContract, BindingRegistrar
      *
      * @param  array|string  $methods
      * @param  string  $uri
-     * @param  \Closure|array|string|null  $action
+     * @param  \Closure|array|string|callable|null  $action
      * @return \Illuminate\Routing\Route
      */
     public function addRoute($methods, $uri, $action)

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -3,14 +3,14 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Routing\Route get(string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route post(string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route put(string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route delete(string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route patch(string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route options(string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route any(string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route match(array|string $methods, string $uri, \Closure|array|string|null $action = null)
+ * @method static \Illuminate\Routing\Route get(string $uri, \Closure|array|string|callable|null $action = null)
+ * @method static \Illuminate\Routing\Route post(string $uri, \Closure|array|string|callable|null $action = null)
+ * @method static \Illuminate\Routing\Route put(string $uri, \Closure|array|string|callable|null $action = null)
+ * @method static \Illuminate\Routing\Route delete(string $uri, \Closure|array|string|callable|null $action = null)
+ * @method static \Illuminate\Routing\Route patch(string $uri, \Closure|array|string|callable|null $action = null)
+ * @method static \Illuminate\Routing\Route options(string $uri, \Closure|array|string|callable|null $action = null)
+ * @method static \Illuminate\Routing\Route any(string $uri, \Closure|array|string|callable|null $action = null)
+ * @method static \Illuminate\Routing\Route match(array|string $methods, string $uri, \Closure|array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\RouteRegistrar prefix(string  $prefix)
  * @method static \Illuminate\Routing\RouteRegistrar where(array  $where)
  * @method static \Illuminate\Routing\PendingResourceRegistration resource(string $name, string $controller, array $options = [])


### PR DESCRIPTION
Yesterday I replied on Twitter on an article about tuple/callable route registration that was recently added. However I wasn't completely right that it works. This PR should make it work.

**Relevant PR**: https://github.com/laravel/framework/pull/24385
**Article**: https://murze.be/a-better-way-to-register-routes-in-laravel
**Tweet**: https://twitter.com/patrickbrouwers/status/1062854056522190849

When using Route registration as follows:

```
Route::get('smth', [SomeController::class, 'methodName']);
```

_(same for typehinted `$router` - as Registrar/Router)_

You can have the benefit of an IDE (tested with PHPStorm) to rename the `methodName` string automatically whenever you refactor/rename the actual method name.

However, PhpStorm only does this when the parameter is docblocked as `callable`. This PR adds the `callable` docblock to the `$action` param, so auto-refactoring works in IDE's.


**Additional suggestion**:

Could be an option to drop the `Closure` docblock, as that's captured with `callable` already.