### PR TITLE
[5.8] Remove the container makeWith method

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -585,18 +585,6 @@ class Container implements ContainerContract
     }
 
     /**
-     * An alias function name for make().
-     *
-     * @param  string  $abstract
-     * @param  array  $parameters
-     * @return mixed
-     */
-    public function makeWith($abstract, array $parameters = [])
-    {
-        return $this->make($abstract, $parameters);
-    }
-
-    /**
      * Resolve the given type from the container.
      *
      * @param  string  $abstract

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -138,7 +138,7 @@ trait BuildsQueries
      */
     protected function paginator($items, $total, $perPage, $currentPage, $options)
     {
-        return Container::getInstance()->makeWith(LengthAwarePaginator::class, compact(
+        return Container::getInstance()->make(LengthAwarePaginator::class, compact(
             'items', 'total', 'perPage', 'currentPage', 'options'
         ));
     }
@@ -154,7 +154,7 @@ trait BuildsQueries
      */
     protected function simplePaginator($items, $perPage, $currentPage, $options)
     {
-        return Container::getInstance()->makeWith(Paginator::class, compact(
+        return Container::getInstance()->make(Paginator::class, compact(
             'items', 'perPage', 'currentPage', 'options'
         ));
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -951,22 +951,6 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $instance->name);
     }
 
-    public function testMakeWithMethodIsAnAliasForMakeMethod()
-    {
-        $mock = $this->getMockBuilder(Container::class)
-                     ->setMethods(['make'])
-                     ->getMock();
-
-        $mock->expects($this->once())
-             ->method('make')
-             ->with(ContainerDefaultValueStub::class, ['default' => 'laurence'])
-             ->will($this->returnValue(new stdClass));
-
-        $result = $mock->makeWith(ContainerDefaultValueStub::class, ['default' => 'laurence']);
-
-        $this->assertInstanceOf(stdClass::class, $result);
-    }
-
     public function testResolvingWithArrayOfParameters()
     {
         $container = new Container;


### PR DESCRIPTION
The `makeWith` method was deprecated and just aliased to the `make` method since Laravel 5.5 -> https://github.com/laravel/framework/pull/19201

This PR aims to finally delete it from the framework as Laravel 5.5 was released quite some time ago.
