### PR TITLE
[5.7] Replace get_called_class() with static::class

### DIFF
--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -34,6 +34,6 @@ trait Dispatchable
      */
     public static function withChain($chain)
     {
-        return new PendingChain(get_called_class(), $chain);
+        return new PendingChain(static::class, $chain);
     }
 }

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -75,7 +75,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public static function collection($resource)
     {
-        return new AnonymousResourceCollection($resource, get_called_class());
+        return new AnonymousResourceCollection($resource, static::class);
     }
 
     /**


### PR DESCRIPTION
`get_called_class()` can be securely replaced with `static::class`.

Also, this function will be marked as deprecated in PHP 7.4:  https://wiki.php.net/rfc/deprecations_php_7_4#get_called_class_function
