### PR TITLE
[5.7] Print relative path to created file

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -71,7 +71,9 @@ abstract class GeneratorCommand extends Command
 
         $this->files->put($path, $this->buildClass($name));
 
-        $this->info($this->type.' created successfully.');
+        $relativeOrAbsolutePath = Str::replaceFirst(getcwd().DIRECTORY_SEPARATOR, '', $path);
+
+        $this->line("<info>{$this->type} created successfully:</info> {$relativeOrAbsolutePath}");
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -105,9 +105,11 @@ class MigrateMakeCommand extends BaseCommand
      */
     protected function writeMigration($name, $table, $create)
     {
-        $file = pathinfo($this->creator->create(
+        $file = $this->creator->create(
             $name, $this->getMigrationPath(), $table, $create
-        ), PATHINFO_FILENAME);
+        );
+
+        $file = Str::replaceFirst(getcwd().DIRECTORY_SEPARATOR, '', $file);
 
         $this->line("<info>Created Migration:</info> {$file}");
     }


### PR DESCRIPTION
This changes the message after a migration was created with `php artisan make:migration`. Instead of just the file name it prints the relative path (relative to the current working directory). 

It prints the absolute path if the migration is not in a subfolder of the current working directory.

This makes it possible to command-click to open the file in e.g iTerm.

![screenshot 2018-12-06 at 15 18 30](https://user-images.githubusercontent.com/34488/49590064-30c78880-f96b-11e8-891a-025823c9061a.png)
