### PR TITLE
[5.5] Prevent double escape of URL

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -52,7 +52,7 @@ Regards,<br>{{ config('app.name') }}
 @isset($actionText)
 @component('mail::subcopy')
 If you’re having trouble clicking the "{{ $actionText }}" button, copy and paste the URL below
-into your web browser: [{!! $actionUrl !!}]({{ $actionUrl }})
+into your web browser: [{{ $actionUrl }}]({!! $actionUrl !!})
 @endcomponent
 @endisset
 @endcomponent

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -52,7 +52,7 @@ Regards,<br>{{ config('app.name') }}
 @isset($actionText)
 @component('mail::subcopy')
 If you’re having trouble clicking the "{{ $actionText }}" button, copy and paste the URL below
-into your web browser: [{{ $actionUrl }}]({{ $actionUrl }})
+into your web browser: [{!! $actionUrl !!}]({{ $actionUrl }})
 @endcomponent
 @endisset
 @endcomponent


### PR DESCRIPTION
`&` in `$actionUrl` will be escaped twice to `&amp;amp;` by `{{ }}`  and `Illuminate\Mail\Markdown::parse()` which cases unexpected behavior