### PR TITLE
[5.8] Remove unused method parameter in cookie serialization

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -100,7 +100,7 @@ class EncryptCookies
     {
         return is_array($cookie)
                         ? $this->decryptArray($cookie)
-                        : $this->encrypter->decrypt($cookie, static::serialized($name));
+                        : $this->encrypter->decrypt($cookie, static::serialized());
     }
 
     /**
@@ -115,7 +115,7 @@ class EncryptCookies
 
         foreach ($cookie as $key => $value) {
             if (is_string($value)) {
-                $decrypted[$key] = $this->encrypter->decrypt($value, static::serialized($key));
+                $decrypted[$key] = $this->encrypter->decrypt($value, static::serialized());
             }
         }
 
@@ -136,7 +136,7 @@ class EncryptCookies
             }
 
             $response->headers->setCookie($this->duplicate(
-                $cookie, $this->encrypter->encrypt($cookie->getValue(), static::serialized($cookie->getName()))
+                $cookie, $this->encrypter->encrypt($cookie->getValue(), static::serialized())
             ));
         }
 
@@ -173,10 +173,9 @@ class EncryptCookies
     /**
      * Determine if the cookie contents should be serialized.
      *
-     * @param  string  $name
      * @return bool
      */
-    public static function serialized($name)
+    public static function serialized()
     {
         return static::$serialize;
     }

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -194,6 +194,6 @@ class VerifyCsrfToken
      */
     public static function serialized()
     {
-        return EncryptCookies::serialized('XSRF-TOKEN');
+        return EncryptCookies::serialized();
     }
 }


### PR DESCRIPTION
It seems the `$name` parameter is never used when checking if cookies should be serialized or not.

Targeted this at `5.8` due to the method signature changing and it is not a bug in its self.

