### PR TITLE
[5.7] Make ResourceCollection countable such that it works with count()

### DIFF
--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -2,11 +2,12 @@
 
 namespace Illuminate\Http\Resources\Json;
 
+use Countable;
 use IteratorAggregate;
 use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Http\Resources\CollectsResources;
 
-class ResourceCollection extends JsonResource implements IteratorAggregate
+class ResourceCollection extends JsonResource implements IteratorAggregate, Countable
 {
     use CollectsResources;
 
@@ -35,6 +36,16 @@ class ResourceCollection extends JsonResource implements IteratorAggregate
         parent::__construct($resource);
 
         $this->resource = $this->collectResource($resource);
+    }
+
+    /**
+     * Return the count of items in the resource collection.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return $this->collection->count();
     }
 
     /**

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -576,6 +576,19 @@ class ResourceTest extends TestCase
         });
     }
 
+    public function test_collection_resources_are_countable()
+    {
+        $posts = collect([
+            new Post(['id' => 1, 'title' => 'Test title']),
+            new Post(['id' => 2, 'title' => 'Test title 2']),
+        ]);
+
+        $collection = new PostCollectionResource($posts);
+
+        $this->assertCount(2, $collection);
+        $this->assertSame(2, count($collection));
+    }
+
     public function test_leading_merge__keyed_value_is_merged_correctly()
     {
         $filter = new class {


### PR DESCRIPTION
I ran into an issue with a Laravel 5.5 project that I've been upgrading to 5.7 and moving to PHP 7.2.

For consistent representation of my models, I transform them using resources via a presenter and when passing a resource collection to the Blade `@each` directive, I was hitting a `count(): Parameter must be an array or an object that implements Countable` error.

This PR makes `ResourceCollection` implement the `Countable` interface so that it can be passed straight into `@each`, which worked fine before the breaking change in 7.2.