### PR TITLE
[5.7] Do not save the url in session if the call is prefetch

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -244,6 +244,17 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Determine if the request is the result of an prefetch call.
+     *
+     * @return bool
+     */
+    public function prefetch()
+    {
+        return strcasecmp($this->server->get('HTTP_X_MOZ'), 'prefetch') === 0 ||
+            strcasecmp($this->headers->get('Purpose'), 'prefetch') === 0;
+    }
+
+    /**
      * Determine if the request is over HTTPS.
      *
      * @return bool

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -154,7 +154,7 @@ class StartSession
      */
     protected function storeCurrentUrl(Request $request, $session)
     {
-        if ($request->method() === 'GET' && $request->route() && ! $request->ajax()) {
+        if ($request->method() === 'GET' && $request->route() && ! $request->ajax() && ! $request->prefetch()) {
             $session->setPreviousUrl($request->fullUrl());
         }
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -223,6 +223,28 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->ajax());
     }
 
+    public function testPrefetchMethod()
+    {
+        $request = Request::create('/', 'GET');
+        $this->assertFalse($request->prefetch());
+
+        $request->server->set('HTTP_X_MOZ', '');
+        $this->assertFalse($request->prefetch());
+        $request->server->set('HTTP_X_MOZ', 'prefetch');
+        $this->assertTrue($request->prefetch());
+        $request->server->set('HTTP_X_MOZ', 'Prefetch');
+        $this->assertTrue($request->prefetch());
+
+        $request->server->remove('HTTP_X_MOZ');
+
+        $request->headers->set('Purpose', '');
+        $this->assertFalse($request->prefetch());
+        $request->headers->set('Purpose', 'prefetch');
+        $this->assertTrue($request->prefetch());
+        $request->headers->set('Purpose', 'Prefetch');
+        $this->assertTrue($request->prefetch());
+    }
+
     public function testPjaxMethod()
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_X_PJAX' => 'true'], '{}');


### PR DESCRIPTION
*Note: This PR is a resubmission of #26996*

## Why ?
I noticed using the new features of `prefetch` that Laravel sessions were working badly.

For example, using this library:  [GoogleChromeLabs/quicklink](https://github.com/GoogleChromeLabs/quicklink), pre-loaded pages modify the session and call the `storeCurrentUrl()` method. Once connected to the site, the `back()` method thus redirects the user to a bad url.

## Solution
To alleviate this problem, I modified the `storeCurrentUrl()` function so that it does not save the current URL if the call is of type `prefetch`.

## Sources
* https://developers.google.com/web/updates/2018/07/nostate-prefetch
* https://medium.com/reloading/preload-prefetch-and-priorities-in-chrome-776165961bbf