### PR TITLE
[5.7] Add Facade::resolved() method to register pending callback until the service is available.

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -23,6 +23,19 @@ abstract class Facade
     protected static $resolvedInstance;
 
     /**
+     * Run a Closure when the facade has been resolved.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function resolved(Closure $callback)
+    {
+        static::$app->afterResolving(static::getFacadeAccessor(), function ($service) use ($callback) {
+            $callback($service);
+        });
+    }
+
+    /**
      * Convert the facade into a Mockery spy.
      *
      * @return \Mockery\MockInterface

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support\Facades;
 
+use Closure;
 use Mockery;
 use RuntimeException;
 use Mockery\MockInterface;


### PR DESCRIPTION
Laravel by default shipped with `Illuminate\Foundation\Application::registerConfiguredProviders()` to ensure `Illuminate` namespace service provider will be loaded first before package discovery, however if a developer for example override `Illuminate\Auth\AuthServiceProvider` and then include `laravel/passport` which uses `Auth::extend()` the developer will faced the following error:

```
Unresolvable dependency resolving [Parameter #0 [ <required> $app ]] in class Illuminate\Support\Manager
```

This can be avoided if package discovery wait until the requested service is be resolved before trying to do anything with it, so I'm proposing the following to be implemented:

### Before

```php
    /**
     * Register the token guard.
     *
     * @return void
     */
    protected function registerGuard()
    {
        Auth::extend('passport', function ($app, $name, array $config) {
            return tap($this->makeGuard($config), function ($guard) {
                $this->app->refresh('request', $guard, 'setRequest');
            });
        });
    }
```

### After

```php
    /**
     * Register the token guard.
     *
     * @return void
     */
    protected function registerGuard()
    {
        Auth::resolved(function ($auth) {
            $auth->extend('passport', function ($app, $name, array $config) {
                return tap($this->makeGuard($config), function ($guard) {
                    $this->app->refresh('request', $guard, 'setRequest');
                });
            });
        });
    }
```


Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
