### PR TITLE
[5.8][WIP] fix for #26791

### DIFF
--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -47,6 +47,23 @@ trait SerializesModels
         }
     }
 
+    public function __clone()
+    {
+        foreach ((new ReflectionClass($this))->getProperties() as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            $value = $this->getPropertyValue($property);
+
+            if (is_object($value) && in_array(SerializesModels::class, trait_uses_recursive($value))) {
+                $value = clone ($value);
+            }
+
+            $property->setValue($this, $value);
+        }
+    }
+
     /**
      * Get the property value for the given property.
      *


### PR DESCRIPTION
After debugging #26791 which has problems with job serialization i found out that the job is improperly cloned when serializing.

The original problem was that the OP was dispatching a job that had a property which was an event (that implemented `SerializesModels`) and therefore the next listener in line didnt get the actual property but a `ModelIdentifier`.

At the moment only the `$job` is cloned in the `Queue@createObjectPayload` method.
```php
return array_merge($payload, [
    'data' => [
        'commandName' => get_class($job),
        'command'     => serialize(clone $job),
    ],
]);
```
But when the underlying property is also an instance of (or well an object that uses) `SerializesModels` it will also serialize this property, which then results in the original property being overridden instead of only the cloned jobs property.

I might be wrong on this part but this does seem to fix the issue.

In the case my theory is right and this might become merged we'll have to decide if this has impact on `Illuminate\Notifications\SendQueuedNotifications` as this class has its own implementation of the magic method `__clone`.
 