### PR TITLE
[5.7] Uploaded file store/storeAs fails when uploaded file is empty

### DIFF
--- a/src/Illuminate/Http/FileHelpers.php
+++ b/src/Illuminate/Http/FileHelpers.php
@@ -56,10 +56,13 @@ trait FileHelpers
         }
 
         $hash = $this->hashName ?: $this->hashName = Str::random(40);
-        
+
         $extension = $this->guessExtension();
-        if ($extension) $extension = '.' . $extension;
-         
-        return $path . $hash . $extension;
+        if ($extension) {
+            $extension = '.'.$extension;
+        }
+
+        return $path.$hash.$extension;
+
     }
 }

--- a/src/Illuminate/Http/FileHelpers.php
+++ b/src/Illuminate/Http/FileHelpers.php
@@ -56,7 +56,10 @@ trait FileHelpers
         }
 
         $hash = $this->hashName ?: $this->hashName = Str::random(40);
-
-        return $path.$hash.'.'.$this->guessExtension();
+        
+        $extension = $this->guessExtension();
+        if ($extension) $extension = '.' . $extension;
+         
+        return $path . $hash . $extension;
     }
 }

--- a/src/Illuminate/Http/FileHelpers.php
+++ b/src/Illuminate/Http/FileHelpers.php
@@ -63,6 +63,5 @@ trait FileHelpers
         }
 
         return $path.$hash.$extension;
-
     }
 }


### PR DESCRIPTION
Resolves #26808.

This PR fixes `hashName` (Illuminate/Http/FileHelpers) function to prevent returning trailing dot if the file extension is not guessed.
