### PR TITLE
[5.7] Masking the content of .env on Whoops page

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/WhoopsHandler.php
+++ b/src/Illuminate/Foundation/Exceptions/WhoopsHandler.php
@@ -89,6 +89,10 @@ class WhoopsHandler
      */
     protected function registerEnvBlacklist($handler)
     {
+        if (! (config('app.debug_env_blacklist'))) {
+            return $this;
+        }
+
         $dotenv = new Dotenv(base_path());
         $dotenv->safeLoad();
         

--- a/src/Illuminate/Foundation/Exceptions/WhoopsHandler.php
+++ b/src/Illuminate/Foundation/Exceptions/WhoopsHandler.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Foundation\Exceptions;
 
+use Dotenv\Dotenv;
 use Illuminate\Support\Arr;
 use Illuminate\Filesystem\Filesystem;
 use Whoops\Handler\PrettyPageHandler;
-use Dotenv\Dotenv;
 
 class WhoopsHandler
 {
@@ -95,7 +95,7 @@ class WhoopsHandler
 
         $dotenv = new Dotenv(base_path());
         $dotenv->safeLoad();
-        
+
         foreach ($dotenv->getEnvironmentVariableNames() as $key) {
             if (in_array($key, config('app.debug_whitelist'))) {
                 continue;


### PR DESCRIPTION
_(This PR is derived from: https://github.com/laravel/framework/pull/21336 and https://github.com/laravel/ideas/issues/1236)_

In this PR, the variable names from the `.env` file are loaded in and passed to the Whoops handler blacklist, which prevents displaying any data such as: database credentials, service keys, etc. I feel like most of the content from the `.env` should be hidden by default due to their nature.

Each time a key/value is added to the `.env` you don't have to repeat the key in the app config blacklist. You actually have to repeat it twice currently, as it appears in `$_ENV` and `$_SERVER`.

Adding `debug_env_blacklist = true` to the app config automatically hides all the variables — I thought _opt-in_ would make more sense for 5.7.

The previous `debug_blacklist` config key has been retained to allow other variables not in the `.env` to be hidden. Additionally, a `debug_whitelist` facility has been added to allow blacklist exceptions which overrides the functionality for that key.

![image](https://user-images.githubusercontent.com/2356082/50389153-34566000-071e-11e9-8076-2a99b914bf38.png)