### PR TITLE
[5.7] Added option to use name on routes groups shared attributes

### DIFF
--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -86,8 +86,10 @@ class RouteGroup
      */
     protected static function formatAs($new, $old)
     {
-        if (isset($old['as'])) {
-            $new['as'] = $old['as'].($new['as'] ?? '');
+        $oldName = $old['as'] ?? $old['name'] ?? null;
+
+        if ($oldName) {
+            $new['as'] = $oldName.($new['as'] ?? '');
         }
 
         return $new;

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -232,6 +232,17 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals('{account}.myapp.com', $this->getRoute()->getDomain());
     }
 
+    public function testCanRegisterGroupWithSharedNameAttribute()
+    {
+        $this->router->group([
+            'name' => 'api.',
+        ], function ($router) {
+            $router->get('users', 'UsersController@index')->name('users');
+        });
+
+        $this->assertEquals('api.users', $this->getRoute()->getName());
+    }
+
     /**
      * @expectedException \BadMethodCallException
      * @expectedExceptionMessage Method Illuminate\Routing\RouteRegistrar::missing does not exist.

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -210,6 +210,28 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals('api.users', $this->getRoute()->getName());
     }
 
+    public function testCanRegisterGroupWithSharedAttributes()
+    {
+        $this->router->group([
+            'middleware' => 'group-middleware',
+            'namespace' => 'App\Http\Controllers',
+            'prefix' => 'api',
+            'as' => 'api.',
+            'domain' => '{account}.myapp.com',
+        ], function ($router) {
+            $router->get('users', 'UsersController@index')->name('users');
+        });
+
+        $this->seeMiddleware('group-middleware');
+        $this->assertEquals(
+            'App\Http\Controllers\UsersController@index',
+            $this->getRoute()->getAction()['uses']
+        );
+        $this->assertEquals('api/users', $this->getRoute()->uri());
+        $this->assertEquals('api.users', $this->getRoute()->getName());
+        $this->assertEquals('{account}.myapp.com', $this->getRoute()->getDomain());
+    }
+
     /**
      * @expectedException \BadMethodCallException
      * @expectedExceptionMessage Method Illuminate\Routing\RouteRegistrar::missing does not exist.


### PR DESCRIPTION
Closes #27161

The only way to add route name prefix with shared attributes is by using the attribute `as`, alias of `name`. Since the most used and documented attribute to add a name prefix to a route is `name`, it should be possible to use it with shared attributes too. Just being consistent.
