### PR TITLE
[5.7] PHPDoc coding style fixes

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -125,7 +125,7 @@ class Gate implements GateContract
      *
      * @param  string  $name
      * @param  string  $class
-     * @param  array|null   $abilities
+     * @param  array|null  $abilities
      * @return $this
      */
     public function resource($name, $class, array $abilities = null)
@@ -333,7 +333,7 @@ class Gate implements GateContract
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @param  \Closure|string|array  $class
-     * @param  string|null $method
+     * @param  string|null  $method
      * @return bool
      */
     protected function canBeCalledWithUser($user, $class, $method = null)

--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -32,7 +32,7 @@ class Login
     /**
      * Create a new event instance.
      *
-     * @param  string $guard
+     * @param  string  $guard
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  bool  $remember
      * @return void

--- a/src/Illuminate/Auth/Events/Logout.php
+++ b/src/Illuminate/Auth/Events/Logout.php
@@ -25,7 +25,7 @@ class Logout
     /**
      * Create a new event instance.
      *
-     * @param  string $guard
+     * @param  string  $guard
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -199,7 +199,7 @@ class PasswordBroker implements PasswordBrokerContract
     /**
      * Create a new password reset token for the given user.
      *
-     * @param  \Illuminate\Contracts\Auth\CanResetPassword $user
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
      * @return string
      */
     public function createToken(CanResetPasswordContract $user)
@@ -210,7 +210,7 @@ class PasswordBroker implements PasswordBrokerContract
     /**
      * Delete password reset tokens of the given user.
      *
-     * @param  \Illuminate\Contracts\Auth\CanResetPassword $user
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
      * @return void
      */
     public function deleteToken(CanResetPasswordContract $user)
@@ -221,8 +221,8 @@ class PasswordBroker implements PasswordBrokerContract
     /**
      * Validate the given password reset token.
      *
-     * @param  \Illuminate\Contracts\Auth\CanResetPassword $user
-     * @param  string $token
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @param  string  $token
      * @return bool
      */
     public function tokenExists(CanResetPasswordContract $user, $token)

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -137,7 +137,7 @@ class PasswordBrokerManager implements FactoryContract
      * Dynamically call the default driver instance.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -30,7 +30,7 @@ class RequestGuard implements Guard
      *
      * @param  callable  $callback
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Contracts\Auth\UserProvider|null $provider
+     * @param  \Illuminate\Contracts\Auth\UserProvider|null  $provider
      * @return void
      */
     public function __construct(callable $callback, Request $request, UserProvider $provider = null)

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -341,7 +341,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * Attempt to authenticate a user using the given credentials.
      *
      * @param  array  $credentials
-     * @param  bool   $remember
+     * @param  bool  $remember
      * @return bool
      */
     public function attempt(array $credentials = [], $remember = false)
@@ -383,7 +383,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * Log the given user ID into the application.
      *
      * @param  mixed  $id
-     * @param  bool   $remember
+     * @param  bool  $remember
      * @return \Illuminate\Contracts\Auth\Authenticatable|false
      */
     public function loginUsingId($id, $remember = false)

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -296,7 +296,7 @@ class BroadcastManager implements FactoryContract
     /**
      * Register a custom driver creator Closure.
      *
-     * @param  string    $driver
+     * @param  string  $driver
      * @param  \Closure  $callback
      * @return $this
      */
@@ -311,7 +311,7 @@ class BroadcastManager implements FactoryContract
      * Dynamically call the default driver instance.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -54,7 +54,7 @@ class ApcStore extends TaggableStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  float|int  $minutes
      * @return void
      */
@@ -67,7 +67,7 @@ class ApcStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function increment($key, $value = 1)
@@ -79,7 +79,7 @@ class ApcStore extends TaggableStore implements Store
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function decrement($key, $value = 1)
@@ -91,7 +91,7 @@ class ApcStore extends TaggableStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/ApcWrapper.php
+++ b/src/Illuminate/Cache/ApcWrapper.php
@@ -36,8 +36,8 @@ class ApcWrapper
      * Store an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $seconds
+     * @param  mixed  $value
+     * @param  int  $seconds
      * @return array|bool
      */
     public function put($key, $value, $seconds)
@@ -49,7 +49,7 @@ class ApcWrapper
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function increment($key, $value)
@@ -61,7 +61,7 @@ class ApcWrapper
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function decrement($key, $value)

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -30,7 +30,7 @@ class ArrayStore extends TaggableStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  float|int  $minutes
      * @return void
      */
@@ -43,7 +43,7 @@ class ArrayStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function increment($key, $value = 1)
@@ -58,7 +58,7 @@ class ArrayStore extends TaggableStore implements Store
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function decrement($key, $value = 1)
@@ -70,7 +70,7 @@ class ArrayStore extends TaggableStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -300,7 +300,7 @@ class CacheManager implements FactoryContract
     /**
      * Register a custom driver creator Closure.
      *
-     * @param  string    $driver
+     * @param  string  $driver
      * @param  \Closure  $callback
      * @return $this
      */
@@ -315,7 +315,7 @@ class CacheManager implements FactoryContract
      * Dynamically call the default driver instance.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -87,7 +87,7 @@ class DatabaseStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  float|int  $minutes
      * @return void
      */
@@ -110,7 +110,7 @@ class DatabaseStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function increment($key, $value = 1)
@@ -124,7 +124,7 @@ class DatabaseStore implements Store
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function decrement($key, $value = 1)
@@ -195,7 +195,7 @@ class DatabaseStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -53,7 +53,7 @@ class FileStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  float|int  $minutes
      * @return void
      */
@@ -83,7 +83,7 @@ class FileStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function increment($key, $value = 1)
@@ -99,7 +99,7 @@ class FileStore implements Store
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function decrement($key, $value = 1)
@@ -111,7 +111,7 @@ class FileStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -44,7 +44,7 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
      * Create a new Memcached store.
      *
      * @param  \Memcached  $memcached
-     * @param  string      $prefix
+     * @param  string  $prefix
      * @return void
      */
     public function __construct($memcached, $prefix = '')
@@ -104,7 +104,7 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  float|int  $minutes
      * @return void
      */
@@ -139,7 +139,7 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
      * Store an item in the cache if the key doesn't exist.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  float|int  $minutes
      * @return bool
      */
@@ -154,7 +154,7 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function increment($key, $value = 1)
@@ -166,7 +166,7 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function decrement($key, $value = 1)
@@ -178,7 +178,7 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -30,7 +30,7 @@ class NullStore extends TaggableStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  float|int  $minutes
      * @return void
      */
@@ -43,7 +43,7 @@ class NullStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function increment($key, $value = 1)
@@ -55,7 +55,7 @@ class NullStore extends TaggableStore implements Store
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function decrement($key, $value = 1)
@@ -67,7 +67,7 @@ class NullStore extends TaggableStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -83,7 +83,7 @@ class RedisStore extends TaggableStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  float|int  $minutes
      * @return void
      */
@@ -116,7 +116,7 @@ class RedisStore extends TaggableStore implements Store
      * Store an item in the cache if the key doesn't exist.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  float|int  $minutes
      * @return bool
      */
@@ -133,7 +133,7 @@ class RedisStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function increment($key, $value = 1)
@@ -145,7 +145,7 @@ class RedisStore extends TaggableStore implements Store
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function decrement($key, $value = 1)
@@ -157,7 +157,7 @@ class RedisStore extends TaggableStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -21,7 +21,7 @@ class RedisTaggedCache extends TaggedCache
      * Store an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  \DateTime|float|int|null  $minutes
      * @return void
      */
@@ -36,7 +36,7 @@ class RedisTaggedCache extends TaggedCache
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function increment($key, $value = 1)
@@ -50,7 +50,7 @@ class RedisTaggedCache extends TaggedCache
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function decrement($key, $value = 1)
@@ -64,7 +64,7 @@ class RedisTaggedCache extends TaggedCache
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -85,7 +85,7 @@ class Repository implements CacheContract, ArrayAccess
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function get($key, $default = null)
@@ -178,7 +178,7 @@ class Repository implements CacheContract, ArrayAccess
      * Retrieve an item from the cache and delete it.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function pull($key, $default = null)
@@ -192,7 +192,7 @@ class Repository implements CacheContract, ArrayAccess
      * Store an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|float|int|null  $minutes
      * @return void
      */
@@ -249,7 +249,7 @@ class Repository implements CacheContract, ArrayAccess
      * Store an item in the cache if the key does not exist.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
      * @return bool
      */
@@ -308,7 +308,7 @@ class Repository implements CacheContract, ArrayAccess
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)
@@ -535,7 +535,7 @@ class Repository implements CacheContract, ArrayAccess
      * Store an item in the cache for the default time.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function offsetSet($key, $value)
@@ -575,7 +575,7 @@ class Repository implements CacheContract, ArrayAccess
      * Handle dynamic calls into macros or pass missing methods to the store.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -33,7 +33,7 @@ class TaggedCache extends Repository
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function increment($key, $value = 1)
@@ -45,7 +45,7 @@ class TaggedCache extends Repository
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function decrement($key, $value = 1)

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -41,7 +41,7 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified configuration value.
      *
      * @param  array|string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function get($key, $default = null)
@@ -78,7 +78,7 @@ class Repository implements ArrayAccess, ConfigContract
      * Set a given configuration value.
      *
      * @param  array|string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function set($key, $value = null)

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -188,7 +188,7 @@ class Command extends SymfonyCommand
      * Call another console command.
      *
      * @param  string  $command
-     * @param  array   $arguments
+     * @param  array  $arguments
      * @return int
      */
     public function call($command, array $arguments = [])
@@ -204,7 +204,7 @@ class Command extends SymfonyCommand
      * Call another console command silently.
      *
      * @param  string  $command
-     * @param  array   $arguments
+     * @param  array  $arguments
      * @return int
      */
     public function callSilent($command, array $arguments = [])
@@ -325,7 +325,7 @@ class Command extends SymfonyCommand
      * Confirm a question with the user.
      *
      * @param  string  $question
-     * @param  bool    $default
+     * @param  bool  $default
      * @return bool
      */
     public function confirm($question, $default = false)
@@ -349,7 +349,7 @@ class Command extends SymfonyCommand
      * Prompt the user for input with auto completion.
      *
      * @param  string  $question
-     * @param  array   $choices
+     * @param  array  $choices
      * @param  string|null  $default
      * @return mixed
      */
@@ -362,7 +362,7 @@ class Command extends SymfonyCommand
      * Prompt the user for input with auto completion.
      *
      * @param  string  $question
-     * @param  array   $choices
+     * @param  array  $choices
      * @param  string|null  $default
      * @return mixed
      */
@@ -379,7 +379,7 @@ class Command extends SymfonyCommand
      * Prompt the user for input but hide the answer from the console.
      *
      * @param  string  $question
-     * @param  bool    $fallback
+     * @param  bool  $fallback
      * @return mixed
      */
     public function secret($question, $fallback = true)
@@ -395,10 +395,10 @@ class Command extends SymfonyCommand
      * Give the user a single choice from an array of answers.
      *
      * @param  string  $question
-     * @param  array   $choices
+     * @param  array  $choices
      * @param  string|null  $default
-     * @param  mixed|null   $attempts
-     * @param  bool|null    $multiple
+     * @param  mixed|null  $attempts
+     * @param  bool|null  $multiple
      * @return string
      */
     public function choice($question, array $choices, $default = null, $attempts = null, $multiple = null)
@@ -413,10 +413,10 @@ class Command extends SymfonyCommand
     /**
      * Format input to textual table.
      *
-     * @param  array   $headers
+     * @param  array  $headers
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $rows
      * @param  string  $tableStyle
-     * @param  array   $columnStyles
+     * @param  array  $columnStyles
      * @return void
      */
     public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [])

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -46,6 +46,7 @@ abstract class GeneratorCommand extends Command
      * Execute the console command.
      *
      * @return bool|null
+     *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
     public function handle()
@@ -153,6 +154,7 @@ abstract class GeneratorCommand extends Command
      *
      * @param  string  $name
      * @return string
+     *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
     protected function buildClass($name)

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -122,7 +122,7 @@ class BoundMethod
     /**
      * Get the proper reflection instance for the given callback.
      *
-     * @param  callable|string $callback
+     * @param  callable|string  $callback
      * @return \ReflectionFunctionAbstract
      *
      * @throws \ReflectionException

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -291,7 +291,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Get the method to be bound in class@method format.
      *
-     * @param  array|string $method
+     * @param  array|string  $method
      * @return string
      */
     protected function parseBindMethod($method)
@@ -358,7 +358,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * "Extend" an abstract type in the container.
      *
-     * @param  string    $abstract
+     * @param  string  $abstract
      * @param  \Closure  $closure
      * @return void
      *
@@ -385,7 +385,7 @@ class Container implements ArrayAccess, ContainerContract
      * Register an existing instance as shared in the container.
      *
      * @param  string  $abstract
-     * @param  mixed   $instance
+     * @param  mixed  $instance
      * @return mixed
      */
     public function instance($abstract, $instance)
@@ -487,7 +487,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Bind a new callback to an abstract's rebind event.
      *
-     * @param  string    $abstract
+     * @param  string  $abstract
      * @param  \Closure  $callback
      * @return mixed
      */
@@ -504,7 +504,7 @@ class Container implements ArrayAccess, ContainerContract
      * Refresh an instance on the given target and method.
      *
      * @param  string  $abstract
-     * @param  mixed   $target
+     * @param  mixed  $target
      * @param  string  $method
      * @return mixed
      */
@@ -690,7 +690,7 @@ class Container implements ArrayAccess, ContainerContract
      * Get the concrete type for a given abstract.
      *
      * @param  string  $abstract
-     * @return mixed   $concrete
+     * @return mixed
      */
     protected function getConcrete($abstract)
     {
@@ -750,7 +750,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Determine if the given concrete is buildable.
      *
-     * @param  mixed   $concrete
+     * @param  mixed  $concrete
      * @param  string  $abstract
      * @return bool
      */
@@ -1004,7 +1004,7 @@ class Container implements ArrayAccess, ContainerContract
      * Fire all of the resolving callbacks.
      *
      * @param  string  $abstract
-     * @param  mixed   $object
+     * @param  mixed  $object
      * @return void
      */
     protected function fireResolvingCallbacks($abstract, $object)
@@ -1022,7 +1022,7 @@ class Container implements ArrayAccess, ContainerContract
      * Fire all of the after resolving callbacks.
      *
      * @param  string  $abstract
-     * @param  mixed   $object
+     * @param  mixed  $object
      * @return void
      */
     protected function fireAfterResolvingCallbacks($abstract, $object)
@@ -1039,8 +1039,7 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  string  $abstract
      * @param  object  $object
-     * @param  array   $callbacksPerType
-     *
+     * @param  array  $callbacksPerType
      * @return array
      */
     protected function getCallbacksForType($abstract, $object, array $callbacksPerType)
@@ -1226,7 +1225,7 @@ class Container implements ArrayAccess, ContainerContract
      * Set the value at a given offset.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function offsetSet($key, $value)
@@ -1262,7 +1261,7 @@ class Container implements ArrayAccess, ContainerContract
      * Dynamically set container services.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function __set($key, $value)

--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -52,7 +52,7 @@ interface PasswordBroker
     /**
      * Reset the password for the given token.
      *
-     * @param  array     $credentials
+     * @param  array  $credentials
      * @param  \Closure  $callback
      * @return mixed
      */

--- a/src/Illuminate/Contracts/Auth/StatefulGuard.php
+++ b/src/Illuminate/Contracts/Auth/StatefulGuard.php
@@ -8,7 +8,7 @@ interface StatefulGuard extends Guard
      * Attempt to authenticate a user using the given credentials.
      *
      * @param  array  $credentials
-     * @param  bool   $remember
+     * @param  bool  $remember
      * @return bool
      */
     public function attempt(array $credentials = [], $remember = false);
@@ -34,7 +34,7 @@ interface StatefulGuard extends Guard
      * Log the given user ID into the application.
      *
      * @param  mixed  $id
-     * @param  bool   $remember
+     * @param  bool  $remember
      * @return \Illuminate\Contracts\Auth\Authenticatable
      */
     public function loginUsingId($id, $remember = false);

--- a/src/Illuminate/Contracts/Auth/UserProvider.php
+++ b/src/Illuminate/Contracts/Auth/UserProvider.php
@@ -15,7 +15,7 @@ interface UserProvider
     /**
      * Retrieve a user by their unique identifier and "remember me" token.
      *
-     * @param  mixed   $identifier
+     * @param  mixed  $identifier
      * @param  string  $token
      * @return \Illuminate\Contracts\Auth\Authenticatable|null
      */

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -19,7 +19,7 @@ interface Repository extends CacheInterface
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function get($key, $default = null);
@@ -28,7 +28,7 @@ interface Repository extends CacheInterface
      * Retrieve an item from the cache and delete it.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function pull($key, $default = null);
@@ -37,7 +37,7 @@ interface Repository extends CacheInterface
      * Store an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
      * @return void
      */
@@ -47,7 +47,7 @@ interface Repository extends CacheInterface
      * Store an item in the cache if the key does not exist.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
      * @return bool
      */
@@ -75,7 +75,7 @@ interface Repository extends CacheInterface
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value);
@@ -111,7 +111,7 @@ interface Repository extends CacheInterface
     /**
      * Remove an item from the cache.
      *
-     * @param  string $key
+     * @param  string  $key
      * @return bool
      */
     public function forget($key);

--- a/src/Illuminate/Contracts/Config/Repository.php
+++ b/src/Illuminate/Contracts/Config/Repository.php
@@ -16,7 +16,7 @@ interface Repository
      * Get the specified configuration value.
      *
      * @param  array|string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function get($key, $default = null);
@@ -32,7 +32,7 @@ interface Repository
      * Set a given configuration value.
      *
      * @param  array|string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function set($key, $value = null);

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -73,7 +73,7 @@ interface Container extends ContainerInterface
     /**
      * "Extend" an abstract type in the container.
      *
-     * @param  string    $abstract
+     * @param  string  $abstract
      * @param  \Closure  $closure
      * @return void
      *
@@ -85,7 +85,7 @@ interface Container extends ContainerInterface
      * Register an existing instance as shared in the container.
      *
      * @param  string  $abstract
-     * @param  mixed   $instance
+     * @param  mixed  $instance
      * @return mixed
      */
     public function instance($abstract, $instance);
@@ -128,7 +128,7 @@ interface Container extends ContainerInterface
     /**
      * Determine if the given abstract type has been resolved.
      *
-     * @param  string $abstract
+     * @param  string  $abstract
      * @return bool
      */
     public function resolved($abstract);

--- a/src/Illuminate/Contracts/Cookie/Factory.php
+++ b/src/Illuminate/Contracts/Cookie/Factory.php
@@ -9,12 +9,12 @@ interface Factory
      *
      * @param  string  $name
      * @param  string  $value
-     * @param  int     $minutes
+     * @param  int  $minutes
      * @param  string  $path
      * @param  string  $domain
