### PR TITLE
[5.8] Fix translation issue (re-submitted)

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -163,6 +163,13 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         if (! isset($line)) {
             $fallback = $this->get($key, $replace, $locale);
 
+            // If the '$key' does not contain any dot character, it means that it doesn't
+            // follow the 'file_name.key' pattern and obviously we can not provide any
+            // string fallback within any translation file for it, so we return here
+            if (mb_strpos($key, '.') === false) {
+                return $this->makeReplacements($line ?: $key, $replace);
+            }
+
             if ($fallback !== $key) {
                 return $fallback;
             }

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -178,6 +178,14 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('foo baz', $t->getFromJson('foo :message', ['message' => 'baz']));
     }
 
+    public function testGetJsonForNonExistingJsonKeyDoesNotReturnAnArrayIfKeyIsDotless()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->with('en', 'foo', '*')->andReturn(['bar' => 'one']);
+        $this->assertEquals('foo', $t->getFromJson('foo'));
+    }
+
     protected function getLoader()
     {
         return m::mock(Loader::class);


### PR DESCRIPTION
This tries to resolve the https://github.com/laravel/framework/issues/26664 issue
in case a missing key in json file, which does not have a dot, is accidentally the same as a file name in the resource/lang folder.

Why it does not break any thing ?
Obviously, this change is narrowed down to :

1 - `getFromJson` method only, (so array validation and usage of  regular translation files will not be affected)
2 - `$key` with no dot character. (which only happens for reading from json files. since access to typical translation files requires at least 1 dot in the $key parameter for separate the filename from the key.)
3 - cases which the json file has nothing to represent as the translation

The issue is described at https://github.com/laravel/framework/issues/26664
so any typical usage following the 'filename.key' pattern will not be affected.


The  added test tries to simulate the situation.
string 'foo' as the $key to translate from json (which is dotless.)
and the line (185) :
`$t->getLoader()->shouldReceive('load')->with('en', 'foo', '*')->andReturn(['bar' => 'one']);`

tries to simulate the existence of a typical translation file with this content (lang/en/foo.php)
```php

<?php

return [
    'bar' => 'one'
];

```

Please take a look at the comments attached on the test code.


