### PR TITLE
[5.7] Isolate tests from each other to fix cascading errors on windows

### DIFF
--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -12,11 +12,13 @@ use Illuminate\Filesystem\FilesystemManager;
 
 class FilesystemTest extends TestCase
 {
+    private static $i = 0;
+
     private $tempDir;
 
     public function setUp()
     {
-        $this->tempDir = __DIR__.'/tmp';
+        $this->tempDir = __DIR__.'/tmp'.self::$i++;
         mkdir($this->tempDir);
     }
 


### PR DESCRIPTION
It seems that creating and deleting a folder on setUp and tearDown of each tests causes the them to affect each other, in snowball effect manner. I get a bunch of mysterious errors on windows 10 with php v7.1 and php v7.2. (see the screen shot)

with this trick it gets fixed. but I really did not find out what causes the deletion of the directory to fail in teardown process of some tests.

Now each test creates and deletes it's own tmp folder so they can not step on each other work.
If one for example does not manage to delete the tmp folder at tearDown.

![image](https://user-images.githubusercontent.com/6961695/50526578-317db580-0af8-11e9-9edb-ff722c7b4714.png)

![image](https://user-images.githubusercontent.com/6961695/50526566-1dd24f00-0af8-11e9-99db-4b5b64412fb6.png)

The problem is with
testFilesMethod
and
testFilesMethodReturnsFileInfoObjects
the folder iterated by these two tests $files->files($this->tempDir.'/foo'); cannot be deleted until the php shuts down and runs again.
instead the contents of the folder get deleted only.
Any feather attempt to delete the folder after $files->files($this->tempDir.'/foo'); will result in a permission denied error.

![image](https://user-images.githubusercontent.com/6961695/50527616-af44bf80-0afe-11e9-9b72-6aff0d542f00.png)

This bug seems to be at php level for windows platforms only. (I think)
