### PR TITLE
[5.8] Use Mailable contract instead of class

### DIFF
--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Mail;
 
-use Illuminate\Contracts\Mail\Mailable as MailableContract;
-use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Translation\HasLocalePreference;
+use Illuminate\Contracts\Mail\Mailable as MailableContract;
 
 class PendingMail
 {

--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Mail;
 
+use Illuminate\Contracts\Mail\Mailable as MailableContract;
+use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 
@@ -10,7 +12,7 @@ class PendingMail
     /**
      * The mailer instance.
      *
-     * @var \Illuminate\Mail\Mailer
+     * @var\Illuminate\Contracts\Mail\Mailer  $mailer
      */
     protected $mailer;
 
@@ -45,10 +47,10 @@ class PendingMail
     /**
      * Create a new mailable mailer instance.
      *
-     * @param  \Illuminate\Mail\Mailer  $mailer
+     * @param  \Illuminate\Contracts\Mail\Mailer  $mailer
      * @return void
      */
-    public function __construct(Mailer $mailer)
+    public function __construct(MailerContract $mailer)
     {
         $this->mailer = $mailer;
     }
@@ -112,10 +114,11 @@ class PendingMail
     /**
      * Send a new mailable message instance.
      *
-     * @param  \Illuminate\Mail\Mailable  $mailable
+     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
+     *
      * @return mixed
      */
-    public function send(Mailable $mailable)
+    public function send(MailableContract $mailable)
     {
         if ($mailable instanceof ShouldQueue) {
             return $this->queue($mailable);
@@ -127,10 +130,10 @@ class PendingMail
     /**
      * Send a mailable message immediately.
      *
-     * @param  \Illuminate\Mail\Mailable  $mailable
+     * @param  \Illuminate\Contracts\Mail\Mailable $mailable;
      * @return mixed
      */
-    public function sendNow(Mailable $mailable)
+    public function sendNow(MailableContract $mailable)
     {
         return $this->mailer->send($this->fill($mailable));
     }
@@ -138,10 +141,10 @@ class PendingMail
     /**
      * Push the given mailable onto the queue.
      *
-     * @param  \Illuminate\Mail\Mailable  $mailable
+     * @param  \Illuminate\Contracts\Mail\Mailable $mailable;
      * @return mixed
      */
-    public function queue(Mailable $mailable)
+    public function queue(MailableContract $mailable)
     {
         $mailable = $this->fill($mailable);
 
@@ -156,10 +159,10 @@ class PendingMail
      * Deliver the queued message after the given delay.
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
-     * @param  \Illuminate\Mail\Mailable  $mailable
+     * @param  \Illuminate\Contracts\Mail\Mailable $mailable;
      * @return mixed
      */
-    public function later($delay, Mailable $mailable)
+    public function later($delay, MailableContract $mailable)
     {
         return $this->mailer->later($delay, $this->fill($mailable));
     }
@@ -167,10 +170,10 @@ class PendingMail
     /**
      * Populate the mailable with the addresses.
      *
-     * @param  \Illuminate\Mail\Mailable  $mailable
+     * @param  \Illuminate\Contracts\Mail\Mailable $mailable;
      * @return \Illuminate\Mail\Mailable
      */
-    protected function fill(Mailable $mailable)
+    protected function fill(MailableContract $mailable)
     {
         return $mailable->to($this->to)
                         ->cc($this->cc)

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -10,7 +10,7 @@ class SendQueuedMailable
     /**
      * The mailable message instance.
      *
-     * @var \Illuminate\Mail\Mailable
+     * @var \Illuminate\Contracts\Mail\Mailable
      */
     public $mailable;
 

--- a/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
-use Illuminate\Mail\Mailable;
 use Illuminate\Mail\PendingMail;
+use Illuminate\Contracts\Mail\Mailable;
 
 class PendingMailFake extends PendingMail
 {
@@ -21,7 +21,7 @@ class PendingMailFake extends PendingMail
     /**
      * Send a new mailable message instance.
      *
-     * @param  \Illuminate\Mail\Mailable $mailable
+     * @param  \Illuminate\Contracts\Mail\Mailable $mailable;
      * @return mixed
      */
     public function send(Mailable $mailable)
@@ -32,7 +32,7 @@ class PendingMailFake extends PendingMail
     /**
      * Send a mailable message immediately.
      *
-     * @param  \Illuminate\Mail\Mailable $mailable
+     * @param  \Illuminate\Contracts\Mail\Mailable $mailable;
      * @return mixed
      */
     public function sendNow(Mailable $mailable)
@@ -43,7 +43,7 @@ class PendingMailFake extends PendingMail
     /**
      * Push the given mailable onto the queue.
      *
-     * @param  \Illuminate\Mail\Mailable $mailable
+     * @param  \Illuminate\Contracts\Mail\Mailable $mailable;
      * @return mixed
      */
     public function queue(Mailable $mailable)

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -5,11 +5,11 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Mail\Mailable;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Support\Testing\Fakes\MailFake;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\Constraint\ExceptionMessage;
 use Illuminate\Contracts\Translation\HasLocalePreference;
+use Illuminate\Contracts\Mail\Mailable as MailableContract;
 
 class SupportTestingMailFakeTest extends TestCase
 {

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Mail\Mailable;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Support\Testing\Fakes\MailFake;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\Constraint\ExceptionMessage;
@@ -141,7 +142,7 @@ class SupportTestingMailFakeTest extends TestCase
     }
 }
 
-class MailableStub extends Mailable
+class MailableStub extends Mailable implements MailableContract
 {
     public $framework = 'Laravel';
 


### PR DESCRIPTION
Hey,

This shouldn't break any existing code, but at my current employer I wanted to add a [custom mail driver](https://www.smtp.com/), and integrate that with the framework as much as possible, but was unable to do so because PendingMail depends on a concrete instance of Mailable, instead of the contract.

This PR solves my issue, and maybe make it easier to add custom mail drivers for everyone in the future.