### PR TITLE
[5.7] Mailable's hasReplyTo docblock fix

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -553,7 +553,7 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
-     * Determine if the given recipient is set on the mailable.
+     * Determine if the given replyTo is set on the mailable.
      *
      * @param  object|array|string  $address
      * @param  string|null  $name


### PR DESCRIPTION
Fixes the docblock of a method introduced on #21093. It was actually mentioned on the PR. It was mentioned by @MrRio but I missed it.