### PR TITLE
[5.7] Add closure support to collection dump()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -331,6 +331,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         (new static(func_get_args()))
             ->push($this)
             ->each(function ($item) {
+                if ($item instanceof \Closure) {
+                    $item = $item($this);
+                }
+
                 VarDumper::dump($item);
             });
 


### PR DESCRIPTION
This adds support of passing closures to the `dump` and `dd` methods in `Illuminate\Support\Collection`.

```php
User::all()->dump(
    function ($users) {
        return $users->pluck('name');
    }
);
```
Gives:

```php
Collection {#2991 ▼
  #items: array:10 [▼
    0 => "Bruce"
    1 => "Peter"
    2 => "Tony"
    3 => "Stephen"
   ]
}
```

This helps when working with large collections of dense objects, and you only care about comparing specific information.