### PR TITLE
[5.7] Fix(TestResponse): assertExactJson false positive for JSON lists (ie non-assoc arrays

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -454,11 +454,11 @@ class TestResponse
      */
     public function assertExactJson(array $data)
     {
-        $actual = json_encode(Arr::sortRecursive(
+        $actual = json_encode(Arr::sortAssocRecursive(
             (array) $this->decodeResponseJson()
         ));
 
-        PHPUnit::assertEquals(json_encode(Arr::sortRecursive($data)), $actual);
+        PHPUnit::assertEquals(json_encode(Arr::sortAssocRecursive($data)), $actual);
 
         return $this;
     }

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -596,7 +596,8 @@ class Arr
 
     /**
      * Recursively sort an assoc array by keys.
-     * @param $array
+     *
+     * @param  array  $array
      * @return mixed
      */
     public static function sortAssocRecursive($array)

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -595,6 +595,26 @@ class Arr
     }
 
     /**
+     * Recursively sort an assoc array by keys.
+     * @param $array
+     * @return mixed
+     */
+    public static function sortAssocRecursive($array)
+    {
+        foreach ($array as &$value) {
+            if (is_array($value)) {
+                $value = static::sortAssocRecursive($value);
+            }
+        }
+
+        if (static::isAssoc($array)) {
+            ksort($array);
+        }
+
+        return $array;
+    }
+
+    /**
      * Convert the array into a query string.
      *
      * @param  array  $array

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -664,6 +664,51 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals($assumedArray, Arr::sortRecursive($array));
     }
 
+    public function testAssocArraySortRecursive()
+    {
+        $array = [
+            'name' => 'bar',
+            'age' => 1
+        ];
+
+        $assumedArray = [
+            'age' => 1,
+            'name' => 'bar',
+        ];
+
+        // Test assoc array
+        $this->assertEquals(json_encode(Arr::sortAssocRecursive($assumedArray)), json_encode(Arr::sortAssocRecursive($array)));
+
+        $array = [
+            [
+                'foo',
+                'bar',
+                'baz',
+            ],
+            [
+                'baz',
+                'foo',
+                'bar',
+            ],
+        ];
+
+        $assumedArray = [
+            [
+                'bar',
+                'baz',
+                'foo',
+            ],
+            [
+                'bar',
+                'baz',
+                'foo',
+            ],
+        ];
+
+        // Test array
+        $this->assertNotEquals(Arr::sortAssocRecursive($array), Arr::sortAssocRecursive($assumedArray));
+    }
+
     public function testArrayWhere()
     {
         $array = ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'f' => 6, 'g' => 7, 'h' => 8];

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -668,7 +668,7 @@ class SupportHelpersTest extends TestCase
     {
         $array = [
             'name' => 'bar',
-            'age' => 1
+            'age' => 1,
         ];
 
         $assumedArray = [


### PR DESCRIPTION
This PR fix #26513.