### PR TITLE
[5.8] ConvertEmptyStringsToNull: Check null strings as per Web IDL spec

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
+++ b/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
@@ -13,6 +13,6 @@ class ConvertEmptyStringsToNull extends TransformsRequest
      */
     protected function transform($key, $value)
     {
-        return is_string($value) && $value === '' ? null : $value;
+        return is_string($value) && ($value === '' || $value === 'null') ? null : $value;
     }
 }


### PR DESCRIPTION
Currently, in the frontend, if we set a value as null using the [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object, some browsers send empty strings and others send the string "null".

As per Web IDL specifications, form data append behaviour on null types is to send the string "null". Some browsers however have been sending empty strings "" so far but that's changing now, with Chrome sending null strings (as per Web IDL specs). 

Many folks using Laravel have the `ConvertEmptyStringsToNull` middleware as it's set by default. So, the earlier behaviour of sending null data was working "magically" even though the FormData object converted it to empty strings. But now, a lot of the browsers are changing this behaviour by sending null strings and moving to the Web IDL specs. 

This PR attempts to fix this across browsers by also checking for "null" strings in the `ConvertEmptyStringsToNull` middleware. Refer [this forum](https://readable-email.org/list/whatwg/topic/form-data-append-behavior-on-null-type) for the different behaviours across browsers.

Since the original intent was to send a null value, it makes sense anyway to convert "null" strings to null values.

As this is a breaking change, this PR is targeting the 5.8 dev branch.

To test this in your browser, open the JS console and type:
```js
var formData = new FormData();
formData.append("test", null);
console.log(formData.getAll('test'));
```

This will return `["null"]` in some browsers and `[""]` in others (older browsers).