### PR TITLE
[5.7] Stop email re-verification with same link

### DIFF
--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -35,6 +35,10 @@ trait VerifiesEmails
         if ($request->route('id') != $request->user()->getKey()) {
             throw new AuthorizationException;
         }
+        
+        if ($request->user()->hasVerifiedEmail()) {
+            return redirect($this->redirectPath());
+        }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -35,7 +35,7 @@ trait VerifiesEmails
         if ($request->route('id') != $request->user()->getKey()) {
             throw new AuthorizationException;
         }
-        
+
         if ($request->user()->hasVerifiedEmail()) {
             return redirect($this->redirectPath());
         }


### PR DESCRIPTION
If a user reopen the sent email verification link, the `email_verified_at` column will be updated. While it should not be updated when the email is verified before (by same provided link).

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
