### PR TITLE
[5.7] Add validation for explicit / implicit model binding.

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlRoutable.php
+++ b/src/Illuminate/Contracts/Routing/UrlRoutable.php
@@ -21,9 +21,10 @@ interface UrlRoutable
     /**
      * Get the validator for the bound value.
      *
+     * @param  mixed  $value
      * @return \Illuminate\Validation\Validator|null
      */
-    public function getRouteKeyValidator();
+    public function getRouteKeyValidator($value);
 
     /**
      * Retrieve the model for a bound value.

--- a/src/Illuminate/Contracts/Routing/UrlRoutable.php
+++ b/src/Illuminate/Contracts/Routing/UrlRoutable.php
@@ -19,6 +19,13 @@ interface UrlRoutable
     public function getRouteKeyName();
 
     /**
+     * Get the validator for the bound value.
+     *
+     * @return \Illuminate\Validation\Validator|null
+     */
+    public function getRouteKeyValidator();
+
+    /**
      * Retrieve the model for a bound value.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1461,9 +1461,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Get the validator for the bound value.
      *
+     * @param  mixed  $value
      * @return \Illuminate\Validation\Validator|null
      */
-    public function getRouteKeyValidator()
+    public function getRouteKeyValidator($value)
     {
         return null;
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1459,6 +1459,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Get the validator for the bound value.
+     *
+     * @return \Illuminate\Validation\Validator|null
+     */
+    public function getRouteKeyValidator()
+    {
+        return null;
+    }
+
+    /**
      * Retrieve the model for a bound value.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Http/Resources/DelegatesToResource.php
+++ b/src/Illuminate/Http/Resources/DelegatesToResource.php
@@ -35,7 +35,7 @@ trait DelegatesToResource
      * @param  mixed  $value
      * @return \Illuminate\Validation\Validator|null
      */
-    public function getRouteKeyValidator()
+    public function getRouteKeyValidator($value)
     {
         return null;
     }

--- a/src/Illuminate/Http/Resources/DelegatesToResource.php
+++ b/src/Illuminate/Http/Resources/DelegatesToResource.php
@@ -32,6 +32,7 @@ trait DelegatesToResource
     /**
      * Get the validator for the bound value.
      *
+     * @param  mixed  $value
      * @return \Illuminate\Validation\Validator|null
      */
     public function getRouteKeyValidator()

--- a/src/Illuminate/Http/Resources/DelegatesToResource.php
+++ b/src/Illuminate/Http/Resources/DelegatesToResource.php
@@ -30,6 +30,16 @@ trait DelegatesToResource
     }
 
     /**
+     * Get the validator for the bound value.
+     *
+     * @return \Illuminate\Validation\Validator|null
+     */
+    public function getRouteKeyValidator()
+    {
+        return null;
+    }
+
+    /**
      * Retrieve the model for a bound value.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -32,7 +32,7 @@ class ImplicitRouteBinding
 
             $instance = $container->make($parameter->getClass()->name);
 
-            if ($validator = $instance->getRouteKeyValidator()) {
+            if ($validator = $instance->getRouteKeyValidator($parameterValue)) {
                 if ($validator->fails()) {
                     throw (new ModelNotFoundException)->setModel(get_class($instance));
                 }

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -32,6 +32,12 @@ class ImplicitRouteBinding
 
             $instance = $container->make($parameter->getClass()->name);
 
+            if ($validator = $instance->getRouteKeyValidator()) {
+                if ($validator->fails()) {
+                    throw (new ModelNotFoundException)->setModel(get_class($instance));
+                }
+            }
+
             if (! $model = $instance->resolveRouteBinding($parameterValue)) {
                 throw (new ModelNotFoundException)->setModel(get_class($instance));
             }

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -65,6 +65,12 @@ class RouteBinding
             // throw a not found exception otherwise we will return the instance.
             $instance = $container->make($class);
 
+            if ($validator = $instance->getRouteKeyValidator($value)) {
+                if ($validator->fails()) {
+                    throw (new ModelNotFoundException)->setModel(get_class($instance));
+                }
+            }
+
             if ($model = $instance->resolveRouteBinding($value)) {
                 return $model;
             }

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -101,6 +101,11 @@ class RoutableInterfaceStub implements UrlRoutable
         return 'routable';
     }
 
+    public function getRouteKeyValidator()
+    {
+        return null;
+    }
+
     public function resolveRouteBinding($routeKey)
     {
         //

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -101,7 +101,7 @@ class RoutableInterfaceStub implements UrlRoutable
         return 'routable';
     }
 
-    public function getRouteKeyValidator()
+    public function getRouteKeyValidator($value)
     {
         return null;
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1822,6 +1822,14 @@ class RoutingTestUserModel extends Model
         return 'id';
     }
 
+    public function getRouteKeyValidator($value)
+    {
+        return Validator::make(
+            [$this->getRouteKeyName() => $value],
+            [$this->getRouteKeyName() => 'string']
+        );
+    }
+
     public function where($key, $value)
     {
         $this->value = $value;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -24,6 +24,9 @@ use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Translation\Translator;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Validation\Validator;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class RoutingRouteTest extends TestCase
@@ -1824,7 +1827,8 @@ class RoutingTestUserModel extends Model
 
     public function getRouteKeyValidator($value)
     {
-        return Validator::make(
+        $translator = new Translator(new ArrayLoader, 'en');
+        return new Validator($translator,
             [$this->getRouteKeyName() => $value],
             [$this->getRouteKeyName() => 'string']
         );

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -16,7 +16,10 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 use Illuminate\Routing\RouteGroup;
 use Illuminate\Container\Container;
+use Illuminate\Validation\Validator;
+use Illuminate\Translation\Translator;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Translation\ArrayLoader;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Routing\ResourceRegistrar;
 use Illuminate\Contracts\Routing\Registrar;
@@ -24,9 +27,6 @@ use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Translation\Translator;
-use Illuminate\Translation\ArrayLoader;
-use Illuminate\Validation\Validator;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class RoutingRouteTest extends TestCase
@@ -1864,6 +1864,7 @@ class RouteModelBindingValidKeyStub extends Model
     public function getRouteKeyValidator($value)
     {
         $translator = new Translator(new ArrayLoader, 'en');
+
         return new Validator($translator,
             [$this->getRouteKeyName() => $value],
             [$this->getRouteKeyName() => 'string']
@@ -1893,6 +1894,7 @@ class RouteModelBindingInvalidKeyStub extends Model
     public function getRouteKeyValidator($value)
     {
         $translator = new Translator(new ArrayLoader, 'en');
+
         return new Validator($translator,
             [$this->getRouteKeyName() => $value],
             [$this->getRouteKeyName() => 'integer']
@@ -2003,6 +2005,7 @@ class RoutingTestValidKeyUserModel extends RoutingTestUserModel
     public function getRouteKeyValidator($value)
     {
         $translator = new Translator(new ArrayLoader, 'en');
+
         return new Validator($translator,
             [$this->getRouteKeyName() => $value],
             [$this->getRouteKeyName() => 'string']
@@ -2015,6 +2018,7 @@ class RoutingTestInvalidKeyUserModel extends RoutingTestUserModel
     public function getRouteKeyValidator($value)
     {
         $translator = new Translator(new ArrayLoader, 'en');
+
         return new Validator($translator,
             [$this->getRouteKeyName() => $value],
             [$this->getRouteKeyName() => 'integer']

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -630,6 +630,11 @@ class RoutableInterfaceStub implements UrlRoutable
         return 'key';
     }
 
+    public function getRouteKeyValidator()
+    {
+        return null;
+    }
+
     public function resolveRouteBinding($routeKey)
     {
         //

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -630,7 +630,7 @@ class RoutableInterfaceStub implements UrlRoutable
         return 'key';
     }
 
-    public function getRouteKeyValidator()
+    public function getRouteKeyValidator($value)
     {
         return null;
     }


### PR DESCRIPTION
This is my first pull request so I hope everything is ok.

I'm not yet sure if I should describe this as a feature or as a bug fix. This is an attempt to fix the issue described in #26239. They still need to add a function getRouteKeyValidator to their Models.

It adds getRouteKeyValidator which return null or a Validator instance. This instance is then used to validate the value for the key in implicit / explicit model binding. I've choosen to keep the current behaviour (no validation).

I have added tests to assure that everything works correctly. There are four extra tests:
 - explicit binding with correct value for validation
 - explicit binding with incorrect value for validation
 - implicit binding with correct value for validation
 - implicit binding with incorrect value for validation

Let me know if there are more changes needed.