### PR TITLE
[5.7] Add starts with validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1505,6 +1505,19 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate the attribute starts with a given substring.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateStartsWith($attribute, $value, $parameters)
+    {
+        return Str::startsWith($value, $parameters);
+    }
+
+    /**
      * Validate that an attribute is a string.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1198,6 +1198,21 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateStartsWith()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'hello world'], ['x' => 'starts_with:hello']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'hello world'], ['x' => 'starts_with:world']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'hello world'], ['x' => 'starts_with:world,hello']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateString()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This PR introduces a "starts with" validation rule. The request input value must start with one of the given rule parameters.

Here is an example of how you could use with stripe credentials:

```php
public function rules()
{
    return [
        'stripe_publishable_key' => [
            'starts_with:pk_test_,pk_live_',
        ],
        'stripe_secret_key' => [
            'starts_with:sk_live_,sk_test_',
        ],
    ];
}
```

Granted this can be done easily with Regex or a custom validation rule already. I'm also conscious that you probably don't want to introduce a bunch of validation rules that are already easily achieved,  however I needed this on a couple of projects and thought it might be handy in core if others think it would be useful to them