### PR TITLE
[5.7] Remove extra alias

### DIFF
--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -11,7 +11,6 @@ use Swift_SmtpTransport as SmtpTransport;
 use Illuminate\Mail\Transport\LogTransport;
 use Illuminate\Mail\Transport\SesTransport;
 use Illuminate\Mail\Transport\ArrayTransport;
-use Swift_SendmailTransport as MailTransport;
 use Illuminate\Mail\Transport\MailgunTransport;
 use Illuminate\Mail\Transport\MandrillTransport;
 use Illuminate\Mail\Transport\SparkPostTransport;
@@ -105,7 +104,7 @@ class TransportManager extends Manager
      */
     protected function createMailDriver()
     {
-        return new MailTransport;
+        return new SendmailTransport;
     }
 
     /**


### PR DESCRIPTION
the `Swift_SendmailTransport` is aliased to both `MailTransport` and `SendmailTransport`.   We can have both the 'mail' and 'sendmail' drivers build up the same class, and remove the need for the extra alias.

I think this also makes it more obvious to the reader that the 'mail' driver doesn't really exist anymore and is actually using sendmail.