### PR TITLE
[5.7] Fixed mail testing with MailFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -295,7 +295,7 @@ class MailFake implements Mailer, MailQueue
         if (method_exists($view, 'build')) {
             $view->build();
         }
-        
+
         $this->mailables[] = $view;
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -292,6 +292,10 @@ class MailFake implements Mailer, MailQueue
             return $this->queue($view, $data);
         }
 
+        if(method_exists($view, 'build')) {
+            $view->build();
+        }
+        
         $this->mailables[] = $view;
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -292,7 +292,7 @@ class MailFake implements Mailer, MailQueue
             return $this->queue($view, $data);
         }
 
-        if(method_exists($view, 'build')) {
+        if (method_exists($view, 'build')) {
             $view->build();
         }
         


### PR DESCRIPTION
Currently mails which use a build method can't be tested easily, because the MailFake class doesn't call the build method on the mail at send.
I've added a call to this method if it's existent, to allow testing such mails without workaround.
Also discussed here: #20056