### PR TITLE
[5.7] Fix breaking change and allow assertExactJson to preserve empty objects

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -450,12 +450,13 @@ class TestResponse
      * Assert that the response has the exact given JSON.
      *
      * @param  array  $data
+     * @param  bool   $preserveEmptyObjects
      * @return $this
      */
-    public function assertExactJson(array $data)
+    public function assertExactJson(array $data, bool $preserveEmptyObjects = false)
     {
         $actual = json_encode(Arr::sortRecursive(
-            (array) $this->decodeResponseJson()
+            (array) $this->decodeResponseJson(null, $preserveEmptyObjects)
         ));
 
         PHPUnit::assertEquals(json_encode(Arr::sortRecursive($data)), $actual);
@@ -682,13 +683,18 @@ class TestResponse
      * Validate and return the decoded response JSON.
      *
      * @param  string|null  $key
+     * @param  bool         $preserveEmptyObjects
      * @return mixed
      */
-    public function decodeResponseJson($key = null)
+    public function decodeResponseJson($key = null, $preserveEmptyObjects = false)
     {
-        $decodedResponse = $this->decodeJsonWhilePreservingEmptyObjects(
-            $this->getContent()
-        );
+        if ($preserveEmptyObjects) {
+            $decodedResponse = $this->decodeJsonWhilePreservingEmptyObjects(
+                $this->getContent()
+            );
+        } else {
+            $decodedResponse = json_decode($this->getContent(), true);
+        }
 
         if (is_null($decodedResponse) || $decodedResponse === false) {
             if ($this->exception) {

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -159,6 +159,15 @@ class FoundationTestResponseTest extends TestCase
         $response->assertHeaderMissing('Location');
     }
 
+    public function testAssertJsonWithEmptyObject()
+    {
+        $response = TestResponse::fromBaseResponse(new JsonResponse(new \stdClass));
+
+        $this->expectException(\PHPUnit\Framework\Exception::class);
+        $this->expectExceptionMessageRegExp("/.*\bFailed asserting that an array\b.*/");
+        $response->assertJson(['foo' => 'bar']);
+    }
+
     public function testAssertJsonWithArray()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
@@ -224,6 +233,9 @@ class FoundationTestResponseTest extends TestCase
 
         // Wildcard (repeating structure)
         $response->assertJsonStructure(['bars' => ['*' => ['bar', 'foo']]]);
+
+        // Wildcard (numerical string keys)
+        $response->assertJsonStructure(['nums' => ['*' => ['foo']]]);
 
         // Nested after wildcard
         $response->assertJsonStructure(['baz' => ['*' => ['foo', 'bar' => ['foo', 'bar']]]]);
@@ -295,7 +307,7 @@ class FoundationTestResponseTest extends TestCase
                 ],
                 'updated_at' => '2018-10-05 20:48:11',
             ],
-        ]);
+        ], true);
     }
 
     public function testAssertJsonMissingExact()
@@ -444,6 +456,11 @@ class JsonSerializableMixedResourcesStub implements JsonSerializable
                 ['bar' => 'foo 0', 'foo' => 'bar 0'],
                 ['bar' => 'foo 1', 'foo' => 'bar 1'],
                 ['bar' => 'foo 2', 'foo' => 'bar 2'],
+            ],
+            'nums'   => [
+                '10' => ['foo' => 'bar 0'],
+                '11' => ['foo' => 'bar 1'],
+                '12' => ['foo' => 'bar 2'],
             ],
             'baz'    => [
                 ['foo' => 'bar 0', 'bar' => ['foo' => 'bar 0', 'bar' => 'foo 0']],


### PR DESCRIPTION
This PR fixes a breaking change that was introduced in https://github.com/laravel/framework/commit/cfab97fbed78c1eddb9a570edcf69122ae197029 (released as part of 5.7.14) where `assertJsonStructure` would throw an exception if the response had numerical string keys (fixes #26677) and where `assertJson` would throw an exception if the response had an empty object response (instead of throwing a more helpful test failure, fixes #26684).

The reason this commit was originally merged was to allow tests using `assertExactJson` to assert more accurately in regards to empty objects. This PR allows that new feature to remain without changing the default behavior that was present in 5.7.13 and lower. Users who wish to preserve empty objects when using `assertExactJson` can simply pass `true` to the function after passing their expected JSON. Users who do not care about preserving objects and just want their tests to remain the same don't have to do anything to adjust for this.