### PR TITLE
[5.8] Upgrade to dotenv v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/routing": "^4.2",
         "symfony/var-dumper": "^4.2",
         "tijsverkoyen/css-to-inline-styles": "^2.2.1",
-        "vlucas/phpdotenv": "^2.2"
+        "vlucas/phpdotenv": "^3.0"
     },
     "replace": {
         "illuminate/auth": "self.version",

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Bootstrap;
 
 use Dotenv\Dotenv;
 use Dotenv\Exception\InvalidFileException;
-use Dotenv\Exception\InvalidPathException;
 use Symfony\Component\Console\Input\ArgvInput;
 use Illuminate\Contracts\Foundation\Application;
 
@@ -25,9 +24,7 @@ class LoadEnvironmentVariables
         $this->checkForSpecificEnvironmentFile($app);
 
         try {
-            (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
-        } catch (InvalidPathException $e) {
-            //
+            Dotenv::create($app->environmentPath(), $app->environmentFile())->safeLoad();
         } catch (InvalidFileException $e) {
             echo 'The environment file is invalid: '.$e->getMessage();
             die(1);


### PR DESCRIPTION
What's new in dotenv v3 that will affect Laravel? The `safeLoad` method was added in v2.5.0 ([#242](https://github.com/vlucas/phpdotenv/pull/242)), and  first-class support for multiline variables has landed in v3.0.0, so that SSH keys and the like can be pasted as is, without adding pseudo-newline characters ([#301](https://github.com/vlucas/phpdotenv/pull/301)).

Finally, a consequence of the improvements in ([#300](https://github.com/vlucas/phpdotenv/pull/300)) mean that the new way to construct a `Dotenv` object is via it's static `create` method.