### PR TITLE
[5.6] Added chunkById support in relations.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -674,6 +674,29 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Chunk the results of a query by comparing numeric IDs.
+     *
+     * @param  int  $count
+     * @param  callable  $callback
+     * @param  string|null  $column
+     * @param  string|null  $alias
+     * @return bool
+     */
+    public function chunkById($count, callable $callback, $column = null, $alias = null)
+    {
+        $this->query->addSelect($this->shouldSelect());
+
+        $column = $column ?? $this->getRelated()->qualifyColumn($this->relatedKey);
+        $alias = $alias ?? $this->relatedKey;
+
+        return $this->query->chunkById($count, function ($results) use ($callback) {
+            $this->hydratePivotRelation($results->all());
+
+            return $callback($results);
+        }, $column, $alias);
+    }
+
+    /**
      * Hydrate the pivot table relationship on the models.
      *
      * @param  array  $models

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -442,7 +442,6 @@ class HasManyThrough extends Relation
         return $this->prepareQueryBuilder()->chunkById($count, $callback, $column, $alias);
     }
 
-
     /**
      * Get a generator for the given query.
      *

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -426,6 +426,24 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Chunk the results of a query by comparing numeric IDs.
+     *
+     * @param  int  $count
+     * @param  callable  $callback
+     * @param  string|null  $column
+     * @param  string|null  $alias
+     * @return bool
+     */
+    public function chunkById($count, callable $callback, $column = null, $alias = null)
+    {
+        $column = $column ?? $this->getRelated()->getQualifiedKeyName();
+        $alias = $alias ?? $this->getRelated()->getKeyName();
+
+        return $this->prepareQueryBuilder()->chunkById($count, $callback, $column, $alias);
+    }
+
+
+    /**
      * Get a generator for the given query.
      *
      * @return \Generator

--- a/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
+{
+    public function setUp()
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+        });
+
+        $this->schema()->create('articles', function ($table) {
+            $table->increments('aid');
+            $table->string('title');
+        });
+
+        $this->schema()->create('article_user', function ($table) {
+            $table->integer('article_id')->unsigned();
+            $table->foreign('article_id')->references('aid')->on('articles');
+            $table->integer('user_id')->unsigned();
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    public function testBelongsToChunkById()
+    {
+        $this->seedData();
+
+        $user = BelongsToManyChunkByIdTestTestUser::query()->first();
+        $i = 0;
+
+        $user->articles()->chunkById(1, function (Collection $collection) use (&$i) {
+            $i++;
+            $this->assertTrue($collection->first()->aid == $i);
+        });
+
+        $this->assertTrue($i === 3);
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('articles');
+        $this->schema()->drop('article_user');
+    }
+
+    /**
+     * Helpers...
+     */
+    protected function seedData()
+    {
+        $user = BelongsToManyChunkByIdTestTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        BelongsToManyChunkByIdTestTestArticle::query()->insert([
+            ['aid' => 1, 'title' => 'Another title'],
+            ['aid' => 2, 'title' => 'Another title'],
+            ['aid' => 3, 'title' => 'Another title'],
+        ]);
+
+        $user->articles()->sync([3, 1, 2]);
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+class BelongsToManyChunkByIdTestTestUser extends Eloquent
+{
+    protected $table = 'users';
+    protected $fillable = ['id', 'email'];
+    public $timestamps = false;
+
+    public function articles()
+    {
+        return $this->belongsToMany(BelongsToManyChunkByIdTestTestArticle::class, 'article_user', 'user_id', 'article_id');
+    }
+}
+
+class BelongsToManyChunkByIdTestTestArticle extends Eloquent
+{
+    protected $primaryKey = 'aid';
+    protected $table = 'articles';
+    protected $keyType = 'string';
+    public $incrementing = false;
+    public $timestamps = false;
+    protected $fillable = ['aid', 'title'];
+}

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -199,6 +199,24 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         });
     }
 
+    public function testChunkById()
+    {
+        $this->seedData();
+        $this->seedDataExtended();
+        $country = HasManyThroughTestCountry::find(2);
+
+        $i = 0;
+        $count = 0;
+
+        $country->posts()->chunkById(2, function ($collection) use (&$i, &$count) {
+            $i++;
+            $count += $collection->count();
+        });
+
+        $this->assertEquals(3, $i);
+        $this->assertEquals(6, $count);
+    }
+
     public function testCursorReturnsCorrectModels()
     {
         $this->seedData();

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -104,6 +104,26 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
         $this->assertEquals($post->id, $tag->posts->first()->id);
     }
 
+    public function testChunkById()
+    {
+        $post = EloquentManyToManyPolymorphicTestPost::create();
+        $tag1 = EloquentManyToManyPolymorphicTestTag::create();
+        $tag2 = EloquentManyToManyPolymorphicTestTag::create();
+        $tag3 = EloquentManyToManyPolymorphicTestTag::create();
+        $post->tags()->attach([$tag1->id, $tag2->id, $tag3->id]);
+
+        $count = 0;
+        $iterations = 0;
+        $post->tags()->chunkById(2, function ($tags) use (&$iterations, &$count) {
+            $this->assertInstanceOf(EloquentManyToManyPolymorphicTestTag::class, $tags->first());
+            $count += $tags->count();
+            $iterations++;
+        });
+
+        $this->assertEquals(2, $iterations);
+        $this->assertEquals(3, $count);
+    }
+
     /**
      * Helpers...
      */


### PR DESCRIPTION
Pivot data doesn't attached to model If you use Builder::chunkById.

This PR is fixing this and using actual of relation keys for chunking.

Related to https://github.com/laravel/nova/issues/152
Backport for https://github.com/laravel/framework/pull/26919
