### PR TITLE
[5.8] Remove prefix setting for Amazon SQS, add url

### DIFF
--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -23,7 +23,9 @@ class SqsConnector implements ConnectorInterface
         }
 
         return new SqsQueue(
-            new SqsClient($config), $config['queue'], $config['prefix'] ?? ''
+            new SqsClient($config),
+            $config['queue'],
+            $config['url'] ?? ''
         );
     }
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -86,7 +86,7 @@ class SqsQueue extends Queue implements QueueContract
     public function pushRaw($payload, $queue = null, array $options = [])
     {
         return $this->sqs->sendMessage([
-            'QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload,
+            'QueueUrl' => $this->url, 'MessageBody' => $payload,
         ])->get('MessageId');
     }
 
@@ -102,7 +102,7 @@ class SqsQueue extends Queue implements QueueContract
     public function later($delay, $job, $data = '', $queue = null)
     {
         return $this->sqs->sendMessage([
-            'QueueUrl' => $this->getQueue($queue),
+            'QueueUrl' => $this->url,
             'MessageBody' => $this->createPayload($job, $queue ?: $this->name, $data),
             'DelaySeconds' => $this->secondsUntil($delay),
         ])->get('MessageId');

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -6,19 +6,19 @@ use Aws\Result;
 use Mockery as m;
 use Aws\Sqs\SqsClient;
 use Illuminate\Queue\SqsQueue;
-use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\Queue as QueueContract;
 
 class QueueSqsQueueTest extends TestCase
 {
     /** @var QueueContract */
     private $sqsQueue;
 
-    const QUEUE_NAME = "emails";
-    const URL = "https://sqs.someregion.amazonaws.com/1234567891011/emails-queue";
+    const QUEUE_NAME = 'emails';
+    const URL = 'https://sqs.someregion.amazonaws.com/1234567891011/emails-queue';
 
     private $mockedSqsClient;
     private $mockedJob;
@@ -51,8 +51,8 @@ class QueueSqsQueueTest extends TestCase
             'displayName' => $this->mockedJob,
             'job' => $this->mockedJob,
             'maxTries' => null,
-            "timeout" => null,
-            'data' => $this->mockedData
+            'timeout' => null,
+            'data' => $this->mockedData,
         ]);
 
         $this->mockedDelay = 10;
@@ -93,7 +93,7 @@ class QueueSqsQueueTest extends TestCase
     {
         $this->mockedSqsClient->shouldReceive('receiveMessage')->once()->with([
             'QueueUrl'       => self::URL,
-            'AttributeNames' => ['ApproximateReceiveCount']
+            'AttributeNames' => ['ApproximateReceiveCount'],
         ])->andReturn($this->mockedReceiveMessageResponseModel);
 
         $result = $this->sqsQueue->pop(self::QUEUE_NAME);
@@ -104,7 +104,7 @@ class QueueSqsQueueTest extends TestCase
     {
         $this->mockedSqsClient->shouldReceive('receiveMessage')->once()->with([
             'QueueUrl'       => self::URL,
-            'AttributeNames' => ['ApproximateReceiveCount']
+            'AttributeNames' => ['ApproximateReceiveCount'],
         ])->andReturn($this->mockedReceiveEmptyMessageResponseModel);
 
         $result = $this->sqsQueue->pop(self::QUEUE_NAME);
@@ -118,7 +118,7 @@ class QueueSqsQueueTest extends TestCase
         $this->mockedSqsClient->shouldReceive('sendMessage')->once()->with([
             'QueueUrl'     => self::URL,
             'MessageBody'  => $this->mockedPayload,
-            'DelaySeconds' => 5
+            'DelaySeconds' => 5,
         ])->andReturn($this->mockedSendMessageResponseModel);
 
         $id = $this->sqsQueue->later($now->addSeconds(5), $this->mockedJob, $this->mockedData, self::QUEUE_NAME);
@@ -130,7 +130,7 @@ class QueueSqsQueueTest extends TestCase
         $this->mockedSqsClient->shouldReceive('sendMessage')->once()->with([
             'QueueUrl'     => self::URL,
             'MessageBody'  => $this->mockedPayload,
-            'DelaySeconds' => $this->mockedDelay
+            'DelaySeconds' => $this->mockedDelay,
         ])->andReturn($this->mockedSendMessageResponseModel);
 
         $id = $this->sqsQueue->later($this->mockedDelay, $this->mockedJob, $this->mockedData, self::QUEUE_NAME);
@@ -141,7 +141,7 @@ class QueueSqsQueueTest extends TestCase
     {
         $this->mockedSqsClient->shouldReceive('sendMessage')->once()->with([
             'QueueUrl'    => self::URL,
-            'MessageBody' => $this->mockedPayload
+            'MessageBody' => $this->mockedPayload,
         ])->andReturn($this->mockedSendMessageResponseModel);
 
         $id = $this->sqsQueue->push($this->mockedJob, $this->mockedData, self::QUEUE_NAME);
@@ -152,7 +152,7 @@ class QueueSqsQueueTest extends TestCase
     {
         $this->mockedSqsClient->shouldReceive('getQueueAttributes')->once()->with([
             'QueueUrl'       => self::URL,
-            'AttributeNames' => ['ApproximateNumberOfMessages']
+            'AttributeNames' => ['ApproximateNumberOfMessages'],
         ])->andReturn($this->mockedQueueAttributesResponseModel);
 
         $size = $this->sqsQueue->size(self::QUEUE_NAME);


### PR DESCRIPTION
When using Amazon SQS as the queue backend, it's not convenient to have the queue name automatically appended to the Amazon SQS endpoint URL. This is because the Amazon SQS URL may need to be different depending on environment, whilst the queue name should remain the same, given code `Job::dispatch()->onQueue('emails')` and `queue:work --queue=emails` commands will specify it.

This PR removes the use of the SQS specific setting `prefix` and relies on a new SQS specific setting `url`. This means it can change independently of the queue name.

This is a obviously, a breaking change so it would have to be in a major version release if it was accepted.

A PR over on the laravel/laravel repository to update config/queue.php has [also been submitted](https://github.com/laravel/laravel/pull/4894).