### PR TITLE
[5.7] Remove container naming and use consistent naming

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -10,16 +10,16 @@ use Illuminate\Contracts\Support\Arrayable;
 class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
 {
     /**
-     * All of the attributes set on the container.
+     * All of the attributes set on the fluent instance.
      *
      * @var array
      */
     protected $attributes = [];
 
     /**
-     * Create a new fluent container instance.
+     * Create a new fluent instance.
      *
-     * @param  array|object    $attributes
+     * @param  array|object  $attributes
      * @return void
      */
     public function __construct($attributes = [])
@@ -30,7 +30,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Get an attribute from the container.
+     * Get an attribute from the fluent instance.
      *
      * @param  string  $key
      * @param  mixed   $default
@@ -46,7 +46,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Get the attributes from the container.
+     * Get the attributes from the fluent instance.
      *
      * @return array
      */
@@ -56,7 +56,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Convert the Fluent instance to an array.
+     * Convert the fluent instance to an array.
      *
      * @return array
      */
@@ -76,7 +76,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Convert the Fluent instance to JSON.
+     * Convert the fluent instance to JSON.
      *
      * @param  int  $options
      * @return string
@@ -132,7 +132,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Handle dynamic calls to the container to set attributes.
+     * Handle dynamic calls to the fluent instance to set attributes.
      *
      * @param  string  $method
      * @param  array   $parameters

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -51,7 +51,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     }
 
     /**
-     * Add a message to the bag.
+     * Add a message to the message bag.
      *
      * @param  string  $key
      * @param  string  $message
@@ -81,7 +81,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     }
 
     /**
-     * Merge a new array of messages into the bag.
+     * Merge a new array of messages into the message bag.
      *
      * @param  \Illuminate\Contracts\Support\MessageProvider|array  $messages
      * @return $this
@@ -140,7 +140,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     }
 
     /**
-     * Get the first message from the bag for a given key.
+     * Get the first message from the message bag for a given key.
      *
      * @param  string  $key
      * @param  string  $format
@@ -156,7 +156,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     }
 
     /**
-     * Get all of the messages from the bag for a given key.
+     * Get all of the messages from the message bag for a given key.
      *
      * @param  string  $key
      * @param  string  $format
@@ -164,9 +164,9 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     public function get($key, $format = null)
     {
-        // If the message exists in the container, we will transform it and return
-        // the message. Otherwise, we'll check if the key is implicit & collect
-        // all the messages that match a given key and output it as an array.
+        // If the message exists in the message bag, we will transform it and return
+        // the message. Otherwise, we will check if the key is implicit & collect
+        // all the messages that match the given key and output it as an array.
         if (array_key_exists($key, $this->messages)) {
             return $this->transform(
                 $this->messages[$key], $this->checkFormat($format), $key
@@ -201,7 +201,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     }
 
     /**
-     * Get all of the messages for every key in the bag.
+     * Get all of the messages for every key in the message bag.
      *
      * @param  string  $format
      * @return array
@@ -220,7 +220,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     }
 
     /**
-     * Get all of the unique messages for every key in the bag.
+     * Get all of the unique messages for every key in the message bag.
      *
      * @param  string  $format
      * @return array
@@ -261,7 +261,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     }
 
     /**
-     * Get the raw messages in the container.
+     * Get the raw messages in the message bag.
      *
      * @return array
      */
@@ -271,7 +271,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     }
 
     /**
-     * Get the raw messages in the container.
+     * Get the raw messages in the message bag.
      *
      * @return array
      */
@@ -344,7 +344,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     }
 
     /**
-     * Get the number of messages in the container.
+     * Get the number of messages in the message bag.
      *
      * @return int
      */


### PR DESCRIPTION
I removed the container namings in the Fluent and MessageBag classes because they don't make sense here. I think these are leftovers from a previous refactor.

I also made sure that the other namings are consistent in these classes.