### PR TITLE
[5.7] Update comment for on method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -427,9 +427,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public static function on($connection = null)
     {
-        // First we will just create a fresh instance of this model, and then we can
-        // set the connection on the model so that it is be used for the queries
-        // we execute, as well as being set on each relationship we retrieve.
+        // First we will just create a fresh instance of this model, and then we can set the
+        // connection on the model so that it is used for the queries we execute, as well
+        // as being set on every relation we retrieve without a custom connection name.
         $instance = new static;
 
         $instance->setConnection($connection);


### PR DESCRIPTION
This clarifies that connection will be set for any retrieved relation without a custom connection name. Without this it could be interpreted that every relationship will get the custom connection which isn't the case.

See https://github.com/laravel/framework/issues/24944#issuecomment-439912177
