### PR TITLE
[5.8] [POC] Adds decorators functionality for app()->call() on the container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -13,6 +13,8 @@ use Illuminate\Contracts\Container\Container as ContainerContract;
 
 class Container implements ContainerContract
 {
+    use DecoratorsTrait;
+
     /**
      * The current globally available container (if any).
      *

--- a/src/Illuminate/Container/DecoratorsTrait.php
+++ b/src/Illuminate/Container/DecoratorsTrait.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Illuminate\Container;
+
+trait DecoratorsTrait
+{
+    /**
+     * All of the decorators for method calls.
+     *
+     * @var array
+     */
+    protected $decorators = [];
+
+    /**
+     * All of the decorator names and definitions.
+     *
+     * @var array
+     */
+    protected $decorations = [];
+
+    /**
+     * Defines a new decorator with name.
+     *
+     * @param  string  $name
+     * @param  callable  $callback
+     * @return void
+     */
+    public function defineDecorator($name, $callback)
+    {
+        $this->decorators[$name] = $callback;
+    }
+
+    /**
+     * Calls a class@method with it's specified decorators.
+     *
+     * @param  string $callback
+     * @param  array  $parameters
+     * @param  string|null $defaultMethod
+     * @return mixed
+     */
+    public function callWithDecorators($callback, array $parameters = [], $defaultMethod = null)
+    {
+        if (is_array($callback)) {
+            $callback = $this->normalizeMethod($callback);
+        }
+
+        $decorations = $this->decorations[$callback] ?? [];
+
+        foreach ($decorations as $decoratorName => $_) {
+            $decorator = $this->decorators[$decoratorName];
+            $callback = $decorator($this, $callback);
+        }
+
+        return BoundMethod::call($this, $callback, $parameters, $defaultMethod);
+    }
+
+    /**
+     * Decorates a callable with a defined decorator name.
+     *
+     * @param  string  $decorated
+     * @param  string  $decorator
+     * @return void
+     */
+    public function decorateWith($decorated, $decorator)
+    {
+        $this->decorations[$decorated][$decorator] = null;
+    }
+
+    public function unDecorate($decorated, $decorator = null)
+    {
+        if (is_null($decorator)) {
+            unset($this->decorations[$decorated]);
+        } else {
+            unset($this->decorations[$decorated][$decorator]);
+        }
+    }
+
+    private function normalizeMethod($callback)
+    {
+        $class = is_string($callback[0]) ? $callback[0] : get_class($callback[0]);
+
+        return "{$class}@{$callback[1]}";
+    }
+}

