### PR TITLE
[5.7] Fix typo in validator contract

### DIFF
--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -38,7 +38,7 @@ interface Validator extends MessageProvider
     public function sometimes($attribute, $rules, callable $callback);
 
     /**
-     * After an after validation callback.
+     * Add an after validation callback.
      *
      * @param  callable|string  $callback
      * @return $this


### PR DESCRIPTION
Change it to match implementation doc block from `\Illuminate\Validation\Validator::after`.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
