### PR TITLE
[5.7] Make queue tests compatible with windows 10

### DIFF
--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -44,7 +44,7 @@ class QueueListenerTest extends TestCase
         $options->memory = 2;
         $options->timeout = 3;
         $process = $listener->makeProcess('connection', 'queue', $options);
-        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '' : '\'';
 
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
@@ -60,7 +60,7 @@ class QueueListenerTest extends TestCase
         $options->memory = 2;
         $options->timeout = 3;
         $process = $listener->makeProcess('connection', 'queue', $options);
-        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '' : '\'';
 
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
@@ -76,7 +76,7 @@ class QueueListenerTest extends TestCase
         $options->memory = 2;
         $options->timeout = 3;
         $process = $listener->makeProcess(null, 'queue', $options);
-        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '' : '\'';
 
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6961695/50470681-cc767280-09c6-11e9-9f03-2e42c51b44e9.png)

On windows 10 I get these error showing that the $escape is wrong for windows.
The only way to make them pass is to select an empty string.

`PHP 7.2.9`
`PHP 7.1.8`