### PR TITLE
[5.7] Bug fix for Blueprint method removeColumn

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1284,7 +1284,7 @@ class Blueprint
     public function removeColumn($name)
     {
         $this->columns = array_values(array_filter($this->columns, function ($c) use ($name) {
-            return $c['attributes']['name'] != $name;
+            return $c['name'] != $name;
         }));
 
         return $this;


### PR DESCRIPTION
Variable `$c` is instance of `\Illuminate\Support\Fluent` class, so when we access it as array - returns content of `attributes`, not `attributes` itself.

This bug makes impossible to delete column from `\Illuminate\Database\Schema\Blueprint`.

I can't find tests for this functionality. (1)
And how can it be fixed in prev versions? (2)
should i make `pull` for another branches like `5.6`, because i got projects on this versions and it would make my life easier if this method was workable?