### PR TITLE
[5.7] Look for multiline localization strings in json

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -155,7 +155,15 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // only one level deep so we do not need to do any fancy searching through it.
         $this->load('*', '*', $locale);
 
-        $line = $this->loaded['*']['*'][$locale][$key] ?? null;
+        // To avoid looking for multiline keys in JSON, we convert new lines to \n so we can actually look up
+        // "multiline" keys in JSON
+        $trimmedKey = collect(explode("\n", $key))
+            ->map(function ($line) {
+                return trim($line);
+            })
+            ->implode("\n");
+
+        $line = $this->loaded['*']['*'][$locale][$trimmedKey] ?? null;
 
         // If we can't find a translation for the JSON key, we will attempt to translate it
         // using the typical translation file. This way developers can always just use a

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -178,6 +178,33 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('foo baz', $t->getFromJson('foo :message', ['message' => 'baz']));
     }
 
+    public function testGetJsonForMultilineKeyLooksForTrimmedKey()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(["foo\nbaz\nbar" => 'foobar']);
+        $this->assertEquals('foobar', $t->getFromJson("foo
+        baz
+bar"));
+        $this->assertEquals('foobar', $t->getFromJson("foo\nbaz\nbar"));
+        $this->assertEquals('foobar', $t->getFromJson('foo
+        baz
+        bar'));
+    }
+
+    public function testGetJsonForMultilineKeyLooksForOriginalKeyInFallbackIfNotFound()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', "foo
+        baz
+bar", '*')->andReturn([]);
+        $this->assertEquals("foo
+        baz
+bar", $t->getFromJson("foo
+        baz
+bar"));
+    }
+
     protected function getLoader()
     {
         return m::mock(Loader::class);


### PR DESCRIPTION
The reason I made this pull request is because I could not find any solution on translation the Laravel default ResetPassword email notification, more directly:
```blade
# src/Illuminate/Notifications/resources/views/email.blade.php#L52-59
@lang(
    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
    'into your web browser: [:actionURL](:actionURL)',
    [
        'actionText' => $actionText,
        'actionURL' => $actionUrl,
    ]
)
```
The problem for me was that this resolves to a multiline key:
```
If you’re having trouble clicking the ":actionText" button, copy and paste the URL below\n
'into your web browser: [:actionURL](:actionURL)
```
Which it was then trying to look up in the configured locale's json file.

Since json does not support multiline keys the solution I went for was to convert the multiline string to a single line, but keeping the newlines, but this time as a raw string rather than compiled new line.

I have targeted 5.7 as this is a minor fix which should not give any consequences since there has not been any support for it (as far as I know) before

-----

I realize that I can just change the contents of that particular email by publishing the resources, but if you already use multiline keys, why not support it 'eh?

If multiline keys is not a feature you want to support, maybe consider changing the default email for reset password