### PR TITLE
[5.7] Refactoring: moved registration of the typical reset password routes to the separate method

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1159,16 +1159,26 @@ class Router implements RegistrarContract, BindingRegistrar
 
         // Password Reset Routes...
         if ($options['reset'] ?? true) {
-            $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
-            $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
-            $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
-            $this->post('password/reset', 'Auth\ResetPasswordController@reset')->name('password.update');
+            $this->resetPassword();
         }
 
         // Email Verification Routes...
         if ($options['verify'] ?? false) {
             $this->emailVerification();
         }
+    }
+
+    /**
+     * Register the typical reset password routes for an application.
+     *
+     * @return void
+     */
+    public function resetPassword()
+    {
+        $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
+        $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
+        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
+        $this->post('password/reset', 'Auth\ResetPasswordController@reset')->name('password.update');
     }
 
     /**


### PR DESCRIPTION
…

 - moved registration of the typical reset password routes to the separate method, like it is for `emailVerification` routes;

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
