### PR TITLE
[5.7] Fixed empty string date values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -127,9 +127,9 @@ trait HasAttributes
 
             $attributes[$key] = empty($attributes[$key])
                 ? ''
-                :  $this->serializeDate(
-                        $this->asDateTime($attributes[$key])
-                   );
+                : $this->serializeDate(
+                      $this->asDateTime($attributes[$key])
+                  );
         }
 
         return $attributes;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -125,9 +125,11 @@ trait HasAttributes
                 continue;
             }
 
-            $attributes[$key] = $this->serializeDate(
-                $this->asDateTime($attributes[$key])
-            );
+            $attributes[$key] = empty($attributes[$key])
+                ? ''
+                :  $this->serializeDate(
+                        $this->asDateTime($attributes[$key])
+                   );
         }
 
         return $attributes;
@@ -355,7 +357,7 @@ trait HasAttributes
         // instance on retrieval, which makes it quite convenient to work with
         // date fields without having to create a mutator for each property.
         if (in_array($key, $this->getDates()) &&
-            ! is_null($value)) {
+            ! empty($value)) {
             return $this->asDateTime($value);
         }
 


### PR DESCRIPTION
the same issue as https://github.com/laravel/framework/pull/22108

To have the same error you can create storage where instead of the date we have an empty string.