### PR TITLE
[5.7] Create a relative symlink, not absolute

### DIFF
--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -32,7 +32,7 @@ class StorageLinkCommand extends Command
         }
 
         $this->laravel->make('files')->link(
-            storage_path('app/public'), public_path('storage')
+            '../storage/app/public', public_path('storage')
         );
 
         $this->info('The [public/storage] directory has been linked.');


### PR DESCRIPTION
Before:
```shell
$ php artisan storage:link
The [public/storage] directory has been linked.

$ ll public/storage
public/storage -> /Users/philiptang/Documents/Code/github.com/philiptang/api.machine/storage/app/public
```
After:
```shell
$ php artisan storage:link
The [public/storage] directory has been linked.

$ ll public/storage
public/storage -> ../storage/app/public
```

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
