### PR TITLE
[5.8] Fix "different" validation with null values

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -437,9 +437,13 @@ trait ValidatesAttributes
         $this->requireParameterCount(1, $parameters, 'different');
 
         foreach ($parameters as $parameter) {
+            if (! Arr::has($this->data, $parameter)) {
+                return false;
+            }
+
             $other = Arr::get($this->data, $parameter);
 
-            if (is_null($other) || $value === $other) {
+            if ($value === $other) {
                 return false;
             }
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1047,6 +1047,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'Different:baz']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['foo' => 'bar', 'baz' => null], ['foo' => 'Different:baz']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'Different:baz']);
         $this->assertFalse($v->passes());
 


### PR DESCRIPTION
The `different` validation fails when the other value is `null`:

```php
$v = Validator::make(['foo' => 'bar', 'baz' => null], ['foo' => 'different:baz']);
$v->passes(); // false
```

`Arr::get()` returns `null` as the default value for missing keys. We have to use `Arr::has()` to differentiate between missing keys and actual `null` values.

Fixes #26749.