### PR TITLE
[5.8] Add `toArray()` to Paginator contract

### DIFF
--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -114,4 +114,11 @@ interface Paginator
      * @return string
      */
     public function render($view = null, $data = []);
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray();
 }


### PR DESCRIPTION
- Laravel Version: 5.7.13
- PHP Version: 7.2

### Description:
It's possible to paginate eloquent results and [use them in a JSON](https://laravel.com/docs/5.7/pagination#converting-results-to-json) response: 

```php
Route::get('users', function () {
    return App\User::paginate();
});
```

I wanted to send some additional data with the response. I `Paginator` converted it `toArray()` and then added my data:

```php
Route::get('users', function () {
    $result = App\User::paginate()->toArray();
    $result['additional_data'] = // ... 
    return $result;
});
```

As `::paginate()` returns a `Paginator`-contract/-interface, I wondered whether `toArray()` could be added to it? That would ease code-completion and analysis. 
