### PR TITLE
[5.8] Replace deprecated phpunit <7.5.0 methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "moontoast/math": "^1.1",
         "orchestra/testbench-core": "3.7.*",
         "pda/pheanstalk": "^3.0",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.5",
         "predis/predis": "^1.1.1",
         "symfony/css-selector": "^4.1",
         "symfony/dom-crawler": "^4.1",

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -732,7 +732,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setRelation('multi', new BaseCollection);
         $array = $model->toArray();
 
-        $this->assertInternalType('array', $array);
+        $this->assertIsArray($array);
         $this->assertEquals('foo', $array['name']);
         $this->assertEquals('baz', $array['names'][0]['bar']);
         $this->assertEquals('boom', $array['names'][1]['bam']);
@@ -1521,8 +1521,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInternalType('boolean', $model->boolAttribute);
         $this->assertInternalType('boolean', $model->booleanAttribute);
         $this->assertInternalType('object', $model->objectAttribute);
-        $this->assertInternalType('array', $model->arrayAttribute);
-        $this->assertInternalType('array', $model->jsonAttribute);
+        $this->assertIsArray($model->arrayAttribute);
+        $this->assertIsArray($model->jsonAttribute);
         $this->assertTrue($model->boolAttribute);
         $this->assertFalse($model->booleanAttribute);
         $this->assertEquals($obj, $model->objectAttribute);
@@ -1542,8 +1542,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInternalType('boolean', $arr['boolAttribute']);
         $this->assertInternalType('boolean', $arr['booleanAttribute']);
         $this->assertInternalType('object', $arr['objectAttribute']);
-        $this->assertInternalType('array', $arr['arrayAttribute']);
-        $this->assertInternalType('array', $arr['jsonAttribute']);
+        $this->assertIsArray($arr['arrayAttribute']);
+        $this->assertIsArray($arr['jsonAttribute']);
         $this->assertTrue($arr['boolAttribute']);
         $this->assertFalse($arr['booleanAttribute']);
         $this->assertEquals($obj, $arr['objectAttribute']);

--- a/tests/Http/HttpMimeTypeTest.php
+++ b/tests/Http/HttpMimeTypeTest.php
@@ -29,7 +29,7 @@ class HttpMimeTypeTest extends TestCase
 
     public function testGetAllMimeTypes()
     {
-        $this->assertInternalType('array', MimeType::get());
+        $this->assertIsArray(MimeType::get());
         $this->assertArraySubset(['jpg' => 'image/jpeg'], MimeType::get());
     }
 

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -49,7 +49,7 @@ class MailableQueuedTest extends TestCase
         $mailable = new MailableQueableStub;
         $attachmentOption = ['mime' => 'image/jpeg', 'as' => 'bar.jpg'];
         $mailable->attach('foo.jpg', $attachmentOption);
-        $this->assertInternalType('array', $mailable->attachments);
+        $this->assertIsArray($mailable->attachments);
         $this->assertCount(1, $mailable->attachments);
         $this->assertEquals($mailable->attachments[0]['options'], $attachmentOption);
         $queueFake->assertNothingPushed();
@@ -80,7 +80,7 @@ class MailableQueuedTest extends TestCase
 
         $mailable->attachFromStorage('/', 'foo.jpg', $attachmentOption);
 
-        $this->assertInternalType('array', $mailable->diskAttachments);
+        $this->assertIsArray($mailable->diskAttachments);
         $this->assertCount(1, $mailable->diskAttachments);
         $this->assertEquals($mailable->diskAttachments[0]['options'], $attachmentOption);
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -309,7 +309,7 @@ class RoutingRouteTest extends TestCase
             return 'foo';
         })->name('foo');
 
-        $this->assertInternalType('array', $route->getAction());
+        $this->assertIsArray($route->getAction());
         $this->assertArrayHasKey('as', $route->getAction());
         $this->assertEquals('foo', $route->getAction('as'));
         $this->assertNull($route->getAction('unknown_property'));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -436,31 +436,31 @@ class SupportArrTest extends TestCase
         $this->assertContains($random, ['foo', 'bar', 'baz']);
 
         $random = Arr::random(['foo', 'bar', 'baz'], 0);
-        $this->assertInternalType('array', $random);
+        $this->assertIsArray($random);
         $this->assertCount(0, $random);
 
         $random = Arr::random(['foo', 'bar', 'baz'], 1);
-        $this->assertInternalType('array', $random);
+        $this->assertIsArray($random);
         $this->assertCount(1, $random);
         $this->assertContains($random[0], ['foo', 'bar', 'baz']);
 
         $random = Arr::random(['foo', 'bar', 'baz'], 2);
-        $this->assertInternalType('array', $random);
+        $this->assertIsArray($random);
         $this->assertCount(2, $random);
         $this->assertContains($random[0], ['foo', 'bar', 'baz']);
         $this->assertContains($random[1], ['foo', 'bar', 'baz']);
 
         $random = Arr::random(['foo', 'bar', 'baz'], '0');
-        $this->assertInternalType('array', $random);
+        $this->assertIsArray($random);
         $this->assertCount(0, $random);
 
         $random = Arr::random(['foo', 'bar', 'baz'], '1');
-        $this->assertInternalType('array', $random);
+        $this->assertIsArray($random);
         $this->assertCount(1, $random);
         $this->assertContains($random[0], ['foo', 'bar', 'baz']);
 
         $random = Arr::random(['foo', 'bar', 'baz'], '2');
-        $this->assertInternalType('array', $random);
+        $this->assertIsArray($random);
         $this->assertCount(2, $random);
         $this->assertContains($random[0], ['foo', 'bar', 'baz']);
         $this->assertContains($random[1], ['foo', 'bar', 'baz']);
@@ -469,11 +469,11 @@ class SupportArrTest extends TestCase
     public function testRandomOnEmptyArray()
     {
         $random = Arr::random([], 0);
-        $this->assertInternalType('array', $random);
+        $this->assertIsArray($random);
         $this->assertCount(0, $random);
 
         $random = Arr::random([], '0');
-        $this->assertInternalType('array', $random);
+        $this->assertIsArray($random);
         $this->assertCount(0, $random);
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1463,7 +1463,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertInstanceOf(Collection::class, $groups);
         $this->assertEquals(['A' => [1], 'B' => [2, 4], 'C' => [3]], $groups->toArray());
-        $this->assertInternalType('array', $groups['A']);
+        $this->assertIsArray($groups['A']);
     }
 
     public function testMapToDictionaryWithNumericKeys()


### PR DESCRIPTION
replace deprecated phpunit methods with new ones

see this link : 

https://github.com/sebastianbergmann/phpunit/issues/3368

Note that the composer.json file now requires phpunit 7.5 or more
--

![image](https://user-images.githubusercontent.com/6961695/50517369-5573d380-0ac5-11e9-98ed-db26d5ab8b5c.png)
