### PR TITLE
[5.7][FIX] Pagination calls into the collection

### DIFF
--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -21,8 +21,7 @@ trait CollectsResources
 
         $collects = $this->collects();
 
-        if($resource instanceof AbstractPaginator) {
-
+        if ($resource instanceof AbstractPaginator) {
             $this->collection = $collects && ! $resource->getCollection()->first() instanceof $collects
                 ? $resource->getCollection()->mapInto($collects)
                 : $resource->getCollection()->toBase();

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -21,13 +21,20 @@ trait CollectsResources
 
         $collects = $this->collects();
 
-        $this->collection = $collects && ! $resource->first() instanceof $collects
-            ? $resource->mapInto($collects)
-            : $resource->toBase();
+        if($resource instanceof AbstractPaginator) {
 
-        return $resource instanceof AbstractPaginator
-                    ? $resource->setCollection($this->collection)
-                    : $this->collection;
+            $this->collection = $collects && ! $resource->getCollection()->first() instanceof $collects
+                ? $resource->getCollection()->mapInto($collects)
+                : $resource->getCollection()->toBase();
+
+            return $resource->setCollection($this->collection);
+        } else {
+            $this->collection = $collects && ! $resource->first() instanceof $collects
+                ? $resource->mapInto($collects)
+                : $resource->toBase();
+
+            return $this->collection;
+        }
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -623,11 +623,13 @@ abstract class AbstractPaginator implements Htmlable
      *
      * @param  string  $method
      * @param  array  $parameters
-     * @return mixed
+     * @return $this
      */
     public function __call($method, $parameters)
     {
-        return $this->forwardCallTo($this->getCollection(), $method, $parameters);
+        $this->items = $this->forwardCallTo($this->getCollection(), $method, $parameters);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -511,6 +511,16 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Items contains item.
+     *
+     * @return bool
+     */
+    public function contains($item)
+    {
+        return $this->items->contains($item);
+    }
+
+    /**
      * Get an iterator for the items.
      *
      * @return \ArrayIterator

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -501,6 +501,16 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Get an array of all items
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $this->items->all();
+    }
+
+    /**
      * Get an iterator for the items.
      *
      * @return \ArrayIterator

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -501,7 +501,7 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
-     * Get an array of all items
+     * Get an array of all items.
      *
      * @return array
      */


### PR DESCRIPTION
When calling collection methods from pagination instance it doesn't apply on the pagination items  . it's only return a collection . I made a horrible helper methods just to help me achieve this . This an old issue by the way. We don't need to ignore it anymore

