### PR TITLE
[5.7] Changing the Migrator to accept not only migration directory paths, but migration file paths too

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -428,7 +428,7 @@ class Migrator
     public function getMigrationFiles($paths)
     {
         return Collection::make($paths)->flatMap(function ($path) {
-            return $this->files->glob($path.'/*_*.php');
+            return ends_with($path, '.php') ? [$path] : $this->files->glob($path.'/*_*.php');
         })->filter()->sortBy(function ($file) {
             return $this->getMigrationName($file);
         })->values()->keyBy(function ($file) {


### PR DESCRIPTION
Hi!

First of all, thanks for such a great framework. I did a small one-line-change that I believe that may be useful for other folks too.

I changed the way the method `Illuminate\Database\Migrations\Migrator::getMigrations` flatMap the array of paths, by considering checking for file paths and not only assuming directory paths.

Initially I made this change because I maintain an app that has migrations inside different folders (separated by modules), so I had to edit the way the migrations is runned (to not run into an out-of-sequence-migration problem) by a third-party package command (`tenant:migrate` - [you can see the PR by clicking here](https://github.com/hyn/multi-tenant/pull/678))

