### PR TITLE
[5.8] fix Illuminate\Console\Scheduling\ManagesFrequencies::dailyAt() accepts a parameter specific to the second, which happened error.it  happen in the initial minute of the corresponding hour.

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -165,7 +165,7 @@ trait ManagesFrequencies
         $segments = explode(':', $time);
 
         return $this->spliceIntoPosition(2, (int) $segments[0])
-                    ->spliceIntoPosition(1, count($segments) === 2 ? (int) $segments[1] : '0');
+                    ->spliceIntoPosition(1, count($segments) === 1 ? '0' : (int) $segments[1]);
     }
 
     /**


### PR DESCRIPTION
fix Illuminate\Console\Scheduling\ManagesFrequencies::dailyAt() accepts a parameter specific to the second, which happened error.it  happen in the initial minute of the corresponding hour.
see [#26752](https://github.com/laravel/framework/issues/26752)
- Laravel Version: 5.*
- PHP Version: 7.1.19
- Database Driver & Version: 

### Description:

First of all, my English is very poor.
`Illuminate\Console\Scheduling\ManagesFrequencies::dailyAt()` accepts a parameter specific to the second, which happened error.
For example 
```
<?php

namespace App\Console;

use App\Console\Commands\Test;
use Illuminate\Console\Scheduling\Schedule;
use Illuminate\Foundation\Console\Kernel as ConsoleKernel;

class Kernel extends ConsoleKernel
{
    /**
     * The Artisan commands provided by your application.
     * @var array
     */
    protected $commands = [
        Test::class,
    ];

    /**
     * Define the application's command schedule.
     * @param  \Illuminate\Console\Scheduling\Schedule $schedule
     * @return void
     */
    protected function schedule(Schedule $schedule)
    {
        $schedule->command('test:test')->dailyAt('12:59:00');
        //$schedule->command('test:test')->dailyAt('12:00');
    }

    /**
     * Register the commands for the application.
     * @return void
     */
    protected function commands()
    {
        $this->load(__DIR__ . '/Commands');

        require base_path('routes/console.php');
    }
}
```
That is, `dailyAt('12:59:00')` => `dailyAt('12:00')`.
This should not happen, although the cron task is executed every minute, not specific to the second, but it should not happen in the initial minute of the corresponding hour.
Let's look at the code
```
    /**
     * Schedule the event to run daily at a given time (10:00, 19:30, etc).
     *
     * @param  string  $time
     * @return $this
     */
    public function dailyAt($time)
    {
        $segments = explode(':', $time);

        return $this->spliceIntoPosition(2, (int) $segments[0])
                    ->spliceIntoPosition(1, count($segments) === 2 ? (int) $segments[1] : '0');
    }
```
I can understand the meaning here: when the developer is lazy, `dailyAt('12')` = `dailyAt('12:00')`.
but `12:59:00` is also a standard time, so I think
`dailyAt('12:59:00')` = `dailyAt('12:59')`
`dailyAt('12:00:00')` = `dailyAt('12:00')` = `dailyAt('12')`
This is reasonable.
Therefore, `dailyAt('12:59:00')` = `dailyAt('12:00')` is a serious bug.
I recommend
```
    public function dailyAt($time)
    {
        $segments = explode(':', $time);

        return $this->spliceIntoPosition(2, (int) $segments[0])
                    ->spliceIntoPosition(1, count($segments) === 1 ? '0' : (int) $segments[1]);
    }
```
### Steps To Reproduce:
I have a timed task, as follows
```
<?php

namespace App\Console;

use App\Console\Commands\Test;
use Illuminate\Console\Scheduling\Schedule;
use Illuminate\Foundation\Console\Kernel as ConsoleKernel;

class Kernel extends ConsoleKernel
{
    /**
     * The Artisan commands provided by your application.
     * @var array
     */
    protected $commands = [
        Test::class,
    ];

    /**
     * Define the application's command schedule.
     * @param  \Illuminate\Console\Scheduling\Schedule $schedule
     * @return void
     */
    protected function schedule(Schedule $schedule)
    {
        $schedule->command('test:test')->dailyAt('12:59:00');
    }

    /**
     * Register the commands for the application.
     * @return void
     */
    protected function commands()
    {
        $this->load(__DIR__ . '/Commands');

        require base_path('routes/console.php');
    }
}
```
But I found that it didn't execute at 12:59
It was executed at 12:00.
#### end
so,I want to submit a pull request to fix it
