### PR TITLE
[5.7] Fix nullable MorphTo touching

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -217,7 +217,7 @@ class MorphTo extends BelongsTo
      */
     public function touch()
     {
-        if (! is_null($this->ownerKey)) {
+        if (! is_null($this->child->{$this->foreignKey})) {
             parent::touch();
         }
     }

--- a/tests/Integration/Database/EloquentMorphToTouchesTest.php
+++ b/tests/Integration/Database/EloquentMorphToTouchesTest.php
@@ -59,7 +59,7 @@ class Comment extends Model
 
     public function commentable()
     {
-        return $this->morphTo();
+        return $this->morphTo(null, null, null, 'id');
     }
 }
 


### PR DESCRIPTION
`MorphTo` has its own `touch()` implementation to handle nullable related models:

```php
Schema::create('comments', function ($table) {
    $table->increments('id');
    $table->nullableMorphs('commentable');
});

class Comment extends Model {
    protected $touches = ['commentable'];

    public function commentable() {
        return $this->morphTo();
    }
}

Comment::create();
```

However, this doesn't cover relationships with a custom `$ownerKey`:

```php
class Comment extends Model {
    protected $touches = ['commentable'];

    public function commentable() {
        return $this->morphTo(null, null, null, 'id');
    }
}
```

We have to check the actual parent key instead of the `$ownerKey`.
