### PR TITLE
[5.8] Container - lazy load tagged services

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -454,19 +454,19 @@ class Container implements ContainerContract
      * Resolve all of the bindings for a given tag.
      *
      * @param  string  $tag
-     * @return array
+     * @return iterable
      */
     public function tagged($tag)
     {
-        $results = [];
-
-        if (isset($this->tags[$tag])) {
-            foreach ($this->tags[$tag] as $abstract) {
-                $results[] = $this->make($abstract);
-            }
+        if (! isset($this->tags[$tag])) {
+            return [];
         }
 
-        return $results;
+        return new RewindableGenerator(function () use ($tag) {
+            foreach ($this->tags[$tag] as $abstract) {
+                yield $this->make($abstract);
+            }
+        }, count($this->tags[$tag]));
     }
 
     /**

--- a/src/Illuminate/Container/RewindableGenerator.php
+++ b/src/Illuminate/Container/RewindableGenerator.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Container;
+
+use Countable;
+use IteratorAggregate;
+
+class RewindableGenerator implements Countable, IteratorAggregate
+{
+    /**
+     * @var callable
+     */
+    private $generator;
+
+    /**
+     * @var callable|int
+     */
+    private $count;
+
+    /**
+     * @param callable     $generator
+     * @param callable|int $count
+     */
+    public function __construct(callable $generator, $count)
+    {
+        $this->generator = $generator;
+        $this->count = $count;
+    }
+
+    public function getIterator()
+    {
+        $generator = $this->generator;
+
+        return $generator();
+    }
+
+    /**
+     * @return int
+     */
+    public function count()
+    {
+        if (is_callable($count = $this->count)) {
+            $this->count = $count();
+        }
+
+        return $this->count;
+    }
+}

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -38,7 +38,7 @@ interface Container extends ArrayAccess, ContainerInterface
      * Resolve all of the bindings for a given tag.
      *
      * @param  string  $tag
-     * @return array
+     * @return iterable
      */
     public function tagged($tag);
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -792,17 +792,77 @@ class ContainerTest extends TestCase
 
         $this->assertCount(1, $container->tagged('bar'));
         $this->assertCount(2, $container->tagged('foo'));
-        $this->assertInstanceOf(ContainerImplementationStub::class, $container->tagged('foo')[0]);
-        $this->assertInstanceOf(ContainerImplementationStub::class, $container->tagged('bar')[0]);
-        $this->assertInstanceOf(ContainerImplementationStubTwo::class, $container->tagged('foo')[1]);
+
+        $fooResults = [];
+        foreach ($container->tagged('foo') as $foo) {
+            $fooResults[] = $foo;
+        }
+
+        $barResults = [];
+        foreach ($container->tagged('bar') as $bar) {
+            $barResults[] = $bar;
+        }
+
+        $this->assertInstanceOf(ContainerImplementationStub::class, $fooResults[0]);
+        $this->assertInstanceOf(ContainerImplementationStub::class, $barResults[0]);
+        $this->assertInstanceOf(ContainerImplementationStubTwo::class, $fooResults[1]);
 
         $container = new Container;
         $container->tag([ContainerImplementationStub::class, ContainerImplementationStubTwo::class], ['foo']);
         $this->assertCount(2, $container->tagged('foo'));
-        $this->assertInstanceOf(ContainerImplementationStub::class, $container->tagged('foo')[0]);
-        $this->assertInstanceOf(ContainerImplementationStubTwo::class, $container->tagged('foo')[1]);
 
-        $this->assertEmpty($container->tagged('this_tag_does_not_exist'));
+        $fooResults = [];
+        foreach ($container->tagged('foo') as $foo) {
+            $fooResults[] = $foo;
+        }
+
+        $this->assertInstanceOf(ContainerImplementationStub::class, $fooResults[0]);
+        $this->assertInstanceOf(ContainerImplementationStubTwo::class, $fooResults[1]);
+
+        $this->assertCount(0, $container->tagged('this_tag_does_not_exist'));
+    }
+
+    public function testTaggedServicesAreLazyLoaded()
+    {
+        $container = $this->createPartialMock(Container::class, ['make']);
+        $container->expects($this->once())->method('make')->willReturn(new ContainerImplementationStub());
+
+        $container->tag(ContainerImplementationStub::class, ['foo']);
+        $container->tag(ContainerImplementationStubTwo::class, ['foo']);
+
+        $fooResults = [];
+        foreach ($container->tagged('foo') as $foo) {
+            $fooResults[] = $foo;
+            break;
+        }
+
+        $this->assertCount(2, $container->tagged('foo'));
+        $this->assertInstanceOf(ContainerImplementationStub::class, $fooResults[0]);
+    }
+
+    public function testLazyLoadedTaggedServicesCanBeLoopedOverMultipleTimes()
+    {
+        $container = new Container;
+        $container->tag(ContainerImplementationStub::class, 'foo');
+        $container->tag(ContainerImplementationStubTwo::class, ['foo']);
+
+        $services = $container->tagged('foo');
+
+        $fooResults = [];
+        foreach ($services as $foo) {
+            $fooResults[] = $foo;
+        }
+
+        $this->assertInstanceOf(ContainerImplementationStub::class, $fooResults[0]);
+        $this->assertInstanceOf(ContainerImplementationStubTwo::class, $fooResults[1]);
+
+        $fooResults = [];
+        foreach ($services as $foo) {
+            $fooResults[] = $foo;
+        }
+
+        $this->assertInstanceOf(ContainerImplementationStub::class, $fooResults[0]);
+        $this->assertInstanceOf(ContainerImplementationStubTwo::class, $fooResults[1]);
     }
 
     public function testForgetInstanceForgetsInstance()

--- a/tests/Container/RewindableGeneratorTest.php
+++ b/tests/Container/RewindableGeneratorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Tests\Container;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\RewindableGenerator;
+
+class RewindableGeneratorTest extends TestCase
+{
+    public function testCountUsesProvidedValue()
+    {
+        $generator = new RewindableGenerator(function () {
+            yield 'foo';
+        }, 999);
+
+        $this->assertSame(999, count($generator));
+    }
+
+    public function testCountUsesProvidedValueAsCallback()
+    {
+        $called = 0;
+
+        $generator = new RewindableGenerator(function () {
+            yield 'foo';
+        }, function () use (&$called) {
+            $called++;
+
+            return 500;
+        });
+
+        // the count callback is called lazily
+        $this->assertSame(0, $called);
+
+        $this->assertCount(500, $generator);
+
+        count($generator);
+
+        // the count callback is called only once
+        $this->assertSame(1, $called);
+    }
+}


### PR DESCRIPTION
Currently the container immediately resolves all services which are tagged with a tag. The resolving of a service from the container doesn't need to happen until the service is actually needed so by deferring the resolving of the service until it's actually needed we potentially don't have to instantiate a bunch of objects which are never gonna be used.

```php
public function __construct(iterable $taggedServices)
{
   $this->taggedServices = $taggedServices;
}

public function foo()
{
    foreach($this->taggedServices as $service) {
        $service->doSomething();
        if (someTrueCondition) {
            break;
        }
    }
}
```

Here only the first service would be resolved from the container as opposed to the current behavior where all services (potentially hundreds) would be resolved immediately.

Breaking changes:

1. The container `tagged` method now returns an `iterable` instead of an explicit `array` which means that doing `$container->tagged('foo')[0]` is not possible anymore (but I don't see why would somebody use that in a real application).
2. If somebody type-hinted the tagged services variable with `array` it will now break, either the `array` type-hint should be removed or it should be replaced with `iterable`.