### PR TITLE
[5.8] Allow the handling of only one request per test

### DIFF
--- a/tests/Integration/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Integration/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Testing\Concerns;
+
+use LogicException;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Route;
+
+class MakesHttpRequestsTest extends TestCase
+{
+    public function testAnExceptionIsThrownIfATestTriesToMakeMoreThanOneRequest()
+    {
+        Route::get('test', function () {
+            return 'Hello world!';
+        });
+
+        $this->get('test')
+            ->assertStatus(200)
+            ->assertSee('Hello world!');
+
+        try {
+            $this->get('test');
+            $this->fail(sprintf('A %s exception should have been thrown.', LogicException::class));
+        } catch (LogicException $exception) {
+            //
+        }
+    }
+
+    public function testARedirectCanBeFollowed()
+    {
+        Route::get('test', function () {
+            return new RedirectResponse('test2');
+        });
+
+        Route::get('test2', function () {
+            return 'Hello world2!';
+        });
+
+        $this->followingRedirects()
+            ->get('test')
+            ->assertStatus(200)
+            ->assertSee('Hello world2!');
+
+        try {
+            $this->followingRedirects()->get('test');
+            $this->fail(sprintf('A %s exception should have been thrown.', LogicException::class));
+        } catch (LogicException $exception) {
+            //
+        }
+    }
+}


### PR DESCRIPTION
The framework gets booted only once per test meaning it can safely handle only one request per test. Making multiple requests per test falls under the category of undefined behavior as the application is left in an unclean state after the first request has been handled since the `tearDown` method which takes care of the cleanup gets called only once after the entire test method gets executed.

IMO, being able to write tests which don't reflect the real world scenario that they are testing (as it isn't possible to do something like that as a client/browser which does real HTTP requests) and which can pass just by coincidence (depending in what state the application was left after handling the previous request) is not a very good thing.

I'm opening this PR because I think the framework shouldn't allow to the developers to write such tests which is evidenced by getting every once in a while a new issue like #27060 which actually isn't an issue, it's just a test being incorrectly written (because not every developer knows the internals of how the framework boots etc).

The proposed solution is to throw an exception if/when a second request is made in the same test. As writing tests in this way hasn't even been documented the impact should be minimal, but obviously some tests out there will have to be refactored.