### PR TITLE
[5.7] Honor PSR-16 SimpleCache interface

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -56,11 +56,11 @@ class ApcStore extends TaggableStore implements Store
      * @param  string  $key
      * @param  mixed   $value
      * @param  float|int  $minutes
-     * @return void
+     * @return bool
      */
     public function put($key, $value, $minutes)
     {
-        $this->apc->put($this->prefix.$key, $value, (int) ($minutes * 60));
+        return $this->apc->put($this->prefix.$key, $value, (int) ($minutes * 60));
     }
 
     /**
@@ -92,11 +92,11 @@ class ApcStore extends TaggableStore implements Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return void
+     * @return bool
      */
     public function forever($key, $value)
     {
-        $this->put($key, $value, 0);
+        return $this->put($key, $value, 0);
     }
 
     /**

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -38,7 +38,7 @@ class ArrayStore extends TaggableStore implements Store
     {
         $this->storage[$key] = $value;
 
-        return array_key_exists($key, $this->storage);
+        return true;
     }
 
     /**

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -32,11 +32,13 @@ class ArrayStore extends TaggableStore implements Store
      * @param  string  $key
      * @param  mixed   $value
      * @param  float|int  $minutes
-     * @return void
+     * @return bool
      */
     public function put($key, $value, $minutes)
     {
         $this->storage[$key] = $value;
+
+        return array_key_exists($key, $this->storage);
     }
 
     /**
@@ -71,11 +73,11 @@ class ArrayStore extends TaggableStore implements Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return void
+     * @return bool
      */
     public function forever($key, $value)
     {
-        $this->put($key, $value, 0);
+        return $this->put($key, $value, 0);
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -103,6 +103,7 @@ class DatabaseStore implements Store
             return $this->table()->insert(compact('key', 'value', 'expiration'));
         } catch (Exception $e) {
             $result = $this->table()->where('key', $key)->update(compact('value', 'expiration'));
+
             return $result > 0;
         }
     }

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -102,7 +102,8 @@ class DatabaseStore implements Store
         try {
             return $this->table()->insert(compact('key', 'value', 'expiration'));
         } catch (Exception $e) {
-            return $this->table()->where('key', $key)->update(compact('value', 'expiration'));
+            $result = $this->table()->where('key', $key)->update(compact('value', 'expiration'));
+            return $result > 0;
         }
     }
 

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -89,7 +89,7 @@ class DatabaseStore implements Store
      * @param  string  $key
      * @param  mixed   $value
      * @param  float|int  $minutes
-     * @return void
+     * @return bool
      */
     public function put($key, $value, $minutes)
     {
@@ -100,9 +100,9 @@ class DatabaseStore implements Store
         $expiration = $this->getTime() + (int) ($minutes * 60);
 
         try {
-            $this->table()->insert(compact('key', 'value', 'expiration'));
+            return $this->table()->insert(compact('key', 'value', 'expiration'));
         } catch (Exception $e) {
-            $this->table()->where('key', $key)->update(compact('value', 'expiration'));
+            return $this->table()->where('key', $key)->update(compact('value', 'expiration'));
         }
     }
 
