### PR TITLE
[5.5] Backport Mailgun endpoint fix

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -33,7 +33,7 @@ class MailgunTransport extends Transport
      *
      * @var string
      */
-    protected $url;
+    protected $endpoint;
 
     /**
      * Create a new Mailgun transport instance.
@@ -41,12 +41,15 @@ class MailgunTransport extends Transport
      * @param  \GuzzleHttp\ClientInterface  $client
      * @param  string  $key
      * @param  string  $domain
+     * @param  string|null  $endpoint
      * @return void
      */
-    public function __construct(ClientInterface $client, $key, $domain)
+    public function __construct(ClientInterface $client, $key, $domain, $endpoint = null)
     {
         $this->key = $key;
         $this->client = $client;
+        $this->endpoint = $endpoint ?? 'api.mailgun.net';
+
         $this->setDomain($domain);
     }
 
@@ -61,7 +64,11 @@ class MailgunTransport extends Transport
 
         $message->setBcc([]);
 
-        $this->client->post($this->url, $this->payload($message, $to));
+        $this->client->request(
+            'POST',
+            "https://{$this->endpoint}/v3/{$this->domain}/messages.mime",
+            $this->payload($message, $to)
+        );
 
         $this->sendPerformed($message);
 
@@ -161,8 +168,6 @@ class MailgunTransport extends Transport
      */
     public function setDomain($domain)
     {
-        $this->url = 'https://api.mailgun.net/v3/'.$domain.'/messages.mime';
-
         return $this->domain = $domain;
     }
 }

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -118,7 +118,9 @@ class TransportManager extends Manager
 
         return new MailgunTransport(
             $this->guzzle($config),
-            $config['secret'], $config['domain']
+            $config['secret'],
+            $config['domain'],
+            $config['endpoint'] ?? null
         );
     }
 


### PR DESCRIPTION
This was fixed for 5.7 but backporting this to 5.5 wouldn't leave all the LTS folks in the dark who still want to use the EU region.

Original PR: https://github.com/laravel/framework/pull/24994
Fixes https://github.com/laravel/framework/issues/26576