### PR TITLE
[5.7] Fix Redis::mget() call, arg should be an array

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -45,7 +45,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     {
         return array_map(function ($value) {
             return $value !== false ? $value : null;
-        }, $this->command('mget', $keys));
+        }, $this->command('mget', [$keys]));
     }
 
     /**


### PR DESCRIPTION
Fixes #26709 . Unfortunately, I could not find a unit test for PhpRedisConnection, and I was not as brave as to introduce a way to test against a Redis connection for the framework, which, apparently, should be the right way to test this kind of changes.