### PR TITLE
[5.5] Consistency in Bootstrap Stub preset style declaration

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/bootstrap-stubs/_variables.scss
+++ b/src/Illuminate/Foundation/Console/Presets/bootstrap-stubs/_variables.scss
@@ -10,7 +10,7 @@ $panel-default-border: $laravel-border-color;
 $panel-inner-border: $laravel-border-color;
 
 // Brands
-$brand-primary: #3097D1;
+$brand-primary: #3097d1;
 $brand-info: #8eb4cb;
 $brand-success: #2ab27b;
 $brand-warning: #cbb956;


### PR DESCRIPTION
Make the declaration for `$brand-primary` match the lowercase convention of the rest of the file.

Admittedly, not the biggest change (or the worst thing in the world to leave as-is tbh), but found this when running [stylelint](https://stylelint.io/) with [color-hex-case](https://stylelint.io/user-guide/rules/color-hex-case/) set to "lower". (Note: can easily be circumvented by ignoring anything from vendor)

✌️ 

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
