### PR TITLE
[5.7] Adds the `addSelectSub()` method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -243,6 +243,24 @@ class Builder
     }
 
     /**
+     * Adds a subselect expression to a select statement.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @param  string  $as
+     * @return \Illuminate\Database\Query\Builder|static
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function addSelectSub($query, $as)
+    {
+        if (is_null($this->columns)) {
+            $this->select();
+        }
+
+        return $this->selectSub($query, $as);
+    }
+
+    /**
      * Add a new "raw" select expression to the query.
      *
      * @param  string  $expression


### PR DESCRIPTION
# Why are you committing this?

The default behaviour of `subSelect()` is to add itself exclusively in the column list to retrieve. So doing something like this:

```php
Basket::where('id', 1)
        ->selectSub('available_apples - consumed_apples', 'remaining_apples')
        ->first()
```

Will output only the select subquery result:

```php
array:1 [
  "remaining_apples" => 8
]
```

The problem is that we need to issue a `select()` before to enable the retrieval of all other columns. this forces the user to use a `select()`, before adding the sub.

# Enter... `addSelectSub()`.

This method works as `selectSub()`, but if the columns to retrieve are empty it will add a `select(['*'])` so the query retrieves all the columns, plus the subSelect. This is the [same mechanism used in `withCount()`](https://github.com/laravel/framework/blob/456eefe5bde4b6a99c41928411e4de073a9a6880/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php#L197-L199).

So doing this:

```php
Basket::where('id', 1)
        ->addSelectSub('available_apples - consumed_apples', 'remaining_apples')
        ->first()
```

Will output everything plus the select sub.

```php
array:1 [
  "id" => 1
  "available_apples " => 10
  "consumed_apples" => 2
  "remaining_apples" => 8
  "are_tasty" => 1
]
```

# Does it break anything?

**NO**

* Users that still use `subSelect()` will not have any change in behaviour.