### PR TITLE
[5.7] Adding `RouteRegistrar` mixin to Router

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -23,6 +23,9 @@ use Illuminate\Contracts\Routing\Registrar as RegistrarContract;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
+/**
+ * @mixin \Illuminate\Routing\RouteRegistrar
+ */
 class Router implements RegistrarContract, BindingRegistrar
 {
     use Macroable {


### PR DESCRIPTION
This is a *fix* for IDE when you're calling something `$this->middleware()` in `App\Providers\RouteServiceProvider` or `Illuminate\Foundation\Support\Providers\RouteServiceProvider` instead of using `Route::middleware()` (Facade).

![routeserviceprovider](https://user-images.githubusercontent.com/3282340/48488900-1560d600-e822-11e8-8dfb-4098cc021f45.jpg)

### Sources: 

* [RouteServiceProvider: __call()](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php#L98-L103)
* [Router: __call()](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Routing/Router.php#L1250-L1261)

**REPOST:** https://github.com/laravel/framework/pull/26504