### PR TITLE
[5.8] Allow for custom encryption packages

### DIFF
--- a/src/Illuminate/Contracts/Encryption/Encrypter.php
+++ b/src/Illuminate/Contracts/Encryption/Encrypter.php
@@ -25,7 +25,7 @@ interface Encrypter
     /**
      * Generate a new key for the chosen cipher.
      *
-     * @param $cipher
+     * @param  string  $cipher
      * @return mixed
      */
     public function generateKey($cipher = null);

--- a/src/Illuminate/Contracts/Encryption/Encrypter.php
+++ b/src/Illuminate/Contracts/Encryption/Encrypter.php
@@ -25,7 +25,7 @@ interface Encrypter
     /**
      * Generate a new key for the chosen cipher.
      *
-     * @param  string  $cipher
+     * @param  string|null  $cipher
      * @return mixed
      */
     public function generateKey($cipher = null);

--- a/src/Illuminate/Contracts/Encryption/Encrypter.php
+++ b/src/Illuminate/Contracts/Encryption/Encrypter.php
@@ -21,4 +21,12 @@ interface Encrypter
      * @return mixed
      */
     public function decrypt($payload, $unserialize = true);
+
+    /**
+     * Generate a new key for the chosen cipher.
+     *
+     * @param $cipher
+     * @return mixed
+     */
+    public function generateKey($cipher = null);
 }

--- a/src/Illuminate/Contracts/Encryption/Encrypter.php
+++ b/src/Illuminate/Contracts/Encryption/Encrypter.php
@@ -14,6 +14,16 @@ interface Encrypter
     public function encrypt($value, $serialize = true);
 
     /**
+     * Encrypt a string without serialization.
+     *
+     * @param  string  $value
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Encryption\EncryptException
+     */
+    public function encryptString($value);
+
+    /**
      * Decrypt the given value.
      *
      * @param  mixed  $payload
@@ -21,6 +31,16 @@ interface Encrypter
      * @return mixed
      */
     public function decrypt($payload, $unserialize = true);
+
+    /**
+     * Decrypt the given string without unserialization.
+     *
+     * @param  string  $payload
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Encryption\DecryptException
+     */
+    public function decryptString($payload);
 
     /**
      * Generate a new key for the chosen cipher.

--- a/src/Illuminate/Contracts/Encryption/Encrypter.php
+++ b/src/Illuminate/Contracts/Encryption/Encrypter.php
@@ -29,4 +29,11 @@ interface Encrypter
      * @return mixed
      */
     public function generateKey($cipher = null);
+
+    /**
+     * Determine whether the encrypter is valid.
+     *
+     * @return bool
+     */
+    public function isValid();
 }

--- a/src/Illuminate/Encryption/EncryptionManager.php
+++ b/src/Illuminate/Encryption/EncryptionManager.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Encryption;
 
 use Illuminate\Support\Str;
