### PR TITLE
[5.7] Accept Models in assertDatabaseHas and assertDatabaseMissing

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -13,13 +13,17 @@ trait InteractsWithDatabase
     /**
      * Assert that a given where condition exists in the database.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Database\Eloquent\Model  $table
      * @param  array  $data
      * @param  string  $connection
      * @return $this
      */
     protected function assertDatabaseHas($table, array $data, $connection = null)
     {
+        if ($table instanceof Model) {
+            return $this->assertDatabaseHas($table->getTable(), [$table->getKeyName() => $table->getKey()], $table->getConnectionName());
+        }
+
         $this->assertThat(
             $table, new HasInDatabase($this->getConnection($connection), $data)
         );
@@ -30,13 +34,17 @@ trait InteractsWithDatabase
     /**
      * Assert that a given where condition does not exist in the database.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Database\Eloquent\Model  $table
      * @param  array  $data
      * @param  string  $connection
      * @return $this
      */
     protected function assertDatabaseMissing($table, array $data, $connection = null)
     {
+        if ($table instanceof Model) {
+            return $this->assertDatabaseMissing($table->getTable(), [$table->getKeyName() => $table->getKey()], $table->getConnectionName());
+        }
+
         $constraint = new ReverseConstraint(
             new HasInDatabase($this->getConnection($connection), $data)
         );


### PR DESCRIPTION
## Description
Minor feature, alternative to #27006.
You can pass `Model` to `assertDatabaseHas` and `assertDatabaseMissing` methods like in `assertSoftDeleted`.

## Usage example
```php
public function testForceDeletePostByAuthor()
{
    $post = App\Post::all()->random();
    $this->actingAs($post->user);
    
    $this->json('DELETE', "/api/post/$post->id")
        ->assertSuccessful();
    
    $this->assertDatabaseMissing($post);
}

public function testForceDeletePostByGuest()
{
    $post = App\Post::all()->random();

    $this->json('DELETE', "/api/post/$post->id")
        ->assertStatus(403);
    
    $this->assertDatabaseHas($post);
}
```