### PR TITLE
[5.7] Allow using Mail::fake for mailables sent via Notifications

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -56,7 +56,7 @@ class MailChannel
         }
 
         if ($message instanceof Mailable) {
-            return $message->send($this->mailer);
+            return $this->mailer->send($message);
         }
 
         $this->mailer->send(

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -226,6 +226,8 @@ class SendingMailNotificationsTest extends TestCase
             'email' => 'taylor@laravel.com',
         ]);
 
+        $this->mailer->shouldReceive('send')->once();
+
         $user->notify($notification);
     }
 }
@@ -303,10 +305,6 @@ class TestMailNotificationWithMailable extends Notification
 
     public function toMail($notifiable)
     {
-        $mailable = m::mock(Mailable::class);
-
-        $mailable->shouldReceive('send')->once();
-
-        return $mailable;
+        return m::mock(Mailable::class);
     }
 }


### PR DESCRIPTION
Currently, if an email is sent via a Notification, the MailChannel sends the message directly via the Mailable send method.  This causes problems when Mail::fake is activated in tests.  The send method in `MailFake.php` expects to see a Mailable passed as the view, but when the mailable itself calls send, it gets passed the result of the call to `buildView` on line 153 of Mailable.php's send method. This causes the assertion that a mail was sent to fail, because MailFake returns when it sees the `$view` is not an instance of a Mailable. This change ensures that the pattern implemented by Mailer and Mailables still works correctly in a mocked environment when sent via notifications.
