### PR TITLE
[5.7] Fix loadCount() attribute syncing

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1010,7 +1010,22 @@ trait HasAttributes
      */
     public function syncOriginalAttribute($attribute)
     {
-        $this->original[$attribute] = $this->attributes[$attribute];
+        return $this->syncOriginalAttributes($attribute);
+    }
+
+    /**
+     * Sync multiple original attribute with their current values.
+     *
+     * @param  array|string  $attributes
+     * @return $this
+     */
+    public function syncOriginalAttributes($attributes)
+    {
+        $attributes = is_array($attributes) ? $attributes : func_get_args();
+
+        foreach ($attributes as $attribute) {
+            $this->original[$attribute] = $this->attributes[$attribute];
+        }
 
         return $this;
     }

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -54,6 +54,7 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $this->assertCount(1, DB::getQueryLog());
         $this->assertSame('2', $posts[0]->comments_count);
         $this->assertSame('0', $posts[1]->comments_count);
+        $this->assertSame('2', $posts[0]->getOriginal('comments_count'));
     }
 
     public function testLoadCountOnDeletedModels()


### PR DESCRIPTION
`loadCount()` doesn't sync the new attributes with `$original`. This breaks `UPDATE` queries:

```php
$user = User::all()->loadCount('posts')->first();
$user->foo = 'bar';
$user->save(); // "Unknown column 'posts_count'"
```