### PR TITLE
[5.7] add sortByIds method to eloquent collections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -197,6 +197,21 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Sort the collection using by primary key.
+     *
+     * @param array $ids
+     * @return static
+     */
+    public function sortByIds(array $ids)
+    {
+        $ids = array_flip($ids);
+
+        return $this->sort(function ($a, $b) use ($ids) {
+            return $ids[$a->getKey()] - $ids[$b->getKey()];
+        });
+    }
+
+    /**
      * Determine if a key exists in the collection.
      *
      * @param  mixed  $key

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -167,6 +167,22 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(['results'], $c->all());
     }
 
+    public function testCollectionSortByIds()
+    {
+        $one = m::mock(Model::class);
+        $one->shouldReceive('getKey')->andReturn(1);
+
+        $two = m::mock(Model::class);
+        $two->shouldReceive('getKey')->andReturn(2);
+
+        $three = m::mock(Model::class);
+        $three->shouldReceive('getKey')->andReturn(3);
+
+        $c = new Collection([$one, $two, $three]);
+
+        $this->assertEquals(new Collection([$two, $one, $three]), $c->sortByIds([2, 1, 3])->values());
+    }
+
     public function testCollectionDictionaryReturnsModelKeys()
     {
         $one = m::mock(Model::class);


### PR DESCRIPTION
This is a feature that is often needed in everyday coding.

We often get Eloquent ids from Redis or Elasticsearch, such as leaderboard,. At this point, we want to get the collection set with the same ID order.

```php
// id from Redis or Elasticsearch ...
$ids = [2, 1, 3]; 

// the data returned by mysql, sorted by id asc: [['id' => 1], ['id' => 2], ['id' => 3]]
$posts = Post::find($ids); 

// reorder by $ids  [1 => ['id' => 2], 0 => ['id' => 1], 2 => ['id' => 3]]
$posts = $posts->sortByIds($ids);
```