-     * @param  bool|null    $secure
-     * @param  bool    $httpOnly
-     * @param  bool         $raw
+     * @param  bool|null  $secure
+     * @param  bool  $httpOnly
+     * @param  bool  $raw
      * @param  string|null  $sameSite
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
@@ -27,9 +27,9 @@ interface Factory
      * @param  string  $value
      * @param  string  $path
      * @param  string  $domain
-     * @param  bool|null    $secure
-     * @param  bool    $httpOnly
-     * @param  bool         $raw
+     * @param  bool|null  $secure
+     * @param  bool  $httpOnly
+     * @param  bool  $raw
      * @param  string|null  $sameSite
      * @return \Symfony\Component\HttpFoundation\Cookie
      */

--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -60,7 +60,7 @@ interface Filesystem
      * Write a new file using a stream.
      *
      * @param  string  $path
-     * @param  resource $resource
+     * @param  resource  $resource
      * @param  array  $options
      * @return bool
      *

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -59,7 +59,7 @@ interface Application extends Container
      * Register a service provider with the application.
      *
      * @param  \Illuminate\Support\ServiceProvider|string  $provider
-     * @param  bool   $force
+     * @param  bool  $force
      * @return \Illuminate\Support\ServiceProvider
      */
     public function register($provider, $force = false);

--- a/src/Illuminate/Contracts/Hashing/Hasher.php
+++ b/src/Illuminate/Contracts/Hashing/Hasher.php
@@ -16,7 +16,7 @@ interface Hasher
      * Hash the given value.
      *
      * @param  string  $value
-     * @param  array   $options
+     * @param  array  $options
      * @return string
      */
     public function make($value, array $options = []);
@@ -26,7 +26,7 @@ interface Hasher
      *
      * @param  string  $value
      * @param  string  $hashedValue
-     * @param  array   $options
+     * @param  array  $options
      * @return bool
      */
     public function check($value, $hashedValue, array $options = []);
@@ -35,7 +35,7 @@ interface Hasher
      * Check if the given hash has been hashed using the given options.
      *
      * @param  string  $hashedValue
-     * @param  array   $options
+     * @param  array  $options
      * @return bool
      */
     public function needsRehash($hashedValue, array $options = []);

--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -28,7 +28,7 @@ interface Job
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0);

--- a/src/Illuminate/Contracts/Queue/Queue.php
+++ b/src/Illuminate/Contracts/Queue/Queue.php
@@ -16,7 +16,7 @@ interface Queue
      * Push a new job onto the queue.
      *
      * @param  string|object  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -27,7 +27,7 @@ interface Queue
      *
      * @param  string  $queue
      * @param  string|object  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @return mixed
      */
     public function pushOn($queue, $job, $data = '');
@@ -37,7 +37,7 @@ interface Queue
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = []);
@@ -47,7 +47,7 @@ interface Queue
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string|object  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -59,7 +59,7 @@ interface Queue
      * @param  string  $queue
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string|object  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @return mixed
      */
     public function laterOn($queue, $delay, $job, $data = '');
@@ -67,8 +67,8 @@ interface Queue
     /**
      * Push an array of jobs onto the queue.
      *
-     * @param  array   $jobs
-     * @param  mixed   $data
+     * @param  array  $jobs
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */

--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -73,7 +73,7 @@ interface Registrar
      *
      * @param  string  $name
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function resource($name, $controller, array $options = []);

--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -25,7 +25,7 @@ interface UrlGenerator
      * Generate a secure, absolute URL to the given path.
      *
      * @param  string  $path
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     public function secure($path, $parameters = []);
@@ -34,7 +34,7 @@ interface UrlGenerator
      * Generate the URL to an application asset.
      *
      * @param  string  $path
-     * @param  bool    $secure
+     * @param  bool  $secure
      * @return string
      */
     public function asset($path, $secure = null);
@@ -43,7 +43,7 @@ interface UrlGenerator
      * Get the URL to a named route.
      *
      * @param  string  $name
-     * @param  mixed   $parameters
+     * @param  mixed  $parameters
      * @param  bool  $absolute
      * @return string
      *
@@ -55,8 +55,8 @@ interface UrlGenerator
      * Get the URL to a controller action.
      *
      * @param  string|array  $action
-     * @param  mixed $parameters
-     * @param  bool $absolute
+     * @param  mixed  $parameters
+     * @param  bool  $absolute
      * @return string
      */
     public function action($action, $parameters = [], $absolute = true);

--- a/src/Illuminate/Contracts/Session/Session.php
+++ b/src/Illuminate/Contracts/Session/Session.php
@@ -76,7 +76,7 @@ interface Session
      * Put a key / value pair or array of key / value pairs in the session.
      *
      * @param  string|array  $key
-     * @param  mixed       $value
+     * @param  mixed  $value
      * @return void
      */
     public function put($key, $value = null);

--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -8,7 +8,7 @@ interface Translator
      * Get the translation for a given key.
      *
      * @param  string  $key
-     * @param  array   $replace
+     * @param  array  $replace
      * @param  string  $locale
      * @return mixed
      */
@@ -19,7 +19,7 @@ interface Translator
      *
      * @param  string  $key
      * @param  int|array|\Countable  $number
-     * @param  array   $replace
+     * @param  array  $replace
      * @param  string  $locale
      * @return string
      */

--- a/src/Illuminate/Contracts/Validation/Factory.php
+++ b/src/Illuminate/Contracts/Validation/Factory.php
@@ -28,7 +28,7 @@ interface Factory
     /**
      * Register a custom implicit validator extension.
      *
-     * @param  string   $rule
+     * @param  string  $rule
      * @param  \Closure|string  $extension
      * @param  string  $message
      * @return void
@@ -38,7 +38,7 @@ interface Factory
     /**
      * Register a custom implicit validator message replacer.
      *
-     * @param  string   $rule
+     * @param  string  $rule
      * @param  \Closure|string  $replacer
      * @return void
      */

--- a/src/Illuminate/Contracts/View/Engine.php
+++ b/src/Illuminate/Contracts/View/Engine.php
@@ -8,7 +8,7 @@ interface Engine
      * Get the evaluated contents of the view.
      *
      * @param  string  $path
-     * @param  array   $data
+     * @param  array  $data
      * @return string
      */
     public function get($path, array $data = []);

--- a/src/Illuminate/Contracts/View/View.php
+++ b/src/Illuminate/Contracts/View/View.php
@@ -17,7 +17,7 @@ interface View extends Renderable
      * Add a piece of data to the view.
      *
      * @param  string|array  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return $this
      */
     public function with($key, $value = null);

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -50,14 +50,14 @@ class CookieJar implements JarContract
     /**
      * Create a new cookie instance.
      *
-     * @param  string       $name
-     * @param  string       $value
-     * @param  int          $minutes
-     * @param  string       $path
-     * @param  string       $domain
-     * @param  bool|null    $secure
-     * @param  bool         $httpOnly
-     * @param  bool         $raw
+     * @param  string  $name
+     * @param  string  $value
+     * @param  int  $minutes
+     * @param  string  $path
+     * @param  string  $domain
+     * @param  bool|null  $secure
+     * @param  bool  $httpOnly
+     * @param  bool  $raw
      * @param  string|null  $sameSite
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
@@ -73,13 +73,13 @@ class CookieJar implements JarContract
     /**
      * Create a cookie that lasts "forever" (five years).
      *
-     * @param  string       $name
-     * @param  string       $value
-     * @param  string       $path
-     * @param  string       $domain
-     * @param  bool|null    $secure
-     * @param  bool         $httpOnly
-     * @param  bool         $raw
+     * @param  string  $name
+     * @param  string  $value
+     * @param  string  $path
+     * @param  string  $domain
+     * @param  bool|null  $secure
+     * @param  bool  $httpOnly
+     * @param  bool  $raw
      * @param  string|null  $sameSite
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
@@ -116,7 +116,7 @@ class CookieJar implements JarContract
      * Get a queued cookie instance.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
     public function queued($key, $default = null)
@@ -155,10 +155,10 @@ class CookieJar implements JarContract
     /**
      * Get the path and domain, or the default values.
      *
-     * @param  string    $path
-     * @param  string    $domain
-     * @param  bool|null $secure
-     * @param  string    $sameSite
+     * @param  string  $path
+     * @param  string  $domain
+     * @param  bool|null  $secure
+     * @param  string  $sameSite
      * @return array
      */
     protected function getPathAndDomain($path, $domain, $secure = null, $sameSite = null)
@@ -171,7 +171,7 @@ class CookieJar implements JarContract
      *
      * @param  string  $path
      * @param  string  $domain
-     * @param  bool    $secure
+     * @param  bool  $secure
      * @param  string  $sameSite
      * @return $this
      */

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -162,7 +162,7 @@ class EncryptCookies
     /**
      * Determine whether encryption has been disabled for the given cookie.
      *
-     * @param  string $name
+     * @param  string  $name
      * @return bool
      */
     public function isDisabled($name)

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -111,7 +111,7 @@ class Manager
     /**
      * Register a connection with the manager.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @param  string  $name
      * @return void
      */
@@ -191,7 +191,7 @@ class Manager
      * Dynamically pass methods to the default connection.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public static function __callStatic($method, $parameters)

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -147,8 +147,8 @@ trait BuildsQueries
      * Create a new simple paginator instance.
      *
      * @param  \Illuminate\Support\Collection  $items
-     * @param  int $perPage
-     * @param  int $currentPage
+     * @param  int  $perPage
+     * @param  int  $currentPage
      * @param  array  $options
      * @return \Illuminate\Pagination\Paginator
      */

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -217,7 +217,8 @@ trait ManagesTransactions
     /**
      * Handle an exception from a rollback.
      *
-     * @param \Exception  $e
+     * @param  \Exception  $e
+     * @return void
      *
      * @throws \Exception
      */

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -153,10 +153,10 @@ class Connection implements ConnectionInterface
     /**
      * Create a new database connection instance.
      *
-     * @param  \PDO|\Closure     $pdo
-     * @param  string   $database
-     * @param  string   $tablePrefix
-     * @param  array    $config
+     * @param  \PDO|\Closure  $pdo
+     * @param  string  $database
+     * @param  string  $tablePrefix
+     * @param  array  $config
      * @return void
      */
     public function __construct($pdo, $database = '', $tablePrefix = '', array $config = [])
@@ -281,7 +281,7 @@ class Connection implements ConnectionInterface
      * Run a select statement and return a single result.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @param  bool  $useReadPdo
      * @return mixed
      */
@@ -296,7 +296,7 @@ class Connection implements ConnectionInterface
      * Run a select statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return array
      */
     public function selectFromWriteConnection($query, $bindings = [])
@@ -403,7 +403,7 @@ class Connection implements ConnectionInterface
      * Run an insert statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return bool
      */
     public function insert($query, $bindings = [])
@@ -415,7 +415,7 @@ class Connection implements ConnectionInterface
      * Run an update statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return int
      */
     public function update($query, $bindings = [])
@@ -427,7 +427,7 @@ class Connection implements ConnectionInterface
      * Run a delete statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return int
      */
     public function delete($query, $bindings = [])
@@ -439,7 +439,7 @@ class Connection implements ConnectionInterface
      * Execute an SQL statement and return the boolean result.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return bool
      */
     public function statement($query, $bindings = [])
@@ -463,7 +463,7 @@ class Connection implements ConnectionInterface
      * Run an SQL statement and get the number of rows affected.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return int
      */
     public function affectingStatement($query, $bindings = [])
@@ -563,7 +563,7 @@ class Connection implements ConnectionInterface
     /**
      * Bind values to their parameters in the given statement.
      *
-     * @param  \PDOStatement $statement
+     * @param  \PDOStatement  $statement
      * @param  array  $bindings
      * @return void
      */
@@ -604,8 +604,8 @@ class Connection implements ConnectionInterface
     /**
      * Run a SQL statement and log its execution context.
      *
-     * @param  string    $query
-     * @param  array     $bindings
+     * @param  string  $query
+     * @param  array  $bindings
      * @param  \Closure  $callback
      * @return mixed
      *
@@ -641,8 +641,8 @@ class Connection implements ConnectionInterface
     /**
      * Run a SQL statement.
      *
-     * @param  string    $query
-     * @param  array     $bindings
+     * @param  string  $query
+     * @param  array  $bindings
      * @param  \Closure  $callback
      * @return mixed
      *
@@ -673,7 +673,7 @@ class Connection implements ConnectionInterface
      * Log a query in the connection's query log.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @param  float|null  $time
      * @return void
      */
@@ -689,7 +689,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the elapsed time since a given starting point.
      *
-     * @param  int    $start
+     * @param  int  $start
      * @return float
      */
     protected function getElapsedTime($start)
@@ -723,8 +723,8 @@ class Connection implements ConnectionInterface
      * Handle a query exception that occurred during query execution.
      *
      * @param  \Illuminate\Database\QueryException  $e
-     * @param  string    $query
-     * @param  array     $bindings
+     * @param  string  $query
+     * @param  array  $bindings
      * @param  \Closure  $callback
      * @return mixed
      *

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -26,7 +26,7 @@ interface ConnectionInterface
      * Run a select statement and return a single result.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @param  bool  $useReadPdo
      * @return mixed
      */
@@ -36,7 +36,7 @@ interface ConnectionInterface
      * Run a select statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @param  bool  $useReadPdo
      * @return array
      */
@@ -56,7 +56,7 @@ interface ConnectionInterface
      * Run an insert statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return bool
      */
     public function insert($query, $bindings = []);
@@ -65,7 +65,7 @@ interface ConnectionInterface
      * Run an update statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return int
      */
     public function update($query, $bindings = []);
@@ -74,7 +74,7 @@ interface ConnectionInterface
      * Run a delete statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return int
      */
     public function delete($query, $bindings = []);
@@ -83,7 +83,7 @@ interface ConnectionInterface
      * Execute an SQL statement and return the boolean result.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return bool
      */
     public function statement($query, $bindings = []);
@@ -92,7 +92,7 @@ interface ConnectionInterface
      * Run an SQL statement and get the number of rows affected.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return int
      */
     public function affectingStatement($query, $bindings = []);

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -35,7 +35,7 @@ class ConnectionFactory
     /**
      * Establish a PDO connection based on the configuration.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @param  string  $name
      * @return \Illuminate\Database\Connection
      */
@@ -53,7 +53,7 @@ class ConnectionFactory
     /**
      * Parse and prepare the database configuration.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @param  string  $name
      * @return array
      */
@@ -130,7 +130,7 @@ class ConnectionFactory
     /**
      * Get a read / write level configuration.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @param  string  $type
      * @return array
      */
@@ -254,11 +254,11 @@ class ConnectionFactory
     /**
      * Create a new connection instance.
      *
-     * @param  string   $driver
-     * @param  \PDO|\Closure     $connection
-     * @param  string   $database
-     * @param  string   $prefix
-     * @param  array    $config
+     * @param  string  $driver
+     * @param  \PDO|\Closure  $connection
+     * @param  string  $database
+     * @param  string  $prefix
+     * @param  array  $config
      * @return \Illuminate\Database\Connection
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -29,8 +29,8 @@ class Connector
      * Create a new PDO connection.
      *
      * @param  string  $dsn
-     * @param  array   $config
-     * @param  array   $options
+     * @param  array  $config
+     * @param  array  $options
      * @return \PDO
      *
      * @throws \Exception
@@ -89,7 +89,7 @@ class Connector
      * @param  string  $dsn
      * @param  string  $username
      * @param  string  $password
-     * @param  array   $options
+     * @param  array  $options
      * @return \PDO
      *
      * @throws \Exception

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -87,7 +87,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
      *
      * Chooses socket or host/port based on the 'unix_socket' config value.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @return string
      */
     protected function getDsn(array $config)

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -132,7 +132,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
     /**
      * Create a DSN string from a configuration.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @return string
      */
     protected function getDsn(array $config)

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -35,7 +35,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
     /**
      * Create a DSN string from a configuration.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @return string
      */
     protected function getDsn(array $config)

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -100,7 +100,7 @@ class MigrateMakeCommand extends BaseCommand
      *
      * @param  string  $name
      * @param  string  $table
-     * @param  bool    $create
+     * @param  bool  $create
      * @return string
      */
     protected function writeMigration($name, $table, $create)

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -32,7 +32,7 @@ class StatusCommand extends BaseCommand
     /**
      * Create a new migration rollback command instance.
      *
-     * @param  \Illuminate\Database\Migrations\Migrator $migrator
+     * @param  \Illuminate\Database\Migrations\Migrator  $migrator
      * @return void
      */
     public function __construct(Migrator $migrator)

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -296,7 +296,7 @@ class DatabaseManager implements ConnectionResolverInterface
     /**
      * Register an extension connection resolver.
      *
-     * @param  string    $name
+     * @param  string  $name
      * @param  callable  $resolver
      * @return void
      */
@@ -319,7 +319,7 @@ class DatabaseManager implements ConnectionResolverInterface
      * Dynamically pass methods to the default connection.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -212,8 +212,8 @@ class Builder
      * Add a basic where clause to the query.
      *
      * @param  string|array|\Closure  $column
-     * @param  mixed   $operator
-     * @param  mixed   $value
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @param  string  $boolean
      * @return $this
      */

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -502,7 +502,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Pad collection to the specified length with a value.
      *
      * @param  int  $size
-     * @param  mixed $value
+     * @param  mixed  $value
      * @return \Illuminate\Support\Collection
      */
     public function pad($size, $value)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1138,7 +1138,7 @@ trait HasAttributes
     /**
      * Determine if the new and old values for a given key are equivalent.
      *
-     * @param  string $key
+     * @param  string  $key
      * @param  mixed  $current
      * @return bool
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -43,7 +43,7 @@ trait HasEvents
     /**
      * Register a single observer with the model.
      *
-     * @param  object|string $class
+     * @param  object|string  $class
      * @return void
      */
     protected function registerObserver($class)

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -18,7 +18,7 @@ trait QueriesRelationships
      *
      * @param  string  $relation
      * @param  string  $operator
-     * @param  int     $count
+     * @param  int  $count
      * @param  string  $boolean
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
@@ -65,7 +65,7 @@ trait QueriesRelationships
      *
      * @param  string  $relations
      * @param  string  $operator
-     * @param  int     $count
+     * @param  int  $count
      * @param  string  $boolean
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
@@ -98,7 +98,7 @@ trait QueriesRelationships
      *
      * @param  string  $relation
      * @param  string  $operator
-     * @param  int     $count
+     * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orHas($relation, $operator = '>=', $count = 1)
@@ -136,7 +136,7 @@ trait QueriesRelationships
      * @param  string  $relation
      * @param  \Closure|null  $callback
      * @param  string  $operator
-     * @param  int     $count
+     * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
@@ -147,10 +147,10 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  string    $relation
+     * @param  string  $relation
      * @param  \Closure  $callback
-     * @param  string    $operator
-     * @param  int       $count
+     * @param  string  $operator
+     * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
@@ -173,7 +173,7 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  string    $relation
+     * @param  string  $relation
      * @param  \Closure  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
