### PR TITLE
[5.8] Fix for container app()->call() method

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -34,11 +34,13 @@ class BoundMethod
     /**
      * Call a string reference to a class using Class@method syntax.
      *
-     * @param  \Illuminate\Container\Container $container
-     * @param  string $target
-     * @param  array $parameters
-     * @param  string|null $defaultMethod
+     * @param  \Illuminate\Container\Container  $container
+     * @param  string  $target
+     * @param  array  $parameters
+     * @param  string|null  $defaultMethod
      * @return mixed
+     *
+     * @throws \InvalidArgumentException
      */
     protected static function callClass($container, $target, array $parameters = [], $defaultMethod = null)
     {
@@ -47,13 +49,16 @@ class BoundMethod
         // We will assume an @ sign is used to delimit the class name from the method
         // name. We will split on this @ sign and then build a callable array that
         // we can pass right back into the "call" method for dependency binding.
-        $method = count($segments) === 2 ? $segments[1] : $defaultMethod;
+        $method = count($segments) === 2
+                        ? $segments[1] : $defaultMethod;
 
         if (is_null($method)) {
             throw new InvalidArgumentException('Method not provided.');
         }
 
-        return static::call($container, [$container->make($segments[0]), $method], $parameters);
+        return static::call(
+            $container, [$container->make($segments[0]), $method], $parameters
+        );
     }
 
     /**
@@ -98,8 +103,8 @@ class BoundMethod
     /**
      * Get all dependencies for a given method.
      *
-     * @param  \Illuminate\Container\Container $container
-     * @param  callable|string $callback
+     * @param  \Illuminate\Container\Container  $container
+     * @param  callable|string  $callback
      * @param array $inputData
      * @return array
      * @throws \ReflectionException
@@ -135,7 +140,9 @@ class BoundMethod
             $callback = explode('::', $callback);
         }
 
-        return is_array($callback) ? new ReflectionMethod($callback[0], $callback[1]) : new ReflectionFunction($callback);
+        return is_array($callback)
+            ? new ReflectionMethod($callback[0], $callback[1])
+            : new ReflectionFunction($callback);
     }
 
     /**

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -128,7 +128,7 @@ class BoundMethod
             return $inputData;
         }
 
-        return static::addDependencyForCallParameter($container, $signature, $inputData);
+        return static::addDependenciesToInputData($container, $signature, $inputData);
     }
 
     /**
@@ -160,7 +160,7 @@ class BoundMethod
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    protected static function addDependencyForCallParameter($container, array $signature, array $inputData)
+    protected static function addDependenciesToInputData($container, array $signature, array $inputData)
     {
         // Here we iterate through the list of declared parameters (in the method signature) and decide
         // whether it should be invoked with the provided input data, or we should resolve an object

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -173,9 +173,11 @@ class BoundMethod
                 $resolvedInputData[] = $inputData[$parameter->name];
             } elseif ($parameter->getClass() && array_key_exists($parameter->getClass()->name, $inputData)) {
                 $resolvedInputData[] = $inputData[$parameter->getClass()->name];
+            } elseif ($parameter->getClass() && isset($inputData[$i]) && is_a($inputData[$i], $parameter->getClass()->name)) {
+                $resolvedInputData[] = $inputData[$i++];
             } elseif ($parameter->getClass()) {
                 $resolvedInputData[] = $container->make($parameter->getClass()->name);
-            } elseif (isset($inputData[$i])) {
+            } elseif (array_key_exists($i, $inputData)) {
                 $resolvedInputData[] = $inputData[$i++];
             } elseif ($parameter->isDefaultValueAvailable()) {
                 $resolvedInputData[] = $parameter->getDefaultValue();

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -50,8 +50,7 @@ class BoundMethod
         // We will assume an @ sign is used to delimit the class name from the method
         // name. We will split on this @ sign and then build a callable array that
         // we can pass right back into the "call" method for dependency binding.
-        $method = count($segments) === 2
-                        ? $segments[1] : $defaultMethod;
+        $method = count($segments) === 2 ? $segments[1] : $defaultMethod;
 
         if (is_null($method)) {
             throw new InvalidArgumentException('Method not provided.');
@@ -106,11 +105,12 @@ class BoundMethod
      *
      * @param  \Illuminate\Container\Container  $container
      * @param  callable|string  $callback
-     * @param  array $inputData
+     * @param  array  $inputData
      * @return array
+     *
      * @throws \ReflectionException
      */
