### PR TITLE
[5.8] InteractsWithEloquent testing concern

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithEloquent.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithEloquent.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+
+
+trait InteractsWithEloquent
+{
+    /**
+     * Return wheter a given model still exists.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return boolean
+     */
+    private function modelExists(Model $model)
+    {
+        return boolval($model::find($model->getRouteKey()));
+    }
+
+    /**
+     * Assert that a given model still exists.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return $this
+     */
+    protected function assertModelExists(Model $model)
+    {
+        $this->assertTrue($this->modelExists($model), 'The ['.get_class($model).'] model doesn\'t exist anymore.');
+        return $this;
+    }
+
+    /**
+     * Assert that a given model doesn't exist anymore.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return $this
+     */
+    protected function assertModelDeleted(Model $model)
+    {
+        $this->assertFalse($this->modelExists($model), 'The ['.get_class($model).'] model still exists.');
+        return $this;
+    }
+}

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithEloquent.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithEloquent.php
@@ -4,14 +4,13 @@ namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 
-
 trait InteractsWithEloquent
 {
     /**
-     * Return wheter a given model still exists.
+     * Return whether a given model still exists.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return boolean
+     * @return bool
      */
     private function modelExists(Model $model)
     {

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -17,6 +17,7 @@ abstract class TestCase extends BaseTestCase
         Concerns\InteractsWithAuthentication,
         Concerns\InteractsWithConsole,
         Concerns\InteractsWithDatabase,
+        Concerns\InteractsWithEloquent,
         Concerns\InteractsWithExceptionHandling,
         Concerns\InteractsWithSession,
         Concerns\MocksApplicationServices;


### PR DESCRIPTION
## Description
Adds a few new asserting methods that make testing eloquent models easier.
- assertModelDeleted
- assertModelExists

There are in a new concern `InteractsWithEloquent`

## Usage example
```php
public function testDeletePostByAuthor()
{
    $post = App\Post::all()->random();

    $this->actingAs($post->user);

    $this->json('DELETE', "/api/post/$post->id")
        ->assertSuccessful();

    $this->assertModelDeleted($post);
}

public function testDeletePostByGuest(Type $var = null)
{
    $post = App\Post::all()->random();

    $this->json('DELETE', "/api/post/$post->id")
        ->assertStatus(403);
    
    $this->assertModelExists($post);
}
```