### PR TITLE
[5.7] Ability to skip auth in the email verification process

### DIFF
--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -32,7 +32,7 @@ trait VerifiesEmails
      */
     public function verify(Request $request)
     {
-        if (!isset($this->forceAuth) || $this->forceAuth) {
+        if (! isset($this->forceAuth) || $this->forceAuth) {
             if ($request->route('id') != $request->user()->getKey()) {
                 throw new AuthorizationException;
             }

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -32,15 +32,20 @@ trait VerifiesEmails
      */
     public function verify(Request $request)
     {
-        if ($request->route('id') != $request->user()->getKey()) {
-            throw new AuthorizationException;
+        if (!isset($this->forceAuth) || $this->forceAuth) {
+            if ($request->route('id') != $request->user()->getKey()) {
+                throw new AuthorizationException;
+            }
+            $user = $request->user();
+        } else {
+            $user = \App\User::findOrFail($request->route('id'));
         }
 
-        if ($request->user()->hasVerifiedEmail()) {
+        if ($user->hasVerifiedEmail()) {
             return redirect($this->redirectPath());
         }
 
-        if ($request->user()->markEmailAsVerified()) {
+        if ($user->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 


### PR DESCRIPTION
Allows you to skip the authentication in the email verification. Useful for when you create an account through the API and don't want them to have to login whenever they click the link. I'll open a PR on the application that goes with this. PR [HERE](https://github.com/laravel/laravel/pull/4901)