### PR TITLE
[5.7] Add Hexadecimal Validator

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -649,6 +649,18 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is a valid hexadecimal string
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateHex($attribute, $value)
+    {
+        return ctype_xdigit($value);
+    }
+
+    /**
      * Get the number of records that exist in storage.
      *
      * @param  mixed   $connection

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -649,7 +649,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate that an attribute is a valid hexadecimal string
+     * Validate that an attribute is a valid hexadecimal string.
      *
      * @param  string  $attribute
      * @param  mixed   $value

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2594,6 +2594,17 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateHex()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'AAFF91aaff'], ['x' => 'hex']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'AAGG91aagg'], ['x' => 'hex']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateTimezone()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This PR adds a "hex" validation rule to validate that a request input is a valid hexadecimal string. While simple, this goes along nicely with the alphanumeric rule and other string-analysis rules to further enhance the stock capabilities of request validation. While one can fairly easily create their own validation rule for hex, the ubiquity of hexadecimals warrants, in my opinion, the inclusion of this rule in core Laravel.

Requires new validation rule lang string provided in [`laravel\laravel` PR 4875](https://github.com/laravel/laravel/pull/4875)