### PR TITLE
[5.8] Add Deferred interface for service providers

### DIFF
--- a/src/Illuminate/Contracts/Support/Deferred.php
+++ b/src/Illuminate/Contracts/Support/Deferred.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+interface Deferred
+{
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides();
+}

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Illuminate\Console\Application as Artisan;
+use Illuminate\Contracts\Support\Deferred;
 
 abstract class ServiceProvider
 {
@@ -297,6 +298,6 @@ abstract class ServiceProvider
      */
     public function isDeferred()
     {
-        return $this->defer;
+        return $this->defer || $this instanceof Deferred;
     }
 }

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Support;
 
-use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Support\Deferred;
+use Illuminate\Console\Application as Artisan;
 
 abstract class ServiceProvider
 {

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -17,6 +17,8 @@ abstract class ServiceProvider
     /**
      * Indicates if loading of the provider is deferred.
      *
+     * @deprecated 5.8 Implement the \Illuminate\Contracts\Support\Deferred interface instead.
+     *
      * @var bool
      */
     protected $defer = false;


### PR DESCRIPTION
As discussed and explained in https://github.com/laravel/ideas/issues/1453. 

If accepted, I will also update the documentation to only recommend using this interface, and leave the `$defer` property undocumented. This way we can remove the property altogether from the 5.9 release (or 5.10, whichever is preferred).