### PR TITLE
[5.7] Remove unneeded call to `parseId`.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -188,7 +188,7 @@ trait InteractsWithPivotTable
             $attributes = $this->addTimestampsToAttachment($attributes, true);
         }
 
-        $updated = $this->newPivotStatementForId($this->parseId($id))->update(
+        $updated = $this->newPivotStatementForId($id)->update(
             $this->castAttributes($attributes)
         );
 


### PR DESCRIPTION
`parseIds` will be called from with in `newPivotStatementForId`

`parseId` check if a `Model` is passed and gets its `relatedKey`, the same is done by `parseIds`.