### PR TITLE
[5.7] Various improvements

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
-/**
- * @mixin \Illuminate\Database\Eloquent\Builder
- */
 class BelongsTo extends Relation
 {
     use SupportsDefaultModels;

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 
-/**
- * @mixin \Illuminate\Database\Eloquent\Builder
- */
 class MorphTo extends BelongsTo
 {
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -857,11 +857,7 @@ class Builder
         // Finally we'll add a binding for each values unless that value is an expression
         // in which case we will just skip over it since it will be the query as a raw
         // string and not as a parameterized place-holder to be replaced by the PDO.
-        foreach ($values as $value) {
-            if (! $value instanceof Expression) {
-                $this->addBinding($value, 'where');
-            }
-        }
+        $this->addBinding($this->cleanBindings($values), 'where');
 
         return $this;
     }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -43,9 +43,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_basic_create_and_retrieve()
     {
-        Carbon::setTestNow(
-            Carbon::createFromFormat('Y-m-d H:i:s', '2017-10-10 10:10:10')
-        );
+        Carbon::setTestNow('2017-10-10 10:10:10');
 
         $post = Post::create(['title' => str_random()]);
 
@@ -110,9 +108,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_custom_pivot_class()
     {
-        Carbon::setTestNow(
-            Carbon::createFromFormat('Y-m-d H:i:s', '2017-10-10 10:10:10')
-        );
+        Carbon::setTestNow('2017-10-10 10:10:10');
 
         $post = Post::create(['title' => str_random()]);
 
@@ -431,9 +427,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $this->assertNotEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
 
-        Carbon::setTestNow(
-            Carbon::createFromFormat('Y-m-d H:i:s', '2017-10-10 10:10:10')
-        );
+        Carbon::setTestNow('2017-10-10 10:10:10');
 
         $tag->update(['name' => $tag->name]);
         $this->assertNotEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
@@ -451,9 +445,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertNotEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
         $this->assertNotEquals('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
 
-        Carbon::setTestNow(
-            Carbon::createFromFormat('Y-m-d H:i:s', '2017-10-10 10:10:10')
-        );
+        Carbon::setTestNow('2017-10-10 10:10:10');
 
         $tag->posts()->sync([$post->id]);
 
@@ -470,9 +462,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertNotEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
         $this->assertNotEquals('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
 
-        Carbon::setTestNow(
-            Carbon::createFromFormat('Y-m-d H:i:s', '2017-10-10 10:10:10')
-        );
+        Carbon::setTestNow('2017-10-10 10:10:10');
 
         $tag->posts()->sync([$post->id]);
 
@@ -513,9 +503,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
             ['post_id' => $post->id, 'tag_id' => 400, 'flag' => ''],
         ]);
 
-        Carbon::setTestNow(
-            Carbon::createFromFormat('Y-m-d H:i:s', '2017-10-10 10:10:10')
-        );
+        Carbon::setTestNow('2017-10-10 10:10:10');
 
         $post->tags()->touch();
 

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -71,7 +71,7 @@ class SendingMailWithLocaleTest extends TestCase
 
     public function test_mail_is_sent_with_locale_updated_listeners_called()
     {
-        Carbon::setTestNow(Carbon::parse('2018-04-01'));
+        Carbon::setTestNow('2018-04-01');
 
         Event::listen(LocaleUpdated::class, function ($event) {
             Carbon::setLocale($event->locale);

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -132,7 +132,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
 
     public function test_mail_is_sent_with_locale_updated_listeners_called()
     {
-        Carbon::setTestNow(Carbon::parse('2018-07-25'));
+        Carbon::setTestNow('2018-07-25');
 
         Event::listen(LocaleUpdated::class, function ($event) {
             Carbon::setLocale($event->locale);


### PR DESCRIPTION
- Simplifies `whereIn()` with `cleanBindings()`.
- We don't need `@mixin` in `BelongsTo` and `MorphTo`, it's already in the parent [`Relation`](https://github.com/laravel/framework/blob/a3738cf4e133a4475c56b51f521a12db78e2ecbb/src/Illuminate/Database/Eloquent/Relations/Relation.php#L15) class.
- `Carbon::setTestNow()` can parse the date itself.