### PR TITLE
[5.7] Prevent php int overflow when use int or intval method when use eloquent offset method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1855,7 +1855,7 @@ class Builder
     {
         $property = $this->unions ? 'unionOffset' : 'offset';
 
-        $this->$property = max(0, $value);
+        $this->$property = min(max(0, $value), \PHP_INT_MAX);
 
         return $this;
     }


### PR DESCRIPTION
when use eloquent builder `offset` method

```
public function offset($value)
{
        $property = $this->unions ? 'unionOffset' : 'offset';

        $this->$property = max(0, $value);

        return $this;
}
```

If the $value overflow PHP_INT_MAX, when compileOffset in query grammar :
```
protected function compileOffset(Builder $query, $offset)
{
        return 'offset '.(int) $offset;
}
```

The `(int)` or `intval` method will lead the `$offset` to be a negative number which will cause sql error :
```
"SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-4571153621781053440' at line 1 (SQL: select `id` from `table` where `table`.`deleted_at` is null order by `id` desc limit 9223372036854775807 offset -4571153621781053440)",
```
By add `min` method get PHP_INT_MAX.

This is only occur for extreme case.
