### PR TITLE
Make `build()` method mandatory in mailables

### DIFF
--- a/src/Illuminate/Contracts/Mail/Mailable.php
+++ b/src/Illuminate/Contracts/Mail/Mailable.php
@@ -30,4 +30,9 @@ interface Mailable
      * @return mixed
      */
     public function later($delay, Queue $queue);
+
+    /**
+     * @return Mailable
+     */
+    public function build();
 }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -16,7 +16,7 @@ use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 
-class Mailable implements MailableContract, Renderable
+abstract class Mailable implements MailableContract, Renderable
 {
     use ForwardsCalls, Localizable;
 
@@ -842,4 +842,9 @@ class Mailable implements MailableContract, Renderable
 
         static::throwBadMethodCallException($method);
     }
+
+    /**
+     * @return MailableContract
+     */
+    abstract public function build(): MailableContract;
 }


### PR DESCRIPTION
- extend `Illuminate\Contracts\Mail\Mailable` by adding `build()` method
- declare `Illuminate\Mail\Mailable` abstract and declare abstract
method `build()`
