### PR TITLE
[5.7] Qualify model name according to make:model before passing it to make:factory

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -71,7 +71,7 @@ class ModelMakeCommand extends GeneratorCommand
 
         $this->call('make:factory', [
             'name' => "{$factory}Factory",
-            '--model' => $this->argument('name'),
+            '--model' => $this->qualifyClass($this->getNameInput()),
         ]);
     }
 


### PR DESCRIPTION
In projects where models are stored in `App\Models`, I like to override the `getDefaultNamespace()` method on `ModelMakeCommand`, and point it to `App\Models`.

Generated controllers with `--controller` or `--all` took this over correctly (because it [uses the same piece of code](https://github.com/laravel/framework/blob/8da5b7ddedaaaf84b223b4ac3f632e45cf9aba0a/src/Illuminate/Foundation/Console/ModelMakeCommand.php#L106) I added in this PR). Now, generated factories with `--factory` or `--all` will also use this namespace.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->