### PR TITLE
[5.8] pagination collection methods updates paginations items 

### DIFF
--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -25,7 +25,7 @@ trait CollectsResources
             ? $resource->mapInto($collects)
             : $resource->toBase();
 
-        if($resource instanceof AbstractPaginator) {
+        if ($resource instanceof AbstractPaginator) {
             $this->collection = $resource->getCollection();
 
             return $resource;

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -25,9 +25,13 @@ trait CollectsResources
             ? $resource->mapInto($collects)
             : $resource->toBase();
 
-        return $resource instanceof AbstractPaginator
-                    ? $resource->setCollection($this->collection)
-                    : $this->collection;
+        if($resource instanceof AbstractPaginator) {
+            $this->collection = $resource->getCollection();
+
+            return $resource;
+        }
+
+        return $this->collection;
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -511,6 +511,36 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Get first item.
+     *
+     * @return mixed
+     */
+    public function first()
+    {
+        return $this->items->first();
+    }
+
+    /**
+     * Get an array of all items.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $this->items->all();
+    }
+
+    /**
+     * Items contains item.
+     *
+     * @return bool
+     */
+    public function contains($item)
+    {
+        return $this->items->contains($item);
+    }
+
+    /**
      * Determine if the list of items is empty.
      *
      * @return bool
@@ -623,11 +653,13 @@ abstract class AbstractPaginator implements Htmlable
      *
      * @param  string  $method
      * @param  array  $parameters
-     * @return mixed
+     * @return $this
      */
     public function __call($method, $parameters)
     {
-        return $this->forwardCallTo($this->getCollection(), $method, $parameters);
+        $this->items = $this->forwardCallTo($this->getCollection(), $method, $parameters);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -513,11 +513,25 @@ abstract class AbstractPaginator implements Htmlable
     /**
      * Get first item.
      *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
      * @return mixed
      */
-    public function first()
+    public function first(callable $callback = null, $default = null)
     {
-        return $this->items->first();
+        return $this->items->first($callback, $default);
+    }
+
+    /**
+     * Get last item.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function last(callable $callback = null, $default = null)
+    {
+        return $this->items->last($callback, $default);
     }
 
     /**

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -46,4 +46,32 @@ class PaginatorTest extends TestCase
 
         $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
     }
+
+    public function testPaginatorCollectionMethodsAndItShouldReturnPaginator()
+    {
+        $p = new Paginator($array = [
+            ['name' => 'item1', 'likes' => 1],
+            ['name' => 'item2', 'likes' => 0],
+            null,
+            ['name' => 'item3', 'likes' => 5],
+        ], 10, 1,
+            ['path' => 'http://website.com/test']);
+
+
+        $this->assertContains(null, $p->getCollection());
+        $this->assertTrue($p->filter() instanceof  Paginator);
+        $this->assertNotContains(null, $p->getCollection());
+
+        $this->assertNotContains(['name' => 'item4', 'likes' => 2], $p->getCollection());
+        $this->assertTrue($p->push(['name' => 'item4', 'likes' => 2]) instanceof  Paginator);
+        $this->assertContains(['name' => 'item4', 'likes' => 2], $p->getCollection());
+
+        $this->assertNotEquals(['name' => 'item3', 'likes' => 5], $p->first());
+        $this->assertTrue($p->sortByDesc('likes') instanceof  Paginator);
+        $this->assertEquals(['name' => 'item3', 'likes' => 5], $p->first());
+
+        $this->assertNotEquals(2, $p->count());
+        $this->assertTrue($p->slice(2) instanceof  Paginator);
+        $this->assertEquals(2, $p->count());
+    }
 }

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -57,7 +57,6 @@ class PaginatorTest extends TestCase
         ], 10, 1,
             ['path' => 'http://website.com/test']);
 
-
         $this->assertContains(null, $p->getCollection());
         $this->assertTrue($p->filter() instanceof  Paginator);
         $this->assertNotContains(null, $p->getCollection());


### PR DESCRIPTION
This PR make updating pagination items possible simply by calling collection methods here are some examples of what can this PR offer : 

```php
Articles::paginate(20)->sortBy(function($item, $key) {
       return $item->likes;
});

```

```php
Articles::paginate(20)->shuffle()
```

```php
Articles::paginate(20)->filter()
```

```php
Articles::paginate(20)->slice(2)
```

```php
Articles::paginate(20)->map(function($item) { 
  $item->paginated = true;
  return $item
});
```

and a lot of collection magic can be done :)

.....

Laravel currently won't apply collection filtering methods  to the pagination items it will only return a filtered collection and leave you frustrated so you need to do it this way

```php
$articles = Articles::paginate(20);

return $articles->setCollection($articles->getCollection()->sortBy(function($item, $key) {
       return $item->likes;
}));
```

or that way:

```php
$pagianted_articles = Articles::paginate(20);

$articles = $pagianted_articles->sortBy(function($item, $key) {
       return $item->likes;
});

$articles = new LengthAwarePaginator($articles, $pagianted_articles->total(), $pagianted_articles->perPage());
```

I hope you like it guys 👏


old PR: #27087 