### PR TITLE
[5.7] Fixed phpDoc

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -721,8 +721,8 @@ class TestResponse
     /**
      * Parse the given JSON object while preserving empty objects.
      *
-     * @param  StdClass|array  $payload
-     * @return
+     * @param  \stdClass|array  $payload
+     * @return \stdClass|array
      */
     protected function parseJsonWhilePreservingEmptyObjects($payload)
     {


### PR DESCRIPTION
 - Fixed PhpDoc for Foundation/Testing/TestResponse.php `parseJsonWhilePreservingEmptyObjects` method

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
