### PR TITLE
[5.7] Validate $line is a string to prevent htmlspecialchars error

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -131,7 +131,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // If the line doesn't exist, we will return back the key which was requested as
         // that will be quick to spot in the UI if language keys are wrong or missing
         // from the application's language files. Otherwise we can return the line.
-        if (isset($line)) {
+        if (isset($line) && is_string($line)) {
             return $line;
         }
 


### PR DESCRIPTION
To resolve: https://github.com/laravel/framework/issues/26664

When a user attempts to translate a key that has an array for its value,
we encounter an error as this array is passed to htmlspecialchars().

Similarly, issue is also encountered when the user attempts to translate
a word that is also used for the name of a translation file.

This fix ensures that if the string to be translated has an array value,
the original string is output to the screen.

Same behaviour will also occur if the string corresponds to the name of a
translation file.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
