### PR TITLE
[5.8] from() testing helper to set previous url in session

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -144,13 +144,15 @@ trait MakesHttpRequests
     }
 
     /**
-     * Set the referer header to simulate a previous request.
+     * Set the referer header and previous url in the session to simulate a previous request.
      *
      * @param  string  $url
      * @return $this
      */
     public function from(string $url)
     {
+        $this->app['session']->setPreviousUrl($url);
+
         return $this->withHeader('referer', $url);
     }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -144,7 +144,7 @@ trait MakesHttpRequests
     }
 
     /**
-     * Set the referer header and previous url in the session to simulate a previous request.
+     * Set the referer header and previous URL session value in odrer to simulate a previous request.
      *
      * @param  string  $url
      * @return $this

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -144,7 +144,7 @@ trait MakesHttpRequests
     }
 
     /**
-     * Set the referer header and previous URL session value in odrer to simulate a previous request.
+     * Set the referer header and previous URL session value in order to simulate a previous request.
      *
      * @param  string  $url
      * @return $this

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -6,6 +6,14 @@ use Orchestra\Testbench\TestCase;
 
 class MakesHttpRequestsTest extends TestCase
 {
+    public function testFromSetsHeaderAndSession()
+    {
+        $this->from('previous/url');
+
+        $this->assertSame('previous/url', $this->defaultHeaders['referer']);
+        $this->assertSame('previous/url', $this->app['session']->previousUrl());
+    }
+
     public function testWithoutAndWithMiddleware()
     {
         $this->assertFalse($this->app->has('middleware.disable'));


### PR DESCRIPTION
Currently the `$this->from($url)` test helper only sets the `"referer"` header. I believe it makes sense for this also to set the previous url in the session. I've been doing this by setting the previous URL on the session manually, but adding it to this helper makes it just that little bit nicer.

This allows you to easily test validation exception redirects (from a FormRequest) as well as redirects with the `redirect()->back()`. Anything that utilises the session's `_previous.url` key to determine where the redirect should send the user.

```php
// the controller returns this...
return redirect()->back()->with(['notice' => 'Quick post created']);


// so my test can look like this...
public function test_can_add_quick_post_from_dashboard()
{
    $response = $this->from('dashboard')->post('quick-posts', [
        'content' => 'expected content',
    ]);

    $response->assertRedirect('dashboard');
    // ...
}
```

This is basically just a shortcut to doing this setup first...

```php
$this->app['session']->setPreviousUrl('dashboard');

$response = $this->post('...
```