### PR TITLE
[5.7] Re-throw NoMatchingExpectationException from PendingCommand

### DIFF
--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -138,6 +138,8 @@ class PendingCommand
             if ($e->getMethodName() === 'askQuestion') {
                 $this->test->fail('Unexpected question "'.$e->getActualArguments()[0]->getQuestion().'" was asked.');
             }
+
+            throw $e;
         }
 
         if ($this->expectedExitCode !== null) {


### PR DESCRIPTION
PendingCommand should re-throw `NoMatchingExpectationException` if `$e->getMethodName()` does not contain `"askQuestion"`.

The $exitCode variable will not be present if the console kernel call throws a NoMatchingExpectationException and will abort at line 145 with:

> ErrorException : Undefined variable: exitCode

imho the exception should be re-thrown.