### PR TITLE
[5.8] Bug fix related to extra calls to resolving callbacks (The other way)

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -261,7 +261,8 @@ class Container implements ArrayAccess, ContainerContract
                 return $container->build($concrete);
             }
 
-            return $container->make($concrete, $parameters);
+            // To prevent extra call to resolving callbacks, we make the object silently.
+            return $container->resolve($concrete, $parameters, true);
         };
     }
 
@@ -630,9 +631,10 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  string  $abstract
      * @param  array  $parameters
+     * @param  bool   $silent
      * @return mixed
      */
-    protected function resolve($abstract, $parameters = [])
+    protected function resolve($abstract, $parameters = [], $silent = false)
     {
         $abstract = $this->getAlias($abstract);
 
@@ -674,8 +676,9 @@ class Container implements ArrayAccess, ContainerContract
             $this->instances[$abstract] = $object;
         }
 
-        $this->fireResolvingCallbacks($abstract, $object);
-
+        if (! $silent) {
+            $this->fireResolvingCallbacks($abstract, $object);
+        }
         // Before returning, we will also set the resolved flag to "true" and pop off
         // the parameter overrides for this build. After those two things are done
         // we will be ready to return back the fully constructed class instance.


### PR DESCRIPTION
(Following the currently open PR https://github.com/laravel/framework/pull/27014) This is an other way of fixing the issue of "multiple calls to resolving callback" which came to my mind while I was under the shower today.🚿 🛀 

Compared to the solution in: https://github.com/laravel/framework/pull/27014 ,it requires a less code and is more understandable and logical.
Plus, it adds an opportunity to have a new feature to the IOC container for "resolving an object silently". (Which will suppress the resolving callbacks.)
for example : `makeSilent(...`

- The tests between the 2 PRs (this one and https://github.com/laravel/framework/pull/27014 ) are exactly the same.

This way we fire the callback attached to the interface and skip the re-firing it when resolving the implementation.
which makes more sense, because the callback was actually attached to the interface like this :
`app()->bind(someInterface::class, 'Myclass'`); `

Anyway I do not know which one you like most, so I leave them both open.
