### PR TITLE
[5.7] Fix array cache store issue.

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -23,7 +23,13 @@ class ArrayStore extends TaggableStore implements Store
      */
     public function get($key)
     {
-        return $this->storage[$key] ?? null;
+        $value = $this->storage[$key] ?? null;
+
+        if (is_object($value)) {
+            return clone $value;
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -84,4 +84,20 @@ class CacheArrayStoreTest extends TestCase
         $store = new ArrayStore;
         $this->assertEmpty($store->getPrefix());
     }
+
+    public function testGettingBackCachedObjectsByValueNotByReference()
+    {
+        $cacheKey = 'testKey';
+        $store = new ArrayStore;
+        $store->put($cacheKey, new \Illuminate\Support\Collection([1, 2, 3]), 60);
+
+        $value1 = $store->get($cacheKey);
+        $value2 = $store->get($cacheKey);
+
+        $mutatedValue1 = $value1->push(4);
+        $mutatedValue2 = $value2->push(5);
+
+        $this->assertEquals(4, $mutatedValue1->last());
+        $this->assertEquals(5, $mutatedValue2->last());
+    }
 }


### PR DESCRIPTION
This fixes https://github.com/laravel/framework/issues/23079 issue.
and a retry for https://github.com/laravel/framework/pull/23082

After all it make more sense because other cache store like redis return back an un-serialized version of the objects, which is not a reference to the original.