### PR TITLE
Fix typehint in auth stub

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/controllers/HomeController.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/controllers/HomeController.stub
@@ -19,7 +19,7 @@ class HomeController extends Controller
     /**
      * Show the application dashboard.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\Response|\Illuminate\Contracts\Support\Renderable
      */
     public function index()
     {

--- a/src/Illuminate/Auth/Console/stubs/make/controllers/HomeController.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/controllers/HomeController.stub
@@ -19,7 +19,7 @@ class HomeController extends Controller
     /**
      * Show the application dashboard.
      *
-     * @return \Illuminate\Http\Response|\Illuminate\Contracts\Support\Renderable
+     * @return \Illuminate\Contracts\Support\Renderable
      */
     public function index()
     {


### PR DESCRIPTION
Tiny nitpick, but the `view()` helper does not return a Response. So it should either be a View, or a Renderable. Or we could remove the Response typehint also.