### PR TITLE
[5.7] Remove duplicate code

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -311,21 +311,6 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
-     * Perform an update on all the related models.
-     *
-     * @param  array  $attributes
-     * @return int
-     */
-    public function update(array $attributes)
-    {
-        if ($this->related->usesTimestamps() && ! is_null($this->relatedUpdatedAt())) {
-            $attributes[$this->relatedUpdatedAt()] = $this->related->freshTimestampString();
-        }
-
-        return $this->query->update($attributes);
-    }
-
-    /**
      * Add the constraints for a relationship query.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -163,27 +163,6 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->updateOrCreate(['foo'], ['bar']));
     }
 
-    public function testUpdateMethodUpdatesModelsWithTimestamps()
-    {
-        $relation = $this->getRelation();
-        $relation->getRelated()->shouldReceive('usesTimestamps')->once()->andReturn(true);
-        $relation->getRelated()->shouldReceive('freshTimestampString')->once()->andReturn(100);
-        $relation->getRelated()->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-        $relation->getQuery()->shouldReceive('update')->once()->with(['foo' => 'bar', 'updated_at' => 100])->andReturn('results');
-
-        $this->assertEquals('results', $relation->update(['foo' => 'bar']));
-    }
-
-    public function testUpdateMethodUpdatesModelsWithNullUpdatedAt()
-    {
-        $relation = $this->getRelation();
-        $relation->getRelated()->shouldReceive('usesTimestamps')->once()->andReturn(true);
-        $relation->getRelated()->shouldReceive('getUpdatedAtColumn')->andReturn(null);
-        $relation->getQuery()->shouldReceive('update')->once()->with(['foo' => 'bar'])->andReturn('results');
-
-        $this->assertEquals('results', $relation->update(['foo' => 'bar']));
-    }
-
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -129,27 +129,6 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertEquals($created, $relation->create(['name' => 'taylor']));
     }
 
-    public function testUpdateMethodUpdatesModelsWithTimestamps()
-    {
-        $relation = $this->getRelation();
-        $relation->getRelated()->shouldReceive('usesTimestamps')->once()->andReturn(true);
-        $relation->getRelated()->shouldReceive('freshTimestampString')->once()->andReturn(100);
-        $relation->getRelated()->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-        $relation->getQuery()->shouldReceive('update')->once()->with(['foo' => 'bar', 'updated_at' => 100])->andReturn('results');
-
-        $this->assertEquals('results', $relation->update(['foo' => 'bar']));
-    }
-
-    public function testUpdateMethodUpdatesModelsWithNullUpdatedAt()
-    {
-        $relation = $this->getRelation();
-        $relation->getRelated()->shouldReceive('usesTimestamps')->once()->andReturn(true);
-        $relation->getRelated()->shouldReceive('getUpdatedAtColumn')->andReturn(null);
-        $relation->getQuery()->shouldReceive('update')->once()->with(['foo' => 'bar'])->andReturn('results');
-
-        $this->assertEquals('results', $relation->update(['foo' => 'bar']));
-    }
-
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();


### PR DESCRIPTION
We don't need `HasOneOrMany::update()`, `Builder::update()` already adds the `UPDATED_AT` timestamp.

The tests expect the `update()` method in the `HasOneOrMany` class, so we have to remove them.