@@ -196,11 +196,11 @@ class DatabaseStore implements Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return void
+     * @return bool
      */
     public function forever($key, $value)
     {
-        $this->put($key, $value, 5256000);
+        return $this->put($key, $value, 5256000);
     }
 
     /**

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -55,15 +55,17 @@ class FileStore implements Store
      * @param  string  $key
      * @param  mixed   $value
      * @param  float|int  $minutes
-     * @return void
+     * @return bool
      */
     public function put($key, $value, $minutes)
     {
         $this->ensureCacheDirectoryExists($path = $this->path($key));
 
-        $this->files->put(
+        $result = $this->files->put(
             $path, $this->expiration($minutes).serialize($value), true
         );
+
+        return $result !== false && $result > 0;
     }
 
     /**
@@ -112,11 +114,11 @@ class FileStore implements Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return void
+     * @return bool
      */
     public function forever($key, $value)
     {
-        $this->put($key, $value, 0);
+        return $this->put($key, $value, 0);
     }
 
     /**

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -106,11 +106,11 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
      * @param  string  $key
      * @param  mixed   $value
      * @param  float|int  $minutes
-     * @return void
+     * @return bool
      */
     public function put($key, $value, $minutes)
     {
-        $this->memcached->set(
+        return $this->memcached->set(
             $this->prefix.$key, $value, $this->calculateExpiration($minutes)
         );
     }
@@ -120,7 +120,7 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
      *
      * @param  array  $values
      * @param  float|int  $minutes
-     * @return void
+     * @return bool
      */
     public function putMany(array $values, $minutes)
     {
@@ -130,7 +130,7 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
             $prefixedValues[$this->prefix.$key] = $value;
         }
 
-        $this->memcached->setMulti(
+        return $this->memcached->setMulti(
             $prefixedValues, $this->calculateExpiration($minutes)
         );
     }
@@ -179,11 +179,11 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return void
+     * @return bool
      */
     public function forever($key, $value)
     {
-        $this->put($key, $value, 0);
+        return $this->put($key, $value, 0);
     }
 
     /**

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -23,7 +23,7 @@ class NullStore extends TaggableStore implements Store
      */
     public function get($key)
     {
-        //
+        return null;
     }
 
     /**
@@ -32,11 +32,11 @@ class NullStore extends TaggableStore implements Store
      * @param  string  $key
      * @param  mixed   $value
      * @param  float|int  $minutes
-     * @return void
+     * @return bool
      */
     public function put($key, $value, $minutes)
     {
-        //
+        return false;
     }
 
     /**
@@ -68,22 +68,22 @@ class NullStore extends TaggableStore implements Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return void
+     * @return bool
      */
     public function forever($key, $value)
     {
-        //
+        return false;
     }
 
     /**
      * Remove an item from the cache.
      *
      * @param  string  $key
-     * @return void
+     * @return bool
      */
     public function forget($key)
     {
-        //
+        return true;
     }
 
     /**

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -85,13 +85,15 @@ class RedisStore extends TaggableStore implements Store
      * @param  string  $key
      * @param  mixed   $value
      * @param  float|int  $minutes
-     * @return void
+     * @return bool
      */
     public function put($key, $value, $minutes)
     {
-        $this->connection()->setex(
+        $result = $this->connection()->setex(
             $this->prefix.$key, (int) max(1, $minutes * 60), $this->serialize($value)
         );
+
+        return $result ? true : false;
     }
 
     /**
@@ -99,17 +101,21 @@ class RedisStore extends TaggableStore implements Store
      *
      * @param  array  $values
      * @param  float|int  $minutes
-     * @return void
+     * @return bool
      */
     public function putMany(array $values, $minutes)
     {
         $this->connection()->multi();
 
+        $resultMany = null;
         foreach ($values as $key => $value) {
-            $this->put($key, $value, $minutes);
+            $result = $this->put($key, $value, $minutes);
+            $resultMany = is_null($resultMany) ? $result : $result && $resultMany;
         }
 
         $this->connection()->exec();
+
+        return $resultMany ?: false;
     }
 
     /**
@@ -158,11 +164,13 @@ class RedisStore extends TaggableStore implements Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return void
+     * @return bool
      */
     public function forever($key, $value)
     {
-        $this->connection()->set($this->prefix.$key, $this->serialize($value));
+        $result = $this->connection()->set($this->prefix.$key, $this->serialize($value));
+
+        return $result ? true : false;
     }
 
     /**

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -23,13 +23,13 @@ class RedisTaggedCache extends TaggedCache
      * @param  string  $key
      * @param  mixed   $value
      * @param  \DateTime|float|int|null  $minutes
-     * @return void
+     * @return bool
      */
     public function put($key, $value, $minutes = null)
     {
         $this->pushStandardKeys($this->tags->getNamespace(), $key);
 
-        parent::put($key, $value, $minutes);
+        return parent::put($key, $value, $minutes);
     }
 
     /**
@@ -65,13 +65,13 @@ class RedisTaggedCache extends TaggedCache
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return void
+     * @return bool
      */
     public function forever($key, $value)
     {
         $this->pushForeverKeys($this->tags->getNamespace(), $key);
 
-        parent::forever($key, $value);
+        return parent::forever($key, $value);
     }
 
     /**

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -207,7 +207,9 @@ class Repository implements CacheContract, ArrayAccess
         if (! is_null($minutes = $this->getMinutes($minutes))) {
             $result = $this->store->put($this->itemKey($key), $value, $minutes);
 
-            $this->event(new KeyWritten($key, $value, $minutes));
+            if ($result) {
+                $this->event(new KeyWritten($key, $value, $minutes));
+            }
 
             return $result;
         }
@@ -235,8 +237,10 @@ class Repository implements CacheContract, ArrayAccess
         if (! is_null($minutes = $this->getMinutes($minutes))) {
             $result = $this->store->putMany($values, $minutes);
 
-            foreach ($values as $key => $value) {
-                $this->event(new KeyWritten($key, $value, $minutes));
+            if ($result) {
+                foreach ($values as $key => $value) {
+                    $this->event(new KeyWritten($key, $value, $minutes));
+                }
             }
 
             return $result;

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -327,7 +327,9 @@ class Repository implements CacheContract, ArrayAccess
     {
         $result = $this->store->forever($this->itemKey($key), $value);
 
-        $this->event(new KeyWritten($key, $value, 0));
+        if ($result) {
+            $this->event(new KeyWritten($key, $value, 0));
+        }
 
         return $result;
     }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -194,21 +194,25 @@ class Repository implements CacheContract, ArrayAccess
      * @param  string  $key
      * @param  mixed   $value
      * @param  \DateTimeInterface|\DateInterval|float|int|null  $minutes
-     * @return void
+     * @return bool
      */
     public function put($key, $value, $minutes = null)
     {
         if (is_array($key)) {
-            $this->putMany($key, $value);
+            $result = $this->putMany($key, $value);
 
-            return;
+            return $result;
         }
 
         if (! is_null($minutes = $this->getMinutes($minutes))) {
-            $this->store->put($this->itemKey($key), $value, $minutes);
+            $result = $this->store->put($this->itemKey($key), $value, $minutes);
 
             $this->event(new KeyWritten($key, $value, $minutes));
+
+            return $result;
         }
+
+        return false;
     }
 
     /**
@@ -216,7 +220,7 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function set($key, $value, $ttl = null)
     {
-        $this->put($key, $value, $ttl);
+        return $this->put($key, $value, $ttl);
     }
 
     /**
@@ -224,17 +228,21 @@ class Repository implements CacheContract, ArrayAccess
      *
      * @param  array  $values
      * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
-     * @return void
+     * @return bool
      */
     public function putMany(array $values, $minutes)
     {
         if (! is_null($minutes = $this->getMinutes($minutes))) {
-            $this->store->putMany($values, $minutes);
+            $result = $this->store->putMany($values, $minutes);
 
             foreach ($values as $key => $value) {
                 $this->event(new KeyWritten($key, $value, $minutes));
             }
+
+            return $result;
         }
+
+        return false;
     }
 
     /**
@@ -242,7 +250,7 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function setMultiple($values, $ttl = null)
     {
-        $this->putMany($values, $ttl);
+        return $this->putMany($values, $ttl);
     }
 
     /**
@@ -309,13 +317,15 @@ class Repository implements CacheContract, ArrayAccess
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return void
+     * @return bool
      */
     public function forever($key, $value)
     {
-        $this->store->forever($this->itemKey($key), $value);
+        $result = $this->store->forever($this->itemKey($key), $value);
 
         $this->event(new KeyWritten($key, $value, 0));
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Cache/RetrievesMultipleKeys.php
+++ b/src/Illuminate/Cache/RetrievesMultipleKeys.php
@@ -28,12 +28,16 @@ trait RetrievesMultipleKeys
      *
      * @param  array  $values
      * @param  float|int  $minutes
-     * @return void
+     * @return bool
      */
     public function putMany(array $values, $minutes)
     {
+        $resultMany = null;
         foreach ($values as $key => $value) {
-            $this->put($key, $value, $minutes);
+            $result = $this->put($key, $value, $minutes);
+            $resultMany = is_null($resultMany) ? $result : $result && $resultMany;
         }
+
+        return $resultMany ?: false;
     }
 }

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -39,7 +39,7 @@ interface Repository extends CacheInterface
      * @param  string  $key
      * @param  mixed   $value
      * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
-     * @return void
+     * @return bool
      */
     public function put($key, $value, $minutes);
 
@@ -76,7 +76,7 @@ interface Repository extends CacheInterface
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return void
+     * @return bool
      */
     public function forever($key, $value);
 

--- a/src/Illuminate/Contracts/Cache/Store.php
+++ b/src/Illuminate/Contracts/Cache/Store.php
@@ -28,7 +28,7 @@ interface Store
      * @param  string  $key
      * @param  mixed  $value
      * @param  float|int  $minutes
-     * @return void
+     * @return bool
      */
     public function put($key, $value, $minutes);
 
@@ -37,7 +37,7 @@ interface Store
      *
      * @param  array  $values
      * @param  float|int  $minutes
-     * @return void
+     * @return bool
      */
     public function putMany(array $values, $minutes);
 
@@ -64,7 +64,7 @@ interface Store
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return void
+     * @return bool
      */
     public function forever($key, $value);
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -115,7 +115,7 @@ class Filesystem
      * @param  string  $path
      * @param  string  $contents
      * @param  bool  $lock
-     * @return int
+     * @return int|bool
      */
     public function put($path, $contents, $lock = false)
     {

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -43,9 +43,12 @@ class CacheApcStoreTest extends TestCase
     public function testSetMethodProperlyCallsAPC()
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['put'])->getMock();
-        $apc->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60));
+        $apc->expects($this->once())
+            ->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60))
+            ->willReturn(true);
         $store = new ApcStore($apc);
