### PR TITLE
[5.7] Prevent breaking eager loading with string keys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -317,7 +317,7 @@ abstract class Relation
     protected function whereInMethod(Model $model, $key)
     {
         return $model->getKeyName() === last(explode('.', $key))
-                    && in_array($model->getKeyType(), ['int', 'integer'])
+                    && $model->getIncrementing()
                         ? 'whereIntegerInRaw'
                         : 'whereIn';
     }

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -177,8 +177,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
     {
         $relation = $this->getRelation(null, false);
         $relation->getRelated()->shouldReceive('getKeyName')->andReturn('id');
-        $relation->getRelated()->shouldReceive('getKeyType')->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('relation.id', m::mustBe([null]));
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', m::mustBe([null]));
         $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
         $relation->addEagerConstraints($models);
     }

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -201,7 +201,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
-        $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
+        $relation->getParent()->shouldReceive('getIncrementing')->once()->andReturn(true);
         $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('table.foreign_key', [1, 2]);
         $model1 = new EloquentHasManyModelStub;
         $model1->id = 1;
@@ -214,7 +214,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
-        $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('string');
+        $relation->getParent()->shouldReceive('getIncrementing')->once()->andReturn(false);
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.foreign_key', [1, 2]);
         $model1 = new EloquentHasManyModelStub;
         $model1->id = 1;

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -164,7 +164,7 @@ class DatabaseEloquentHasOneTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
-        $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
+        $relation->getParent()->shouldReceive('getIncrementing')->once()->andReturn(true);
         $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('table.foreign_key', [1, 2]);
         $model1 = new EloquentHasOneModelStub;
         $model1->id = 1;

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -29,7 +29,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getOneRelation();
         $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
-        $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('string');
+        $relation->getParent()->shouldReceive('getIncrementing')->once()->andReturn(false);
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', [1, 2]);
         $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
 
@@ -53,7 +53,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getManyRelation();
         $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
-        $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
+        $relation->getParent()->shouldReceive('getIncrementing')->once()->andReturn(true);
         $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('table.morph_id', [1, 2]);
         $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
 

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -19,7 +19,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getParent()->shouldReceive('getKeyName')->andReturn('id');
-        $relation->getParent()->shouldReceive('getKeyType')->andReturn('int');
+        $relation->getParent()->shouldReceive('getIncrementing')->once()->andReturn(true);
         $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('taggables.taggable_id', [1, 2]);
         $relation->getQuery()->shouldReceive('where')->once()->with('taggables.taggable_type', get_class($relation->getParent()));
         $model1 = new EloquentMorphToManyModelStub;


### PR DESCRIPTION
The eager loading improvement introduced in #26434 and #26453 broke some applications with string keys.

The [documentation](https://laravel.com/docs/5.7/eloquent#defining-models) advices users with string keys to set both `$incrementing = false` *and* `$keyType = 'string'`. However, the affected users only adjusted `$incrementing` and left the default `$keyType = 'int'` unchanged. This has been working fine up to the latest release, as the `$keyType` is only [used](https://github.com/laravel/framework/blob/b24870a0e1fd9daefcd885abecd1a6f727b64a9b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L905) for auto-incrementing keys.

With this PR, the performance improvement is only applied to auto-incrementing primary keys. As a result, users with non-incrementing integer keys don't benefit from it anymore (but there probably aren't that many cases).