### PR TITLE
[5.7] Revert breaking change to assert JSON functions

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -686,9 +686,7 @@ class TestResponse
      */
     public function decodeResponseJson($key = null)
     {
-        $decodedResponse = $this->decodeJsonWhilePreservingEmptyObjects(
-            $this->getContent()
-        );
+        $decodedResponse = json_decode($this->getContent(), true);
 
         if (is_null($decodedResponse) || $decodedResponse === false) {
             if ($this->exception) {
@@ -699,50 +697,6 @@ class TestResponse
         }
 
         return data_get($decodedResponse, $key);
-    }
-
-    /**
-     * Decode the JSON string while preserving empty objects.
-     *
-     * @param  string  $json
-     * @return mixed
-     */
-    public function decodeJsonWhilePreservingEmptyObjects(string $json)
-    {
-        $payload = json_decode($json);
-
-        if ($payload === false) {
-            return $payload;
-        }
-
-        return $this->parseJsonWhilePreservingEmptyObjects($payload);
-    }
-
-    /**
-     * Parse the given JSON object while preserving empty objects.
-     *
-     * @param  \stdClass|array  $payload
-     * @return \stdClass|array
-     */
-    protected function parseJsonWhilePreservingEmptyObjects($payload)
-    {
-        if (is_object($payload)) {
-            $originalPayload = $payload;
-
-            $payload = (array) $payload;
-
-            if (empty($payload)) {
-                return $originalPayload;
-            }
-        }
-
-        foreach ($payload as $key => $item) {
-            if (is_array($item) || is_object($item)) {
-                $payload[$key] = $this->parseJsonWhilePreservingEmptyObjects($item);
-            }
-        }
-
-        return $payload;
     }
 
     /**

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -6,7 +6,6 @@ use Mockery as m;
 use JsonSerializable;
 use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Contracts\View\View;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Database\Eloquent\Model;
@@ -257,45 +256,6 @@ class FoundationTestResponseTest extends TestCase
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
         $response->assertJsonMissing(['id' => 20]);
-    }
-
-    public function testAssertExactJson()
-    {
-        $response = new TestResponse((new JsonResponse([
-            'payload' => (object) [],
-            'a' => [],
-            'b' => (object) [],
-            'status' => 'success',
-            'data' => [
-                'name' => 'West Fannieland',
-                'updated_at' => '2018-10-05 20:48:11',
-                'created_at' => '2018-10-05 20:48:11',
-                'id' => 1,
-                'b' => (object) [],
-                'c' => [
-                    'b' => (object) [],
-                    'name' => 'albert',
-                ],
-            ],
-        ])));
-
-        $response->assertExactJson([
-            'payload' => (object) [],
-            'b' => (object) [],
-            'a' => [],
-            'status' => 'success',
-            'data' => [
-                'name' => 'West Fannieland',
-                'created_at' => '2018-10-05 20:48:11',
-                'id' => 1,
-                'b' => (object) [],
-                'c' => [
-                    'b' => (object) [],
-                    'name' => 'albert',
-                ],
-                'updated_at' => '2018-10-05 20:48:11',
-            ],
-        ]);
     }
 
     public function testAssertJsonMissingExact()


### PR DESCRIPTION
This PR reverts a breaking change that was introduced in cfab97f (released as part of 5.7.14) where assertJsonStructure would throw an exception if the response had numerical string keys (fixes #26677) and where assertJson would throw an exception if the response had an empty object response (instead of throwing a more helpful test failure, fixes #26684).