### PR TITLE
[5.7] Fix loadMissing() with duplicate relation names

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -118,10 +118,14 @@ class Collection extends BaseCollection implements QueueableCollection
                 $segments[count($segments) - 1] .= ':'.explode(':', $key)[1];
             }
 
-            $path = array_combine($segments, $segments);
+            $path = [];
+
+            foreach ($segments as $segment) {
+                $path[] = [$segment => $segment];
+            }
 
             if (is_callable($value)) {
-                $path[end($segments)] = $value;
+                $path[count($segments) - 1][end($segments)] = $value;
             }
 
             $this->loadMissingRelation($this, $path);
@@ -139,7 +143,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     protected function loadMissingRelation(Collection $models, array $path)
     {
-        $relation = array_splice($path, 0, 1);
+        $relation = array_shift($path);
 
         $name = explode(':', key($relation))[0];
 

--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -43,6 +43,7 @@ class EloquentCollectionLoadMissingTest extends DatabaseTestCase
 
         Comment::create(['parent_id' => null, 'post_id' => 1]);
         Comment::create(['parent_id' => 1, 'post_id' => 1]);
+        Comment::create(['parent_id' => 2, 'post_id' => 1]);
 
         Revision::create(['comment_id' => 1]);
     }
@@ -74,6 +75,19 @@ class EloquentCollectionLoadMissingTest extends DatabaseTestCase
         $this->assertCount(1, DB::getQueryLog());
         $this->assertTrue($posts[0]->comments[0]->relationLoaded('parent'));
         $this->assertArrayNotHasKey('post_id', $posts[0]->comments[1]->parent->getAttributes());
+    }
+
+    public function testLoadMissingWithDuplicateRelationName()
+    {
+        $posts = Post::with('comments')->get();
+
+        DB::enableQueryLog();
+
+        $posts->loadMissing('comments.parent.parent');
+
+        $this->assertCount(2, DB::getQueryLog());
+        $this->assertTrue($posts[0]->comments[0]->relationLoaded('parent'));
+        $this->assertTrue($posts[0]->comments[1]->parent->relationLoaded('parent'));
     }
 }
 


### PR DESCRIPTION
`loadMissing()` doesn't work with duplicate relationship names:

```php
$posts = Post::with('comments')->get();
$posts->loadMissing('comments.parent.parent');
                                     ^^^^^^
```

This is caused by the structure of the internal `$path` array:

```php
// before
array:2 [
  "comments" => "comments"
  "parent" => "parent"
]

// now
array:3 [
  0 => array:1 [
    "comments" => "comments"
  ]
  1 => array:1 [
    "parent" => "parent"
  ]
  2 => array:1 [
    "parent" => "parent"
  ]
]
```

Fixes #27039.