### PR TITLE
[5.7] added token in reset password email as explicit param

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -59,7 +59,7 @@ class ResetPassword extends Notification
         return (new MailMessage)
             ->subject(Lang::getFromJson('Reset Password Notification'))
             ->line(Lang::getFromJson('You are receiving this email because we received a password reset request for your account.'))
-            ->action(Lang::getFromJson('Reset Password'), url(config('app.url').route('password.reset', $this->token, false)))
+            ->action(Lang::getFromJson('Reset Password'), url(config('app.url').route('password.reset', ['token' => $this->token], false)))
             ->line(Lang::getFromJson('If you did not request a password reset, no further action is required.'));
     }
 


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
I've added token as explicit param because,  for example, I've had situation where we had language in route (I mean something like this `en.foo.com \  de.foo.com` where `en/de` is route param), and based on this in current behavior it should be something like this `en.foo.com/password/reset/2u3ri32rf23r2`
but what it does is it substitutes the first parameter `en` and it becomes `2u3ri32rf23r2.foo.com/password/reset/` which is not right