### PR TITLE
[5.8] Rename app:name command to app:namespace

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNamespaceCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNamespaceCommand.php
@@ -8,14 +8,14 @@ use Symfony\Component\Finder\Finder;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
 
-class AppNameCommand extends Command
+class AppNamespaceCommand extends Command
 {
     /**
      * The console command name.
      *
      * @var string
      */
-    protected $name = 'app:name';
+    protected $name = 'app:namespace';
 
     /**
      * The console command description.

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -12,7 +12,7 @@ use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Foundation\Console\ServeCommand;
 use Illuminate\Foundation\Console\PresetCommand;
 use Illuminate\Queue\Console\FailedTableCommand;
-use Illuminate\Foundation\Console\AppNameCommand;
+use Illuminate\Foundation\Console\AppNamespaceCommand;
 use Illuminate\Foundation\Console\JobMakeCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
 use Illuminate\Foundation\Console\MailMakeCommand;
@@ -132,7 +132,7 @@ class ArtisanServiceProvider extends ServiceProvider
      * @var array
      */
     protected $devCommands = [
-        'AppName' => 'command.app.name',
+        'AppNamespace' => 'command.app.namespace',
         'AuthMake' => 'command.auth.make',
         'CacheTable' => 'command.cache.table',
         'ChannelMake' => 'command.channel.make',
@@ -197,10 +197,10 @@ class ArtisanServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function registerAppNameCommand()
+    protected function registerAppNamespaceCommand()
     {
-        $this->app->singleton('command.app.name', function ($app) {
-            return new AppNameCommand($app['composer'], $app['files']);
+        $this->app->singleton('command.app.namespace', function ($app) {
+            return new AppNamespaceCommand($app['composer'], $app['files']);
         });
     }
 


### PR DESCRIPTION
As raised in [ideas#1338](https://github.com/laravel/ideas/issues/1338), the command sigature `app:name` is confusingly named as "app name" can also refer to the `env('APP_NAME')` configuration option, not just the application's namespace.

This PR solves that by renaming the command's signature to make it more explicit: `app:namespace`