### PR TITLE
[5.8] Release cache lock if callback fails

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -62,9 +62,11 @@ abstract class Lock implements LockContract
         $result = $this->acquire();
 
         if ($result && is_callable($callback)) {
-            return tap($callback(), function () {
+            try {
+                return $callback();
+            } finally {
                 $this->release();
-            });
+            }
         }
 
         return $result;


### PR DESCRIPTION
Currently if the callback passed to `Cache::lock()` fails then the lock isn't released. This can cause issues if the failure is temporary and the request is retried as the lock won't have been released.

To get around this all users of Cache::lock()` would have to wrap their code in a try-catch block, but it feels like this is something the framework should be taking care of.

I don't believe this is a breaking change but I've targeted it at master just in case.
