### PR TITLE
[5.7] Updated Builder.php file for supporting aggregate object in upper and lower cases

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2160,7 +2160,7 @@ class Builder
         } elseif (! isset($results[0])) {
             return 0;
         } elseif (is_object($results[0])) {
-            return (int) $results[0]->aggregate;
+            return (int) ($results[0]->aggregate ?? $results[0]->AGGREGATE);
         }
 
         return (int) array_change_key_case((array) $results[0])['aggregate'];


### PR DESCRIPTION
[ERROR when updating Laravel 5.2 to 5.7 - this error I didn't get in older versions]
I'm using Laravel with MySQL and Firebird Databases. For MySQL it is working perfectly but for Firebird I'm getting this error when using Eloquent for paginating (yes, this error occurs just on paginate function):

```
ErrorException (E_NOTICE)
Undefined property: stdClass::$aggregate
```
This error happens in Builder.php file on line `return (int) $results[0]->aggregate;`
This error is happening because Firebird uses upper case in this stdClass aggregate, getting AGGREGATE attribute.

I tried to use the PDO option:
'options'   => [
      PDO::ATTR_CASE => PDO::CASE_NATURAL,
],
but the problem is that all attributes are on uppercase and all classes turn to be lowercase after the option. So I would had to change all my files do lowercase.

So, I did this change:
`return (int) ($results[0]->aggregate ?? $results[0]->AGGREGATE);`

It worked perfectly. 
I don't know if it's the best option to solv this. But I decided to make this PR to see if we can solv this problem.

Thanks a lot!!

