### PR TITLE
[5.7] Adding Transactions commit and rollback helpers methods

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -239,4 +239,62 @@ trait ManagesTransactions
     {
         return $this->transactions;
     }
+
+    /**
+     * Evaluates the condition and commits or rollback
+     *
+     * @param  bool $condition
+     *
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function commitIf($condition)
+    {
+        $condition ? $this->commit() : $this->rollback();
+    }
+
+    /**
+     * Evaluates the condition and commits or rollback
+     *
+     * @param  bool $condition
+     *
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function commitUnless($condition)
+    {
+        $this->commitIf(!$condition);
+    }
+
+    /**
+     * Evaluates the condition and commits or rollback
+     *
+     * @param  bool $condition
+     * @param  int|null $toLevel
+     *
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function rollbackIf($condition, $toLevel = null)
+    {
+        $condition ? $this->rollback($toLevel) : $this->commit();
+    }
+
+    /**
+     * Evaluates the condition and commits or rollback
+     *
+     * @param  bool $condition
+     * @param  int|null $toLevel
+     *
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function rollbackUnless($condition, $toLevel = null)
+    {
+        $this->rollbackIf(!$condition, $toLevel);
+    }
 }

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -241,7 +241,7 @@ trait ManagesTransactions
     }
 
     /**
-     * Evaluates the condition and commits or rollback
+     * Evaluates the condition and commits or rollback.
      *
      * @param  bool $condition
      *
@@ -255,7 +255,7 @@ trait ManagesTransactions
     }
 
     /**
-     * Evaluates the condition and commits or rollback
+     * Evaluates the condition and commits or rollback.
      *
      * @param  bool $condition
      *
@@ -265,11 +265,11 @@ trait ManagesTransactions
      */
     public function commitUnless($condition)
     {
-        $this->commitIf(!$condition);
+        $this->commitIf(! $condition);
     }
 
     /**
-     * Evaluates the condition and commits or rollback
+     * Evaluates the condition and commits or rollback.
      *
      * @param  bool $condition
      * @param  int|null $toLevel
@@ -284,7 +284,7 @@ trait ManagesTransactions
     }
 
     /**
-     * Evaluates the condition and commits or rollback
+     * Evaluates the condition and commits or rollback.
      *
      * @param  bool $condition
      * @param  int|null $toLevel
@@ -295,6 +295,6 @@ trait ManagesTransactions
      */
     public function rollbackUnless($condition, $toLevel = null)
     {
-        $this->rollbackIf(!$condition, $toLevel);
+        $this->rollbackIf(! $condition, $toLevel);
     }
 }


### PR DESCRIPTION
Working with transactions the end user needs to decide if he transactions is committed or rollback. 
That code usually looks like

`
if ($condition) {
    DB::commit();
} else {
    DB::rollback();
}
`

With this change I added new methods that encapsulates this type of code. I have not change the code related on how a commit or a rollback are done just adding flavor to make the code more readable.

`DB::commitIf($condition)`
This code will replace the code above. in addition I added other methods 
`DB::commitUnless($condition)`
`DB::rollbackIf($condition)`
`DB::rollbackUnless($condition)`

