### PR TITLE
[5.8] Added `passes` method declaration

### DIFF
--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -21,6 +21,13 @@ interface Validator extends MessageProvider
     public function validated();
 
     /**
+     * Determine if the data passes the validation rules.
+     *
+     * @return bool
+     */
+    public function passes();
+
+    /**
      * Determine if the data fails the validation rules.
      *
      * @return bool


### PR DESCRIPTION
Added `passes` method declaration to ValidatorContract
There is method called like that in the `Illuminate\Validation\Validator`, but there are no such declaration in interface
Closing this https://github.com/laravel/ideas/issues/1397

Adding this will make IDE highlighting while referencing the interface.
It will also introduce BC to those who implement this interface so it will go to 5.8
