### PR TITLE
[5.7] Allows (optional) merge columns on retrieval methods

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2563,13 +2563,13 @@ class Builder
         $original = $this->columns;
 
         // If the original columns are not set, we will use the ones issued to this method
-        // to run the callback. When not, we will merge both arrays and keep only unique
-        // values and dispose of the '*' selector when asking for more than one column.
+        // to run the callback. When not, we will merge all columns and keep only unique
+        // values. Then we dispose of the '*' selector when we are asking for columns.
         $this->columns = is_null($original)
             ? $columns
             : array_unique(array_merge($columns, $this->columns));
 
-        if (count($this->columns) > 1 && ($all = array_search('*', $this->columns)) !== false) {
+        if (count($columns) > 1 && ($all = array_search('*', $this->columns)) !== false) {
             unset($this->columns[$all]);
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -80,7 +80,7 @@ class Builder
      * 
      * @var bool
      */
-    public $mergeSelects = false;
+    public $mergingSelects = false;
 
     /**
      * Indicates if the query returns distinct results.
@@ -236,9 +236,9 @@ class Builder
      *
      * @return $this
      */
-    public function mergeSelects()
+    public function mergingSelects()
     {
-        $this->mergeSelects = true;
+        $this->mergingSelects = true;
 
         return $this;
     }
@@ -248,9 +248,9 @@ class Builder
      *
      * @return $this
      */
-    public function ignoreSelects()
+    public function ignoringSelects()
     {
-        $this->mergeSelects = false;
+        $this->mergingSelects = false;
 
         return $this;
     }
@@ -2596,7 +2596,7 @@ class Builder
         // If we are allowing the merge of columns, we will use the columns along with the
         // internal columns. When not, we will discard the columns argument and use only
         // the internal columns, as long it's not empty, which is the default process.
-        if ($this->mergeSelects) {
+        if ($this->mergingSelects) {
             $this->columns = array_unique(array_merge($columns, $this->columns));
         } elseif (is_null($original)) {
             $this->columns = $columns;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2564,7 +2564,7 @@ class Builder
         
         $this->columns = is_null($original)
             ? $columns
-            : array_merge($columns, $this->columns);
+            : array_unique(array_merge($columns, $this->columns));
 
         $result = $callback();
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -78,7 +78,7 @@ class Builder
     /**
      * Indicates if the retrieval methods should merge selects
      * 
-     * @var bool 
+     * @var bool
      */
     public $mergeSelects = false;
 
@@ -232,7 +232,7 @@ class Builder
     }
 
     /**
-     * Merge columns on retrieval methods
+     * Merge columns on retrieval methods.
      *
      * @return $this
      */
@@ -244,7 +244,7 @@ class Builder
     }
 
     /**
-     * Retrieval methods will respect previous select statements
+     * Retrieval methods will respect previous select statements.
      *
      * @return $this
      */
@@ -2598,7 +2598,7 @@ class Builder
         // the internal columns, as long it's not empty, which is the default process.
         if ($this->mergeSelects) {
             $this->columns = array_unique(array_merge($columns, $this->columns));
-        } elseif(is_null($original)) {
+        } elseif (is_null($original)) {
             $this->columns = $columns;
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -76,7 +76,7 @@ class Builder
     public $columns;
 
     /**
-     * Indicates if the retrieval methods should merge selects
+     * Indicates if the retrieval methods should merge selects.
      * 
      * @var bool
      */

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2563,18 +2563,14 @@ class Builder
         $original = $this->columns;
 
         // If the original columns are not set, we will use the ones issued to this method
-        // to run the callback. When not, we will merge both arrays and keep only unique 
+        // to run the callback. When not, we will merge both arrays and keep only unique
         // values and dispose of the '*' selector when asking for more than one column.
-        if (is_null($original)) {
-            $this->columns = $columns;
-        } else {
-            $this->columns = array_unique(array_merge($columns, $this->columns));
-        }
+        $this->columns = is_null($original)
+            ? $columns
+            : array_unique(array_merge($columns, $this->columns));
 
-        $hasAll = array_search('*', $this->columns);
-
-        if (count($this->columns) > 1 && $hasAll !== false) {
-            unset($this->columns[$hasAll]);
+        if (count($this->columns) > 1 && ($all = array_search('*', $this->columns)) !== false) {
+            unset($this->columns[$all]);
         }
 
         $result = $callback();

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2562,9 +2562,9 @@ class Builder
     {
         $original = $this->columns;
 
-        $this->columns = is_null($original)
-            ? array_unique(array_merge($this->columns, $columns))
-            : $columns;
+        if (is_null($original)) {
+            $this->columns = $columns;
+        }
 
         $result = $callback();
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2561,10 +2561,10 @@ class Builder
     protected function onceWithColumns($columns, $callback)
     {
         $original = $this->columns;
-        
+
         $this->columns = is_null($original)
-            ? $columns
-            : array_unique(array_merge($columns, $this->columns));
+            ? array_unique(array_merge($this->columns, $columns))
+            : $columns;
 
         $result = $callback();
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2561,10 +2561,10 @@ class Builder
     protected function onceWithColumns($columns, $callback)
     {
         $original = $this->columns;
-
-        if (is_null($original)) {
-            $this->columns = $columns;
-        }
+        
+        $this->columns = is_null($original)
+            ? $columns
+            : array_merge($columns, $this->columns);
 
         $result = $callback();
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2562,8 +2562,19 @@ class Builder
     {
         $original = $this->columns;
 
+        // If the original columns are not set, we will use the ones issued to this method
+        // to run the callback. When not, we will merge both arrays and keep only unique 
+        // values and dispose of the '*' selector when asking for more than one column.
         if (is_null($original)) {
             $this->columns = $columns;
+        } else {
+            $this->columns = array_unique(array_merge($columns, $this->columns));
+        }
+
+        $hasAll = array_search('*', $this->columns);
+
+        if (count($this->columns) > 1 && $hasAll !== false) {
+            unset($this->columns[$hasAll]);
         }
 
         $result = $callback();

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -77,7 +77,7 @@ class Builder
 
     /**
      * Indicates if the retrieval methods should merge selects.
-     * 
+     *
      * @var bool
      */
     public $mergingSelects = false;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2569,7 +2569,7 @@ class Builder
             ? $columns
             : array_unique(array_merge($columns, $this->columns));
 
-        if (count($columns) > 1 && ($all = array_search('*', $this->columns)) !== false) {
+        if (count($this->columns) > 1 && ($all = array_search('*', $this->columns)) !== false) {
             unset($this->columns[$all]);
         }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -193,6 +193,27 @@ class DatabaseEloquentIntegrationTest extends TestCase
         }
     }
 
+    public function testBasicModelRetrievalWithSelectSub()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
+        $model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')
+            ->selectSub('id + ' . ($rand = rand(1,99)), 'plusId')
+            ->first();
+        $this->assertEquals($rand + 1, $model->plusId);
+        $this->assertTrue(isset($model->email));
+        $this->assertTrue(isset($model->friends));
+
+        $model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')
+            ->selectSub('id + ' . ($rand = rand(1,99)), 'plusId')
+            ->first(['email']);
+        $this->assertEquals($rand + 1, $model->plusId);
+        $this->assertTrue(isset($model->email));
+        $this->assertTrue(isset($model->friends));
+        $this->assertFalse(isset($model->id));
+    }
+
     public function testBasicModelCollectionRetrieval()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -193,30 +193,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
         }
     }
 
-    public function testBasicModelRetrievalWithSelectSub()
-    {
-        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
-        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
-
-        $model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')
-            ->selectSub('id + '.($rand = rand(1, 99)), 'plusId')
-            ->mergeSelects()
-            ->first();
-        $this->assertEquals($rand + 1, $model->plusId);
-        $this->assertTrue(isset($model->email));
-        $this->assertTrue(isset($model->email));
-        $this->assertTrue(isset($model->friends));
-
-        $model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')
-            ->selectSub('id + '.($rand = rand(1, 99)), 'plusId')
-            ->first(['email']);
-
-        $this->assertEquals($rand + 1, $model->plusId);
-        $this->assertTrue(isset($model->friends));
-        $this->assertFalse(isset($model->email));
-        $this->assertFalse(isset($model->id));
-    }
-
     public function testBasicModelCollectionRetrieval()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -200,17 +200,20 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')
             ->selectSub('id + '.($rand = rand(1, 99)), 'plusId')
+            ->mergeSelects()
             ->first();
         $this->assertEquals($rand + 1, $model->plusId);
+        $this->assertTrue(isset($model->email));
         $this->assertTrue(isset($model->email));
         $this->assertTrue(isset($model->friends));
 
         $model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')
             ->selectSub('id + '.($rand = rand(1, 99)), 'plusId')
             ->first(['email']);
+
         $this->assertEquals($rand + 1, $model->plusId);
-        $this->assertTrue(isset($model->email));
         $this->assertTrue(isset($model->friends));
+        $this->assertFalse(isset($model->email));
         $this->assertFalse(isset($model->id));
     }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -199,14 +199,14 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
 
         $model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')
-            ->selectSub('id + ' . ($rand = rand(1,99)), 'plusId')
+            ->selectSub('id + '.($rand = rand(1, 99)), 'plusId')
             ->first();
         $this->assertEquals($rand + 1, $model->plusId);
         $this->assertTrue(isset($model->email));
         $this->assertTrue(isset($model->friends));
 
         $model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')
-            ->selectSub('id + ' . ($rand = rand(1,99)), 'plusId')
+            ->selectSub('id + '.($rand = rand(1, 99)), 'plusId')
             ->first(['email']);
         $this->assertEquals($rand + 1, $model->plusId);
         $this->assertTrue(isset($model->email));

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2525,7 +2525,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals($expectedBindings, $builder->getBindings());
     }
 
-    public function testMergeSelects()
+    public function testMergingSelects()
     {
         $expectedSql = 'select "foo", "bar", "qux", (select "baz" from "two" where "subkey" = ?) as "sub", (corge - uier) as "grault" from "one" where "key" = ?';
         $expectedBindings = ['subval', 'val'];
@@ -2542,13 +2542,13 @@ class DatabaseQueryBuilderTest extends TestCase
             $query->from('two')->select('baz')->where('subkey', '=', 'subval');
         }, 'sub');
         $builder->selectSub('corge - uier', 'grault');
-        $builder->mergeSelects();
+        $builder->mergingSelects();
         $builder->get(['foo', 'bar']);
 
         $this->assertEquals($expectedBindings, $builder->getBindings());
     }
 
-    public function testIgnoresSelects()
+    public function testIgnoringSelects()
     {
         $expectedSql = 'select "qux", (select "baz" from "two" where "subkey" = ?) as "sub", (corge - uier) as "grault" from "one" where "key" = ?';
         $expectedBindings = ['subval', 'val'];
@@ -2565,7 +2565,7 @@ class DatabaseQueryBuilderTest extends TestCase
             $query->from('two')->select('baz')->where('subkey', '=', 'subval');
         }, 'sub');
         $builder->selectSub('corge - uier', 'grault');
-        $builder->ignoreSelects();
+        $builder->ignoringSelects();
         $builder->get(['foo', 'bar']);
 
         $this->assertEquals($expectedBindings, $builder->getBindings());


### PR DESCRIPTION
Adds a new method called `mergeSelects()` and `ignoreSelects()`.

The first will allow to merge selects on the final retrieval method (like get or first), while the other will default to ignore them, which is the default behaviour on the framework.