-    protected static function getMethodDependencies($container, $callback, array $inputData = []) : array
+    protected static function getMethodDependencies($container, $callback, array $inputData = [])
     {
         $signature = static::getCallReflector($callback)->getParameters();
 
@@ -134,12 +134,12 @@ class BoundMethod
     /**
      * Get the proper reflection instance for the given callback.
      *
-     * @param  callable|string $callback
+     * @param  callable|string  $callback
      * @return \ReflectionFunctionAbstract
      *
      * @throws \ReflectionException
      */
-    protected static function getCallReflector($callback): \Reflector
+    protected static function getCallReflector($callback)
     {
         if (is_string($callback) && strpos($callback, '::') !== false) {
             $callback = explode('::', $callback);
@@ -153,13 +153,14 @@ class BoundMethod
     /**
      * Add the dependencies to the input data.
      *
-     * @param  \Illuminate\Container\Container $container
-     * @param  array $signature
-     * @param  array $inputData
+     * @param  \Illuminate\Container\Container  $container
+     * @param  array  $signature
+     * @param  array  $inputData
      * @return array
+     *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    protected static function addDependencyForCallParameter($container, array $signature, array $inputData): array
+    protected static function addDependencyForCallParameter($container, array $signature, array $inputData)
     {
         $resolvedInputData = [];
         $i = 0;
@@ -184,10 +185,10 @@ class BoundMethod
     /**
      * Determine if the given string is in Class@method syntax.
      *
-     * @param  mixed  $callback
+     * @param  string|callable  $callback
      * @return bool
      */
-    protected static function isCallableWithAtSign($callback): bool
+    protected static function isCallableWithAtSign($callback)
     {
         return is_string($callback) && strpos($callback, '@') !== false;
     }

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -162,6 +162,9 @@ class BoundMethod
      */
     protected static function addDependencyForCallParameter($container, array $signature, array $inputData)
     {
+        // Here we iterate through the list of declared parameters (in the method signature) and decide
+        // whether it should be invoked with the provided input data, or we should resolve an object
+        // for it (according to it's type-hint) or just call it with it's defined "default" value.
         $resolvedInputData = [];
         $i = 0;
 

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -24,6 +24,7 @@ class BoundMethod
      * @param  array  $inputData
      * @param  string|null  $defaultMethod
      * @return mixed
+     *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public static function call(ContainerContract $container, $callback, array $inputData = [], $defaultMethod = null)

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -18,6 +18,7 @@ class BoundMethod
      * @param  array  $parameters
      * @param  string|null  $defaultMethod
      * @return mixed
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public static function call($container, $callback, array $parameters = [], $defaultMethod = null)
     {
@@ -42,6 +43,7 @@ class BoundMethod
      * @return mixed
      *
      * @throws \InvalidArgumentException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected static function callClass($container, $target, array $parameters = [], $defaultMethod = null)
     {
@@ -109,6 +111,7 @@ class BoundMethod
      * @return array
      *
      * @throws \ReflectionException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected static function getMethodDependencies($container, $callback, array $inputData = [])
     {

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Container;
 
 use Closure;
-use Illuminate\Support\Arr;
 use ReflectionMethod;
 use ReflectionFunction;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
 class BoundMethod

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -114,12 +114,16 @@ class BoundMethod
     {
         $signature = static::getCallReflector($callback)->getParameters();
 
-        // In case the method has no explicit input parameters defined
-        // we will call it, with whatever input data available to us.
+        // In case the method has no explicit input parameters we will
+        // call that with whatever input data available to us since
+        // they may have used func_get_args() to catch the input.
         if (count($signature) === 0) {
             return $inputData;
         }
 
+        // When receive method input as an indexed array and the count of passed arguments
+        // is not less than the declared parameters, it means that we are provided with
+        // everything needed, So the IOC container should not bother about injection.
         if (! Arr::isAssoc($inputData) && (count($signature) <= count($inputData))) {
             return $inputData;
         }
@@ -153,6 +157,7 @@ class BoundMethod
      * @param  array $signature
      * @param  array $inputData
      * @return array
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected static function addDependencyForCallParameter($container, array $signature, array $inputData): array
     {

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -167,8 +167,7 @@ class BoundMethod
             } elseif ($parameter->getClass()) {
                 $resolvedInputData[] = $container->make($parameter->getClass()->name);
             } elseif (isset($inputData[$i])) {
-                $resolvedInputData[] = $inputData[$i];
-                $i++;
+                $resolvedInputData[] = $inputData[$i++];
             } elseif ($parameter->isDefaultValueAvailable()) {
                 $resolvedInputData[] = $parameter->getDefaultValue();
             }

--- a/tests/Container/BoundMethodTest.php
+++ b/tests/Container/BoundMethodTest.php
@@ -62,7 +62,19 @@ class BoundMethodTest extends TestCase
         $this->assertEquals('a', $a);
         $this->assertEquals('default b', $b);
         $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
-        $this->assertFalse(isset($args[4]));
+        $this->assertArrayNotHasKey(4, $args);
+
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $injected, [null, null]);
+        $this->assertNull($a);
+        $this->assertNull($b);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
+        $this->assertArrayNotHasKey(4, $args);
+
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $injected, [null, null]);
+        $this->assertNull($a);
+        $this->assertNull($b);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
+        $this->assertArrayNotHasKey(4, $args);
 
         [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $injected, [
             'a' => 'passed a',
@@ -72,7 +84,7 @@ class BoundMethodTest extends TestCase
         $this->assertEquals('passed a', $a);
         $this->assertEquals('value b', $b);
         $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
-        $this->assertFalse(isset($args[4]));
+        $this->assertArrayNotHasKey(4, $args);
 
         [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $injected, [
             'a' => 'passed a',
@@ -81,7 +93,7 @@ class BoundMethodTest extends TestCase
         $this->assertEquals('passed a', $a);
         $this->assertEquals('default b', $b);
         $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
-        $this->assertFalse(isset($args[4]));
+        $this->assertArrayNotHasKey(4, $args);
     }
 
     public function testCallingWithNoArgs()
@@ -107,38 +119,38 @@ class BoundMethodTest extends TestCase
         $this->assertEquals('passed a', $a);
         $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
         $this->assertEquals('default c', $c);
-        $this->assertFalse(isset($args[4]));
+        $this->assertArrayNotHasKey(4, $args);
 
         [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $callee, ['c' => 'value c', 'junk' => 'junk', 'a' => 'passed a']);
         $this->assertEquals('passed a', $a);
         $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
         $this->assertEquals('value c', $c);
-        $this->assertFalse(isset($args[4]));
+        $this->assertArrayNotHasKey(4, $args);
 
         [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $callee, ['passed a', 'value c']);
         $this->assertEquals('passed a', $a);
         $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
         $this->assertEquals('value c', $c);
-        $this->assertFalse(isset($args[4]));
+        $this->assertArrayNotHasKey(4, $args);
 
         $obj = new ContainerBoundMethodStub;
         [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $callee, ['passed a', $obj]);
         $this->assertEquals('passed a', $a);
         $this->assertSame($obj, $b);
         $this->assertEquals('default c', $c);
-        $this->assertFalse(isset($args[4]));
+        $this->assertArrayNotHasKey(4, $args);
 
         [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $callee, ['passed a', $obj, 'passed c']);
         $this->assertEquals('passed a', $a);
         $this->assertSame($obj, $b);
         $this->assertEquals('passed c', $c);
-        $this->assertFalse(isset($args[4]));
+        $this->assertArrayNotHasKey(4, $args);
 
         $stub2 = new ContainerBoundMethodStub2;
         [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $callee, ['passed a', $stub2]);
         $this->assertEquals('passed a', $a);
         $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
         $this->assertSame($stub2, $c);
-        $this->assertFalse(isset($args[4]));
+        $this->assertArrayNotHasKey(4, $args);
     }
 }

--- a/tests/Container/BoundMethodTest.php
+++ b/tests/Container/BoundMethodTest.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Container;
 
-use Illuminate\Container\BoundMethod;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
+use Illuminate\Container\BoundMethod;
 
 class BoundMethodAccessor extends BoundMethod
 {
@@ -35,8 +35,7 @@ class BoundMethodTest extends TestCase
     {
         $container = new Container();
 
-        $defaulty = function ($a, $b = 'default b', $c = 'default c')
-        {
+        $defaulty = function ($a, $b = 'default b', $c = 'default c') {
         };
 
         $args = BoundMethodAccessor::getMethodDependencies($container, $defaulty, ['a', 'b', 'c']);

--- a/tests/Container/BoundMethodTest.php
+++ b/tests/Container/BoundMethodTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Illuminate\Tests\Container;
+
+use Illuminate\Container\BoundMethod;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+
+class BoundMethodAccessor extends BoundMethod
+{
+    public static function getMethodDependencies($container, $callback, array $inputData = [])
+    {
+        return parent::getMethodDependencies($container, $callback, $inputData);
+    }
+}
+
+class ContainerBoundMethodStub
+{
+}
+
+class ContainerBoundMethodStub2
+{
+}
+
+class BoundMethodAccessorStub
+{
+    public function injectedAtMiddle($a, ContainerBoundMethodStub $b, $c = 'default c')
+    {
+    }
+}
+
+class BoundMethodTest extends TestCase
+{
+    public function testBoundMethodAccessor()
+    {
+        $container = new Container();
+
+        $defaulty = function ($a, $b = 'default b', $c = 'default c')
+        {
+        };
+
+        $args = BoundMethodAccessor::getMethodDependencies($container, $defaulty, ['a', 'b', 'c']);
+        $this->assertSame(['a', 'b', 'c'], $args);
+
+        $args = BoundMethodAccessor::getMethodDependencies($container, $defaulty, ['a', 'b']);
+        $this->assertSame(['a', 'b', 'default c'], $args);
+
+        $args = BoundMethodAccessor::getMethodDependencies($container, $defaulty, ['a', 'b', null]);
+        $this->assertSame(['a', 'b', null], $args);
+
+        $args = BoundMethodAccessor::getMethodDependencies($container, $defaulty, ['a', null]);
+        $this->assertSame(['a', null, 'default c'], $args);
+    }
+
+    public function testEndInjection()
+    {
+        $container = new Container();
+
+        $injected = function ($a, $b = 'default b', ContainerBoundMethodStub $c) {
+        };
+
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $injected, ['a']);
+        $this->assertEquals('a', $a);
+        $this->assertEquals('default b', $b);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
+        $this->assertFalse(isset($args[4]));
+
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $injected, [
+            'a' => 'passed a',
+            'b' => 'value b',
+            'junk' => 'junk',
+        ]);
+        $this->assertEquals('passed a', $a);
+        $this->assertEquals('value b', $b);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
+        $this->assertFalse(isset($args[4]));
+
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $injected, [
+            'a' => 'passed a',
+            'junk' => 'junk',
+        ]);
+        $this->assertEquals('passed a', $a);
+        $this->assertEquals('default b', $b);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
+        $this->assertFalse(isset($args[4]));
+    }
+
+    public function testCallingWithNoArgs()
+    {
+        $container = new Container();
+        $callee = function () {
+        };
+
+        $args = BoundMethodAccessor::getMethodDependencies($container, $callee, ['a', 'b', 'c']);
+        $this->assertSame(['a', 'b', 'c'], $args);
+
+        $args = BoundMethodAccessor::getMethodDependencies($container, $callee, ['key_a' => 'value_a', 'key_b' => 'value_b']);
+        $this->assertSame(['key_a' => 'value_a', 'key_b' => 'value_b'], $args);
+    }
+
+    public function testCanInjectAtMiddle()
+    {
+        $container = new Container();
+        $callee = function ($a, ContainerBoundMethodStub $b, $c = 'default c') {
+        };
+
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $callee, ['a' => 'passed a', 'junk' => 'junk']);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertEquals('default c', $c);
+        $this->assertFalse(isset($args[4]));
+
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $callee, ['c' => 'value c', 'junk' => 'junk', 'a' => 'passed a']);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertEquals('value c', $c);
+        $this->assertFalse(isset($args[4]));
+
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $callee, ['passed a', 'value c']);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertEquals('value c', $c);
+        $this->assertFalse(isset($args[4]));
+
+        $obj = new ContainerBoundMethodStub;
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $callee, ['passed a', $obj]);
+        $this->assertEquals('passed a', $a);
+        $this->assertSame($obj, $b);
+        $this->assertEquals('default c', $c);
+        $this->assertFalse(isset($args[4]));
+
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $callee, ['passed a', $obj, 'passed c']);
+        $this->assertEquals('passed a', $a);
+        $this->assertSame($obj, $b);
+        $this->assertEquals('passed c', $c);
+        $this->assertFalse(isset($args[4]));
+
+        $stub2 = new ContainerBoundMethodStub2;
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($container, $callee, ['passed a', $stub2]);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertSame($stub2, $c);
+        $this->assertFalse(isset($args[4]));
+    }
+}

--- a/tests/Container/BoundMethodTest.php
+++ b/tests/Container/BoundMethodTest.php
@@ -75,11 +75,12 @@ class BoundMethodTest extends TestCase
         $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
         $this->assertArrayNotHasKey(4, $args);
 
-        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($injected, [null, null]);
-        $this->assertNull($a);
-        $this->assertNull($b);
-        $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
+        $args = BoundMethodAccessor::getMethodDependencies($injected, [null, null, null]);
+        $this->assertSame([null, null, null], $args);
         $this->assertArrayNotHasKey(4, $args);
+
+        $args = BoundMethodAccessor::getMethodDependencies($injected, ['a', 'b', 'c']);
+        $this->assertEquals(['a', 'b', 'c'], $args);
 
         [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($injected, [
             'a' => 'passed a',
@@ -99,6 +100,20 @@ class BoundMethodTest extends TestCase
         $this->assertEquals('default b', $b);
         $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
         $this->assertArrayNotHasKey(4, $args);
+    }
+
+    public function testExtraNumberOfInputArePassedIntoMethod()
+    {
+        BoundMethodAccessor::setContainer(new Container());
+
+        $callable = function ($a, $b) {
+        };
+
+        $args = BoundMethodAccessor::getMethodDependencies($callable, ['a', 'b', 'c', 'd']);
+        $this->assertEquals(['a', 'b', 'c', 'd'], $args);
+
+        $args = BoundMethodAccessor::getMethodDependencies($callable, ['a', 'b', 'c', null]);
+        $this->assertEquals(['a', 'b', 'c', null], $args);
     }
 
     public function testCallingWithNoArgs()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1115,8 +1115,6 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ContainerConcreteStub::class, $class);
     }
 
-
-
     public function testWithDefaultParametersIndexedArraySyntax()
     {
         $container = new Container;
@@ -1203,7 +1201,6 @@ class ContainerTest extends TestCase
         $container->call(function (ContainerConcreteStub $stub) {
         }, ['foo' => 'bar', 'stub' => new ContainerConcreteStub]);
     }
-
 }
 
 class ContainerConcreteStub
@@ -1217,14 +1214,17 @@ class ContainerTestDefaultyParams
     {
         return func_get_args();
     }
+
     public function defaultyBandC($a, $b = 'default b', $c = 'default c')
     {
         return func_get_args();
     }
+
     public function defaultyOnlyC($a, $b, $c = 'default c')
     {
         return func_get_args();
     }
+
     public function noDefault($a, $b, $c)
     {
         return func_get_args();

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -596,6 +596,16 @@ class ContainerTest extends TestCase
         $result = $container->call([new ContainerTestCallStub, 'inject'], ['_stub' => 'foo']);
         $this->assertInstanceOf(ContainerConcreteStub::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
+
+        $container = new Container;
+        $result = $container->call([new ContainerTestCallStub, 'inject'], ['baz']);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result[0]);
+        $this->assertEquals('baz', $result[1]);
+
+        $container = new Container;
+        $result = $container->call([new ContainerTestCallStub, 'inject'], ['baz', 'foo']);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result[0]);
+        $this->assertEquals('baz', $result[1]);
     }
 
     public function testBindMethodAcceptsAnArray()
