### PR TITLE
[5.7] Add nullableTimestamp method to Schema Blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -939,6 +939,18 @@ class Blueprint
     }
 
     /**
+     * Create a new nullable timestamp column on the table.
+     *
+     * @param  string  $column
+     * @param  int  $precision
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function nullableTimestamp($column, $precision = 0)
+    {
+        return $this->timestamp($column, $precision)->nullable();
+    }
+
+    /**
      * Create a new timestamp (with time zone) column on the table.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -582,6 +582,15 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
+    public function testAddingNullableTimestamp()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->nullableTimestamp('activated_at');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "activated_at" datetime null', $statements[0]);
+    }
+
     public function testAddingTimestampWithPrecision()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
I've found that there is a need to add nullable timestamp columns pretty frequently.

```php
$table->timestamp('banned_at')->nullable();
```

And since we have `nullableTimestamps()` method, it's will be good to have `nullableTimestamp()` for creating only one nullable datetime column.

```php
$table->nullableTimestamp('banned_at');
```