### PR TITLE
[5.8] Fix array cache store issue.

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -23,7 +23,7 @@ class ArrayStore extends TaggableStore
     {
         $value = $this->storage[$key] ?? null;
 
-        if (is_object($value)) {
+        if (gettype($value) === 'object') {
             return clone $value;
         }
 

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -21,7 +21,13 @@ class ArrayStore extends TaggableStore
      */
     public function get($key)
     {
-        return $this->storage[$key] ?? null;
+        $value = $this->storage[$key] ?? null;
+
+        if (is_object($value)) {
+            return clone $value;
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Cache;
 
 use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\ArrayStore;
+use Illuminate\Support\Collection;
 
 class CacheArrayStoreTest extends TestCase
 {
@@ -89,5 +90,21 @@ class CacheArrayStoreTest extends TestCase
     {
         $store = new ArrayStore;
         $this->assertEmpty($store->getPrefix());
+    }
+
+    public function testGettingBackCachedObjectsByValueNotByReference()
+    {
+        $cacheKey = 'testKey';
+        $store = new ArrayStore;
+        $store->put($cacheKey, new Collection([]), 60);
+
+        $obj1 = $store->get($cacheKey);
+        $obj2 = $store->get($cacheKey);
+
+        $mutatedObj1 = $obj1->push('taylor');
+        $mutatedObj2 = $obj2->push('jeffery');
+
+        $this->assertEquals('taylor', $mutatedObj1->last());
+        $this->assertEquals('jeffery', $mutatedObj2->last());
     }
 }


### PR DESCRIPTION
This fixes https://github.com/laravel/framework/issues/23079 issue.
and a retry for https://github.com/laravel/framework/pull/23082

After all it make more sense because other cache store like redis return back an un-serialized version of the objects, which is not a reference to the original.