@@ -282,7 +282,7 @@ trait QueriesRelationships
     /**
      * Add a sub-query count clause to this query.
      *
-     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $operator
      * @param  int  $count
      * @param  string  $boolean

--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -144,7 +144,7 @@ class Factory implements ArrayAccess
      *
      * @param  string  $class
      * @param  callable  $callback
-     * @param  string $name
+     * @param  string  $name
      * @return $this
      */
     public function afterCreating($class, callable $callback, $name = 'default')

--- a/src/Illuminate/Database/Eloquent/JsonEncodingException.php
+++ b/src/Illuminate/Database/Eloquent/JsonEncodingException.php
@@ -23,7 +23,7 @@ class JsonEncodingException extends RuntimeException
      *
      * @param  mixed  $model
      * @param  mixed  $key
-     * @param  string $message
+     * @param  string  $message
      * @return static
      */
     public static function forAttribute($model, $key, $message)

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -144,7 +144,7 @@ class BelongsTo extends Relation
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -160,7 +160,7 @@ class BelongsTo extends Relation
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -220,7 +220,7 @@ class BelongsToMany extends Relation
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -236,7 +236,7 @@ class BelongsToMany extends Relation
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
@@ -320,7 +320,7 @@ class BelongsToMany extends Relation
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  string  $boolean
      * @return $this
      */
@@ -335,9 +335,9 @@ class BelongsToMany extends Relation
      * Set a "where in" clause for a pivot table column.
      *
      * @param  string  $column
-     * @param  mixed   $values
+     * @param  mixed  $values
      * @param  string  $boolean
-     * @param  bool    $not
+     * @param  bool  $not
      * @return $this
      */
     public function wherePivotIn($column, $values, $boolean = 'and', $not = false)
@@ -352,7 +352,7 @@ class BelongsToMany extends Relation
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return $this
      */
     public function orWherePivot($column, $operator = null, $value = null)
@@ -392,7 +392,7 @@ class BelongsToMany extends Relation
      * Set an "or where in" clause for a pivot table column.
      *
      * @param  string  $column
-     * @param  mixed   $values
+     * @param  mixed  $values
      * @return $this
      */
     public function orWherePivotIn($column, $values)
@@ -436,7 +436,7 @@ class BelongsToMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $joining
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return \Illuminate\Database\Eloquent\Model
      */
     public function firstOrCreate(array $attributes, array $joining = [], $touch = true)
@@ -454,7 +454,7 @@ class BelongsToMany extends Relation
      * @param  array  $attributes
      * @param  array  $values
      * @param  array  $joining
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return \Illuminate\Database\Eloquent\Model
      */
     public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
@@ -525,7 +525,7 @@ class BelongsToMany extends Relation
     /**
      * Execute the query and get the first result.
      *
-     * @param  array   $columns
+     * @param  array  $columns
      * @return mixed
      */
     public function first($columns = ['*'])
@@ -840,7 +840,7 @@ class BelongsToMany extends Relation
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  array  $pivotAttributes
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return \Illuminate\Database\Eloquent\Model
      */
     public function save(Model $model, array $pivotAttributes = [], $touch = true)
@@ -875,7 +875,7 @@ class BelongsToMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $joining
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return \Illuminate\Database\Eloquent\Model
      */
     public function create(array $attributes = [], array $joining = [], $touch = true)

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -33,9 +33,9 @@ trait AsPivot
      * Create a new pivot model instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent
-     * @param  array   $attributes
+     * @param  array  $attributes
      * @param  string  $table
-     * @param  bool    $exists
+     * @param  bool  $exists
      * @return static
      */
     public static function fromAttributes(Model $parent, $attributes, $table, $exists = false)
@@ -66,9 +66,9 @@ trait AsPivot
      * Create a new pivot model from raw values returned from a query.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent
-     * @param  array   $attributes
+     * @param  array  $attributes
      * @param  string  $table
-     * @param  bool    $exists
+     * @param  bool  $exists
      * @return static
      */
     public static function fromRawAttributes(Model $parent, $attributes, $table, $exists = false)

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -14,7 +14,7 @@ trait InteractsWithPivotTable
      * Each existing model is detached, and non existing ones are attached.
      *
      * @param  mixed  $ids
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return array
      */
     public function toggle($ids, $touch = true)
@@ -76,7 +76,7 @@ trait InteractsWithPivotTable
      * Sync the intermediate tables with a list of IDs or collection of models.
      *
      * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
-     * @param  bool   $detaching
+     * @param  bool  $detaching
      * @return array
      */
     public function sync($ids, $detaching = true)
@@ -145,7 +145,7 @@ trait InteractsWithPivotTable
      *
      * @param  array  $records
      * @param  array  $current
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return array
      */
     protected function attachNew(array $records, array $current, $touch = true)
@@ -179,7 +179,7 @@ trait InteractsWithPivotTable
      *
      * @param  mixed  $id
      * @param  array  $attributes
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return int
      */
     public function updateExistingPivot($id, array $attributes, $touch = true)
@@ -204,7 +204,7 @@ trait InteractsWithPivotTable
      *
      * @param  mixed  $id
      * @param  array  $attributes
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return void
      */
     public function attach($id, array $attributes = [], $touch = true)
@@ -250,10 +250,10 @@ trait InteractsWithPivotTable
     /**
      * Create a full attachment record payload.
      *
-     * @param  int    $key
+     * @param  int  $key
      * @param  mixed  $value
      * @param  array  $attributes
-     * @param  bool   $hasTimestamps
+     * @param  bool  $hasTimestamps
      * @return array
      */
     protected function formatAttachRecord($key, $value, $attributes, $hasTimestamps)
@@ -283,7 +283,7 @@ trait InteractsWithPivotTable
     /**
      * Create a new pivot attachment record.
      *
-     * @param  int   $id
+     * @param  int  $id
      * @param  bool  $timed
      * @return array
      */
@@ -311,7 +311,7 @@ trait InteractsWithPivotTable
      * Set the creation and update timestamps on an attach record.
      *
      * @param  array  $record
-     * @param  bool   $exists
+     * @param  bool  $exists
      * @return array
      */
     protected function addTimestampsToAttachment(array $record, $exists = false)
@@ -386,7 +386,7 @@ trait InteractsWithPivotTable
      * Create a new pivot model instance.
      *
      * @param  array  $attributes
-     * @param  bool   $exists
+     * @param  bool  $exists
      * @return \Illuminate\Database\Eloquent\Relations\Pivot
      */
     public function newPivot(array $attributes = [], $exists = false)
@@ -529,7 +529,7 @@ trait InteractsWithPivotTable
     /**
      * Cast the given pivot attributes.
      *
-     * @param  array $attributes
+     * @param  array  $attributes
      * @return array
      */
     protected function castAttributes($attributes)
@@ -542,7 +542,7 @@ trait InteractsWithPivotTable
     /**
      * Converts a given value to a given type value.
      *
-     * @param  string $type
+     * @param  string  $type
      * @param  mixed  $value
      * @return mixed
      */

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -21,7 +21,7 @@ class HasMany extends HasOneOrMany
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -37,7 +37,7 @@ class HasMany extends HasOneOrMany
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -156,7 +156,7 @@ class HasManyThrough extends Relation
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -172,7 +172,7 @@ class HasManyThrough extends Relation
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
@@ -249,7 +249,7 @@ class HasManyThrough extends Relation
     /**
      * Execute the query and get the first related model.
      *
-     * @param  array   $columns
+     * @param  array  $columns
      * @return mixed
      */
     public function first($columns = ['*'])

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -27,7 +27,7 @@ class HasOne extends HasOneOrMany
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -91,7 +91,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * Match the eagerly loaded results to their single parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
@@ -104,7 +104,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * Match the eagerly loaded results to their many parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
@@ -117,7 +117,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * Match the eagerly loaded results to their many parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @param  string  $type
@@ -144,7 +144,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * Get the value of a relationship by one or many type.
      *
-     * @param  array   $dictionary
+     * @param  array  $dictionary
      * @param  string  $key
      * @param  string  $type
      * @return mixed

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -21,7 +21,7 @@ class MorphMany extends MorphOneOrMany
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -37,7 +37,7 @@ class MorphMany extends MorphOneOrMany
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -27,7 +27,7 @@ class MorphOne extends MorphOneOrMany
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -43,7 +43,7 @@ class MorphOne extends MorphOneOrMany
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -147,7 +147,7 @@ class MorphTo extends BelongsTo
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
@@ -261,7 +261,7 @@ class MorphTo extends BelongsTo
      * Handle dynamic method calls to the relationship.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -89,7 +89,7 @@ class MorphToMany extends BelongsToMany
     /**
      * Create a new pivot attachment record.
      *
-     * @param  int   $id
+     * @param  int  $id
      * @param  bool  $timed
      * @return array
      */
@@ -129,7 +129,7 @@ class MorphToMany extends BelongsToMany
      * Create a new pivot model instance.
      *
      * @param  array  $attributes
-     * @param  bool   $exists
+     * @param  bool  $exists
      * @return \Illuminate\Database\Eloquent\Relations\Pivot
      */
     public function newPivot(array $attributes = [], $exists = false)

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -111,7 +111,7 @@ abstract class Relation
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -120,7 +120,7 @@ abstract class Relation
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
@@ -203,7 +203,7 @@ abstract class Relation
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  \Illuminate\Database\Eloquent\Builder  $parentQuery
-     * @param  array|mixed $columns
+     * @param  array|mixed  $columns
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
@@ -216,7 +216,7 @@ abstract class Relation
     /**
      * Get all of the primary keys for an array of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $key
      * @return array
      */
@@ -374,7 +374,7 @@ abstract class Relation
      * Handle dynamic method calls to the relationship.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -46,7 +46,7 @@ abstract class Grammar
      * Wrap a value in keyword identifiers.
      *
      * @param  \Illuminate\Database\Query\Expression|string  $value
-     * @param  bool    $prefixAlias
+     * @param  bool  $prefixAlias
      * @return string
      */
     public function wrap($value, $prefixAlias = false)
@@ -121,7 +121,7 @@ abstract class Grammar
     /**
      * Convert an array of column names into a delimited string.
      *
-     * @param  array   $columns
+     * @param  array  $columns
      * @return string
      */
     public function columnize(array $columns)
@@ -132,7 +132,7 @@ abstract class Grammar
     /**
      * Create query parameter place-holders for an array.
      *
-     * @param  array   $values
+     * @param  array  $values
      * @return string
      */
     public function parameterize(array $values)
@@ -143,7 +143,7 @@ abstract class Grammar
     /**
      * Get the appropriate query parameter place-holder for a value.
      *
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return string
      */
     public function parameter($value)

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -40,7 +40,7 @@ class MigrationCreator
      * @param  string  $name
      * @param  string  $path
      * @param  string  $table
-     * @param  bool    $create
+     * @param  bool  $create
      * @return string
      *
      * @throws \Exception
@@ -86,7 +86,7 @@ class MigrationCreator
      * Get the migration stub file.
      *
      * @param  string  $table
-     * @param  bool    $create
+     * @param  bool  $create
      * @return string
      */
     protected function getStub($table, $create)

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -156,8 +156,8 @@ class Migrator
      * Run "up" a migration instance.
      *
      * @param  string  $file
-     * @param  int     $batch
-     * @param  bool    $pretend
+     * @param  int  $batch
+     * @param  bool  $pretend
      * @return void
      */
     protected function runUp($file, $batch, $pretend)
@@ -188,7 +188,7 @@ class Migrator
     /**
      * Rollback the last migration operation.
      *
-     * @param  array|string $paths
+     * @param  array|string  $paths
      * @param  array  $options
      * @return array
      */
@@ -265,7 +265,7 @@ class Migrator
     /**
      * Rolls all of the currently applied migrations back.
      *
-     * @param  array|string $paths
+     * @param  array|string  $paths
      * @param  bool  $pretend
      * @return array
      */
@@ -314,7 +314,7 @@ class Migrator
      *
      * @param  string  $file
      * @param  object  $migration
-     * @param  bool    $pretend
+     * @param  bool  $pretend
      * @return void
      */
     protected function runDown($file, $migration, $pretend)
@@ -439,7 +439,7 @@ class Migrator
     /**
      * Require in all the migration files in a given path.
      *
-     * @param  array   $files
+     * @param  array  $files
      * @return void
      */
     public function requireFiles(array $files)

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -68,7 +68,7 @@ class MySqlConnection extends Connection
     /**
      * Bind values to their parameters in the given statement.
      *
-     * @param  \PDOStatement $statement
+     * @param  \PDOStatement  $statement
      * @param  array  $bindings
      * @return void
      */

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -227,7 +227,7 @@ class Builder
     /**
      * Add a subselect expression to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
      * @param  string  $as
      * @return \Illuminate\Database\Query\Builder|static
      *
@@ -246,7 +246,7 @@ class Builder
      * Add a new "raw" select expression to the query.
      *
      * @param  string  $expression
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function selectRaw($expression, array $bindings = [])
@@ -263,7 +263,7 @@ class Builder
     /**
      * Makes "from" fetch from a subquery.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
      * @param  string  $as
      * @return \Illuminate\Database\Query\Builder|static
      *
@@ -280,7 +280,7 @@ class Builder
      * Add a raw from clause to the query.
      *
      * @param  string  $expression
-     * @param  mixed   $bindings
+     * @param  mixed  $bindings
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function fromRaw($expression, $bindings = [])
@@ -295,7 +295,7 @@ class Builder
     /**
      * Creates a subquery and parse it.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
      * @return array
      */
     protected function createSub($query)
@@ -377,7 +377,7 @@ class Builder
      * @param  string|null  $operator
      * @param  string|null  $second
      * @param  string  $type
-     * @param  bool    $where
+     * @param  bool  $where
      * @return $this
      */
     public function join($table, $first, $operator = null, $second = null, $type = 'inner', $where = false)
@@ -427,13 +427,13 @@ class Builder
     /**
      * Add a subquery join clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
      * @param  string  $as
      * @param  \Closure|string  $first
      * @param  string|null  $operator
      * @param  string|null  $second
      * @param  string  $type
-     * @param  bool    $where
+     * @param  bool  $where
      * @return \Illuminate\Database\Query\Builder|static
      *
      * @throws \InvalidArgumentException
@@ -480,7 +480,7 @@ class Builder
     /**
      * Add a subquery left join to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
      * @param  string  $as
      * @param  string  $first
      * @param  string|null  $operator
@@ -523,7 +523,7 @@ class Builder
     /**
      * Add a subquery right join to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
      * @param  string  $as
      * @param  string  $first
      * @param  string|null  $operator
@@ -558,7 +558,7 @@ class Builder
     /**
      * Get a new join clause.
      *
-     * @param  \Illuminate\Database\Query\Builder $parentQuery
+     * @param  \Illuminate\Database\Query\Builder  $parentQuery
      * @param  string  $type
      * @param  string  $table
      * @return \Illuminate\Database\Query\JoinClause
@@ -588,8 +588,8 @@ class Builder
      * Add a basic where clause to the query.
      *
      * @param  string|array|\Closure  $column
-     * @param  mixed   $operator
-     * @param  mixed   $value
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @param  string  $boolean
      * @return $this
      */
@@ -800,7 +800,7 @@ class Builder
      * Add a raw where clause to the query.
      *
      * @param  string  $sql
-     * @param  mixed   $bindings
+     * @param  mixed  $bindings
      * @param  string  $boolean
      * @return $this
      */
@@ -817,7 +817,7 @@ class Builder
      * Add a raw or where clause to the query.
      *
      * @param  string  $sql
-     * @param  mixed   $bindings
+     * @param  mixed  $bindings
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereRaw($sql, $bindings = [])
@@ -829,9 +829,9 @@ class Builder
      * Add a "where in" clause to the query.
      *
      * @param  string  $column
-     * @param  mixed   $values
+     * @param  mixed  $values
      * @param  string  $boolean
-     * @param  bool    $not
+     * @param  bool  $not
      * @return $this
      */
     public function whereIn($column, $values, $boolean = 'and', $not = false)
@@ -879,7 +879,7 @@ class Builder
      * Add an "or where in" clause to the query.
      *
      * @param  string  $column
-     * @param  mixed   $values
+     * @param  mixed  $values
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereIn($column, $values)
@@ -891,7 +891,7 @@ class Builder
      * Add a "where not in" clause to the query.
      *
      * @param  string  $column
-     * @param  mixed   $values
+     * @param  mixed  $values
      * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
@@ -904,7 +904,7 @@ class Builder
      * Add an "or where not in" clause to the query.
      *
      * @param  string  $column
-     * @param  mixed   $values
+     * @param  mixed  $values
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereNotIn($column, $values)
@@ -915,10 +915,10 @@ class Builder
     /**
      * Add a where in with a sub-select to the query.
      *
-     * @param  string   $column
-     * @param  \Closure $callback
-     * @param  string   $boolean
-     * @param  bool     $not
+     * @param  string  $column
+     * @param  \Closure  $callback
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
      */
     protected function whereInSub($column, Closure $callback, $boolean, $not)
@@ -940,10 +940,10 @@ class Builder
     /**
      * Add an external sub-select to the query.
      *
-     * @param  string   $column
+     * @param  string  $column
      * @param  \Illuminate\Database\Query\Builder|static  $query
-     * @param  string   $boolean
-     * @param  bool     $not
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
      */
     protected function whereInExistingQuery($column, $query, $boolean, $not)
@@ -1001,7 +1001,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string  $boolean
-     * @param  bool    $not
+     * @param  bool  $not
      * @return $this
      */
     public function whereNull($column, $boolean = 'and', $not = false)
@@ -1040,7 +1040,7 @@ class Builder
      * Add a where between statement to the query.
      *
      * @param  string  $column
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
@@ -1060,7 +1060,7 @@ class Builder
      * Add an or where between statement to the query.
      *
      * @param  string  $column
-     * @param  array   $values
+     * @param  array  $values
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereBetween($column, array $values)
@@ -1072,7 +1072,7 @@ class Builder
      * Add a where not between statement to the query.
      *
      * @param  string  $column
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
@@ -1085,7 +1085,7 @@ class Builder
      * Add an or where not between statement to the query.
      *
      * @param  string  $column
-     * @param  array   $values
+     * @param  array  $values
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereNotBetween($column, array $values)
@@ -1147,9 +1147,9 @@ class Builder
      * Add a "where time" statement to the query.
      *
      * @param  string  $column
-     * @param  string   $operator
+     * @param  string  $operator
      * @param  \DateTimeInterface|string  $value
-     * @param  string   $boolean
+     * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function whereTime($column, $operator, $value = null, $boolean = 'and')
@@ -1169,7 +1169,7 @@ class Builder
      * Add an "or where time" statement to the query.
      *
      * @param  string  $column
-     * @param  string   $operator
+     * @param  string  $operator
      * @param  \DateTimeInterface|string  $value
      * @return \Illuminate\Database\Query\Builder|static
      */
