### PR TITLE
[5.7] Allow the dollar sign to be used when resolving with params.

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -891,7 +891,9 @@ class Container implements ArrayAccess, ContainerContract
             return $concrete instanceof Closure ? $concrete($this) : $concrete;
         }
 
-        if ($parameter->isDefaultValueAvailable()) {
+        if (! empty($this->getLastParameterOverride()['$'.$parameter->name])) {
+            return $this->getLastParameterOverride()['$'.$parameter->name];
+        } elseif ($parameter->isDefaultValueAvailable()) {
             return $parameter->getDefaultValue();
         }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -983,6 +983,9 @@ class ContainerTest extends TestCase
         $instance = $container->make(ContainerDefaultValueStub::class, ['default' => 'adam']);
         $this->assertEquals('adam', $instance->default);
 
+        $instance = $container->make(ContainerDefaultValueStub::class, ['$default' => 'abigail']);
+        $this->assertEquals('abigail', $instance->default);
+
         $instance = $container->make(ContainerDefaultValueStub::class);
         $this->assertEquals('taylor', $instance->default);
 


### PR DESCRIPTION
This allows a dollar sign to be used when resolving with params. The reason I think this is necessary is because when we bind in using a dollar sign we should be able to resolve out using the same format.

Take this example based on the documentation: 
```PHP
$this->app->when('App\Http\Controllers\UserController')
    ->needs('$variableName')
    ->give('taylor');
```

When you try to resolve with using the same format it doesn't work:
```PHP
app('App\Http\Controllers\UserController', ['$variableName' => 'abigail'])->variableName; 
// taylor
```

Here is the current format that must be used in order to get this to work: 
```PHP
app('App\Http\Controllers\UserController', ['variableName' => 'abigail'])->variableName; 
// abigail
```

However my PR allows us to use that same format that they binded with to resolve: 
```PHP
app('App\Http\Controllers\UserController', ['$variableName' => 'abigail'])->variableName; 
// abigail
```

While still keeping the current format so that it's not a breaking change.