### PR TITLE
Allow eloquent where to accept model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -211,7 +211,7 @@ class Builder
     /**
      * Add a basic where clause to the query.
      *
-     * @param  string|array|\Closure  $column
+     * @param  string|array|\Closure|Model  $column
      * @param  mixed   $operator
      * @param  mixed   $value
      * @param  string  $boolean
@@ -219,6 +219,10 @@ class Builder
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
+        if ($column instanceof Model) {
+            return $this->where($column->getKeyName(), $column->getKey());
+        }
+
         if ($column instanceof Closure) {
             $column($query = $this->model->newModelQuery());
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -6,6 +6,7 @@ use Closure;
 use stdClass;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Auth\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\ConnectionInterface;
@@ -634,6 +635,14 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getQuery()->shouldReceive('where')->once()->with('foo', '=', 'bar');
         $result = $builder->where('foo', '=', 'bar');
         $this->assertEquals($result, $builder);
+    }
+
+    public function testWhereModel()
+    {
+        $user = tap(new User)->forceFill(['id' => 1]);
+        $query = EloquentBuilderTestModelParentStub::query()->where($user);
+        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "id" = ?', $query->toSql());
+        $this->assertEquals([0 => $user->id], $query->getBindings());
     }
 
     public function testPostgresOperatorsWhere()


### PR DESCRIPTION
Add the ability to pass a model into eloquent where. 
This will bind the primary key and value.

```php
$user = User::first();
$permission = Post::where($user)->get();
```
