### PR TITLE
[5.8] Add ArrayAccess to config repository contract

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -2,11 +2,10 @@
 
 namespace Illuminate\Config;
 
-use ArrayAccess;
 use Illuminate\Support\Arr;
 use Illuminate\Contracts\Config\Repository as ConfigContract;
 
-class Repository implements ArrayAccess, ConfigContract
+class Repository implements ConfigContract
 {
     /**
      * All of the configuration items.

--- a/src/Illuminate/Contracts/Config/Repository.php
+++ b/src/Illuminate/Contracts/Config/Repository.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Contracts\Config;
 
-interface Repository
+use ArrayAccess;
+
+interface Repository extends ArrayAccess
 {
     /**
      * Determine if the given configuration value exists.


### PR DESCRIPTION
This is the same as it's been done with the container in #26378. Basically a bunch of code throughout the framework uses `ArrayAccess` for getting configuration values even though that is not on the contract at the moment which means it'd break with any other implementation thus rendering the contract pointless without this change.
