### PR TITLE
[5.8] Easy attach related models to Eloquent Factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -456,13 +456,19 @@ class FactoryBuilder
             return $this->macroableCall($method, $parameters);
         }
 
-        $instance = new $this->class();
+        $this->afterCreating[$this->class][$this->name][] = function ($model) use ($relationshipMethod, $parameters) {
+            $instance = new $this->class();
 
-        $relationship = $instance->$relationshipMethod();
+            $relationship = $instance->$relationshipMethod();
 
-        $this->afterCreating[$this->class][$this->name][] = function ($model) use ($relationship,$relationshipMethod) {
+            $amount = $parameters[0] ?? 1;
+
+            $name = isset($parameters[1]) && is_string($parameters[1]) ? $parameters[1] : 'default';
+
+            $states = $parameters[2] ?? isset($parameters[1]) && is_array($parameters[1]) ? $parameters[1] : [];
+
             $model->$relationshipMethod()->saveMany(
-                factory(get_class($relationship->getRelated()), 2)->make()
+                factory(get_class($relationship->getRelated()), $name, $amount)->states($states)->make()
             );
         };
 

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -471,7 +471,6 @@ class FactoryBuilder
         return $this->macroableCall($method, $parameters);
     }
 
-
     /**
      * Handles creating related models.
      *


### PR DESCRIPTION
This PR allows for something like:

```
$server = factory(Server::class)
            ->withSites(2, 'siteWithWWW')
            ->withDatabases(4, ['mysql', 'migrated'])
            ->create();
```

This will create a Server, create 2 sites with the factory named `siteWithWWW`, and create 4 databases with states of `mysql` and `migrated`.

It works with all relationship types except `HasManyThrough`.

You can also do:

```
$certificate = factory(Certificate::class)->forSite($site)->create();
```