### PR TITLE
[5.8] Allow to set default time zone for scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -148,13 +148,15 @@ class Event
      *
      * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
      * @param  string  $command
+     * @param  \DateTimeZone|string $timezone
      * @return void
      */
-    public function __construct(EventMutex $mutex, $command)
+    public function __construct(EventMutex $mutex, $command, $timezone = null)
     {
         $this->mutex = $mutex;
         $this->command = $command;
         $this->output = $this->getDefaultOutput();
+        $this->timezone = $timezone;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -32,6 +32,13 @@ class Schedule
     protected $schedulingMutex;
 
     /**
+     * The timezone the date should be evaluated on.
+     *
+     * @var \DateTimeZone|string
+     */
+    public $timezone;
+
+    /**
      * Create a new schedule instance.
      *
      * @return void
@@ -47,6 +54,12 @@ class Schedule
         $this->schedulingMutex = $container->bound(SchedulingMutex::class)
                                 ? $container->make(SchedulingMutex::class)
                                 : $container->make(CacheSchedulingMutex::class);
+
+        if ($container->bound('config')) {
+            $config = $container->get('config');
+            $this->timezone = $config->get('app.scheduler_timezone') ?: $config->get('app.timezone');
+        }
+
     }
 
     /**
@@ -119,7 +132,7 @@ class Schedule
             $command .= ' '.$this->compileParameters($parameters);
         }
 
-        $this->events[] = $event = new Event($this->eventMutex, $command);
+        $this->events[] = $event = new Event($this->eventMutex, $command, $this->timezone);
 
         return $event;
     }

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -59,7 +59,6 @@ class Schedule
             $config = $container->get('config');
             $this->timezone = $config->get('app.scheduler_timezone') ?: $config->get('app.timezone');
         }
-
     }
 
     /**

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -71,6 +71,7 @@ class ConsoleEventSchedulerTest extends TestCase
         $this->assertEquals("path/to/command {$escape}one{$escape} {$escape}two{$escape}", $events[6]->command);
         $this->assertEquals("path/to/command {$escape}-1 minute{$escape}", $events[7]->command);
     }
+
     public function testExecCreatesNewCommandWithTimezone()
     {
         $container = Container::getInstance();

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -6,12 +6,12 @@ use Mockery as m;
 use Illuminate\Console\Command;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
+use Illuminate\Config\Repository as Config;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\EventMutex;
 use Illuminate\Console\Scheduling\CacheEventMutex;
 use Illuminate\Console\Scheduling\SchedulingMutex;
 use Illuminate\Console\Scheduling\CacheSchedulingMutex;
-use Illuminate\Config\Repository as Config;
 
 class ConsoleEventSchedulerTest extends TestCase
 {
@@ -70,10 +70,9 @@ class ConsoleEventSchedulerTest extends TestCase
         $this->assertEquals("path/to/command --title={$escape}A {$escapeReal}real{$escapeReal} test{$escape}", $events[5]->command);
         $this->assertEquals("path/to/command {$escape}one{$escape} {$escape}two{$escape}", $events[6]->command);
         $this->assertEquals("path/to/command {$escape}-1 minute{$escape}", $events[7]->command);
-
     }
-    public function testExecCreatesNewCommandWithTimezone(){
-
+    public function testExecCreatesNewCommandWithTimezone()
+    {
         $container = Container::getInstance();
 
         $config = new Config([
@@ -87,7 +86,7 @@ class ConsoleEventSchedulerTest extends TestCase
         $schedule = new Schedule(m::mock(EventMutex::class));
         $schedule->exec('path/to/command');
         $events = $schedule->events();
-        $this->assertEquals("UTC", $events[0]->timezone);
+        $this->assertEquals('UTC', $events[0]->timezone);
 
         $config = new Config([
             'app' => [
@@ -100,8 +99,7 @@ class ConsoleEventSchedulerTest extends TestCase
         $schedule = new Schedule(m::mock(EventMutex::class));
         $schedule->exec('path/to/command');
         $events = $schedule->events();
-        $this->assertEquals("Asia/Tokyo", $events[0]->timezone);
-
+        $this->assertEquals('Asia/Tokyo', $events[0]->timezone);
     }
 
     public function testCommandCreatesNewArtisanCommand()

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -11,6 +11,7 @@ use Illuminate\Console\Scheduling\EventMutex;
 use Illuminate\Console\Scheduling\CacheEventMutex;
 use Illuminate\Console\Scheduling\SchedulingMutex;
 use Illuminate\Console\Scheduling\CacheSchedulingMutex;
+use Illuminate\Config\Repository as Config;
 
 class ConsoleEventSchedulerTest extends TestCase
 {
@@ -69,6 +70,38 @@ class ConsoleEventSchedulerTest extends TestCase
         $this->assertEquals("path/to/command --title={$escape}A {$escapeReal}real{$escapeReal} test{$escape}", $events[5]->command);
         $this->assertEquals("path/to/command {$escape}one{$escape} {$escape}two{$escape}", $events[6]->command);
         $this->assertEquals("path/to/command {$escape}-1 minute{$escape}", $events[7]->command);
+
+    }
+    public function testExecCreatesNewCommandWithTimezone(){
+
+        $container = Container::getInstance();
+
+        $config = new Config([
+            'app' => [
+                'timezone' => 'UTC',
+                'scheduler_timezone' => null,
+            ],
+        ]);
+
+        $container->instance('config', $config);
+        $schedule = new Schedule(m::mock(EventMutex::class));
+        $schedule->exec('path/to/command');
+        $events = $schedule->events();
+        $this->assertEquals("UTC", $events[0]->timezone);
+
+        $config = new Config([
+            'app' => [
+                'timezone' => 'UTC',
+                'scheduler_timezone' => 'Asia/Tokyo',
+            ],
+        ]);
+
+        $container->instance('config', $config);
+        $schedule = new Schedule(m::mock(EventMutex::class));
+        $schedule->exec('path/to/command');
+        $events = $schedule->events();
+        $this->assertEquals("Asia/Tokyo", $events[0]->timezone);
+
     }
 
     public function testCommandCreatesNewArtisanCommand()


### PR DESCRIPTION
this PR is related to this one: https://github.com/laravel/ideas/issues/221

you can set default time zone for scheduler in config/app.php as below.

```
'scheduler_timezone' => 'America/New_York',
```

if it gets accepted, I am going to add it to https://github.com/laravel/laravel.