### PR TITLE
[5.8] Add to dailyAt() parameter legality check and unit test

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -6,10 +6,12 @@ use Illuminate\Support\Carbon;
 
 trait ManagesFrequencies
 {
+    protected $hourMinutePregMatchRule = '/(^((([0-1][0-9])|[0-9]|2[0-3]):([0-5][0-9]|[0-9]))$)|(^(([0-1][0-9])|[0-9]|2[0-3])$)/';
+
     /**
      * The Cron expression representing the event's frequency.
      *
-     * @param  string  $expression
+     * @param  string $expression
      * @return $this
      */
     public function cron($expression)
@@ -22,8 +24,8 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run between start and end time.
      *
-     * @param  string  $startTime
-     * @param  string  $endTime
+     * @param  string $startTime
+     * @param  string $endTime
      * @return $this
      */
     public function between($startTime, $endTime)
@@ -34,8 +36,8 @@ trait ManagesFrequencies
     /**
      * Schedule the event to not run between start and end time.
      *
-     * @param  string  $startTime
-     * @param  string  $endTime
+     * @param  string $startTime
+     * @param  string $endTime
      * @return $this
      */
     public function unlessBetween($startTime, $endTime)
@@ -46,8 +48,8 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run between start and end time.
      *
-     * @param  string  $startTime
-     * @param  string  $endTime
+     * @param  string $startTime
+     * @param  string $endTime
      * @return \Closure
      */
     private function inTimeInterval($startTime, $endTime)
@@ -124,7 +126,7 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run hourly at a given offset in the hour.
      *
-     * @param  int  $offset
+     * @param  int $offset
      * @return $this
      */
     public function hourlyAt($offset)
@@ -146,8 +148,9 @@ trait ManagesFrequencies
     /**
      * Schedule the command at a given time.
      *
-     * @param  string  $time
+     * @param  string $time
      * @return $this
+     * @throws \Exception
      */
     public function at($time)
     {
@@ -157,27 +160,31 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run daily at a given time (10:00, 19:30, etc).
      *
-     * @param  string  $time
+     * @param  string $time
      * @return $this
+     * @throws \Exception
      */
     public function dailyAt($time)
     {
+        if (mb_strlen($time) > 5 || is_bool($time) || preg_match($this->hourMinutePregMatchRule, $time, $matches) !== 1) {
+            throw new \Exception('Function dailyAt() accepted an invalid parameter.It can only be a time e.g(10:00, 19:30, etc)');
+        }
         $segments = explode(':', $time);
 
-        return $this->spliceIntoPosition(2, (int) $segments[0])
-                    ->spliceIntoPosition(1, count($segments) === 2 ? (int) $segments[1] : '0');
+        return $this->spliceIntoPosition(2, (int)$segments[0])
+                    ->spliceIntoPosition(1, count($segments) === 2 ? (int)$segments[1] : '0');
     }
 
     /**
      * Schedule the event to run twice daily.
      *
-     * @param  int  $first
-     * @param  int  $second
+     * @param  int $first
+     * @param  int $second
      * @return $this
      */
     public function twiceDaily($first = 1, $second = 13)
     {
-        $hours = $first.','.$second;
+        $hours = $first . ',' . $second;
 
         return $this->spliceIntoPosition(1, 0)
                     ->spliceIntoPosition(2, $hours);
@@ -288,9 +295,10 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run weekly on a given day and time.
      *
-     * @param  int  $day
-     * @param  string  $time
+     * @param  int    $day
+     * @param  string $time
      * @return $this
+     * @throws \Exception
      */
     public function weeklyOn($day, $time = '0:0')
     {
@@ -314,9 +322,10 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run monthly on a given day and time.
      *
-     * @param  int  $day
-     * @param  string  $time
+     * @param  int    $day
+     * @param  string $time
      * @return $this
+     * @throws \Exception
      */
     public function monthlyOn($day = 1, $time = '0:0')
     {
@@ -328,17 +337,17 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run twice monthly.
      *
-     * @param  int  $first
-     * @param  int  $second
+     * @param  int $first
+     * @param  int $second
      * @return $this
      */
     public function twiceMonthly($first = 1, $second = 16)
     {
-        $days = $first.','.$second;
+        $days = $first . ',' . $second;
 
         return $this->spliceIntoPosition(1, 0)
-            ->spliceIntoPosition(2, 0)
-            ->spliceIntoPosition(3, $days);
+                    ->spliceIntoPosition(2, 0)
+                    ->spliceIntoPosition(3, $days);
     }
 
     /**
@@ -370,7 +379,7 @@ trait ManagesFrequencies
     /**
      * Set the days of the week the command should run on.
      *
-     * @param  array|mixed  $days
+     * @param  array|mixed $days
      * @return $this
      */
     public function days($days)
@@ -383,7 +392,7 @@ trait ManagesFrequencies
     /**
      * Set the timezone the date should be evaluated on.
      *
-     * @param  \DateTimeZone|string  $timezone
+     * @param  \DateTimeZone|string $timezone
      * @return $this
      */
     public function timezone($timezone)
@@ -396,8 +405,8 @@ trait ManagesFrequencies
     /**
      * Splice the given value into the given position of the expression.
      *
-     * @param  int  $position
-     * @param  string  $value
+     * @param  int    $position
+     * @param  string $value
      * @return $this
      */
     protected function spliceIntoPosition($position, $value)

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Console\Scheduling;
 
-use Mockery as m;
-use PHPUnit\Framework\TestCase;
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\EventMutex;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
 class FrequencyTest extends TestCase
 {
@@ -38,6 +38,66 @@ class FrequencyTest extends TestCase
         $this->assertEquals('0 0 * * *', $this->event->daily()->getExpression());
     }
 
+    public function testDailyAt()
+    {
+        $this->assertEquals('59 12 * * *', $this->event->dailyAt('12:59')->getExpression());
+        $this->assertEquals('0 12 * * *', $this->event->dailyAt('12')->getExpression());
+        $this->assertEquals('0 0 * * *', $this->event->dailyAt('0')->getExpression());
+        $this->assertEquals('0 0 * * *', $this->event->dailyAt(0)->getExpression());
+        $this->assertEquals('0 0 * * *', $this->event->dailyAt('00')->getExpression());
+        $this->assertEquals('0 0 * * *', $this->event->dailyAt('00:00')->getExpression());
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testDailyAtAcceptInvalidDataExceptionOne()
+    {
+        $this->event->dailyAt('12:abc');
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testDailyAtAcceptInvalidDataExceptionTwo()
+    {
+        $this->event->dailyAt('1 :59');
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testDailyAtAcceptDatetimeException()
+    {
+        $this->event->dailyAt('2018-12-06 18:06:37');
+
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testDailyAtAcceptSecondException()
+    {
+        $this->event->dailyAt('12:59:00');
+
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testDailyAtAcceptBoolException()
+    {
+        $this->event->dailyAt(true);
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testDailyAtAcceptWordException()
+    {
+        $this->event->dailyAt('word');
+    }
+
     public function testTwiceDaily()
     {
         $this->assertEquals('0 3,15 * * *', $this->event->twiceDaily(3, 15)->getExpression());
@@ -52,6 +112,14 @@ class FrequencyTest extends TestCase
     public function testMonthlyOn()
     {
         $this->assertEquals('0 15 4 * *', $this->event->monthlyOn(4, '15:00')->getExpression());
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testMonthlyOnAcceptWordException()
+    {
+        $this->event->monthlyOn(1, 'word');
     }
 
     public function testTwiceMonthly()
@@ -77,6 +145,37 @@ class FrequencyTest extends TestCase
     public function testWeekdays()
     {
         $this->assertEquals('* * * * 1-5', $this->event->weekdays()->getExpression());
+    }
+
+    public function testWeeklyOn()
+    {
+        $this->assertEquals('0 8 * * 1', $this->event->weeklyOn(1, '08:00')->getExpression());
+    }
+
+    public function testWeeklyOnWithMinutes()
+    {
+        $this->assertEquals('12 8 * * 1', $this->event->weeklyOn(1, '08:12')->getExpression());
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testWeeklyOnAcceptWordException()
+    {
+        $this->event->weeklyOn(1, 'word');
+    }
+
+    public function testAt()
+    {
+        $this->assertEquals('22 13 * * 1', $this->event->weekly()->mondays()->at('13:22')->getExpression());
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testAtAcceptWordException()
+    {
+        $this->event->weekly()->mondays()->at('word');
     }
 
     public function testSundays()


### PR DESCRIPTION
see [#26752](https://github.com/laravel/framework/pull/26752)
see [#26753](https://github.com/laravel/framework/pull/26753)

> It's not a proper way to run dailyAt('12:59:00') at 12:00. If dailyAt('12:59:00') is considered as an invalid parameter, instead of identifying it as dailyAt('12:00'). It's better to throw an exception.
> Anyway, It does not make sense to treat the time specific to the seconds as the first minute of the hour it belongs to.

Compared to run dailyAt('12:59:00') at 12:00, throwing exceptions makes it easier for developers to find themselves using them incorrectly during the testing phase.
So I built this version that throws an exception when it detects invalid data.