### PR TITLE
[5.8] Auto clear views before caching

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -30,6 +30,8 @@ class ViewCacheCommand extends Command
      */
     public function handle()
     {
+        $this->call('view:clear');
+
         $this->paths()->each(function ($path) {
             $this->compileViews($this->bladeFilesIn([$path]));
         });


### PR DESCRIPTION
Before calling the command "view:cache", I believe that anyone will call the command "view:clear" firstly.

Well, although all views are still re-compiled, it's reasonable to clear compiled things before re-caching, isn't it?

I think it's better to call the command "view:clear" automatically each time "view:cache" is triggered.

The commands "config:cache" and "route:cache" have already done with the action "clear" at the begin of the progress. 
