### PR TITLE
[5.7] Add assertion for amount of database queries executed

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -120,7 +120,7 @@ trait InteractsWithDatabase
     /**
      * Assert the amount of database queries executed since we started counting.
      *
-     * @param  int
+     * @param  int  $expectedCount
      * @return $this
      */
     public function assertDatabaseQueriesExecutedCount($expectedCount)


### PR DESCRIPTION
This PR adds the ability to count and assert the amount of database queries executed. This is useful when checking pages for N+1 queries, and to protected against adding unnecessary queries when refactoring code.

Example:
```php
/** @test */
function it_can_efficiently_show_the_posts_index()
{
    factory(Post::class, 25)->create()->each(function ($post) {
        $post->comments()->saveMany(factory(Comment::class, 3)->make())
    });

    $this->startCountingDatabaseQueries()
        ->get(route('posts.index'))
        ->assertStatus(200);

    $this->assertDatabaseQueriesExecutedCount(2);
}
```