### PR TITLE
[5.7] Addition of Arr::mergeConcat / array_merge_concat

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -347,6 +347,33 @@ class Arr
     }
 
     /**
+     * Merge arrays by concatenating the existing key values.
+     *
+     * @param  mixed  $glue
+     * @param  array  ...$arrays
+     * @return array
+     */
+    public static function mergeConcat($glue, ...$arrays)
+    {
+        if (is_array($glue)) {
+            array_unshift($arrays, $glue);
+            $glue = ' ';
+        }
+
+        $result = [];
+
+        foreach ($arrays as $array) {
+            foreach ($array as $key => $value) {
+                $result[$key] = static::exists($result, $key) ?
+                    $result[$key].$glue.$value :
+                    $value;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Determines if an array is associative.
      *
      * An array is "associative" if it doesn't have sequential numerical keys beginning with zero.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -171,6 +171,20 @@ if (! function_exists('array_has')) {
     }
 }
 
+if (! function_exists('array_merge_concat')) {
+    /**
+     * Merge arrays by concatenating the existing key values.
+     *
+     * @param  mixed  $glue
+     * @param  array  ...$arrays
+     * @return array
+     */
+    function array_merge_concat($glue, ...$arrays)
+    {
+        return Arr::mergeConcat($glue, ...$arrays);
+    }
+}
+
 if (! function_exists('array_last')) {
     /**
      * Return the last element in an array passing a given truth test.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Optional;
+use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Htmlable;
 
 class SupportHelpersTest extends TestCase
@@ -207,6 +208,47 @@ class SupportHelpersTest extends TestCase
     public function testArrayFlatten()
     {
         $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten([['#foo', '#bar'], ['#baz']]));
+    }
+
+    public function testArrayMergeConcat()
+    {
+        $this->assertEquals(
+            ['id' => 'here', 'class' => 'header sticky'],
+            Arr::mergeConcat(
+                ['id' => 'here', 'class' => 'header'],
+                ['class' => 'sticky']
+            )
+        );
+
+        $this->assertEquals(
+            ['id' => 'here', 'class' => 'header:sticky:no-margin', 'ref' => 'drag:handler:0.25'],
+            Arr::mergeConcat(
+                ':',
+                ['id' => 'here', 'class' => 'header', 'ref' => 'drag'],
+                ['class' => 'sticky', 'ref' => 'handler'],
+                ['class' => 'no-margin', 'ref' => 0.25]
+            )
+        );
+
+        $this->assertEquals(
+            ['here:sticky:no-margin', 'header:handler:0.25', 'drag'],
+            Arr::mergeConcat(
+                ':',
+                ['here', 'header', 'drag'],
+                ['sticky', 'handler'],
+                ['no-margin', 0.25]
+            )
+        );
+
+        $this->assertEquals(
+            ['here:no-margin', 'header:0.25', 'drag', 'class' => 'drop:sticky', 'id' => 'handler'],
+            Arr::mergeConcat(
+                ':',
+                new Collection(['here', 'header', 'drag', 'class' => 'drop']),
+                ['class' => 'sticky', 'id' => 'handler'],
+                new Collection(['no-margin', 0.25])
+            )
+        );
     }
 
     public function testStrIs()


### PR DESCRIPTION
Adds functionality, which allows for merging arrays where existing non object / iterable values are concatenated.

It can be used when merging multiple sets of attributes for an html tag or processing form request where array field values need concatenating etc.

```php
Arr::mergeConcat(
    ['id' => 'here', 'class' => 'header'],
    ['class' => 'sticky']
)

// ['id' => 'here', 'class' => 'header sticky']

Arr::mergeConcat(
    ':',
    ['id' => 'here', 'class' => 'header', 'ref' => 'drag'],
    ['class' => 'sticky', 'ref' => 'handler'],
    ['class' => 'no-margin', 'ref' => 0.25]
)

// ['id' => 'here', 'class' => 'header:sticky:no-margin', 'ref' => 'drag:handler:0.25']
```