### PR TITLE
[5.8] Fix qualified UPDATED_AT timestamps

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -857,12 +857,18 @@ class Builder
             return $values;
         }
 
-        $column = $this->qualifyColumn($this->model->getUpdatedAtColumn());
+        $column = $this->model->getUpdatedAtColumn();
 
-        return array_merge(
+        $values = array_merge(
             [$column => $this->model->freshTimestampString()],
             $values
         );
+
+        $values[$this->qualifyColumn($column)] = $values[$column];
+
+        unset($values[$column]);
+
+        return $values;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1081,9 +1081,25 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->mockConnectionForModel($model, '');
         $builder->setModel($model);
         $builder->getConnection()->shouldReceive('update')->once()
-            ->with('update "table" set "table"."updated_at" = ?, "foo" = ?', [$now, 'bar'])->andReturn(1);
+            ->with('update "table" set "foo" = ?, "table"."updated_at" = ?', ['bar', $now])->andReturn(1);
 
         $result = $builder->update(['foo' => 'bar']);
+        $this->assertEquals(1, $result);
+
+        Carbon::setTestNow(null);
+    }
+
+    public function testUpdateWithTimestampValue()
+    {
+        $query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));
+        $builder = new Builder($query);
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, '');
+        $builder->setModel($model);
+        $builder->getConnection()->shouldReceive('update')->once()
+            ->with('update "table" set "foo" = ?, "table"."updated_at" = ?', ['bar', null])->andReturn(1);
+
+        $result = $builder->update(['foo' => 'bar', 'updated_at' => null]);
         $this->assertEquals(1, $result);
 
         Carbon::setTestNow(null);


### PR DESCRIPTION
#26031 qualified `UPDATED_AT` timestamps to fix ambiguity issues.

This doesn't work properly when the attributes already contain an `updated_at` value:

```php
User::first()->update(['name' => 'foo']);
```

In this case, `Builder::addUpdatedAtColumn()` returns an array with two separate `updated_at` values:

```php
array:3 [▼
  "users.updated_at" => "2018-12-30 16:01:40"
  "name" => "foo"
  "updated_at" => "2018-12-30 16:01:40"
]
```

We have to merge the attributes first and *then* qualify the column by replacing the array key.

Fixes #26995.