### PR TITLE
[5.7] Make unlessEmpty and unlessNotEmpty aliases

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -560,7 +560,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function unlessEmpty(callable $callback, callable $default = null)
     {
-        return $this->unless($this->isEmpty(), $callback, $default);
+        return $this->whenNotEmpty($callback, $default);
     }
 
     /**
@@ -572,7 +572,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function unlessNotEmpty(callable $callback, callable $default = null)
     {
-        return $this->unless($this->isNotEmpty(), $callback, $default);
+        return $this->whenEmpty($callback, $default);
     }
 
     /**


### PR DESCRIPTION
Update for https://github.com/laravel/framework/pull/26345. These are the same as the methods to which I referenced them. It's better to make them true aliases instead of defining the behavior twice.

I wasn't sure if this is "breaking" or not. Technically if the `whenEmpty` and `whenNotEmpty` methods were overwritten this could be considered breaking but I wouldn't know why you would do that tbh.