### PR TITLE
[5.4] Fix Query Builder breakage with PHP 7.3

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1226,7 +1226,7 @@ class Builder
     {
         $type = $not ? 'NotExists' : 'Exists';
 
-        $this->wheres[] = compact('type', 'operator', 'query', 'boolean');
+        $this->wheres[] = compact('type', 'query', 'boolean');
 
         $this->addBinding($query->getBindings(), 'where');
 


### PR DESCRIPTION
remove undefined `operator` variable from `compact` method

this undefined variable breaks 5.4 on php 7.3

Fixes #26936