### PR TITLE
[5.7] Add original parameters to Route

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -99,6 +99,13 @@ class Route
     public $compiled;
 
     /**
+     * The matched parameters' original state.
+     *
+     * @var array
+     */
+    protected $originalParameters;
+
+    /**
      * The router instance used by the route.
      *
      * @var \Illuminate\Routing\Router
@@ -300,6 +307,8 @@ class Route
         $this->parameters = (new RouteParameterBinder($this))
                         ->parameters($request);
 
+        $this->originalParameters = $this->parameters;
+
         return $this;
     }
 
@@ -341,6 +350,18 @@ class Route
     }
 
     /**
+     * Get original value of a given parameter from the route.
+     *
+     * @param  string  $name
+     * @param  mixed   $default
+     * @return string|object
+     */
+    public function originalParameter($name, $default = null)
+    {
+        return Arr::get($this->originalParameters(), $name, $default);
+    }
+
+    /**
      * Set a parameter to the given value.
      *
      * @param  string  $name
@@ -378,6 +399,22 @@ class Route
     {
         if (isset($this->parameters)) {
             return $this->parameters;
+        }
+
+        throw new LogicException('Route is not bound.');
+    }
+
+    /**
+     * Get the key / value list of original parameters for the route.
+     *
+     * @return array
+     *
+     * @throws \LogicException
+     */
+    public function originalParameters()
+    {
+        if (isset($this->originalParameters)) {
+            return $this->originalParameters;
         }
 
         throw new LogicException('Route is not bound.');

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1061,6 +1061,29 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('prefix', $routes[0]->uri());
     }
 
+    public function testRoutePreservingOriginalParametersState()
+    {
+        $phpunit = $this;
+        $router = $this->getRouter();
+        $router->bind('bar', function ($value) {
+            return strlen($value);
+        });
+        $router->get('foo/{bar}', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function ($bar) use ($router, $phpunit) {
+                $route = $router->getCurrentRoute();
+
+                $phpunit->assertEquals('taylor', $route->originalParameter('bar'));
+                $phpunit->assertEquals('default', $route->originalParameter('unexisting', 'default'));
+                $phpunit->assertEquals(['bar' => 'taylor'], $route->originalParameters());
+
+                return $bar;
+            },
+        ]);
+
+        $this->assertEquals(6, $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
     public function testMergingControllerUses()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
Recently had a need to retrieve original (on-bound) route's parameters values (similar to original attributes values in Eloquent), such feature was requested for some time too. Here is the issue https://github.com/laravel/ideas/issues/1260 where this feature has been requested/discussed previously.

This PR just adds additional field to `Illuminate\Routing\Route` to preserve parameters original state - this field is initialized only once when route is bound and has public getters that mimic already existing methods for parameters field.