### PR TITLE
[5.7] Passing $callback instead of new function with calling the same $callback

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -165,9 +165,7 @@ class MailFake implements Mailer, MailQueue
             return true;
         };
 
-        return $this->mailablesOf($mailable)->filter(function ($mailable) use ($callback) {
-            return $callback($mailable);
-        });
+        return $this->mailablesOf($mailable)->filter($callback);
     }
 
     /**
@@ -198,9 +196,7 @@ class MailFake implements Mailer, MailQueue
             return true;
         };
 
-        return $this->queuedMailablesOf($mailable)->filter(function ($mailable) use ($callback) {
-            return $callback($mailable);
-        });
+        return $this->queuedMailablesOf($mailable)->filter($callback);
     }
 
     /**


### PR DESCRIPTION
No need to pass another function with callback when you can pass $callback as a argument

$callback is validated before passing into filter method

This solution has minor performance improvements and is more readable and clear
