### PR TITLE
[5.7] Fix self-referencing HasManyThrough existence queries

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -503,7 +503,7 @@ class HasManyThrough extends Relation
     {
         $query->from($query->getModel()->getTable().' as '.$hash = $this->getRelationCountHash());
 
-        $query->join($this->throughParent->getTable(), $this->getQualifiedParentKeyName(), '=', $hash.'.'.$this->secondLocalKey);
+        $query->join($this->throughParent->getTable(), $this->getQualifiedParentKeyName(), '=', $hash.'.'.$this->secondKey);
 
         if ($this->throughParentSoftDeletes()) {
             $query->whereNull($this->throughParent->getQualifiedDeletedAtColumn());

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -33,7 +33,7 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
     {
         $user = User::create(['name' => str_random()]);
 
-        $team1 = Team::create(['owner_id' => $user->id]);
+        $team1 = Team::create(['id' => 10, 'owner_id' => $user->id]);
         $team2 = Team::create(['owner_id' => $user->id]);
 
         $mate1 = User::create(['name' => str_random(), 'team_id' => $team1->id]);
@@ -127,5 +127,5 @@ class Team extends Model
 {
     public $table = 'teams';
     public $timestamps = false;
-    protected $guarded = ['id'];
+    protected $guarded = [];
 }


### PR DESCRIPTION
Existence queries of self-referencing `HasManyThrough` relationships are incorrect:

```php
class User extends Model {
    public function teamMates() {
        return $this->hasManyThrough(self::class, Team::class, 'owner_id');
    }
}

User::has('teamMates')->get();
```

```sql
# expected
select * from `users` where exists (
  select * from `users` as `laravel_reserved_0`
  inner join `teams` on `teams`.`id` = `laravel_reserved_0`.`team_id`
  where `users`.`id` = `teams`.`owner_id`
)

# actual
select * from `users` where exists (
  select * from `users` as `laravel_reserved_0`
  inner join `teams` on `teams`.`id` = `laravel_reserved_0`.`id`
  where `users`.`id` = `teams`.`owner_id`                    ^^
)
```

The tests didn't catch this because all the models have the same ids `1` and `2`.