### PR TITLE
[5.7] Allow storage assertions to handle multiple files at once

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -51,7 +51,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      * Assert that the given file exists.
      *
      * @param  string  $path
-     * @return void
+     * @return $this
      */
     public function assertExists($path)
     {
@@ -62,13 +62,15 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
                 $this->exists($path), "Unable to find a file at path [{$path}]."
             );
         }
+
+        return $this;
     }
 
     /**
      * Assert that the given file does not exist.
      *
      * @param  string  $path
-     * @return void
+     * @return $this
      */
     public function assertMissing($path)
     {
@@ -79,6 +81,8 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
                 $this->exists($path), "Found unexpected file at path [{$path}]."
             );
         }
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -55,9 +55,13 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      */
     public function assertExists($path)
     {
-        PHPUnit::assertTrue(
-            $this->exists($path), "Unable to find a file at path [{$path}]."
-        );
+        $paths = array_wrap($path);
+
+        foreach($paths as $path) {
+            PHPUnit::assertTrue(
+                $this->exists($path), "Unable to find a file at path [{$path}]."
+            );
+        }
     }
 
     /**
@@ -68,15 +72,19 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      */
     public function assertMissing($path)
     {
-        PHPUnit::assertFalse(
-            $this->exists($path), "Found unexpected file at path [{$path}]."
-        );
+        $paths = array_wrap($path);
+
+        foreach($paths as $path) {
+            PHPUnit::assertFalse(
+                $this->exists($path), "Found unexpected file at path [{$path}]."
+            );
+        }
     }
 
     /**
      * Determine if a file exists.
      *
-     * @param  string  $path
+     * @param  string|array  $path
      * @return bool
      */
     public function exists($path)
@@ -87,7 +95,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     /**
      * Get the full path for the file at the given "short" path.
      *
-     * @param  string  $path
+     * @param  string|array  $path
      * @return string
      */
     public function path($path)

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -57,7 +57,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     {
         $paths = array_wrap($path);
 
-        foreach($paths as $path) {
+        foreach ($paths as $path) {
             PHPUnit::assertTrue(
                 $this->exists($path), "Unable to find a file at path [{$path}]."
             );
@@ -74,7 +74,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     {
         $paths = array_wrap($path);
 
-        foreach($paths as $path) {
+        foreach ($paths as $path) {
             PHPUnit::assertFalse(
                 $this->exists($path), "Found unexpected file at path [{$path}]."
             );

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -50,7 +50,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     /**
      * Assert that the given file exists.
      *
-     * @param  string  $path
+     * @param  string|array  $path
      * @return $this
      */
     public function assertExists($path)
@@ -69,7 +69,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     /**
      * Assert that the given file does not exist.
      *
-     * @param  string  $path
+     * @param  string|array  $path
      * @return $this
      */
     public function assertMissing($path)
@@ -88,7 +88,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     /**
      * Determine if a file exists.
      *
-     * @param  string|array  $path
+     * @param  string  $path
      * @return bool
      */
     public function exists($path)
@@ -99,7 +99,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     /**
      * Get the full path for the file at the given "short" path.
      *
-     * @param  string|array  $path
+     * @param  string  $path
      * @return string
      */
     public function path($path)


### PR DESCRIPTION
This allows `assertExists` and `assertMissing` to handle multiple files at once. It also makes them chainable.

```
Storage::disk('local')
    ->assertExists([
        $path,
        $anotherPath,
    ])
    ->assertMissing([
        $yetAnotherPath,
        $oneMoreFilePath,
    ]);
```

There are no existing tests for the assertions, so I didn't add any for this new functionality.