### PR TITLE
[5.8] Improved naming convention consistency

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -51,13 +51,14 @@ class BelongsTo extends Relation
      * @param  \Illuminate\Database\Eloquent\Model  $child
      * @param  string  $foreignKey
      * @param  string  $ownerKey
-     * @param  string  $relation
+     * @param  string  $relationName
+     *
      * @return void
      */
-    public function __construct(Builder $query, Model $child, $foreignKey, $ownerKey, $relation)
+    public function __construct(Builder $query, Model $child, $foreignKey, $ownerKey, $relationName)
     {
         $this->ownerKey = $ownerKey;
-        $this->relationName = $relation;
+        $this->relationName = $relationName;
         $this->foreignKey = $foreignKey;
 
         // In the underlying base relationship class, this variable is referred to as

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -35,7 +35,7 @@ class BelongsTo extends Relation
      *
      * @var string
      */
-    protected $relation;
+    protected $relationName;
 
     /**
      * The count of self joins.
@@ -57,7 +57,7 @@ class BelongsTo extends Relation
     public function __construct(Builder $query, Model $child, $foreignKey, $ownerKey, $relation)
     {
         $this->ownerKey = $ownerKey;
-        $this->relation = $relation;
+        $this->relationName = $relation;
         $this->foreignKey = $foreignKey;
 
         // In the underlying base relationship class, this variable is referred to as
@@ -219,9 +219,9 @@ class BelongsTo extends Relation
         $this->child->setAttribute($this->foreignKey, $ownerKey);
 
         if ($model instanceof Model) {
-            $this->child->setRelation($this->relation, $model);
+            $this->child->setRelation($this->relationName, $model);
         } elseif ($this->child->isDirty($this->foreignKey)) {
-            $this->child->unsetRelation($this->relation);
+            $this->child->unsetRelation($this->relationName);
         }
 
         return $this->child;
@@ -236,7 +236,7 @@ class BelongsTo extends Relation
     {
         $this->child->setAttribute($this->foreignKey, null);
 
-        return $this->child->setRelation($this->relation, null);
+        return $this->child->setRelation($this->relationName, null);
     }
 
     /**
@@ -366,8 +366,8 @@ class BelongsTo extends Relation
      *
      * @return string
      */
-    public function getRelation()
+    public function getRelationName()
     {
-        return $this->relation;
+        return $this->relationName;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -181,7 +181,7 @@ class MorphTo extends BelongsTo
 
             if (isset($this->dictionary[$type][$ownerKey])) {
                 foreach ($this->dictionary[$type][$ownerKey] as $model) {
-                    $model->setRelation($this->relation, $result);
+                    $model->setRelation($this->relationName, $result);
                 }
             }
         }
@@ -203,7 +203,7 @@ class MorphTo extends BelongsTo
             $this->morphType, $model instanceof Model ? $model->getMorphClass() : null
         );
 
-        return $this->parent->setRelation($this->relation, $model);
+        return $this->parent->setRelation($this->relationName, $model);
     }
 
     /**
@@ -217,7 +217,7 @@ class MorphTo extends BelongsTo
 
         $this->parent->setAttribute($this->morphType, null);
 
-        return $this->parent->setRelation($this->relation, null);
+        return $this->parent->setRelation($this->relationName, null);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -153,7 +153,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation = $this->getRelation($parent);
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
         $parent->shouldReceive('isDirty')->once()->andReturn(true);
-        $parent->shouldReceive('unsetRelation')->once()->with($relation->getRelation());
+        $parent->shouldReceive('unsetRelation')->once()->with($relation->getRelationName());
         $relation->associate(1);
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1090,7 +1090,7 @@ class DatabaseEloquentModelTest extends TestCase
         $relation = $model->morphToStub();
         $this->assertEquals('morph_to_stub_id', $relation->getForeignKeyName());
         $this->assertEquals('morph_to_stub_type', $relation->getMorphType());
-        $this->assertEquals('morphToStub', $relation->getRelation());
+        $this->assertEquals('morphToStub', $relation->getRelationName());
         $this->assertSame($model, $relation->getParent());
         $this->assertInstanceOf(EloquentModelSaveStub::class, $relation->getQuery()->getModel());
 
@@ -1098,19 +1098,19 @@ class DatabaseEloquentModelTest extends TestCase
         $relation2 = $model->morphToStubWithKeys();
         $this->assertEquals('id', $relation2->getForeignKeyName());
         $this->assertEquals('type', $relation2->getMorphType());
-        $this->assertEquals('morphToStubWithKeys', $relation2->getRelation());
+        $this->assertEquals('morphToStubWithKeys', $relation2->getRelationName());
 
         // $this->morphTo('someName');
         $relation3 = $model->morphToStubWithName();
         $this->assertEquals('some_name_id', $relation3->getForeignKeyName());
         $this->assertEquals('some_name_type', $relation3->getMorphType());
-        $this->assertEquals('someName', $relation3->getRelation());
+        $this->assertEquals('someName', $relation3->getRelationName());
 
         // $this->morphTo('someName', 'type', 'id');
         $relation4 = $model->morphToStubWithNameAndKeys();
         $this->assertEquals('id', $relation4->getForeignKeyName());
         $this->assertEquals('type', $relation4->getMorphType());
-        $this->assertEquals('someName', $relation4->getRelation());
+        $this->assertEquals('someName', $relation4->getRelationName());
     }
 
     public function testBelongsToManyCreatesProperRelation()


### PR DESCRIPTION
This is similar to #26374
> Added `Name` as the suffix to clarify that it's the "key" but not the "value" of the "key".

it should align to:
https://github.com/laravel/framework/blob/5.7/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php#L1069-L1072

Also, the method `relation` actually override it's parent's one, which can cause problem when some one wants to call it's parent's `relation` method.

I'm not sure if the `relationName` should be implemented in all the Relation classes, but at least it should keep the naming convention consistency.
By the way, I have a use case when calling the `\Illuminate\Database\Eloquent\Builder::whereHas` method, because I'm getting the relation name programmatically if all Relation classes implement this `relationName` can be very helpful(it's really tricky to get the relation name from the relation object itself).