### PR TITLE
[5.8] Fix View contract violations

### DIFF
--- a/src/Illuminate/Contracts/View/View.php
+++ b/src/Illuminate/Contracts/View/View.php
@@ -7,6 +7,13 @@ use Illuminate\Contracts\Support\Renderable;
 interface View extends Renderable
 {
     /**
+     * Get the array of view data.
+     *
+     * @return array
+     */
+    public function getData();
+
+    /**
      * Get the name of the view.
      *
      * @return string

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -720,7 +720,7 @@ class TestResponse
     {
         $this->ensureResponseHasView();
 
-        PHPUnit::assertEquals($value, $this->original->getName());
+        PHPUnit::assertEquals($value, $this->original->name());
 
         return $this;
     }
@@ -743,11 +743,11 @@ class TestResponse
         if (is_null($value)) {
             PHPUnit::assertArrayHasKey($key, $this->original->getData());
         } elseif ($value instanceof Closure) {
-            PHPUnit::assertTrue($value($this->original->$key));
+            PHPUnit::assertTrue($value($this->original->getData()[$key]));
         } elseif ($value instanceof Model) {
-            PHPUnit::assertTrue($value->is($this->original->$key));
+            PHPUnit::assertTrue($value->is($this->original->getData()[$key]));
         } else {
-            PHPUnit::assertEquals($value, $this->original->$key);
+            PHPUnit::assertEquals($value, $this->original->getData()[$key]);
         }
 
         return $this;
@@ -782,7 +782,7 @@ class TestResponse
     {
         $this->ensureResponseHasView();
 
-        return $this->original->$key;
+        return $this->original->getData()[$key];
     }
 
     /**

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -20,7 +20,7 @@ class FoundationTestResponseTest extends TestCase
         $response = $this->makeMockResponse([
             'render' => 'hello world',
             'getData' => ['foo' => 'bar'],
-            'getName' => 'dir.my-view',
+            'name' => 'dir.my-view',
         ]);
 
         $response->assertViewIs('dir.my-view');

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -125,7 +125,7 @@ class ViewTest extends TestCase
     public function testViewGettersSetters()
     {
         $view = $this->getView(['foo' => 'bar']);
-        $this->assertEquals($view->getName(), 'view');
+        $this->assertEquals($view->name(), 'view');
         $this->assertEquals($view->getPath(), 'path');
         $data = $view->getData();
         $this->assertEquals($data['foo'], 'bar');


### PR DESCRIPTION
1. There was no method on the contract to access the view data even though one was obviously needed - this also meant that all the code in the framework which was trying to access the view data was violating the contract (e.g. in `TestResponse`). The `ensureResponseHasView` literally checks if `$this->original` is an instance of the `View` contract and then after that the data is accessed like this: `$this->original->$key` (this would obviously break with any other implementation of the contract). Fixing this requires adding the `getData` method to the contract.

2. The `assertViewIs` method in `TestResponse` was calling the `getName` method which is not on the contract, while `name` is and should be used instead as it gives the same result.