@@ -1186,6 +1196,10 @@ class ContainerTest extends TestCase
         $container = new Container;
         $container->call(function (ContainerConcreteStub $stub) {
         }, ['foo' => 'bar']);
+
+        $container->call(function (ContainerConcreteStub $stub) {
+        }, ['bar']);
+
         $container->call(function (ContainerConcreteStub $stub) {
         }, ['foo' => 'bar', 'stub' => new ContainerConcreteStub]);
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -603,9 +603,10 @@ class ContainerTest extends TestCase
         $this->assertEquals('baz', $result[1]);
 
         $container = new Container;
-        $result = $container->call([new ContainerTestCallStub, 'inject'], ['baz', 'foo']);
-        $this->assertInstanceOf(ContainerConcreteStub::class, $result[0]);
-        $this->assertEquals('baz', $result[1]);
+        $object = new ContainerConcreteStub();
+        $result = $container->call([new ContainerTestCallStub, 'inject'], [$object, 'foo']);
+        $this->assertSame($object, $result[0]);
+        $this->assertEquals('foo', $result[1]);
     }
 
     public function testBindMethodAcceptsAnArray()
@@ -1196,7 +1197,7 @@ class ContainerTest extends TestCase
         }, ['foo' => 'bar']);
 
         $container->call(function (ContainerConcreteStub $stub) {
-        }, ['bar']);
+        }, [new ContainerConcreteStub]);
 
         $container->call(function (ContainerConcreteStub $stub) {
         }, ['foo' => 'bar', 'stub' => new ContainerConcreteStub]);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1223,14 +1223,11 @@ class ContainerTest extends TestCase
         $this->assertEquals('foo', $result[0]);
         $this->assertSame($obj, $result[1]);
 
