### PR TITLE
[5.8] Add fallback locales to JSON translator

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -160,7 +160,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         foreach ($locales as $_locale) {
             $this->load('*', '*', $_locale);
 
-            if (!is_null($line = $this->loaded['*']['*'][$_locale][$key] ?? null)) {
+            if (! is_null($line = $this->loaded['*']['*'][$_locale][$key] ?? null)) {
                 break;
             }
         }


### PR DESCRIPTION
Currently PHP based translations can fallback to multiple locales, where JSON based translations have no fallback at all.

I simply grabbed the same functionality that the PHP based translator used and added it to the JSON based translator.

This update ensures that the system has one standard across the translations. 
