### PR TITLE
[5.7] Remove duplicated code in Illuminate\Database\Eloquent\Model::loadMissing()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -500,8 +500,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function loadMissing($relations)
     {
-        $relations = is_string($relations) ? func_get_args() : $relations;
-
         $this->newCollection([$this])->loadMissing($relations);
 
         return $this;


### PR DESCRIPTION
Remove duplicated code check and wrap method argument to array if it is string.
```
$relations = is_string($relations) ? func_get_args() : $relations;
```
It is duplicated with https://github.com/laravel/framework/edit/5.7/src/Illuminate/Database/Eloquent/Collection.php#L100-102