-
         $result = $container->call(function ($foo = 'default foo', ContainerConcreteStub $stub) {
             return [$foo, $stub];
         }, ['foo']);
         $this->assertEquals('foo', $result[0]);
         $this->assertInstanceOf(ContainerConcreteStub::class, $result[1]);
-
-
 
         $result = $container->call(function ($foo = 'default foo', ContainerConcreteStub $stub = null) {
             return [$foo, $stub];

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -586,6 +586,16 @@ class ContainerTest extends TestCase
         });
         $result = $container->call([new ContainerTestCallStub, 'unresolvable']);
         $this->assertEquals(['foo', 'bar'], $result);
+
+        $container = new Container;
+        $result = $container->call([new ContainerTestCallStub, 'inject'], ['_stub' => 'foo', 'default' => 'bar']);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result[0]);
+        $this->assertEquals('bar', $result[1]);
+
+        $container = new Container;
+        $result = $container->call([new ContainerTestCallStub, 'inject'], ['_stub' => 'foo']);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result[0]);
+        $this->assertEquals('taylor', $result[1]);
     }
 
     public function testBindMethodAcceptsAnArray()
@@ -1094,11 +1104,117 @@ class ContainerTest extends TestCase
 
         $this->assertInstanceOf(ContainerConcreteStub::class, $class);
     }
