### PR TITLE
[5.8] Fix: Route list command

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -91,7 +91,7 @@ class RouteListCommand extends Command
     {
         $routes = collect($this->routes)->map(function ($route) {
             return $this->getRouteInformation($route);
-        })->all();
+        })->filter()->all();
 
         if ($sort = $this->option('sort')) {
             $routes = $this->sortRoutes($sort, $routes);
@@ -101,9 +101,7 @@ class RouteListCommand extends Command
             $routes = array_reverse($routes);
         }
 
-        $routes = $this->pluckColumns($routes);
-
-        return array_filter($routes);
+        return $this->pluckColumns($routes);
     }
 
     /**


### PR DESCRIPTION
This [PR](https://github.com/laravel/framework/pull/25683) introduced a bug in the `route:list` command.

Applying a filter such as:

`php artisan route:list --method=get` 
or
`php artisan route:list --name=telescope`

results in an exception because `$routes` is passed to the pluckColumns() method without being filtered. Because a filter has been applied the `$routes` array may contain keys with `null` values.

This PR fixes this issue. 


