### PR TITLE
[5.8] Remove attributes property from TransformsRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
@@ -8,24 +8,14 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 class TransformsRequest
 {
     /**
-     * The additional attributes passed to the middleware.
-     *
-     * @var array
-     */
-    protected $attributes = [];
-
-    /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
-     * @param  array  ...$attributes
      * @return mixed
      */
-    public function handle($request, Closure $next, ...$attributes)
+    public function handle($request, Closure $next)
     {
-        $this->attributes = $attributes;
-
         $this->clean($request);
 
         return $next($request);

--- a/tests/Foundation/Http/Middleware/TransformsRequestTest.php
+++ b/tests/Foundation/Http/Middleware/TransformsRequestTest.php
@@ -100,6 +100,7 @@ class ManipulateInput extends TransformsRequest
         if ($key === 'beers') {
             $value++;
         }
+
         if ($key === 'age') {
             $value--;
         }
@@ -115,6 +116,7 @@ class ManipulateArrayInput extends TransformsRequest
         if (str_contains($key, 'beers')) {
             $value++;
         }
+
         if (str_contains($key, 'age')) {
             $value--;
         }


### PR DESCRIPTION
This served no purpose in the middleware. If people really need it they could add it in their own class.