+
+
+
+    public function testWithDefaultParametersIndexedArraySyntax()
+    {
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar', 'baz']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty');
+        $this->assertEquals(['default a', 'default b', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['foo']);
+        $this->assertEquals(['foo', 'default b', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['foo', 'bar', 'baz']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+    }
+
+    public function testWithDefaultParametersAssociativeSyntax()
+    {
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['a' => 'foo', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['a' => 'foo', 'b' => 'bar', 'c' => 'baz']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['a' => 'foo', 'c' => 'baz', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['a' => 'foo', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['a' => 'foo']);
+        $this->assertEquals(['foo', 'default b', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['a' => 'foo', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['a' => 'foo', 'b' => 'bar', 'c' => 'baz']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['a' => 'foo', 'c' => 'baz', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+    }
+
+    public function testClosureCallWithInjectedDependency()
+    {
+        $container = new Container;
+        $container->call(function (ContainerConcreteStub $stub) {
+        }, ['foo' => 'bar']);
+        $container->call(function (ContainerConcreteStub $stub) {
+        }, ['foo' => 'bar', 'stub' => new ContainerConcreteStub]);
+    }
+
 }
 
 class ContainerConcreteStub
 {
     //
+}
+
+class ContainerTestDefaultyParams
+{
+    public function defaulty($a = 'default a', $b = 'default b', $c = 'default c')
+    {
+        return func_get_args();
+    }
+    public function defaultyBandC($a, $b = 'default b', $c = 'default c')
+    {
+        return func_get_args();
+    }
+    public function defaultyOnlyC($a, $b, $c = 'default c')
+    {
+        return func_get_args();
+    }
+    public function noDefault($a, $b, $c)
+    {
+        return func_get_args();
+    }
 }
 
 interface IContainerContractStub

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1145,6 +1145,10 @@ class ContainerTest extends TestCase
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['foo', 'bar', 'baz']);
         $this->assertEquals(['foo', 'bar', 'baz'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['foo', 'bar', 'baz', 'foo2', 'bar2', 'baz2']);
+        $this->assertEquals(['foo', 'bar', 'baz', 'foo2', 'bar2', 'baz2'], $result);
     }
 
     public function testWithDefaultParametersAssociativeSyntax()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1197,14 +1197,46 @@ class ContainerTest extends TestCase
     public function testClosureCallWithInjectedDependency()
     {
         $container = new Container;
-        $container->call(function (ContainerConcreteStub $stub) {
+        $result = $container->call(function (ContainerConcreteStub $stub) {
+            return $stub;
         }, ['foo' => 'bar']);
 
-        $container->call(function (ContainerConcreteStub $stub) {
-        }, [new ContainerConcreteStub]);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result);
 
-        $container->call(function (ContainerConcreteStub $stub) {
-        }, ['foo' => 'bar', 'stub' => new ContainerConcreteStub]);
+        $obj = new ContainerConcreteStub;
+        $result = $container->call(function (ContainerConcreteStub $stub) {
+            return $stub;
+        }, [$obj]);
+        $this->assertSame($obj, $result);
+
+        $obj = new ContainerConcreteStub;
+        $result = $container->call(function (ContainerConcreteStub $stub, $baz = 'taylor') {
+            return [$stub, $baz];
+        }, ['foo' => 'bar', 'stub' => $obj]);
+        $this->assertSame($obj, $result[0]);
+        $this->assertEquals('taylor', $result[1]);
+
+        $obj = new ContainerConcreteStub;
+        $result = $container->call(function ($foo, ContainerConcreteStub $stub) {
+            return [$foo, $stub];
+        }, ['foo', $obj]);
+        $this->assertEquals('foo', $result[0]);
+        $this->assertSame($obj, $result[1]);
+
+
+        $result = $container->call(function ($foo = 'default foo', ContainerConcreteStub $stub) {
+            return [$foo, $stub];
+        }, ['foo']);
+        $this->assertEquals('foo', $result[0]);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result[1]);
+
+
+
+        $result = $container->call(function ($foo = 'default foo', ContainerConcreteStub $stub = null) {
+            return [$foo, $stub];
+        }, []);
+        $this->assertEquals('default foo', $result[0]);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result[1]);
     }
 }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1232,6 +1232,15 @@ class ContainerTest extends TestCase
         $this->assertEquals('default foo', $result[0]);
         $this->assertInstanceOf(ContainerConcreteStub::class, $result[1]);
     }
+
+    public function testTypeErrorHappensWhenWrongDataIsPassed()
+    {
+        $callable = function (ContainerConcreteStub $stub) {
+        };
+
+        $this->expectException(\TypeError::class);
+        (new Container)->call($callable, ['foo']);
+    }
 }
 
 class ContainerConcreteStub

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -553,6 +553,11 @@ class ContainerTest extends TestCase
         $stub = new ContainerTestCallStub;
         $result = $container->call([$stub, 'work'], ['foo', 'bar']);
         $this->assertEquals(['foo', 'bar'], $result);
+
+        $container = new Container;
+        $stub = new ContainerTestCallStub;
+        $result = $container->call([$stub, 'work'], ['b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['bar', 'foo'], $result);
     }
 
     public function testCallWithStaticMethodNameString()
@@ -1119,10 +1124,6 @@ class ContainerTest extends TestCase
     public function testWithDefaultParametersIndexedArraySyntax()
     {
         $container = new Container;
-        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar']);
-        $this->assertEquals(['foo', 'bar', 'default c'], $result);
-
-        $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar', 'baz']);
         $this->assertEquals(['foo', 'bar', 'baz'], $result);
 
@@ -1139,12 +1140,12 @@ class ContainerTest extends TestCase
         $this->assertEquals(['foo', 'default b', 'default c'], $result);
 
         $container = new Container;
-        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['foo', 'bar']);
-        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['foo', null]);
+        $this->assertEquals(['foo', null, 'default c'], $result);
 
         $container = new Container;
-        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['foo', 'bar', 'baz']);
-        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', [null, null, null]);
+        $this->assertEquals([null, null, null], $result);
 
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['foo', 'bar', 'baz', 'foo2', 'bar2', 'baz2']);
@@ -1162,7 +1163,7 @@ class ContainerTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'default c'], $result);
 
         $container = new Container;
