### PR TITLE
[5.8] Fix container docblock

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -602,6 +602,8 @@ class Container implements ContainerContract
      * @param  string  $abstract
      * @param  array  $parameters
      * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function make($abstract, array $parameters = [])
     {
@@ -630,6 +632,8 @@ class Container implements ContainerContract
      * @param  string  $abstract
      * @param  array  $parameters
      * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function resolve($abstract, $parameters = [])
     {
@@ -816,6 +820,8 @@ class Container implements ContainerContract
      *
      * @param  array  $dependencies
      * @return array
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function resolveDependencies(array $dependencies)
     {


### PR DESCRIPTION

- Container::resolvePrimitive() or Container::resolveClass() may throws BindingResolutionException.
- Container::resolveDependencies() calls Container::resolvePrimitive() or Container::resolveClass() without try-catch block.
- Container::build() calls Container::resolveDependencies() without try-catch block.
- Container::resolve() calls Container::build() without try-catch block.
- Container::make() directly calls Container::resolve().