### PR TITLE
[5.7] Adds the missing necessary tests for Container

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1094,6 +1094,15 @@ class ContainerTest extends TestCase
 
         $this->assertInstanceOf(ContainerConcreteStub::class, $class);
     }
+
+    public function testClosureCallWithInjectedDependency()
+    {
+        app()->call(function (ContainerConcreteStub $stub) {
+        }, ['foo' => 'bar']);
+
+        app()->call(function (ContainerConcreteStub $stub) {
+        }, ['foo' => 'bar', 'stub' => new ContainerConcreteStub]);
+    }
 }
 
 class ContainerConcreteStub

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -586,6 +586,16 @@ class ContainerTest extends TestCase
         });
         $result = $container->call([new ContainerTestCallStub, 'unresolvable']);
         $this->assertEquals(['foo', 'bar'], $result);
+
+        $container = new Container;
+        $result = $container->call([new ContainerTestCallStub, 'inject'], ['_stub' => 'foo', 'default' => 'bar']);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result[0]);
+        $this->assertEquals('bar', $result[1]);
+
+        $container = new Container;
+        $result = $container->call([new ContainerTestCallStub, 'inject'], ['_stub' => 'foo']);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result[0]);
+        $this->assertEquals('taylor', $result[1]);
     }
 
     public function testBindMethodAcceptsAnArray()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1097,10 +1097,11 @@ class ContainerTest extends TestCase
 
     public function testClosureCallWithInjectedDependency()
     {
-        app()->call(function (ContainerConcreteStub $stub) {
+        $container = new Container;
+        $container->call(function (ContainerConcreteStub $stub) {
         }, ['foo' => 'bar']);
 
-        app()->call(function (ContainerConcreteStub $stub) {
+        $container->call(function (ContainerConcreteStub $stub) {
         }, ['foo' => 'bar', 'stub' => new ContainerConcreteStub]);
     }
 }


### PR DESCRIPTION
These tests could have revealed the bugs created by my PR https://github.com/laravel/framework/pull/26852 (pardon me for that) but they were missing. So having them can prevent the same mistake from happening again.