### PR TITLE
[5.8] Support command name aliases

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -55,6 +55,13 @@ class Command extends SymfonyCommand
     protected $name;
 
     /**
+     * The command name aliases.
+     *
+     * @var array
+     */
+    protected $aliases = [];
+
+    /**
      * The console command description.
      *
      * @var string
@@ -108,6 +115,8 @@ class Command extends SymfonyCommand
         // related properties of the command. If a signature wasn't used to build
         // the command we'll set the arguments and the options on this command.
         $this->setDescription($this->description);
+
+        $this->setAliases($this->aliases);
 
         $this->setHidden($this->isHidden());
 


### PR DESCRIPTION

Sometimes I really want to use command name aliases. Here is an example of my commands:

```bash
php artisan make:class App\SomeClass # php artisan mc App\SomeClass
php artisan make:interface App\SomeInterface # php artisan mi App\SomeInterface
```

In fact, I can call `$this->setAliases(['an:alias'])` after the `parrent::construct()` line.

```php
public function __construct()
{
    parent::construct();

    $this->setAliases(['an:alias']);
}
```

But It's pretty convenient to support aliases registration via the command property.

```php
class MyCommand extends Command
{
    /**
     * The command name aliases.
     *
     * @var array
     */
    protected $aliases = ['an:alias'];
}
```