@@ -1323,8 +1323,8 @@ class Builder
     /**
      * Add a nested where statement to the query.
      *
-     * @param  \Closure $callback
-     * @param  string   $boolean
+     * @param  \Closure  $callback
+     * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function whereNested(Closure $callback, $boolean = 'and')
@@ -1347,7 +1347,7 @@ class Builder
     /**
      * Add another query builder as a nested where to the query builder.
      *
-     * @param  \Illuminate\Database\Query\Builder|static $query
+     * @param  \Illuminate\Database\Query\Builder|static  $query
      * @param  string  $boolean
      * @return $this
      */
@@ -1367,10 +1367,10 @@ class Builder
     /**
      * Add a full sub-select to the query.
      *
-     * @param  string   $column
-     * @param  string   $operator
-     * @param  \Closure $callback
-     * @param  string   $boolean
+     * @param  string  $column
+     * @param  string  $operator
+     * @param  \Closure  $callback
+     * @param  string  $boolean
      * @return $this
      */
     protected function whereSub($column, $operator, Closure $callback, $boolean)
@@ -1394,9 +1394,9 @@ class Builder
     /**
      * Add an exists clause to the query.
      *
-     * @param  \Closure $callback
-     * @param  string   $boolean
-     * @param  bool     $not
+     * @param  \Closure  $callback
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
      */
     public function whereExists(Closure $callback, $boolean = 'and', $not = false)
@@ -1414,8 +1414,8 @@ class Builder
     /**
      * Add an or exists clause to the query.
      *
-     * @param  \Closure $callback
-     * @param  bool     $not
+     * @param  \Closure  $callback
+     * @param  bool  $not
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereExists(Closure $callback, $not = false)
@@ -1426,8 +1426,8 @@ class Builder
     /**
      * Add a where not exists clause to the query.
      *
-     * @param  \Closure $callback
-     * @param  string   $boolean
+     * @param  \Closure  $callback
+     * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function whereNotExists(Closure $callback, $boolean = 'and')
@@ -1449,7 +1449,7 @@ class Builder
     /**
      * Add an exists clause to the query.
      *
-     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
@@ -1468,9 +1468,9 @@ class Builder
     /**
      * Adds a where condition using row values.
      *
-     * @param  array   $columns
+     * @param  array  $columns
      * @param  string  $operator
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $boolean
      * @return $this
      */
@@ -1492,9 +1492,9 @@ class Builder
     /**
      * Adds a or where condition using row values.
      *
-     * @param  array   $columns
+     * @param  array  $columns
      * @param  string  $operator
-     * @param  array   $values
+     * @param  array  $values
      * @return $this
      */
     public function orWhereRowValues($columns, $operator, $values)
@@ -1652,8 +1652,8 @@ class Builder
      *
      * @param  string  $segment
      * @param  string  $connector
-     * @param  array   $parameters
-     * @param  int     $index
+     * @param  array  $parameters
+     * @param  int  $index
      * @return void
      */
     protected function addDynamic($segment, $connector, $parameters, $index)
@@ -1761,7 +1761,7 @@ class Builder
      * Add a raw having clause to the query.
      *
      * @param  string  $sql
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @param  string  $boolean
      * @return $this
      */
@@ -1780,7 +1780,7 @@ class Builder
      * Add a raw or having clause to the query.
      *
      * @param  string  $sql
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orHavingRaw($sql, array $bindings = [])
@@ -2049,7 +2049,7 @@ class Builder
     /**
      * Execute a query for a single record by ID.
      *
-     * @param  int    $id
+     * @param  int  $id
      * @param  array  $columns
      * @return mixed|static
      */
@@ -2322,8 +2322,8 @@ class Builder
      * Retrieve column values from rows represented as objects.
      *
      * @param  array  $queryResult
-     * @param  string $column
-     * @param  string $key
+     * @param  string  $column
+     * @param  string  $key
      * @return \Illuminate\Support\Collection
      */
     protected function pluckFromObjectColumn($queryResult, $column, $key)
@@ -2347,8 +2347,8 @@ class Builder
      * Retrieve column values from rows represented as arrays.
      *
      * @param  array  $queryResult
-     * @param  string $column
-     * @param  string $key
+     * @param  string  $column
+     * @param  string  $key
      * @return \Illuminate\Support\Collection
      */
     protected function pluckFromArrayColumn($queryResult, $column, $key)
@@ -2485,7 +2485,7 @@ class Builder
      * Execute an aggregate function on the database.
      *
      * @param  string  $function
-     * @param  array   $columns
+     * @param  array  $columns
      * @return mixed
      */
     public function aggregate($function, $columns = ['*'])
@@ -2504,7 +2504,7 @@ class Builder
      * Execute a numeric aggregate function on the database.
      *
      * @param  string  $function
-     * @param  array   $columns
+     * @param  array  $columns
      * @return float|int
      */
     public function numericAggregate($function, $columns = ['*'])
@@ -2806,7 +2806,7 @@ class Builder
     /**
      * Set the bindings on the query builder.
      *
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @param  string  $type
      * @return $this
      *
@@ -2826,7 +2826,7 @@ class Builder
     /**
      * Add a binding to the query.
      *
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  string  $type
      * @return $this
      *
@@ -2949,7 +2949,7 @@ class Builder
      * Handle dynamic method calls into the method.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      *
      * @throws \BadMethodCallException

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -488,8 +488,8 @@ class Grammar extends BaseGrammar
     /**
      * Compile a where condition with a sub-select.
      *
-     * @param  \Illuminate\Database\Query\Builder $query
-     * @param  array   $where
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
      * @return string
      */
     protected function whereSub(Builder $query, $where)
@@ -638,7 +638,7 @@ class Grammar extends BaseGrammar
     /**
      * Compile a single having clause.
      *
-     * @param  array   $having
+     * @param  array  $having
      * @return string
      */
     protected function compileHaving(array $having)
@@ -658,7 +658,7 @@ class Grammar extends BaseGrammar
     /**
      * Compile a basic having clause.
      *
-     * @param  array   $having
+     * @param  array  $having
      * @return string
      */
     protected function compileBasicHaving($having)
@@ -860,7 +860,7 @@ class Grammar extends BaseGrammar
      * Compile an insert and get ID statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $sequence
      * @return string
      */
@@ -1016,7 +1016,7 @@ class Grammar extends BaseGrammar
      * Wrap a value in keyword identifiers.
      *
      * @param  \Illuminate\Database\Query\Expression|string  $value
-     * @param  bool    $prefixAlias
+     * @param  bool  $prefixAlias
      * @return string
      */
     public function wrap($value, $prefixAlias = false)
@@ -1095,7 +1095,7 @@ class Grammar extends BaseGrammar
     /**
      * Concatenate an array of segments, removing empties.
      *
-     * @param  array   $segments
+     * @param  array  $segments
      * @return string
      */
     protected function concatenate($segments)

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -146,7 +146,7 @@ class PostgresGrammar extends Grammar
      * Compile an insert and get ID statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $sequence
      * @return string
      */
@@ -185,7 +185,7 @@ class PostgresGrammar extends Grammar
     /**
      * Compile the columns for the update statement.
      *
-     * @param  array   $values
+     * @param  array  $values
      * @return string
      */
     protected function compileUpdateColumns($values)

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -30,7 +30,7 @@ class JoinClause extends Builder
     /**
      * Create a new join clause instance.
      *
-     * @param  \Illuminate\Database\Query\Builder $parentQuery
+     * @param  \Illuminate\Database\Query\Builder  $parentQuery
      * @param  string  $type
      * @param  string  $table
      * @return void

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -11,7 +11,7 @@ class PostgresProcessor extends Processor
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $sql
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $sequence
      * @return int
      */

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -23,7 +23,7 @@ class Processor
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $sql
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $sequence
      * @return int
      */

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -13,7 +13,7 @@ class SqlServerProcessor extends Processor
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $sql
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $sequence
      * @return int
      */

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -26,7 +26,7 @@ class QueryException extends PDOException
      *
      * @param  string  $sql
      * @param  array  $bindings
-     * @param  \Exception $previous
+     * @param  \Exception  $previous
      * @return void
      */
     public function __construct($sql, array $bindings, $previous)
@@ -48,7 +48,7 @@ class QueryException extends PDOException
      *
      * @param  string  $sql
      * @param  array  $bindings
-     * @param  \Exception $previous
+     * @param  \Exception  $previous
      * @return string
      */
     protected function formatMessage($sql, $bindings, $previous)

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -13,10 +13,10 @@ class SQLiteConnection extends Connection
     /**
      * Create a new database connection instance.
      *
-     * @param  \PDO|\Closure     $pdo
-     * @param  string   $database
-     * @param  string   $tablePrefix
-     * @param  array    $config
+     * @param  \PDO|\Closure  $pdo
+     * @param  string  $database
+     * @param  string  $tablePrefix
+     * @param  array  $config
      * @return void
      */
     public function __construct($pdo, $database = '', $tablePrefix = '', array $config = [])

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -92,7 +92,7 @@ class Builder
      * Determine if the given table has given columns.
      *
      * @param  string  $table
-     * @param  array   $columns
+     * @param  array  $columns
      * @return bool
      */
     public function hasColumns($table, array $columns)
@@ -140,7 +140,7 @@ class Builder
     /**
      * Modify a table on the schema.
      *
-     * @param  string    $table
+     * @param  string  $table
      * @param  \Closure  $callback
      * @return void
      */
@@ -152,7 +152,7 @@ class Builder
     /**
      * Create a new table on the schema.
      *
-     * @param  string    $table
+     * @param  string  $table
      * @param  \Closure  $callback
      * @return void
      */

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -19,7 +19,7 @@ class ChangeColumn
      * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @param  \Illuminate\Database\Connection $connection
+     * @param  \Illuminate\Database\Connection  $connection
      * @return array
      *
      * @throws \RuntimeException

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -44,7 +44,7 @@ abstract class Grammar extends BaseGrammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @param  \Illuminate\Database\Connection $connection
+     * @param  \Illuminate\Database\Connection  $connection
      * @return array
      *
      * @throws \RuntimeException
@@ -97,7 +97,7 @@ abstract class Grammar extends BaseGrammar
     /**
      * Compile the blueprint's column definitions.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint $blueprint
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @return array
      */
     protected function getColumns(Blueprint $blueprint)
@@ -180,7 +180,7 @@ abstract class Grammar extends BaseGrammar
      * Add a prefix to an array of values.
      *
      * @param  string  $prefix
-     * @param  array   $values
+     * @param  array  $values
      * @return array
      */
     public function prefixArray($prefix, array $values)
@@ -193,7 +193,7 @@ abstract class Grammar extends BaseGrammar
     /**
      * Wrap a table in keyword identifiers.
      *
-     * @param  mixed   $table
+     * @param  mixed  $table
      * @return string
      */
     public function wrapTable($table)
@@ -207,7 +207,7 @@ abstract class Grammar extends BaseGrammar
      * Wrap a value in keyword identifiers.
      *
      * @param  \Illuminate\Database\Query\Expression|string  $value
-     * @param  bool    $prefixAlias
+     * @param  bool  $prefixAlias
      * @return string
      */
     public function wrap($value, $prefixAlias = false)
