### PR TITLE
[5.7] Delete unneeded assert

### DIFF
--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -586,7 +586,6 @@ class ResourceTest extends TestCase
         $collection = new PostCollectionResource($posts);
 
         $this->assertCount(2, $collection);
-        $this->assertSame(2, count($collection));
     }
 
     public function test_leading_merge__keyed_value_is_merged_correctly()


### PR DESCRIPTION
I have delete one assert, since

```PHP
$this->assertSame(2, count($collection));
```
the same as
```PHP
$this->assertCount(2, $collection);
```

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
