### PR TITLE
[5.7] Reset doctrineConnection property on Database/Connection when reconnecting

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -752,6 +752,7 @@ class Connection implements ConnectionInterface
     {
         if (is_callable($this->reconnector)) {
             $this->doctrineConnection = null;
+            
             return call_user_func($this->reconnector, $this);
         }
 

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -752,7 +752,7 @@ class Connection implements ConnectionInterface
     {
         if (is_callable($this->reconnector)) {
             $this->doctrineConnection = null;
-            
+
             return call_user_func($this->reconnector, $this);
         }
 

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -751,6 +751,7 @@ class Connection implements ConnectionInterface
     public function reconnect()
     {
         if (is_callable($this->reconnector)) {
+            $this->doctrineConnection = null;
             return call_user_func($this->reconnector, $this);
         }
 


### PR DESCRIPTION
Reset the `doctrineConnection` property on Database/Connection when reconnecting. This prevents subsequent calls to `Database/Connection::getDoctrineConnection()` to use the old and disconnected PDO connection and therefore throwing a `server has gone away` exception.

It fixes this issue [#22650 (Doctrine connection not reset on DB::reconnect())](https://github.com/laravel/framework/issues/22650)