### PR TITLE
[5.7] Add whereNotBetween method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -691,6 +691,20 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Filter items where the given key not between values.
+     *
+     * @param  string  $key
+     * @param  array  $values
+     * @return static
+     */
+    public function whereNotBetween($key, $values)
+    {
+        return $this->filter(function ($item) use ($key, $values) {
+            return data_get($item, $key) < reset($values) || data_get($item, $key) > end($values);
+        });
+    }
+
+    /**
      * Filter items by the given key value pair.
      *
      * @param  string  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -553,6 +553,15 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([['v' => 3], ['v' => '3']], $c->whereBetween('v', [3, 3])->values()->all());
     }
 
+    public function testWhereNotBetween()
+    {
+        $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
+
+        $this->assertEquals([['v' => 1]], $c->whereNotBetween('v', [2, 4])->values()->all());
+        $this->assertEquals([['v' => 2], ['v' => 3], ['v' => 3], ['v' => 4] ], $c->whereNotBetween('v', [-1, 1])->values()->all());
+        $this->assertEquals([['v' => 1], ['v' => '2'], ['v' => '4']], $c->whereNotBetween('v', [3, 3])->values()->all());
+    }
+
     public function testFlatten()
     {
         // Flat arrays are unaffected

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -558,7 +558,7 @@ class SupportCollectionTest extends TestCase
         $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
 
         $this->assertEquals([['v' => 1]], $c->whereNotBetween('v', [2, 4])->values()->all());
-        $this->assertEquals([['v' => 2], ['v' => 3], ['v' => 3], ['v' => 4] ], $c->whereNotBetween('v', [-1, 1])->values()->all());
+        $this->assertEquals([['v' => 2], ['v' => 3], ['v' => 3], ['v' => 4]], $c->whereNotBetween('v', [-1, 1])->values()->all());
         $this->assertEquals([['v' => 1], ['v' => '2'], ['v' => '4']], $c->whereNotBetween('v', [3, 3])->values()->all());
     }
 


### PR DESCRIPTION
this **PR** adds **whereNotBetween** to collection object , since we have **whenEmpty** & **whenNotEmpty** , **whereIn** & **whereNotIn** , i thought that **whereNotBetween** method should be added to collection object as a convention 

```php
$collection = collect([
    ['product' => 'Pencil', 'price' => 30],
    ['product' => 'Chair', 'price' => 80],
    ['product' => 'Door', 'price' => 100],
    ['product' => 'Bookcase', 'price' => 150],
   ['product' => 'Desk', 'price' => 200],
]);

$filtered = $collection->whereNotBetween('price', [100, 200]);

$filtered->all();

/*
    [
        ['product' => 'Bookcase', 'price' => 30],
        ['product' => 'Bookcase', 'price' => 80],
    ]
*/
```