### PR TITLE
[5.7] UrlGenerator docblocks: include DateInterval in signed route methods

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -312,7 +312,7 @@ class UrlGenerator implements UrlGeneratorContract
      *
      * @param  string  $name
      * @param  array  $parameters
-     * @param  \DateTimeInterface|int  $expiration
+     * @param  \DateTimeInterface|\DateInterval|int  $expiration
      * @param  bool  $absolute
      * @return string
      */
@@ -337,7 +337,7 @@ class UrlGenerator implements UrlGeneratorContract
      * Create a temporary signed route URL for a named route.
      *
      * @param  string  $name
-     * @param  \DateTimeInterface|int  $expiration
+     * @param  \DateTimeInterface|\DateInterval|int  $expiration
      * @param  array  $parameters
      * @param  bool  $absolute
      * @return string

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -353,7 +353,7 @@ class QueueFake extends QueueManager implements Queue
      *
      * @return array
      */
-    public function getJobs(): array
+    public function getJobs()
     {
         return $this->jobs;
     }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -328,6 +328,16 @@ class QueueFake extends QueueManager implements Queue
     }
 
     /**
+     * Get the jobs that have been pushed.
+     *
+     * @return array
+     */
+    public function pushedJobs()
+    {
+        return $this->jobs;
+    }
+
+    /**
      * Get the connection name for the queue.
      *
      * @return string
@@ -346,15 +356,5 @@ class QueueFake extends QueueManager implements Queue
     public function setConnectionName($name)
     {
         return $this;
-    }
-
-    /**
-     * Get the jobs which have been pushed.
-     *
-     * @return array
-     */
-    public function getJobs()
-    {
-        return $this->jobs;
     }
 }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -347,4 +347,14 @@ class QueueFake extends QueueManager implements Queue
     {
         return $this;
     }
+    
+    /**
+     * Get the jobs which have been pushed.
+     *
+     * @return array
+     */
+    public function getJobs(): array
+    {
+        return $this->jobs;
+    }
 }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -347,7 +347,7 @@ class QueueFake extends QueueManager implements Queue
     {
         return $this;
     }
-    
+
     /**
      * Get the jobs which have been pushed.
      *


### PR DESCRIPTION
Expiration time for signed routes may be expressed as `\DateInterval`.