### PR TITLE
[5.7] Moved recaller unserialize call to prevent unnecessary calls

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -135,9 +135,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // If the user is null, but we decrypt a "recaller" cookie we can attempt to
         // pull the user data on that cookie which serves as a remember cookie on
         // the application. Once we have a user we can return it to the caller.
-        $recaller = $this->recaller();
-
-        if (is_null($this->user) && ! is_null($recaller)) {
+        if (is_null($this->user) && ! is_null($recaller = $this->recaller())) {
             $this->user = $this->userFromRecaller($recaller);
 
             if ($this->user) {


### PR DESCRIPTION
This change moves the call to create a new `Recaller` and unserialize the recaller cookie string into the short-circuited right side of the && statement in which it is used.

The purpose of this is to remove unnecessary calls to unserialize the recaller string on every request despite possibly having already resolved the user from the session.