### PR TITLE
Float values loosing decimals on save when PDO::ATTR_EMULATE_PREPARES = true

### DIFF
--- a/tests/Integration/Database/DatabaseAttrEmulatePrepareTest.php
+++ b/tests/Integration/Database/DatabaseAttrEmulatePrepareTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use PDO;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+
+class DatabaseAttrEmulatePrepareTest extends Testcase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('products', function (Blueprint $table) {
+            $table->increments('id');
+            $table->double('price', 12, 3);
+            $table->timestamps();
+        });
+    }
+
+    public function tearDown()
+    {
+        Schema::dropIfExists('products');
+
+        parent::tearDown();
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'mysql',
+            'host' => '127.0.0.1',
+            'username' => 'root',
+            'password' => '',
+            'database' => 'forge',
+            'prefix' => '',
+            'options' => [
+                PDO::ATTR_EMULATE_PREPARES => true,
+            ],
+        ]);
+    }
+
+    public function test_float_is_saved_correctly_when_attr_emulate_prepares_is_true()
+    {
+        $product = Product::forceCreate([
+            'price' => 1.234,
+        ])->fresh();
+
+        $this->assertEquals(1.234, $product->price);
+    }
+}
+
+class Product extends Model
+{
+    protected $table = 'products';
+}


### PR DESCRIPTION
Laravel Version: >= 5.3
PHP Version: 7.2
Database: mysql

This pull request contains a failing test which will showcase that when `PDO::ATTR_EMULATE_PREPARES = true`, float values are not saved correctly.

```php config/database.php
'mysql' => [
    //
    'options' => array(
        PDO::ATTR_EMULATE_PREPARES => true,
    ),
],
```

```php
$product = new Product;
$product->price = 1.234; // this is saved as 1.000
$product->save()
```


All started with #16069. This change didn't cause much trouble back then, because php 7.2 were not released, and this behaviour only happens on this version. **On php 7.0 / 7.1 seems to work ok.**


The code which is responsible for this behaviour is in MysqlConnection@bindValues. If the value is a float it is casted as PDO::PARAM_INT.

`is_int($value) || is_float($value) ? PDO::PARAM_INT : PDO::PARAM_STR`


At first glance the fix is simple, remove the `|| is_float($value)`, but I am sure Mohamed had strong reasons why it did that. He wanted to fix #16063, but there are no tests in that pull request #16069. so I don't know how big the impact will be if this is going to be reverted.

I don't have enough knowledge about the inner things in the framework and I let someone with enough expertise to review this and take proper actions.

Thanks!


