### PR TITLE
[5.8] Isolate filesystem tests

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -34,11 +34,13 @@ class BoundMethod
     /**
      * Call a string reference to a class using Class@method syntax.
      *
-     * @param  \Illuminate\Container\Container $container
-     * @param  string $target
-     * @param  array $parameters
-     * @param  string|null $defaultMethod
+     * @param  \Illuminate\Container\Container  $container
+     * @param  string  $target
+     * @param  array  $parameters
+     * @param  string|null  $defaultMethod
      * @return mixed
+     *
+     * @throws \InvalidArgumentException
      */
     protected static function callClass($container, $target, array $parameters = [], $defaultMethod = null)
     {
@@ -47,13 +49,16 @@ class BoundMethod
         // We will assume an @ sign is used to delimit the class name from the method
         // name. We will split on this @ sign and then build a callable array that
         // we can pass right back into the "call" method for dependency binding.
-        $method = count($segments) === 2 ? $segments[1] : $defaultMethod;
+        $method = count($segments) === 2
+                        ? $segments[1] : $defaultMethod;
 
         if (is_null($method)) {
             throw new InvalidArgumentException('Method not provided.');
         }
 
-        return static::call($container, [$container->make($segments[0]), $method], $parameters);
+        return static::call(
+            $container, [$container->make($segments[0]), $method], $parameters
+        );
     }
 
     /**
@@ -98,8 +103,8 @@ class BoundMethod
     /**
      * Get all dependencies for a given method.
      *
-     * @param  \Illuminate\Container\Container $container
-     * @param  callable|string $callback
+     * @param  \Illuminate\Container\Container  $container
+     * @param  callable|string  $callback
      * @param array $inputData
      * @return array
      * @throws \ReflectionException
@@ -135,7 +140,9 @@ class BoundMethod
             $callback = explode('::', $callback);
         }
 
-        return is_array($callback) ? new ReflectionMethod($callback[0], $callback[1]) : new ReflectionFunction($callback);
+        return is_array($callback)
+            ? new ReflectionMethod($callback[0], $callback[1])
+            : new ReflectionFunction($callback);
     }
 
     /**

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -50,8 +50,7 @@ class BoundMethod
         // We will assume an @ sign is used to delimit the class name from the method
         // name. We will split on this @ sign and then build a callable array that
         // we can pass right back into the "call" method for dependency binding.
-        $method = count($segments) === 2
-                        ? $segments[1] : $defaultMethod;
+        $method = count($segments) === 2 ? $segments[1] : $defaultMethod;
 
         if (is_null($method)) {
             throw new InvalidArgumentException('Method not provided.');
@@ -106,11 +105,12 @@ class BoundMethod
      *
      * @param  \Illuminate\Container\Container  $container
      * @param  callable|string  $callback
-     * @param  array $inputData
+     * @param  array  $inputData
      * @return array
+     *
      * @throws \ReflectionException
      */
