### PR TITLE
[5.7] Added a new message for MS SQL support

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -37,6 +37,7 @@ trait DetectsLostConnections
             'Name or service not known',
             'ORA-03114',
             'Packets out of order. Expected',
+            'Adaptive Server connection failed',
         ]);
     }
 }


### PR DESCRIPTION
Added the message, "Adaptive Server connection failed" to support MS SQL Server when using the FreeTDS (pdo_dblib) driver on Mac and Linux due to intermittent DB connection issues.

The benefit is so that for any developer that develops in PHP, but uses MS SQL Server as the RDBMS, intermittent DB connection issues will not exist.

Tests were not needed based on simply adding another message that occurs on Mac and Linux platforms when connecting to MS SQL Server.