### PR TITLE
[5.7] Allow filtering of route:list columns

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -145,7 +145,7 @@ class RouteListCommand extends Command
     }
 
     /**
-     * Get filtered headers that should be shown
+     * Get filtered headers that should be shown.
      *
      * @return array
      */
@@ -162,7 +162,7 @@ class RouteListCommand extends Command
     }
 
     /**
-     * Get the columns that should be shown
+     * Get the columns that should be shown.
      *
      * @return \Illuminate\Support\Collection
      */
@@ -172,7 +172,7 @@ class RouteListCommand extends Command
     }
 
     /**
-     * Check if the columns contain a particular value
+     * Check if the columns contain a particular value.
      *
      * @param string $value
      * @return \Illuminate\Support\Collection
@@ -186,7 +186,7 @@ class RouteListCommand extends Command
     }
 
     /**
-     * Filter the routes by column
+     * Filter the routes by column.
      *
      * @param array $routes
      * @return array


### PR DESCRIPTION
Adds a `columns` argument that allows a comma separated list of the columns you want to show.

```
$ art route:list --columns=uri,name
+-------+-------------+
| URI   | Name        |
+-------+-------------+
| admin | admin.index |
+-------+-------------+
```