### PR TITLE
[5.7] Add localization helper

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/403.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/403.blade.php
@@ -8,4 +8,4 @@
 </div>
 @endsection
 
-@section('message', __($exception->getMessage() ?: 'Sorry, you are forbidden from accessing this page.'))
+@section('message', __($exception->getMessage() ?: __('Sorry, you are forbidden from accessing this page.')))


### PR DESCRIPTION
Add a localization helper function, to translate the default 403 error text, in accordance to the other error pages.