### PR TITLE
[5.8] Fix test compatibility for windows 10

### DIFF
--- a/tests/Integration/Mail/RenderingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/RenderingMailWithLocaleTest.php
@@ -31,14 +31,14 @@ class RenderingMailWithLocaleTest extends TestCase
     {
         $mail = new RenderedTestMail;
 
-        $this->assertEquals("name\n", $mail->render());
+        $this->assertEquals('name'.PHP_EOL, $mail->render());
     }
 
     public function testMailableRendersInSelectedLocale()
     {
         $mail = (new RenderedTestMail)->locale('es');
 
-        $this->assertEquals("nombre\n", $mail->render());
+        $this->assertEquals('nombre'.PHP_EOL, $mail->render());
     }
 
     public function testMailableRendersInAppSelectedLocale()
@@ -47,7 +47,7 @@ class RenderingMailWithLocaleTest extends TestCase
 
         $mail = new RenderedTestMail;
 
-        $this->assertEquals("nombre\n", $mail->render());
+        $this->assertEquals('nombre'.PHP_EOL, $mail->render());
     }
 }
 


### PR DESCRIPTION
Currently, these tests just fail on windows.
This fixes provides compatibility for tests running in a windows environments.
by make the carriage return character optional in the check.