### PR TITLE
[5.7] Replace other phpunit deprecations

### DIFF
--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -41,7 +41,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
 
         $results = $repo->create($user);
 
-        $this->assertInternalType('string', $results);
+        $this->assertIsString($results);
         $this->assertGreaterThan(1, strlen($results));
     }
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -73,7 +73,7 @@ class DatabaseConnectionTest extends TestCase
         $log = $mock->getQueryLog();
         $this->assertEquals('foo', $log[0]['query']);
         $this->assertEquals(['foo' => 'bar'], $log[0]['bindings']);
-        $this->assertInternalType('numeric', $log[0]['time']);
+        $this->assertIsNumeric($log[0]['time']);
     }
 
     public function testInsertCallsTheStatementMethod()
@@ -114,7 +114,7 @@ class DatabaseConnectionTest extends TestCase
         $log = $mock->getQueryLog();
         $this->assertEquals('foo', $log[0]['query']);
         $this->assertEquals(['bar'], $log[0]['bindings']);
-        $this->assertInternalType('numeric', $log[0]['time']);
+        $this->assertIsNumeric($log[0]['time']);
     }
 
     public function testAffectingStatementProperlyCallsPDO()
@@ -132,7 +132,7 @@ class DatabaseConnectionTest extends TestCase
         $log = $mock->getQueryLog();
         $this->assertEquals('foo', $log[0]['query']);
         $this->assertEquals(['foo' => 'bar'], $log[0]['bindings']);
-        $this->assertInternalType('numeric', $log[0]['time']);
+        $this->assertIsNumeric($log[0]['time']);
     }
 
     public function testTransactionLevelNotIncrementedOnTransactionException()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1054,7 +1054,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
 
         $user = EloquentTestUser::first();
-        $this->assertInternalType('int', $user->id);
+        $this->assertIsInt($user->id);
     }
 
     public function testDefaultIncrementingPrimaryKeyIntegerCastCanBeOverwritten()
@@ -1062,7 +1062,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestUserWithStringCastId::create(['email' => 'taylorotwell@gmail.com']);
 
         $user = EloquentTestUserWithStringCastId::first();
-        $this->assertInternalType('string', $user->id);
+        $this->assertIsString($user->id);
     }
 
     public function testRelationsArePreloadedInGlobalScope()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1515,12 +1515,12 @@ class DatabaseEloquentModelTest extends TestCase
         $model->datetimeAttribute = '1969-07-20 22:56:00';
         $model->timestampAttribute = '1969-07-20 22:56:00';
 
-        $this->assertInternalType('int', $model->intAttribute);
-        $this->assertInternalType('float', $model->floatAttribute);
-        $this->assertInternalType('string', $model->stringAttribute);
-        $this->assertInternalType('boolean', $model->boolAttribute);
-        $this->assertInternalType('boolean', $model->booleanAttribute);
-        $this->assertInternalType('object', $model->objectAttribute);
+        $this->assertIsInt($model->intAttribute);
+        $this->assertIsFloat($model->floatAttribute);
+        $this->assertIsString($model->stringAttribute);
+        $this->assertIsBool($model->boolAttribute);
+        $this->assertIsBool($model->booleanAttribute);
+        $this->assertIsObject($model->objectAttribute);
         $this->assertInternalType('array', $model->arrayAttribute);
         $this->assertInternalType('array', $model->jsonAttribute);
         $this->assertTrue($model->boolAttribute);
@@ -1536,12 +1536,12 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(-14173440, $model->timestampAttribute);
 
         $arr = $model->toArray();
