### PR TITLE
[5.7] Fix doc-blocks of Translator.php file

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -94,7 +94,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  string  $key
      * @param  array   $replace
      * @param  string  $locale
-     * @return string|array|null
+     * @return string|array
      */
     public function trans($key, array $replace = [], $locale = null)
     {
@@ -108,7 +108,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  array   $replace
      * @param  string|null  $locale
      * @param  bool  $fallback
-     * @return string|array|null
+     * @return string|array
      */
     public function get($key, array $replace = [], $locale = null, $fallback = true)
     {
@@ -144,7 +144,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  string  $key
      * @param  array  $replace
      * @param  string  $locale
-     * @return string|array|null
+     * @return string|array
      */
     public function getFromJson($key, array $replace = [], $locale = null)
     {


### PR DESCRIPTION
If we take a close look at the `get` method it is obvious that it can never return a null value.

$line is checked not to be a null at line 124. and $key is a string parameter of the method. So both return statements are returning non null values.

The same is true for getFromJson and trans method.

And nowhere in the tests we have assumed the returned value from the get method is null.

