### PR TITLE
[5.7] Add support for invokable route actions

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Closure;
 use LogicException;
+use ReflectionMethod;
 use ReflectionFunction;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -193,9 +194,12 @@ class Route
     protected function runCallable()
     {
         $callable = $this->action['uses'];
+        $reflection = $callable instanceof Closure ?
+            new ReflectionFunction($callable) :
+            new ReflectionMethod($callable, '__invoke');
 
         return $callable(...array_values($this->resolveMethodDependencies(
-            $this->parametersWithoutNulls(), new ReflectionFunction($this->action['uses'])
+            $this->parametersWithoutNulls(), $reflection
         )));
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -488,7 +488,7 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     protected function actionReferencesController($action)
     {
-        if (! $action instanceof Closure) {
+        if (! (is_object($action) && method_exists($action, '__invoke'))) {
             return is_string($action) || (isset($action['uses']) && is_string($action['uses']));
         }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -511,6 +511,18 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals('users.index', $this->getRoute()->getName());
     }
 
+    public function testCanUseInvokableObjectAsAction()
+    {
+        $this->router->get('users', new class {
+            public function __invoke()
+            {
+                return 'all-users';
+            }
+        });
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+    }
+
     /**
      * Get the last route registered with the router.
      *

--- a/tests/Routing/RouteSignatureParametersTest.php
+++ b/tests/Routing/RouteSignatureParametersTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use ReflectionParameter;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Routing\RouteSignatureParameters;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+if (! class_exists(RouteSignatureParametersTestController::class)) {
+    class RouteSignatureParametersTestController
+    {
+        public function show($id)
+        {
+        }
+    }
+}
+
+class RouteSignatureParametersTest extends TestCase
+{
+    public function actionProvider()
+    {
+        return [
+            [
+                RouteSignatureParametersTestController::class.'@show',
+                ['id'],
+            ],
+            [
+                function ($one) {
+                },
+                ['one'],
+            ],
+            [
+                function () {
+                },
+                [],
+            ],
+            [
+                new class {
+                    public function __invoke($one)
+                    {
+                    }
+                },
+                ['one'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider actionProvider
+     * @param mixed $action
+     * @param array $expectedNames
+     */
+    public function testFromActionFindsParameters($action, array $expectedNames)
+    {
+        /* @var ReflectionParameter[] $parameters */
+        $parameters = RouteSignatureParameters::fromAction([
+            'uses' => $action,
+        ]);
+
+        $this->assertEquals(count($expectedNames), count($parameters));
+
+        foreach ($expectedNames as $idx => $name) {
+            $this->assertEquals($name, $parameters[$idx]->getName());
+        }
+    }
+
+    public function testFromActionWithSubclassFilter()
+    {
+        $parameters = RouteSignatureParameters::fromAction([
+            'uses' => function (Request $response) {
+            },
+        ], SymfonyRequest::class);
+
+        $this->assertCount(1, $parameters);
+    }
+
+    public function testFromActionWithFailingSubclassFilter()
+    {
+        $parameters = RouteSignatureParameters::fromAction([
+            'uses' => function (Request $response) {
+            },
+        ], Response::class);
+
+        $this->assertEmpty($parameters);
+    }
+}


### PR DESCRIPTION
This PR adds support for invokable objects as route actions. Very useful for extracting Closure-based actions into reusable units of code. Example:
```php
class FileAction
{
    protected $path;

    function __construct(string $path)
    {
        $this->path = $path;
    }

    public function __invoke()
    {
        return file_get_contents($this->path);
    }
}

$router->get('/a', new FileAction('my-file.txt'));
$router->get('/b', new FileAction('my-other-file.txt'));
```