### PR TITLE
[5.7] Add missing test for removeColumn()

### DIFF
--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -134,4 +134,19 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint = clone $base;
         $this->assertEquals(['alter table `users` add `money` decimal(10, 2) unsigned not null'], $blueprint->toSql($connection, new MySqlGrammar));
     }
+
+    public function testRemoveColumn()
+    {
+        $base = new Blueprint('users', function ($table) {
+            $table->string('foo');
+            $table->string('remove_this');
+            $table->removeColumn('remove_this');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+
+        $this->assertEquals(['alter table `users` add `foo` varchar(255) not null'], $blueprint->toSql($connection, new MySqlGrammar));
+    }
 }


### PR DESCRIPTION
There was a bug (#27115) that caused the uncommonly used `removeColumn()` function to break. 

This method is untested -- This test will make sure the specified column is removed from the blueprint.