### PR TITLE
[5.7] Redis: Be able to set serializer for PhpRedis connector

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -203,16 +203,17 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function zadd($key, ...$dictionary)
     {
+        $newDictionary = [];
+        $newDictionary[] = $key;
+
         if (is_array(end($dictionary))) {
             foreach (array_pop($dictionary) as $member => $score) {
-                $dictionary[] = $score;
-                $dictionary[] = $member;
+                $newDictionary[] = $score;
+                $newDictionary[] = $member;
             }
         }
 
-        $key = $this->applyPrefix($key);
-
-        return $this->executeRaw(array_merge(['zadd', $key], $dictionary));
+        return $this->command('zadd', $newDictionary);
     }
 
     /**

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -73,6 +73,10 @@ class PhpRedisConnector
                 $client->select($config['database']);
             }
 
+            if (! empty($config['serializer'])) {
+                $client->setOption(Redis::OPT_SERIALIZER, $config['serializer']);
+            }
+
             if (! empty($config['prefix'])) {
                 $client->setOption(Redis::OPT_PREFIX, $config['prefix']);
             }


### PR DESCRIPTION
Would be good to have the ability to set php redis serializer like below via config files 

Example of config (database.php):

```php
'client' => 'phpredis',

'default' => [
    'host'       => env('REDIS_HOST', '127.0.0.1'),
    'password'   => env('REDIS_PASSWORD', null),
    'port'       => env('REDIS_PORT', 6379),
    'options'    => [
        'prefix'     => env('REDIS_NAMESPACE', '_'),
        'serializer' => \Redis::SERIALIZER_PHP.
    ],
    'database'   => 1,
],
```
