### PR TITLE
[5.8] Skip testing symlink functionality due to php bug

### DIFF
--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -44,6 +44,10 @@ class FilesystemTest extends TestCase
 
     public function testReplaceStoresFiles()
     {
+        if (DIRECTORY_SEPARATOR == '\\') {
+            $this->markTestSkipped('symlink function has a bug on windows.');
+        }
+
         $tempFile = "{$this->tempDir}/file.txt";
         $symlinkDir = "{$this->tempDir}/symlink_dir";
         $symlink = "{$symlinkDir}/symlink.txt";


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6961695/50473513-760f3100-09d2-11e9-97e6-dc44dcb78d4f.png)

This test is going to always throw an error on windows 10 and php 7.2.9
And is possibly somehow related to the reported issues of php mentioned below

https://bugs.php.net/bug.php?id=69473
https://bugs.php.net/bug.php?id=68167