### PR TITLE
[5.7] Bug fix related to extra calls to resolving callbacks (The Other way)

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1022,6 +1022,356 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $instance->name);
     }
 
+    public function testResolvingCallbacksAreCalledOnceForImplementation()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testGlobalResolvingCallbacksAreCalledOnceForImplementation()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(function ($some) use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testAfterResolvingCallbacksAreCalledOnceForImplementation()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->afterResolving(IContainerContractStub::class, function ($some) use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledOnceForSingletonConcretes()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+        $container->bind(ContainerImplementationStub::class);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(3, $callCounter);
+    }
+
+    public function testResolvingCallbacksCanStillBeAddedAfterTheFirstResolution()
+    {
+        $container = new Container;
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(ContainerImplementationStub::class);
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCanceledWhenInterfaceGetsBoundToSomeOtherConcrete()
+    {
+        $container = new Container;
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $callCounter = 0;
+        $container->resolving(ContainerImplementationStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStubTwo::class);
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledOnceForStringAbstractions()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving('foo', function ($some) use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind('foo', ContainerImplementationStub::class);
+
+        $container->make('foo');
+        $this->assertEquals(1, $callCounter);
+
+        $container->make('foo');
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledOnceForImplementation2()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, function () {
+            return new ContainerImplementationStub;
+        });
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(3, $callCounter);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(4, $callCounter);
+    }
+
+    public function testRebindingDoesNotAffectResolvingCallbacks()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+        $container->bind(IContainerContractStub::class, function () {
+            return new ContainerImplementationStub;
+        });
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(3, $callCounter);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(4, $callCounter);
+    }
+
+    public function testParametersPassedIntoResolvingCallbacks()
+    {
+        $container = new Container;
+
+        $container->resolving(IContainerContractStub::class, function ($obj, $app) use ($container) {
+            $this->assertInstanceOf(IContainerContractStub::class, $obj);
+            $this->assertInstanceOf(ContainerImplementationStubTwo::class, $obj);
+            $this->assertSame($container, $app);
+        });
+
+        $container->afterResolving(IContainerContractStub::class, function ($obj, $app) use ($container) {
+            $this->assertInstanceOf(IContainerContractStub::class, $obj);
+            $this->assertInstanceOf(ContainerImplementationStubTwo::class, $obj);
+            $this->assertSame($container, $app);
+        });
+
+        $container->afterResolving(function ($obj, $app) use ($container) {
+            $this->assertInstanceOf(IContainerContractStub::class, $obj);
+            $this->assertInstanceOf(ContainerImplementationStubTwo::class, $obj);
+            $this->assertSame($container, $app);
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStubTwo::class);
+        $container->make(IContainerContractStub::class);
+    }
+
+    public function testResolvingCallbacksAreCallWhenRebindHappenForResolvedAbstract()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStubTwo::class);
+        $this->assertEquals(2, $callCounter);
+
+        $container->make(ContainerImplementationStubTwo::class);
+        $this->assertEquals(3, $callCounter);
+
+        $container->bind(IContainerContractStub::class, function () {
+            return new ContainerImplementationStubTwo();
+        });
+        $this->assertEquals(4, $callCounter);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(5, $callCounter);
+    }
+
+    public function testRebindingDoesNotAffectMultipleResolvingCallbacks()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->resolving(ContainerImplementationStubTwo::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        // it should call the callback for interface
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        // it should call the callback for interface
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+
+        // should call the callback for the interface it implements
+        // plus the callback for ContainerImplementationStubTwo.
+        $container->make(ContainerImplementationStubTwo::class);
+        $this->assertEquals(4, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledForInterfaces()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(IContainerContractStub::class);
+
+        $this->assertEquals(1, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledForConcretesWhenAttachedOnInterface()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(ContainerImplementationStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledForConcretesWhenAttachedOnConcretes()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(ContainerImplementationStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $container->make(IContainerContractStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledForConcretesWithNoBinding()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(ContainerImplementationStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testResolvingCallbacksAreCalledForInterFacesWithNoBinding()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(IContainerContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+        $container->make(ContainerImplementationStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
     public function testMakeWithMethodIsAnAliasForMakeMethod()
     {
         $mock = $this->getMockBuilder(Container::class)


### PR DESCRIPTION
(Following the currently open PR https://github.com/laravel/framework/pull/27014) This is an other way of fixing the issue of "multiple calls to resolving callback" which came to my mind while I was under the shower today.🚿 🛀 

Compared to the solution in: https://github.com/laravel/framework/pull/27014 ,it requires a less code and is more understandable and logical.
Plus, it adds an opportunity to have a fully backward compatible new feature to the IOC container for resolving an object silently. (Which will suppress the resolving callbacks.)
for example : `makeSilent(...`

- The tests between the 2 PRs (this one and https://github.com/laravel/framework/pull/27014 ) are exactly the same.

This way we fire the callback attached to the interface and skip the re-firing it when resolving the implementation.
which makes more sense, because the callback was actually attached to the interface like this :
`app()->bind(someInterface::class, 'Myclass'`); `

Anyway I do not know which one you like most, so I leave them both open.
