### PR TITLE
Arr::has code clean up

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -313,10 +313,6 @@ class Arr
      */
     public static function has($array, $keys)
     {
-        if (is_null($keys)) {
-            return false;
-        }
-
         $keys = (array) $keys;
 
         if (! $array) {

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -315,11 +315,7 @@ class Arr
     {
         $keys = (array) $keys;
 
-        if (! $array) {
-            return false;
-        }
-
-        if ($keys === []) {
+        if (! $array || $keys === []) {
             return false;
         }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -321,6 +321,12 @@ class SupportArrTest extends TestCase
 
         $this->assertFalse(Arr::has([], [null]));
         $this->assertFalse(Arr::has(null, [null]));
+
+        $this->assertTrue(Arr::has(['' => 'some'], ''));
+        $this->assertTrue(Arr::has(['' => 'some'], ['']));
+        $this->assertFalse(Arr::has([''], ''));
+        $this->assertFalse(Arr::has([], ''));
+        $this->assertFalse(Arr::has([], ['']));
     }
 
     public function testIsAssoc()


### PR DESCRIPTION
It just simplifies and removes some lines.
Please see each commit separately.
I think laravel has enough tests covering this situation. (tests/Support/SupportArrTest.php line 277-323)

But I wanted to cover one more edge case for empty sting as array key, to be more secure.