### PR TITLE
[5.7] Simplify \Illuminate\Console\Command::context().

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Console;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
@@ -238,15 +237,15 @@ class Command extends SymfonyCommand
      */
     protected function context()
     {
-        return collect(Arr::only($this->option(), [
+        return collect($this->option())->only([
             'ansi',
             'no-ansi',
             'no-interaction',
             'quiet',
             'verbose',
-        ]))->mapWithKeys(function ($value, $key) {
+        ])->filter()->mapWithKeys(function ($value, $key) {
             return ["--{$key}" => $value];
-        })->filter()->all();
+        })->all();
     }
 
     /**


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Simplify \Illuminate\Console\Command::context():
- no need to use `Arr::`
- No need to map filtered values