-        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['a' => 'foo', 'b' => 'bar', 'c' => 'baz']);
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['c' => 'baz', 'b' => 'bar', 'a' => 'foo']);
         $this->assertEquals(['foo', 'bar', 'baz'], $result);
 
         $container = new Container;
@@ -1170,7 +1171,7 @@ class ContainerTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'baz'], $result);
 
         $container = new Container;
-        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['a' => 'foo', 'b' => 'bar']);
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['b' => 'bar', 'a' => 'foo',]);
         $this->assertEquals(['foo', 'bar', 'default c'], $result);
 
         $container = new Container;
@@ -1184,10 +1185,6 @@ class ContainerTest extends TestCase
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['b' => 'bar', 'a' => 'foo']);
         $this->assertEquals(['foo', 'bar', 'default c'], $result);
-
-        $container = new Container;
-        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['a' => 'foo', 'b' => 'bar', 'c' => 'baz']);
-        $this->assertEquals(['foo', 'bar', 'baz'], $result);
 
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['a' => 'foo', 'c' => 'baz', 'b' => 'bar']);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1171,7 +1171,7 @@ class ContainerTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'baz'], $result);
 
         $container = new Container;
-        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['b' => 'bar', 'a' => 'foo',]);
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['b' => 'bar', 'a' => 'foo']);
         $this->assertEquals(['foo', 'bar', 'default c'], $result);
 
         $container = new Container;


### PR DESCRIPTION
Addresses these issues :
https://github.com/laravel/framework/issues/26851
https://github.com/laravel/framework/issues/22687
https://github.com/laravel/framework/issues/26837

Following my previous bug fix https://github.com/laravel/framework/pull/26852 which caused a new nasty bug and eventually got reverted...
I created an other PR to add the missing tests to cover more cases https://github.com/laravel/framework/pull/26897

Now I am coming up with an other solution for making it really fixed.