### PR TITLE
[5.7] throw InvalidArgumentException for invalid orderBy direction

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1784,7 +1784,7 @@ class Builder
      */
     public function orderBy($column, $direction = 'asc')
     {
-        if (! in_array($direction, ['asc', 'desc'])) {
+        if (! in_array(strtolower($direction), ['asc', 'desc'])) {
             throw new InvalidArgumentException("Invalid orderBy direction: {$direction}.");
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1781,16 +1781,19 @@ class Builder
      * @param  string  $column
      * @param  string  $direction
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function orderBy($column, $direction = 'asc')
     {
-        if (! in_array(strtolower($direction), ['asc', 'desc'])) {
+        $direction = strtolower($direction);
+        if (! in_array($direction, ['asc', 'desc'])) {
             throw new InvalidArgumentException("Invalid orderBy direction: {$direction}.");
         }
 
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
             'column' => $column,
-            'direction' => strtolower($direction) === 'asc' ? 'asc' : 'desc',
+            'direction' => $direction === 'asc' ? 'asc' : 'desc',
         ];
 
         return $this;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1784,6 +1784,10 @@ class Builder
      */
     public function orderBy($column, $direction = 'asc')
     {
+        if (! in_array($direction, ['asc', 'desc'])) {
+            throw new InvalidArgumentException("Invalid orderBy direction: {$direction}.");
+        }
+
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
             'column' => $column,
             'direction' => strtolower($direction) === 'asc' ? 'asc' : 'desc',


### PR DESCRIPTION
Currently If $direction is a typo (ex. 'as', 'aesc'), that means orderBy('desc'), laravel does not inform you that only 'asc' and 'desc' are allowed.

This PR solves this problem.