### PR TITLE
Email verification link expiration has to be configurable

### DIFF
--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -59,7 +59,7 @@ class VerifyEmail extends Notification
     protected function verificationUrl($notifiable)
     {
         return URL::temporarySignedRoute(
-            'verification.verify', Carbon::now()->addMinutes(60), ['id' => $notifiable->getKey()]
+            'verification.verify', Carbon::now()->addMinutes(config('auth.email_verification_expiration', 60)), ['id' => $notifiable->getKey()]
         );
     }
 


### PR DESCRIPTION
Hi,

the email verification link expires in 60 minutes which was hardcoded and can't be configurable.

If PR goes by, we will be able to configure this within the auth config file by adding
````php
// Setting expiration link to 24h after registration

'email_verification_expiration' => 60 * 24

````