### PR TITLE
[5.7] Eloquent Query Builder: Eloquent Collection will be transformed to model keys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -248,6 +248,61 @@ class Builder
     }
 
     /**
+     * Add a "where in" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed   $values
+     * @param  string  $boolean
+     * @param  bool    $not
+     * @return $this
+     */
+    public function whereIn($column, $values, $boolean = 'and', $not = false)
+    {
+        if ($values instanceof Collection) {
+            $values = $values->modelKeys();
+        }
+        $this->query->whereIn($column, $values, $boolean, $not);
+        return $this;
+    }
+
+    /**
+     * Add an "or where in" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed   $values
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function orWhereIn($column, $values)
+    {
+        return $this->whereIn($column, $values, 'or');
+    }
+
+    /**
+     * Add a "where not in" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed   $values
+     * @param  string  $boolean
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function whereNotIn($column, $values, $boolean = 'and')
+    {
+        return $this->whereIn($column, $values, $boolean, true);
+    }
+
+    /**
+     * Add an "or where not in" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed   $values
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function orWhereNotIn($column, $values)
+    {
+        return $this->whereNotIn($column, $values, 'or');
+    }
+
+    /**
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -262,6 +262,7 @@ class Builder
             $values = $values->modelKeys();
         }
         $this->query->whereIn($column, $values, $boolean, $not);
+
         return $this;
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1061,6 +1061,23 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->oldest('foo');
     }
 
+    public function testWhereInMethodWithEloquentCollection()
+    {
+        $model = $this->getMockModel();
+        $builder = $this->getBuilder()->setModel($model);
+
+        $mockModel = m::mock(Model::class);
+        $mockModel->shouldReceive('getKey')->withNoArgs()->andReturn(1);
+        $mockModel2 = m::mock(Model::class);
+        $mockModel2->shouldReceive('getKey')->withNoArgs()->andReturn(2);
+        $collection = new Collection([$mockModel, $mockModel2]);
+        
+
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_bar', [1,2], 'and', false);
+
+        $builder->whereIn('foo_bar', $collection);
+    }
+
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1071,9 +1071,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $mockModel2 = m::mock(Model::class);
         $mockModel2->shouldReceive('getKey')->withNoArgs()->andReturn(2);
         $collection = new Collection([$mockModel, $mockModel2]);
-        
 
-        $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_bar', [1,2], 'and', false);
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_bar', [1, 2], 'and', false);
 
         $builder->whereIn('foo_bar', $collection);
     }


### PR DESCRIPTION
If you pass a collection to whereIn method like Model::whereIn('foo_bar', $collection) the query will have wrong results because the collection is transformed to a multidimensional array. (to much bindings)

This pull request will transform an eloquent collection to an array of primary keys of the models. Normal collections will not be transformed because there is no known primary key.

This should not be a breaking change, at the moment this doesn't work and you need to use $collection->modelKeys() oder ->pluck() manually.

