### PR TITLE
[5.7] Add ability to use the dollar sign for resolve with params. (Option #2)

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -851,9 +851,11 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function hasParameterOverride($dependency)
     {
-        return array_key_exists(
-            $dependency->name, $this->getLastParameterOverride()
-        );
+        if (array_key_exists($dependency->name, $this->getLastParameterOverride())) {
+            return true;
+        } else {
+            return array_key_exists('$'.$dependency->name, $this->getLastParameterOverride());
+        }
     }
 
     /**
@@ -864,7 +866,8 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getParameterOverride($dependency)
     {
-        return $this->getLastParameterOverride()[$dependency->name];
+        return $this->getLastParameterOverride()[$dependency->name]
+            ?? $this->getLastParameterOverride()['$'.$dependency->name];
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -983,6 +983,9 @@ class ContainerTest extends TestCase
         $instance = $container->make(ContainerDefaultValueStub::class, ['default' => 'adam']);
         $this->assertEquals('adam', $instance->default);
 
+        $instance = $container->make(ContainerDefaultValueStub::class, ['$default' => 'abigail']);
+        $this->assertEquals('abigail', $instance->default);
+
         $instance = $container->make(ContainerDefaultValueStub::class);
         $this->assertEquals('taylor', $instance->default);
 


### PR DESCRIPTION
This is the same as #27078 but it just does it differently in the code. Here I'm not looking over the param keys to strip out the `$`, I'm just adding the `$` to the dependency name if the non `$` version wasn't found. That way everyone who's currently doing it without the `$` won't add any more work when resolving out. 

I'm aware that this will create a merge conflict with #27077 which I will fix when/if that gets merged.