### PR TITLE
Implement hasAll(), hasAny(), doesNotHave() and doesNotHaveAny()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -869,12 +869,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Determine if an item exists in the collection by key.
+     * Determine if all items exist in the collection by their keys.
      *
      * @param  mixed  $key
      * @return bool
      */
-    public function has($key)
+    public function hasAll($key)
     {
         $keys = is_array($key) ? $key : func_get_args();
 
@@ -885,6 +885,70 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         return true;
+    }
+
+    /**
+     * Determine if any items exist in the collection by their keys.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function hasAny($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if ($this->offsetExists($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if one items is missing in the collection by its key.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function doesNotHave($key)
+    {
+        return ! $this->offsetExists($key);
+    }
+
+    /**
+     * Determine if none of the items exist in the collection by their keys.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function doesNotHaveAny($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if ($this->offsetExists($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if an item exists in the collection by key.
+     *
+     * @param  mixed  $key
+     * @return bool
+     *
+     * @deprecated use hasAll() instead
+     */
+    public function has($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        return $this->hasAll($keys);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1095,7 +1095,49 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue($data->has('first'));
         $this->assertFalse($data->has('third'));
         $this->assertTrue($data->has(['first', 'second']));
+        $this->assertTrue($data->has('first', 'second'));
         $this->assertFalse($data->has(['third', 'first']));
+        $this->assertFalse($data->has('third', 'first'));
+    }
+
+    public function testHasAll()
+    {
+        $data = new Collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
+        $this->assertTrue($data->hasAll('first'));
+        $this->assertFalse($data->hasAll('third'));
+        $this->assertTrue($data->hasAll(['first', 'second']));
+        $this->assertTrue($data->hasAll('first', 'second'));
+        $this->assertFalse($data->hasAll(['third', 'first']));
+        $this->assertFalse($data->hasAll('third', 'first'));
+    }
+
+    public function testHasAny()
+    {
+        $data = new Collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
+        $this->assertTrue($data->hasAny('first'));
+        $this->assertFalse($data->hasAny('third'));
+        $this->assertTrue($data->hasAny(['first', 'second']));
+        $this->assertTrue($data->hasAny('first', 'second'));
+        $this->assertTrue($data->hasAny(['third', 'first']));
+        $this->assertTrue($data->hasAny('third', 'first'));
+    }
+
+    public function testDoesNotHave()
+    {
+        $data = new Collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
+        $this->assertFalse($data->doesNotHave('first'));
+        $this->assertTrue($data->doesNotHave('third'));
+    }
+
+    public function testDoesNotHaveAny()
+    {
+        $data = new Collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
+        $this->assertFalse($data->doesNotHaveAny('first'));
+        $this->assertTrue($data->doesNotHaveAny('third'));
+        $this->assertFalse($data->doesNotHaveAny(['first', 'third']));
+        $this->assertFalse($data->doesNotHaveAny('first', 'third'));
+        $this->assertTrue($data->doesNotHaveAny(['name', 'third']));
+        $this->assertTrue($data->doesNotHaveAny('name', 'third'));
     }
 
     public function testImplode()


### PR DESCRIPTION
Many time I had to check whether an item did not exist in a collection, and using the `!` operator always seemed a bit less readable that it could be. So, I decided to implement the `doesNotHave()` method.

I have also implemented other useful, IMHO, methods to help: `hasAny()` and `doesNotHaveAny()`.

The current `has()` method as been deprecated in favour of `hasAll()` which is more in line to what it actually does.
