### PR TITLE
[5.8] Fix missing methods in queue job contract

### DIFF
--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -62,6 +62,13 @@ interface Job
     public function attempts();
 
     /**
+     * Mark the job as "failed".
+     *
+     * @return void
+     */
+    public function markAsFailed();
+
+    /**
      * Process an exception that caused the job to fail.
      *
      * @param  \Throwable  $e

--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -62,6 +62,13 @@ interface Job
     public function attempts();
 
     /**
+     * Determine if the job has been marked as a failure.
+     *
+     * @return bool
+     */
+    public function hasFailed();
+
+    /**
      * Mark the job as "failed".
      *
      * @return void

--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -34,6 +34,13 @@ interface Job
     public function release($delay = 0);
 
     /**
+     * Determine if the job was released back into the queue.
+     *
+     * @return bool
+     */
+    public function isReleased();
+
+    /**
      * Delete the job from the queue.
      *
      * @return void

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -438,6 +438,11 @@ class WorkerFakeJob implements QueueJobContract
         $this->failedWith = $e;
     }
 
+    public function hasFailed()
+    {
+        return $this->failed;
+    }
+
     public function getName()
     {
         return 'WorkerFakeJob';

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -416,6 +416,11 @@ class WorkerFakeJob implements QueueJobContract
         $this->releaseAfter = $delay;
     }
 
+    public function isReleased()
+    {
+        return $this->released;
+    }
+
     public function isDeletedOrReleased()
     {
         return $this->deleted || $this->released;

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -426,6 +426,11 @@ class WorkerFakeJob implements QueueJobContract
         return $this->attempts;
     }
 
+    public function markAsFailed()
+    {
+        $this->failed = true;
+    }
+
     public function failed($e)
     {
         $this->markAsFailed();


### PR DESCRIPTION
A queue job that *just* implements the queue job contract causes 5 test failures in [QueueWorkerTest](https://github.com/laravel/framework/blob/5.7/tests/Queue/QueueWorkerTest.php). This is due to the contract missing the following 3 methods: `markAsFailed()`, `hasFailed()`, and `isReleased()`. The first commit shows the problem and the next three add the missing methods, one at a time, causing the failing tests to progressively start passing again until they all do.