### PR TITLE
[5.7] Creation of artisan command make:globalscope

### DIFF
--- a/src/Illuminate/Foundation/Console/GlobalscopeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/GlobalscopeMakeCommand.php
@@ -34,7 +34,7 @@ class GlobalscopeMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__ . '/stubs/globalscope.stub';
+        return __DIR__.'/stubs/globalscope.stub';
     }
 
     /**
@@ -45,6 +45,6 @@ class GlobalscopeMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace . '\Scopes';
+        return $rootNamespace.'\Scopes';
     }
 }

--- a/src/Illuminate/Foundation/Console/GlobalscopeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/GlobalscopeMakeCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+
+class GlobalscopeMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:globalscope';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new global scope class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Scope';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__ . '/stubs/globalscope.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . '\Scopes';
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/globalscope.stub
+++ b/src/Illuminate/Foundation/Console/stubs/globalscope.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class DummyClass implements Scope
+{
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function apply(Builder $builder, Model $model)
+    {
+        //
+    }
+}


### PR DESCRIPTION
Added an artisan command and stub for the creation of global scopes.

Usage: 
`php artisan make:globalscope TestScope`