### PR TITLE
[5.7] Backport #26486 - Fix FormRequest validation triggering twice

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -59,6 +59,13 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $errorBag = 'default';
 
     /**
+     * The validator instance.
+     *
+     * @var \Illuminate\Contracts\Validation\Validator
+     */
+    protected $validator;
+
+    /**
      * Get the validator instance for the request.
      *
      * @return \Illuminate\Contracts\Validation\Validator
@@ -77,7 +84,9 @@ class FormRequest extends Request implements ValidatesWhenResolved
             $this->withValidator($validator);
         }
 
-        return $validator;
+        $this->setValidator($validator);
+
+        return $this->validator;
     }
 
     /**
@@ -172,7 +181,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function validated()
     {
-        return $this->getValidatorInstance()->validated();
+        return $this->validator->validated();
     }
 
     /**
@@ -193,6 +202,19 @@ class FormRequest extends Request implements ValidatesWhenResolved
     public function attributes()
     {
         return [];
+    }
+
+    /**
+     * Set the Validator instance.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator(Validator $validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
     }
 
     /**

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -10,6 +10,7 @@ use Illuminate\Container\Container;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\Validation\Factory as ValidationFactoryContract;
@@ -65,6 +66,15 @@ class FoundationFormRequestTest extends TestCase
         $request->validateResolved();
 
         $this->assertEquals(['nested' => [['bar' => 'baz'], ['bar' => 'baz2']]], $request->validated());
+    }
+
+    public function test_validated_method_not_validate_twice()
+    {
+        $payload = ['name' => 'specified', 'with' => 'extras'];
+        $request = $this->createRequest($payload, FoundationTestFormRequestTwiceStub::class);
+        $request->validateResolved();
+        $request->validated();
+        $this->assertEquals(1, FoundationTestFormRequestTwiceStub::$count);
     }
 
     /**
@@ -246,6 +256,28 @@ class FoundationTestFormRequestNestedArrayStub extends FormRequest
     }
 }
 
+class FoundationTestFormRequestTwiceStub extends FormRequest
+{
+    public static $count = 0;
+
+    public function rules()
+    {
+        return ['name' => 'required'];
+    }
+
+    public function withValidator(Validator $validator)
+    {
+        $validator->after(function ($validator) {
+            self::$count++;
+        });
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
 class FoundationTestFormRequestForbiddenStub extends FormRequest
 {
     public function authorize()
@@ -253,6 +285,7 @@ class FoundationTestFormRequestForbiddenStub extends FormRequest
         return false;
     }
 }
+
 class FoundationTestFormRequestHooks extends FormRequest
 {
     public function rules()


### PR DESCRIPTION
As discussed in issue #25736 , after some changes introduced in https://github.com/laravel/framework/commit/941c8c7be2ad4441cdba12053c15f5dc46980707 the `FormRequest` rules were being triggered twice.

This issue was first addressed in the 5.8 branch by the PR #26419 which was backported to 5.7 in PR #26604 .

This fixes the issue in the Validator side, but when using the FormRequest this fix wasn't sufficient as every time the `getValidatorInstance()` method was called it creates a new validator instance which triggers the validation's rules again. 

If one uses the `validated()` method two instances would be created one when resolving the request, other when calling this method.

Later another PR was sent to the 5.8 branch ( #26486 ) which caches the validator instance instantiated in the `FormRequest` object.

This solves the problem as there will be only one Validator instance.

This PR backports the fix in PR #26486 to the 5.7 branch.

