### PR TITLE
[5.7] Allow various callable syntax for actions

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -428,14 +428,16 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Format the given controller action.
      *
-     * @param  string|array  $action
+     * @param  string|callable  $action
      * @return string
      */
     protected function formatAction($action)
     {
-        if (is_array($action)) {
-            $action = '\\'.implode('@', $action);
+        if (is_callable($action, true, $action)) {
+            // convert $action callback into a tuple notation (example: "someClass::someMethod")
         }
+
+        $action = str_replace('::', '@', $action);
 
         if ($this->rootNamespace && strpos($action, '\\') !== 0) {
             return $this->rootNamespace.'\\'.$action;

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Routing;
 
 use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
 use Illuminate\Routing\Route;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -226,6 +227,12 @@ class RoutingUrlGeneratorTest extends TestCase
         $routes->add($route);
 
         /*
+         * Controller class instance
+         */
+        $route = new Route(['GET'], 'foo/controller-class', ['controller' => FooControllerStub::class.'@index']);
+        $routes->add($route);
+
+        /*
          * With Default Parameter
          */
         $url->defaults(['locale' => 'en']);
@@ -248,6 +255,9 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('http://www.foo.com/foo/bam', $url->action('foo@bar'));
         $this->assertEquals('http://www.foo.com/foo/bam', $url->action(['foo', 'bar']));
         $this->assertEquals('http://www.foo.com/foo/invoke', $url->action('InvokableActionStub'));
+        $this->assertEquals('http://www.foo.com/foo/controller-class', $url->action([FooControllerStub::class, 'index']));
+        $this->assertEquals('http://www.foo.com/foo/controller-class', $url->action([new FooControllerStub, 'index']));
+        $this->assertEquals('http://www.foo.com/foo/controller-class', $url->action(FooControllerStub::class.'::index'));
         $this->assertEquals('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['wall', 'woz', 'boom' => 'otwell', 'baz' => 'taylor']));
         $this->assertEquals('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['taylor', 'otwell', 'wall', 'woz']));
         $this->assertEquals('http://www.foo.com/foo/bar/%C3%A5%CE%B1%D1%84/%C3%A5%CE%B1%D1%84', $url->route('foobarbaz', ['baz' => 'åαф']));
@@ -641,5 +651,12 @@ class InvokableActionStub
     public function __invoke()
     {
         return 'hello';
+    }
+}
+
+class FooControllerStub extends Controller
+{
+    public function index()
+    {
     }
 }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Tests\Routing;
 
 use Illuminate\Http\Request;
-use Illuminate\Routing\Controller;
 use Illuminate\Routing\Route;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Routing\Controller;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Contracts\Routing\UrlRoutable;


### PR DESCRIPTION
it allows to use the following native PHP callable syntax:
```php
action([new SomeController, 'someAction'])
action('\App\Http\Controllers\SomeController::someAction')
```

Previously added by #24738 syntax is also supported:
```php
action([SomeController::class, 'someAction'])
```

as well as original Laravel syntax:
```php
action('\App\Http\Controllers\SomeController@someAction'])
```

Having this update you can use the following syntax from a controller:
```php
return redirect()->action([$this, 'someAction'])
// what is the same as:
return redirect()->action([self::class, 'someAction'])
```