### PR TITLE
adding reset key option to array_where function helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -309,11 +309,14 @@ if (! function_exists('array_where')) {
      *
      * @param  array  $array
      * @param  callable  $callback
+     * @param  bool  $resetKey
      * @return array
      */
-    function array_where($array, callable $callback)
+    function array_where($array, callable $callback, $resetKey = false)
     {
-        return Arr::where($array, $callback);
+        $filtered = Arr::where($array, $callback);
+
+        return $resetKey ? array_values($filtered) : $filtered;
     }
 }
 


### PR DESCRIPTION
This addition will give the users the ability to reset array keys when using ```array_where``` function helpers.