### PR TITLE
[5.7] Improve Manager create driver exceptions

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -96,6 +96,11 @@ abstract class Manager
                 return $this->$method();
             }
         }
+        
+        if(!class_exists($driver)) {
+            throw new InvalidArgumentException("Class [$driver] not found.");
+        }
+        
         throw new InvalidArgumentException("Driver [$driver] not supported.");
     }
 


### PR DESCRIPTION
I was trying to create my custom notification driver, and I was just receiving `Driver [MyCustomDriver] not supported` I thought there is a place where I need to register my notification drivers and after a lot of searches and reading docs I decided to debug the create driver method and the issue was that the import of namespace is not correct which it doesn't seem related to the error message as I guess, so maybe this check for if class not exists would give better error for users