### PR TITLE
[5.7] Makes Eloquent Model macroable

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -7,6 +7,7 @@ use ArrayAccess;
 use JsonSerializable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\ForwardsCalls;
@@ -27,7 +28,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         Concerns\HasTimestamps,
         Concerns\HidesAttributes,
         Concerns\GuardsAttributes,
-        ForwardsCalls;
+        ForwardsCalls,
+        Macroable {
+            __call as macroCall;
+        }
 
     /**
      * The connection name for the model.
@@ -1601,6 +1605,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
         if (in_array($method, ['increment', 'decrement'])) {
             return $this->$method(...$parameters);
         }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1809,6 +1809,17 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($called);
     }
 
+    public function testModelIsMacroable()
+    {
+        $model = new EloquentModelStub;
+
+        $model->macro('foo', function () {
+            return 'bar';
+        });
+
+        $this->assertEquals('bar', $model->foo());
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock(ConnectionResolverInterface::class));


### PR DESCRIPTION
This PR allows you to do this:

```
User::macro('foo', function() {...});

User::foo();
```

for any created Eloquent model
