### PR TITLE
[5.7] Added Str::equalsIgnoreCase

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -520,6 +520,18 @@ class Str
     {
         return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
     }
+    
+    /**
+     * Check if two strings are equal, ignoring case.
+     *
+     * @param  string  $a
+     * @param  string  $b
+     * @return bool
+     */
+    public static function equalsIgnoreCase($a, $b)
+    {
+        return static::lower($a) === static::lower($b);
+    }
 
     /**
      * Generate a UUID (version 4).

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -520,7 +520,7 @@ class Str
     {
         return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
     }
-    
+
     /**
      * Check if two strings are equal, ignoring case.
      *

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -293,6 +293,14 @@ class SupportStrTest extends TestCase
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());
         $this->assertInstanceOf(UuidInterface::class, Str::orderedUuid());
     }
+
+    public function testEqualsIgnoreCase()
+    {
+        $this->assertFalse(Str::equalsIgnoreCase('', 'foo'));
+        $this->assertFalse(Str::equalsIgnoreCase('bar', 'foo'));
+        $this->assertTrue(Str::equalsIgnoreCase('FoO', 'foo'));
+        $this->assertTrue(Str::equalsIgnoreCase('Мама', 'мама'));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
It would be useful if Laravel provided `Str::equalsIgnoreCase`, for example it could be used in the implementation of https://github.com/laravel/framework/pull/26996 when comparing the header value.

NB The name of this method is chosen to match that of Java's String class: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#equalsIgnoreCase(java.lang.String).