### PR TITLE
[5.8] Safe Email Verification

### DIFF
--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -35,4 +35,14 @@ trait MustVerifyEmail
     {
         $this->notify(new Notifications\VerifyEmail);
     }
+
+    /**
+     * Get the email key for the model.
+     *
+     * @return string
+     */
+    public function getEmailFieldName()
+    {
+        return 'email';
+    }
 }

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -59,7 +59,10 @@ class VerifyEmail extends Notification
     protected function verificationUrl($notifiable)
     {
         return URL::temporarySignedRoute(
-            'verification.verify', Carbon::now()->addMinutes(60), ['id' => $notifiable->getKey()]
+            'verification.verify', Carbon::now()->addMinutes(60), [
+                'id' => $notifiable->getKey(),
+                $notifiable->getEmailFieldName() => $notifiable->routeNotificationFor('mail', $this),
+            ]
         );
     }
 

--- a/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
@@ -24,4 +24,11 @@ interface MustVerifyEmail
      * @return void
      */
     public function sendEmailVerificationNotification();
+
+    /**
+     * Get the email key for the model.
+     *
+     * @return string
+     */
+    public function getEmailFieldName();
 }

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -32,7 +32,12 @@ trait VerifiesEmails
      */
     public function verify(Request $request)
     {
-        if ($request->route('id') != $request->user()->getKey()) {
+        $emailFieldName = $request->user()->getEmailFieldName();
+
+        if (
+            $request->route('id') != $request->user()->getKey()
+            || $request->user()->getAttribute($emailFieldName) !== $request->query($emailFieldName)
+        ) {
             throw new AuthorizationException;
         }
 


### PR DESCRIPTION
A problem in current email verification behavior:
Application generates signed url based on user id and send it to a current user email.
If we change the user email, previous email verification link will be still valid. Following it, a new user email will be verified.
So, we should check - if a verification request is really for current user email?

Haven't found any integration tests for current verification process. Maybe it should be done?
And probably it should be fixed for 5.7