### PR TITLE
[5.7] Fix Skipping Redis tests problem

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -55,10 +55,8 @@ trait InteractsWithRedis
             $this->redis['predis']->connection()->flushdb();
         } catch (Exception $e) {
             if ($host === '127.0.0.1' && $port === 6379 && getenv('REDIS_HOST') === false) {
-                $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
                 static::$connectionFailedOnceWithDefaultsSkip = true;
-
-                return;
+                $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
             }
         }
     }


### PR DESCRIPTION
During my recent contributions some slow skipping tests annoyed me a lot. 🤕 

I found that the redis tests have a mechanism to skip fast, but it does not work.
Simply because when we mark a test a skipped it does not execute the rest of the code. (we had dead code)
We should first set the static variable to true then skip.
