### PR TITLE
[5.8] Delete unused const

### DIFF
--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -12,13 +12,6 @@ class MemcachedStore extends TaggableStore implements LockProvider
     use InteractsWithTime;
 
     /**
-     * The maximum value that can be specified as an expiration delta.
-     *
-     * @var int
-     */
-    const REALTIME_MAXDELTA_IN_MINUTES = 43200;
-
-    /**
      * The Memcached instance.
      *
      * @var \Memcached


### PR DESCRIPTION
- https://github.com/laravel/framework/pull/25912 was merged to the master and after this this PR was reverted (e5be0dbb4ff2bf2ce9861065f64fc1552a3d59f9) but not fully.

This PR is removed unused const REALTIME_MAXDELTA_IN_MINUTES which is added in https://github.com/laravel/framework/pull/25912, but not used yet

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
