### PR TITLE
[5.7] - UrlGenerator - Minor change

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -362,7 +362,7 @@ class UrlGenerator implements UrlGeneratorContract
             Arr::except($request->query(), 'signature')
         ), '?');
 
-        $expires = Arr::get($request->query(), 'expires');
+        $expires = $request->query('expires');
 
         $signature = hash_hmac('sha256', $original, call_user_func($this->keyResolver));
 


### PR DESCRIPTION
Just calling `$request->query()` directly. It doesn't break the current behavior (we already have tests for it).