### PR TITLE
[5.7] DB seed function in testing now accept an array too

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -84,12 +84,14 @@ trait InteractsWithDatabase
     /**
      * Seed a given database connection.
      *
-     * @param  string  $class
+     * @param  string|array $classes
      * @return $this
      */
-    public function seed($class = 'DatabaseSeeder')
+    public function seed($classes = 'DatabaseSeeder')
     {
-        $this->artisan('db:seed', ['--class' => $class, '--no-interaction' => true]);
+        foreach ((array) $classes as $class) {
+            $this->artisan('db:seed', ['--class' => $class, '--no-interaction' => true]);
+        }
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Illuminate\Support\Arr;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\Constraints\HasInDatabase;
 use PHPUnit\Framework\Constraint\LogicalNot as ReverseConstraint;
@@ -84,12 +85,12 @@ trait InteractsWithDatabase
     /**
      * Seed a given database connection.
      *
-     * @param  string|array $classes
+     * @param  string|array $class
      * @return $this
      */
-    public function seed($classes = 'DatabaseSeeder')
+    public function seed($class = 'DatabaseSeeder')
     {
-        foreach ((array) $classes as $class) {
+        foreach (Arr::wrap($class) as $class) {
             $this->artisan('db:seed', ['--class' => $class, '--no-interaction' => true]);
         }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -85,7 +85,7 @@ trait InteractsWithDatabase
     /**
      * Seed a given database connection.
      *
-     * @param  string|array $class
+     * @param  array|string $class
      * @return $this
      */
     public function seed($class = 'DatabaseSeeder')

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -85,7 +85,7 @@ trait InteractsWithDatabase
     /**
      * Seed a given database connection.
      *
-     * @param  array|string $class
+     * @param  array|string  $class
      * @return $this
      */
     public function seed($class = 'DatabaseSeeder')


### PR DESCRIPTION
This pull requests add the ability to accept an array of seed classes too.

`/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase@seed`

😀