-        $store->put('foo', 'bar', 1);
+        $result = $store->put('foo', 'bar', 1);
+        $this->assertTrue($result);
     }
 
     public function testSetMultipleMethodProperlyCallsAPC()
@@ -57,13 +60,14 @@ class CacheApcStoreTest extends TestCase
             $this->equalTo('baz'), $this->equalTo('qux'), $this->equalTo(60),
         ], [
             $this->equalTo('bar'), $this->equalTo('norf'), $this->equalTo(60),
-        ]);
+        ])->willReturn(true);
         $store = new ApcStore($apc);
-        $store->putMany([
+        $result = $store->putMany([
             'foo'   => 'bar',
             'baz'   => 'qux',
             'bar'   => 'norf',
         ], 1);
+        $this->assertTrue($result);
     }
 
     public function testIncrementMethodProperlyCallsAPC()
@@ -85,17 +89,21 @@ class CacheApcStoreTest extends TestCase
     public function testStoreItemForeverProperlyCallsAPC()
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['put'])->getMock();
-        $apc->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0));
+        $apc->expects($this->once())
+            ->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0))
+            ->willReturn(true);
         $store = new ApcStore($apc);
-        $store->forever('foo', 'bar');
+        $result = $store->forever('foo', 'bar');
+        $this->assertTrue($result);
     }
 
     public function testForgetMethodProperlyCallsAPC()
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['delete'])->getMock();
-        $apc->expects($this->once())->method('delete')->with($this->equalTo('foo'));
+        $apc->expects($this->once())->method('delete')->with($this->equalTo('foo'))->willReturn(true);
         $store = new ApcStore($apc);
