### PR TITLE
[5.7] Test the TransportManager creates a log driver with any LoggerInterface instance

### DIFF
--- a/tests/Mail/MailLogTransportTest.php
+++ b/tests/Mail/MailLogTransportTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Mail;
 
 use Monolog\Logger;
+use Psr\Log\NullLogger;
 use Psr\Log\LoggerInterface;
 use Orchestra\Testbench\TestCase;
 use Monolog\Handler\StreamHandler;
@@ -29,5 +30,14 @@ class MailLogTransportTest extends TestCase
         $this->assertInstanceOf(Logger::class, $monolog = $logger->getLogger());
         $this->assertCount(1, $handlers = $monolog->getHandlers());
         $this->assertInstanceOf(StreamHandler::class, $handler = $handlers[0]);
+    }
+
+    public function testGetLogTransportWithPsrLogger()
+    {
+        $logger = $this->app->instance('log', new NullLogger());
+
+        $manager = $this->app['swift.transport'];
+
+        $this->assertAttributeEquals($logger, 'logger', $manager->driver('log'));
     }
 }


### PR DESCRIPTION
In addition to #26842, this test asserts that the `TransportManager` can create a log driver when the application has a different implementation of the `Psr\Log\LoggerInterface`, e.g. when the `illuminate/mail` package is used outside of Laravel.