-    protected static function getMethodDependencies($container, $callback, array $inputData = []) : array
+    protected static function getMethodDependencies($container, $callback, array $inputData = [])
     {
         $signature = static::getCallReflector($callback)->getParameters();
 
@@ -134,12 +134,12 @@ class BoundMethod
     /**
      * Get the proper reflection instance for the given callback.
      *
-     * @param  callable|string $callback
+     * @param  callable|string  $callback
      * @return \ReflectionFunctionAbstract
      *
      * @throws \ReflectionException
      */
-    protected static function getCallReflector($callback): \Reflector
+    protected static function getCallReflector($callback)
     {
         if (is_string($callback) && strpos($callback, '::') !== false) {
             $callback = explode('::', $callback);
@@ -153,13 +153,14 @@ class BoundMethod
     /**
      * Add the dependencies to the input data.
      *
-     * @param  \Illuminate\Container\Container $container
-     * @param  array $signature
-     * @param  array $inputData
+     * @param  \Illuminate\Container\Container  $container
+     * @param  array  $signature
+     * @param  array  $inputData
      * @return array
+     *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    protected static function addDependencyForCallParameter($container, array $signature, array $inputData): array
+    protected static function addDependencyForCallParameter($container, array $signature, array $inputData)
     {
         $resolvedInputData = [];
         $i = 0;
@@ -184,10 +185,10 @@ class BoundMethod
     /**
      * Determine if the given string is in Class@method syntax.
      *
-     * @param  mixed  $callback
+     * @param  string|callable  $callback
      * @return bool
      */
-    protected static function isCallableWithAtSign($callback): bool
+    protected static function isCallableWithAtSign($callback)
     {
         return is_string($callback) && strpos($callback, '@') !== false;
     }

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -162,6 +162,9 @@ class BoundMethod
      */
     protected static function addDependencyForCallParameter($container, array $signature, array $inputData)
     {
+        // Here we iterate through the list of declared parameters (in the method signature) and decide
+        // whether it should be invoked with the provided input data, or we should resolve an object
+        // for it (according to it's type-hint) or just call it with it's defined "default" value.
         $resolvedInputData = [];
         $i = 0;
 

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Container;
 
 use Closure;
-use Illuminate\Support\Arr;
 use ReflectionMethod;
 use ReflectionFunction;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
 class BoundMethod

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -114,12 +114,16 @@ class BoundMethod
     {
         $signature = static::getCallReflector($callback)->getParameters();
 
-        // In case the method has no explicit input parameters defined
-        // we will call it, with whatever input data available to us.
+        // In case the method has no explicit input parameters we will
+        // call that with whatever input data available to us since
+        // they may have used func_get_args() to catch the input.
         if (count($signature) === 0) {
             return $inputData;
         }
 
+        // When receive method input as an indexed array and the count of passed arguments
+        // is not less than the declared parameters, it means that we are provided with
+        // everything needed, So the IOC container should not bother about injection.
         if (! Arr::isAssoc($inputData) && (count($signature) <= count($inputData))) {
             return $inputData;
         }
@@ -153,6 +157,7 @@ class BoundMethod
      * @param  array $signature
      * @param  array $inputData
      * @return array
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected static function addDependencyForCallParameter($container, array $signature, array $inputData): array
     {

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -167,8 +167,7 @@ class BoundMethod
             } elseif ($parameter->getClass()) {
                 $resolvedInputData[] = $container->make($parameter->getClass()->name);
             } elseif (isset($inputData[$i])) {
-                $resolvedInputData[] = $inputData[$i];
-                $i++;
+                $resolvedInputData[] = $inputData[$i++];
             } elseif ($parameter->isDefaultValueAvailable()) {
                 $resolvedInputData[] = $parameter->getDefaultValue();
             }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1115,8 +1115,6 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ContainerConcreteStub::class, $class);
     }
 
-
-
     public function testWithDefaultParametersIndexedArraySyntax()
     {
         $container = new Container;
@@ -1203,7 +1201,6 @@ class ContainerTest extends TestCase
         $container->call(function (ContainerConcreteStub $stub) {
         }, ['foo' => 'bar', 'stub' => new ContainerConcreteStub]);
     }
-
 }
 
 class ContainerConcreteStub
@@ -1217,14 +1214,17 @@ class ContainerTestDefaultyParams
     {
         return func_get_args();
     }
+
     public function defaultyBandC($a, $b = 'default b', $c = 'default c')
     {
         return func_get_args();
     }
+
     public function defaultyOnlyC($a, $b, $c = 'default c')
     {
         return func_get_args();
     }
+
     public function noDefault($a, $b, $c)
     {
         return func_get_args();

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -596,6 +596,16 @@ class ContainerTest extends TestCase
         $result = $container->call([new ContainerTestCallStub, 'inject'], ['_stub' => 'foo']);
         $this->assertInstanceOf(ContainerConcreteStub::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
+
+        $container = new Container;
+        $result = $container->call([new ContainerTestCallStub, 'inject'], ['baz']);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result[0]);
+        $this->assertEquals('baz', $result[1]);
+
+        $container = new Container;
+        $result = $container->call([new ContainerTestCallStub, 'inject'], ['baz', 'foo']);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result[0]);
+        $this->assertEquals('baz', $result[1]);
     }
 
     public function testBindMethodAcceptsAnArray()
@@ -1186,6 +1196,10 @@ class ContainerTest extends TestCase
         $container = new Container;
         $container->call(function (ContainerConcreteStub $stub) {
         }, ['foo' => 'bar']);
+
+        $container->call(function (ContainerConcreteStub $stub) {
+        }, ['bar']);
+
         $container->call(function (ContainerConcreteStub $stub) {
         }, ['foo' => 'bar', 'stub' => new ContainerConcreteStub]);
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -603,9 +603,10 @@ class ContainerTest extends TestCase
         $this->assertEquals('baz', $result[1]);
 
         $container = new Container;
-        $result = $container->call([new ContainerTestCallStub, 'inject'], ['baz', 'foo']);
-        $this->assertInstanceOf(ContainerConcreteStub::class, $result[0]);
-        $this->assertEquals('baz', $result[1]);
+        $object = new ContainerConcreteStub();
+        $result = $container->call([new ContainerTestCallStub, 'inject'], [$object, 'foo']);
+        $this->assertSame($object, $result[0]);
+        $this->assertEquals('foo', $result[1]);
     }
 
     public function testBindMethodAcceptsAnArray()
