### PR TITLE
[5.8] Add InvalidArgumentException For orderBy() in Illuminate\Database\Query\Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1792,13 +1792,14 @@ class Builder
      */
     public function orderBy($column, $direction = 'asc')
     {
-        if (! in_array(strtolower($direction), ['asc', 'desc'], true)) {
+        $direction = strtolower($direction);
+        if (! in_array($direction, ['asc', 'desc'], true)) {
             throw new InvalidArgumentException('Invalid value of direction.');
         }
 
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
             'column' => $column,
-            'direction' => strtolower($direction),
+            'direction' => $direction,
         ];
 
         return $this;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1798,7 +1798,7 @@ class Builder
 
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
             'column' => $column,
-            'direction' => strtolower($direction) === 'asc' ? 'asc' : 'desc',
+            'direction' => strtolower($direction),
         ];
 
         return $this;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1787,9 +1787,15 @@ class Builder
      * @param  string  $column
      * @param  string  $direction
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function orderBy($column, $direction = 'asc')
     {
+        if (!in_array(strtolower($direction), ['asc', 'desc'], true)) {
+            throw new InvalidArgumentException('Invalid value of direction.');
+        }
+
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
             'column' => $column,
             'direction' => strtolower($direction) === 'asc' ? 'asc' : 'desc',

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1792,7 +1792,7 @@ class Builder
      */
     public function orderBy($column, $direction = 'asc')
     {
-        if (!in_array(strtolower($direction), ['asc', 'desc'], true)) {
+        if (! in_array(strtolower($direction), ['asc', 'desc'], true)) {
             throw new InvalidArgumentException('Invalid value of direction.');
         }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -982,6 +982,15 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" order by "name" desc', $builder->toSql());
     }
 
+    public function testOrderByInvalidDirectionParam()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid value of direction.');
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('age', 'asec');
+    }
+
     public function testHavings()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR is related to [laravel/ideas#1434](https://github.com/laravel/ideas/issues/1434)

I add ```InvalidArgumentException``` For ```orderBy()``` in Illuminate\Database\Query\Builder because this prevents the bug of direction making unintentionally.
For example, if ```orderBy('id', 'aesc')``` executes...

Before: means ```orderBy('id', 'desc')```.
After: throws ```InvalidArgumentException```.



