### PR TITLE
[5.7] Add one query MAX_EXECUTION_TIME for mysql 5.7.8+

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -195,6 +195,12 @@ class Builder
     public $useWritePdo = false;
 
     /**
+     * Limits statement execution time ,can timeout by db serve
+     * @var int
+     */
+    public $maxExecutionTime = 0;
+
+    /**
      * Create a new query builder instance.
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection
@@ -2894,6 +2900,22 @@ class Builder
             }
         });
     }
+
+    /**
+     * set the  MAX_EXECUTION_TIME(ms) for query ,it effect  after mysql5.7.8
+     *
+     * @param int $maxExecutionTime
+     * @return $this
+     */
+    public function setMaxExecutionTime(int $maxExecutionTime=0){
+        if($maxExecutionTime>0){
+            $this->maxExecutionTime = $maxExecutionTime;
+        }else{
+            $this->maxExecutionTime = 0;
+        }
+        return $this;
+    }
+
 
     /**
      * Handle dynamic method calls into the method.

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -110,6 +110,21 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->distinct()->select('foo', 'bar')->from('users');
         $this->assertEquals('select distinct "foo", "bar" from "users"', $builder->toSql());
     }
+    
+    
+    public function testMysqlSelectMaxExecutionTime(){
+        $builder = $this->getMySqlBuilder();
+        $builder->setMaxExecutionTime(10000)->select('foo', 'bar')->from('users');
+        $this->assertEquals('select /*+ MAX_EXECUTION_TIME(10000) */ `foo`, `bar` from `users`', $builder->toSql());
+    }
+
+    public function testMysqlSelectDistinctMaxExecutionTime(){
+        $builder = $this->getMySqlBuilder();
+        $builder->distinct()->setMaxExecutionTime(10000)->select('foo', 'bar')->from('users');
+        $this->assertEquals('select /*+ MAX_EXECUTION_TIME(10000) */ distinct `foo`, `bar` from `users`', $builder->toSql());
+    }
+
+    
 
     public function testBasicAlias()
     {


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
sometimes  php script timeout ,but the query for db server  still running , that bring too much load or read-write to the mysql server,   the mysql5.7.8+ add the MAX_EXECUTION_TIME for select can timeout query by mysql server 

https://dev.mysql.com/doc/refman/5.7/en/optimizer-hints.html#optimizer-hints-execution-time
