### PR TITLE
[5.8] Modify collection only method to be consistent with array_only

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -358,7 +358,7 @@ class Collection extends BaseCollection implements QueueableCollection
     public function only($keys)
     {
         if (is_null($keys)) {
-            return new static($this->items);
+            return new static;
         }
 
         $dictionary = Arr::only($this->getDictionary(), $keys);

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1219,7 +1219,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function only($keys)
     {
         if (is_null($keys)) {
-            return new static($this->items);
+            return new static;
         }
 
         if ($keys instanceof self) {

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -287,7 +287,7 @@ class DatabaseEloquentCollectionTest extends TestCase
 
         $c = new Collection([$one, $two, $three]);
 
-        $this->assertEquals($c, $c->only(null));
+        $this->assertEmpty($c->only(null));
         $this->assertEquals(new Collection([$one]), $c->only(1));
         $this->assertEquals(new Collection([$two, $three]), $c->only([2, 3]));
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2108,7 +2108,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new Collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);
 
-        $this->assertEquals($data->all(), $data->only(null)->all());
+        $this->assertEmpty($data->only(null)->all());
         $this->assertEquals(['first' => 'Taylor'], $data->only(['first', 'missing'])->all());
         $this->assertEquals(['first' => 'Taylor'], $data->only('first', 'missing')->all());
         $this->assertEquals(['first' => 'Taylor'], $data->only(collect(['first', 'missing']))->all());


### PR DESCRIPTION
```php
$array = ['product_id' => 1, 'name' => 'Desk', 'price' => 100, 'discount' => false];

array_only($array, null); //returns empty

collect($array)->only(null); //returns the whole collection
```
so this **PR** , makes ``` collection only()``` method consistent with ``` array_only()``` method .

as ```collection except()``` method and ```array_except()``` method are both consistent

```php
/***** both methods are consistent *****/
array_except($array, null); // returns the whole array

collect($array)->except(null); // returns the whole collection
```