### PR TITLE
[5.8] Fix Arr::only exception when passing invalid keys

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -370,7 +370,11 @@ class Arr
      */
     public static function only($array, $keys)
     {
-        return array_intersect_key($array, array_flip((array) $keys));
+        $filteredKeys = array_filter((array) $keys, function($value){
+            return is_string($value) || is_int($value);
+        });
+
+        return array_intersect_key($array, array_flip($filteredKeys));
     }
 
     /**

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -370,7 +370,7 @@ class Arr
      */
     public static function only($array, $keys)
     {
-        $filteredKeys = array_filter((array) $keys, function($value){
+        $filteredKeys = array_filter((array) $keys, function ($value) {
             return is_string($value) || is_int($value);
         });
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -339,7 +339,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
 
         $invalidKeys = [1.5, null, ['key' => 'value'], new stdClass];
-        $this->assertEmpty(Arr::only($array,$invalidKeys));
+        $this->assertEmpty(Arr::only($array, $invalidKeys));
     }
 
     public function testPluck()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -337,6 +337,9 @@ class SupportArrTest extends TestCase
         $array = ['name' => 'Desk', 'price' => 100, 'orders' => 10];
         $array = Arr::only($array, ['name', 'price']);
         $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
+
+        $invalidKeys = [1.5, null, ['key' => 'value'], new stdClass];
+        $this->assertEmpty(Arr::only($array,$invalidKeys));
     }
 
     public function testPluck()


### PR DESCRIPTION
Fix ```Arr::only``` exception when passing **Invalid Keys** , for example when passing something like this will throw this exception

```php
$invalidKeys = [1.5, null, ['key' => 'value'], new stdClass];

Arr::only($array,$invalidKeys);
```

![screenshot from 2018-11-22 19-23-06](https://user-images.githubusercontent.com/17250137/48917451-9148c700-ee8f-11e8-8b71-fc0790f6098d.png)

