### PR TITLE
[5.7] Fix hidden commands

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -117,6 +117,14 @@ class Command extends SymfonyCommand
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function isHidden()
+    {
+        return $this->hidden;
+    }
+
+    /**
      * Configure the console command using a fluent definition.
      *
      * @return void


### PR DESCRIPTION
https://github.com/laravel/framework/pull/25342 broke the way this worked. Because we overwrite the property's visibility we also need to overwrite the `isHidden` method so it takes the property's value from the child class.

Fixes https://github.com/laravel/framework/issues/26779