-        $store->forget('foo');
+        $result = $store->forget('foo');
+        $this->assertTrue($result);
     }
 
     public function testFlushesCached()

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -10,18 +10,21 @@ class CacheArrayStoreTest extends TestCase
     public function testItemsCanBeSetAndRetrieved()
     {
         $store = new ArrayStore;
-        $store->put('foo', 'bar', 10);
+        $result = $store->put('foo', 'bar', 10);
+        $this->assertTrue($result);
         $this->assertEquals('bar', $store->get('foo'));
     }
 
     public function testMultipleItemsCanBeSetAndRetrieved()
     {
         $store = new ArrayStore;
-        $store->put('foo', 'bar', 10);
-        $store->putMany([
+        $result = $store->put('foo', 'bar', 10);
+        $resultMany = $store->putMany([
             'fizz'  => 'buz',
             'quz'   => 'baz',
         ], 10);
+        $this->assertTrue($result);
+        $this->assertTrue($resultMany);
         $this->assertEquals([
             'foo'   => 'bar',
             'fizz'  => 'buz',
@@ -33,8 +36,11 @@ class CacheArrayStoreTest extends TestCase
     public function testStoreItemForeverProperlyStoresInArray()
     {
         $mock = $this->getMockBuilder(ArrayStore::class)->setMethods(['put'])->getMock();
-        $mock->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0));
-        $mock->forever('foo', 'bar');
+        $mock->expects($this->once())
+            ->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0))
+            ->willReturn(true);
+        $result = $mock->forever('foo', 'bar');
+        $this->assertTrue($result);
     }
 
     public function testValuesCanBeIncremented()

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -69,9 +69,10 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->will($this->returnValue(1));
-        $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61]);
+        $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61])->andReturnTrue();
 
-        $store->put('foo', 'bar', 1);
+        $result = $store->put('foo', 'bar', 1);
+        $this->assertTrue($result);
     }
 
     public function testValueIsUpdatedWhenInsertThrowsException()
@@ -84,9 +85,10 @@ class CacheDatabaseStoreTest extends TestCase
             throw new Exception;
         });
         $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
