### PR TITLE
[5.8] Don't deprecate makeWith

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -590,8 +590,6 @@ class Container implements ContainerContract
      * @param  string  $abstract
      * @param  array  $parameters
      * @return mixed
-     *
-     * @deprecated The make() method should be used instead. Will be removed in Laravel 5.9.
      */
     public function makeWith($abstract, array $parameters = [])
     {


### PR DESCRIPTION
I'd like to propose that we **don't** deprecate `makeWith`. My reasoning is that there's no benefit from this deprecation as it's just an alias and therefore doesn't really reduce any feature maintenance or eliminates any technical debt. The `makeWith` is expressive, which is the Laravel differential, not to mention it's going to break people's application without any apparent benefit. It's a perfect commodity that helps the code reader to be aware that the request to the container explicitly overrides the auto wired or bound dependency injection.
I hope this can be reconsidered.