### PR TITLE
[5.7] Fix Redis::mget() call, arg should be an array #26710

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -45,7 +45,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     {
         return array_map(function ($value) {
             return $value !== false ? $value : null;
-        }, $this->command('mget', $keys));
+        }, $this->command('mget', [$keys]));
     }
 
     /**

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -440,6 +440,7 @@ class RedisConnectionTest extends TestCase
     public function test_it_gets_multiple_keys()
     {
         $valueSet = ['name' => 'mohamed', 'hobby' => 'diving'];
+
         foreach ($this->connections() as $redis) {
             $redis->mset($valueSet);
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -437,6 +437,21 @@ class RedisConnectionTest extends TestCase
         }
     }
 
+    public function test_it_gets_multiple_keys()
+    {
+        $valueSet = ['name' => 'mohamed', 'hobby' => 'diving'];
+        foreach ($this->connections() as $redis) {
+            $redis->mset($valueSet);
+
+            $this->assertEquals(
+                array_values($valueSet),
+                $redis->mget(array_keys($valueSet))
+            );
+
+            $redis->flushall();
+        }
+    }
+
     public function test_it_runs_eval()
     {
         foreach ($this->connections() as $redis) {


### PR DESCRIPTION
Fixes #26710 , adds test for Redis::mget() to RedisConnectionTest