### PR TITLE
[5.8] Simplify code Arr::wrap()

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -617,10 +617,6 @@ class Arr
      */
     public static function wrap($value)
     {
-        if (is_null($value)) {
-            return [];
-        }
-
-        return is_array($value) ? $value : [$value];
+        return is_object($value) ? [$value] : (array) $value;
     }
 }


### PR DESCRIPTION
Simplifies the code a little bit.

Let me mention that according to official docs of php :

> [7.2.0] is_object() now returns TRUE for unserialized objects without a class definition (class of __PHP_Incomplete_Class). Previously FALSE was returned.
--

But we do not have to worry about those edge cases, since `unserialized objects without a class definition` can only happen when `spl_auto_loader` is not used.
In other words, in presence of the composer autoloader that can never bite us.

https://stackoverflow.com/questions/6574984/php-problem-with-php-incomplete-class

so we can just pretend that `is_object()` behaves consistently between `php7.1` and `php7.2`