### PR TITLE
expected behavior like works in laravel 5.1

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -662,7 +662,7 @@ class Builder
                 if (is_numeric($key) && is_array($value)) {
                     $query->{$method}(...array_values($value));
                 } else {
-                    $query->$method($key, '=', $value, $boolean);
+                    $query->$method($key, '=', $value, 'and');
                 }
             }
         }, $boolean);


### PR DESCRIPTION
See this example :
Model::where([‘a’=>’b’,’c’=>’d’])->orwhere([‘a’=>’b’,’c’=>’d’])

Expected use “and” between orwhere array but “or” used its not true logically