### PR TITLE
[5.8] Allow to control cached directory path

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -279,6 +279,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $this->instance('path', $this->path());
         $this->instance('path.base', $this->basePath());
         $this->instance('path.lang', $this->langPath());
+        $this->instance('path.cache', $this->cachePath());
         $this->instance('path.config', $this->configPath());
         $this->instance('path.public', $this->publicPath());
         $this->instance('path.storage', $this->storagePath());
@@ -318,6 +319,23 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function bootstrapPath($path = '')
     {
         return $this->basePath.DIRECTORY_SEPARATOR.'bootstrap'.($path ? DIRECTORY_SEPARATOR.$path : $path);
+    }
+
+    /**
+     * Get the path to the cache directory.
+     *
+     * @param  string $path Optionally, a path to append to the cache path
+     *
+     * @return string
+     */
+    public function cachePath($path = '')
+    {
+        $envCachePath = $_ENV['APP_CACHE'] ?? null;
+        $pathTransform = $path ? DIRECTORY_SEPARATOR.$path : $path;
+
+        return $envCachePath
+            ? $envCachePath.$pathTransform
+            : $this->bootstrapPath().'/cache'.$pathTransform;
     }
 
     /**
@@ -861,7 +879,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedServicesPath()
     {
-        return $this->bootstrapPath().'/cache/services.php';
+        return $this->cachePath().'/services.php';
     }
 
     /**
@@ -871,7 +889,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedPackagesPath()
     {
-        return $this->bootstrapPath().'/cache/packages.php';
+        return $this->cachePath().'/packages.php';
     }
 
     /**
@@ -891,7 +909,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedConfigPath()
     {
-        return $_ENV['APP_CONFIG_CACHE'] ?? $this->bootstrapPath().'/cache/config.php';
+        return $this->cachePath().'/config.php';
     }
 
     /**
@@ -911,7 +929,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedRoutesPath()
     {
-        return $this->bootstrapPath().'/cache/routes.php';
+        return $this->cachePath().'/routes.php';
     }
 
     /**

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -189,6 +189,63 @@ class FoundationApplicationTest extends TestCase
         $this->assertFalse($app->environment(['qux', 'bar']));
     }
 
+    public function testCachePath()
+    {
+        $app = new Application;
+
+        $this->assertEquals('/bootstrap/cache', $app->cachePath());
+        $this->assertEquals('/bootstrap/cache/test', $app->cachePath('test'));
+
+        $_ENV['APP_CACHE'] = '/custom_dir';
+        $this->assertEquals('/custom_dir', $app->cachePath());
+        $this->assertEquals('/custom_dir/test', $app->cachePath('test'));
+        unset($_ENV['APP_CACHE']);
+    }
+
+    public function testGetCachedServicesPath()
+    {
+        $app = new Application;
+
+        $this->assertEquals('/bootstrap/cache/services.php', $app->getCachedServicesPath());
+
+        $_ENV['APP_CACHE'] = '/custom_dir';
+        $this->assertEquals('/custom_dir/services.php', $app->getCachedServicesPath());
+        unset($_ENV['APP_CACHE']);
+    }
+
+    public function testGetCachedPackagesPath()
+    {
+        $app = new Application;
+
+        $this->assertEquals('/bootstrap/cache/packages.php', $app->getCachedPackagesPath());
+
+        $_ENV['APP_CACHE'] = '/custom_dir';
+        $this->assertEquals('/custom_dir/packages.php', $app->getCachedPackagesPath());
+        unset($_ENV['APP_CACHE']);
+    }
+
+    public function testGetCachedConfigPath()
+    {
+        $app = new Application;
+
+        $this->assertEquals('/bootstrap/cache/config.php', $app->getCachedConfigPath());
+
+        $_ENV['APP_CACHE'] = '/custom_dir';
+        $this->assertEquals('/custom_dir/config.php', $app->getCachedConfigPath());
+        unset($_ENV['APP_CACHE']);
+    }
+
+    public function testGetCachedRoutesPath()
+    {
+        $app = new Application;
+
+        $this->assertEquals('/bootstrap/cache/routes.php', $app->getCachedRoutesPath());
+
+        $_ENV['APP_CACHE'] = '/custom_dir';
+        $this->assertEquals('/custom_dir/routes.php', $app->getCachedRoutesPath());
+        unset($_ENV['APP_CACHE']);
+    }
+
     public function testMethodAfterLoadingEnvironmentAddsClosure()
     {
         $app = new Application;


### PR DESCRIPTION
in https://github.com/laravel/framework/commit/578bc83f0247b97ec87fefe39a8da7e9bbfd4a66 was added env for rewrite of getCachedConfigPath method;

I have proposition for allowing to control cached directory;

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
