### PR TITLE
[5.7] Bug fix related to extra calls to resolving callbacks (The first way)

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1022,6 +1022,356 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $instance->name);
     }
 
+    public function testResolvingCallbacksAreCalledOnceForImplementation()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testGlobalResolvingCallbacksAreCalledOnceForImplementation()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(function ($some) use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testAfterResolvingCallbacksAreCalledOnceForImplementation()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->afterResolving(IContainerContractStub::class, function ($some) use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledOnceForSingletonConcretes()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+        $container->bind(ContainerImplementationStub::class);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(3, $callCounter);
+    }
+
+    public function testResolvingCallbacksCanStillBeAddedAfterTheFirstResolution()
+    {
+        $container = new Container;
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(ContainerImplementationStub::class);
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCanceledWhenInterfaceGetsBoundToSomeOtherConcrete()
+    {
+        $container = new Container;
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $callCounter = 0;
+        $container->resolving(ContainerImplementationStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStubTwo::class);
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledOnceForStringAbstractions()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving('foo', function ($some) use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind('foo', ContainerImplementationStub::class);
+
+        $container->make('foo');
+        $this->assertEquals(1, $callCounter);
+
+        $container->make('foo');
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledOnceForImplementation2()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, function () {
+            return new ContainerImplementationStub;
+        });
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(3, $callCounter);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(4, $callCounter);
+    }
+
+    public function testRebindingDoesNotAffectResolvingCallbacks()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+        $container->bind(IContainerContractStub::class, function () {
+            return new ContainerImplementationStub;
+        });
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(3, $callCounter);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(4, $callCounter);
+    }
+
+    public function testParametersPassedIntoResolvingCallbacks()
+    {
+        $container = new Container;
+
+        $container->resolving(IContainerContractStub::class, function ($obj, $app) use ($container) {
+            $this->assertInstanceOf(IContainerContractStub::class, $obj);
+            $this->assertInstanceOf(ContainerImplementationStubTwo::class, $obj);
+            $this->assertSame($container, $app);
+        });
+
+        $container->afterResolving(IContainerContractStub::class, function ($obj, $app) use ($container) {
+            $this->assertInstanceOf(IContainerContractStub::class, $obj);
+            $this->assertInstanceOf(ContainerImplementationStubTwo::class, $obj);
+            $this->assertSame($container, $app);
+        });
+
+        $container->afterResolving(function ($obj, $app) use ($container) {
+            $this->assertInstanceOf(IContainerContractStub::class, $obj);
+            $this->assertInstanceOf(ContainerImplementationStubTwo::class, $obj);
+            $this->assertSame($container, $app);
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStubTwo::class);
+        $container->make(IContainerContractStub::class);
+    }
+
+    public function testResolvingCallbacksAreCallWhenRebindHappenForResolvedAbstract()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStubTwo::class);
+        $this->assertEquals(2, $callCounter);
+
+        $container->make(ContainerImplementationStubTwo::class);
+        $this->assertEquals(3, $callCounter);
+
+        $container->bind(IContainerContractStub::class, function () {
+            return new ContainerImplementationStubTwo();
+        });
+        $this->assertEquals(4, $callCounter);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(5, $callCounter);
+    }
+
+    public function testRebindingDoesNotAffectMultipleResolvingCallbacks()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->resolving(ContainerImplementationStubTwo::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        // it should call the callback for interface
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        // it should call the callback for interface
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+
+        // should call the callback for the interface it implements
+        // plus the callback for ContainerImplementationStubTwo.
+        $container->make(ContainerImplementationStubTwo::class);
+        $this->assertEquals(4, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledForInterfaces()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(IContainerContractStub::class);
+
+        $this->assertEquals(1, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledForConcretesWhenAttachedOnInterface()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(ContainerImplementationStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledForConcretesWhenAttachedOnConcretes()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(ContainerImplementationStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledForConcretesWithNoBinding()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(ContainerImplementationStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledForInterFacesWithNoBinding()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
     public function testMakeWithMethodIsAnAliasForMakeMethod()
     {
         $mock = $this->getMockBuilder(Container::class)


### PR DESCRIPTION
Add missing tests for the resolving callbacks on the container
+ bug fix related to multiple calls to resolving callbacks
The issue is described here :
https://github.com/laravel/framework/issues/23699
Also a retry for:
https://github.com/laravel/framework/pull/23701
https://github.com/laravel/framework/pull/23290