### PR TITLE
Allow PendingDispatch to be cancelled.

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -12,9 +12,9 @@ class PendingDispatch
      * @var mixed
      */
     protected $job;
-    
+
     /**
-     * Whether the dispatch has been cancelled
+     * Whether the dispatch has been cancelled.
      *
      * @var bool
      */
@@ -128,7 +128,7 @@ class PendingDispatch
      */
     public function __destruct()
     {
-        if(! $this->cancelled) {
+        if (! $this->cancelled) {
             app(Dispatcher::class)->dispatch($this->job);
         }
     }

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -12,6 +12,13 @@ class PendingDispatch
      * @var mixed
      */
     protected $job;
+    
+    /**
+     * Whether the dispatch has been cancelled
+     *
+     * @var bool
+     */
+    protected $cancelled = false;
 
     /**
      * Create a new pending job dispatch.
@@ -77,6 +84,18 @@ class PendingDispatch
     }
 
     /**
+     * Cancel the dispatch.
+     *
+     * @return $this
+     */
+    public function cancel()
+    {
+        $this->cancelled = true;
+
+        return $this;
+    }
+
+    /**
      * Set the desired delay for the job.
      *
      * @param  \DateTime|int|null  $delay
@@ -109,6 +128,8 @@ class PendingDispatch
      */
     public function __destruct()
     {
-        app(Dispatcher::class)->dispatch($this->job);
+        if(! $this->cancelled) {
+            app(Dispatcher::class)->dispatch($this->job);
+        }
     }
 }


### PR DESCRIPTION
Currently there is no way to cancel a pending dispatch.

This change allows a PendingDispatch to be cancelled before the application shuts down.
This is useful when queueing multiple (but still parallel - hence a chain is not appropriate) jobs but if one fails you don't want the others to be queued either.

```php
$jobs = collect();
try {
    foreach(getItemsFromSomewhere() as $item) {
        $jobs->push(SomeJob::dispatch($item));
    }
} catch (\Throwable $throwable) {
    $jobs->each->cancel();
    throw $throwable;
}
```

I have added no tests, as it appears that due to the simple nature of PendingDispatch it does not have any existing tests (if this is wrong please point me towards the current tests and I'll add a test).