### PR TITLE
[5.7] Automatically append accessors to model serialization

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -69,7 +69,7 @@ trait HasAttributes
      * @var bool
      */
     public static $snakeAttributes = true;
-    
+
     /**
      * Indicates whether accessors are automatically appended to model serialization.
      *

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1260,3 +1260,4 @@ trait HasAttributes
         return $matches[1];
     }
 }
+

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -76,7 +76,7 @@ trait HasAttributes
      * @var bool
      */
     protected $autoAppend = false;
-	
+
     /**
      * The cache of the mutated attributes for each class.
      *
@@ -225,7 +225,7 @@ trait HasAttributes
         if ($this->autoAppend) {
             $this->appendAccessors();
         }
-        
+
         if (! count($this->appends)) {
             return [];
         }
@@ -234,7 +234,7 @@ trait HasAttributes
             array_combine($this->appends, $this->appends)
         );
     }
-    
+
     /**
      * Append all accessors.
      *

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -222,7 +222,7 @@ trait HasAttributes
      */
     protected function getArrayableAppends()
     {
-        if($this->autoAppend) {
+        if ($this->autoAppend) {
             $this->appendAccessors();
         }
         
@@ -236,11 +236,12 @@ trait HasAttributes
     }
     
     /**
-     * Append all accessors
+     * Append all accessors.
      *
      * @return void
      */
-    public function appendAccessors(){
+    public function appendAccessors()
+    {
         foreach(static::getMutatorMethods(static::class) as $method){
             $accessor = lcfirst(static::$snakeAttributes ? Str::snake($method) : $method);
             $this->append($accessor);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -76,7 +76,7 @@ trait HasAttributes
      * @var bool
      */
     protected $autoAppend = false;
-    
+	
     /**
      * The cache of the mutated attributes for each class.
      *

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -242,7 +242,7 @@ trait HasAttributes
      */
     public function appendAccessors()
     {
-        foreach(static::getMutatorMethods(static::class) as $method) {
+        foreach (static::getMutatorMethods(static::class) as $method) {
             $accessor = lcfirst(static::$snakeAttributes ? Str::snake($method) : $method);
             $this->append($accessor);
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -69,6 +69,13 @@ trait HasAttributes
      * @var bool
      */
     public static $snakeAttributes = true;
+    
+    /**
+     * Indicates whether accessors are automatically appended to model serialization.
+     *
+     * @var bool
+     */
+    protected $autoAppend = false;
 
     /**
      * The cache of the mutated attributes for each class.
@@ -215,6 +222,10 @@ trait HasAttributes
      */
     protected function getArrayableAppends()
     {
+        if($this->autoAppend) {
+            $this->appendAccessors();
+        }
+        
         if (! count($this->appends)) {
             return [];
         }
@@ -222,6 +233,18 @@ trait HasAttributes
         return $this->getArrayableItems(
             array_combine($this->appends, $this->appends)
         );
+    }
+    
+    /**
+     * Append all accessors
+     *
+     * @return void
+     */
+    public function appendAccessors(){
+        foreach(static::getMutatorMethods(static::class) as $method){
+            $accessor = lcfirst(static::$snakeAttributes ? Str::snake($method) : $method);
+            $this->append($accessor);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -76,7 +76,7 @@ trait HasAttributes
      * @var bool
      */
     protected $autoAppend = false;
-
+    
     /**
      * The cache of the mutated attributes for each class.
      *
@@ -242,7 +242,7 @@ trait HasAttributes
      */
     public function appendAccessors()
     {
-        foreach(static::getMutatorMethods(static::class) as $method){
+        foreach(static::getMutatorMethods(static::class) as $method) {
             $accessor = lcfirst(static::$snakeAttributes ? Str::snake($method) : $method);
             $this->append($accessor);
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1260,4 +1260,3 @@ trait HasAttributes
         return $matches[1];
     }
 }
-


### PR DESCRIPTION
Added ability to automatically append accessors to model serialization (disabled by default). To enable set the property`$autoAppend` to `true` on the model.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
