### PR TITLE
[5.8] Add deleted_at date cast for soft deleting models

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -22,6 +22,16 @@ trait SoftDeletes
     }
 
     /**
+     * Initialize the soft deleting trait for an instance.
+     *
+     * @return void
+     */
+    public function initializeSoftDeletes()
+    {
+        $this->dates[] = $this->getDeletedAtColumn();
+    }
+
+    /**
      * Force a hard delete on a soft deleted model.
      *
      * @return bool|null

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -756,7 +756,6 @@ class SoftDeletesTestUser extends Eloquent
 {
     use SoftDeletes;
 
-    protected $dates = ['deleted_at'];
     protected $table = 'users';
     protected $guarded = [];
 
@@ -780,7 +779,6 @@ class SoftDeletesTestUserWithTrashedPosts extends Eloquent
 {
     use SoftDeletes;
 
-    protected $dates = ['deleted_at'];
     protected $table = 'users';
     protected $guarded = [];
 
@@ -797,7 +795,6 @@ class SoftDeletesTestPost extends Eloquent
 {
     use SoftDeletes;
 
-    protected $dates = ['deleted_at'];
     protected $table = 'posts';
     protected $guarded = [];
 
@@ -828,7 +825,6 @@ class SoftDeletesTestComment extends Eloquent
 {
     use SoftDeletes;
 
-    protected $dates = ['deleted_at'];
     protected $table = 'comments';
     protected $guarded = [];
 
@@ -842,7 +838,6 @@ class SoftDeletesTestCommentWithTrashed extends Eloquent
 {
     use SoftDeletes;
 
-    protected $dates = ['deleted_at'];
     protected $table = 'comments';
     protected $guarded = [];
 
@@ -859,7 +854,6 @@ class SoftDeletesTestAddress extends Eloquent
 {
     use SoftDeletes;
 
-    protected $dates = ['deleted_at'];
     protected $table = 'addresses';
     protected $guarded = [];
 }
@@ -871,7 +865,6 @@ class SoftDeletesTestGroup extends Eloquent
 {
     use SoftDeletes;
 
-    protected $dates = ['deleted_at'];
     protected $table = 'groups';
     protected $guarded = [];
 

--- a/tests/Database/DatabaseSoftDeletingTest.php
+++ b/tests/Database/DatabaseSoftDeletingTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class DatabaseSoftDeletingTest extends TestCase
+{
+    public function testDeletedAtIsAddedToDateCasts()
+    {
+        $model = new SoftDeletingModel;
+
+        $this->assertContains('deleted_at', $model->getDates());
+    }
+
+    public function testDeletedAtIsUniqueWhenAlreadyExists()
+    {
+        $model = new class extends SoftDeletingModel {
+            protected $dates = ['deleted_at'];
+        };
+        $entries = array_filter($model->getDates(), function ($attribute) {
+            return $attribute === 'deleted_at';
+        });
+
+        $this->assertCount(1, $entries);
+    }
+
+    public function testDeletedAtIsCastToCarbonInstance()
+    {
+        Carbon::setTestNow(Carbon::now());
+        $expected = Carbon::createFromFormat('Y-m-d H:i:s', '2018-12-29 13:59:39');
+        $model = new SoftDeletingModel(['deleted_at' => $expected->format('Y-m-d H:i:s')]);
+
+        $this->assertInstanceOf(Carbon::class, $model->deleted_at);
+        $this->assertTrue($expected->eq($model->deleted_at));
+    }
+
+    public function testExistingCastOverridesAddedDateCast()
+    {
+        $model = new class(['deleted_at' => '2018-12-29 13:59:39']) extends SoftDeletingModel {
+            protected $casts = ['deleted_at' => 'bool'];
+        };
+
+        $this->assertTrue($model->deleted_at);
+    }
+
+    public function testExistingMutatorOverridesAddedDateCast()
+    {
+        $model = new class(['deleted_at' => '2018-12-29 13:59:39']) extends SoftDeletingModel {
+            protected function getDeletedAtAttribute()
+            {
+                return 'expected';
+            }
+        };
+
+        $this->assertSame('expected', $model->deleted_at);
+    }
+
+    public function testCastingToStringOverridesAutomaticDateCastingToRetainPreviousBehaviour()
+    {
+        $model = new class(['deleted_at' => '2018-12-29 13:59:39']) extends SoftDeletingModel {
+            protected $casts = ['deleted_at' => 'string'];
+        };
+
+        $this->assertSame('2018-12-29 13:59:39', $model->deleted_at);
+    }
+}
+
+class SoftDeletingModel extends Model
+{
+    use SoftDeletes;
+
+    protected $guarded = [];
+
+    protected $dateFormat = 'Y-m-d H:i:s';
+}

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -123,5 +123,4 @@ class TestUpdateModel2 extends Model
 
     public $table = 'test_model2';
     protected $fillable = ['name'];
-    protected $dates = ['deleted_at'];
 }


### PR DESCRIPTION
This PR utilises a trait initializer to automatically add `deleted_at` to the `$dates` array of any model that uses the `SoftDeletes` trait. Previously this has to be added manually to each model - unlike the `created_at` and `updated_at` that is handled "under the hood".

In essence...

```php
class Post extends Eloquent
{
    use SoftDeletes;

    // no need for this anymore
    // protected $dates = ['deleted_at'];
}
```

**Notes:**
- An existing`$casts` entry for `deleted_at` will take precedence (test exists).
- A duplicate `$dates` entry for `deleted_at` will have no impact as the array is not a key => value pair, but a value array. Also when `getDates` is called it already runs `array_unique` to remove any duplicate entries (test exists).
- An existing mutator `getDeletedAtAttribute` will take precedence (test exists).

**Breaking:**

This will be a breaking change if you are not expecting the value of `deleted_at` to be cast, i.e. you never added it to the `$dates` array as [outlined in the docs](https://laravel.com/docs/5.7/eloquent#deleting-models). But as mentioned earlier, a mutator will take precedence if for whatever reason you don't want the automatic casting.