### PR TITLE
[5.7] Prevent unnecessary relationship queries

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -75,6 +75,10 @@ class BelongsTo extends Relation
      */
     public function getResults()
     {
+        if (is_null($this->child->{$this->foreignKey})) {
+            return $this->getDefaultFor($this->parent);
+        }
+
         return $this->query->first() ?: $this->getDefaultFor($this->parent);
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -559,7 +559,9 @@ class BelongsToMany extends Relation
      */
     public function getResults()
     {
-        return $this->get();
+        return ! is_null($this->parent->{$this->parentKey})
+                ? $this->get()
+                : $this->related->newCollection();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -13,7 +13,9 @@ class HasMany extends HasOneOrMany
      */
     public function getResults()
     {
-        return $this->query->get();
+        return ! is_null($this->getParentKey())
+                ? $this->query->get()
+                : $this->related->newCollection();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -343,7 +343,9 @@ class HasManyThrough extends Relation
      */
     public function getResults()
     {
-        return $this->get();
+        return ! is_null($this->farParent->{$this->localKey})
+                ? $this->get()
+                : $this->related->newCollection();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -17,6 +17,10 @@ class HasOne extends HasOneOrMany
      */
     public function getResults()
     {
+        if (is_null($this->getParentKey())) {
+            return $this->getDefaultFor($this->parent);
+        }
+
         return $this->query->first() ?: $this->getDefaultFor($this->parent);
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -13,7 +13,9 @@ class MorphMany extends MorphOneOrMany
      */
     public function getResults()
     {
-        return $this->query->get();
+        return ! is_null($this->getParentKey())
+                ? $this->query->get()
+                : $this->related->newCollection();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -17,6 +17,10 @@ class MorphOne extends MorphOneOrMany
      */
     public function getResults()
     {
+        if (is_null($this->getParentKey())) {
+            return $this->getDefaultFor($this->parent);
+        }
+
         return $this->query->first() ?: $this->getDefaultFor($this->parent);
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -84,16 +84,6 @@ class MorphTo extends BelongsTo
     /**
      * Get the results of the relationship.
      *
-     * @return mixed
-     */
-    public function getResults()
-    {
-        return $this->ownerKey ? parent::getResults() : null;
-    }
-
-    /**
-     * Get the results of the relationship.
-     *
      * Called via eager load method of Eloquent query builder.
      *
      * @return mixed


### PR DESCRIPTION
Prevents unnecessary queries when lazy loading empty relationships:

```php
(new Post(['user_id' => null]))->user; // null
(new User)->posts;                     // []
```

`MorphTo::getResults()` is now handled by `BelongsTo::getResults()` (#8586).

This does *not* apply to custom relationship queries like `(new User)->posts()->get()`.

I don't think we need additional tests for this. There are plenty of tests that verify relationship queries.

Fixes #25214, #24241, #20616 and https://github.com/laravel/ideas/issues/748.