### PR TITLE
[5.7] Allow predefined log channels to change formatter from config

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -232,7 +232,7 @@ class LogManager implements LoggerInterface
                 new StreamHandler(
                     $config['path'], $this->level($config),
                     $config['bubble'] ?? true, $config['permission'] ?? null, $config['locking'] ?? false
-                )
+                ), $config
             ),
         ]);
     }
@@ -249,7 +249,7 @@ class LogManager implements LoggerInterface
             $this->prepareHandler(new RotatingFileHandler(
                 $config['path'], $config['days'] ?? 7, $this->level($config),
                 $config['bubble'] ?? true, $config['permission'] ?? null, $config['locking'] ?? false
-            )),
+            ), $config),
         ]);
     }
 
@@ -288,7 +288,7 @@ class LogManager implements LoggerInterface
         return new Monolog($this->parseChannel($config), [
             $this->prepareHandler(new SyslogHandler(
                 $this->app['config']['app.name'], $config['facility'] ?? LOG_USER, $this->level($config)
-            )),
+            ), $config),
         ]);
     }
 

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -8,7 +8,9 @@ use Illuminate\Log\LogManager;
 use Monolog\Logger as Monolog;
 use Orchestra\Testbench\TestCase;
 use Monolog\Handler\StreamHandler;
+use Monolog\Handler\SyslogHandler;
 use Monolog\Formatter\HtmlFormatter;
+use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\NewRelicHandler;
 use Monolog\Handler\LogEntriesHandler;
 use Monolog\Formatter\NormalizerFormatter;
@@ -109,6 +111,130 @@ class LogManagerTest extends TestCase
         $formatter = $handler->getFormatter();
 
         $this->assertInstanceOf(NewRelicHandler::class, $handler);
+        $this->assertInstanceOf(HtmlFormatter::class, $formatter);
+
+        $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
+        $dateFormat->setAccessible(true);
+
+        $this->assertEquals('Y/m/d--test', $dateFormat->getValue($formatter));
+    }
+
+    public function testLogManagerCreateSingleDriverWithConfiguredFormatter()
+    {
+        $config = $this->app['config'];
+        $config->set('logging.channels.defaultsingle', [
+            'driver' => 'single',
+            'name' => 'ds',
+            'path' => storage_path('logs/laravel.log'),
+        ]);
+
+        $manager = new LogManager($this->app);
+
+        // create logger with handler specified from configuration
+        $logger = $manager->channel('defaultsingle');
+        $handler = $logger->getLogger()->getHandlers()[0];
+        $formatter = $handler->getFormatter();
+
+        $this->assertInstanceOf(StreamHandler::class, $handler);
+        $this->assertInstanceOf(LineFormatter::class, $formatter);
+
+        $config->set('logging.channels.formattedsingle', [
+            'driver' => 'single',
+            'name' => 'fs',
+            'path' => storage_path('logs/laravel.log'),
+            'formatter' => HtmlFormatter::class,
+            'formatter_with' => [
+                'dateFormat' => 'Y/m/d--test',
+            ],
+        ]);
+
+        $logger = $manager->channel('formattedsingle');
+        $handler = $logger->getLogger()->getHandlers()[0];
+        $formatter = $handler->getFormatter();
+
+        $this->assertInstanceOf(StreamHandler::class, $handler);
+        $this->assertInstanceOf(HtmlFormatter::class, $formatter);
+
+        $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
+        $dateFormat->setAccessible(true);
+
+        $this->assertEquals('Y/m/d--test', $dateFormat->getValue($formatter));
+    }
+
+    public function testLogManagerCreateDailyDriverWithConfiguredFormatter()
+    {
+        $config = $this->app['config'];
+        $config->set('logging.channels.defaultdaily', [
+            'driver' => 'daily',
+            'name' => 'dd',
+            'path' => storage_path('logs/laravel.log'),
+        ]);
+
+        $manager = new LogManager($this->app);
+
+        // create logger with handler specified from configuration
+        $logger = $manager->channel('defaultdaily');
+        $handler = $logger->getLogger()->getHandlers()[0];
+        $formatter = $handler->getFormatter();
+
+        $this->assertInstanceOf(StreamHandler::class, $handler);
+        $this->assertInstanceOf(LineFormatter::class, $formatter);
+
+        $config->set('logging.channels.formatteddaily', [
+            'driver' => 'daily',
+            'name' => 'fd',
+            'path' => storage_path('logs/laravel.log'),
+            'formatter' => HtmlFormatter::class,
+            'formatter_with' => [
+                'dateFormat' => 'Y/m/d--test',
+            ],
+        ]);
+
+        $logger = $manager->channel('formatteddaily');
+        $handler = $logger->getLogger()->getHandlers()[0];
+        $formatter = $handler->getFormatter();
+
+        $this->assertInstanceOf(StreamHandler::class, $handler);
+        $this->assertInstanceOf(HtmlFormatter::class, $formatter);
+
+        $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
+        $dateFormat->setAccessible(true);
+
+        $this->assertEquals('Y/m/d--test', $dateFormat->getValue($formatter));
+    }
+
+    public function testLogManagerCreateSyslogDriverWithConfiguredFormatter()
+    {
+        $config = $this->app['config'];
+        $config->set('logging.channels.defaultsyslog', [
+            'driver' => 'syslog',
+            'name' => 'ds',
+        ]);
+
+        $manager = new LogManager($this->app);
+
+        // create logger with handler specified from configuration
+        $logger = $manager->channel('defaultsyslog');
+        $handler = $logger->getLogger()->getHandlers()[0];
+        $formatter = $handler->getFormatter();
+
+        $this->assertInstanceOf(SyslogHandler::class, $handler);
+        $this->assertInstanceOf(LineFormatter::class, $formatter);
+
+        $config->set('logging.channels.formattedsyslog', [
+            'driver' => 'syslog',
+            'name' => 'fs',
+            'formatter' => HtmlFormatter::class,
+            'formatter_with' => [
+                'dateFormat' => 'Y/m/d--test',
+            ],
+        ]);
+
+        $logger = $manager->channel('formattedsyslog');
+        $handler = $logger->getLogger()->getHandlers()[0];
+        $formatter = $handler->getFormatter();
+
+        $this->assertInstanceOf(SyslogHandler::class, $handler);
         $this->assertInstanceOf(HtmlFormatter::class, $formatter);
 
         $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');


### PR DESCRIPTION
This PR is about the ability to specify a formatter from the config file for the single, daily and syslog driver.

The default formatter, the LineFormatter, print the date and time, channel name, level and text for every message logged. To change the format of the message, for example to remove the channel name, or to use a different formatter, for example the HtmlFormatter, you have to use the monolog driver with the correct handler.

Compare the following configurations:

```php
return [
    "channels" => [
        "formatted_single" => [
            "driver" => "monolog",
            "handler" => StreamHandler::class
            "handler_with" => [
                "stream" => storage_path("logs/laravel.log"),
                "level" => "info",
            ],
            "formatter" => LineFormatter::class,
            "formatter_with" => [
                "format" => "[%datetime%] %level_name%: %message%",
            ],
        ]
    ]
]
```

and

```php
return [
    "channels" => [
        "formatted_single" => [
            "driver" => "single",
            "path" => storage_path("logs/laravel.log"),
            "level" => "info",
            "formatter" => LineFormatter::class,
            "formatter_with" => [
                "format" => "[%datetime%] %level_name%: %message%",
            ],
        ]
    ]
]
```