-use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Support\Manager;
+use Illuminate\Contracts\Encryption\Encrypter;
 
 class EncryptionManager extends Manager implements Encrypter
 {

--- a/src/Illuminate/Encryption/EncryptionManager.php
+++ b/src/Illuminate/Encryption/EncryptionManager.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Illuminate\Encryption;
+
+use Illuminate\Support\Str;
+use Illuminate\Contracts\Encryption\Encrypter;
+use Illuminate\Support\Manager;
+
+class EncryptionManager extends Manager implements Encrypter
+{
+    /**
+     * Create an instance of the OpenSSL encryption Driver.
+     *
+     * @return \Illuminate\Encryption\OpenSSLEncrypter
+     */
+    public function createOpenSSLDriver()
+    {
+        $config = $this->app->make('config')->get('app.encryption');
+
+        // If the key starts with "base64:", we will need to decode the key before handing
+        // it off to the encrypter. Keys may be base-64 encoded for presentation and we
+        // want to make sure to convert them back to the raw bytes before encrypting.
+        if (Str::startsWith($key = $config['key'], 'base64:')) {
+            $key = base64_decode(substr($key, 7));
+        }
+
+        return new OpenSSLEncrypter($key, $config['cipher']);
+    }
+
+    /**
+     * Create a new encryption key for the given driver and cipher.
+     *
+     * @param  string  $driver
+     * @param  string  $cipher
+     * @return string
+     *
+     * @throws \Exception
+     */
+    public function generateKey($driver = null, $cipher = null)
+    {
+        return $this->driver($driver)->generateKey($cipher);
+    }
+
+    /**
+     * Encrypt the given value.
+     *
+     * @param  mixed  $value
+     * @param  bool  $serialize
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Encryption\EncryptException
+     */
+    public function encrypt($value, $serialize = true)
+    {
+        return $this->driver()->encrypt($value, $serialize);
+    }
+
+    /**
+     * Encrypt a string without serialization.
+     *
+     * @param  string  $value
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Encryption\EncryptException
+     */
+    public function encryptString($value)
+    {
+        return $this->encrypt($value, false);
+    }
+
+    /**
+     * Decrypt the given value.
+     *
+     * @param  mixed  $payload
+     * @param  bool  $unserialize
+     * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Encryption\DecryptException
+     */
+    public function decrypt($payload, $unserialize = true)
+    {
+        return $this->driver()->decrypt($payload, $unserialize);
+    }
+
+    /**
+     * Decrypt the given string without unserialization.
+     *
+     * @param  string  $payload
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Encryption\DecryptException
+     */
+    public function decryptString($payload)
+    {
+        return $this->decrypt($payload, false);
+    }
+
+    /**
+     * Get the encryption key.
+     *
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->driver()->getKey();
+    }
+
+    /**
+     * Get the default driver name.
+     *
+     * @return string
+     */
+    public function getDefaultDriver()
+    {
+        return $this->app['config']['app.encryption.driver'] ?? 'openssl';
+    }
+}

--- a/src/Illuminate/Encryption/EncryptionManager.php
+++ b/src/Illuminate/Encryption/EncryptionManager.php
@@ -34,8 +34,6 @@ class EncryptionManager extends Manager implements Encrypter
      *
      * @param  string|null  $cipher
      * @return string
-     *
-     * @throws \Exception
      */
     public function generateKey($cipher = null)
     {

--- a/src/Illuminate/Encryption/EncryptionManager.php
+++ b/src/Illuminate/Encryption/EncryptionManager.php
@@ -17,7 +17,7 @@ class EncryptionManager extends Manager implements Encrypter
      */
     public function createOpenSslDriver()
     {
-        $config = $this->app->make('config')->get('app.encryption');
+        $config = $this->app->make('config')->get('encryption');
 
         // If the key starts with "base64:", we will need to decode the key before handing
         // it off to the encrypter. Keys may be base-64 encoded for presentation and we
@@ -68,7 +68,7 @@ class EncryptionManager extends Manager implements Encrypter
      */
     public function encryptString($value)
     {
-        return $this->encrypt($value, false);
+        return $this->driver()->encryptString($value);
     }
 
     /**
@@ -99,7 +99,7 @@ class EncryptionManager extends Manager implements Encrypter
      */
     public function decryptString($payload)
     {
-        return $this->decrypt($payload, false);
+        return $this->driver()->decryptString($payload);
     }
 
     /**
@@ -129,6 +129,6 @@ class EncryptionManager extends Manager implements Encrypter
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['app.encryption.driver'] ?? 'openssl';
+        return $this->app['config']['encryption.driver'] ?? 'openssl';
     }
 }

--- a/src/Illuminate/Encryption/EncryptionManager.php
+++ b/src/Illuminate/Encryption/EncryptionManager.php
@@ -32,7 +32,7 @@ class EncryptionManager extends Manager implements Encrypter
     /**
      * Create a new encryption key for the cipher.
      *
-     * @param  string  $cipher
+     * @param  string|null  $cipher
      * @return string
      *
      * @throws \Exception

--- a/src/Illuminate/Encryption/EncryptionManager.php
+++ b/src/Illuminate/Encryption/EncryptionManager.php
@@ -106,6 +106,16 @@ class EncryptionManager extends Manager implements Encrypter
     }
 
     /**
+     * Determine whether the encrypter is valid.
+     *
+     * @return bool
+     */
+    public function isValid()
+    {
+        return $this->driver()->isValid();
+    }
+
+    /**
      * Get the default driver name.
      *
      * @return string

--- a/src/Illuminate/Encryption/EncryptionManager.php
+++ b/src/Illuminate/Encryption/EncryptionManager.php
@@ -28,17 +28,16 @@ class EncryptionManager extends Manager implements Encrypter
     }
 
     /**
-     * Create a new encryption key for the given driver and cipher.
+     * Create a new encryption key for the cipher.
      *
-     * @param  string  $driver
      * @param  string  $cipher
      * @return string
      *
      * @throws \Exception
      */
-    public function generateKey($driver = null, $cipher = null)
+    public function generateKey($cipher = null)
     {
-        return $this->driver($driver)->generateKey($cipher);
+        return $this->driver()->generateKey($cipher);
     }
 
     /**

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Encryption;
 
-use RuntimeException;
-use Illuminate\Support\Str;
 use Illuminate\Support\ServiceProvider;
 
 class EncryptionServiceProvider extends ServiceProvider
@@ -16,35 +14,7 @@ class EncryptionServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('encrypter', function ($app) {
-            $config = $app->make('config')->get('app');
-
-            // If the key starts with "base64:", we will need to decode the key before handing
-            // it off to the encrypter. Keys may be base-64 encoded for presentation and we
-            // want to make sure to convert them back to the raw bytes before encrypting.
-            if (Str::startsWith($key = $this->key($config), 'base64:')) {
-                $key = base64_decode(substr($key, 7));
-            }
-
-            return new Encrypter($key, $config['cipher']);
-        });
-    }
-
-    /**
-     * Extract the encryption key from the given configuration.
-     *
-     * @param  array  $config
-     * @return string
-     *
-     * @throws \RuntimeException
-     */
-    protected function key(array $config)
-    {
-        return tap($config['key'], function ($key) {
-            if (empty($key)) {
-                throw new RuntimeException(
-                    'No application encryption key has been specified.'
-                );
-            }
+            return new EncryptionManager($app);
         });
     }
 }

--- a/src/Illuminate/Encryption/OpenSSLEncrypter.php
+++ b/src/Illuminate/Encryption/OpenSSLEncrypter.php
@@ -32,8 +32,6 @@ class OpenSSLEncrypter implements EncrypterContract
      * @param  string  $key
      * @param  string  $cipher
      * @return void
-     *
-     * @throws \RuntimeException
      */
     public function __construct($key, $cipher = self::AES_128)
     {

--- a/src/Illuminate/Encryption/OpenSSLEncrypter.php
+++ b/src/Illuminate/Encryption/OpenSSLEncrypter.php
@@ -93,7 +93,7 @@ class OpenSSLEncrypter implements EncrypterContract
      */
     public function encrypt($value, $serialize = true)
     {
-        if (!$this->isValid()) {
+        if (! $this->isValid()) {
             throw new EncryptException('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
         }
 
@@ -136,7 +136,7 @@ class OpenSSLEncrypter implements EncrypterContract
      */
     public function decrypt($payload, $unserialize = true)
     {
-        if (!$this->isValid()) {
+        if (! $this->isValid()) {
             throw new DecryptException('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
         }
 

--- a/src/Illuminate/Encryption/OpenSslEncrypter.php
+++ b/src/Illuminate/Encryption/OpenSslEncrypter.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Encryption;
 
+use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\EncryptException;
-use Illuminate\Contracts\Encryption\Encrypter;
 
 class OpenSslEncrypter implements Encrypter
 {

--- a/src/Illuminate/Encryption/OpenSslEncrypter.php
+++ b/src/Illuminate/Encryption/OpenSslEncrypter.php
@@ -127,6 +127,19 @@ class OpenSslEncrypter implements Encrypter
     }
 
     /**
+     * Encrypt a string without serialization.
+     *
+     * @param  string  $value
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Encryption\EncryptException
+     */
+    public function encryptString($value)
+    {
+        return $this->encrypt($value, false);
+    }
+
+    /**
      * Decrypt the given value.
      *
      * @param  mixed  $payload
@@ -153,6 +166,19 @@ class OpenSslEncrypter implements Encrypter
         }
 
         return $unserialize ? unserialize($decrypted) : $decrypted;
+    }
+
+    /**
+     * Decrypt the given string without unserialization.
+     *
+     * @param  string  $payload
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Encryption\DecryptException
+     */
+    public function decryptString($payload)
+    {
+        return $this->decrypt($payload, false);
     }
 
     /**

--- a/src/Illuminate/Encryption/OpenSslEncrypter.php
+++ b/src/Illuminate/Encryption/OpenSslEncrypter.php
@@ -65,12 +65,17 @@ class OpenSslEncrypter implements Encrypter
      * @return string
      *
      * @throws \Exception
+     * @throws \InvalidArgumentException
      */
     public function generateKey($cipher = null)
     {
         $cipher = $cipher ?? $this->cipher;
 
-        return random_bytes($cipher === self::AES_128 ? 16 : 32);
+        if (! isset(self::KEY_LENGTHS[$cipher])) {
+            throw new \InvalidArgumentException("{$cipher} is not a supported cipher.");
+        }
+
+        return random_bytes(self::KEY_LENGTHS[$cipher]);
     }
 
     /**

--- a/src/Illuminate/Encryption/OpenSslEncrypter.php
+++ b/src/Illuminate/Encryption/OpenSslEncrypter.php
@@ -61,7 +61,7 @@ class OpenSslEncrypter implements Encrypter
     /**
      * Create a new encryption key for the given cipher.
      *
-     * @param  string  $cipher
+     * @param  string|null  $cipher
      * @return string
      *
      * @throws \Exception

--- a/src/Illuminate/Encryption/OpenSslEncrypter.php
+++ b/src/Illuminate/Encryption/OpenSslEncrypter.php
@@ -64,7 +64,6 @@ class OpenSslEncrypter implements Encrypter
      * @param  string|null  $cipher
      * @return string
      *
-     * @throws \Exception
      * @throws \InvalidArgumentException
      */
     public function generateKey($cipher = null)
@@ -95,7 +94,6 @@ class OpenSslEncrypter implements Encrypter
      * @param  bool  $serialize
      * @return string
      *
-     * @throws \Exception
      * @throws \Illuminate\Contracts\Encryption\EncryptException
      */
     public function encrypt($value, $serialize = true)

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1084,7 +1084,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'cache.store'          => [\Illuminate\Cache\Repository::class, \Illuminate\Contracts\Cache\Repository::class],
             'config'               => [\Illuminate\Config\Repository::class, \Illuminate\Contracts\Config\Repository::class],
             'cookie'               => [\Illuminate\Cookie\CookieJar::class, \Illuminate\Contracts\Cookie\Factory::class, \Illuminate\Contracts\Cookie\QueueingFactory::class],
-            'encrypter'            => [\Illuminate\Encryption\Encrypter::class, \Illuminate\Contracts\Encryption\Encrypter::class],
+            'encrypter'            => [\Illuminate\Encryption\EncryptionManager::class, \Illuminate\Contracts\Encryption\Encrypter::class],
             'db'                   => [\Illuminate\Database\DatabaseManager::class],
             'db.connection'        => [\Illuminate\Database\Connection::class, \Illuminate\Database\ConnectionInterface::class],
             'events'               => [\Illuminate\Events\Dispatcher::class, \Illuminate\Contracts\Events\Dispatcher::class],

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -3,7 +3,8 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Encryption\Encrypter;
+use Illuminate\Encryption\EncryptionManager;
+use Illuminate\Encryption\OpenSSLEncrypter;
 use Illuminate\Console\ConfirmableTrait;
 
 class KeyGenerateCommand extends Command
@@ -46,7 +47,7 @@ class KeyGenerateCommand extends Command
             return;
         }
 
-        $this->laravel['config']['app.key'] = $key;
+        $this->laravel['config']['app.encryption.key'] = $key;
 
         $this->info('Application key set successfully.');
     }
@@ -59,7 +60,7 @@ class KeyGenerateCommand extends Command
     protected function generateRandomKey()
     {
         return 'base64:'.base64_encode(
-            Encrypter::generateKey($this->laravel['config']['app.cipher'])
+            $this->laravel->make('encrypter')->generateKey()
         );
     }
 
@@ -71,7 +72,7 @@ class KeyGenerateCommand extends Command
      */
     protected function setKeyInEnvironmentFile($key)
     {
-        $currentKey = $this->laravel['config']['app.key'];
+        $currentKey = $this->laravel['config']['app.encryption.key'];
 
         if (strlen($currentKey) !== 0 && (! $this->confirmToProceed())) {
             return false;
@@ -104,7 +105,7 @@ class KeyGenerateCommand extends Command
      */
     protected function keyReplacementPattern()
     {
-        $escaped = preg_quote('='.$this->laravel['config']['app.key'], '/');
+        $escaped = preg_quote('='.$this->laravel['config']['app.encryption.key'], '/');
 
         return "/^APP_KEY{$escaped}/m";
     }

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -45,7 +45,7 @@ class KeyGenerateCommand extends Command
             return;
         }
 
-        $this->laravel['config']['app.encryption.key'] = $key;
+        $this->laravel['config']['encryption.key'] = $key;
 
         $this->info('Application key set successfully.');
     }
@@ -70,7 +70,7 @@ class KeyGenerateCommand extends Command
      */
     protected function setKeyInEnvironmentFile($key)
     {
-        $currentKey = $this->laravel['config']['app.encryption.key'];
+        $currentKey = $this->laravel['config']['encryption.key'];
 
         if (strlen($currentKey) !== 0 && (! $this->confirmToProceed())) {
             return false;
@@ -103,7 +103,7 @@ class KeyGenerateCommand extends Command
      */
     protected function keyReplacementPattern()
     {
-        $escaped = preg_quote('='.$this->laravel['config']['app.encryption.key'], '/');
+        $escaped = preg_quote('='.$this->laravel['config']['encryption.key'], '/');
 
         return "/^APP_KEY{$escaped}/m";
     }

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -3,8 +3,6 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Encryption\EncryptionManager;
-use Illuminate\Encryption\OpenSSLEncrypter;
 use Illuminate\Console\ConfirmableTrait;
 
 class KeyGenerateCommand extends Command

--- a/src/Illuminate/Support/Facades/Crypt.php
+++ b/src/Illuminate/Support/Facades/Crypt.php
@@ -6,7 +6,7 @@ namespace Illuminate\Support\Facades;
  * @method static string encrypt(string $value, bool $serialize = true)
  * @method static string decrypt(string $payload, bool $unserialize = true)
  *
- * @see \Illuminate\Encryption\Encrypter
+ * @see \Illuminate\Encryption\EncryptionManager
  */
 class Crypt extends Facade
 {

--- a/src/Illuminate/Support/Facades/Crypt.php
+++ b/src/Illuminate/Support/Facades/Crypt.php
@@ -5,6 +5,8 @@ namespace Illuminate\Support\Facades;
 /**
  * @method static string encrypt(string $value, bool $serialize = true)
  * @method static string decrypt(string $payload, bool $unserialize = true)
+ * @method static string generateKey(string $cipher = null)
+ * @method static bool isValid()
  *
  * @see \Illuminate\Encryption\EncryptionManager
  */

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -10,7 +10,7 @@ use Illuminate\Cookie\CookieJar;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Routing\Controller;
 use Illuminate\Container\Container;
-use Illuminate\Encryption\OpenSSLEncrypter;
+use Illuminate\Encryption\OpenSslEncrypter;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
@@ -32,7 +32,7 @@ class EncryptCookiesTest extends TestCase
 
         $container = new Container;
         $container->singleton(EncrypterContract::class, function () {
-            return new OpenSSLEncrypter(str_repeat('a', 16));
+            return new OpenSslEncrypter(str_repeat('a', 16));
         });
 
         $this->router = new Router(new Dispatcher, $container);

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -10,7 +10,7 @@ use Illuminate\Cookie\CookieJar;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Routing\Controller;
 use Illuminate\Container\Container;
-use Illuminate\Encryption\Encrypter;
+use Illuminate\Encryption\OpenSSLEncrypter;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
@@ -32,7 +32,7 @@ class EncryptCookiesTest extends TestCase
 
         $container = new Container;
         $container->singleton(EncrypterContract::class, function () {
-            return new Encrypter(str_repeat('a', 16));
+            return new OpenSSLEncrypter(str_repeat('a', 16));
         });
 
         $this->router = new Router(new Dispatcher, $container);

--- a/tests/Encryption/OpenSSLEncrypterTest.php
+++ b/tests/Encryption/OpenSSLEncrypterTest.php
@@ -3,13 +3,13 @@
 namespace Illuminate\Tests\Encryption;
 
 use PHPUnit\Framework\TestCase;
-use Illuminate\Encryption\OpenSSLEncrypter;
+use Illuminate\Encryption\OpenSslEncrypter;
 
 class OpenSSLEncrypterTest extends TestCase
 {
     public function testEncryption()
     {
-        $e = new OpenSSLEncrypter(str_repeat('a', 16));
+        $e = new OpenSslEncrypter(str_repeat('a', 16));
         $encrypted = $e->encrypt('foo');
         $this->assertNotEquals('foo', $encrypted);
         $this->assertEquals('foo', $e->decrypt($encrypted));
@@ -17,7 +17,7 @@ class OpenSSLEncrypterTest extends TestCase
 
     public function testRawStringEncryption()
     {
-        $e = new OpenSSLEncrypter(str_repeat('a', 16));
+        $e = new OpenSslEncrypter(str_repeat('a', 16));
         $encrypted = $e->encrypt('foo', false);
         $this->assertNotEquals('foo', $encrypted);
         $this->assertEquals('foo', $e->decrypt($encrypted, false));
@@ -25,7 +25,7 @@ class OpenSSLEncrypterTest extends TestCase
 
     public function testEncryptionUsingBase64EncodedKey()
     {
-        $e = new OpenSSLEncrypter(random_bytes(16));
+        $e = new OpenSslEncrypter(random_bytes(16));
         $encrypted = $e->encrypt('foo');
         $this->assertNotEquals('foo', $encrypted);
         $this->assertEquals('foo', $e->decrypt($encrypted));
@@ -33,12 +33,12 @@ class OpenSSLEncrypterTest extends TestCase
 
     public function testWithCustomCipher()
     {
-        $e = new OpenSSLEncrypter(str_repeat('b', 32), OpenSSLEncrypter::AES_256);
+        $e = new OpenSslEncrypter(str_repeat('b', 32), OpenSslEncrypter::AES_256);
         $encrypted = $e->encrypt('bar');
         $this->assertNotEquals('bar', $encrypted);
         $this->assertEquals('bar', $e->decrypt($encrypted));
 
-        $e = new OpenSSLEncrypter(random_bytes(32), OpenSSLEncrypter::AES_256);
+        $e = new OpenSslEncrypter(random_bytes(32), OpenSslEncrypter::AES_256);
         $encrypted = $e->encrypt('foo');
         $this->assertNotEquals('foo', $encrypted);
         $this->assertEquals('foo', $e->decrypt($encrypted));
@@ -46,56 +46,16 @@ class OpenSSLEncrypterTest extends TestCase
 
     public function testGenerateKey()
     {
-        $e = new OpenSSLEncrypter('');
-        $f = new OpenSSLEncrypter($e->generateKey());
+        $e = new OpenSslEncrypter('');
+        $f = new OpenSslEncrypter($e->generateKey());
         $f->encrypt('bar');
     }
 
     public function testGenerateKeyWithCustomCipher()
     {
-        $e = new OpenSSLEncrypter('');
-        $f = new OpenSSLEncrypter($e->generateKey(OpenSSLEncrypter::AES_256), OpenSSLEncrypter::AES_256);
+        $e = new OpenSslEncrypter('');
+        $f = new OpenSslEncrypter($e->generateKey(OpenSslEncrypter::AES_256), OpenSslEncrypter::AES_256);
         $f->encrypt('bar');
-    }
-
-    /**
-     * @expectedException \Illuminate\Contracts\Encryption\EncryptException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
-     */
-    public function testDoNoAllowLongerKey()
-    {
-        $e = new OpenSSLEncrypter(str_repeat('z', 32));
-        $e->encrypt('bar');
-    }
-
-    /**
-     * @expectedException \Illuminate\Contracts\Encryption\EncryptException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
-     */
-    public function testWithBadKeyLength()
-    {
-        $e = new OpenSSLEncrypter(str_repeat('a', 5));
-        $e->encrypt('bar');
-    }
-
-    /**
-     * @expectedException \Illuminate\Contracts\Encryption\EncryptException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
-     */
-    public function testWithBadKeyLengthAlternativeCipher()
-    {
-        $e = new OpenSSLEncrypter(str_repeat('a', 16), 'AES-256-CFB8');
-        $e->encrypt('bar');
-    }
-
-    /**
-     * @expectedException \Illuminate\Contracts\Encryption\EncryptException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
-     */
-    public function testWithUnsupportedCipher()
-    {
-        $e = new OpenSSLEncrypter(str_repeat('c', 16), 'AES-256-CFB8');
-        $e->encrypt('bar');
     }
 
     /**
@@ -104,7 +64,7 @@ class OpenSSLEncrypterTest extends TestCase
      */
     public function testExceptionThrownWhenPayloadIsInvalid()
     {
-        $e = new OpenSSLEncrypter(str_repeat('a', 16));
+        $e = new OpenSslEncrypter(str_repeat('a', 16));
         $payload = $e->encrypt('foo');
         $payload = str_shuffle($payload);
         $e->decrypt($payload);
@@ -116,8 +76,8 @@ class OpenSSLEncrypterTest extends TestCase
      */
     public function testExceptionThrownWithDifferentKey()
     {
-        $a = new OpenSSLEncrypter(str_repeat('a', 16));
-        $b = new OpenSSLEncrypter(str_repeat('b', 16));
+        $a = new OpenSslEncrypter(str_repeat('a', 16));
+        $b = new OpenSslEncrypter(str_repeat('b', 16));
         $b->decrypt($a->encrypt('baz'));
     }
 
@@ -127,7 +87,7 @@ class OpenSSLEncrypterTest extends TestCase
      */
     public function testExceptionThrownWhenIvIsTooLong()
     {
-        $e = new OpenSSLEncrypter(str_repeat('a', 16));
+        $e = new OpenSslEncrypter(str_repeat('a', 16));
         $payload = $e->encrypt('foo');
         $data = json_decode(base64_decode($payload), true);
         $data['iv'] .= $data['value'][0];

--- a/tests/Integration/Encryption/EncryptionTest.php
+++ b/tests/Integration/Encryption/EncryptionTest.php
@@ -2,16 +2,20 @@
 
 namespace Illuminate\Tests\Integration\Encryption;
 
-use RuntimeException;
+use Illuminate\Contracts\Encryption\EncryptException;
+use Illuminate\Encryption\EncryptionManager;
 use Orchestra\Testbench\TestCase;
-use Illuminate\Encryption\Encrypter;
 use Illuminate\Encryption\EncryptionServiceProvider;
 
 class EncryptionTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.key', 'base64:IUHRqAQ99pZ0A1MPjbuv1D6ff3jxv0GIvS2qIW4JNU4=');
+        $app['config']->set('app.encryption', [
+            'driver' => 'openssl',
+            'cipher' => 'AES-256-CBC',
+            'key'    => 'base64:IUHRqAQ99pZ0A1MPjbuv1D6ff3jxv0GIvS2qIW4JNU4='
+        ]);
     }
 
     protected function getPackageProviders($app)
@@ -21,15 +25,28 @@ class EncryptionTest extends TestCase
 
     public function test_encryption_provider_bind()
     {
-        self::assertInstanceOf(Encrypter::class, $this->app->make('encrypter'));
+        self::assertInstanceOf(EncryptionManager::class, $this->app->make('encrypter'));
     }
 
-    public function test_encryption_will_not_be_instantiable_when_missing_app_key()
+    public function test_generate_key()
     {
-        $this->expectException(RuntimeException::class);
+        $e = $this->app->make('encrypter');
 
-        $this->app['config']->set('app.key', null);
+        $this->app['config']->set('app.encryption.key', $e->generateKey());
 
-        $this->app->make('encrypter');
+        $e = $this->app->make('encrypter');
+
+        $e->encrypt('bar');
+    }
+
+    public function test_encryption_will_not_be_usable_when_missing_app_key()
+    {
+        $this->expectException(EncryptException::class);
+
+        $this->app['config']->set('app.encryption.key', null);
+
+        $e = $this->app->make('encrypter');
+
+        $e->encrypt('bar');
     }
 }

--- a/tests/Integration/Encryption/EncryptionTest.php
+++ b/tests/Integration/Encryption/EncryptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Encryption;
 
+use Illuminate\Encryption\OpenSslEncrypter;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Encryption\EncryptionManager;
 use Illuminate\Encryption\EncryptionServiceProvider;
@@ -44,6 +45,52 @@ class EncryptionTest extends TestCase
         $this->expectException(EncryptException::class);
 
         $this->app['config']->set('app.encryption.key', null);
+
+        $e = $this->app->make('encrypter');
+
+        $e->encrypt('bar');
+    }
+
+    public function test_do_not_allow_longer_key()
+    {
+        $this->expectException(EncryptException::class);
+
+        $this->app['config']->set('app.encryption.key', str_repeat('z', 32));
+        $this->app['config']->set('app.encryption.cipher', OpenSslEncrypter::AES_128);
+
+        $e = $this->app->make('encrypter');
+
+        $e->encrypt('bar');
+    }
+
+    public function test_with_bad_key_length()
+    {
+        $this->expectException(EncryptException::class);
+
+        $this->app['config']->set('app.encryption.key', str_repeat('z', 5));
+
+        $e = $this->app->make('encrypter');
+
+        $e->encrypt('bar');
+    }
+
+    public function test_with_bad_key_length_alternative_cipher()
+    {
+        $this->expectException(EncryptException::class);
+
+        $this->app['config']->set('app.encryption.key', str_repeat('z', 16));
+
+        $e = $this->app->make('encrypter');
+
+        $e->encrypt('bar');
+    }
+
+    public function testWithUnsupportedCipher()
+    {
+        $this->expectException(EncryptException::class);
+
+        $this->app['config']->set('app.encryption.key', str_repeat('z', 16));
+        $this->app['config']->set('app.encryption.cipher', 'AES-256-CFB8');
 
         $e = $this->app->make('encrypter');
 

--- a/tests/Integration/Encryption/EncryptionTest.php
+++ b/tests/Integration/Encryption/EncryptionTest.php
@@ -12,7 +12,7 @@ class EncryptionTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.encryption', [
+        $app['config']->set('encryption', [
             'driver' => 'openssl',
             'cipher' => 'AES-256-CBC',
             'key'    => 'base64:IUHRqAQ99pZ0A1MPjbuv1D6ff3jxv0GIvS2qIW4JNU4=',
@@ -33,7 +33,7 @@ class EncryptionTest extends TestCase
     {
         $e = $this->app->make('encrypter');
 
-        $this->app['config']->set('app.encryption.key', $e->generateKey());
+        $this->app['config']->set('encryption.key', $e->generateKey());
 
         $e = $this->app->make('encrypter');
 
@@ -44,7 +44,7 @@ class EncryptionTest extends TestCase
     {
         $this->expectException(EncryptException::class);
 
-        $this->app['config']->set('app.encryption.key', null);
+        $this->app['config']->set('encryption.key', null);
 
         $e = $this->app->make('encrypter');
 
@@ -55,8 +55,8 @@ class EncryptionTest extends TestCase
     {
         $this->expectException(EncryptException::class);
 
-        $this->app['config']->set('app.encryption.key', str_repeat('z', 32));
-        $this->app['config']->set('app.encryption.cipher', OpenSslEncrypter::AES_128);
+        $this->app['config']->set('encryption.key', str_repeat('z', 32));
+        $this->app['config']->set('encryption.cipher', OpenSslEncrypter::AES_128);
 
         $e = $this->app->make('encrypter');
 
@@ -67,7 +67,7 @@ class EncryptionTest extends TestCase
     {
         $this->expectException(EncryptException::class);
 
-        $this->app['config']->set('app.encryption.key', str_repeat('z', 5));
+        $this->app['config']->set('encryption.key', str_repeat('z', 5));
 
         $e = $this->app->make('encrypter');
 
@@ -78,7 +78,7 @@ class EncryptionTest extends TestCase
     {
         $this->expectException(EncryptException::class);
 
-        $this->app['config']->set('app.encryption.key', str_repeat('z', 16));
+        $this->app['config']->set('encryption.key', str_repeat('z', 16));
 
         $e = $this->app->make('encrypter');
 
@@ -89,8 +89,8 @@ class EncryptionTest extends TestCase
     {
         $this->expectException(EncryptException::class);
 
-        $this->app['config']->set('app.encryption.key', str_repeat('z', 16));
-        $this->app['config']->set('app.encryption.cipher', 'AES-256-CFB8');
+        $this->app['config']->set('encryption.key', str_repeat('z', 16));
+        $this->app['config']->set('encryption.cipher', 'AES-256-CFB8');
 
         $e = $this->app->make('encrypter');
 

--- a/tests/Integration/Encryption/EncryptionTest.php
+++ b/tests/Integration/Encryption/EncryptionTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Encryption;
 
-use Illuminate\Encryption\OpenSslEncrypter;
 use Orchestra\Testbench\TestCase;
+use Illuminate\Encryption\OpenSslEncrypter;
 use Illuminate\Encryption\EncryptionManager;
 use Illuminate\Encryption\EncryptionServiceProvider;
 use Illuminate\Contracts\Encryption\EncryptException;

--- a/tests/Integration/Encryption/EncryptionTest.php
+++ b/tests/Integration/Encryption/EncryptionTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Integration\Encryption;
 
-use Illuminate\Contracts\Encryption\EncryptException;
-use Illuminate\Encryption\EncryptionManager;
 use Orchestra\Testbench\TestCase;
+use Illuminate\Encryption\EncryptionManager;
 use Illuminate\Encryption\EncryptionServiceProvider;
+use Illuminate\Contracts\Encryption\EncryptException;
 
 class EncryptionTest extends TestCase
 {
@@ -14,7 +14,7 @@ class EncryptionTest extends TestCase
         $app['config']->set('app.encryption', [
             'driver' => 'openssl',
             'cipher' => 'AES-256-CBC',
-            'key'    => 'base64:IUHRqAQ99pZ0A1MPjbuv1D6ff3jxv0GIvS2qIW4JNU4='
+            'key'    => 'base64:IUHRqAQ99pZ0A1MPjbuv1D6ff3jxv0GIvS2qIW4JNU4=',
         ]);
     }
 

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -4,20 +4,28 @@ namespace Illuminate\Tests\Integration\Http\Middleware;
 
 use Illuminate\Http\Request;
 use Orchestra\Testbench\TestCase;
-use Illuminate\Encryption\OpenSSLEncrypter;
 
 class VerifyCsrfTokenExceptTest extends TestCase
 {
     private $stub;
     private $request;
 
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.encryption', [
+            'driver' => 'openssl',
+            'cipher' => 'AES-256-CBC',
+            'key'    => 'base64:IUHRqAQ99pZ0A1MPjbuv1D6ff3jxv0GIvS2qIW4JNU4=',
+        ]);
+    }
+
     public function setUp()
     {
         parent::setUp();
 
-        $e = new OpenSSLEncrypter('');
+        $e = $this->app->make('encrypter');
 
-        $this->stub = new VerifyCsrfTokenExceptStub(app(), new OpenSSLEncrypter($e->generateKey()));
+        $this->stub = new VerifyCsrfTokenExceptStub(app(), $e);
         $this->request = Request::create('http://example.com/foo/bar', 'POST');
     }
 

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\Integration\Http\Middleware;
 
 use Illuminate\Http\Request;
 use Orchestra\Testbench\TestCase;
-use Illuminate\Encryption\Encrypter;
+use Illuminate\Encryption\OpenSSLEncrypter;
 
 class VerifyCsrfTokenExceptTest extends TestCase
 {
@@ -15,7 +15,9 @@ class VerifyCsrfTokenExceptTest extends TestCase
     {
         parent::setUp();
 
-        $this->stub = new VerifyCsrfTokenExceptStub(app(), new Encrypter(Encrypter::generateKey('AES-128-CBC')));
+        $e = new OpenSSLEncrypter('');
+
+        $this->stub = new VerifyCsrfTokenExceptStub(app(), new OpenSSLEncrypter($e->generateKey()));
         $this->request = Request::create('http://example.com/foo/bar', 'POST');
     }
 

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -12,7 +12,7 @@ class VerifyCsrfTokenExceptTest extends TestCase
 
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.encryption', [
+        $app['config']->set('encryption', [
             'driver' => 'openssl',
             'cipher' => 'AES-256-CBC',
             'key'    => 'base64:IUHRqAQ99pZ0A1MPjbuv1D6ff3jxv0GIvS2qIW4JNU4=',


### PR DESCRIPTION
Before this change, the encryption feature was heavily coupled with the OpenSSL encryption suite and was limited to only 2 ciphers.

This change allows for the use of custom packages to extend Laravel's encryption capability. For instance, if an end user is running PHP 7.2+, the sodium extension is compiled into the core by default and enables the use of more secure ciphers.

The only changes to the API are that instantiating an encryptor without a key will no longer throw a runtime exception as the validity check was moved to the `encrypt()` and `decrypt()` functions, a change in configuration format, and `generateKey()` was made non-static to fit the Manager-Driver pattern demonstrated in the Hasher.

This change includes an addition to the app configuration like so:
`'encryption' => [
    'driver' => 'openssl',
    'cipher' => OpenSSLEncrypter::AES_128,
    'key' => env('APP_KEY')
]`

Because of these changes and the addition of a function to a contract, I believe this should be released in 5.8.

Please let me know if anything isn't up to snuff as this is my first contribution!