@@ -1196,7 +1197,7 @@ class ContainerTest extends TestCase
         }, ['foo' => 'bar']);
 
         $container->call(function (ContainerConcreteStub $stub) {
-        }, ['bar']);
+        }, [new ContainerConcreteStub]);
 
         $container->call(function (ContainerConcreteStub $stub) {
         }, ['foo' => 'bar', 'stub' => new ContainerConcreteStub]);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1223,14 +1223,11 @@ class ContainerTest extends TestCase
         $this->assertEquals('foo', $result[0]);
         $this->assertSame($obj, $result[1]);
 
-
         $result = $container->call(function ($foo = 'default foo', ContainerConcreteStub $stub) {
             return [$foo, $stub];
         }, ['foo']);
         $this->assertEquals('foo', $result[0]);
         $this->assertInstanceOf(ContainerConcreteStub::class, $result[1]);
-
-
 
         $result = $container->call(function ($foo = 'default foo', ContainerConcreteStub $stub = null) {
             return [$foo, $stub];

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -586,6 +586,16 @@ class ContainerTest extends TestCase
         });
         $result = $container->call([new ContainerTestCallStub, 'unresolvable']);
         $this->assertEquals(['foo', 'bar'], $result);
+
+        $container = new Container;
+        $result = $container->call([new ContainerTestCallStub, 'inject'], ['_stub' => 'foo', 'default' => 'bar']);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result[0]);
+        $this->assertEquals('bar', $result[1]);
+
+        $container = new Container;
+        $result = $container->call([new ContainerTestCallStub, 'inject'], ['_stub' => 'foo']);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result[0]);
+        $this->assertEquals('taylor', $result[1]);
     }
 
     public function testBindMethodAcceptsAnArray()
@@ -1094,11 +1104,117 @@ class ContainerTest extends TestCase
 
         $this->assertInstanceOf(ContainerConcreteStub::class, $class);
     }
