### PR TITLE
[5.8] Allow scheduled events ->thenPing() to specify HTTP method

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -465,12 +465,13 @@ class Event
      * Register a callback to ping a given URL before the job runs.
      *
      * @param  string  $url
+     * @param  string  $method
      * @return $this
      */
-    public function pingBefore($url)
+    public function pingBefore($url, $method = 'GET')
     {
-        return $this->before(function () use ($url) {
-            (new HttpClient)->get($url);
+        return $this->before(function () use ($method, $url) {
+            (new HttpClient)->request($method, $url);
         });
     }
 
@@ -479,23 +480,25 @@ class Event
      *
      * @param  bool  $value
      * @param  string  $url
+     * @param  string  $method
      * @return $this
      */
-    public function pingBeforeIf($value, $url)
+    public function pingBeforeIf($value, $url, $method = 'GET')
     {
-        return $value ? $this->pingBefore($url) : $this;
+        return $value ? $this->pingBefore($url, $method) : $this;
     }
 
     /**
      * Register a callback to ping a given URL after the job runs.
      *
      * @param  string  $url
+     * @param  string  $method
      * @return $this
      */
-    public function thenPing($url)
+    public function thenPing($url, $method = 'GET')
     {
-        return $this->then(function () use ($url) {
-            (new HttpClient)->get($url);
+        return $this->then(function () use ($method, $url) {
+            (new HttpClient)->request($method, $url);
         });
     }
 
@@ -504,11 +507,12 @@ class Event
      *
      * @param  bool  $value
      * @param  string  $url
+     * @param  string  $method
      * @return $this
      */
-    public function thenPingIf($value, $url)
+    public function thenPingIf($value, $url, $method = 'GET')
     {
-        return $value ? $this->thenPing($url) : $this;
+        return $value ? $this->thenPing($url, $method) : $this;
     }
 
     /**


### PR DESCRIPTION
Currently `->thenPing()` only performs an HTTP GET when sending the request to the provided URL.

This would allow you to pass the method as a second, optional parameter:

```php
$schedule->command('foo')
         ->hourly()
         ->thenPing('https://example.com/webhook', 'POST');
```

I held short of making the default parameter a `HEAD` request because I felt that might be an unnecessary breaking change.