### PR TITLE
[5.8] Fix translation issue

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -160,7 +160,10 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // If we can't find a translation for the JSON key, we will attempt to translate it
         // using the typical translation file. This way developers can always just use a
         // helper such as __ instead of having to pick between trans or __ with views.
-        if (! isset($line)) {
+
+        // we check to see if the $key has a dot, to be sure that $fallback is not the entire
+        // array within a translation file, in case of $key value is the same as file name
+        if (! isset($line) && mb_strpos($key, '.')) {
             $fallback = $this->get($key, $replace, $locale);
 
             if ($fallback !== $key) {

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -163,7 +163,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
 
         // we check to see if the $key has a dot, to be sure that $fallback is not the entire
         // array within a translation file, in case of $key value is the same as file name
-        if (! isset($line) && mb_strpos($key, '.')) {
+        if (is_null($line) && mb_strpos($key, '.')) {
             $fallback = $this->get($key, $replace, $locale);
 
             if ($fallback !== $key) {

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -154,6 +154,14 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('one', $t->getFromJson('foo.bar'));
     }
 
+    public function testGetJsonForNonExistingJsonKeyDoesNotLookForRegularKeysIfKeyIsNotNested()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->never()->with('en', 'foo', '*')->andReturn(['bar' => 'one']);
+        $this->assertEquals('foo', $t->getFromJson('foo'));
+    }
+
     public function testGetJsonForNonExistingJsonKeyLooksForRegularKeysAndReplace()
     {
         $t = new Translator($this->getLoader(), 'en');
@@ -166,16 +174,16 @@ class TranslationTranslatorTest extends TestCase
     {
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'Foo that bar', '*')->andReturn([]);
-        $this->assertEquals('Foo that bar', $t->getFromJson('Foo that bar'));
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'Foo', '*')->andReturn([]);
+        $this->assertEquals('Foo.that.bar', $t->getFromJson('Foo.that.bar'));
     }
 
     public function testGetJsonForNonExistingReturnsSameKeyAndReplaces()
     {
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
-        $this->assertEquals('foo baz', $t->getFromJson('foo :message', ['message' => 'baz']));
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'baz', '*')->andReturn([]);
+        $this->assertEquals('baz.foo baz', $t->getFromJson('baz.foo :message', ['message' => 'baz']));
     }
 
     protected function getLoader()


### PR DESCRIPTION
This tries to resolve the https://github.com/laravel/framework/issues/26664 issue
in case a missing key in json file, which does not have a dot, is accidentally the same as a file name in the resource/lang folder.