### PR TITLE
[5.7] Update `laravel/slack-notification-channel` dep version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "tijsverkoyen/css-to-inline-styles": "^2.2.1",
         "vlucas/phpdotenv": "^2.2",
         "laravel/nexmo-notification-channel": "^1.0",
-        "laravel/slack-notification-channel": "^1.0"
+        "laravel/slack-notification-channel": "^1.0.1"
     },
     "replace": {
         "illuminate/auth": "self.version",


### PR DESCRIPTION
 - update laravel/slack-notification-channel dep version since of `https://github.com/laravel/slack-notification-channel/commit/b9fc8ec31a5c8eb57c92902d38ac48463c9318b9`

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
