### PR TITLE
[5.7] Cast key value to string when your related table uses string

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -129,14 +129,7 @@ class BelongsTo extends Relation
         // execute a "where in" statement to gather up all of those related records.
         foreach ($models as $model) {
             if (! is_null($value = $model->{$this->foreignKey})) {
-                switch ($keyType) {
-                    case 'string':
-                        $keys[] = (string) $value;
-                        break;
-                    default:
-                        $keys[] = $value;
-                        break;
-                }
+                $keys[] = $keyType === 'string' ? (string) $value : $value;
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -128,7 +128,14 @@ class BelongsTo extends Relation
         // execute a "where in" statement to gather up all of those related records.
         foreach ($models as $model) {
             if (! is_null($value = $model->{$this->foreignKey})) {
-                $keys[] = $value;
+                switch ($this->related->getKeyType()) {
+                    case 'string':
+                        $keys[] = (string)$value;
+                        break;
+                    default:
+                        $keys[] = $value;
+                        break;
+                }
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -123,12 +123,14 @@ class BelongsTo extends Relation
     {
         $keys = [];
 
+        $keyType = $this->related->getKeyType();
+        
         // First we need to gather all of the keys from the parent models so we know what
         // to query for via the eager loading query. We will add them to an array then
         // execute a "where in" statement to gather up all of those related records.
         foreach ($models as $model) {
             if (! is_null($value = $model->{$this->foreignKey})) {
-                switch ($this->related->getKeyType()) {
+                switch ($keyType) {
                     case 'string':
                         $keys[] = (string) $value;
                         break;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -124,7 +124,6 @@ class BelongsTo extends Relation
         $keys = [];
 
         $keyType = $this->related->getKeyType();
-        
         // First we need to gather all of the keys from the parent models so we know what
         // to query for via the eager loading query. We will add them to an array then
         // execute a "where in" statement to gather up all of those related records.

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -130,7 +130,7 @@ class BelongsTo extends Relation
             if (! is_null($value = $model->{$this->foreignKey})) {
                 switch ($this->related->getKeyType()) {
                     case 'string':
-                        $keys[] = (string)$value;
+                        $keys[] = (string) $value;
                         break;
                     default:
                         $keys[] = $value;


### PR DESCRIPTION
When working with an database that was managed remote we ran into performance issues. The indexes on columns were not used. After a EXPLAIN EXTENDED we noticed this was a issue with mismatching data types.

The parent table uses INT for the primary key but the related tables uses varchar for their fields. Because this database is not ours we can not change this!

The suggested change fixes this issue. It uses the existing KeyType that is present on the Model instance.

In our case 4 queries before this fix, 4000ms, after the fix. 40ms.
