### PR TITLE
[5.8] Make a closure function that can help users to define their own token…

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -49,10 +49,11 @@ class PasswordBroker implements PasswordBrokerContract
     /**
      * Send a password reset link to a user.
      *
-     * @param  array  $credentials
+     * @param array $credentials
+     * @param Closure $callback
      * @return string
      */
-    public function sendResetLink(array $credentials)
+    public function sendResetLink(array $credentials, Closure $callback)
     {
         // First we will check to see if we found a user at the given credentials and
         // if we did not we will redirect back to this current URI with a piece of
@@ -63,11 +64,13 @@ class PasswordBroker implements PasswordBrokerContract
             return static::INVALID_USER;
         }
 
+        $token = $callback($user, $this->getRepository());
+
         // Once we have the reset token, we are ready to send the message out to this
         // user with a link to reset their password. We will then redirect back to
         // the current URI having nothing set in the session to indicate errors.
         $user->sendPasswordResetNotification(
-            $this->tokens->create($user)
+            $token
         );
 
         return static::RESET_LINK_SENT;

--- a/src/Illuminate/Auth/Passwords/TokenRepositoryInterface.php
+++ b/src/Illuminate/Auth/Passwords/TokenRepositoryInterface.php
@@ -37,4 +37,21 @@ interface TokenRepositoryInterface
      * @return void
      */
     public function deleteExpired();
+
+
+    /**
+     * Delete expired token by a given user
+     *
+     * @param CanResetPasswordContract $user
+     * @return void
+     */
+    public function deleteExpiredByUser(CanResetPasswordContract $user);
+
+    /**
+     * Get existing token by a given user
+     *
+     * @param CanResetPasswordContract $user
+     * @return bool
+     */
+    public function existingToken(CanResetPasswordContract $user);
 }

--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -44,10 +44,11 @@ interface PasswordBroker
     /**
      * Send a password reset link to a user.
      *
-     * @param  array  $credentials
+     * @param array $credentials
+     * @param Closure $callback
      * @return string
      */
-    public function sendResetLink(array $credentials);
+    public function sendResetLink(array $credentials, Closure $callback);
 
     /**
      * Reset the password for the given token.


### PR DESCRIPTION
**Background**
This is an issue that I encountered during my company, my leader wants me to change password reset logic to retain those valid tokens(not expired) to be still available while the users submit multiple times. For the current system, if a user submits one time, the system generates A token. If he does second time, it generates B token and A token gets removed from database. We would like to have A token still be valid and also be invalid only if it's expired.

**Benefits**
Case 1: The reason that we need to do this as we found out some users cannot receive email when they first attempt the button, so they try to reset password multiple times. (Yeah, there might be potential email delays or whatever the network issue is that we can't really guarantee the emails can be delivered in time sometimes....) The users may receive some old token link emails that are invalid because all tokens got removed and only the latest token is valid which they may still haven't received.

Case 2: In general speaking, the users still need to customise a bit on password reset module in their own system to some extent. The current structure is truly difficult to extend our own logic, I have googled and also searched github forum, there people also have this issue, for example, lets say, I want to make a minor change on reset password token generation, I finally find out DatabaseTokenRepository is where I need to put code in, however, this class is resolved by PasswordBrokerManager, and PasswordBrokerManager is init from PasswordResetServiceProvider. There might be 3 or 4 classes need to be extended from just only 1-2 lines modifications.

**Other notes**
I agree that framework needs to be flexible and should do not bind with any specific business logic. From my point of view, the token generation should be handled for end-users to implement their logic easily.

**Brief Explanation on changes**
Every time we call create() in DatabaseTokenRepository, the system deletes all existing tokens first and then create a new one, so the create() function actually is doing two separate things, delete tokens and create tokens. So I decouple it, as the Repository should do minor stuff as small as possible, I added two more Contract functions: deleteExpiredByUser and existingToken. The PasswordBroker is the main driver where it controls the logic. I added a new Closure in sendResetLink function which will be further used in trait SendsPasswordResetEmails for end-users. In the trait, I implement Closure and with two default functions, checkToken() and createToken(), the current logic still follows existing system(delete all tokens for a user and then create a new one). However, this has big benefit for user to control token, for example, I have options to re-use valid token or not delete them etc in callback function.










