### PR TITLE
[5.7] data_get 2nd parameter accepts integer actually.

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -443,7 +443,7 @@ if (! function_exists('data_get')) {
      * Get an item from an array or object using "dot" notation.
      *
      * @param  mixed   $target
-     * @param  string|array  $key
+     * @param  string|array|int  $key
      * @param  mixed   $default
      * @return mixed
      */


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

**Benefit:**
phpstan static code analysis. if do not include int in the annotation, it will cause verify error:

![image](https://user-images.githubusercontent.com/6964962/49681465-f7168f00-fadc-11e8-970c-2611582ec189.png)
