### PR TITLE
[5.7] Allow to test count of sent and queued mailables of any type

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -50,6 +50,20 @@ class MailFake implements Mailer, MailQueue
     }
 
     /**
+     * Assert if there is given number of sent mailables.
+     *
+     * @param  int  $times
+     * @return void
+     */
+    public function assertSentCount($times)
+    {
+        PHPUnit::assertTrue(
+            ($count = count($this->mailables)) === $times,
+            "Mailables were sent {$count} times instead of {$times} times."
+        );
+    }
+
+    /**
      * Assert if a mailable was sent a number of times.
      *
      * @param  string  $mailable
@@ -105,6 +119,20 @@ class MailFake implements Mailer, MailQueue
         PHPUnit::assertTrue(
             $this->queued($mailable, $callback)->count() > 0,
             "The expected [{$mailable}] mailable was not queued."
+        );
+    }
+
+    /**
+     * Assert if there is given number of queued mailables.
+     *
+     * @param  int  $times
+     * @return void
+     */
+    public function assertQueuedCount($times)
+    {
+        PHPUnit::assertTrue(
+            ($count = count($this->queuedMailables)) === $times,
+            "Mailables were queued {$count} times instead of {$times} times."
         );
     }
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -139,6 +139,44 @@ class SupportTestingMailFakeTest extends TestCase
             $this->assertThat($e, new ExceptionMessage('Mailables were sent unexpectedly.'));
         }
     }
+
+    public function testAssertSentCount()
+    {
+        $this->fake->assertSentCount(0);
+
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertSentCount(1);
+
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertSentCount(2);
+
+        try {
+            $this->fake->assertSentCount(3);
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('Mailables were sent 2 times instead of 3 times.'));
+        }
+    }
+
+    public function testAssertQueuedCount()
+    {
+        $this->fake->assertQueuedCount(0);
+
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+
+        $this->fake->assertQueuedCount(1);
+
+        $this->fake->to('taylor@laravel.com')->send(new QueueableMailableStub());
+
+        $this->fake->assertQueuedCount(2);
+
+        try {
+            $this->fake->assertQueuedCount(3);
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('Mailables were queued 2 times instead of 3 times.'));
+        }
+    }
 }
 
 class MailableStub extends Mailable


### PR DESCRIPTION
This PR adds possibility to test count of sent/queued mailables no matter of their type.

Although it was possible to test count of given type of mailables  for example: `assertSent(Mailable::class, 2)` I believe so far it was not possible to test count of all mailables no matter of type and it's useful in case you sent multiple types of mailable using some conditions.