### PR TITLE
[5.7] Bug fix for app()->call()

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -162,6 +162,8 @@ class BoundMethod
             $dependencies[] = $container->make($parameter->getClass()->name);
         } elseif ($parameter->isDefaultValueAvailable()) {
             $dependencies[] = $parameter->getDefaultValue();
+        } else {
+            $dependencies[] = null;
         }
     }
 

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -116,7 +116,7 @@ class BoundMethod
             static::addDependencyForCallParameter($container, $parameter, $parameters, $dependencies);
         }
 
-        return array_merge($dependencies, $parameters);
+        return array_merge($parameters, $dependencies);
     }
 
     /**

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -116,7 +116,7 @@ class BoundMethod
             static::addDependencyForCallParameter($container, $parameter, $parameters, $dependencies);
         }
 
-        return array_merge($parameters, $dependencies);
+        return $parameters + $dependencies;
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -515,18 +515,17 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
     }
-    
+
     public function testWithDefalutParameters()
     {
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar']);
         $this->assertEquals(['foo', 'bar', 'default c'], $result);
-        
-        
+
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar', 'baz']);
         $this->assertEquals(['foo', 'bar', 'baz'], $result);
-        
+
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty');
         $this->assertEquals(['default a', 'default b', 'default c'], $result);
@@ -1288,7 +1287,6 @@ class ContainerTestContextInjectInstantiations implements IContainerContractStub
     }
 }
 
-
 class ContainerTestDefaultyParams
 {
     public function defaulty($a = 'default a', $b = 'default b', $c = 'default c')
@@ -1296,5 +1294,3 @@ class ContainerTestDefaultyParams
         return func_get_args();
     }
 }
-
-

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -520,15 +520,24 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar']);
-        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+       
+        $this->assertEquals('foo', $result[0]);
+        $this->assertEquals('bar', $result[1]);
+        $this->assertEquals('default c', $result[2]);
 
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar', 'baz']);
-        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+        
+        $this->assertEquals('foo', $result[0]);
+        $this->assertEquals('bar', $result[1]);
+        $this->assertEquals('baz', $result[2]);
 
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty');
-        $this->assertEquals(['default a', 'default b', 'default c'], $result);
+        
+        $this->assertEquals('default a', $result[0]);
+        $this->assertEquals('default b', $result[1]);
+        $this->assertEquals('default c', $result[2]);
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -515,6 +515,22 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
     }
+    
+    public function testWithDefalutParameters()
+    {
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+        
+        
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar', 'baz']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+        
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty');
+        $this->assertEquals(['default a', 'default b', 'default c'], $result);
+    }
 
     /**
      * @expectedException \ReflectionException
@@ -1271,3 +1287,14 @@ class ContainerTestContextInjectInstantiations implements IContainerContractStub
         static::$instantiations++;
     }
 }
+
+
+class ContainerTestDefaultyParams
+{
+    public function defaulty($a = 'default a', $b = 'default b', $c = 'default c')
+    {
+        return func_get_args();
+    }
+}
+
+

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -520,21 +520,21 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar']);
-       
+
         $this->assertEquals('foo', $result[0]);
         $this->assertEquals('bar', $result[1]);
         $this->assertEquals('default c', $result[2]);
 
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar', 'baz']);
-        
+
         $this->assertEquals('foo', $result[0]);
         $this->assertEquals('bar', $result[1]);
         $this->assertEquals('baz', $result[2]);
 
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty');
-        
+
         $this->assertEquals('default a', $result[0]);
         $this->assertEquals('default b', $result[1]);
         $this->assertEquals('default c', $result[2]);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -538,6 +538,14 @@ class ContainerTest extends TestCase
         $this->assertEquals('default a', $result[0]);
         $this->assertEquals('default b', $result[1]);
         $this->assertEquals('default c', $result[2]);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['foo', 'bar']);
+
+        $this->assertEquals('foo', $result[0]);
+        $this->assertEquals('bar', $result[1]);
+        $this->assertEquals('default c', $result[2]);
+
     }
 
     /**
@@ -1299,6 +1307,11 @@ class ContainerTestContextInjectInstantiations implements IContainerContractStub
 class ContainerTestDefaultyParams
 {
     public function defaulty($a = 'default a', $b = 'default b', $c = 'default c')
+    {
+        return func_get_args();
+    }
+
+    public function defaultyOnlyC($a, $b, $c = 'default c')
     {
         return func_get_args();
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -553,7 +553,7 @@ class ContainerTest extends TestCase
 
         $this->assertEquals(['foo', 'bar', 'baz'], $result);
     }
-    
+
     public function testWithDefaultParametersAssociativeSyntax()
     {
         $container = new Container;

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -516,7 +516,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $result[1]);
     }
 
-    public function testWithDefaultParameters()
+    public function testWithDefaultParametersIndexedArraySyntax()
     {
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar']);
@@ -550,6 +550,39 @@ class ContainerTest extends TestCase
 
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['foo', 'bar', 'baz']);
+
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+    }
+    
+    public function testWithDefaultParametersAssociativeSyntax()
+    {
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['a' => 'foo', 'b' => 'bar']);
+
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['a' => 'foo', 'b' => 'bar', 'c' => 'baz']);
+
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['a' => 'foo', 'b' => 'bar']);
+
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['a' => 'foo']);
+
+        $this->assertEquals(['foo', 'default b', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['a' => 'foo', 'b' => 'bar']);
+
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['a' => 'foo', 'b' => 'bar', 'c' => 'baz']);
 
         $this->assertEquals(['foo', 'bar', 'baz'], $result);
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -545,7 +545,6 @@ class ContainerTest extends TestCase
         $this->assertEquals('foo', $result[0]);
         $this->assertEquals('bar', $result[1]);
         $this->assertEquals('default c', $result[2]);
-
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -534,9 +534,24 @@ class ContainerTest extends TestCase
         $this->assertEquals(['default a', 'default b', 'default c'], $result);
 
         $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['foo', 'bar']);
+
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['foo']);
+
+        $this->assertEquals(['foo', 'default b', 'default c'], $result);
+
+        $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['foo', 'bar']);
 
         $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['foo', 'bar', 'baz']);
+
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
     }
 
     /**
@@ -1302,7 +1317,17 @@ class ContainerTestDefaultyParams
         return func_get_args();
     }
 
+    public function defaultyBandC($a, $b = 'default b', $c = 'default c')
+    {
+        return func_get_args();
+    }
+
     public function defaultyOnlyC($a, $b, $c = 'default c')
+    {
+        return func_get_args();
+    }
+
+    public function noDefault($a, $b, $c)
     {
         return func_get_args();
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -516,35 +516,27 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $result[1]);
     }
 
-    public function testWithDefalutParameters()
+    public function testWithDefaultParameters()
     {
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar']);
 
-        $this->assertEquals('foo', $result[0]);
-        $this->assertEquals('bar', $result[1]);
-        $this->assertEquals('default c', $result[2]);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
 
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar', 'baz']);
 
-        $this->assertEquals('foo', $result[0]);
-        $this->assertEquals('bar', $result[1]);
-        $this->assertEquals('baz', $result[2]);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
 
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty');
 
-        $this->assertEquals('default a', $result[0]);
-        $this->assertEquals('default b', $result[1]);
-        $this->assertEquals('default c', $result[2]);
+        $this->assertEquals(['default a', 'default b', 'default c'], $result);
 
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['foo', 'bar']);
 
-        $this->assertEquals('foo', $result[0]);
-        $this->assertEquals('bar', $result[1]);
-        $this->assertEquals('default c', $result[2]);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
     }
 
     /**


### PR DESCRIPTION
Bug fix for app()->call('class@method', ['x1' , 'x2', ... ]);

fixes:
https://github.com/laravel/framework/issues/26851
https://github.com/laravel/framework/issues/22687
https://github.com/laravel/framework/issues/26837

The problem is described clearly on the issue and this PR will simply fix it.
And adds unit tests for it.

Let me mention this https://github.com/laravel/framework/pull/22709 PR which has tried to solve the same issue.