### PR TITLE
Added orderByPivot() method to BelongsToMany relationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -63,6 +63,13 @@ class BelongsToMany extends Relation
     protected $pivotColumns = [];
 
     /**
+     * Any pivot table restrictions for orderBy clauses.
+     *
+     * @var array
+     */
+    protected $pivotOrderBys = [];
+
+    /**
      * Any pivot table restrictions for where clauses.
      *
      * @var array
@@ -313,6 +320,22 @@ class BelongsToMany extends Relation
         $this->accessor = $accessor;
 
         return $this;
+    }
+
+    /**
+     * Set an "order by" clause for a pivot table column.
+     *
+     * @param  string  $column
+     * @param  string  $operator
+     * @param  mixed   $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function orderByPivot($column, $direction = 'asc')
+    {
+        $this->pivotOrderBys[] = func_get_args();
+
+        return $this->orderBy($this->table.'.'.$column, $direction);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -439,6 +439,10 @@ trait InteractsWithPivotTable
     {
         $query = $this->newPivotStatement();
 
+        foreach ($this->pivotOrderBys as $arguments) {
+            call_user_func_array([$query, 'orderBy'], $arguments);
+        }
+
         foreach ($this->pivotWheres as $arguments) {
             call_user_func_array([$query, 'where'], $arguments);
         }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -594,6 +594,18 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('taylorotwell@gmail.com', $results->first()->email);
     }
 
+    public function testHasOnSelfReferencingBelongsToManyRelationshipWithOrderByPivotDesc()
+    {
+        $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
+        $user->friends()->create(['email' => 'foo@gmail.com']);
+
+        $results = EloquentTestUser::has('friendsOrderedByEmailDesc')->get();
+
+        $this->assertCount(2, $results);
+        $this->assertEquals('foo@gmail.com', $results->first()->email);
+    }
+
     public function testHasOnSelfReferencingBelongsToRelationship()
     {
         $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'user_id' => 1]);
@@ -1598,6 +1610,11 @@ class EloquentTestUser extends Eloquent
     public function friendsTwo()
     {
         return $this->belongsToMany(EloquentTestUser::class, 'friends', 'user_id', 'friend_id')->wherePivot('user_id', 2);
+    }
+
+    public function friendsOrderedByEmailDesc()
+    {
+        return $this->belongsToMany(EloquentTestUser::class, 'friends', 'user_id', 'friend_id')->orderByPivot('email', 'desc');
     }
 
     public function posts()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -600,10 +600,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
         $user->friends()->create(['email' => 'foo@gmail.com']);
 
-        $results = EloquentTestUser::has('friendsOrderedByEmailDesc')->get();
+        $results = EloquentTestUser::with('friendsOrderedByEmailDesc')->get();
 
-        $this->assertCount(2, $results);
-        $this->assertEquals('foo@gmail.com', $results->first()->email);
+        $this->assertCount(1, $results);
+        $this->assertEquals('foo@gmail.com', $results->first()->friendsOrderedByEmailDesc->first()->email);
     }
 
     public function testHasOnSelfReferencingBelongsToRelationship()


### PR DESCRIPTION
This PR adds a orderByPivot() method to the BelongsToMany relationship. Much like wherePivot() allows a query to be restricted by a pivot value, this PR allows a query to be ordered by a pivot value.