### PR TITLE
[5.7] Add "NOT VALID" option for skipping validation when adding postgres foreign keys

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -166,6 +166,10 @@ class PostgresGrammar extends Grammar
             $sql .= $command->initiallyImmediate ? ' initially immediate' : ' initially deferred';
         }
 
+        if (! is_null($command->notValid)) {
+            $sql .= ' not valid';
+        }
+
         return $sql;
     }
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -729,6 +729,13 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable initially deferred', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreign('parent_id')->references('id')->on('parents')->onDelete('cascade')->deferrable()->notValid();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable not valid', $statements[0]);
     }
 
     public function testAddingGeometry()


### PR DESCRIPTION
Adding a foreign index to a postgres table requires an exclusive access lock on the table as postgres validates the existing data. This can be a lengthy check, and in our case lead to the lock queue spinning out of control. 

"not valid", tells postgres to skip this data validation and therefore it doesn't require an exclusive lock.

Further reading:
https://travisofthenorth.com/blog/2017/2/2/postgres-adding-foreign-keys-with-zero-downtime