### PR TITLE
[5.7] Fix assertSessionDoesntHaveErrors() when there is no errors

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -901,6 +901,12 @@ class TestResponse
             return $this->assertSessionMissing('errors');
         }
 
+        if (is_null($this->session()->get('errors'))) {
+            PHPUnit::assertTrue(true);
+
+            return $this;
+        }
+
         $errors = $this->session()->get('errors')->getBag($errorBag);
 
         foreach ($keys as $key => $value) {


### PR DESCRIPTION
When the response has no errors at all and we do

```php
$response->assertSessionDoesntHaveErrors('can_be_invited_as_reviewer');
```

A php error will occur
`
Error : Call to a member function getBag() on null
 F:\projects\quick-conference\src\quick-conference\vendor\laravel\framework\src\Illuminate\Foundation\Testing\TestResponse.php:904
`

The reason is that the assertion method is not taking into consideration someone checking that a specific error is missing when there is no errors at all.

Having this in a test
```php
$response->assertSessionDoesntHaveErrors('can_be_invited_as_reviewer');
```
intead of this
```php
$response->assertSessionDoesntHaveErrors();
```

makes it clearer that the test is checking that the `can_be_invited_as_reviewer` is missing.

Edit: btw the `assertJsonMissingValidationErrors()` allows for the behavior that the PR is adding, this will make things more consistent.
