### PR TITLE
[5.7] Adds the missing parameters in the method call

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -840,7 +840,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function handle(SymfonyRequest $request, $type = self::MASTER_REQUEST, $catch = true)
     {
-        return $this[HttpKernelContract::class]->handle(Request::createFromBase($request));
+        return $this[HttpKernelContract::class]->handle(Request::createFromBase($request), $type, $catch);
     }
 
     /**


### PR DESCRIPTION
It seems that `app()->handle(...)` is just a thin wrapper around `app(HttpKernelContract::class)->handle(...);`
but it throws away the last 2 accepted arguments and only uses the first one ($request).
So why it accepts them in the first place if it is intended to call the handle with only one parameter ?!

issue : https://github.com/laravel/framework/issues/26502