### PR TITLE
[5.7] Bug Fix: Allow Null Broadcast Connection Driver

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -176,10 +176,6 @@ class BroadcastManager implements FactoryContract
     {
         $config = $this->getConfig($name);
 
-        if (is_null($config)) {
-            throw new InvalidArgumentException("Broadcaster [{$name}] is not defined.");
-        }
-
         if (isset($this->customCreators[$config['driver']])) {
             return $this->callCustomCreator($config);
         }
@@ -269,7 +265,11 @@ class BroadcastManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        return $this->app['config']["broadcasting.connections.{$name}"];
+        if (! is_null($name) && $name !== 'null') {
+            return $this->app['config']["broadcasting.connections.{$name}"];
+        }
+
+        return ['driver' => 'null'];
     }
 
     /**


### PR DESCRIPTION
Fixes #27132 

via Docs:

> Additionally, a  null driver is included which allows you to totally disable broadcasting

However, `BROADCAST_DRIVER=null` returns `Broadcaster [] is not defined.` within app.

This PR will allow a `null` Broadcast Driver to be disabled within the app.