### PR TITLE
Remove unused imports from test and unit-test stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.stub
@@ -3,8 +3,6 @@
 namespace DummyNamespace;
 
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class DummyClass extends TestCase
 {

--- a/src/Illuminate/Foundation/Console/stubs/unit-test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/unit-test.stub
@@ -3,8 +3,6 @@
 namespace DummyNamespace;
 
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class DummyClass extends TestCase
 {


### PR DESCRIPTION
Before this PR, running `php artisan make:test ExampleTest` and `php artisan make:test ExampleTest --unit` create a php test class with unused imports.

This PR copies over an updated stub to fix that.