### PR TITLE
[5.8] fix Unresolvable dependency Error when resolving optional primitive parameter

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -835,9 +835,11 @@ class Container implements ArrayAccess, ContainerContract
             // If the class is null, it means the dependency is a string or some other
             // primitive type which we can not resolve since it is not a class and
             // we will just bomb out with an error since we have no-where to go.
-            $results[] = is_null($dependency->getClass())
-                            ? $this->resolvePrimitive($dependency)
-                            : $this->resolveClass($dependency);
+            if ( ! is_null($dependency->getClass()) ) {
+                $results[] = $this->resolveClass($dependency);
+            } else if ( ! $dependency->isOptional() ) {
+                $results[] = $this->resolvePrimitive($dependency);
+            }
         }
 
         return $results;


### PR DESCRIPTION
I used app container when initializing php standard object in order to
test using instance mock for specific case ( example: test required fixed now datetime)
but I encounter error msg.

**error case**
app(\DateTime::class) // Error

**error msg**
Unresolvable dependency resolving [Parameter #0 [ <optional> $time ]] in class DateTime

**more info**
public DateTime::__construct ([ string $time = "now" [, DateTimeZone $timezone = NULL ]] )

$r = new ReflectionClass('DateTime');
foreach ( $r->getConstructor()->getParameters() as $p )
{
    var_dump($p->isOptional(), $p->isDefaultValueAvailable()); // result: true, false, true false
}




