### PR TITLE
[5.7] Addition of hasAny method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -888,7 +888,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Determine if any of the given keys exist in the collection
+     * Determine if any of the given keys exist in the collection.
      *
      * @param  mixed  $keys
      * @return bool

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -888,6 +888,25 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Determine if any of the given keys exist in the collection
+     *
+     * @param  mixed  $keys
+     * @return bool
+     */
+    public function hasAny($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        foreach ($keys as $value) {
+            if ($this->offsetExists($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  string  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1098,6 +1098,18 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse($data->has(['third', 'first']));
     }
 
+    public function testHasAny()
+    {
+        $data = new Collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
+        $this->assertTrue($data->hasAny('first'));
+        $this->assertFalse($data->hasAny('third'));
+        $this->assertTrue($data->hasAny(['first', 'second']));
+        $this->assertTrue($data->hasAny(['first', 'third']));
+        $this->assertFalse($data->hasAny(['third', 'fourth']));
+        $this->assertTrue($data->hasAny('first', 'third'));
+        $this->assertFalse($data->hasAny('third', 'fourth'));
+    }
+
     public function testImplode()
     {
         $data = new Collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);


### PR DESCRIPTION
Adds a hasAny method to Collection to determine if the items include any of the given keys. 

Complements the same method currently featuring in both Request and MessageBag.

```
$collection = new Collection(['first' => 'one', 'second' => 'two']);

$collection->has(['first', 'third']); // false
$collection->hasAny(['first', 'third']); // true
```