### PR TITLE
[5.7] allow to set default time zone for scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -149,7 +149,7 @@ class Event
      * @param  string  $command
      * @return void
      */
-    public function __construct(EventMutex $mutex, $command, $timezone=null)
+    public function __construct(EventMutex $mutex, $command, $timezone = null)
     {
         $this->mutex = $mutex;
         $this->command = $command;

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -147,6 +147,7 @@ class Event
      *
      * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
      * @param  string  $command
+     * @param  \DateTimeZone|string $timezone
      * @return void
      */
     public function __construct(EventMutex $mutex, $command, $timezone = null)

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -149,11 +149,12 @@ class Event
      * @param  string  $command
      * @return void
      */
-    public function __construct(EventMutex $mutex, $command)
+    public function __construct(EventMutex $mutex, $command, $timezone=null)
     {
         $this->mutex = $mutex;
         $this->command = $command;
         $this->output = $this->getDefaultOutput();
+        $this->timezone = $timezone;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -55,9 +55,9 @@ class Schedule
                                 ? $container->make(SchedulingMutex::class)
                                 : $container->make(CacheSchedulingMutex::class);
 
-        if($container->bound('config')){
-            $config = $container->get("config");
-            $this->timezone = $config->get('app.schedular_timezone')?:$config->get('app.timezone');
+        if ($container->bound('config')) {
+            $config = $container->get('config');
+            $this->timezone = $config->get('app.schedular_timezone') ?: $config->get('app.timezone');
         }
 
     }

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -32,6 +32,13 @@ class Schedule
     protected $schedulingMutex;
 
     /**
+     * The timezone the date should be evaluated on.
+     *
+     * @var \DateTimeZone|string
+     */
+    public $timezone;
+
+    /**
      * Create a new schedule instance.
      *
      * @return void
@@ -47,6 +54,12 @@ class Schedule
         $this->schedulingMutex = $container->bound(SchedulingMutex::class)
                                 ? $container->make(SchedulingMutex::class)
                                 : $container->make(CacheSchedulingMutex::class);
+
+        if($container->bound('config')){
+            $config = $container->get("config");
+            $this->timezone = $config->get('app.schedular_timezone')?:$config->get('app.timezone');
+        }
+
     }
 
     /**
@@ -119,7 +132,7 @@ class Schedule
             $command .= ' '.$this->compileParameters($parameters);
         }
 
-        $this->events[] = $event = new Event($this->eventMutex, $command);
+        $this->events[] = $event = new Event($this->eventMutex, $command, $this->timezone);
 
         return $event;
     }


### PR DESCRIPTION
this PR is related to this one: https://github.com/laravel/ideas/issues/221

you can set default time zone for scheduler in config/app.php as below.

```
'scheduler_timezone' => 'America/New_York',
```

if it gets accepted, I am going to add it to https://github.com/laravel/laravel.
