### PR TITLE
[5.7] Create new model with configurable states

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -390,13 +390,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $model->exists = $exists;
 
-        $model->setConnection(
-            $this->getConnectionName()
-        );
-
-        $model->setTable($this->getTable());
-
-        return $model;
+        // Apply all configurable states for the new model instance.
+        return $model
+            ->setTable($this->getTable())
+            ->setKeyName($this->getKeyName())
+            ->setKeyType($this->getKeyType())
+            ->setPerPage($this->getPerPage())
+            ->setConnection($this->getConnectionName())
+            ->setIncrementing($this->getIncrementing());
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -168,13 +168,23 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('taylor', $instance->name);
     }
 
-    public function testNewInstanceReturnsNewInstanceWithTableSet()
+    public function testNewInstanceReturnsNewInstanceWithConfigurableStates()
     {
         $model = new EloquentModelStub;
-        $model->setTable('test');
+        $model->setTable('foo_tests');
+        $model->setKeyName('foo_test_id');
+        $model->setKeyType('string');
+        $model->setPerPage(11);
+        $model->setConnection('foo_connection');
+        $model->setIncrementing(false);
         $newInstance = $model->newInstance();
 
-        $this->assertEquals('test', $newInstance->getTable());
+        $this->assertSame('foo_tests', $newInstance->getTable());
+        $this->assertSame('foo_test_id', $newInstance->getKeyName());
+        $this->assertSame('string', $newInstance->getKeyType());
+        $this->assertSame(11, $newInstance->getPerPage());
+        $this->assertSame('foo_connection', $newInstance->getConnectionName());
+        $this->assertFalse($newInstance->getIncrementing());
     }
 
     public function testCreateMethodSavesNewModel()
@@ -1976,11 +1986,6 @@ class EloquentModelSaveStub extends Model
     public function save(array $options = [])
     {
         $_SERVER['__eloquent.saved'] = true;
-    }
-
-    public function setIncrementing($value)
-    {
-        $this->incrementing = $value;
     }
 
     public function getConnection()


### PR DESCRIPTION
To resolve completely this issue https://github.com/laravel/framework/pull/26085. I think it's better to create a new model with configurable states that could be changed via setters (public set* methods) such as:

+ setTable()
+ setKeyName()
+ setKeyType()
+ setPerPage()
+ setConnection()
+ setIncrementing()