### PR TITLE
[5.7] Update QueueFake with jobs getter.

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -353,7 +353,7 @@ class QueueFake extends QueueManager implements Queue
      *
      * @return array
      */
-    public function getJobs(): array
+    public function getJobs()
     {
         return $this->jobs;
     }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -347,4 +347,14 @@ class QueueFake extends QueueManager implements Queue
     {
         return $this;
     }
+    
+    /**
+     * Get the jobs which have been pushed.
+     *
+     * @return array
+     */
+    public function getJobs(): array
+    {
+        return $this->jobs;
+    }
 }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -347,7 +347,7 @@ class QueueFake extends QueueManager implements Queue
     {
         return $this;
     }
-    
+
     /**
      * Get the jobs which have been pushed.
      *


### PR DESCRIPTION
When testing a queue this is super handy for testing whether the correct jobs have been pushed to the fake queue. For example if you're expecting multiple jobs to be pushed by a service, you can run the service and check `Queue::getJobs()` has the correct value.


<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
