### PR TITLE
Fix/improve function signatures and phpdoc for `environments()`

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -23,9 +23,11 @@ interface Application extends Container
     /**
      * Get or check the current application environment.
      *
-     * @return string
+     * @param   void|array|mixed  $envs,... Optional environments to check against
+     * @return  string|bool Whether one of the given environments currently applies
+     *                      or the current environment if no arguments were passed
      */
-    public function environment();
+    public function environment(...$envs);
 
     /**
      * Determine if the application is running in the console.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -215,7 +215,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function afterLoadingEnvironment(Closure $callback)
     {
-        return $this->afterBootstrapping(
+        $this->afterBootstrapping(
             LoadEnvironmentVariables::class, $callback
         );
     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -472,12 +472,14 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get or check the current application environment.
      *
-     * @return string|bool
+     * @param   void|array|mixed  $envs,... Optional environments to check against
+     * @return  string|bool Whether one of the given environments currently applies
+     *                      or the current environment if no arguments were passed
      */
-    public function environment()
+    public function environment(...$envs)
     {
-        if (func_num_args() > 0) {
-            $patterns = is_array(func_get_arg(0)) ? func_get_arg(0) : func_get_args();
+        if (!empty($envs)) {
+            $patterns = is_array($envs[0]) ? $envs[0] : $envs;
 
             return Str::is($patterns, $this['env']);
         }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -478,7 +478,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function environment(...$envs)
     {
-        if (!empty($envs)) {
+        if (! empty($envs)) {
             $patterns = is_array($envs[0]) ? $envs[0] : $envs;
 
             return Str::is($patterns, $this['env']);

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -110,7 +110,7 @@ class ApplicationDatabaseMigrationStub extends Application
         }
     }
 
-    public function environment()
+    public function environment(...$envs)
     {
         return 'development';
     }

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -99,7 +99,7 @@ class ApplicationDatabaseRefreshStub extends Application
         }
     }
 
-    public function environment()
+    public function environment(...$envs)
     {
         return 'development';
     }

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -62,7 +62,7 @@ class ApplicationDatabaseResetStub extends Application
         }
     }
 
-    public function environment()
+    public function environment(...$envs)
     {
         return 'development';
     }

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -88,7 +88,7 @@ class ApplicationDatabaseRollbackStub extends Application
         }
     }
 
-    public function environment()
+    public function environment(...$envs)
     {
         return 'development';
     }


### PR DESCRIPTION
`environment()` supports multiple arguments and return types but that was not reflected in the phpdoc. (causing warnings in IDEs) This PR fixes that.

NB phpdoc format for variadic function arguments as suggested by https://stackoverflow.com/questions/14513356/phpdoc-documenting-a-function-with-a-variable-number-of-arguments

NB Also fixes what looks to be a no-op return statement in `afterLoadingEnvironment()`