-        $this->assertInternalType('int', $arr['intAttribute']);
-        $this->assertInternalType('float', $arr['floatAttribute']);
-        $this->assertInternalType('string', $arr['stringAttribute']);
-        $this->assertInternalType('boolean', $arr['boolAttribute']);
-        $this->assertInternalType('boolean', $arr['booleanAttribute']);
-        $this->assertInternalType('object', $arr['objectAttribute']);
+        $this->assertIsInt($arr['intAttribute']);
+        $this->assertIsFloat($arr['floatAttribute']);
+        $this->assertIsString($arr['stringAttribute']);
+        $this->assertIsBool($arr['boolAttribute']);
+        $this->assertIsBool($arr['booleanAttribute']);
+        $this->assertIsObject($arr['objectAttribute']);
         $this->assertInternalType('array', $arr['arrayAttribute']);
         $this->assertInternalType('array', $arr['jsonAttribute']);
         $this->assertTrue($arr['boolAttribute']);

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -21,7 +21,7 @@ class UrlSigningTest extends TestCase
             return $request->hasValidSignature() ? 'valid' : 'invalid';
         })->name('foo');
 
-        $this->assertInternalType('string', $url = URL::signedRoute('foo', ['id' => 1]));
+        $this->assertIsString($url = URL::signedRoute('foo', ['id' => 1]));
         $this->assertEquals('valid', $this->get($url)->original);
     }
 
@@ -32,7 +32,7 @@ class UrlSigningTest extends TestCase
         })->name('foo');
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1));
-        $this->assertInternalType('string', $url = URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1]));
+        $this->assertIsString($url = URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1]));
         $this->assertEquals('valid', $this->get($url)->original);
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1)->addMinutes(10));
@@ -55,7 +55,7 @@ class UrlSigningTest extends TestCase
         })->name('foo')->middleware(ValidateSignature::class);
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1));
-        $this->assertInternalType('string', $url = URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1]));
+        $this->assertIsString($url = URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1]));
         $this->assertEquals('valid', $this->get($url)->original);
     }
 
@@ -66,7 +66,7 @@ class UrlSigningTest extends TestCase
         })->name('foo')->middleware(ValidateSignature::class);
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1));
-        $this->assertInternalType('string', $url = URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1]));
+        $this->assertIsString($url = URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1]));
         Carbon::setTestNow(Carbon::create(2018, 1, 1)->addMinutes(10));
 
         $response = $this->get($url);
@@ -82,7 +82,7 @@ class UrlSigningTest extends TestCase
             return $request->hasValidSignature() ? $routable : 'invalid';
         })->name('foo');
 
-        $this->assertInternalType('string', $url = URL::signedRoute('foo', $model));
+        $this->assertIsString($url = URL::signedRoute('foo', $model));
         $this->assertEquals('routable', $this->get($url)->original);
     }
 }

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -27,7 +27,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
             $this->assertEquals(json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data']]), $array['payload']);
             $this->assertEquals(0, $array['attempts']);
             $this->assertNull($array['reserved_at']);
-            $this->assertInternalType('int', $array['available_at']);
+            $this->assertIsInt($array['available_at']);
         });
 
         $queue->push('foo', ['data']);
@@ -47,7 +47,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
             $this->assertEquals(json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data']]), $array['payload']);
             $this->assertEquals(0, $array['attempts']);
             $this->assertNull($array['reserved_at']);
-            $this->assertInternalType('int', $array['available_at']);
+            $this->assertIsInt($array['available_at']);
         });
 
         $queue->later(10, 'foo', ['data']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1135,7 +1135,7 @@ class SupportCollectionTest extends TestCase
         $data = new Collection([1, 2, 3, 4, 5, 6]);
 
         $random = $data->random();
-        $this->assertInternalType('integer', $random);
+        $this->assertIsInt($random);
         $this->assertContains($random, $data->all());
 
         $random = $data->random(0);

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -239,7 +239,7 @@ class SupportHelpersTest extends TestCase
     public function testStrRandom()
     {
         $result = Str::random(20);
-        $this->assertInternalType('string', $result);
+        $this->assertIsString($result);
         $this->assertEquals(20, strlen($result));
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -200,7 +200,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals(16, strlen(Str::random()));
         $randomInteger = random_int(1, 100);
         $this->assertEquals($randomInteger, strlen(Str::random($randomInteger)));
-        $this->assertInternalType('string', Str::random());
+        $this->assertIsString(Str::random());
     }
 
     public function testReplaceArray()


### PR DESCRIPTION
This simply replaces the rest of the phpunit deprecated methods for other php native types.