### PR TITLE
[5.7] Allow models to be created with an API resource

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -176,7 +176,7 @@ class ModelMakeCommand extends GeneratorCommand
 
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
 
-            ['apiResource', null, InputOption::VALUE_NONE, 'Create a new API resource for the model']
+            ['apiResource', null, InputOption::VALUE_NONE, 'Create a new API resource for the model'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -58,6 +58,10 @@ class ModelMakeCommand extends GeneratorCommand
         if ($this->option('controller') || $this->option('resource')) {
             $this->createController();
         }
+
+        if ($this->option('apiResource')) {
+            $this->createApiResource();
+        }
     }
 
     /**
@@ -112,6 +116,20 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Create a resource for the model.
+     *
+     * @return void
+     */
+    protected function createApiResource()
+    {
+        $resource = Str::studly(class_basename($this->argument('name')));
+
+        $this->call('make:resource', [
+            'name' => "{$resource}Resource",
+        ]);
+    }
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string
@@ -157,6 +175,8 @@ class ModelMakeCommand extends GeneratorCommand
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
 
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
+
+            ['apiResource', null, InputOption::VALUE_NONE, 'Create a new API resource for the model']
         ];
     }
 }


### PR DESCRIPTION
I work in projects where all models have resources and this is a bit convenient - I imagine it would be useful to some people too.  

Not a big or interesting change, just something I thought would be nice.