### PR TITLE
[5.8] Add feature for resolving an object without raising events

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -613,6 +613,20 @@ class Container implements ContainerContract
     }
 
     /**
+     * Resolve the given type from the container without raising events.
+     *
+     * @param  string  $abstract
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function makeSilently($abstract, array $parameters = [])
+    {
+        return $this->resolve($abstract, $parameters, false);
+    }
+
+    /**
      *  {@inheritdoc}
      */
     public function get($id)

--- a/tests/Container/MakeSilentlyTest.php
+++ b/tests/Container/MakeSilentlyTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Tests\Container;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+
+class MakeSilentlyTest extends TestCase
+{
+    public function testMakeSilentlyForStringAbstract()
+    {
+        $container = new Container;
+
+        $container->bind('foo', MadeSilent::class);
+
+        $callCounter = 0;
+        $container->resolving('foo', function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->afterResolving('foo', function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->resolving(function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->makeSilently('foo');
+        $container->makeSilently(MadeSilent::class);
+        $this->assertEquals(0, $callCounter);
+    }
+
+    public function testMakeSilentlyForConcretes()
+    {
+        $container = new Container;
+
+        $callCounter = 0;
+        $container->resolving(MadeSilent::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->afterResolving(MadeSilent::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->resolving(function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        $container->makeSilently(MadeSilent::class);
+        $this->assertEquals(0, $callCounter);
+    }
+}
+
+class MadeSilent
+{
+}


### PR DESCRIPTION
Following my bug fix, I added a private feature to resolve an object silently.
It can also be exposed to public.

The idea is discussed here :
https://github.com/laravel/ideas/issues/1470