### PR TITLE
[5.7] Cleaner package discovery output

### DIFF
--- a/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
+++ b/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
@@ -31,7 +31,7 @@ class PackageDiscoverCommand extends Command
     {
         $manifest->build();
 
-        if (! empty($manifest->manifest)) {        
+        if (! empty($manifest->manifest)) {
             $this->line("Discovered Packages:");
 
             foreach (array_keys($manifest->manifest) as $package) {

--- a/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
+++ b/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
@@ -31,8 +31,12 @@ class PackageDiscoverCommand extends Command
     {
         $manifest->build();
 
-        foreach (array_keys($manifest->manifest) as $package) {
-            $this->line("Discovered Package: <info>{$package}</info>");
+        if (! empty($manifest->manifest)) {        
+            $this->line("Discovered Packages:");
+
+            foreach (array_keys($manifest->manifest) as $package) {
+                $this->line(" - <info>{$package}</info>");
+            }
         }
 
         $this->info('Package manifest generated successfully.');


### PR DESCRIPTION
This is a little opinionated but I think that there is no need to repeat `Discovered Package:` 

**Before**
<img width="408" alt="screenshot 2018-12-12 at 21 50 31" src="https://user-images.githubusercontent.com/340752/49901044-1e13ee80-fe58-11e8-8478-d3ba4b8776ce.png">

**After**
<img width="316" alt="screenshot 2018-12-12 at 21 49 52" src="https://user-images.githubusercontent.com/340752/49901063-28ce8380-fe58-11e8-881a-28a96cb3aeb4.png">
