### PR TITLE
[5.7] Fixes including subSelect to Query

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2563,13 +2563,13 @@ class Builder
         $original = $this->columns;
 
         // If the original columns are not set, we will use the ones issued to this method
-        // to run the callback. When not, we will merge both arrays and keep only unique
-        // values and dispose of the '*' selector when asking for more than one column.
+        // to run the callback. When not, we will merge all columns and keep only unique
+        // values. Then we dispose of the '*' selector when we are asking for columns.
         $this->columns = is_null($original)
             ? $columns
             : array_unique(array_merge($columns, $this->columns));
 
-        if (count($this->columns) > 1 && ($all = array_search('*', $this->columns)) !== false) {
+        if (count($columns) > 1 && ($all = array_search('*', $this->columns)) !== false) {
             unset($this->columns[$all]);
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2564,7 +2564,7 @@ class Builder
         
         $this->columns = is_null($original)
             ? $columns
-            : array_merge($columns, $this->columns);
+            : array_unique(array_merge($columns, $this->columns));
 
         $result = $callback();
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2563,18 +2563,14 @@ class Builder
         $original = $this->columns;
 
         // If the original columns are not set, we will use the ones issued to this method
-        // to run the callback. When not, we will merge both arrays and keep only unique 
+        // to run the callback. When not, we will merge both arrays and keep only unique
         // values and dispose of the '*' selector when asking for more than one column.
-        if (is_null($original)) {
-            $this->columns = $columns;
-        } else {
-            $this->columns = array_unique(array_merge($columns, $this->columns));
-        }
+        $this->columns = is_null($original)
+            ? $columns
+            : array_unique(array_merge($columns, $this->columns));
 
-        $hasAll = array_search('*', $this->columns);
-
-        if (count($this->columns) > 1 && $hasAll !== false) {
-            unset($this->columns[$hasAll]);
+        if (count($this->columns) > 1 && ($all = array_search('*', $this->columns)) !== false) {
+            unset($this->columns[$all]);
         }
 
         $result = $callback();

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2562,9 +2562,9 @@ class Builder
     {
         $original = $this->columns;
 
-        $this->columns = is_null($original)
-            ? array_unique(array_merge($this->columns, $columns))
-            : $columns;
+        if (is_null($original)) {
+            $this->columns = $columns;
+        }
 
         $result = $callback();
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2561,10 +2561,10 @@ class Builder
     protected function onceWithColumns($columns, $callback)
     {
         $original = $this->columns;
-        
+
         $this->columns = is_null($original)
-            ? $columns
-            : array_unique(array_merge($columns, $this->columns));
+            ? array_unique(array_merge($this->columns, $columns))
+            : $columns;
 
         $result = $callback();
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2561,10 +2561,10 @@ class Builder
     protected function onceWithColumns($columns, $callback)
     {
         $original = $this->columns;
-
-        if (is_null($original)) {
-            $this->columns = $columns;
-        }
+        
+        $this->columns = is_null($original)
+            ? $columns
+            : array_merge($columns, $this->columns);
 
         $result = $callback();
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2562,8 +2562,19 @@ class Builder
     {
         $original = $this->columns;
 
+        // If the original columns are not set, we will use the ones issued to this method
+        // to run the callback. When not, we will merge both arrays and keep only unique 
+        // values and dispose of the '*' selector when asking for more than one column.
         if (is_null($original)) {
             $this->columns = $columns;
+        } else {
+            $this->columns = array_unique(array_merge($columns, $this->columns));
+        }
+
+        $hasAll = array_search('*', $this->columns);
+
+        if (count($this->columns) > 1 && $hasAll !== false) {
+            unset($this->columns[$hasAll]);
         }
 
         $result = $callback();

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2569,7 +2569,7 @@ class Builder
             ? $columns
             : array_unique(array_merge($columns, $this->columns));
 
-        if (count($columns) > 1 && ($all = array_search('*', $this->columns)) !== false) {
+        if (count($this->columns) > 1 && ($all = array_search('*', $this->columns)) !== false) {
             unset($this->columns[$all]);
         }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -193,6 +193,27 @@ class DatabaseEloquentIntegrationTest extends TestCase
         }
     }
 
+    public function testBasicModelRetrievalWithSelectSub()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
+        $model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')
+            ->selectSub('id + ' . ($rand = rand(1,99)), 'plusId')
+            ->first();
+        $this->assertEquals($rand + 1, $model->plusId);
+        $this->assertTrue(isset($model->email));
+        $this->assertTrue(isset($model->friends));
+
+        $model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')
+            ->selectSub('id + ' . ($rand = rand(1,99)), 'plusId')
+            ->first(['email']);
+        $this->assertEquals($rand + 1, $model->plusId);
+        $this->assertTrue(isset($model->email));
+        $this->assertTrue(isset($model->friends));
+        $this->assertFalse(isset($model->id));
+    }
+
     public function testBasicModelCollectionRetrieval()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -199,14 +199,14 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
 
         $model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')
-            ->selectSub('id + ' . ($rand = rand(1,99)), 'plusId')
+            ->selectSub('id + '.($rand = rand(1, 99)), 'plusId')
             ->first();
         $this->assertEquals($rand + 1, $model->plusId);
         $this->assertTrue(isset($model->email));
         $this->assertTrue(isset($model->friends));
 
         $model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')
-            ->selectSub('id + ' . ($rand = rand(1,99)), 'plusId')
+            ->selectSub('id + '.($rand = rand(1, 99)), 'plusId')
             ->first(['email']);
         $this->assertEquals($rand + 1, $model->plusId);
         $this->assertTrue(isset($model->email));


### PR DESCRIPTION
Fixes #26979

Adds the `selectSub` value into the columns to be set, instead of excluding the rest of columns and leaving only the selectSub.