### PR TITLE
[5.7] Add comment for MySQL tables

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -50,6 +50,13 @@ class Blueprint
     public $engine;
 
     /**
+     * The comment for the entire table.
+     *
+     * @var string
+     */
+    public $comment;
+
+    /**
      * The default character set that should be used for the table.
      */
     public $charset;

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -59,8 +59,13 @@ class MySqlGrammar extends Grammar
             $blueprint, $command, $connection
         );
 
+        // Add a comment on the table, if it's present.
+        $sql = $this->compileCreateComment(
+            $sql, $connection, $blueprint
+        );
+
         // Once we have the primary SQL, we can add the encoding option to the SQL for
-        // the table.  Then, we can check if a storage engine has been supplied for
+        // the table. Then, we can check if a storage engine has been supplied for
         // the table. If so, we will add the engine declaration to the SQL query.
         $sql = $this->compileCreateEncoding(
             $sql, $connection, $blueprint
@@ -89,6 +94,23 @@ class MySqlGrammar extends Grammar
             $this->wrapTable($blueprint),
             implode(', ', $this->getColumns($blueprint))
         );
+    }
+
+    /**
+     * Append the comment specifications to a command.
+     *
+     * @param  string  $sql
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @return string
+     */
+    protected function compileCreateComment($sql, Connection $connection, Blueprint $blueprint)
+    {
+        if (isset($blueprint->comment)) {
+            return $sql.' comment = '.$connection->getPdo()->quote($blueprint->comment);
+        }
+
+        return $sql;
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Database;
 
-use Mockery as m;
 use PDO;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;


### PR DESCRIPTION
Implementing the [idea](https://github.com/laravel/ideas/issues/897).

Currently there is no way to add a comment for the entire table using Schema Builder. Users want it, see e.g. the [question](https://laracasts.com/discuss/channels/eloquent/how-do-i-add-a-table-comment-using-eloquent-schema-builder).
To add such a comment, a developer should append after the creation of a table an additional _raw_ query to the migration:

`DB::statement("ALTER TABLE users COMMENT = 'Only active users please'");`

This PR implements the _php artisan_'s way of adding a table comment:

`$table->comment = "It's a true way!";`

The `comment` is a new table option, like existing ones: `engine`, `charset`, `collation`.