@@ -220,7 +220,7 @@ abstract class Grammar extends BaseGrammar
     /**
      * Format a value so that it can be used in "default" clauses.
      *
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return string
      */
     protected function getDefaultValue($value)

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -345,8 +345,8 @@ class MySqlGrammar extends Grammar
     /**
      * Compile a rename index command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint $blueprint
-     * @param  \Illuminate\Support\Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileRenameIndex(Blueprint $blueprint, Fluent $command)

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -338,8 +338,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a rename index command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint $blueprint
-     * @param  \Illuminate\Support\Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileRenameIndex(Blueprint $blueprint, Fluent $command)

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -334,9 +334,9 @@ class SQLiteGrammar extends Grammar
     /**
      * Compile a rename index command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint $blueprint
-     * @param  \Illuminate\Support\Fluent $command
-     * @param  \Illuminate\Database\Connection $connection
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @param  \Illuminate\Database\Connection  $connection
      * @return array
      */
     public function compileRenameIndex(Blueprint $blueprint, Fluent $command, Connection $connection)

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -280,8 +280,8 @@ class SqlServerGrammar extends Grammar
     /**
      * Compile a rename index command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint $blueprint
-     * @param  \Illuminate\Support\Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileRenameIndex(Blueprint $blueprint, Fluent $command)

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -108,7 +108,7 @@ abstract class Seeder
     /**
      * Run the database seeds.
      *
-     * @return dynamic
+     * @return mixed
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Filesystem/Cache.php
+++ b/src/Illuminate/Filesystem/Cache.php
@@ -31,9 +31,10 @@ class Cache extends AbstractCache
     /**
      * Create a new cache instance.
      *
-     * @param \Illuminate\Contracts\Cache\Repository  $repository
-     * @param string  $key
-     * @param int|null  $expire
+     * @param  \Illuminate\Contracts\Cache\Repository  $repository
+     * @param  string  $key
+     * @param  int|null  $expire
+     * @return void
      */
     public function __construct(Repository $repository, $key = 'flysystem', $expire = null)
     {

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -393,7 +393,7 @@ class Filesystem
      * Find path names matching a given pattern.
      *
      * @param  string  $pattern
-     * @param  int     $flags
+     * @param  int  $flags
      * @return array
      */
     public function glob($pattern, $flags = 0)
@@ -452,9 +452,9 @@ class Filesystem
      * Create a directory.
      *
      * @param  string  $path
-     * @param  int     $mode
-     * @param  bool    $recursive
-     * @param  bool    $force
+     * @param  int  $mode
+     * @param  bool  $recursive
+     * @param  bool  $force
      * @return bool
      */
     public function makeDirectory($path, $mode = 0755, $recursive = false, $force = false)
@@ -488,7 +488,7 @@ class Filesystem
      *
      * @param  string  $directory
      * @param  string  $destination
-     * @param  int     $options
+     * @param  int  $options
      * @return bool
      */
     public function copyDirectory($directory, $destination, $options = null)
@@ -541,7 +541,7 @@ class Filesystem
      * The directory itself may be optionally preserved.
      *
      * @param  string  $directory
-     * @param  bool    $preserve
+     * @param  bool  $preserve
      * @return bool
      */
     public function deleteDirectory($directory, $preserve = false)

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -459,8 +459,8 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     /**
      * Get the URL for the file at the given path.
      *
-     * @param  \League\Flysystem\Rackspace\RackspaceAdapter $adapter
-     * @param  string $path
+     * @param  \League\Flysystem\Rackspace\RackspaceAdapter  $adapter
+     * @param  string  $path
      * @return string
      */
     protected function getRackspaceUrl($adapter, $path)
@@ -530,9 +530,9 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      * Get a temporary URL for the file at the given path.
      *
      * @param  \League\Flysystem\AwsS3v3\AwsS3Adapter  $adapter
-     * @param  string $path
-     * @param  \DateTimeInterface $expiration
-     * @param  array $options
+     * @param  string  $path
+     * @param  \DateTimeInterface  $expiration
+     * @param  array  $options
      * @return string
      */
     public function getAwsTemporaryUrl($adapter, $path, $expiration, $options)
@@ -570,8 +570,8 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     /**
      * Concatenate a path to a URL.
      *
-     * @param  string $url
-     * @param  string $path
+     * @param  string  $url
+     * @param  string  $path
      * @return string
      */
     protected function concatPathToUrl($url, $path)

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -376,7 +376,7 @@ class FilesystemManager implements FactoryContract
     /**
      * Register a custom driver creator Closure.
      *
-     * @param  string    $driver
+     * @param  string  $driver
      * @param  \Closure  $callback
      * @return $this
      */
@@ -391,7 +391,7 @@ class FilesystemManager implements FactoryContract
      * Dynamically call the default driver instance.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -554,7 +554,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      * Register a service provider with the application.
      *
      * @param  \Illuminate\Support\ServiceProvider|string  $provider
-     * @param  bool   $force
+     * @param  bool  $force
      * @return \Illuminate\Support\ServiceProvider
      */
     public function register($provider, $force = false)
@@ -927,9 +927,9 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Throw an HttpException with the given data.
      *
-     * @param  int     $code
+     * @param  int  $code
      * @param  string  $message
-     * @param  array   $headers
+     * @param  array  $headers
      * @return void
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -28,6 +28,7 @@ trait VerifiesEmails
      *
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
+     *
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function verify(Request $request)

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -254,7 +254,7 @@ class Kernel implements KernelContract
      * Queue the given console command.
      *
      * @param  string  $command
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
     public function queue($command, array $parameters = [])

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -272,7 +272,7 @@ class Handler implements ExceptionHandlerContract
      * Prepare a response for the given exception.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Exception $e
+     * @param  \Exception  $e
      * @return \Symfony\Component\HttpFoundation\Response
      */
     protected function prepareResponse($request, Exception $e)
@@ -423,7 +423,7 @@ class Handler implements ExceptionHandlerContract
      * Prepare a JSON response for the given exception.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Exception $e
+     * @param  \Exception  $e
      * @return \Illuminate\Http\JsonResponse
      */
     protected function prepareJsonResponse($request, Exception $e)

--- a/src/Illuminate/Foundation/Exceptions/WhoopsHandler.php
+++ b/src/Illuminate/Foundation/Exceptions/WhoopsHandler.php
@@ -27,7 +27,7 @@ class WhoopsHandler
     /**
      * Register the application paths with the handler.
      *
-     * @param  \Whoops\Handler\PrettyPageHandler $handler
+     * @param  \Whoops\Handler\PrettyPageHandler  $handler
      * @return $this
      */
     protected function registerApplicationPaths($handler)
@@ -55,7 +55,7 @@ class WhoopsHandler
     /**
      * Register the blacklist with the handler.
      *
-     * @param  \Whoops\Handler\PrettyPageHandler $handler
+     * @param  \Whoops\Handler\PrettyPageHandler  $handler
      * @return $this
      */
     protected function registerBlacklist($handler)
@@ -72,7 +72,7 @@ class WhoopsHandler
     /**
      * Register the editor with the handler.
      *
-     * @param  \Whoops\Handler\PrettyPageHandler $handler
+     * @param  \Whoops\Handler\PrettyPageHandler  $handler
      * @return $this
      */
     protected function registerEditor($handler)

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -35,7 +35,7 @@ trait MakesHttpRequests
     /**
      * Define additional headers to be sent with the request.
      *
-     * @param  array $headers
+     * @param  array  $headers
      * @return $this
      */
     public function withHeaders(array $headers)
@@ -48,8 +48,8 @@ trait MakesHttpRequests
     /**
      * Add a header to be sent with the request.
      *
-     * @param  string $name
-     * @param  string $value
+     * @param  string  $name
+     * @param  string  $value
      * @return $this
      */
     public function withHeader(string $name, string $value)

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -494,7 +494,7 @@ class TestResponse
      * Assert that the response does not contain the given JSON fragment.
      *
      * @param  array  $data
-     * @param  bool   $exact
+     * @param  bool  $exact
      * @return $this
      */
     public function assertJsonMissing(array $data, $exact = false)
@@ -713,7 +713,7 @@ class TestResponse
     /**
      * Assert that the response view equals the given value.
      *
-     * @param  string $value
+     * @param  string  $value
      * @return $this
      */
     public function assertViewIs($value)

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -27,9 +27,9 @@ if (! function_exists('abort')) {
     /**
      * Throw an HttpException with the given data.
      *
-     * @param  \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int     $code
+     * @param  \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int  $code
      * @param  string  $message
-     * @param  array   $headers
+     * @param  array  $headers
      * @return void
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
@@ -51,10 +51,10 @@ if (! function_exists('abort_if')) {
     /**
      * Throw an HttpException with the given data if the given condition is true.
      *
-     * @param  bool    $boolean
-     * @param  int     $code
+     * @param  bool  $boolean
+     * @param  int  $code
      * @param  string  $message
-     * @param  array   $headers
+     * @param  array  $headers
      * @return void
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
@@ -72,10 +72,10 @@ if (! function_exists('abort_unless')) {
     /**
      * Throw an HttpException with the given data unless the given condition is true.
      *
-     * @param  bool    $boolean
-     * @param  int     $code
+     * @param  bool  $boolean
+     * @param  int  $code
      * @param  string  $message
-     * @param  array   $headers
+     * @param  array  $headers
      * @return void
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
@@ -94,8 +94,8 @@ if (! function_exists('action')) {
      * Generate the URL to a controller action.
      *
      * @param  string|array  $name
-     * @param  mixed   $parameters
-     * @param  bool    $absolute
+     * @param  mixed  $parameters
+     * @param  bool  $absolute
      * @return string
      */
     function action($name, $parameters = [], $absolute = true)
@@ -109,7 +109,7 @@ if (! function_exists('app')) {
      * Get the available container instance.
      *
      * @param  string  $abstract
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed|\Illuminate\Foundation\Application
      */
     function app($abstract = null, array $parameters = [])
@@ -140,7 +140,7 @@ if (! function_exists('asset')) {
      * Generate an asset path for the application.
      *
      * @param  string  $path
-     * @param  bool    $secure
+     * @param  bool  $secure
      * @return string
      */
     function asset($path, $secure = null)
@@ -170,7 +170,7 @@ if (! function_exists('back')) {
     /**
      * Create a new redirect response to the previous location.
      *
-     * @param  int    $status
+     * @param  int  $status
      * @param  array  $headers
      * @param  mixed  $fallback
      * @return \Illuminate\Http\RedirectResponse
@@ -374,7 +374,7 @@ if (! function_exists('decrypt')) {
      * Decrypt the given value.
      *
      * @param  string  $value
-     * @param  bool   $unserialize
+     * @param  bool  $unserialize
      * @return mixed
      */
     function decrypt($value, $unserialize = true)
@@ -459,7 +459,7 @@ if (! function_exists('encrypt')) {
      * Encrypt the given value.
      *
      * @param  mixed  $value
-     * @param  bool   $serialize
+     * @param  bool  $serialize
      * @return string
      */
     function encrypt($value, $serialize = true)
@@ -511,7 +511,7 @@ if (! function_exists('info')) {
      * Write some information to the log.
      *
      * @param  string  $message
-     * @param  array   $context
+     * @param  array  $context
      * @return void
      */
     function info($message, $context = [])
@@ -628,7 +628,7 @@ if (! function_exists('now')) {
     /**
      * Create a new Carbon instance for the current time.
      *
-     * @param  \DateTimeZone|string|null $tz
+     * @param  \DateTimeZone|string|null  $tz
      * @return \Illuminate\Support\Carbon
      */
     function now($tz = null)
@@ -642,7 +642,7 @@ if (! function_exists('old')) {
      * Retrieve an old input item.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     function old($key = null, $default = null)
@@ -684,9 +684,9 @@ if (! function_exists('redirect')) {
      * Get an instance of the redirector.
      *
      * @param  string|null  $to
-     * @param  int     $status
-     * @param  array   $headers
-     * @param  bool    $secure
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool  $secure
      * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
      */
     function redirect($to = null, $status = 302, $headers = [], $secure = null)
@@ -722,7 +722,7 @@ if (! function_exists('request')) {
      * Get an instance of the current request or an input item from the request.
      *
      * @param  array|string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return \Illuminate\Http\Request|string|array
      */
     function request($key = null, $default = null)
@@ -792,8 +792,8 @@ if (! function_exists('response')) {
      * Return a new response from the application.
      *
      * @param  \Illuminate\View\View|string|array|null  $content
-     * @param  int     $status
-     * @param  array   $headers
+     * @param  int  $status
+     * @param  array  $headers
      * @return \Illuminate\Http\Response|\Illuminate\Contracts\Routing\ResponseFactory
      */
     function response($content = '', $status = 200, array $headers = [])
@@ -841,7 +841,7 @@ if (! function_exists('secure_url')) {
      * Generate a HTTPS url for the application.
      *
      * @param  string  $path
-     * @param  mixed   $parameters
+     * @param  mixed  $parameters
      * @return string
      */
     function secure_url($path, $parameters = [])
@@ -891,7 +891,7 @@ if (! function_exists('today')) {
     /**
      * Create a new Carbon instance for the current date.
      *
-     * @param  \DateTimeZone|string|null $tz
+     * @param  \DateTimeZone|string|null  $tz
      * @return \Illuminate\Support\Carbon
      */
     function today($tz = null)
@@ -905,7 +905,7 @@ if (! function_exists('trans')) {
      * Translate the given message.
      *
      * @param  string  $key
-     * @param  array   $replace
+     * @param  array  $replace
      * @param  string  $locale
      * @return \Illuminate\Contracts\Translation\Translator|string|array|null
      */
@@ -925,7 +925,7 @@ if (! function_exists('trans_choice')) {
      *
      * @param  string  $key
      * @param  int|array|\Countable  $number
-     * @param  array   $replace
+     * @param  array  $replace
      * @param  string  $locale
      * @return string
      */
@@ -955,8 +955,8 @@ if (! function_exists('url')) {
      * Generate a url for the application.
      *
      * @param  string  $path
-     * @param  mixed   $parameters
-     * @param  bool    $secure
+     * @param  mixed  $parameters
+     * @param  bool  $secure
      * @return \Illuminate\Contracts\Routing\UrlGenerator|string
      */
     function url($path = null, $parameters = [], $secure = null)
@@ -996,8 +996,8 @@ if (! function_exists('view')) {
      * Get the evaluated view contents for the given view.
      *
      * @param  string  $view
-     * @param  array   $data
-     * @param  array   $mergeData
+     * @param  array  $data
+     * @param  array  $mergeData
      * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
      */
     function view($view = null, $data = [], $mergeData = [])

--- a/src/Illuminate/Hashing/AbstractHasher.php
+++ b/src/Illuminate/Hashing/AbstractHasher.php
@@ -7,7 +7,7 @@ abstract class AbstractHasher
     /**
      * Get information about the given hashed value.
      *
-     * @param  string $hashedValue
+     * @param  string  $hashedValue
      * @return array
      */
     public function info($hashedValue)

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -37,7 +37,7 @@ class BcryptHasher extends AbstractHasher implements HasherContract
      * Hash the given value.
      *
      * @param  string  $value
-     * @param  array   $options
+     * @param  array  $options
      * @return string
      *
      * @throws \RuntimeException
@@ -78,7 +78,7 @@ class BcryptHasher extends AbstractHasher implements HasherContract
      * Check if the given hash has been hashed using the given options.
      *
      * @param  string  $hashedValue
-     * @param  array   $options
+     * @param  array  $options
      * @return bool
      */
     public function needsRehash($hashedValue, array $options = [])

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -52,7 +52,7 @@ class HashManager extends Manager implements Hasher
      * Hash the given value.
      *
      * @param  string  $value
-     * @param  array   $options
+     * @param  array  $options
      * @return string
      */
     public function make($value, array $options = [])
@@ -65,7 +65,7 @@ class HashManager extends Manager implements Hasher
      *
      * @param  string  $value
      * @param  string  $hashedValue
-     * @param  array   $options
+     * @param  array  $options
      * @return bool
      */
     public function check($value, $hashedValue, array $options = [])
@@ -77,7 +77,7 @@ class HashManager extends Manager implements Hasher
      * Check if the given hash has been hashed using the given options.
      *
      * @param  string  $hashedValue
-     * @param  array   $options
+     * @param  array  $options
      * @return bool
      */
     public function needsRehash($hashedValue, array $options = [])

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -269,7 +269,6 @@ trait InteractsWithInput
      *
      * @param  string  $key
      * @param  string|array|null  $default
-     *
      * @return string|array|null
      */
     public function post($key = null, $default = null)

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -19,9 +19,9 @@ class JsonResponse extends BaseJsonResponse
      * Constructor.
      *
      * @param  mixed  $data
-     * @param  int    $status
+     * @param  int  $status
      * @param  array  $headers
-     * @param  int    $options
+     * @param  int  $options
      * @return void
      */
     public function __construct($data = null, $status = 200, $headers = [], $options = 0)

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -338,7 +338,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * Get the JSON payload for the request.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return \Symfony\Component\HttpFoundation\ParameterBag|mixed
      */
     public function json($key = null, $default = null)
@@ -517,7 +517,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * Get the route handling the request.
      *
      * @param  string|null  $param
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return \Illuminate\Routing\Route|object|string
      */
     public function route($param = null, $default = null)

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -65,7 +65,7 @@ class Response extends BaseResponse
     /**
      * Morph the given content into JSON.
      *
-     * @param  mixed   $content
+     * @param  mixed  $content
      * @return string
      */
     protected function morphToJson($content)

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -59,7 +59,7 @@ trait ResponseTrait
      *
      * @param  string  $key
      * @param  array|string  $values
-     * @param  bool    $replace
+     * @param  bool  $replace
      * @return $this
      */
     public function header($key, $values, $replace = true)

--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -107,7 +107,7 @@ class UploadedFile extends SymfonyUploadedFile
      * Create a new file instance from a base instance.
      *
      * @param  \Symfony\Component\HttpFoundation\File\UploadedFile  $file
-     * @param  bool $test
+     * @param  bool  $test
      * @return static
      */
     public static function createFromBase(SymfonyUploadedFile $file, $test = false)

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -424,7 +424,7 @@ class LogManager implements LoggerInterface
     /**
      * Register a custom driver creator Closure.
      *
-     * @param  string    $driver
+     * @param  string  $driver
      * @param  \Closure  $callback
      * @return $this
      */
@@ -438,9 +438,8 @@ class LogManager implements LoggerInterface
     /**
      * System is unusable.
      *
-     * @param string $message
-     * @param array  $context
-     *
+     * @param  string  $message
+     * @param  array  $context
      * @return void
      */
     public function emergency($message, array $context = [])
@@ -454,9 +453,8 @@ class LogManager implements LoggerInterface
      * Example: Entire website down, database unavailable, etc. This should
      * trigger the SMS alerts and wake you up.
      *
-     * @param string $message
-     * @param array  $context
-     *
+     * @param  string  $message
+     * @param  array  $context
      * @return void
      */
     public function alert($message, array $context = [])
@@ -469,9 +467,8 @@ class LogManager implements LoggerInterface
      *
      * Example: Application component unavailable, unexpected exception.
      *
-     * @param string $message
-     * @param array  $context
-     *
+     * @param  string  $message
+     * @param  array  $context
      * @return void
      */
     public function critical($message, array $context = [])
@@ -483,9 +480,8 @@ class LogManager implements LoggerInterface
      * Runtime errors that do not require immediate action but should typically
      * be logged and monitored.
      *
-     * @param string $message
-     * @param array  $context
-     *
+     * @param  string  $message
+     * @param  array  $context
      * @return void
      */
     public function error($message, array $context = [])
@@ -499,9 +495,8 @@ class LogManager implements LoggerInterface
      * Example: Use of deprecated APIs, poor use of an API, undesirable things
      * that are not necessarily wrong.
      *
-     * @param string $message
-     * @param array  $context
-     *
+     * @param  string  $message
+     * @param  array  $context
      * @return void
      */
     public function warning($message, array $context = [])
@@ -512,9 +507,8 @@ class LogManager implements LoggerInterface
     /**
      * Normal but significant events.
      *
-     * @param string $message
-     * @param array  $context
-     *
+     * @param  string  $message
+     * @param  array  $context
      * @return void
      */
     public function notice($message, array $context = [])
@@ -527,9 +521,8 @@ class LogManager implements LoggerInterface
      *
      * Example: User logs in, SQL logs.
      *
-     * @param string $message
-     * @param array  $context
-     *
+     * @param  string  $message
+     * @param  array  $context
      * @return void
      */
     public function info($message, array $context = [])
@@ -540,9 +533,8 @@ class LogManager implements LoggerInterface
     /**
      * Detailed debug information.
      *
-     * @param string $message
-     * @param array  $context
-     *
+     * @param  string  $message
+     * @param  array  $context
      * @return void
      */
     public function debug($message, array $context = [])
@@ -553,10 +545,9 @@ class LogManager implements LoggerInterface
     /**
      * Logs with an arbitrary level.
      *
-     * @param mixed  $level
-     * @param string $message
-     * @param array  $context
-     *
+     * @param  mixed  $level
+     * @param  string  $message
+     * @param  array  $context
      * @return void
      */
     public function log($level, $message, array $context = [])
@@ -568,7 +559,7 @@ class LogManager implements LoggerInterface
      * Dynamically call the default driver instance.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -198,7 +198,7 @@ class Logger implements LoggerInterface
      *
      * @param  string  $level
      * @param  string  $message
-     * @param  array   $context
+     * @param  array  $context
      * @return void
      */
     protected function fireLogEvent($level, $message, array $context = [])

--- a/src/Illuminate/Mail/Events/MessageSending.php
+++ b/src/Illuminate/Mail/Events/MessageSending.php
@@ -21,7 +21,7 @@ class MessageSending
     /**
      * Create a new event instance.
      *
-     * @param  \Swift_Message $message
+     * @param  \Swift_Message  $message
      * @param  array  $data
      * @return void
      */

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -724,7 +724,7 @@ class Mailable implements MailableContract, Renderable
      * Set the view data for the message.
      *
      * @param  string|array  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return $this
      */
     public function with($key, $value = null)
@@ -829,7 +829,7 @@ class Mailable implements MailableContract, Renderable
      * Dynamically bind parameters to the message.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return $this
      *
      * @throws \BadMethodCallException

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -43,7 +43,7 @@ class LogTransport extends Transport
     /**
      * Get a loggable string out of a Swiftmailer entity.
      *
-     * @param  \Swift_Mime_SimpleMimeEntity $entity
+     * @param  \Swift_Mime_SimpleMimeEntity  $entity
      * @return string
      */
     protected function getMimeEntityString(Swift_Mime_SimpleMimeEntity $entity)

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -60,7 +60,7 @@ class MandrillTransport extends Transport
      *
      * Note that Mandrill still respects CC, BCC headers in raw message itself.
      *
-     * @param  \Swift_Mime_SimpleMessage $message
+     * @param  \Swift_Mime_SimpleMessage  $message
      * @return array
      */
     protected function getTo(Swift_Mime_SimpleMessage $message)

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -80,7 +80,7 @@ class SparkPostTransport extends Transport
      *
      * Note that SparkPost still respects CC, BCC headers in raw message itself.
      *
-     * @param  \Swift_Mime_SimpleMessage $message
+     * @param  \Swift_Mime_SimpleMessage  $message
      * @return array
      */
     protected function getRecipients(Swift_Mime_SimpleMessage $message)

--- a/src/Illuminate/Notifications/Console/NotificationTableCommand.php
+++ b/src/Illuminate/Notifications/Console/NotificationTableCommand.php
@@ -38,7 +38,7 @@ class NotificationTableCommand extends Command
      * Create a new notifications table command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  \Illuminate\Support\Composer    $composer
+     * @param  \Illuminate\Support\Composer  $composer
      * @return void
      */
     public function __construct(Filesystem $files, Composer $composer)

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -252,7 +252,7 @@ abstract class AbstractPaginator implements Htmlable
     /**
      * Load a set of relationships onto the mixed relationship collection.
      *
-     * @param  string $relation
+     * @param  string  $relation
      * @param  array  $relations
      * @return $this
      */

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -161,7 +161,7 @@ class Pipeline implements PipelineContract
     /**
      * Parse full pipe string to get name and parameters.
      *
-     * @param  string $pipe
+     * @param  string  $pipe
      * @return array
      */
     protected function parsePipeString($pipe)

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -62,7 +62,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -76,7 +76,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -91,7 +91,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */

--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -89,7 +89,7 @@ class Manager
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @param  string  $connection
      * @return mixed
@@ -102,8 +102,8 @@ class Manager
     /**
      * Push a new an array of jobs onto the queue.
      *
-     * @param  array   $jobs
-     * @param  mixed   $data
+     * @param  array  $jobs
+     * @param  mixed  $data
      * @param  string  $queue
      * @param  string  $connection
      * @return mixed
@@ -118,7 +118,7 @@ class Manager
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @param  string  $connection
      * @return mixed
@@ -142,7 +142,7 @@ class Manager
     /**
      * Register a connection with the manager.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @param  string  $name
      * @return void
      */
@@ -177,7 +177,7 @@ class Manager
      * Dynamically pass methods to the default connection.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public static function __callStatic($method, $parameters)

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -39,7 +39,7 @@ class FailedTableCommand extends Command
      * Create a new failed queue jobs table command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  \Illuminate\Support\Composer    $composer
+     * @param  \Illuminate\Support\Composer  $composer
      * @return void
      */
     public function __construct(Filesystem $files, Composer $composer)

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -39,7 +39,7 @@ class TableCommand extends Command
      * Create a new queue job table command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  \Illuminate\Support\Composer    $composer
+     * @param  \Illuminate\Support\Composer  $composer
      * @return void
      */
     public function __construct(Filesystem $files, Composer $composer)

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -144,7 +144,7 @@ class WorkCommand extends Command
      * Write the status output for the queue worker.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
-     * @param  string $status
+     * @param  string  $status
      * @return void
      */
     protected function writeOutput(Job $job, $status)

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -72,7 +72,7 @@ class DatabaseQueue extends Queue implements QueueContract
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -88,7 +88,7 @@ class DatabaseQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -101,7 +101,7 @@ class DatabaseQueue extends Queue implements QueueContract
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return void
      */
@@ -115,8 +115,8 @@ class DatabaseQueue extends Queue implements QueueContract
     /**
      * Push an array of jobs onto the queue.
      *
-     * @param  array   $jobs
-     * @param  mixed   $data
+     * @param  array  $jobs
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */

--- a/src/Illuminate/Queue/FailingJob.php
+++ b/src/Illuminate/Queue/FailingJob.php
@@ -13,7 +13,7 @@ class FailingJob
      *
      * @param  string  $connectionName
      * @param  \Illuminate\Queue\Jobs\Job  $job
-     * @param  \Exception $e
+     * @param  \Exception  $e
      * @return void
      */
     public static function handle($connectionName, $job, $e = null)

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -51,7 +51,7 @@ trait InteractsWithQueue
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0)

--- a/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
+++ b/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
@@ -45,7 +45,7 @@ class BeanstalkdJob extends Job implements JobContract
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0)

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -106,7 +106,7 @@ abstract class Job
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0)

--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -87,7 +87,7 @@ class RedisJob extends Job implements JobContract
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0)

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -27,7 +27,7 @@ class SqsJob extends Job implements JobContract
      *
      * @param  \Illuminate\Container\Container  $container
      * @param  \Aws\Sqs\SqsClient  $sqs
-     * @param  array   $job
+     * @param  array  $job
      * @param  string  $connectionName
      * @param  string  $queue
      * @return void
@@ -44,7 +44,7 @@ class SqsJob extends Job implements JobContract
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0)

--- a/src/Illuminate/Queue/Jobs/SyncJob.php
+++ b/src/Illuminate/Queue/Jobs/SyncJob.php
@@ -41,7 +41,7 @@ class SyncJob extends Job implements JobContract
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0)

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -21,7 +21,7 @@ class NullQueue extends Queue implements QueueContract
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -35,7 +35,7 @@ class NullQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -48,7 +48,7 @@ class NullQueue extends Queue implements QueueContract
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -36,7 +36,7 @@ abstract class Queue
      *
      * @param  string  $queue
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @return mixed
      */
     public function pushOn($queue, $job, $data = '')
@@ -50,7 +50,7 @@ abstract class Queue
      * @param  string  $queue
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @return mixed
      */
     public function laterOn($queue, $delay, $job, $data = '')
@@ -61,8 +61,8 @@ abstract class Queue
     /**
      * Push an array of jobs onto the queue.
      *
-     * @param  array   $jobs
-     * @param  mixed   $data
+     * @param  array  $jobs
+     * @param  mixed  $data
      * @param  string  $queue
      * @return void
      */
@@ -78,7 +78,7 @@ abstract class Queue
      *
      * @param  string  $job
      * @param  string  $queue
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @return string
      *
      * @throws \Illuminate\Queue\InvalidPayloadException

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -178,7 +178,7 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Add a queue connection resolver.
      *
-     * @param  string    $driver
+     * @param  string  $driver
      * @param  \Closure  $resolver
      * @return void
      */
@@ -190,7 +190,7 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Add a queue connection resolver.
      *
-     * @param  string    $driver
+     * @param  string  $driver
      * @param  \Closure  $resolver
      * @return void
      */
@@ -260,7 +260,7 @@ class QueueManager implements FactoryContract, MonitorContract
      * Dynamically pass calls to the default connection.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -82,7 +82,7 @@ class RedisQueue extends Queue implements QueueContract
      * Push a new job onto the queue.
      *
      * @param  object|string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -96,7 +96,7 @@ class RedisQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -111,7 +111,7 @@ class RedisQueue extends Queue implements QueueContract
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  object|string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -141,8 +141,8 @@ class RedisQueue extends Queue implements QueueContract
      * Create a payload string from the given job and data.
      *
      * @param  string  $job
-     * @param  string   $queue
-     * @param  mixed   $data
+     * @param  string  $queue
+     * @param  mixed  $data
      * @return string
      */
     protected function createPayloadArray($job, $queue, $data = '')

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -66,7 +66,7 @@ class SqsQueue extends Queue implements QueueContract
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -80,7 +80,7 @@ class SqsQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -95,7 +95,7 @@ class SqsQueue extends Queue implements QueueContract
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -26,7 +26,7 @@ class SyncQueue extends Queue implements QueueContract
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      *
@@ -126,7 +126,7 @@ class SyncQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -139,7 +139,7 @@ class SyncQueue extends Queue implements QueueContract
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -541,7 +541,7 @@ class Worker
     /**
      * Determine if the memory limit has been exceeded.
      *
-     * @param  int   $memoryLimit
+     * @param  int  $memoryLimit
      * @return bool
      */
     public function memoryExceeded($memoryLimit)
@@ -582,7 +582,7 @@ class Worker
     /**
      * Sleep the script for a given number of seconds.
      *
-     * @param  int|float   $seconds
+     * @param  int|float  $seconds
      * @return void
      */
     public function sleep($seconds)

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -104,7 +104,7 @@ abstract class Connection
      * Run a command against the Redis database.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function command($method, array $parameters = [])

--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -51,10 +51,10 @@ class DurationLimiter
     /**
      * Create a new duration limiter instance.
      *
-     * @param  \Illuminate\Redis\Connections\Connection $redis
-     * @param  string $name
-     * @param  int $maxLocks
-     * @param  int $decay
+     * @param  \Illuminate\Redis\Connections\Connection  $redis
+     * @param  string  $name
+     * @param  int  $maxLocks
+     * @param  int  $decay
      * @return void
      */
     public function __construct($redis, $name, $maxLocks, $decay)
@@ -68,8 +68,8 @@ class DurationLimiter
     /**
      * Attempt to acquire the lock for the given number of seconds.
      *
-     * @param  int $timeout
-     * @param  callable|null $callback
+     * @param  int  $timeout
+     * @param  callable|null  $callback
      * @return bool
      *
      * @throws \Illuminate\Contracts\Redis\LimiterTimeoutException

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -17,7 +17,7 @@ abstract class Controller
      * Register middleware on the controller.
      *
      * @param  array|string|\Closure  $middleware
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\ControllerMiddlewareOptions
      */
     public function middleware($middleware, array $options = [])
@@ -46,7 +46,7 @@ abstract class Controller
      * Execute an action on the controller.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function callAction($method, $parameters)
@@ -58,7 +58,7 @@ abstract class Controller
      * Handle calls to missing methods on the controller.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      *
      * @throws \BadMethodCallException

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -49,7 +49,7 @@ class Redirector
     /**
      * Create a new redirect response to the previous location.
      *
-     * @param  int    $status
+     * @param  int  $status
      * @param  array  $headers
      * @param  mixed  $fallback
      * @return \Illuminate\Http\RedirectResponse
@@ -62,7 +62,7 @@ class Redirector
     /**
      * Create a new redirect response to the current URI.
      *
-     * @param  int    $status
+     * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
@@ -75,9 +75,9 @@ class Redirector
      * Create a new redirect response, while putting the current URL in the session.
      *
      * @param  string  $path
-     * @param  int     $status
-     * @param  array   $headers
-     * @param  bool    $secure
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool  $secure
      * @return \Illuminate\Http\RedirectResponse
      */
     public function guest($path, $status = 302, $headers = [], $secure = null)
@@ -99,9 +99,9 @@ class Redirector
      * Create a new redirect response to the previously intended location.
      *
      * @param  string  $default
-     * @param  int     $status
-     * @param  array   $headers
-     * @param  bool    $secure
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool  $secure
      * @return \Illuminate\Http\RedirectResponse
      */
     public function intended($default = '/', $status = 302, $headers = [], $secure = null)
@@ -126,9 +126,9 @@ class Redirector
      * Create a new redirect response to the given path.
      *
      * @param  string  $path
-     * @param  int     $status
-     * @param  array   $headers
-     * @param  bool    $secure
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool  $secure
      * @return \Illuminate\Http\RedirectResponse
      */
     public function to($path, $status = 302, $headers = [], $secure = null)
@@ -140,8 +140,8 @@ class Redirector
      * Create a new redirect response to an external URL (no validation).
      *
      * @param  string  $path
-     * @param  int     $status
-     * @param  array   $headers
+     * @param  int  $status
+     * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
     public function away($path, $status = 302, $headers = [])
@@ -153,8 +153,8 @@ class Redirector
      * Create a new redirect response to the given HTTPS path.
      *
      * @param  string  $path
-     * @param  int     $status
-     * @param  array   $headers
+     * @param  int  $status
+     * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
     public function secure($path, $status = 302, $headers = [])
@@ -166,9 +166,9 @@ class Redirector
      * Create a new redirect response to a named route.
      *
      * @param  string  $route
-     * @param  mixed   $parameters
-     * @param  int     $status
-     * @param  array   $headers
+     * @param  mixed  $parameters
+     * @param  int  $status
+     * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
     public function route($route, $parameters = [], $status = 302, $headers = [])
@@ -180,9 +180,9 @@ class Redirector
      * Create a new redirect response to a controller action.
      *
      * @param  string|array  $action
-     * @param  mixed   $parameters
-     * @param  int     $status
-     * @param  array   $headers
+     * @param  mixed  $parameters
+     * @param  int  $status
+     * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
     public function action($action, $parameters = [], $status = 302, $headers = [])
@@ -194,8 +194,8 @@ class Redirector
      * Create a new redirect response.
      *
      * @param  string  $path
-     * @param  int     $status
-     * @param  array   $headers
+     * @param  int  $status
+     * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
     protected function createRedirect($path, $status, $headers)

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -67,7 +67,7 @@ class ResourceRegistrar
      *
      * @param  string  $name
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\RouteCollection
      */
     public function register($name, $controller, array $options = [])
@@ -108,7 +108,7 @@ class ResourceRegistrar
      *
      * @param  string  $name
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return void
      */
     protected function prefixedResource($name, $controller, array $options)
@@ -171,7 +171,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceIndex($name, $base, $controller, $options)
@@ -189,7 +189,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceCreate($name, $base, $controller, $options)
@@ -207,7 +207,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceStore($name, $base, $controller, $options)
@@ -225,7 +225,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceShow($name, $base, $controller, $options)
@@ -243,7 +243,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceEdit($name, $base, $controller, $options)
@@ -261,7 +261,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceUpdate($name, $base, $controller, $options)
@@ -279,7 +279,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceDestroy($name, $base, $controller, $options)
@@ -316,7 +316,7 @@ class ResourceRegistrar
     /**
      * Get the URI for a nested resource segment array.
      *
-     * @param  array   $segments
+     * @param  array  $segments
      * @return string
      */
     protected function getNestedResourceUri(array $segments)
@@ -354,7 +354,7 @@ class ResourceRegistrar
      * @param  string  $resource
      * @param  string  $controller
      * @param  string  $method
-     * @param  array   $options
+     * @param  array  $options
      * @return array
      */
     protected function getResourceAction($resource, $controller, $method, $options)
@@ -375,7 +375,7 @@ class ResourceRegistrar
      *
      * @param  string  $resource
      * @param  string  $method
-     * @param  array   $options
+     * @param  array  $options
      * @return string
      */
     protected function getResourceRouteName($resource, $method, $options)
@@ -425,7 +425,7 @@ class ResourceRegistrar
     /**
      * Set the global parameter mapping.
      *
-     * @param  array $parameters
+     * @param  array  $parameters
      * @return void
      */
     public static function setParameters(array $parameters = [])

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -316,7 +316,7 @@ class Route
     /**
      * Determine a given parameter exists from the route.
      *
-     * @param  string $name
+     * @param  string  $name
      * @return bool
      */
     public function hasParameter($name)
@@ -332,7 +332,7 @@ class Route
      * Get a given parameter from the route.
      *
      * @param  string  $name
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return string|object
      */
     public function parameter($name, $default = null)
@@ -344,7 +344,7 @@ class Route
      * Set a parameter to the given value.
      *
      * @param  string  $name
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function setParameter($name, $value)
@@ -761,7 +761,7 @@ class Route
     /**
      * Get or set the middlewares attached to the route.
      *
-     * @param  array|string|null $middleware
+     * @param  array|string|null  $middleware
      * @return $this|array
      */
     public function middleware($middleware = null)

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -78,7 +78,7 @@ class RouteAction
     /**
      * Make an action for an invokable controller.
      *
-     * @param  string $action
+     * @param  string  $action
      * @return string
      *
      * @throws \UnexpectedValueException

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -215,7 +215,7 @@ class UrlGenerator implements UrlGeneratorContract
      * Generate a secure, absolute URL to the given path.
      *
      * @param  string  $path
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     public function secure($path, $parameters = [])
@@ -374,7 +374,7 @@ class UrlGenerator implements UrlGeneratorContract
      * Get the URL to a named route.
      *
      * @param  string  $name
-     * @param  mixed   $parameters
+     * @param  mixed  $parameters
      * @param  bool  $absolute
      * @return string
      *
@@ -394,7 +394,7 @@ class UrlGenerator implements UrlGeneratorContract
      *
      * @param  \Illuminate\Routing\Route  $route
      * @param  mixed  $parameters
-     * @param  bool   $absolute
+     * @param  bool  $absolute
      * @return string
      *
      * @throws \Illuminate\Routing\Exceptions\UrlGenerationException
@@ -410,8 +410,8 @@ class UrlGenerator implements UrlGeneratorContract
      * Get the URL to a controller action.
      *
      * @param  string|array  $action
-     * @param  mixed   $parameters
-     * @param  bool    $absolute
+     * @param  mixed  $parameters
+     * @param  bool  $absolute
      * @return string
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/Session/EncryptedStore.php
+++ b/src/Illuminate/Session/EncryptedStore.php
@@ -18,10 +18,10 @@ class EncryptedStore extends Store
     /**
      * Create a new session instance.
      *
-     * @param  string $name
-     * @param  \SessionHandlerInterface $handler
-     * @param  \Illuminate\Contracts\Encryption\Encrypter $encrypter
-     * @param  string|null $id
+     * @param  string  $name
+     * @param  \SessionHandlerInterface  $handler
+     * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
+     * @param  string|null  $id
      * @return void
      */
     public function __construct($name, SessionHandlerInterface $handler, EncrypterContract $encrypter, $id = null)

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -49,9 +49,9 @@ class Store implements Session
     /**
      * Create a new session instance.
      *
-     * @param  string $name
-     * @param  \SessionHandlerInterface $handler
-     * @param  string|null $id
+     * @param  string  $name
+     * @param  \SessionHandlerInterface  $handler
+     * @param  string|null  $id
      * @return void
      */
     public function __construct($name, SessionHandlerInterface $handler, $id = null)
@@ -236,7 +236,7 @@ class Store implements Session
      * Get the requested item from the flashed input array.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function getOldInput($key = null, $default = null)
@@ -259,7 +259,7 @@ class Store implements Session
      * Put a key / value pair or array of key / value pairs in the session.
      *
      * @param  string|array  $key
-     * @param  mixed       $value
+     * @param  mixed  $value
      * @return void
      */
     public function put($key, $value = null)
@@ -295,7 +295,7 @@ class Store implements Session
      * Push a value onto a session array.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function push($key, $value)
@@ -337,7 +337,7 @@ class Store implements Session
      * Flash a key / value pair to the session.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function flash(string $key, $value = true)
@@ -352,8 +352,8 @@ class Store implements Session
     /**
      * Flash a key / value pair to the session for immediate use.
      *
-     * @param  string $key
-     * @param  mixed $value
+     * @param  string  $key
+     * @param  mixed  $value
      * @return void
      */
     public function now($key, $value)

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -24,9 +24,9 @@ class Arr
     /**
      * Add an element to an array using "dot" notation if it doesn't exist.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return array
      */
     public static function add($array, $key, $value)
@@ -102,7 +102,7 @@ class Arr
     /**
      * Flatten a multi-dimensional associative array with dots.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $prepend
      * @return array
      */
@@ -272,7 +272,7 @@ class Arr
      *
      * @param  \ArrayAccess|array  $array
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public static function get($array, $key, $default = null)
@@ -447,9 +447,9 @@ class Arr
     /**
      * Get a value from the array, and remove it.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public static function pull(&$array, $key, $default = null)
@@ -506,9 +506,9 @@ class Arr
      *
      * If no key is given to the method, the entire array will be replaced.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return array
      */
     public static function set(&$array, $key, $value)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -172,7 +172,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the median of a given key.
      *
-     * @param  string|array|null $key
+     * @param  string|array|null  $key
      * @return mixed
      */
     public function median($key = null)
@@ -397,7 +397,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the items in the collection whose keys are not present in the given items.
      *
-     * @param  mixed   $items
+     * @param  mixed  $items
      * @param  callable  $callback
      * @return static
      */
@@ -1297,7 +1297,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Pass the collection to the given callback and return the result.
      *
-     * @param  callable $callback
+     * @param  callable  $callback
      * @return mixed
      */
     public function pipe(callable $callback)
@@ -1638,7 +1638,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Sort the collection keys in descending order.
      *
-     * @param  int $options
+     * @param  int  $options
      * @return static
      */
     public function sortKeysDesc($options = SORT_REGULAR)

--- a/src/Illuminate/Support/Facades/Cookie.php
+++ b/src/Illuminate/Support/Facades/Cookie.php
@@ -26,7 +26,7 @@ class Cookie extends Facade
      * Retrieve a cookie from the request.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return string|array|null
      */
     public static function get($key = null, $default = null)

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -221,7 +221,7 @@ abstract class Facade
      * Handle dynamic, static calls to the object.
      *
      * @param  string  $method
-     * @param  array   $args
+     * @param  array  $args
      * @return mixed
      *
      * @throws \RuntimeException

--- a/src/Illuminate/Support/Facades/Input.php
+++ b/src/Illuminate/Support/Facades/Input.php
@@ -52,7 +52,7 @@ class Input extends Facade
      * This method is used for all request verbs (GET, POST, PUT, and DELETE)
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public static function get($key = null, $default = null)

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -33,7 +33,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      * Get an attribute from the fluent instance.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function get($key, $default = null)
@@ -112,7 +112,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      * Set the value at the given offset.
      *
      * @param  string  $offset
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function offsetSet($offset, $value)
@@ -135,7 +135,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      * Handle dynamic calls to the fluent instance to set attributes.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return $this
      */
     public function __call($method, $parameters)
@@ -160,7 +160,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      * Dynamically set the value of an attribute.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function __set($key, $value)

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -113,7 +113,7 @@ abstract class Manager
     /**
      * Register a custom driver creator Closure.
      *
-     * @param  string    $driver
+     * @param  string  $driver
      * @param  \Closure  $callback
      * @return $this
      */
@@ -138,7 +138,7 @@ abstract class Manager
      * Dynamically call the default driver instance.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -233,7 +233,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     /**
      * Format an array of messages.
      *
-     * @param  array   $messages
+     * @param  array  $messages
      * @param  string  $format
      * @param  string  $messageKey
      * @return array

--- a/src/Illuminate/Support/NamespacedItemResolver.php
+++ b/src/Illuminate/Support/NamespacedItemResolver.php
@@ -92,7 +92,7 @@ class NamespacedItemResolver
      * Set the parsed value of a key.
      *
      * @param  string  $key
-     * @param  array   $parsed
+     * @param  array  $parsed
      * @return void
      */
     public function setParsedKey($key, $parsed)

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -59,7 +59,7 @@ class Pluralizer
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int     $count
+     * @param  int  $count
      * @return string
      */
     public static function plural($value, $count = 2)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -213,7 +213,7 @@ class Str
      * Limit the number of characters in a string.
      *
      * @param  string  $value
-     * @param  int     $limit
+     * @param  int  $limit
      * @param  string  $end
      * @return string
      */
@@ -241,7 +241,7 @@ class Str
      * Limit the number of words in a string.
      *
      * @param  string  $value
-     * @param  int     $words
+     * @param  int  $words
      * @param  string  $end
      * @return string
      */
@@ -272,7 +272,7 @@ class Str
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int     $count
+     * @param  int  $count
      * @return string
      */
     public static function plural($value, $count = 2)
@@ -305,7 +305,7 @@ class Str
      * Replace a given value in the string sequentially with an array.
      *
      * @param  string  $search
-     * @param  array   $replace
+     * @param  array  $replace
      * @param  string  $subject
      * @return string
      */

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -261,8 +261,8 @@ class EventFake implements Dispatcher
     /**
      * Dispatch an event and call the listeners.
      *
-     * @param  string|object $event
-     * @param  mixed $payload
+     * @param  string|object  $event
+     * @param  mixed  $payload
      * @return void
      */
     public function until($event, $payload = [])

--- a/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
@@ -21,7 +21,7 @@ class PendingMailFake extends PendingMail
     /**
      * Send a new mailable message instance.
      *
-     * @param  \Illuminate\Mail\Mailable $mailable
+     * @param  \Illuminate\Mail\Mailable  $mailable
      * @return mixed
      */
     public function send(Mailable $mailable)
@@ -32,7 +32,7 @@ class PendingMailFake extends PendingMail
     /**
      * Send a mailable message immediately.
      *
-     * @param  \Illuminate\Mail\Mailable $mailable
+     * @param  \Illuminate\Mail\Mailable  $mailable
      * @return mixed
      */
     public function sendNow(Mailable $mailable)
@@ -43,7 +43,7 @@ class PendingMailFake extends PendingMail
     /**
      * Push the given mailable onto the queue.
      *
-     * @param  \Illuminate\Mail\Mailable $mailable
+     * @param  \Illuminate\Mail\Mailable  $mailable
      * @return mixed
      */
     public function queue(Mailable $mailable)

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -71,9 +71,9 @@ class QueueFake extends QueueManager implements Queue
     /**
      * Assert if a job was pushed with chained jobs based on a truth-test callback.
      *
-     * @param  string $job
-     * @param  array $expectedChain
-     * @param  callable|null $callback
+     * @param  string  $job
+     * @param  array  $expectedChain
+     * @param  callable|null  $callback
      * @return void
      */
     public function assertPushedWithChain($job, $expectedChain = [], $callback = null)
@@ -96,9 +96,9 @@ class QueueFake extends QueueManager implements Queue
     /**
      * Assert if a job was pushed with chained jobs based on a truth-test callback.
      *
-     * @param  string $job
-     * @param  array $expectedChain
-     * @param  callable|null $callback
+     * @param  string  $job
+     * @param  array  $expectedChain
+     * @param  callable|null  $callback
      * @return void
      */
     protected function assertPushedWithChainOfObjects($job, $expectedChain, $callback)
@@ -118,9 +118,9 @@ class QueueFake extends QueueManager implements Queue
     /**
      * Assert if a job was pushed with chained jobs based on a truth-test callback.
      *
-     * @param  string $job
-     * @param  array $expectedChain
-     * @param  callable|null $callback
+     * @param  string  $job
+     * @param  array  $expectedChain
+     * @param  callable|null  $callback
      * @return void
      */
     protected function assertPushedWithChainOfClasses($job, $expectedChain, $callback)
@@ -235,7 +235,7 @@ class QueueFake extends QueueManager implements Queue
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -252,7 +252,7 @@ class QueueFake extends QueueManager implements Queue
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -265,7 +265,7 @@ class QueueFake extends QueueManager implements Queue
      *
      * @param  \DateTime|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -279,7 +279,7 @@ class QueueFake extends QueueManager implements Queue
      *
      * @param  string  $queue
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @return mixed
      */
     public function pushOn($queue, $job, $data = '')
@@ -293,7 +293,7 @@ class QueueFake extends QueueManager implements Queue
      * @param  string  $queue
      * @param  \DateTime|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @return mixed
      */
     public function laterOn($queue, $delay, $job, $data = '')
@@ -315,9 +315,9 @@ class QueueFake extends QueueManager implements Queue
     /**
      * Push an array of jobs onto the queue.
      *
-     * @param  array $jobs
-     * @param  mixed $data
-     * @param  string $queue
+     * @param  array  $jobs
+     * @param  mixed  $data
+     * @param  string  $queue
      * @return mixed
      */
     public function bulk($jobs, $data = '', $queue = null)
@@ -340,7 +340,7 @@ class QueueFake extends QueueManager implements Queue
     /**
      * Set the connection name for the queue.
      *
-     * @param  string $name
+     * @param  string  $name
      * @return $this
      */
     public function setConnectionName($name)

--- a/src/Illuminate/Support/Traits/Localizable.php
+++ b/src/Illuminate/Support/Traits/Localizable.php
@@ -9,8 +9,8 @@ trait Localizable
     /**
      * Run the callback with the given locale.
      *
-     * @param  string   $locale
-     * @param  \Closure $callback
+     * @param  string  $locale
+     * @param  \Closure  $callback
      * @return mixed
      */
     public function withLocale($locale, $callback)

--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -19,9 +19,8 @@ trait Macroable
     /**
      * Register a custom macro.
      *
-     * @param  string $name
+     * @param  string  $name
      * @param  object|callable  $macro
-     *
      * @return void
      */
     public static function macro($name, $macro)
@@ -65,7 +64,7 @@ trait Macroable
      * Dynamically handle calls to the class.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      *
      * @throws \BadMethodCallException
@@ -89,7 +88,7 @@ trait Macroable
      * Dynamically handle calls to the class.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      *
      * @throws \BadMethodCallException

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -34,9 +34,9 @@ if (! function_exists('array_add')) {
     /**
      * Add an element to an array using "dot" notation if it doesn't exist.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return array
      */
     function array_add($array, $key, $value)
@@ -75,7 +75,7 @@ if (! function_exists('array_dot')) {
     /**
      * Flatten a multi-dimensional associative array with dots.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $prepend
      * @return array
      */
@@ -148,7 +148,7 @@ if (! function_exists('array_get')) {
      *
      * @param  \ArrayAccess|array  $array
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     function array_get($array, $key, $default = null)
@@ -204,7 +204,7 @@ if (! function_exists('array_pluck')) {
     /**
      * Pluck an array of values from an array.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string|array  $value
      * @param  string|array|null  $key
      * @return array
@@ -234,9 +234,9 @@ if (! function_exists('array_pull')) {
     /**
      * Get a value from the array, and remove it.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     function array_pull(&$array, $key, $default = null)
@@ -265,9 +265,9 @@ if (! function_exists('array_set')) {
      *
      * If no key is given to the method, the entire array will be replaced.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return array
      */
     function array_set(&$array, $key, $value)
@@ -427,7 +427,7 @@ if (! function_exists('data_fill')) {
     /**
      * Fill in data where it's missing.
      *
-     * @param  mixed   $target
+     * @param  mixed  $target
      * @param  string|array  $key
      * @param  mixed  $value
      * @return mixed
@@ -442,9 +442,9 @@ if (! function_exists('data_get')) {
     /**
      * Get an item from an array or object using "dot" notation.
      *
-     * @param  mixed   $target
+     * @param  mixed  $target
      * @param  string|array|int  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     function data_get($target, $key, $default = null)
@@ -584,7 +584,7 @@ if (! function_exists('env')) {
      * Gets the value of an environment variable.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     function env($key, $default = null)
@@ -676,7 +676,7 @@ if (! function_exists('object_get')) {
      *
      * @param  object  $object
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     function object_get($object, $key, $default = null)
@@ -720,7 +720,7 @@ if (! function_exists('preg_replace_array')) {
      * Replace a given pattern with each value in the array in sequentially.
      *
      * @param  string  $pattern
-     * @param  array   $replacements
+     * @param  array  $replacements
      * @param  string  $subject
      * @return string
      */
@@ -871,7 +871,7 @@ if (! function_exists('str_limit')) {
      * Limit the number of characters in a string.
      *
      * @param  string  $value
-     * @param  int     $limit
+     * @param  int  $limit
      * @param  string  $end
      * @return string
      */
@@ -886,7 +886,7 @@ if (! function_exists('str_plural')) {
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int     $count
+     * @param  int  $count
      * @return string
      */
     function str_plural($value, $count = 2)
@@ -915,7 +915,7 @@ if (! function_exists('str_replace_array')) {
      * Replace a given value in the string sequentially with an array.
      *
      * @param  string  $search
-     * @param  array   $replace
+     * @param  array  $replace
      * @param  string  $subject
      * @return string
      */
@@ -1059,6 +1059,7 @@ if (! function_exists('throw_unless')) {
      * @param  \Throwable|string  $exception
      * @param  array  ...$parameters
      * @return mixed
+     *
      * @throws \Throwable
      */
     function throw_unless($condition, $exception, ...$parameters)

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -92,7 +92,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * Get the translation for a given key.
      *
      * @param  string  $key
-     * @param  array   $replace
+     * @param  array  $replace
      * @param  string  $locale
      * @return string|array
      */
@@ -105,7 +105,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * Get the translation for the given key.
      *
      * @param  string  $key
-     * @param  array   $replace
+     * @param  array  $replace
      * @param  string|null  $locale
      * @param  bool  $fallback
      * @return string|array
@@ -176,7 +176,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      *
      * @param  string  $key
      * @param  int|array|\Countable  $number
-     * @param  array   $replace
+     * @param  array  $replace
      * @param  string  $locale
      * @return string
      */
@@ -190,7 +190,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      *
      * @param  string  $key
      * @param  int|array|\Countable  $number
-     * @param  array   $replace
+     * @param  array  $replace
      * @param  string  $locale
      * @return string
      */
@@ -232,7 +232,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  string  $group
      * @param  string  $locale
      * @param  string  $item
-     * @param  array   $replace
+     * @param  array  $replace
      * @return string|array|null
      */
     protected function getLine($namespace, $group, $locale, $item, array $replace)
@@ -252,7 +252,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * Make the place-holder replacements on a line.
      *
      * @param  string  $line
-     * @param  array   $replace
+     * @param  array  $replace
      * @return string
      */
     protected function makeReplacements($line, array $replace)

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -197,7 +197,7 @@ trait FormatsMessages
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     public function makeReplacements($message, $attribute, $rule, $parameters)
@@ -305,7 +305,7 @@ trait FormatsMessages
      * Get the displayable name of the value.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return string
      */
     public function getDisplayableValue($attribute, $value)
@@ -349,7 +349,7 @@ trait FormatsMessages
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @param  \Illuminate\Validation\Validator  $validator
      * @return string|null
      */
@@ -371,7 +371,7 @@ trait FormatsMessages
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @param  \Illuminate\Validation\Validator  $validator
      * @return string
      */

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -12,7 +12,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceBetween($message, $attribute, $rule, $parameters)
@@ -26,7 +26,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceDateFormat($message, $attribute, $rule, $parameters)
@@ -40,7 +40,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceDifferent($message, $attribute, $rule, $parameters)
@@ -54,7 +54,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceDigits($message, $attribute, $rule, $parameters)
@@ -68,7 +68,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceDigitsBetween($message, $attribute, $rule, $parameters)
@@ -82,7 +82,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceMin($message, $attribute, $rule, $parameters)
@@ -96,7 +96,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceMax($message, $attribute, $rule, $parameters)
@@ -110,7 +110,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceIn($message, $attribute, $rule, $parameters)
@@ -128,7 +128,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceNotIn($message, $attribute, $rule, $parameters)
@@ -142,7 +142,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceInArray($message, $attribute, $rule, $parameters)
@@ -156,7 +156,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceMimetypes($message, $attribute, $rule, $parameters)
@@ -170,7 +170,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceMimes($message, $attribute, $rule, $parameters)
@@ -184,7 +184,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceRequiredWith($message, $attribute, $rule, $parameters)
@@ -198,7 +198,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceRequiredWithAll($message, $attribute, $rule, $parameters)
@@ -212,7 +212,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceRequiredWithout($message, $attribute, $rule, $parameters)
@@ -226,7 +226,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceRequiredWithoutAll($message, $attribute, $rule, $parameters)
@@ -240,7 +240,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceSize($message, $attribute, $rule, $parameters)
@@ -254,7 +254,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceGt($message, $attribute, $rule, $parameters)
@@ -272,7 +272,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceLt($message, $attribute, $rule, $parameters)
@@ -290,7 +290,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceGte($message, $attribute, $rule, $parameters)
@@ -308,7 +308,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceLte($message, $attribute, $rule, $parameters)
@@ -326,7 +326,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceRequiredIf($message, $attribute, $rule, $parameters)
@@ -344,7 +344,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceRequiredUnless($message, $attribute, $rule, $parameters)
@@ -366,7 +366,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceSame($message, $attribute, $rule, $parameters)
@@ -380,7 +380,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceBefore($message, $attribute, $rule, $parameters)
@@ -398,7 +398,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceBeforeOrEqual($message, $attribute, $rule, $parameters)
@@ -412,7 +412,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceAfter($message, $attribute, $rule, $parameters)
@@ -426,7 +426,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceAfterOrEqual($message, $attribute, $rule, $parameters)
@@ -440,7 +440,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceDateEquals($message, $attribute, $rule, $parameters)
@@ -454,7 +454,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceDimensions($message, $attribute, $rule, $parameters)
@@ -476,7 +476,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceStartsWith($message, $attribute, $rule, $parameters)

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -26,7 +26,7 @@ trait ValidatesAttributes
      * This validation rule implies the attribute is "required".
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateAccepted($attribute, $value)
@@ -40,7 +40,7 @@ trait ValidatesAttributes
      * Validate that an attribute is an active URL.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateActiveUrl($attribute, $value)
@@ -76,8 +76,8 @@ trait ValidatesAttributes
      * Validate the date is before a given date.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateBefore($attribute, $value, $parameters)
@@ -91,8 +91,8 @@ trait ValidatesAttributes
      * Validate the date is before or equal a given date.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateBeforeOrEqual($attribute, $value, $parameters)
@@ -106,8 +106,8 @@ trait ValidatesAttributes
      * Validate the date is after a given date.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateAfter($attribute, $value, $parameters)
@@ -121,8 +121,8 @@ trait ValidatesAttributes
      * Validate the date is equal or after a given date.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateAfterOrEqual($attribute, $value, $parameters)
@@ -233,7 +233,7 @@ trait ValidatesAttributes
     /**
      * Get a DateTime instance from a string with no format.
      *
-     * @param  string $value
+     * @param  string  $value
      * @return \DateTime|null
      */
     protected function getDateTime($value)
@@ -252,7 +252,7 @@ trait ValidatesAttributes
     /**
      * Check if the given value should be adjusted to Carbon::getTestNow().
      *
-     * @param  mixed $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function isTestingRelativeDateTime($value)
@@ -266,7 +266,7 @@ trait ValidatesAttributes
      * Validate that an attribute contains only alphabetic characters.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateAlpha($attribute, $value)
@@ -278,7 +278,7 @@ trait ValidatesAttributes
      * Validate that an attribute contains only alpha-numeric characters, dashes, and underscores.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateAlphaDash($attribute, $value)
@@ -294,7 +294,7 @@ trait ValidatesAttributes
      * Validate that an attribute contains only alpha-numeric characters.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateAlphaNum($attribute, $value)
@@ -310,7 +310,7 @@ trait ValidatesAttributes
      * Validate that an attribute is an array.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateArray($attribute, $value)
@@ -322,8 +322,8 @@ trait ValidatesAttributes
      * Validate the size of an attribute is between a set of values.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateBetween($attribute, $value, $parameters)
@@ -339,7 +339,7 @@ trait ValidatesAttributes
      * Validate that an attribute is a boolean.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateBoolean($attribute, $value)
@@ -353,7 +353,7 @@ trait ValidatesAttributes
      * Validate that an attribute has a matching confirmation.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateConfirmed($attribute, $value)
@@ -365,7 +365,7 @@ trait ValidatesAttributes
      * Validate that an attribute is a valid date.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateDate($attribute, $value)
@@ -387,8 +387,8 @@ trait ValidatesAttributes
      * Validate that an attribute matches a date format.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateDateFormat($attribute, $value, $parameters)
@@ -410,8 +410,8 @@ trait ValidatesAttributes
      * Validate that an attribute is equal to another date.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateDateEquals($attribute, $value, $parameters)
@@ -425,8 +425,8 @@ trait ValidatesAttributes
      * Validate that an attribute is different from another attribute.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateDifferent($attribute, $value, $parameters)
@@ -448,8 +448,8 @@ trait ValidatesAttributes
      * Validate that an attribute has a given number of digits.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateDigits($attribute, $value, $parameters)
@@ -464,8 +464,8 @@ trait ValidatesAttributes
      * Validate that an attribute is between a given number of digits.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateDigitsBetween($attribute, $value, $parameters)
@@ -481,9 +481,9 @@ trait ValidatesAttributes
     /**
      * Validate the dimensions of an image matches the given values.
      *
-     * @param  string $attribute
-     * @param  mixed $value
-     * @param  array $parameters
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateDimensions($attribute, $value, $parameters)
@@ -555,8 +555,8 @@ trait ValidatesAttributes
      * Validate an attribute is unique among other values.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateDistinct($attribute, $value, $parameters)
@@ -614,7 +614,7 @@ trait ValidatesAttributes
      * Validate that an attribute is a valid e-mail address.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateEmail($attribute, $value)
@@ -626,8 +626,8 @@ trait ValidatesAttributes
      * Validate the existence of an attribute value in a database table.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateExists($attribute, $value, $parameters)
@@ -651,11 +651,11 @@ trait ValidatesAttributes
     /**
      * Get the number of records that exist in storage.
      *
-     * @param  mixed   $connection
+     * @param  mixed  $connection
      * @param  string  $table
      * @param  string  $column
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return int
      */
     protected function getExistCount($connection, $table, $column, $value, $parameters)
@@ -681,8 +681,8 @@ trait ValidatesAttributes
      * If a database column is not specified, the attribute will be used.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateUnique($attribute, $value, $parameters)
@@ -832,7 +832,7 @@ trait ValidatesAttributes
      * Validate the given value is a valid file.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateFile($attribute, $value)
@@ -844,7 +844,7 @@ trait ValidatesAttributes
      * Validate the given attribute is filled if it is present.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateFilled($attribute, $value)
@@ -860,8 +860,8 @@ trait ValidatesAttributes
      * Validate that an attribute is greater than another attribute.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateGt($attribute, $value, $parameters)
@@ -885,8 +885,8 @@ trait ValidatesAttributes
      * Validate that an attribute is less than another attribute.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateLt($attribute, $value, $parameters)
@@ -910,8 +910,8 @@ trait ValidatesAttributes
      * Validate that an attribute is greater than or equal another attribute.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateGte($attribute, $value, $parameters)
@@ -935,8 +935,8 @@ trait ValidatesAttributes
      * Validate that an attribute is less than or equal another attribute.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateLte($attribute, $value, $parameters)
@@ -960,7 +960,7 @@ trait ValidatesAttributes
      * Validate the MIME type of a file is an image MIME type.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateImage($attribute, $value)
@@ -972,8 +972,8 @@ trait ValidatesAttributes
      * Validate an attribute is contained within a list of values.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateIn($attribute, $value, $parameters)
@@ -995,8 +995,8 @@ trait ValidatesAttributes
      * Validate that the values of an attribute is in another attribute.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateInArray($attribute, $value, $parameters)
@@ -1018,7 +1018,7 @@ trait ValidatesAttributes
      * Validate that an attribute is an integer.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateInteger($attribute, $value)
@@ -1030,7 +1030,7 @@ trait ValidatesAttributes
      * Validate that an attribute is a valid IP.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateIp($attribute, $value)
@@ -1042,7 +1042,7 @@ trait ValidatesAttributes
      * Validate that an attribute is a valid IPv4.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateIpv4($attribute, $value)
@@ -1054,7 +1054,7 @@ trait ValidatesAttributes
      * Validate that an attribute is a valid IPv6.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateIpv6($attribute, $value)
@@ -1066,7 +1066,7 @@ trait ValidatesAttributes
      * Validate the attribute is a valid JSON string.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateJson($attribute, $value)
@@ -1084,8 +1084,8 @@ trait ValidatesAttributes
      * Validate the size of an attribute is less than a maximum value.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateMax($attribute, $value, $parameters)
@@ -1104,7 +1104,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return bool
      */
     public function validateMimes($attribute, $value, $parameters)
@@ -1169,8 +1169,8 @@ trait ValidatesAttributes
      * Validate the size of an attribute is greater than a minimum value.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateMin($attribute, $value, $parameters)
@@ -1196,8 +1196,8 @@ trait ValidatesAttributes
      * Validate an attribute is not contained within a list of values.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateNotIn($attribute, $value, $parameters)
@@ -1209,7 +1209,7 @@ trait ValidatesAttributes
      * Validate that an attribute is numeric.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateNumeric($attribute, $value)
@@ -1221,7 +1221,7 @@ trait ValidatesAttributes
      * Validate that an attribute exists even if not filled.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validatePresent($attribute, $value)
@@ -1233,8 +1233,8 @@ trait ValidatesAttributes
      * Validate that an attribute passes a regular expression check.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateRegex($attribute, $value, $parameters)
@@ -1252,8 +1252,8 @@ trait ValidatesAttributes
      * Validate that an attribute does not pass a regular expression check.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateNotRegex($attribute, $value, $parameters)
@@ -1271,7 +1271,7 @@ trait ValidatesAttributes
      * Validate that a required attribute exists.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateRequired($attribute, $value)
@@ -1293,8 +1293,8 @@ trait ValidatesAttributes
      * Validate that an attribute exists when another attribute has a given value.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
+     * @param  mixed  $value
+     * @param  mixed  $parameters
      * @return bool
      */
     public function validateRequiredIf($attribute, $value, $parameters)
@@ -1362,8 +1362,8 @@ trait ValidatesAttributes
      * Validate that an attribute exists when any other attribute exists.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
+     * @param  mixed  $value
+     * @param  mixed  $parameters
      * @return bool
      */
     public function validateRequiredWith($attribute, $value, $parameters)
@@ -1379,8 +1379,8 @@ trait ValidatesAttributes
      * Validate that an attribute exists when all other attributes exists.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
+     * @param  mixed  $value
+     * @param  mixed  $parameters
      * @return bool
      */
     public function validateRequiredWithAll($attribute, $value, $parameters)
@@ -1396,8 +1396,8 @@ trait ValidatesAttributes
      * Validate that an attribute exists when another attribute does not.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
+     * @param  mixed  $value
+     * @param  mixed  $parameters
      * @return bool
      */
     public function validateRequiredWithout($attribute, $value, $parameters)
@@ -1413,8 +1413,8 @@ trait ValidatesAttributes
      * Validate that an attribute exists when all other attributes do not.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
+     * @param  mixed  $value
+     * @param  mixed  $parameters
      * @return bool
      */
     public function validateRequiredWithoutAll($attribute, $value, $parameters)
@@ -1464,8 +1464,8 @@ trait ValidatesAttributes
      * Validate that two attributes match.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateSame($attribute, $value, $parameters)
@@ -1481,8 +1481,8 @@ trait ValidatesAttributes
      * Validate the size of an attribute.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateSize($attribute, $value, $parameters)
@@ -1508,8 +1508,8 @@ trait ValidatesAttributes
      * Validate the attribute starts with a given substring.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     public function validateStartsWith($attribute, $value, $parameters)
@@ -1521,7 +1521,7 @@ trait ValidatesAttributes
      * Validate that an attribute is a string.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateString($attribute, $value)
@@ -1533,7 +1533,7 @@ trait ValidatesAttributes
      * Validate that an attribute is a valid timezone.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateTimezone($attribute, $value)
@@ -1553,7 +1553,7 @@ trait ValidatesAttributes
      * Validate that an attribute is a valid URL.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     public function validateUrl($attribute, $value)
@@ -1606,7 +1606,7 @@ trait ValidatesAttributes
      * Get the size of an attribute.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return mixed
      */
     protected function getSize($attribute, $value)
@@ -1691,7 +1691,7 @@ trait ValidatesAttributes
     /**
      * Require a certain number of parameters to be present.
      *
-     * @param  int    $count
+     * @param  int  $count
      * @param  array  $parameters
      * @param  string  $rule
      * @return void
@@ -1726,7 +1726,6 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  string  $rule
-     *
      * @return void
      */
     protected function shouldBeNumeric($attribute, $rule)

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -60,8 +60,8 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface
      *
      * @param  string  $collection
      * @param  string  $column
-     * @param  array   $values
-     * @param  array   $extra
+     * @param  array  $values
+     * @param  array  $extra
      * @return int
      */
     public function getMultiCount($collection, $column, array $values, array $extra = [])

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -76,7 +76,7 @@ class Factory implements FactoryContract
     /**
      * Create a new Validator factory instance.
      *
-     * @param  \Illuminate\Contracts\Translation\Translator $translator
+     * @param  \Illuminate\Contracts\Translation\Translator  $translator
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @return void
      */
@@ -196,7 +196,7 @@ class Factory implements FactoryContract
     /**
      * Register a custom implicit validator extension.
      *
-     * @param  string   $rule
+     * @param  string  $rule
      * @param  \Closure|string  $extension
      * @param  string  $message
      * @return void
@@ -213,7 +213,7 @@ class Factory implements FactoryContract
     /**
      * Register a custom dependent validator extension.
      *
-     * @param  string   $rule
+     * @param  string  $rule
      * @param  \Closure|string  $extension
      * @param  string  $message
      * @return void
@@ -230,7 +230,7 @@ class Factory implements FactoryContract
     /**
      * Register a custom validator message replacer.
      *
-     * @param  string   $rule
+     * @param  string  $rule
      * @param  \Closure|string  $replacer
      * @return void
      */

--- a/src/Illuminate/Validation/PresenceVerifierInterface.php
+++ b/src/Illuminate/Validation/PresenceVerifierInterface.php
@@ -10,9 +10,9 @@ interface PresenceVerifierInterface
      * @param  string  $collection
      * @param  string  $column
      * @param  string  $value
-     * @param  int     $excludeId
+     * @param  int  $excludeId
      * @param  string  $idColumn
-     * @param  array   $extra
+     * @param  array  $extra
      * @return int
      */
     public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = []);
@@ -22,8 +22,8 @@ interface PresenceVerifierInterface
      *
      * @param  string  $collection
      * @param  string  $column
-     * @param  array   $values
-     * @param  array   $extra
+     * @param  array  $values
+     * @param  array  $extra
      * @return int
      */
     public function getMultiCount($collection, $column, array $values, array $extra = []);

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -470,7 +470,7 @@ class Validator implements ValidatorContract
      *
      * @param  object|string  $rule
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function isValidatable($rule, $attribute, $value)
@@ -486,7 +486,7 @@ class Validator implements ValidatorContract
      *
      * @param  object|string  $rule
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function presentOrRuleIsImplicit($rule, $attribute, $value)
@@ -612,7 +612,7 @@ class Validator implements ValidatorContract
      *
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return void
      */
     public function addFailure($attribute, $rule, $parameters = [])
@@ -931,7 +931,7 @@ class Validator implements ValidatorContract
     /**
      * Register a custom implicit validator extension.
      *
-     * @param  string   $rule
+     * @param  string  $rule
      * @param  \Closure|string  $extension
      * @return void
      */
@@ -945,7 +945,7 @@ class Validator implements ValidatorContract
     /**
      * Register a custom dependent validator extension.
      *
-     * @param  string   $rule
+     * @param  string  $rule
      * @param  \Closure|string  $extension
      * @return void
      */
@@ -1139,7 +1139,7 @@ class Validator implements ValidatorContract
      * Call a custom validator extension.
      *
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return bool|null
      */
     protected function callExtension($rule, $parameters)
@@ -1157,7 +1157,7 @@ class Validator implements ValidatorContract
      * Call a class based validator extension.
      *
      * @param  string  $callback
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return bool
      */
     protected function callClassBasedExtension($callback, $parameters)
@@ -1171,7 +1171,7 @@ class Validator implements ValidatorContract
      * Handle dynamic calls to class methods.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      *
      * @throws \BadMethodCallException

--- a/src/Illuminate/View/Concerns/ManagesEvents.php
+++ b/src/Illuminate/View/Concerns/ManagesEvents.php
@@ -11,7 +11,7 @@ trait ManagesEvents
     /**
      * Register a view creator event.
      *
-     * @param  array|string     $views
+     * @param  array|string  $views
      * @param  \Closure|string  $callback
      * @return array
      */
@@ -85,9 +85,9 @@ trait ManagesEvents
     /**
      * Register a class based view composer.
      *
-     * @param  string    $view
-     * @param  string    $class
-     * @param  string    $prefix
+     * @param  string  $view
+     * @param  string  $class
+     * @param  string  $prefix
      * @return \Closure
      */
     protected function addClassEvent($view, $class, $prefix)
@@ -153,7 +153,7 @@ trait ManagesEvents
     /**
      * Add a listener to the event dispatcher.
      *
-     * @param  string    $name
+     * @param  string  $name
      * @param  \Closure  $callback
      * @return void
      */

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -37,7 +37,7 @@ class CompilerEngine extends PhpEngine
      * Get the evaluated contents of the view.
      *
      * @param  string  $path
-     * @param  array   $data
+     * @param  array  $data
      * @return string
      */
     public function get($path, array $data = [])

--- a/src/Illuminate/View/Engines/EngineResolver.php
+++ b/src/Illuminate/View/Engines/EngineResolver.php
@@ -26,7 +26,7 @@ class EngineResolver
      *
      * The engine string typically corresponds to a file extension.
      *
-     * @param  string   $engine
+     * @param  string  $engine
      * @param  \Closure  $resolver
      * @return void
      */

--- a/src/Illuminate/View/Engines/FileEngine.php
+++ b/src/Illuminate/View/Engines/FileEngine.php
@@ -10,7 +10,7 @@ class FileEngine implements Engine
      * Get the evaluated contents of the view.
      *
      * @param  string  $path
-     * @param  array   $data
+     * @param  array  $data
      * @return string
      */
     public function get($path, array $data = [])

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -13,7 +13,7 @@ class PhpEngine implements Engine
      * Get the evaluated contents of the view.
      *
      * @param  string  $path
-     * @param  array   $data
+     * @param  array  $data
      * @return string
      */
     public function get($path, array $data = [])
@@ -25,7 +25,7 @@ class PhpEngine implements Engine
      * Get the evaluated contents of the view at the given path.
      *
      * @param  string  $__path
-     * @param  array   $__data
+     * @param  array  $__data
      * @return string
      */
     protected function evaluatePath($__path, $__data)

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -103,8 +103,8 @@ class Factory implements FactoryContract
      * Get the evaluated view contents for the given view.
      *
      * @param  string  $path
-     * @param  \Illuminate\Contracts\Support\Arrayable|array   $data
-     * @param  array   $mergeData
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
+     * @param  array  $mergeData
      * @return \Illuminate\Contracts\View\View
      */
     public function file($path, $data = [], $mergeData = [])
@@ -120,8 +120,8 @@ class Factory implements FactoryContract
      * Get the evaluated view contents for the given view.
      *
      * @param  string  $view
-     * @param  \Illuminate\Contracts\Support\Arrayable|array   $data
-     * @param  array   $mergeData
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
+     * @param  array  $mergeData
      * @return \Illuminate\Contracts\View\View
      */
     public function make($view, $data = [], $mergeData = [])
@@ -144,8 +144,8 @@ class Factory implements FactoryContract
      * Get the first view that actually exists from the given list.
      *
      * @param  array  $views
-     * @param  \Illuminate\Contracts\Support\Arrayable|array   $data
-     * @param  array   $mergeData
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
+     * @param  array  $mergeData
      * @return \Illuminate\Contracts\View\View
      *
      * @throws \InvalidArgumentException
@@ -168,8 +168,8 @@ class Factory implements FactoryContract
      *
      * @param  bool  $condition
      * @param  string  $view
-     * @param  \Illuminate\Contracts\Support\Arrayable|array   $data
-     * @param  array   $mergeData
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
+     * @param  array  $mergeData
      * @return string
      */
     public function renderWhen($condition, $view, $data = [], $mergeData = [])
@@ -185,7 +185,7 @@ class Factory implements FactoryContract
      * Get the rendered contents of a partial from a loop.
      *
      * @param  string  $view
-     * @param  array   $data
+     * @param  array  $data
      * @param  string  $iterator
      * @param  string  $empty
      * @return string
@@ -220,7 +220,7 @@ class Factory implements FactoryContract
     /**
      * Normalize a view name.
      *
-     * @param  string $name
+     * @param  string  $name
      * @return string
      */
     protected function normalizeName($name)
@@ -407,8 +407,8 @@ class Factory implements FactoryContract
     /**
      * Register a valid view extension and its engine.
      *
-     * @param  string    $extension
-     * @param  string    $engine
+     * @param  string  $extension
+     * @param  string  $engine
      * @param  \Closure  $resolver
      * @return void
      */
@@ -547,7 +547,7 @@ class Factory implements FactoryContract
      * Get an item from the shared data.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function shared($key, $default = null)

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -119,7 +119,7 @@ class FileViewFinder implements ViewFinderInterface
      * Find the given view in the list of paths.
      *
      * @param  string  $name
-     * @param  array   $paths
+     * @param  array  $paths
      * @return string
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -178,7 +178,7 @@ class View implements ArrayAccess, ViewContract
      * Add a piece of data to the view.
      *
      * @param  string|array  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return $this
      */
     public function with($key, $value = null)
@@ -197,7 +197,7 @@ class View implements ArrayAccess, ViewContract
      *
      * @param  string  $key
      * @param  string  $view
-     * @param  array   $data
+     * @param  array  $data
      * @return $this
      */
     public function nest($key, $view, array $data = [])
@@ -327,7 +327,7 @@ class View implements ArrayAccess, ViewContract
      * Set a piece of data on the view.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function offsetSet($key, $value)
@@ -361,7 +361,7 @@ class View implements ArrayAccess, ViewContract
      * Set a piece of data on the view.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function __set($key, $value)
@@ -395,7 +395,7 @@ class View implements ArrayAccess, ViewContract
      * Dynamically bind parameters to the view.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return \Illuminate\View\View
      *
      * @throws \BadMethodCallException

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -621,9 +621,9 @@ class AuthAccessGateTest extends TestCase
     /**
      * @dataProvider hasAbilitiesTestDataProvider
      *
-     * @param array $abilitiesToSet
-     * @param array|string $abilitiesToCheck
-     * @param bool $expectedHasValue
+     * @param  array  $abilitiesToSet
+     * @param  array|string  $abilitiesToCheck
+     * @param  bool  $expectedHasValue
      */
     public function test_has_abilities($abilitiesToSet, $abilitiesToCheck, $expectedHasValue)
     {

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -177,7 +177,8 @@ class CacheRepositoryTest extends TestCase
 
     /**
      * @dataProvider dataProviderTestGetMinutes
-     * @param mixed $duration
+     *
+     * @param  mixed  $duration
      */
     public function testGetMinutes($duration)
     {

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -28,7 +28,7 @@ class RedisCacheIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testRedisCacheAddTwice($driver)
     {
@@ -44,7 +44,7 @@ class RedisCacheIntegrationTest extends TestCase
      *
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testRedisCacheAddFalse($driver)
     {
@@ -60,7 +60,7 @@ class RedisCacheIntegrationTest extends TestCase
      *
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testRedisCacheAddNull($driver)
     {

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -537,7 +537,7 @@ class FilesystemTest extends TestCase
     }
 
     /**
-     * @param string $file
+     * @param  string  $file
      * @return int
      */
     private function getFilePermissions($file)

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -68,7 +68,7 @@ class HttpJsonResponseTest extends TestCase
     }
 
     /**
-     * @param mixed $data
+     * @param  mixed  $data
      *
      * @expectedException \InvalidArgumentException
      *
@@ -80,7 +80,7 @@ class HttpJsonResponseTest extends TestCase
     }
 
     /**
-     * @param mixed $data
+     * @param  mixed  $data
      *
      * @dataProvider jsonErrorDataProvider
      */

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -13,8 +13,7 @@ class EventFakeTest extends TestCase
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application   $app
-     *
+     * @param  \Illuminate\Foundation\Application  $app
      * @return void
      */
     protected function getEnvironmentSetUp($app)

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -78,8 +78,9 @@ class sendRawEmailMock
 
     /**
      * Mock the get() call for the sendRawEmail response.
-     * @param  [type] $key [description]
-     * @return [type]      [description]
+     *
+     * @param  string  $key
+     * @return mixed
      */
     public function get($key)
     {

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -38,7 +38,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testExpiredJobsArePopped($driver)
     {
@@ -68,7 +68,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testPopProperlyPopsJobOffOfRedis($driver)
     {
@@ -103,7 +103,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testPopProperlyPopsDelayedJobOffOfRedis($driver)
     {
@@ -130,7 +130,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testPopPopsDelayedJobOffOfRedisWhenExpireNull($driver)
     {
@@ -159,7 +159,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testNotExpireJobsWhenExpireNull($driver)
     {
@@ -203,7 +203,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testExpireJobsWhenExpireSet($driver)
     {
@@ -232,7 +232,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testRelease($driver)
     {
@@ -273,7 +273,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testReleaseInThePast($driver)
     {
@@ -291,7 +291,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testDelete($driver)
     {
@@ -315,7 +315,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testSize($driver)
     {
@@ -334,7 +334,7 @@ class RedisQueueIntegrationTest extends TestCase
     }
 
     /**
-     * @param string $driver
+     * @param  string  $driver
      */
     private function setQueue($driver)
     {


### PR DESCRIPTION
This PR modifies **only** PHPDoc blocks and has no functional changes.

According to the [Contribution Guide](https://laravel.com/docs/5.7/contributions#coding-style):

> @param attribute is followed by two spaces, the argument type, two more spaces, and finally the variable name

Which was NOT true in many places.

This PR fixes it for all Laravel codebase.