### PR TITLE
[5.7] Improved DNS Prefetching in view files

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -13,7 +13,7 @@
     <script src="{{ asset('js/app.js') }}" defer></script>
 
     <!-- Fonts -->
-    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet" type="text/css">
 
     <!-- Styles -->

--- a/src/Illuminate/Foundation/Exceptions/views/illustrated-layout.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/illustrated-layout.blade.php
@@ -7,6 +7,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
         <!-- Fonts -->
+        <link rel="dns-prefetch" href="//fonts.gstatic.com">
         <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet" type="text/css">
 
         <!-- Styles -->

--- a/src/Illuminate/Foundation/Exceptions/views/layout.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/layout.blade.php
@@ -7,6 +7,7 @@
         <title>@yield('title')</title>
 
         <!-- Fonts -->
+        <link rel="dns-prefetch" href="//fonts.gstatic.com">
         <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet" type="text/css">
 
         <!-- Styles -->


### PR DESCRIPTION
Changed DNS prefetching in Auth app stub & Exception files.

> It is equivalent (but **unnecessary**) to use a full URL

From: https://www.chromium.org/developers/design-documents/dns-prefetching