### PR TITLE
[5.8] tests for collection contains method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -261,17 +261,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function contains($key, $operator = null, $value = null)
     {
-        if (func_num_args() === 1) {
-            if ($this->useAsCallable($key)) {
-                $placeholder = new stdClass;
-
-                return $this->first($key, $placeholder) !== $placeholder;
-            }
-
-            return in_array($key, $this->items);
+        if (func_num_args() !== 1) {
+            return $this->contains($this->operatorForWhere(...func_get_args()));
         }
 
-        return $this->contains($this->operatorForWhere(...func_get_args()));
+        if ($this->useAsCallable($key)) {
+            $placeholder = new stdClass;
+
+            return $this->first($key, $placeholder) !== $placeholder;
+        }
+
+        return in_array($key, $this->items);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1819,13 +1819,23 @@ class SupportCollectionTest extends TestCase
         $c = new Collection([1, 3, 5]);
 
         $this->assertTrue($c->contains(1));
+        $this->assertTrue($c->contains(true));
+        $this->assertTrue($c->contains('1'));
         $this->assertFalse($c->contains(2));
+        $this->assertFalse($c->contains(false));
         $this->assertTrue($c->contains(function ($value) {
             return $value < 5;
         }));
         $this->assertFalse($c->contains(function ($value) {
             return $value > 5;
         }));
+
+        $c = new Collection(['1', '3', '5', 0]);
+        $this->assertTrue($c->contains(1));
+        $this->assertTrue($c->contains(false));
+        $this->assertTrue($c->contains(null));
+        $this->assertTrue($c->contains('1'));
+        $this->assertFalse($c->contains(2));
 
         $c = new Collection([['v' => 1], ['v' => 3], ['v' => 5]]);
 


### PR DESCRIPTION
1. Added some tests covering the loose comparison of primitive php values and 
2. Flatten code to be consistent with the way `containsStrict` method is written.