-        $table->shouldReceive('update')->once()->with(['value' => serialize('bar'), 'expiration' => 61]);
+        $table->shouldReceive('update')->once()->with(['value' => serialize('bar'), 'expiration' => 61])->andReturnTrue();
 
-        $store->put('foo', 'bar', 1);
+        $result = $store->put('foo', 'bar', 1);
+        $this->assertTrue($result);
     }
 
     public function testValueIsInsertedOnPostgres()
@@ -95,16 +97,18 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->will($this->returnValue(1));
-        $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => base64_encode(serialize("\0")), 'expiration' => 61]);
+        $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => base64_encode(serialize("\0")), 'expiration' => 61])->andReturnTrue();
 
-        $store->put('foo', "\0", 1);
+        $result = $store->put('foo', "\0", 1);
+        $this->assertTrue($result);
     }
 
     public function testForeverCallsStoreItemWithReallyLongTime()
     {
         $store = $this->getMockBuilder(DatabaseStore::class)->setMethods(['put'])->setConstructorArgs($this->getMocks())->getMock();
-        $store->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(5256000));
-        $store->forever('foo', 'bar');
+        $store->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(5256000))->willReturn(true);
+        $result = $store->forever('foo', 'bar');
+        $this->assertTrue($result);
     }
 
     public function testItemsMayBeRemovedFromCache()

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -37,11 +37,13 @@ class CacheFileStoreTest extends TestCase
     {
         $files = $this->mockFilesystem();
         $hash = sha1('foo');
+        $contents = '0000000000';
         $full_dir = __DIR__.'/'.substr($hash, 0, 2).'/'.substr($hash, 2, 2);
         $files->expects($this->once())->method('makeDirectory')->with($this->equalTo($full_dir), $this->equalTo(0777), $this->equalTo(true));
-        $files->expects($this->once())->method('put')->with($this->equalTo($full_dir.'/'.$hash));
+        $files->expects($this->once())->method('put')->with($this->equalTo($full_dir.'/'.$hash))->willReturn(strlen($contents));
         $store = new FileStore($files, __DIR__);
-        $store->put('foo', '0000000000', 0);
+        $result = $store->put('foo', $contents, 0);
+        $this->assertTrue($result);
     }
 
     public function testExpiredItemsReturnNull()
@@ -72,8 +74,9 @@ class CacheFileStoreTest extends TestCase
         $contents = '1111111111'.serialize('Hello World');
         $hash = sha1('foo');
         $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
-        $files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash), $this->equalTo($contents));
-        $store->put('foo', 'Hello World', 10);
+        $files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash), $this->equalTo($contents))->willReturn(strlen($contents));
+        $result = $store->put('foo', 'Hello World', 10);
+        $this->assertTrue($result);
     }
 
     public function testForeversAreStoredWithHighTimestamp()
@@ -82,9 +85,10 @@ class CacheFileStoreTest extends TestCase
         $contents = '9999999999'.serialize('Hello World');
         $hash = sha1('foo');
         $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
-        $files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash), $this->equalTo($contents));
+        $files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash), $this->equalTo($contents))->willReturn(strlen($contents));
         $store = new FileStore($files, __DIR__);
-        $store->forever('foo', 'Hello World', 10);
+        $result = $store->forever('foo', 'Hello World', 10);
+        $this->assertTrue($result);
     }
 
     public function testForeversAreNotRemovedOnIncrement()

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -67,9 +67,10 @@ class CacheMemcachedStoreTest extends TestCase
 
         Carbon::setTestNow($now = Carbon::now());
         $memcache = $this->getMockBuilder(Memcached::class)->setMethods(['set'])->getMock();
-        $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo($now->timestamp + 60));
+        $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo($now->timestamp + 60))->willReturn(true);
         $store = new MemcachedStore($memcache);
-        $store->put('foo', 'bar', 1);
+        $result = $store->put('foo', 'bar', 1);
+        $this->assertTrue($result);
         Carbon::setTestNow();
     }
 
@@ -104,9 +105,10 @@ class CacheMemcachedStoreTest extends TestCase
         }
 
         $memcache = $this->getMockBuilder(Memcached::class)->setMethods(['set'])->getMock();
-        $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0));
+        $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0))->willReturn(true);
         $store = new MemcachedStore($memcache);
