### PR TITLE
[5.7] Add Model to sync & syncWithoutDetaching docblocks

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -64,7 +64,7 @@ trait InteractsWithPivotTable
     /**
      * Sync the intermediate tables with a list of IDs without detaching.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\Collection|array  $ids
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\Collection|array|Model  $ids
      * @return array
      */
     public function syncWithoutDetaching($ids)
@@ -75,7 +75,7 @@ trait InteractsWithPivotTable
     /**
      * Sync the intermediate tables with a list of IDs or collection of models.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\Collection|array  $ids
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\Collection|array|Model  $ids
      * @param  bool   $detaching
      * @return array
      */


### PR DESCRIPTION
Both methods internally use the `parseIds` method which, unless extended by a model, handles a `Model`.  Since these methods list out all of the supported argument types, list this alternative as well.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
