### PR TITLE
[5.7] Improve loadMorph()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -186,8 +186,7 @@ class Collection extends BaseCollection implements QueueableCollection
                 return Arr::has($relations, $className);
             })
             ->each(function ($models, $className) use ($relations) {
-                $className::with($relations[$className])
-                    ->eagerLoadRelations($models->all());
+                static::make($models)->load($relations[$className]);
             });
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -182,11 +182,8 @@ class Collection extends BaseCollection implements QueueableCollection
             ->groupBy(function ($model) {
                 return get_class($model);
             })
-            ->filter(function ($models, $className) use ($relations) {
-                return Arr::has($relations, $className);
-            })
             ->each(function ($models, $className) use ($relations) {
-                static::make($models)->load($relations[$className]);
+                static::make($models)->load($relations[$className] ?? []);
             });
 
         return $this;


### PR DESCRIPTION
`loadMorph()` has the same issue that #22363 fixed for `load()`:

```php
class Post extends Model {
    protected $with = ['user'];
}

$comments = Comment::with('commentable')->get()
    ->loadMorph('commentable', [
        Post::class => 'tags',
    ]);
```

When `loadMorph()` loads the `tags` relationship, it also loads the `user` relationship from `$with`.

We can fix it by just calling `load()` – which is also shorter.

We can also replace the `filter()` clause with a null coalescing operator.