### PR TITLE
[5.7] Add model factory type annotation

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -1,5 +1,9 @@
 <?php
 
+/** 
+ * @var  \Illuminate\Database\Eloquent\Factory  $factory
+ */
+
 use Faker\Generator as Faker;
 
 $factory->define(DummyModel::class, function (Faker $faker) {


### PR DESCRIPTION
Adding the type annotation to the model factory stub will help autocompletion tools to provide method suggestions.

This is more useful for methods like `state()` or `afterCreating()` that might not be used as often as `define()`. 