### PR TITLE
[5.8] Dispatch concrete notification events

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -144,6 +144,7 @@ class NotificationSender
         $response = $this->manager->driver($channel)->send($notifiable, $notification);
 
         $this->events->dispatch(
+            'notification.sent: '.get_class($notification),
             new Events\NotificationSent($notifiable, $notification, $channel, $response)
         );
     }
@@ -159,6 +160,7 @@ class NotificationSender
     protected function shouldSendNotification($notifiable, $notification, $channel)
     {
         return $this->events->until(
+            'notification.sending: '.get_class($notification),
             new Events\NotificationSending($notifiable, $notification, $channel)
         ) !== false;
     }

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -32,9 +32,9 @@ class NotificationChannelManagerTest extends TestCase
         Container::setInstance($container);
         $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
         $manager->shouldReceive('driver')->andReturn($driver = m::mock());
-        $events->shouldReceive('until')->with(m::type(NotificationSending::class))->andReturn(true);
+        $events->shouldReceive('until')->with('notification.sending: '.NotificationChannelManagerTestNotification::class, m::type(NotificationSending::class))->andReturn(true);
         $driver->shouldReceive('send')->once();
-        $events->shouldReceive('dispatch')->with(m::type(NotificationSent::class));
+        $events->shouldReceive('dispatch')->with('notification.sent: '.NotificationChannelManagerTestNotification::class, m::type(NotificationSent::class));
 
         $manager->send(new NotificationChannelManagerTestNotifiable, new NotificationChannelManagerTestNotification);
     }
@@ -47,11 +47,11 @@ class NotificationChannelManagerTest extends TestCase
         $container->instance(Dispatcher::class, $events = m::mock());
         Container::setInstance($container);
         $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
-        $events->shouldReceive('until')->once()->with(m::type(NotificationSending::class))->andReturn(false);
-        $events->shouldReceive('until')->with(m::type(NotificationSending::class))->andReturn(true);
+        $events->shouldReceive('until')->once()->with('notification.sending: '.NotificationChannelManagerTestNotificationWithTwoChannels::class, m::type(NotificationSending::class))->andReturn(false);
+        $events->shouldReceive('until')->with('notification.sending: '.NotificationChannelManagerTestNotificationWithTwoChannels::class, m::type(NotificationSending::class))->andReturn(true);
         $manager->shouldReceive('driver')->once()->andReturn($driver = m::mock());
         $driver->shouldReceive('send')->once();
-        $events->shouldReceive('dispatch')->with(m::type(NotificationSent::class));
+        $events->shouldReceive('dispatch')->with('notification.sent: '.NotificationChannelManagerTestNotificationWithTwoChannels::class, m::type(NotificationSent::class));
 
         $manager->send([new NotificationChannelManagerTestNotifiable], new NotificationChannelManagerTestNotificationWithTwoChannels);
     }


### PR DESCRIPTION
Currently all notifications emit a generic event (`NotificationSending` / `NotificationSent`) and it is only in the listener that one is able to differentiate the action upon inspection of `$event->notification`. This becomes cumbersome when a lot of notifications should each react differently.

Current solutions include:
* one listener containing a big conditional
* separate listeners containing a preliminary if statement (each listener gets executed every single time)
* emitting custom events by means of chaining (see note below)

In my opinion this is quite counterintuitive and somehow working around the hot potato.

By adopting Eloquent's approach notification events are named `notification.sending: MyNotificationClass` and following benefits are achieved:
* a listener only runs when its appropriate notification triggers it
* previous behavior of listening to all notifications can still be achieved by leveraging the Dispatcher's wildcard feature: `notification.*`

My use case: for some notifications I need to update a database value when a notification is sent. For instance queueing an invoice and then saving the actual sent date when the notification has been processed.

I deliberately chose to not include the channel in the event name as I think the listener should be responsible for differentiating between channels through the event instance when applicable.

This will be a breaking change for those that listen to `NotificationSending` and `NotificationSent` but is solved easily by replacing the events with the respective wildcard definition.

---
Note: did you know that Notifications **cannot** be chained with other jobs, even though they can be queued? Including notifications in job chains could be a more intuitive approach instead of writing an additional boilerplate job just for sending the notification.