### PR TITLE
[5.7] Fix broken db command code

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -47,13 +47,13 @@ class FreshCommand extends Command
 
         $this->info('Dropped all tables successfully.');
 
-        $this->call('migrate', [
+        $this->call('migrate', array_filter([
             '--database' => $database,
             '--path' => $this->input->getOption('path'),
             '--realpath' => $this->input->getOption('realpath'),
             '--force' => true,
             '--step' => $this->option('step'),
-        ]);
+        ]));
 
         if ($this->needsSeeding()) {
             $this->runSeeder($database);
@@ -104,11 +104,11 @@ class FreshCommand extends Command
      */
     protected function runSeeder($database)
     {
-        $this->call('db:seed', [
+        $this->call('db:seed', array_filter([
             '--database' => $database,
             '--class' => $this->option('seeder') ?: 'DatabaseSeeder',
-            '--force' => $this->option('force'),
-        ]);
+            '--force' => true,
+        ]));
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -89,9 +89,9 @@ class MigrateCommand extends BaseCommand
         $this->migrator->setConnection($this->option('database'));
 
         if (! $this->migrator->repositoryExists()) {
-            $this->call(
-                'migrate:install', ['--database' => $this->option('database')]
-            );
+            $this->call('migrate:install', array_filter([
+                '--database' => $this->option('database'),
+            ]));
         }
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -42,28 +42,26 @@ class RefreshCommand extends Command
 
         $path = $this->input->getOption('path');
 
-        $force = $this->input->getOption('force');
-
         // If the "step" option is specified it means we only want to rollback a small
         // number of migrations before migrating again. For example, the user might
         // only rollback and remigrate the latest four migrations instead of all.
         $step = $this->input->getOption('step') ?: 0;
 
         if ($step > 0) {
-            $this->runRollback($database, $path, $step, $force);
+            $this->runRollback($database, $path, $step);
         } else {
-            $this->runReset($database, $path, $force);
+            $this->runReset($database, $path);
         }
 
         // The refresh command is essentially just a brief aggregate of a few other of
         // the migration commands and just provides a convenient wrapper to execute
         // them in succession. We'll also see if we need to re-seed the database.
-        $this->call('migrate', [
+        $this->call('migrate', array_filter([
             '--database' => $database,
             '--path' => $path,
             '--realpath' => $this->input->getOption('realpath'),
-            '--force' => $force,
-        ]);
+            '--force' => true,
+        ]));
 
         if ($this->needsSeeding()) {
             $this->runSeeder($database);
@@ -75,19 +73,18 @@ class RefreshCommand extends Command
      *
      * @param  string  $database
      * @param  string  $path
-     * @param  bool  $step
-     * @param  bool  $force
+     * @param  int  $step
      * @return void
      */
-    protected function runRollback($database, $path, $step, $force)
+    protected function runRollback($database, $path, $step)
     {
-        $this->call('migrate:rollback', [
+        $this->call('migrate:rollback', array_filter([
             '--database' => $database,
             '--path' => $path,
             '--realpath' => $this->input->getOption('realpath'),
             '--step' => $step,
-            '--force' => $force,
-        ]);
+            '--force' => true,
+        ]));
     }
 
     /**
@@ -95,17 +92,16 @@ class RefreshCommand extends Command
      *
      * @param  string  $database
      * @param  string  $path
-     * @param  bool  $force
      * @return void
      */
-    protected function runReset($database, $path, $force)
+    protected function runReset($database, $path)
     {
-        $this->call('migrate:reset', [
+        $this->call('migrate:reset', array_filter([
             '--database' => $database,
             '--path' => $path,
             '--realpath' => $this->input->getOption('realpath'),
-            '--force' => $force,
-        ]);
+            '--force' => true,
+        ]));
     }
 
     /**
@@ -126,11 +122,11 @@ class RefreshCommand extends Command
      */
     protected function runSeeder($database)
     {
-        $this->call('db:seed', [
+        $this->call('db:seed', array_filter([
             '--database' => $database,
             '--class' => $this->option('seeder') ?: 'DatabaseSeeder',
-            '--force' => $this->option('force'),
-        ]);
+            '--force' => true,
+        ]));
     }
 
     /**

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -45,7 +45,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
         $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(false);
-        $command->expects($this->once())->method('call')->with($this->equalTo('migrate:install'), $this->equalTo(['--database' => null]));
+        $command->expects($this->once())->method('call')->with($this->equalTo('migrate:install'), $this->equalTo([]));
 
         $this->runCommand($command);
     }

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -38,8 +38,8 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
         $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
 
         $quote = DIRECTORY_SEPARATOR == '\\' ? '"' : "'";
-        $resetCommand->shouldReceive('run')->with(new InputMatcher("--database --path --realpath --force {$quote}migrate:reset{$quote}"), m::any());
-        $migrateCommand->shouldReceive('run')->with(new InputMatcher('--database --path --realpath --force migrate'), m::any());
+        $resetCommand->shouldReceive('run')->with(new InputMatcher("--force=1 {$quote}migrate:reset{$quote}"), m::any());
+        $migrateCommand->shouldReceive('run')->with(new InputMatcher('--force=1 migrate'), m::any());
 
         $this->runCommand($command);
     }
@@ -61,8 +61,8 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
         $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
 
         $quote = DIRECTORY_SEPARATOR == '\\' ? '"' : "'";
-        $rollbackCommand->shouldReceive('run')->with(new InputMatcher("--database --path --realpath --step=2 --force {$quote}migrate:rollback{$quote}"), m::any());
-        $migrateCommand->shouldReceive('run')->with(new InputMatcher('--database --path --realpath --force migrate'), m::any());
+        $rollbackCommand->shouldReceive('run')->with(new InputMatcher("--step=2 --force=1 {$quote}migrate:rollback{$quote}"), m::any());
+        $migrateCommand->shouldReceive('run')->with(new InputMatcher('--force=1 migrate'), m::any());
 
         $this->runCommand($command, ['--step' => 2]);
     }


### PR DESCRIPTION
We can see by the changes to the tests that when force was set to false, `--false` was still actually being added!!! But, we do want all sub-commands to be forced though, actually, so we should just pass `true` to avoid confusion, because it otherwise looks like the user would have been asked again if they want to continue for subcommands, when they are not!

The other change is to filter out the defaults, so the empty string is not passed along for no reason.