### PR TITLE
[5.8] Also update phpdoc for return type in contract

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -71,7 +71,7 @@ interface Application extends Container
      * Get or check the current application environment.
      *
      * @param  string|array  $environments
-     * @return string
+     * @return string|bool
      */
     public function environment(...$environments);
 


### PR DESCRIPTION
Minor fix for new `environment()` phpdoc
See: https://github.com/laravel/framework/pull/26296