### PR TITLE
[5.7] Modify ELoquent Api Resource merge() methods to accept JsonResource object

### DIFF
--- a/src/Illuminate/Http/Resources/MergeValue.php
+++ b/src/Illuminate/Http/Resources/MergeValue.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Resources;
 
+use JsonSerializable;
 use Illuminate\Support\Collection;
 
 class MergeValue
@@ -21,6 +22,12 @@ class MergeValue
      */
     public function __construct($data)
     {
-        $this->data = $data instanceof Collection ? $data->all() : $data;
+        if ($data instanceof Collection) {
+            $this->data = $data->all();
+        } elseif ($data instanceof JsonSerializable) {
+            $this->data = $data->jsonSerialize();
+        } else {
+            $this->data = $data;
+        }
     }
 }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -684,6 +684,63 @@ class ResourceTest extends TestCase
         ], $results);
     }
 
+    public function test_merge_value_can_merge_json_serializable()
+    {
+        $filter = new class {
+            use ConditionallyLoadsAttributes;
+
+            public function work()
+            {
+                $postResource = new PostResource(new Post([
+                    'id' => 1,
+                    'title' => 'Test Title 1',
+                ]));
+                   
+                return $this->filter([
+                    new MergeValue($postResource),
+                    'user' => 'test user',
+                    'age' => 'test age',
+                ]);
+            }
+        };
+
+        $results = $filter->work();
+
+        $this->assertEquals([
+            'id' => 1,
+            'title' => 'Test Title 1',
+            'custom' => true,
+            'user' => 'test user',
+            'age' => 'test age',
+        ], $results);
+    }
+
+    public function test_merge_value_can_merge_collection_of_json_serializable()
+    {
+        $filter = new class {
+            use ConditionallyLoadsAttributes;
+
+            public function work()
+            {
+                $posts = collect([
+                    new Post(['id' => 1, 'title' => 'Test title 1']),
+                    new Post(['id' => 2, 'title' => 'Test title 2']),
+                ]);
+
+                return $this->filter([
+                    new MergeValue(PostResource::collection($posts)),
+                ]);
+            }
+        };
+
+        $results = $filter->work();
+
+        $this->assertEquals([
+            ['id' => 1, 'title' => 'Test title 1', 'custom' => true],
+            ['id' => 2, 'title' => 'Test title 2', 'custom' => true],
+        ], $results);
+    }
+
     public function test_all_merge_values_may_be_missing()
     {
         $filter = new class {

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -695,7 +695,7 @@ class ResourceTest extends TestCase
                     'id' => 1,
                     'title' => 'Test Title 1',
                 ]));
-                   
+
                 return $this->filter([
                     new MergeValue($postResource),
                     'user' => 'test user',


### PR DESCRIPTION
this **PR** , allows both **merge** & **mergeWhen** to accept **JsonResource** object , to remove duplicate of referencing same attributes in different resources .

**simplified example** of use case , we want to retrieve a user with his profile , but the case is the **UserResource** mustn't change cause the class has been used in **different places in a messy project** and could cause **api compatibility issues if changed** :

```php
class UserResource extends JsonResource
{
     public function toArray($request)
     {
        return ['name' => $this->name , 'age' => $this->age];
     }

}
```
```php
class UserWithAvatarResource extends JsonResource
{
     public function toArray($request)
     {
       //old way
       return ['name' => $this->name , 'age' => $this->age , 'avatar' => $this->avatar];

        //another way
       return array_merge(
             (new UserResource($this))->jsonSerialize() ,
             ['avatar' => $this->avatar] 
        );

       //when PR accepted
       return [
            $this->merge(new UserResource($this)),
            'avatar' => $this->avatar, 
        ];
     }

}
```

```php

```