### PR TITLE
[5.8] Fix qualified UPDATED_AT timestamps

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -853,7 +853,8 @@ class Builder
      */
     protected function addUpdatedAtColumn(array $values)
     {
-        if (! $this->model->usesTimestamps() || is_null($this->model->getUpdatedAtColumn())) {
+        if (! $this->model->usesTimestamps() || 
+            is_null($this->model->getUpdatedAtColumn())) {
             return $values;
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -853,7 +853,7 @@ class Builder
      */
     protected function addUpdatedAtColumn(array $values)
     {
-        if (! $this->model->usesTimestamps()) {
+        if (! $this->model->usesTimestamps() || is_null($this->model->getUpdatedAtColumn())) {
             return $values;
         }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1101,8 +1101,20 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->update(['foo' => 'bar', 'updated_at' => null]);
         $this->assertEquals(1, $result);
+    }
 
-        Carbon::setTestNow(null);
+    public function testUpdateWithoutTimestamp()
+    {
+        $query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));
+        $builder = new Builder($query);
+        $model = new EloquentBuilderTestStubWithoutTimestamp;
+        $this->mockConnectionForModel($model, '');
+        $builder->setModel($model);
+        $builder->getConnection()->shouldReceive('update')->once()
+            ->with('update "table" set "foo" = ?', ['bar'])->andReturn(1);
+
+        $result = $builder->update(['foo' => 'bar']);
+        $this->assertEquals(1, $result);
     }
 
     protected function mockConnectionForModel($model, $database)
@@ -1264,4 +1276,11 @@ class EloquentBuilderTestModelSelfRelatedStub extends Model
     {
         return $this->hasMany(EloquentBuilderTestModelFarRelatedStub::class, 'foreign_key', 'id', 'bar');
     }
+}
+
+class EloquentBuilderTestStubWithoutTimestamp extends Model
+{
+    const UPDATED_AT = null;
+
+    protected $table = 'table';
 }


### PR DESCRIPTION
#26031 qualified `UPDATED_AT` timestamps to fix ambiguity issues.

This broke queries on models without an `UPDATED_AT` timestamp:

```php
class User extends Model {
    public $timestamps = true;

    const UPDATED_AT = null;
}

User::query()->update(['name' => 'foo']);
```

```sql
update `users` set `name` = ?, `users`.`` = ?
                                       ^
```

Before, this case has been handled by [`Arr::add()` ](https://github.com/laravel/framework/pull/26031/files#diff-668bf88875179a4d26f558794a587abf). Now, we have to take care of it ourselves.