### PR TITLE
[5.8] Strip keys from array when converting paginator objects to array

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -156,13 +156,16 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     /**
      * Get the instance as an array.
      *
+     * @param  bool  $preserveKeys
      * @return array
      */
-    public function toArray()
+    protected function compile($preserveKeys = true)
     {
+        $items = $this->items->toArray();
+
         return [
             'current_page' => $this->currentPage(),
-            'data' => $this->items->toArray(),
+            'data' => $preserveKeys ? $items : array_values($items),
             'first_page_url' => $this->url(1),
             'from' => $this->firstItem(),
             'last_page' => $this->lastPage(),
@@ -177,13 +180,23 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     }
 
     /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->compile();
+    }
+
+    /**
      * Convert the object into something JSON serializable.
      *
      * @return array
      */
     public function jsonSerialize()
     {
-        return $this->toArray();
+        return $this->compile(false);
     }
 
     /**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -137,13 +137,16 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     /**
      * Get the instance as an array.
      *
+     * @param  bool  $preserveKeys
      * @return array
      */
-    public function toArray()
+    protected function compile($preserveKeys = true)
     {
+        $items = $this->items->toArray();
+
         return [
             'current_page' => $this->currentPage(),
-            'data' => $this->items->toArray(),
+            'data' => $preserveKeys ? $items : array_values($items),
             'first_page_url' => $this->url(1),
             'from' => $this->firstItem(),
             'next_page_url' => $this->nextPageUrl(),
@@ -155,13 +158,23 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     }
 
     /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->compile();
+    }
+
+    /**
      * Convert the object into something JSON serializable.
      *
      * @return array
      */
     public function jsonSerialize()
     {
-        return $this->toArray();
+        return $this->compile(false);
     }
 
     /**

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -97,4 +97,28 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEquals('http://website.com?key=value%20with%20spaces&foo=2',
                             $this->p->url($this->p->currentPage()));
     }
+
+    public function testPaginatorAlwaysReturnsDataKeyAsArrayWhenTransformingToJson()
+    {
+        $paginator = new LengthAwarePaginator(
+            $array = [1 => 'item1', 'foo' => 'item2', 2 => 'item3', ['bar' => 'item4']], 4, 2, 2
+        );
+
+        $json = json_encode([
+            'current_page' => 2,
+            'data' => ['item1', 'item2', 'item3', ['bar' => 'item4']],
+            'first_page_url' => '/?page=1',
+            'from' => 3,
+            'last_page' => 2,
+            'last_page_url' => '/?page=2',
+            'next_page_url' => null,
+            'path' => '/',
+            'per_page' => 2,
+            'prev_page_url' => '/?page=1',
+            'to' => 6,
+            'total' => 4,
+        ]);
+
+        $this->assertJsonStringEqualsJsonString($json, $paginator->toJson());
+    }
 }

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -46,4 +46,23 @@ class PaginatorTest extends TestCase
 
         $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
     }
+
+    public function testPaginatorAlwaysMakesDataKeyAnArrayInJson()
+    {
+        $p = new Paginator($array = [1 => 'item1', 'foo' => 'item2', 2 => 'item3', ['bar' => 'item4']], 2, 2);
+
+        $json = json_encode([
+            'current_page' => 2,
+            'data' => ['item1', 'item2'],
+            'first_page_url' => '/?page=1',
+            'from' => 3,
+            'next_page_url' => '/?page=3',
+            'path' => '/',
+            'per_page' => 2,
+            'prev_page_url' => '/?page=1',
+            'to' => 4,
+        ]);
+
+        $this->assertJsonStringEqualsJsonString($json, $p->toJson());
+    }
 }


### PR DESCRIPTION
When looking at https://github.com/laravel/framework/issues/26677 I stumbled on a discrepancy with the paginator instances. At the moment when paginator objects with an item set without a standard sequence of numbers starting from 0 are being compiled to JSON the data key will be converted to an object. This seems odd given that the whole point of paginators being a collection of paginated items which would always be expected to be an array. You'd never expect a collection to be transformed to an object either.

This commit will always make sure that the data key is an array and that any keys are stripped when converting to JSON. For this a new `compile` method was added with an option to strip the keys from the data array. This approach allows for the `toArray` to keep its current behavior and only modify the behavior when converting to JSON. I wasn't sure about the naming of `compile` though. 

Another approach would be to always strip the keys for the data array. In this case we can simply always the `array_values` function and leave most of the other code untouched. Let me know if you want to change it to this.

**This is absolutely breaking** and therefor I target the master branch. In cases where people expect the data key to be an object when, for example, returning a pagination object for in a route they'll have to re-account that it's now always an array.

If at all I'm making no sense with all this, feel free to point that out to me :)