### PR TITLE
[5.8] Fixed broken command call code

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -178,15 +178,9 @@ class Application extends SymfonyApplication implements ApplicationContract
             throw new CommandNotFoundException(sprintf('The command "%s" does not exist.', $command));
         }
 
-        $this->setCatchExceptions(false);
-
-        $result = $this->run(
+        return $this->run(
             $input, $this->lastOutput = $outputBuffer ?: new BufferedOutput
         );
-
-        $this->setCatchExceptions(true);
-
-        return $result;
     }
 
     /**


### PR DESCRIPTION
When the application class is constructed, catching exception is already set to false. I'm confused as to why we're setting it to false again, and then forcing it to true afterwards! Very odd.