--- a/tests/Container/DecoratorTest.php
+++ b/tests/Container/DecoratorTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Illuminate\Tests\Container;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+
+class DecoratorTest extends TestCase
+{
+    public function testSimpleDecorator()
+    {
+        $container = new Container;
+
+        $stringifyDecorator = function ($container, $decorated) {
+            return function (...$params) use ($container, $decorated) {
+                return (string) $container->call($decorated, $params);
+            };
+        };
+
+        $container->defineDecorator('stringifyResult', $stringifyDecorator);
+
+        $container->decorateWith(Calculator::class.'@add', 'stringifyResult');
+
+        $result = $container->callWithDecorators(Calculator::class.'@add', [-10, -10]);
+        $this->assertIsString($result);
+        $this->assertEquals('-20', $result);
+
+        $result = $container->callWithDecorators([Calculator::class, 'add'], [-10, -10]);
+        $this->assertIsString($result);
+        $this->assertEquals('-20', $result);
+
+        $result = $container->callWithDecorators([new Calculator(), 'add'], [-10, -10]);
+        $this->assertIsString($result);
+        $this->assertEquals('-20', $result);
+    }
+
+    public function testSimpleDecoratorOnInterface()
+    {
+        $container = new Container;
+
+        $stringifyDecorator = function ($container, $decorated) {
+            return function (...$params) use ($container, $decorated) {
+                return (string) $container->call($decorated, $params);
+            };
+        };
+
+        $container->defineDecorator('stringifyResult', $stringifyDecorator);
+
+        $container->decorateWith(ICalculator::class.'@add', 'stringifyResult');
+        $container->bind(ICalculator::class, Calculator::class);
+
+        $result = $container->callWithDecorators(ICalculator::class.'@add', [10, 10]);
+        $this->assertIsString($result);
+        $this->assertEquals('20', $result);
+    }
+
+    public function testTwoDecorators()
+    {
+        $container = new Container;
+
+        $stringifyDecorator = function ($app, $decorated) {
+            return function (...$params) use ($app, $decorated) {
+                return (string) $app->call($decorated, $params);
+            };
+        };
+
+        $intifyParamsDecorator = function ($container, $decorated) {
+            return function ($x, $y) use ($container, $decorated) {
+                return $container->call($decorated, [(int) $x, (int) $y]);
+            };
+        };
+
+        $container->defineDecorator('stringifyResult', $stringifyDecorator);
+        $container->defineDecorator('intifyParams', $intifyParamsDecorator);
+
+        $container->decorateWith(Calculator::class.'@add', 'intifyParams');
+        $container->decorateWith(Calculator::class.'@add', 'stringifyResult');
+
+        $result = $container->callWithDecorators(Calculator::class.'@add', ['-10', '-10']);
+
+        $this->assertIsString($result);
+        $this->assertEquals('-20', $result);
+    }
+
+    public function testMultipleDecorators()
+    {
+        $container = new Container;
+
+        $container->defineDecorator('noNegativeParam', function ($container, $decorated) {
+            return function ($x, $y) use ($container, $decorated) {
+                $x = ($x < 0) ? 0 : $x;
+                $y = ($y < 0) ? 0 : $y;
+
+                return $container->call($decorated, [$x, $y]);
+            };
+        });
+
+        $container->defineDecorator('noPositiveResult', function ($container, $decorated) {
+            return function (...$params) use ($container, $decorated) {
+                return abs($container->call($decorated, $params)) * -1;
+            };
+        });
+
+        $container->defineDecorator('stringifyResult', function ($container, $decorated) {
+            return function (...$params) use ($container, $decorated) {
+                return (string) $container->call($decorated, $params);
+            };
+        });
+
+        $container->decorateWith(Calculator::class.'@add', 'noNegativeParam');
+        $container->decorateWith(Calculator::class.'@add', 'noPositiveResult');
+        $container->decorateWith(Calculator::class.'@add', 'stringifyResult');
+
+        $result = $container->callWithDecorators(Calculator::class.'@add', ['x' => -100, 'y' => -100]);
+        $this->assertEquals('0', $result);
+        $this->assertIsString($result);
+
+        $result = $container->callWithDecorators(Calculator::class.'@add', ['x' => 2, 'y' => 2]);
+
+        $this->assertEquals('-4', $result);
+        $this->assertIsString($result);
+
+        $result = $container->callWithDecorators(Calculator::class.'@add', ['x' => -200, 'y' => 1]);
+        $this->assertEquals('-1', $result);
+        $this->assertIsString($result);
+
+        $result = $container->callWithDecorators(Calculator::class.'@add', ['x' => -100, 'y' => -100]);
+        $this->assertEquals('0', $result);
+        $this->assertIsString($result);
+    }
+}
+
+interface ICalculator
+{
+    public function add(int $x, int $y): int;
+}
+
+class Calculator implements ICalculator
+{
+    public function add(int $x, int $y): int
+    {
+        return $x + $y;
+    }
+}


### PR DESCRIPTION
This is just a proof of concept, to be able to "decorate" method calls.

Base on the assumption that a `decorator` :
1 - Is a callable
2 - That takes a callable (as it's argument)
3 - And returns a callable

Something like python decorators.
I know at the moment it lacks a lot of features, and the implementation may look somewhat silly, but it is just a proof of concept for now.

### Usage Example:
Imagine that you want to put a cache layer between a `MadRepository` and a `MadController`.
But they are both so mad, that they do not allow you to touch a single line of their code.
It smells like `open-closed principle` yeah ?! 👃 
**(Probably both classes are imprisoned in the `vendor` folder and are part of a laravel package, so you can not touch them)**

```php
class MadController extends Controller
{
    public function index () {
        $mads = app()->call(MadRepository::class.'@allMadPeople');
        ...
    }
}
```
So, what now ?!
Then you can go to `AppServiceProvider.php` (without any mad person realizing it.) 😁 

```php
public function boot( ) {
     ...
    app( )->decorate(MadRepository::class.'@allMadPeople', 'cacheDecorator');
}
```
Just that. You will get cached results in your controller, then !

Definition of the `cacheDecorator` can be placed in the `register` method and get reused.
Or even laravel can provide a `cacheDecorator` for you, out of the box. 🎁 

```php
     $stringifyDecorator = function ($container, $decorated) {
            return function (...$params) use ($container, $decorated) {
                return cache()->remember('a_mad_key', 10, function () use ($container, $decorated, $params) {
                    return $container->call($decorated, $params);
                });
            };
        };
```

### To do
- class@method as decorators.
- Decorator factories.
- Wrapping facade calls.
- etc