### PR TITLE
[5.7] Add another case to causedByLostConnection()

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -36,6 +36,7 @@ trait DetectsLostConnections
             'TCP Provider: Error code 0x68',
             'Name or service not known',
             'ORA-03114',
+            'Error while sending QUERY packet',
         ]);
     }
 }


### PR DESCRIPTION
"Error while sending QUERY packet" is seen when either sending larger packages then MySQL will handle or when the connection was silently closed by the database.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
