### PR TITLE
[5.7] Packets out of order when losing connection

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -36,6 +36,7 @@ trait DetectsLostConnections
             'TCP Provider: Error code 0x68',
             'Name or service not known',
             'ORA-03114',
+            'Packets out of order. Expected',
         ]);
     }
 }


### PR DESCRIPTION
See laravel/framework#24255

When losing connection to MariaDB, exceptions like "Packets out of order. Expected 1 received 0. Packet size=30", where expected can be more than 1. Added "Packets out of order. Expected" to "DetectsLostConnections" strings list