### PR TITLE
[5.7] Fix HasManyThrough existence queries with same parent and through parent table

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -480,8 +480,12 @@ class HasManyThrough extends Relation
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
-        if ($parentQuery->getQuery()->from == $query->getQuery()->from) {
+        if ($parentQuery->getQuery()->from === $query->getQuery()->from) {
             return $this->getRelationExistenceQueryForSelfRelation($query, $parentQuery, $columns);
+        }
+
+        if ($parentQuery->getQuery()->from === $this->throughParent->getTable()) {
+            return $this->getRelationExistenceQueryForThroughSelfRelation($query, $parentQuery, $columns);
         }
 
         $this->performJoin($query);
@@ -513,6 +517,29 @@ class HasManyThrough extends Relation
 
         return $query->select($columns)->whereColumn(
             $parentQuery->getQuery()->from.'.'.$this->localKey, '=', $this->getQualifiedFirstKeyName()
+        );
+    }
+
+    /**
+     * Add the constraints for a relationship query on the same table as the through parent.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $parentQuery
+     * @param  array|mixed  $columns
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function getRelationExistenceQueryForThroughSelfRelation(Builder $query, Builder $parentQuery, $columns = ['*'])
+    {
+        $table = $this->throughParent->getTable().' as '.$hash = $this->getRelationCountHash();
+
+        $query->join($table, $hash.'.'.$this->secondLocalKey, '=', $this->getQualifiedFarKeyName());
+
+        if ($this->throughParentSoftDeletes()) {
+            $query->whereNull($hash.'.'.$this->throughParent->getDeletedAtColumn());
+        }
+
+        return $query->select($columns)->whereColumn(
+            $parentQuery->getQuery()->from.'.'.$this->localKey, '=', $hash.'.'.$this->firstKey
         );
     }
 


### PR DESCRIPTION
Laravel already supports self-referencing `HasManyThrough` relationships with the same parent and related model (#26662).

This PR adds support for relationships with the same parent and *through parent* model:

```php
class Category extends Model {
    public function subProducts() {
        return $this->hasManyThrough(Product::class, self::class, 'parent_id');
    }
}

Category::has('subProducts')->get();
```

In existence/`withCount()` queries, we have to alias the through parent table:

```sql
# expected
select * from `categories` where exists (
  select * from `products`
  inner join `categories` as `laravel_reserved_0`
  on `laravel_reserved_0`.`id` = `products`.`category_id`
  where `categories`.`id` = `laravel_reserved_0`.`parent_id`
)

# actual
select * from `categories` where exists (
  select * from `products`
  inner join `categories`
  on `categories`.`id` = `products`.`category_id`
  where `categories`.`id` = `categories`.`parent_id`
)

```

Fixes #26623.