### PR TITLE
[5.8] Add to ManagesFrequencies::dailyAt() parameter legality check and and improve related unit testing

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Carbon;
 trait ManagesFrequencies
 {
     /**
-     * valid hour:minute preg_match rule
+     * valid hour:minute preg_match rule.
      *
      * @var string
      */

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -7,6 +7,13 @@ use Illuminate\Support\Carbon;
 trait ManagesFrequencies
 {
     /**
+     * valid hour:minute preg_match rule
+     *
+     * @var string
+     */
+    protected $hourMinutePregMatchRule = '/(^((([0-1][0-9])|[0-9]|2[0-3]):([0-5][0-9]|[0-9]))$)|(^(([0-1][0-9])|[0-9]|2[0-3])$)/';
+
+    /**
      * The Cron expression representing the event's frequency.
      *
      * @param  string  $expression
@@ -148,6 +155,7 @@ trait ManagesFrequencies
      *
      * @param  string  $time
      * @return $this
+     * @throws \Exception
      */
     public function at($time)
     {
@@ -159,9 +167,13 @@ trait ManagesFrequencies
      *
      * @param  string  $time
      * @return $this
+     * @throws \Exception
      */
     public function dailyAt($time)
     {
+        if (mb_strlen($time) > 5 || is_bool($time) || preg_match($this->hourMinutePregMatchRule, $time, $matches) !== 1) {
+            throw new \Exception('Function dailyAt() accepted an invalid parameter.It can only be a time e.g(10:00, 19:30, etc)');
+        }
         $segments = explode(':', $time);
 
         return $this->spliceIntoPosition(2, (int) $segments[0])
@@ -291,6 +303,7 @@ trait ManagesFrequencies
      * @param  int  $day
      * @param  string  $time
      * @return $this
+     * @throws \Exception
      */
     public function weeklyOn($day, $time = '0:0')
     {
@@ -317,6 +330,7 @@ trait ManagesFrequencies
      * @param  int  $day
      * @param  string  $time
      * @return $this
+     * @throws \Exception
      */
     public function monthlyOn($day = 1, $time = '0:0')
     {

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -38,6 +38,66 @@ class FrequencyTest extends TestCase
         $this->assertEquals('0 0 * * *', $this->event->daily()->getExpression());
     }
 
+    public function testDailyAt()
+    {
+        $this->assertEquals('59 12 * * *', $this->event->dailyAt('12:59')->getExpression());
+        $this->assertEquals('0 12 * * *', $this->event->dailyAt('12')->getExpression());
+        $this->assertEquals('0 0 * * *', $this->event->dailyAt('0')->getExpression());
+        $this->assertEquals('0 0 * * *', $this->event->dailyAt(0)->getExpression());
+        $this->assertEquals('0 0 * * *', $this->event->dailyAt('00')->getExpression());
+        $this->assertEquals('0 0 * * *', $this->event->dailyAt('00:00')->getExpression());
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testDailyAtAcceptInvalidDataExceptionOne()
+    {
+        $this->event->dailyAt('12:abc');
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testDailyAtAcceptInvalidDataExceptionTwo()
+    {
+        $this->event->dailyAt('1 :59');
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testDailyAtAcceptDatetimeException()
+    {
+        $this->event->dailyAt('2018-12-06 18:06:37');
+
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testDailyAtAcceptSecondException()
+    {
+        $this->event->dailyAt('12:59:00');
+
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testDailyAtAcceptBoolException()
+    {
+        $this->event->dailyAt(true);
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testDailyAtAcceptWordException()
+    {
+        $this->event->dailyAt('word');
+    }
+
     public function testTwiceDaily()
     {
         $this->assertEquals('0 3,15 * * *', $this->event->twiceDaily(3, 15)->getExpression());
@@ -52,6 +112,14 @@ class FrequencyTest extends TestCase
     public function testMonthlyOn()
     {
         $this->assertEquals('0 15 4 * *', $this->event->monthlyOn(4, '15:00')->getExpression());
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testMonthlyOnAcceptWordException()
+    {
+        $this->event->monthlyOn(1, 'word');
     }
 
     public function testTwiceMonthly()
@@ -77,6 +145,37 @@ class FrequencyTest extends TestCase
     public function testWeekdays()
     {
         $this->assertEquals('* * * * 1-5', $this->event->weekdays()->getExpression());
+    }
+
+    public function testWeeklyOn()
+    {
+        $this->assertEquals('0 8 * * 1', $this->event->weeklyOn(1, '08:00')->getExpression());
+    }
+
+    public function testWeeklyOnWithMinutes()
+    {
+        $this->assertEquals('12 8 * * 1', $this->event->weeklyOn(1, '08:12')->getExpression());
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testWeeklyOnAcceptWordException()
+    {
+        $this->event->weeklyOn(1, 'word');
+    }
+
+    public function testAt()
+    {
+        $this->assertEquals('22 13 * * 1', $this->event->weekly()->mondays()->at('13:22')->getExpression());
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testAtAcceptWordException()
+    {
+        $this->event->weekly()->mondays()->at('word');
     }
 
     public function testSundays()

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -70,7 +70,6 @@ class FrequencyTest extends TestCase
     public function testDailyAtAcceptDatetimeException()
     {
         $this->event->dailyAt('2018-12-06 18:06:37');
-
     }
 
     /**
@@ -79,7 +78,6 @@ class FrequencyTest extends TestCase
     public function testDailyAtAcceptSecondException()
     {
         $this->event->dailyAt('12:59:00');
-
     }
 
     /**
@@ -88,6 +86,14 @@ class FrequencyTest extends TestCase
     public function testDailyAtAcceptBoolException()
     {
         $this->event->dailyAt(true);
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testDailyAtAcceptNullException()
+    {
+        $this->event->dailyAt(null);
     }
 
     /**


### PR DESCRIPTION
**Compared to run dailyAt('12:59:00') at 12:00, throwing exceptions makes it easier for developers to find themselves using them incorrectly during the testing phase.**
So I built this version that throws an exception when it detects invalid data.
**vaild**: `12`,`12:00`,`12:0`,`0:1` (normal execution)
**invaild**: `'0 :12'`,`'word'`,`'09:15:49'`,`'2018-12-07 09:15:57'`,true,null (throw an exception)