### PR TITLE
[5.8] Deprecate useless Arr and Str global helper methods

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Illuminate\Support\Arr;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\PendingCommand;
@@ -44,11 +45,11 @@ trait InteractsWithConsole
 
         $this->beforeApplicationDestroyed(function () {
             if (count($this->expectedQuestions)) {
-                $this->fail('Question "'.array_first($this->expectedQuestions)[0].'" was not asked.');
+                $this->fail('Question "'.Arr::first($this->expectedQuestions)[0].'" was not asked.');
             }
 
             if (count($this->expectedOutput)) {
-                $this->fail('Output "'.array_first($this->expectedOutput).'" was not printed.');
+                $this->fail('Output "'.Arr::first($this->expectedOutput).'" was not printed.');
             }
         });
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -38,6 +38,8 @@ if (! function_exists('array_add')) {
      * @param  string  $key
      * @param  mixed   $value
      * @return array
+     *
+     * @deprecated Arr::add() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_add($array, $key, $value)
     {
@@ -51,6 +53,8 @@ if (! function_exists('array_collapse')) {
      *
      * @param  array  $array
      * @return array
+     *
+     * @deprecated Arr::collapse() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_collapse($array)
     {
@@ -64,6 +68,8 @@ if (! function_exists('array_divide')) {
      *
      * @param  array  $array
      * @return array
+     *
+     * @deprecated Arr::divide() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_divide($array)
     {
@@ -78,6 +84,8 @@ if (! function_exists('array_dot')) {
      * @param  array   $array
      * @param  string  $prepend
      * @return array
+     *
+     * @deprecated Arr::dot() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_dot($array, $prepend = '')
     {
@@ -92,6 +100,8 @@ if (! function_exists('array_except')) {
      * @param  array  $array
      * @param  array|string  $keys
      * @return array
+     *
+     * @deprecated Arr::except() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_except($array, $keys)
     {
@@ -107,6 +117,8 @@ if (! function_exists('array_first')) {
      * @param  callable|null  $callback
      * @param  mixed  $default
      * @return mixed
+     *
+     * @deprecated Arr::first() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_first($array, callable $callback = null, $default = null)
     {
@@ -121,6 +133,8 @@ if (! function_exists('array_flatten')) {
      * @param  array  $array
      * @param  int  $depth
      * @return array
+     *
+     * @deprecated Arr::flatten() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_flatten($array, $depth = INF)
     {
@@ -135,6 +149,8 @@ if (! function_exists('array_forget')) {
      * @param  array  $array
      * @param  array|string  $keys
      * @return void
+     *
+     * @deprecated Arr::forget() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_forget(&$array, $keys)
     {
@@ -150,6 +166,8 @@ if (! function_exists('array_get')) {
      * @param  string  $key
      * @param  mixed   $default
      * @return mixed
+     *
+     * @deprecated Arr::get() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_get($array, $key, $default = null)
     {
@@ -164,6 +182,8 @@ if (! function_exists('array_has')) {
      * @param  \ArrayAccess|array  $array
      * @param  string|array  $keys
      * @return bool
+     *
+     * @deprecated Arr::has() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_has($array, $keys)
     {
@@ -179,6 +199,8 @@ if (! function_exists('array_last')) {
      * @param  callable|null  $callback
      * @param  mixed  $default
      * @return mixed
+     *
+     * @deprecated Arr::last() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_last($array, callable $callback = null, $default = null)
     {
@@ -193,6 +215,8 @@ if (! function_exists('array_only')) {
      * @param  array  $array
      * @param  array|string  $keys
      * @return array
+     *
+     * @deprecated Arr::only() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_only($array, $keys)
     {
@@ -208,6 +232,8 @@ if (! function_exists('array_pluck')) {
      * @param  string|array  $value
      * @param  string|array|null  $key
      * @return array
+     *
+     * @deprecated Arr::pluck() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_pluck($array, $value, $key = null)
     {
@@ -223,6 +249,8 @@ if (! function_exists('array_prepend')) {
      * @param  mixed  $value
      * @param  mixed  $key
      * @return array
+     *
+     * @deprecated Arr::prepend() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_prepend($array, $value, $key = null)
     {
@@ -238,6 +266,8 @@ if (! function_exists('array_pull')) {
      * @param  string  $key
      * @param  mixed   $default
      * @return mixed
+     *
+     * @deprecated Arr::pull() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_pull(&$array, $key, $default = null)
     {
@@ -252,6 +282,8 @@ if (! function_exists('array_random')) {
      * @param  array  $array
      * @param  int|null  $num
      * @return mixed
+     *
+     * @deprecated Arr::random() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_random($array, $num = null)
     {
@@ -269,6 +301,8 @@ if (! function_exists('array_set')) {
      * @param  string  $key
      * @param  mixed   $value
      * @return array
+     *
+     * @deprecated Arr::set() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_set(&$array, $key, $value)
     {
@@ -283,6 +317,8 @@ if (! function_exists('array_sort')) {
      * @param  array  $array
      * @param  callable|string|null  $callback
      * @return array
+     *
+     * @deprecated Arr::sort() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_sort($array, $callback = null)
     {
@@ -296,6 +332,8 @@ if (! function_exists('array_sort_recursive')) {
      *
      * @param  array  $array
      * @return array
+     *
+     * @deprecated Arr::sortRecursive() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_sort_recursive($array)
     {
@@ -310,6 +348,8 @@ if (! function_exists('array_where')) {
      * @param  array  $array
      * @param  callable  $callback
      * @return array
+     *
+     * @deprecated Arr::where() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_where($array, callable $callback)
     {
@@ -323,6 +363,8 @@ if (! function_exists('array_wrap')) {
      *
      * @param  mixed  $value
      * @return array
+     *
+     * @deprecated Arr::wrap() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function array_wrap($value)
     {
@@ -365,6 +407,8 @@ if (! function_exists('camel_case')) {
      *
      * @param  string  $value
      * @return string
+     *
+     * @deprecated Str::camel() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function camel_case($value)
     {
@@ -572,6 +616,8 @@ if (! function_exists('ends_with')) {
      * @param  string  $haystack
      * @param  string|array  $needles
      * @return bool
+     *
+     * @deprecated Str::endsWith() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function ends_with($haystack, $needles)
     {
@@ -650,6 +696,8 @@ if (! function_exists('kebab_case')) {
      *
      * @param  string  $value
      * @return string
+     *
+     * @deprecated Str::kebab() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function kebab_case($value)
     {
@@ -778,6 +826,8 @@ if (! function_exists('snake_case')) {
      * @param  string  $value
      * @param  string  $delimiter
      * @return string
+     *
+     * @deprecated Str::snake() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function snake_case($value, $delimiter = '_')
     {
@@ -792,6 +842,8 @@ if (! function_exists('starts_with')) {
      * @param  string  $haystack
      * @param  string|array  $needles
      * @return bool
+     *
+     * @deprecated Str::startsWith() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function starts_with($haystack, $needles)
     {
@@ -806,6 +858,8 @@ if (! function_exists('str_after')) {
      * @param  string  $subject
      * @param  string  $search
      * @return string
+     *
+     * @deprecated Str::after() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function str_after($subject, $search)
     {
@@ -820,6 +874,8 @@ if (! function_exists('str_before')) {
      * @param  string  $subject
      * @param  string  $search
      * @return string
+     *
+     * @deprecated Str::before() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function str_before($subject, $search)
     {
@@ -834,6 +890,8 @@ if (! function_exists('str_contains')) {
      * @param  string  $haystack
      * @param  string|array  $needles
      * @return bool
+     *
+     * @deprecated Str::contains() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function str_contains($haystack, $needles)
     {
@@ -848,6 +906,8 @@ if (! function_exists('str_finish')) {
      * @param  string  $value
      * @param  string  $cap
      * @return string
+     *
+     * @deprecated Str::finish() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function str_finish($value, $cap)
     {
@@ -862,6 +922,8 @@ if (! function_exists('str_is')) {
      * @param  string|array  $pattern
      * @param  string  $value
      * @return bool
+     *
+     * @deprecated Str::is() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function str_is($pattern, $value)
     {
@@ -877,6 +939,8 @@ if (! function_exists('str_limit')) {
      * @param  int     $limit
      * @param  string  $end
      * @return string
+     *
+     * @deprecated Str::limit() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function str_limit($value, $limit = 100, $end = '...')
     {
@@ -891,6 +955,8 @@ if (! function_exists('str_plural')) {
      * @param  string  $value
      * @param  int     $count
      * @return string
+     *
+     * @deprecated Str::plural() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function str_plural($value, $count = 2)
     {
@@ -906,6 +972,8 @@ if (! function_exists('str_random')) {
      * @return string
      *
      * @throws \RuntimeException
+     *
+     * @deprecated Str::random() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function str_random($length = 16)
     {
@@ -921,6 +989,8 @@ if (! function_exists('str_replace_array')) {
      * @param  array   $replace
      * @param  string  $subject
      * @return string
+     *
+     * @deprecated Str::replaceArray() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function str_replace_array($search, array $replace, $subject)
     {
@@ -936,6 +1006,8 @@ if (! function_exists('str_replace_first')) {
      * @param  string  $replace
      * @param  string  $subject
      * @return string
+     *
+     * @deprecated Str::replaceFirst() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function str_replace_first($search, $replace, $subject)
     {
@@ -951,6 +1023,8 @@ if (! function_exists('str_replace_last')) {
      * @param  string  $replace
      * @param  string  $subject
      * @return string
+     *
+     * @deprecated Str::replaceLast() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function str_replace_last($search, $replace, $subject)
     {
@@ -964,6 +1038,8 @@ if (! function_exists('str_singular')) {
      *
      * @param  string  $value
      * @return string
+     *
+     * @deprecated Str::singular() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function str_singular($value)
     {
@@ -979,6 +1055,8 @@ if (! function_exists('str_slug')) {
      * @param  string  $separator
      * @param  string  $language
      * @return string
+     *
+     * @deprecated Str::slug() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function str_slug($title, $separator = '-', $language = 'en')
     {
@@ -993,6 +1071,8 @@ if (! function_exists('str_start')) {
      * @param  string  $value
      * @param  string  $prefix
      * @return string
+     *
+     * @deprecated Str::start() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function str_start($value, $prefix)
     {
@@ -1006,6 +1086,8 @@ if (! function_exists('studly_case')) {
      *
      * @param  string  $value
      * @return string
+     *
+     * @deprecated Str::studly() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function studly_case($value)
     {
@@ -1080,6 +1162,8 @@ if (! function_exists('title_case')) {
      *
      * @param  string  $value
      * @return string
+     *
+     * @deprecated Str::title() should be used directly instead. Will be removed in Laravel 5.9.
      */
     function title_case($value)
     {

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Foundation;
 
 use stdClass;
 use Mockery as m;
+use Illuminate\Support\Str;
 use Illuminate\Foundation\Mix;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
@@ -210,7 +211,7 @@ class FoundationHelpersTest extends TestCase
             return __DIR__;
         });
 
-        $path = public_path(str_finish($directory, '/').'hot');
+        $path = public_path(Str::finish($directory, '/').'hot');
 
         // Laravel mix when run 'hot' has a new line after the
         // url, so for consistency this "\n" is added.
@@ -225,7 +226,7 @@ class FoundationHelpersTest extends TestCase
             return __DIR__;
         });
 
-        $path = public_path(str_finish($directory, '/').'mix-manifest.json');
+        $path = public_path(Str::finish($directory, '/').'mix-manifest.json');
 
         touch($path);
 

--- a/tests/Foundation/Http/Middleware/TransformsRequestTest.php
+++ b/tests/Foundation/Http/Middleware/TransformsRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation\Http\Middleware;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Http\Middleware\TransformsRequest;
@@ -113,11 +114,11 @@ class ManipulateArrayInput extends TransformsRequest
 {
     protected function transform($key, $value)
     {
-        if (str_contains($key, 'beers')) {
+        if (Str::contains($key, 'beers')) {
             $value++;
         }
 
-        if (str_contains($key, 'age')) {
+        if (Str::contains($key, 'age')) {
             $value--;
         }
 

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Auth;
 
+use Illuminate\Support\Str;
 use Illuminate\Auth\Events\Login;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Auth\Events\Failed;
@@ -209,7 +210,7 @@ class AuthenticationTest extends TestCase
             'username' => 'username2',
             'email' => 'email2',
             'password' => bcrypt('password'),
-            'remember_token' => $token = str_random(),
+            'remember_token' => $token = Str::random(),
             'is_active' => false,
         ]);
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -45,11 +46,11 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     {
         Carbon::setTestNow('2017-10-10 10:10:10');
 
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = Tag::create(['name' => str_random()]);
-        $tag2 = Tag::create(['name' => str_random()]);
-        $tag3 = Tag::create(['name' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
 
         $post->tags()->sync([
             $tag->id => ['flag' => 'taylor'],
@@ -80,8 +81,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_refresh_on_other_model_works()
     {
-        $post = Post::create(['title' => str_random()]);
-        $tag = Tag::create(['name' => $tagName = str_random()]);
+        $post = Post::create(['title' => Str::random()]);
+        $tag = Tag::create(['name' => $tagName = Str::random()]);
 
         $post->tags()->sync([
             $tag->id,
@@ -110,9 +111,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     {
         Carbon::setTestNow('2017-10-10 10:10:10');
 
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = TagWithCustomPivot::create(['name' => str_random()]);
+        $tag = TagWithCustomPivot::create(['name' => Str::random()]);
 
         $post->tagsWithCustomPivot()->attach($tag->id);
 
@@ -135,16 +136,16 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_attach_method()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = Tag::create(['name' => str_random()]);
-        $tag2 = Tag::create(['name' => str_random()]);
-        $tag3 = Tag::create(['name' => str_random()]);
-        $tag4 = Tag::create(['name' => str_random()]);
-        $tag5 = Tag::create(['name' => str_random()]);
-        $tag6 = Tag::create(['name' => str_random()]);
-        $tag7 = Tag::create(['name' => str_random()]);
-        $tag8 = Tag::create(['name' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $tag4 = Tag::create(['name' => Str::random()]);
+        $tag5 = Tag::create(['name' => Str::random()]);
+        $tag6 = Tag::create(['name' => Str::random()]);
+        $tag7 = Tag::create(['name' => Str::random()]);
+        $tag8 = Tag::create(['name' => Str::random()]);
 
         $post->tags()->attach($tag->id);
         $this->assertEquals($tag->name, $post->tags[0]->name);
@@ -175,15 +176,15 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_detach_method()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = Tag::create(['name' => str_random()]);
-        $tag2 = Tag::create(['name' => str_random()]);
-        $tag3 = Tag::create(['name' => str_random()]);
-        $tag4 = Tag::create(['name' => str_random()]);
-        $tag5 = Tag::create(['name' => str_random()]);
-        Tag::create(['name' => str_random()]);
-        Tag::create(['name' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $tag4 = Tag::create(['name' => Str::random()]);
+        $tag5 = Tag::create(['name' => Str::random()]);
+        Tag::create(['name' => Str::random()]);
+        Tag::create(['name' => Str::random()]);
 
         $post->tags()->attach(Tag::all());
 
@@ -218,9 +219,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_first_method()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = Tag::create(['name' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
 
         $post->tags()->attach(Tag::all());
 
@@ -232,17 +233,17 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
      */
     public function test_firstOrFail_method()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
         $post->tags()->firstOrFail(['id' => 10]);
     }
 
     public function test_find_method()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = Tag::create(['name' => str_random()]);
-        $tag2 = Tag::create(['name' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
 
         $post->tags()->attach(Tag::all());
 
@@ -255,9 +256,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
      */
     public function test_findOrFail_method()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        Tag::create(['name' => str_random()]);
+        Tag::create(['name' => Str::random()]);
 
         $post->tags()->attach(Tag::all());
 
@@ -266,9 +267,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_findOrNew_method()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = Tag::create(['name' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
 
         $post->tags()->attach(Tag::all());
 
@@ -280,9 +281,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_firstOrNew_method()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = Tag::create(['name' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
 
         $post->tags()->attach(Tag::all());
 
@@ -294,9 +295,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_firstOrCreate_method()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = Tag::create(['name' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
 
         $post->tags()->attach(Tag::all());
 
@@ -309,9 +310,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_updateOrCreate_method()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = Tag::create(['name' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
 
         $post->tags()->attach(Tag::all());
 
@@ -324,12 +325,12 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_sync_method()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = Tag::create(['name' => str_random()]);
-        $tag2 = Tag::create(['name' => str_random()]);
-        $tag3 = Tag::create(['name' => str_random()]);
-        $tag4 = Tag::create(['name' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $tag4 = Tag::create(['name' => Str::random()]);
 
         $post->tags()->sync([$tag->id, $tag2->id]);
 
@@ -367,10 +368,10 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_syncWithoutDetaching_method()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = Tag::create(['name' => str_random()]);
-        $tag2 = Tag::create(['name' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
 
         $post->tags()->sync([$tag->id]);
 
@@ -389,10 +390,10 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_toggle_method()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = Tag::create(['name' => str_random()]);
-        $tag2 = Tag::create(['name' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
 
         $post->tags()->toggle([$tag->id]);
 
@@ -419,9 +420,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_touching_parent()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = TouchingTag::create(['name' => str_random()]);
+        $tag = TouchingTag::create(['name' => Str::random()]);
 
         $post->touchingTags()->attach([$tag->id]);
 
@@ -432,15 +433,15 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $tag->update(['name' => $tag->name]);
         $this->assertNotEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
 
-        $tag->update(['name' => str_random()]);
+        $tag->update(['name' => Str::random()]);
         $this->assertEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
     }
 
     public function test_touching_related_models_on_sync()
     {
-        $tag = TouchingTag::create(['name' => str_random()]);
+        $tag = TouchingTag::create(['name' => Str::random()]);
 
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
         $this->assertNotEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
         $this->assertNotEquals('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
@@ -455,9 +456,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_no_touching_happens_if_not_configured()
     {
-        $tag = Tag::create(['name' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
 
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
         $this->assertNotEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
         $this->assertNotEquals('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
@@ -472,11 +473,11 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_can_retrieve_related_ids()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
         DB::table('tags')->insert([
             ['id' => 200, 'name' => 'excluded'],
-            ['id' => 300, 'name' => str_random()],
+            ['id' => 300, 'name' => Str::random()],
         ]);
 
         DB::table('posts_tags')->insert([
@@ -490,11 +491,11 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_can_touch_related_models()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
         DB::table('tags')->insert([
-            ['id' => 200, 'name' => str_random()],
-            ['id' => 300, 'name' => str_random()],
+            ['id' => 200, 'name' => Str::random()],
+            ['id' => 300, 'name' => Str::random()],
         ]);
 
         DB::table('posts_tags')->insert([
@@ -516,8 +517,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_can_update_existing_pivot()
     {
-        $tag = Tag::create(['name' => str_random()]);
-        $post = Post::create(['title' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
 
         DB::table('posts_tags')->insert([
             ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'empty'],
@@ -533,10 +534,10 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     public function test_can_update_existing_pivot_using_arrayable_of_ids()
     {
         $tags = new Collection([
-            $tag1 = Tag::create(['name' => str_random()]),
-            $tag2 = Tag::create(['name' => str_random()]),
+            $tag1 = Tag::create(['name' => Str::random()]),
+            $tag2 = Tag::create(['name' => Str::random()]),
         ]);
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
         DB::table('posts_tags')->insert([
             ['post_id' => $post->id, 'tag_id' => $tag1->id, 'flag' => 'empty'],
@@ -552,8 +553,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_can_update_existing_pivot_using_model()
     {
-        $tag = Tag::create(['name' => str_random()]);
-        $post = Post::create(['title' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
 
         DB::table('posts_tags')->insert([
             ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'empty'],
@@ -568,9 +569,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_custom_related_key()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
-        $tag = $post->tagsWithCustomRelatedKey()->create(['name' => str_random()]);
+        $tag = $post->tagsWithCustomRelatedKey()->create(['name' => Str::random()]);
         $this->assertEquals($tag->name, $post->tagsWithCustomRelatedKey()->first()->pivot->tag_id);
 
         $post->tagsWithCustomRelatedKey()->detach($tag);
@@ -589,8 +590,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function test_global_scope_columns()
     {
-        $tag = Tag::create(['name' => str_random()]);
-        $post = Post::create(['title' => str_random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
 
         DB::table('posts_tags')->insert([
             ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'empty'],

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentBelongsToTest;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
@@ -22,7 +23,7 @@ class EloquentBelongsToTest extends DatabaseTestCase
             $table->string('parent_slug')->nullable();
         });
 
-        $user = User::create(['slug' => str_random()]);
+        $user = User::create(['slug' => Str::random()]);
         User::create(['parent_id' => $user->id, 'parent_slug' => $user->slug]);
     }
 

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentHasManyThroughTest;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -43,15 +44,15 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
 
     public function test_basic_create_and_retrieve()
     {
-        $user = User::create(['name' => str_random()]);
+        $user = User::create(['name' => Str::random()]);
 
         $team1 = Team::create(['id' => 10, 'owner_id' => $user->id]);
         $team2 = Team::create(['owner_id' => $user->id]);
 
-        $mate1 = User::create(['name' => str_random(), 'team_id' => $team1->id]);
-        $mate2 = User::create(['name' => str_random(), 'team_id' => $team2->id]);
+        $mate1 = User::create(['name' => Str::random(), 'team_id' => $team1->id]);
+        $mate2 = User::create(['name' => Str::random(), 'team_id' => $team2->id]);
 
-        User::create(['name' => str_random()]);
+        User::create(['name' => Str::random()]);
 
         $this->assertEquals([$mate1->id, $mate2->id], $user->teamMates->pluck('id')->toArray());
         $this->assertEquals([$user->id], User::has('teamMates')->pluck('id')->toArray());
@@ -59,11 +60,11 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
 
     public function test_global_scope_columns()
     {
-        $user = User::create(['name' => str_random()]);
+        $user = User::create(['name' => Str::random()]);
 
         $team1 = Team::create(['owner_id' => $user->id]);
 
-        User::create(['name' => str_random(), 'team_id' => $team1->id]);
+        User::create(['name' => Str::random(), 'team_id' => $team1->id]);
 
         $teamMates = $user->teamMatesWithGlobalScope;
 
@@ -72,11 +73,11 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
 
     public function test_has_self()
     {
-        $user = User::create(['name' => str_random()]);
+        $user = User::create(['name' => Str::random()]);
 
         $team = Team::create(['owner_id' => $user->id]);
 
-        User::create(['name' => str_random(), 'team_id' => $team->id]);
+        User::create(['name' => Str::random(), 'team_id' => $team->id]);
 
         $users = User::has('teamMates')->get();
 
@@ -85,11 +86,11 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
 
     public function test_has_self_custom_owner_key()
     {
-        $user = User::create(['slug' => str_random(), 'name' => str_random()]);
+        $user = User::create(['slug' => Str::random(), 'name' => Str::random()]);
 
         $team = Team::create(['owner_slug' => $user->slug]);
 
-        User::create(['name' => str_random(), 'team_id' => $team->id]);
+        User::create(['name' => Str::random(), 'team_id' => $team->id]);
 
         $users = User::has('teamMatesBySlug')->get();
 

--- a/tests/Integration/Database/EloquentModelConnectionsTest.php
+++ b/tests/Integration/Database/EloquentModelConnectionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
@@ -59,14 +60,14 @@ class EloquentModelConnectionsTest extends TestCase
 
     public function test_child_obeys_parent_connection()
     {
-        $parent1 = ParentModel::create(['name' => str_random()]);
+        $parent1 = ParentModel::create(['name' => Str::random()]);
         $parent1->children()->create(['name' => 'childOnConn1']);
         $parents1 = ParentModel::with('children')->get();
         $this->assertEquals('childOnConn1', ChildModel::on('conn1')->first()->name);
         $this->assertEquals('childOnConn1', $parent1->children()->first()->name);
         $this->assertEquals('childOnConn1', $parents1[0]->children[0]->name);
 
-        $parent2 = ParentModel::on('conn2')->create(['name' => str_random()]);
+        $parent2 = ParentModel::on('conn2')->create(['name' => Str::random()]);
         $parent2->children()->create(['name' => 'childOnConn2']);
         $parents2 = ParentModel::on('conn2')->with('children')->get();
         $this->assertEquals('childOnConn2', ChildModel::on('conn2')->first()->name);
@@ -76,7 +77,7 @@ class EloquentModelConnectionsTest extends TestCase
 
     public function test_child_uses_its_own_connection_if_set()
     {
-        $parent1 = ParentModel::create(['name' => str_random()]);
+        $parent1 = ParentModel::create(['name' => Str::random()]);
         $parent1->childrenDefaultConn2()->create(['name' => 'childAlwaysOnConn2']);
         $parents1 = ParentModel::with('childrenDefaultConn2')->get();
         $this->assertEquals('childAlwaysOnConn2', ChildModelDefaultConn2::first()->name);
@@ -87,7 +88,7 @@ class EloquentModelConnectionsTest extends TestCase
 
     public function test_child_uses_its_own_connection_if_set_even_if_parent_explicit_connection()
     {
-        $parent1 = ParentModel::on('conn1')->create(['name' => str_random()]);
+        $parent1 = ParentModel::on('conn1')->create(['name' => Str::random()]);
         $parent1->childrenDefaultConn2()->create(['name' => 'childAlwaysOnConn2']);
         $parents1 = ParentModel::on('conn1')->with('childrenDefaultConn2')->get();
         $this->assertEquals('childAlwaysOnConn2', ChildModelDefaultConn2::first()->name);

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
@@ -45,7 +46,7 @@ class EloquentModelTest extends DatabaseTestCase
     public function test_attribute_changes()
     {
         $user = TestModel2::create([
-            'name' => str_random(), 'title' => str_random(),
+            'name' => Str::random(), 'title' => Str::random(),
         ]);
 
         $this->assertEmpty($user->getDirty());
@@ -53,7 +54,7 @@ class EloquentModelTest extends DatabaseTestCase
         $this->assertFalse($user->isDirty());
         $this->assertFalse($user->wasChanged());
 
-        $user->name = $name = str_random();
+        $user->name = $name = Str::random();
 
         $this->assertEquals(['name' => $name], $user->getDirty());
         $this->assertEmpty($user->getChanges());

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentMorphManyTest;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
@@ -35,7 +36,7 @@ class EloquentMorphManyTest extends DatabaseTestCase
 
     public function test_update_model_with_default_withCount()
     {
-        $post = Post::create(['title' => str_random()]);
+        $post = Post::create(['title' => Str::random()]);
 
         $post->update(['title' => 'new name']);
 

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentTouchParentWithGlobalScopeTest;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
@@ -34,11 +35,11 @@ class EloquentTouchParentWithGlobalScopeTest extends DatabaseTestCase
 
     public function test_basic_create_and_retrieve()
     {
-        $post = Post::create(['title' => str_random(), 'updated_at' => '2016-10-10 10:10:10']);
+        $post = Post::create(['title' => Str::random(), 'updated_at' => '2016-10-10 10:10:10']);
 
         $this->assertEquals('2016-10-10', $post->fresh()->updated_at->toDateString());
 
-        $post->comments()->create(['title' => str_random()]);
+        $post->comments()->create(['title' => Str::random()]);
 
         $this->assertNotEquals('2016-10-10', $post->fresh()->updated_at->toDateString());
     }

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
@@ -47,7 +48,7 @@ class EloquentUpdateTest extends TestCase
     public function testBasicUpdate()
     {
         TestUpdateModel1::create([
-            'name' => str_random(),
+            'name' => Str::random(),
             'title' => 'Ms.',
         ]);
 
@@ -76,7 +77,7 @@ class EloquentUpdateTest extends TestCase
         ]);
 
         TestUpdateModel2::create([
-            'name' => str_random(),
+            'name' => Str::random(),
         ]);
 
         TestUpdateModel2::join('test_model1', function ($join) {
@@ -92,12 +93,12 @@ class EloquentUpdateTest extends TestCase
     public function testSoftDeleteWithJoins()
     {
         TestUpdateModel1::create([
-            'name' => str_random(),
+            'name' => Str::random(),
             'title' => 'Mr.',
         ]);
 
         TestUpdateModel2::create([
-            'name' => str_random(),
+            'name' => Str::random(),
         ]);
 
         TestUpdateModel2::join('test_model1', function ($join) {

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Tests\Integration\Foundation;
 
 use Exception;
+use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 
 /**
@@ -107,7 +107,7 @@ class FoundationHelpersTest extends TestCase
             return __DIR__;
         });
 
-        $path = public_path(str_finish($directory, '/').'mix-manifest.json');
+        $path = public_path(Str::finish($directory, '/').'mix-manifest.json');
 
         touch($path);
 

--- a/tests/Integration/Session/SessionPersistenceTest.php
+++ b/tests/Integration/Session/SessionPersistenceTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Session;
 
 use Mockery;
+use Illuminate\Support\Str;
 use Illuminate\Http\Response;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
@@ -42,7 +43,7 @@ class SessionPersistenceTest extends TestCase
 
         $handler->shouldReceive('render')->andReturn(new Response);
 
-        $app['config']->set('app.key', str_random(32));
+        $app['config']->set('app.key', Str::random(32));
         $app['config']->set('session.driver', 'fake-null');
         $app['config']->set('session.expire_on_close', true);
     }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -270,9 +270,9 @@ class SupportHelpersTest extends TestCase
 
     public function testStrAfter()
     {
-        $this->assertEquals('nah', str_after('hannah', 'han'));
-        $this->assertEquals('nah', str_after('hannah', 'n'));
-        $this->assertEquals('hannah', str_after('hannah', 'xxxx'));
+        $this->assertEquals('nah', Str::after('hannah', 'han'));
+        $this->assertEquals('nah', Str::after('hannah', 'n'));
+        $this->assertEquals('hannah', Str::after('hannah', 'xxxx'));
     }
 
     public function testStrContains()


### PR DESCRIPTION
The goal of this PR is to deprecate the global `Arr` and `Str` helper methods for Laravel 5.8 and then remove them in Laravel 5.9 as they are totally useless.

They pollute the global namespace and they don't bring any additional value to the framework. They don't even save you the amount of characters that you have to type as in a bunch (or maybe in all?) of cases it's actually shorter to use the `Arr` and `Str` methods directly.