### PR TITLE
[5.8] Fix routing test

### DIFF
--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -40,7 +40,7 @@ class FallbackRouteTest extends TestCase
         $this->assertContains('one', $this->get('/prefix/one')->getContent());
         $this->assertContains('fallback', $this->get('/prefix/non-existing')->getContent());
         $this->assertContains('fallback', $this->get('/prefix/non-existing/with/multiple/segments')->getContent());
-        $this->assertContains('Page Not Found', $this->get('/non-existing')->getContent());
+        $this->assertContains('Not Found', $this->get('/non-existing')->getContent());
     }
 
     public function test_fallback_with_wildcards()


### PR DESCRIPTION
83ca9a7 (`404.blade.php`) broke a routing test.