+
+
+
+    public function testWithDefaultParametersIndexedArraySyntax()
+    {
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar', 'baz']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty');
+        $this->assertEquals(['default a', 'default b', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['foo']);
+        $this->assertEquals(['foo', 'default b', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['foo', 'bar', 'baz']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+    }
+
+    public function testWithDefaultParametersAssociativeSyntax()
+    {
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['a' => 'foo', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['a' => 'foo', 'b' => 'bar', 'c' => 'baz']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['a' => 'foo', 'c' => 'baz', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['a' => 'foo', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['a' => 'foo']);
+        $this->assertEquals(['foo', 'default b', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['a' => 'foo', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['a' => 'foo', 'b' => 'bar', 'c' => 'baz']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['a' => 'foo', 'c' => 'baz', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+    }
+
+    public function testClosureCallWithInjectedDependency()
+    {
+        $container = new Container;
+        $container->call(function (ContainerConcreteStub $stub) {
+        }, ['foo' => 'bar']);
+        $container->call(function (ContainerConcreteStub $stub) {
+        }, ['foo' => 'bar', 'stub' => new ContainerConcreteStub]);
+    }
+
 }
 
 class ContainerConcreteStub
 {
     //
+}
+
+class ContainerTestDefaultyParams
+{
+    public function defaulty($a = 'default a', $b = 'default b', $c = 'default c')
+    {
+        return func_get_args();
+    }
+    public function defaultyBandC($a, $b = 'default b', $c = 'default c')
+    {
+        return func_get_args();
+    }
+    public function defaultyOnlyC($a, $b, $c = 'default c')
+    {
+        return func_get_args();
+    }
+    public function noDefault($a, $b, $c)
+    {
+        return func_get_args();
+    }
 }
 
 interface IContainerContractStub

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1145,6 +1145,10 @@ class ContainerTest extends TestCase
         $container = new Container;
         $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['foo', 'bar', 'baz']);
         $this->assertEquals(['foo', 'bar', 'baz'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['foo', 'bar', 'baz', 'foo2', 'bar2', 'baz2']);
+        $this->assertEquals(['foo', 'bar', 'baz', 'foo2', 'bar2', 'baz2'], $result);
     }
 
     public function testWithDefaultParametersAssociativeSyntax()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1197,14 +1197,46 @@ class ContainerTest extends TestCase
     public function testClosureCallWithInjectedDependency()
     {
         $container = new Container;
-        $container->call(function (ContainerConcreteStub $stub) {
+        $result = $container->call(function (ContainerConcreteStub $stub) {
+            return $stub;
         }, ['foo' => 'bar']);
 
-        $container->call(function (ContainerConcreteStub $stub) {
-        }, [new ContainerConcreteStub]);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result);
 
-        $container->call(function (ContainerConcreteStub $stub) {
-        }, ['foo' => 'bar', 'stub' => new ContainerConcreteStub]);
+        $obj = new ContainerConcreteStub;
+        $result = $container->call(function (ContainerConcreteStub $stub) {
+            return $stub;
+        }, [$obj]);
+        $this->assertSame($obj, $result);
+
+        $obj = new ContainerConcreteStub;
+        $result = $container->call(function (ContainerConcreteStub $stub, $baz = 'taylor') {
+            return [$stub, $baz];
+        }, ['foo' => 'bar', 'stub' => $obj]);
+        $this->assertSame($obj, $result[0]);
+        $this->assertEquals('taylor', $result[1]);
+
+        $obj = new ContainerConcreteStub;
+        $result = $container->call(function ($foo, ContainerConcreteStub $stub) {
+            return [$foo, $stub];
+        }, ['foo', $obj]);
+        $this->assertEquals('foo', $result[0]);
+        $this->assertSame($obj, $result[1]);
+
+
+        $result = $container->call(function ($foo = 'default foo', ContainerConcreteStub $stub) {
+            return [$foo, $stub];
+        }, ['foo']);
+        $this->assertEquals('foo', $result[0]);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result[1]);
+
+
+
+        $result = $container->call(function ($foo = 'default foo', ContainerConcreteStub $stub = null) {
+            return [$foo, $stub];
+        }, []);
+        $this->assertEquals('default foo', $result[0]);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $result[1]);
     }
 }
 

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -12,11 +12,13 @@ use Illuminate\Filesystem\FilesystemManager;
 
 class FilesystemTest extends TestCase
 {
+    private static $i = 0;
+
     private $tempDir;
 
     public function setUp()
     {
-        $this->tempDir = __DIR__.'/tmp';
+        $this->tempDir = __DIR__.'/tmp'.self::$i++;
         mkdir($this->tempDir);
     }
 


### PR DESCRIPTION
It seems that creating and deleting a folder on setUp and tearDown of each tests causes the them to affect each other, in snowball effect manner. I get a bunch of mysterious errors on `windows 10` with `php v7.1` and `php v7.2`. (see the screen shot)

