### PR TITLE
[5.8] Change some methods related to validation from being protected to being public

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -775,7 +775,7 @@ trait ValidatesAttributes
      * @param  string  $table
      * @return array
      */
-    protected function parseTable($table)
+    public function parseTable($table)
     {
         return Str::contains($table, '.') ? explode('.', $table, 2) : [null, $table];
     }
@@ -787,7 +787,7 @@ trait ValidatesAttributes
      * @param  string  $attribute
      * @return bool
      */
-    protected function getQueryColumn($parameters, $attribute)
+    public function getQueryColumn($parameters, $attribute)
     {
         return isset($parameters[1]) && $parameters[1] !== 'NULL'
                     ? $parameters[1] : $this->guessColumnForQuery($attribute);
@@ -1698,7 +1698,7 @@ trait ValidatesAttributes
      *
      * @throws \InvalidArgumentException
      */
-    protected function requireParameterCount($count, $parameters, $rule)
+    public function requireParameterCount($count, $parameters, $rule)
     {
         if (count($parameters) < $count) {
             throw new InvalidArgumentException("Validation rule $rule requires at least $count parameters.");

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -120,7 +120,7 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface
      * @param  string  $table
      * @return \Illuminate\Database\Query\Builder
      */
-    protected function table($table)
+    public function table($table)
     {
         return $this->db->connection($this->connection)->table($table)->useWritePdo();
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1085,7 +1085,7 @@ class Validator implements ValidatorContract
      *
      * @throws \RuntimeException
      */
-    protected function getPresenceVerifierFor($connection)
+    public function getPresenceVerifierFor($connection)
     {
         return tap($this->getPresenceVerifier(), function ($verifier) use ($connection) {
             $verifier->setConnection($connection);


### PR DESCRIPTION
Make the following methods public:

1. Illuminate\Validation\Concerns\ValidatesAttributes
    - parseTable
    - getQueryColumn
    - requireParameterCount

2. Illuminate\Validation\DatabasePresenceVerifier
    - table

3. Illuminate\Validation\Validator
    - getPresenceVerifierFor

Making these methods public will allow users write some nice custom validation methods that implies database checks, such as this one:

In this example the user is specifying the table(customers), the column to search(name), the percentage(85) and how many records to inspect(5).

```
$rules = ['name' => ['required', 'similarity:customers,name,85,5']];
```

```php
Validator::extend('similarity', function ($attribute, $value, $parameters, $validator) {
    $validator->requireParameterCount(3, $parameters, 'similarity');

    [$connection, $table] = $validator->parseTable($parameters[0]);
    $percent = $parameters[2];
    $limit = $parameters[3] ?? 5;

    // The second parameter position holds the name of the column that needs to
    // be verified as unique. If this parameter isn't specified we will just
    // assume that this column to be verified shares the attribute's name.
    $column = $validator->getQueryColumn($parameters, $attribute);

    // The presence verifier is responsible for counting rows within this store
    // mechanism which might be a relational database or any other permanent
    // data store like Redis, etc. We will use it to determine uniqueness.
    $verifier = $validator->getPresenceVerifierFor($connection);

    $similarities = $verifier->table($table)->where($column, 'like', '%' . str_replace(' ', '%', $value) . '%')
        ->limit($limit)
        ->get()
        ->filter(function ($item) use($percent, $column, $value) {
            $found = 0;
            $similar = similar_text($item->$column, $value, $found);

            return $found >= $percent;
        });

    return count($similarities) == 0;
});
```