### PR TITLE
[5.7] support change redis sentinel connection to default  without change version control file database.php in some production environment

### DIFF
--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -69,7 +69,8 @@ class RedisManager implements Factory
      */
     public function connection($name = null)
     {
-        $name = $name ?: 'default';
+        $default_connection = $this->config['default_connection'] ?: 'default';
+        $name = $name ?: $default_connection;
 
         if (isset($this->connections[$name])) {
             return $this->connections[$name];


### PR DESCRIPTION
Enable Define default connection so that support redis sentinel connection without change version control file database.php in some production environment. In this way Just change .env REDIS_DEFAULT_CONNECTION.

For eg:

'default_connection' => env('REDIS_DEFAULT_CONNECTION', 'default'), 'default' => [ 'host' => env('REDIS_HOST', '127.0.0.1'), 'password' => env('REDIS_PASSWORD', null), 'port' => env('REDIS_PORT', 6379), 'database' => 0, ], 'sentinel' => [ 'tcp://192.168.104.65:26379?timeout=0.100', 'tcp://192.168.104.65:26380?timeout=0.100', 'options' => [ 'replication' => 'sentinel', 'service' => 'clouds', 'parameters' => [ 'password' => 'clouds@1234', 'database' => 0, ], ], ],