### PR TITLE
[5.7] Allow resolve with to accept type hinted params.

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -851,9 +851,15 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function hasParameterOverride($dependency)
     {
-        return array_key_exists(
-            $dependency->name, $this->getLastParameterOverride()
-        );
+        // We need to check if the user's trying to override the dependency using the
+        // parameter variable name first. If the parameter was not found using the
+        // variable name then check if they passed through a type hint instead.
+        return array_key_exists($dependency->name, $this->getLastParameterOverride()) ||
+            (
+                ! empty($dependency->getClass()->name)
+                    ? array_key_exists($dependency->getClass()->name, $this->getLastParameterOverride())
+                    : false
+            );
     }
 
     /**
@@ -864,7 +870,8 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getParameterOverride($dependency)
     {
-        return $this->getLastParameterOverride()[$dependency->name];
+        return $this->getLastParameterOverride()[$dependency->name]
+            ?? $this->getLastParameterOverride()[$dependency->getClass()->name];
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1001,6 +1001,18 @@ class ContainerTest extends TestCase
         $this->assertEquals('laurence', $instance->something);
     }
 
+    public function testResolvingWithTypeHintedParams()
+    {
+        $container = new Container;
+        $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $implementation = $container->make(ContainerImplementationStubTwo::class);
+
+        $class = $container->make(ContainerDependentStub::class, [IContainerContractStub::class => $implementation]);
+
+        $this->assertSame($implementation, $class->impl);
+    }
+
     public function testNestedParameterOverride()
     {
         $container = new Container;


### PR DESCRIPTION
This PR follows up on the PR #24234. This allows us to resolve out of the container with params without needing to know their param variable name, we can just type hint them.

This adds fluency and consistency, with the way that we bind into the container. The way we bind in should be the way we can resolve out. We bind without knowing the params and we resolve without knowing the params.

`app(ContainerDependentStub::class, [IContainerContractStub::class => $implementation])`

