### PR TITLE
[5.7] Add ForeignKeyDefinition meta class

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -518,7 +518,7 @@ class Blueprint
      *
      * @param  string|array  $columns
      * @param  string  $name
-     * @return \Illuminate\Support\Fluent
+     * @return \Illuminate\Support\Fluent|\Illuminate\Database\Schema\ForeignKeyDefinition
      */
     public function foreign($columns, $name = null)
     {

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -5,24 +5,25 @@ namespace Illuminate\Database\Schema;
 use Illuminate\Support\Fluent;
 
 /**
- * Class ColumnDefinition.
  * @method ColumnDefinition after(string $column) Place the column "after" another column (MySQL)
+ * @method ColumnDefinition always() Used as a modifier for generatedAs() (PostgreSQL)
  * @method ColumnDefinition autoIncrement() Set INTEGER columns as auto-increment (primary key)
+ * @method ColumnDefinition change() Change the column
  * @method ColumnDefinition charset(string $charset) Specify a character set for the column (MySQL)
  * @method ColumnDefinition collation(string $collation) Specify a collation for the column (MySQL/SQL Server)
  * @method ColumnDefinition comment(string $comment) Add a comment to the column (MySQL)
  * @method ColumnDefinition default(mixed $value) Specify a "default" value for the column
  * @method ColumnDefinition first() Place the column "first" in the table (MySQL)
- * @method ColumnDefinition nullable($value = true) Allow NULL values to be inserted into the column
- * @method ColumnDefinition storedAs($expression) Create a stored generated column (MySQL)
+ * @method ColumnDefinition generatedAs(string $expression) Create a SQL compliant identity column (PostgreSQL)
+ * @method ColumnDefinition index() Add an index
+ * @method ColumnDefinition nullable(bool $value = true) Allow NULL values to be inserted into the column
+ * @method ColumnDefinition primary() Add a primary index
+ * @method ColumnDefinition spatialIndex() Add a spatial index
+ * @method ColumnDefinition storedAs(string $expression) Create a stored generated column (MySQL)
  * @method ColumnDefinition unique() Add a unique index
  * @method ColumnDefinition unsigned() Set the INTEGER column as UNSIGNED (MySQL)
  * @method ColumnDefinition useCurrent() Set the TIMESTAMP column to use CURRENT_TIMESTAMP as default value
  * @method ColumnDefinition virtualAs(string $expression) Create a virtual generated column (MySQL)
- * @method ColumnDefinition generatedAs($expression) Create a SQL compliant identity column (PostgreSQL)
- * @method ColumnDefinition always() Used as a modifier for generatedAs() (PostgreSQL)
- * @method ColumnDefinition index() Add an index
- * @method ColumnDefinition change() Change the column
  */
 class ColumnDefinition extends Fluent
 {

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Database\Schema;
+
+use Illuminate\Support\Fluent;
+
+/**
+ * @method ForeignKeyDefinition deferrable(bool $value = true) Set the foreign key as deferrable (PostgreSQL)
+ * @method ForeignKeyDefinition initiallyImmediate(bool $value = true) Set the default time to check the constraint (PostgreSQL)
+ * @method ForeignKeyDefinition on(string $table) Specify the referenced table
+ * @method ForeignKeyDefinition onDelete(string $action) Specify the "on delete" action
+ * @method ForeignKeyDefinition onUpdate(string $action) Specify the "on update" action
+ * @method ForeignKeyDefinition references(string|array $columns) Specify the referenced column(s)
+ */
+class ForeignKeyDefinition extends Fluent
+{
+    //
+}


### PR DESCRIPTION
#24444 added the `ColumnDefinition` meta class to provide better IDE support when creating columns.

This PR adds the corresponding `ForeignKeyDefinition` class which provides the same functionality for foreign key constraints.

The PR also improves the `ColumnDefinition` class: It adds the `primary()` and `spatialIndex()` methods, restores the alphabetical order and adds type hints.