### PR TITLE
[5.8] Bump symfony to 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,8 +87,8 @@
         "pda/pheanstalk": "^3.0",
         "phpunit/phpunit": "^7.0",
         "predis/predis": "^1.1.1",
-        "symfony/css-selector": "^4.1",
-        "symfony/dom-crawler": "^4.1",
+        "symfony/css-selector": "^4.2",
+        "symfony/dom-crawler": "^4.2",
         "true/punycode": "^2.1"
     },
     "autoload": {
@@ -131,8 +131,8 @@
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^3.0).",
         "predis/predis": "Required to use the redis cache and queue drivers (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^3.0).",
-        "symfony/css-selector": "Required to use some of the crawler integration testing tools (^4.1).",
-        "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (^4.1).",
+        "symfony/css-selector": "Required to use some of the crawler integration testing tools (^4.2).",
+        "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (^4.2).",
         "symfony/psr-http-message-bridge": "Required to psr7 bridging features (^1.0)."
     },
     "config": {


### PR DESCRIPTION
in https://github.com/laravel/framework/pull/26685 not all components were bumped to the 4.2