### PR TITLE
[5.7] Add --resource and --api options to make:test command

### DIFF
--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -12,7 +12,7 @@ class TestMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'make:test {name : The name of the class} {--unit : Create a unit test}';
+    protected $signature = 'make:test {name : The name of the class} {--unit : Create a unit test} {--resource : Create a resource test} {--api : Create a api test}';
 
     /**
      * The console command description.
@@ -37,6 +37,14 @@ class TestMakeCommand extends GeneratorCommand
     {
         if ($this->option('unit')) {
             return __DIR__.'/stubs/unit-test.stub';
+        }
+
+        if ($this->option('resource')) {
+            return __DIR__.'/stubs/resource-test.stub';
+        }
+
+        if ($this->option('api')) {
+            return __DIR__.'/stubs/api-test.stub';
         }
 
         return __DIR__.'/stubs/test.stub';

--- a/src/Illuminate/Foundation/Console/stubs/api-test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/api-test.stub
@@ -1,0 +1,40 @@
+<?php
+
+namespace DummyNamespace;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class DummyClass extends TestCase
+{
+    /**
+     * A test for listing of the resource
+     *
+     * @return void
+     */
+    public function testIndex()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testStore()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testShow()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testUpdate()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testDestroy()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/resource-test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/resource-test.stub
@@ -1,0 +1,50 @@
+<?php
+
+namespace DummyNamespace;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class DummyClass extends TestCase
+{
+    /**
+     * A test for listing of the resource
+     *
+     * @return void
+     */
+    public function testIndex()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testCreate()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testStore()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testShow()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testEdit()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testUpdate()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testDestroy()
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Adding --resource and --api options to make:test command to generate resource and api test will help make a basic test for resource controller or api controllers.