### PR TITLE
[5.7] Ignore --seed option for artisan migrate --pretend

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -74,7 +74,7 @@ class MigrateCommand extends BaseCommand
         // Finally, if the "seed" option has been given, we will re-run the database
         // seed task to re-populate the database, which is convenient when adding
         // a migration and a seed at the same time, as it is only this command.
-        if ($this->option('seed')) {
+        if ($this->option('seed') && ! $this->option('pretend')) {
             $this->call('db:seed', ['--force' => true]);
         }
     }


### PR DESCRIPTION
Ignores `--seed` option when running `artisan migrate --pretend`. Otherwise, Laravel tries to seed a potentially empty database.

Fixes #27008.