### PR TITLE
[5.7] Get the model's original attributes values that were changed since last sync

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1235,4 +1235,14 @@ trait HasAttributes
 
         return $matches[1];
     }
+
+    /**
+     * Get the model's original attributes values that were changed since last sync.
+     *
+     * @return array
+     */
+    public function getOriginalChanged()
+    {
+        return array_intersect_key($this->getOriginal(), $this->getDirty());
+    }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1429,6 +1429,17 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['firstName', 'middleName', 'lastName'], $model->getMutatedAttributes());
     }
 
+    public function testGetOriginalChanged()
+    {
+        $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);
+        $model->syncOriginal();
+        $model->foo = 1;
+        $model->bar = 20;
+        $model->baz = 30;
+
+        $this->assertEquals(['bar' => 2, 'baz' => 3], $model->getOriginalChanged());
+    }
+
     public function testReplicateCreatesANewModelInstanceWithSameAttributeValues()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
This PR add a new method for Models that allows to get only the original attributes values that were changed.