### PR TITLE
[5.8] Applications can define routesAreCached() for localization

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -30,7 +30,7 @@ class RouteServiceProvider extends ServiceProvider
     {
         $this->setRootControllerNamespace();
 
-        if ($this->app->routesAreCached()) {
+        if ($this->routesAreCached()) {
             $this->loadCachedRoutes();
         } else {
             $this->loadRoutes();
@@ -52,6 +52,16 @@ class RouteServiceProvider extends ServiceProvider
         if (! is_null($this->namespace)) {
             $this->app[UrlGenerator::class]->setRootControllerNamespace($this->namespace);
         }
+    }
+
+    /**
+     * Determine if the application routes are cached.
+     *
+     * @return bool
+     */
+    protected function routesAreCached()
+    {
+        return $this->app->routesAreCached();
     }
 
     /**


### PR DESCRIPTION
This allow applications to choose a custom routes cache without the need to define a new application container class to override `Illuminate\Foundation\Application@routesAreCached()`.

**Illuminate\Foundation\Support\Providers\RouteServiceProvider**:

![foundation-routeserviceprovider](https://user-images.githubusercontent.com/823566/50728971-f420b580-10ff-11e9-9024-7a09b1411368.png)

Since Laravel 5.2 I've had to copy and paste all of `Illuminate\Foundation\Support\Providers\RouteServiceProvider@boot()` into the application provider and monitor each framework  release for changes to that method.

For example, this pull request allows a custom provider to cache default 'en' / routes, localized /es/, and localized /fr/ routes in 3 separate files:

```php
namespace App\Providers;

use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
use Illuminate\Support\Facades\Route;

class RouteServiceProvider extends ServiceProvider
{
    protected $namespace = 'App\Http\Controllers';

    const LOCALE_PREFIXES = [
        'es',
        'fr',
    ];

    // no need to redefine or customize boot()

    protected function routesAreCached()
    {
        return $this->app['files']->exists($this->cachedRoutesPath());
    }

    protected function loadCachedRoutes()
    {
        $this->app->booted(function () {
            require $this->cachedRoutesPath();
        });
    }

    public function map()
    {
        $this->mapApiRoutes();
        $this->mapWebRoutes();
    }

    protected function mapApiRoutes()
    {
        Route::group([
            'namespace' => $this->namespace,
            'middleware' => 'api',
            'prefix' => $this->localePrefix(),
        ], function ($router) {
            require base_path('routes/api.php');
        });
    }

    protected function mapWebRoutes()
    {
        Route::group([
            'namespace' => $this->namespace,
            'middleware' => 'web',
            'prefix' => $this->localePrefix(),
        ], function ($router) {
            require base_path('routes/web.php');
        });
    }

    protected function localePrefix()
    {
        if ($this->supportsLocale($this->app['request']->segment(1))) {
            return $this->app['request']->segment(1);
        }

        if ($this->isCachingLocale()) {
            return $this->app['routes_locale'];
        }
    }

    protected function isCachingLocale()
    {
        return $this->app->bound('routes_locale') &&
            $this->supportsLocale($this->app['routes_locale']);
    }

    protected function supportsLocale($locale)
    {
        return in_array($locale, self::LOCALE_PREFIXES, true);
    }

    protected function cachedRoutesPath()
    {
        if ($locale = $this->localePrefix()) {
            return $this->getPrefixedCachedRoutesPath($locale);
        }

        return $this->app->getCachedRoutesPath();
    }

    protected function getPrefixedCachedRoutesPath($locale)
    {
        return substr($this->app->getCachedRoutesPath(), 0, -4) . "_$locale.php";
    }
}
```

For 793 defined routes, this is the difference between loading a 4.4mb serialized cache file every request/command or 13mb+ when all prefixes are stored as one.
