### PR TITLE
[5.7] Fixes broken `setHidden` method

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -546,6 +546,16 @@ class Command extends SymfonyCommand
     /**
      * {@inheritdoc}
      */
+    public function setHidden($hidden)
+    {
+        parent::setHidden($this->hidden = $hidden);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function isHidden()
     {
         return $this->hidden;

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -546,19 +546,19 @@ class Command extends SymfonyCommand
     /**
      * {@inheritdoc}
      */
-    public function setHidden($hidden)
+    public function isHidden()
     {
-        parent::setHidden($this->hidden = $hidden);
-
-        return $this;
+        return $this->hidden;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function isHidden()
+    public function setHidden($hidden)
     {
-        return $this->hidden;
+        parent::setHidden($this->hidden = $hidden);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Not sure if is related to https://github.com/laravel/framework/pull/25342 or https://github.com/laravel/framework/pull/26781, but the `setHidden` method no longer works as expected.

**Issue**: When the developer calls the method `setHidden` that exists the on the `Symfony\Command::class`, the property `$hidden` that gets changed it's the private one on the `Symfony\Command::class` instead of the protected one on the `Laravel\Command::class`:
```php
$command->setHidden(true);
$command->isHidden(); // returns false
```

**Solution**: Add the method `setHidden` on the `Laravel\Command::class` to make sure that both attributes have the same value:

```php
    /**
     * {@inheritdoc}
     */
    public function setHidden($hidden)
    {
        parent::setHidden($this->hidden = $hidden);

        return $this;
    }
```

Result:
```php
$command->setHidden(true);
$command->isHidden(); // returns true
```

**Note:** We should consider add some tests on this new `hidden` related methods. Please close the Pull Request if you want me to add tests on this.