### PR TITLE
[5.7] Fix pagination slider when it's too close to the end

### DIFF
--- a/src/Illuminate/Pagination/UrlWindow.php
+++ b/src/Illuminate/Pagination/UrlWindow.php
@@ -123,7 +123,7 @@ class UrlWindow
     protected function getSliderTooCloseToEnding($window)
     {
         $last = $this->paginator->getUrlRange(
-            $this->lastPage() - ($window + 2),
+            $this->lastPage() - ($window + 1),
             $this->lastPage()
         );
 

--- a/tests/Pagination/UrlWindowTest.php
+++ b/tests/Pagination/UrlWindowTest.php
@@ -43,7 +43,7 @@ class UrlWindowTest extends TestCase
         $p = new LengthAwarePaginator($array, count($array), 1, 8);
         $window = new UrlWindow($p);
         $last = [];
-        for ($i = 5; $i <= 13; $i++) {
+        for ($i = 6; $i <= 13; $i++) {
             $last[$i] = '/?page='.$i;
         }
 


### PR DESCRIPTION
Make the number of pages that are shown close to the end, equal to
the number of pages that are shown close to the beginning.

![laravel-pagination-fix](https://user-images.githubusercontent.com/8286154/48270355-1f17c180-e44f-11e8-8298-fa0d5a8e96af.png)

As you can see before the fix when current page is close to the end, the pagination shows 9 pages close the end, but when the current page is close to the beginning, it shows only 8 pages close to the beginning. 

I thought it should be symmetric.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