-        $store->forever('foo', 'bar');
+        $result = $store->forever('foo', 'bar');
+        $this->assertTrue($result);
     }
 
     public function testForgetMethodProperlyCallsMemcache()

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -62,8 +62,9 @@ class CacheRedisStoreTest extends TestCase
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
-        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60 * 60, serialize('foo'));
-        $redis->put('foo', 'foo', 60);
+        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60 * 60, serialize('foo'))->andReturn('OK');
+        $result = $redis->put('foo', 'foo', 60);
+        $this->assertTrue($result);
     }
 
     public function testSetMultipleMethodProperlyCallsRedis()
@@ -73,16 +74,17 @@ class CacheRedisStoreTest extends TestCase
         $connection = $redis->getRedis();
         $connection->shouldReceive('connection')->with('default')->andReturn($redis->getRedis());
         $connection->shouldReceive('multi')->once();
-        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60 * 60, serialize('bar'));
-        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:baz', 60 * 60, serialize('qux'));
-        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:bar', 60 * 60, serialize('norf'));
+        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60 * 60, serialize('bar'))->andReturn('OK');
+        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:baz', 60 * 60, serialize('qux'))->andReturn('OK');
+        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:bar', 60 * 60, serialize('norf'))->andReturn('OK');
         $connection->shouldReceive('exec')->once();
 
-        $redis->putMany([
+        $result = $redis->putMany([
             'foo'   => 'bar',
             'baz'   => 'qux',
             'bar' => 'norf',
         ], 60);
+        $this->assertTrue($result);
     }
 
     public function testSetMethodProperlyCallsRedisForNumerics()
@@ -90,7 +92,8 @@ class CacheRedisStoreTest extends TestCase
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
         $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60 * 60, 1);
-        $redis->put('foo', 1, 60);
+        $result = $redis->put('foo', 1, 60);
+        $this->assertFalse($result);
     }
 
     public function testIncrementMethodProperlyCallsRedis()
@@ -113,8 +116,9 @@ class CacheRedisStoreTest extends TestCase
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
-        $redis->getRedis()->shouldReceive('set')->once()->with('prefix:foo', serialize('foo'));
-        $redis->forever('foo', 'foo', 60);
+        $redis->getRedis()->shouldReceive('set')->once()->with('prefix:foo', serialize('foo'))->andReturn('OK');
+        $result = $redis->forever('foo', 'foo', 60);
+        $this->assertTrue($result);
     }
 
     public function testForgetMethodProperlyCallsRedis()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -132,16 +132,19 @@ class CacheRepositoryTest extends TestCase
     {
         // Alias of PuttingMultiple
         $repo = $this->getRepository();
-        $repo->getStore()->shouldReceive('putMany')->once()->with(['foo' => 'bar', 'bar' => 'baz'], 1);
-        $repo->setMultiple(['foo' => 'bar', 'bar' => 'baz'], 1);
+        $repo->getStore()->shouldReceive('putMany')->once()->with(['foo' => 'bar', 'bar' => 'baz'], 1)->andReturn(true);
+        $result = $repo->setMultiple(['foo' => 'bar', 'bar' => 'baz'], 1);
+        $this->assertTrue($result);
     }
 
     public function testPutWithDatetimeInPastOrZeroSecondsDoesntSaveItem()
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('put')->never();
-        $repo->put('foo', 'bar', Carbon::now()->subMinutes(10));
-        $repo->put('foo', 'bar', Carbon::now());
+        $result = $repo->put('foo', 'bar', Carbon::now()->subMinutes(10));
+        $this->assertFalse($result);
+        $result = $repo->put('foo', 'bar', Carbon::now());
+        $this->assertFalse($result);
     }
 
     public function testAddWithDatetimeInPastOrZeroSecondsReturnsImmediately()
@@ -215,8 +218,9 @@ class CacheRepositoryTest extends TestCase
     public function testSettingCache()
     {
         $repo = $this->getRepository();
-        $repo->getStore()->shouldReceive('put')->with($key = 'foo', $value = 'bar', 1);
-        $repo->set($key, $value, 1);
+        $repo->getStore()->shouldReceive('put')->with($key = 'foo', $value = 'bar', 1)->andReturn(true);
+        $result = $repo->set($key, $value, 1);
+        $this->assertTrue($result);
     }
 
     public function testClearingWholeCache()


### PR DESCRIPTION
Cache repository methods `set` and `setMultiple`, defined in the SimpleCache interface do not return any value, but they should according to PSR-16. This PR aims to solve this and fix issue laravel/framework#26674.

Cache stores Apc, Array, Database, File, Memcached, Null, and Redis are affected. Their respective unit tests were updated to check for return values.