### PR TITLE
[5.8] Fix cache TTL compliance to PSR interface

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -53,11 +53,15 @@ class ApcStore extends TaggableStore
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function put($key, $value, $minutes)
     {
+        if (is_null($minutes)) {
+            return false;
+        }
+
         return $this->apc->put($this->prefix.$key, $value, (int) ($minutes * 60));
     }
 

--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -58,7 +58,7 @@ class ApcStore extends TaggableStore
      */
     public function put($key, $value, $minutes)
     {
-        if (is_null($minutes)) {
+        if ($minutes === null) {
             return false;
         }
 

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -34,7 +34,7 @@ class ArrayStore extends TaggableStore
      */
     public function put($key, $value, $minutes)
     {
-        if (is_null($minutes)) {
+        if ($minutes === null) {
             return false;
         }
 

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -29,11 +29,15 @@ class ArrayStore extends TaggableStore
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function put($key, $value, $minutes)
     {
+        if (is_null($minutes)) {
+            return false;
+        }
+
         $this->storage[$key] = $value;
 
         return true;

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -88,11 +88,15 @@ class DatabaseStore implements Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function put($key, $value, $minutes)
     {
+        if (is_null($minutes)) {
+            return false;
+        }
+
         $key = $this->prefix.$key;
 
         $value = $this->serialize($value);

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -93,7 +93,7 @@ class DatabaseStore implements Store
      */
     public function put($key, $value, $minutes)
     {
-        if (is_null($minutes)) {
+        if ($minutes === null) {
             return false;
         }
 

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -239,11 +239,15 @@ class DynamoDbStore implements Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function add($key, $value, $minutes)
     {
+        if (is_null($minutes)) {
+            return false;
+        }
+
         try {
             $response = $this->dynamo->putItem([
                 'TableName' => $this->table,

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -171,11 +171,15 @@ class DynamoDbStore implements Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return void
      */
     public function put($key, $value, $minutes)
     {
+        if (is_null($minutes)) {
+            return false;
+        }
+
         $this->dynamo->putItem([
             'TableName' => $this->table,
             'Item' => [

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -176,7 +176,7 @@ class DynamoDbStore implements Store
      */
     public function put($key, $value, $minutes)
     {
-        if (is_null($minutes)) {
+        if ($minutes === null) {
             return false;
         }
 
@@ -205,7 +205,7 @@ class DynamoDbStore implements Store
      */
     public function putMany(array $values, $minutes)
     {
-        if (is_null($minutes)) {
+        if ($minutes === null) {
             return false;
         }
 
@@ -244,7 +244,7 @@ class DynamoDbStore implements Store
      */
     public function add($key, $value, $minutes)
     {
-        if (is_null($minutes)) {
+        if ($minutes === null) {
             return false;
         }
 

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -200,11 +200,15 @@ class DynamoDbStore implements Store
      * Store multiple items in the cache for a given number of minutes.
      *
      * @param  array  $values
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return void
      */
     public function putMany(array $values, $minutes)
     {
+        if (is_null($minutes)) {
+            return false;
+        }
+
         $expiration = $this->toTimestamp($minutes);
 
         $this->dynamo->batchWriteItem([

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -54,11 +54,15 @@ class FileStore implements Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function put($key, $value, $minutes)
     {
+        if (is_null($minutes)) {
+            return false;
+        }
+
         $this->ensureCacheDirectoryExists($path = $this->path($key));
 
         $result = $this->files->put(

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -59,7 +59,7 @@ class FileStore implements Store
      */
     public function put($key, $value, $minutes)
     {
-        if (is_null($minutes)) {
+        if ($minutes === null) {
             return false;
         }
 

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -115,11 +115,15 @@ class MemcachedStore extends TaggableStore implements LockProvider
      * Store multiple items in the cache for a given number of minutes.
      *
      * @param  array  $values
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function putMany(array $values, $minutes)
     {
+        if (is_null($minutes)) {
+            return false;
+        }
+
         $prefixedValues = [];
 
         foreach ($values as $key => $value) {

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -140,11 +140,15 @@ class MemcachedStore extends TaggableStore implements LockProvider
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function add($key, $value, $minutes)
     {
+        if (is_null($minutes)) {
+            return false;
+        }
+
         return $this->memcached->add(
             $this->prefix.$key, $value, $this->calculateExpiration($minutes)
         );

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -97,11 +97,15 @@ class MemcachedStore extends TaggableStore implements LockProvider
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function put($key, $value, $minutes)
     {
+        if (is_null($minutes)) {
+            return false;
+        }
+
         return $this->memcached->set(
             $this->prefix.$key, $value, $this->calculateExpiration($minutes)
         );

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -102,7 +102,7 @@ class MemcachedStore extends TaggableStore implements LockProvider
      */
     public function put($key, $value, $minutes)
     {
-        if (is_null($minutes)) {
+        if ($minutes === null) {
             return false;
         }
 
@@ -120,7 +120,7 @@ class MemcachedStore extends TaggableStore implements LockProvider
      */
     public function putMany(array $values, $minutes)
     {
-        if (is_null($minutes)) {
+        if ($minutes === null) {
             return false;
         }
 
@@ -145,7 +145,7 @@ class MemcachedStore extends TaggableStore implements LockProvider
      */
     public function add($key, $value, $minutes)
     {
-        if (is_null($minutes)) {
+        if ($minutes === null) {
             return false;
         }
 

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -29,7 +29,7 @@ class NullStore extends TaggableStore
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function put($key, $value, $minutes)

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -89,7 +89,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function put($key, $value, $minutes)
     {
-        if (is_null($minutes)) {
+        if ($minutes === null) {
             return false;
         }
 
@@ -109,7 +109,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function putMany(array $values, $minutes)
     {
-        if (is_null($minutes)) {
+        if ($minutes === null) {
             return false;
         }
 
@@ -138,7 +138,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function add($key, $value, $minutes)
     {
-        if (is_null($minutes)) {
+        if ($minutes === null) {
             return false;
         }
 

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -104,11 +104,15 @@ class RedisStore extends TaggableStore implements LockProvider
      * Store multiple items in the cache for a given number of minutes.
      *
      * @param  array  $values
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function putMany(array $values, $minutes)
     {
+        if (is_null($minutes)) {
+            return false;
+        }
+
         $this->connection()->multi();
 
         $manyResult = null;

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -84,11 +84,15 @@ class RedisStore extends TaggableStore implements LockProvider
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function put($key, $value, $minutes)
     {
+        if (is_null($minutes)) {
+            return false;
+        }
+
         $result = $this->connection()->setex(
             $this->prefix.$key, (int) max(1, $minutes * 60), $this->serialize($value)
         );

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -133,11 +133,15 @@ class RedisStore extends TaggableStore implements LockProvider
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function add($key, $value, $minutes)
     {
+        if (is_null($minutes)) {
+            return false;
+        }
+
         $lua = "return redis.call('exists',KEYS[1])<1 and redis.call('setex',KEYS[1],ARGV[2],ARGV[1])";
 
         return (bool) $this->connection()->eval(

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -22,7 +22,7 @@ class RedisTaggedCache extends TaggedCache
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTime|float|int|null  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int|null  $minutes
      * @return bool
      */
     public function put($key, $value, $minutes = null)

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -284,9 +284,7 @@ class Repository implements CacheContract, ArrayAccess
         // so it exists for subsequent requests. Then, we will return true so it is
         // easy to know if the value gets added. Otherwise, we will return false.
         if (is_null($this->get($key))) {
-            $this->put($key, $value, $minutes);
-
-            return true;
+            return $this->put($key, $value, $minutes);
         }
 
         return false;

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -262,7 +262,7 @@ class Repository implements CacheContract, ArrayAccess
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int|null  $minutes
      * @return bool
      */
     public function add($key, $value, $minutes)

--- a/src/Illuminate/Cache/RetrievesMultipleKeys.php
+++ b/src/Illuminate/Cache/RetrievesMultipleKeys.php
@@ -32,7 +32,7 @@ trait RetrievesMultipleKeys
      */
     public function putMany(array $values, $minutes)
     {
-        if (is_null($minutes)) {
+        if ($minutes === null) {
             return false;
         }
 

--- a/src/Illuminate/Cache/RetrievesMultipleKeys.php
+++ b/src/Illuminate/Cache/RetrievesMultipleKeys.php
@@ -27,11 +27,15 @@ trait RetrievesMultipleKeys
      * Store multiple items in the cache for a given number of minutes.
      *
      * @param  array  $values
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function putMany(array $values, $minutes)
     {
+        if (is_null($minutes)) {
+            return false;
+        }
+
         $manyResult = null;
 
         foreach ($values as $key => $value) {

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -48,7 +48,7 @@ interface Repository extends CacheInterface
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int|null  $minutes
      * @return bool
      */
     public function add($key, $value, $minutes);

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -38,7 +38,7 @@ interface Repository extends CacheInterface
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int|null  $minutes
      * @return bool
      */
     public function put($key, $value, $minutes);

--- a/src/Illuminate/Contracts/Cache/Store.php
+++ b/src/Illuminate/Contracts/Cache/Store.php
@@ -36,7 +36,7 @@ interface Store
      * Store multiple items in the cache for a given number of minutes.
      *
      * @param  array  $values
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function putMany(array $values, $minutes);

--- a/src/Illuminate/Contracts/Cache/Store.php
+++ b/src/Illuminate/Contracts/Cache/Store.php
@@ -27,7 +27,7 @@ interface Store
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @param  float|int  $minutes
+     * @param  float|int|null  $minutes
      * @return bool
      */
     public function put($key, $value, $minutes);

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -51,6 +51,16 @@ class CacheApcStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testSetMethodWithNullTTLFails()
+    {
+        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['put'])->getMock();
+        $apc->expects($this->never())
+            ->method('put');
+        $store = new ApcStore($apc);
+        $result = $store->put('foo', 'bar', null);
+        $this->assertFalse($result);
+    }
+
     public function testSetMultipleMethodProperlyCallsAPC()
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['put'])->getMock();

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -15,6 +15,14 @@ class CacheArrayStoreTest extends TestCase
         $this->assertEquals('bar', $store->get('foo'));
     }
 
+    public function testAnItemWithNoTTLCannotBeSet()
+    {
+        $store = new ArrayStore;
+        $result = $store->put('foo', 'bar', null);
+        $this->assertFalse($result);
+        $this->assertNull($store->get('foo'));
+    }
+
     public function testMultipleItemsCanBeSetAndRetrieved()
     {
         $store = new ArrayStore;

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Cache;
 
 use Closure;
+use Illuminate\Database\ConnectionInterface;
 use stdClass;
 use Exception;
 use Mockery as m;
@@ -73,6 +74,17 @@ class CacheDatabaseStoreTest extends TestCase
 
         $result = $store->put('foo', 'bar', 1);
         $this->assertTrue($result);
+    }
+
+    public function testValueIsNotInsertedWithoutTTL()
+    {
+        $connection = m::mock(ConnectionInterface::class);
+        $connection->shouldReceive('table')->never();
+
+        $store = new DatabaseStore($connection, 'table');
+
+        $result = $store->put('foo', 'bar', null);
+        $this->assertFalse($result);
     }
 
     public function testValueIsUpdatedWhenInsertThrowsException()

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Cache;
 
 use Closure;
-use Illuminate\Database\ConnectionInterface;
 use stdClass;
 use Exception;
 use Mockery as m;
@@ -11,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\DatabaseStore;
 use Illuminate\Database\Connection;
 use Illuminate\Database\PostgresConnection;
+use Illuminate\Database\ConnectionInterface;
 
 class CacheDatabaseStoreTest extends TestCase
 {

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -46,6 +46,15 @@ class CacheFileStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testPutReturnsFalseForNullTTL()
+    {
+        $files = $this->mockFilesystem();
+        $contents = '0000000000';
+        $store = new FileStore($files, __DIR__);
+        $result = $store->put('foo', $contents, null);
+        $this->assertFalse($result);
+    }
+
     public function testExpiredItemsReturnNull()
     {
         $files = $this->mockFilesystem();

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -74,6 +74,20 @@ class CacheMemcachedStoreTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function testPutMethodReturnsFalseIfTTLIsNull()
+    {
+        if (! class_exists(Memcached::class)) {
+            $this->markTestSkipped('Memcached module not installed');
+        }
+
+        Carbon::setTestNow($now = Carbon::now());
+        $memcached = $this->getMockBuilder(Memcached::class)->setMethods(['set'])->getMock();
+        $store = new MemcachedStore($memcached);
+        $result = $store->put('foo', 'bar', null);
+        $this->assertFalse($result);
+        Carbon::setTestNow();
+    }
+
     public function testIncrementMethodProperlyCallsMemcache()
     {
         if (! class_exists(Memcached::class)) {

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -67,6 +67,13 @@ class CacheRedisStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testPutMethodReturnsFalseIfTTLIsNull()
+    {
+        $redis = $this->getRedis();
+        $result = $redis->put('foo', 'foo', null);
+        $this->assertFalse($result);
+    }
+
     public function testSetMultipleMethodProperlyCallsRedis()
     {
         $redis = $this->getRedis();

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -69,9 +69,7 @@ class CacheRedisStoreTest extends TestCase
 
     public function testPutMethodReturnsFalseIfTTLIsNull()
     {
-        $redis = $this->getRedis();
-        $result = $redis->put('foo', 'foo', null);
-        $this->assertFalse($result);
+        $this->assertFalse($this->getRedis()->put('foo', 'foo', null));
     }
 
     public function testSetMultipleMethodProperlyCallsRedis()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -157,6 +157,31 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testPutWorksForNullTTL()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', null)->andReturn(true);
+        $result = $repo->put('foo', 'bar', null);
+        $this->assertTrue($result);
+    }
+
+    public function testPutManyWorksForNullTTL()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('putMany')->once()->with(['foo' => 'bar', 'bar' => 'baz'], null)->andReturn(true);
+        $result = $repo->putMany(['foo' => 'bar', 'bar' => 'baz'], null);
+        $this->assertTrue($result);
+    }
+
+    public function testAddWorksForNullTTL()
+    {
+        $store = m::mock(RedisStore::class);
+        $store->shouldReceive('add')->once()->with('foo', 'bar', null)->andReturn(true);
+        $repository = new Repository($store);
+        $result = $repository->add('foo', 'bar', null);
+        $this->assertTrue($result);
+    }
+
     public function testCacheAddCallsRedisStoreAdd()
     {
         $store = m::mock(RedisStore::class);

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -161,16 +161,14 @@ class CacheRepositoryTest extends TestCase
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', null)->andReturn(true);
-        $result = $repo->put('foo', 'bar', null);
-        $this->assertTrue($result);
+        $this->assertTrue($repo->put('foo', 'bar', null));
     }
 
     public function testPutManyWorksForNullTTL()
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('putMany')->once()->with(['foo' => 'bar', 'bar' => 'baz'], null)->andReturn(true);
-        $result = $repo->putMany(['foo' => 'bar', 'bar' => 'baz'], null);
-        $this->assertTrue($result);
+        $this->assertTrue($repo->putMany(['foo' => 'bar', 'bar' => 'baz'], null));
     }
 
     public function testAddWorksForNullTTL()
@@ -178,8 +176,7 @@ class CacheRepositoryTest extends TestCase
         $store = m::mock(RedisStore::class);
         $store->shouldReceive('add')->once()->with('foo', 'bar', null)->andReturn(true);
         $repository = new Repository($store);
-        $result = $repository->add('foo', 'bar', null);
-        $this->assertTrue($result);
+        $this->assertTrue($repository->add('foo', 'bar', null));
     }
 
     public function testCacheAddCallsRedisStoreAdd()

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -112,7 +112,7 @@ class CacheTaggedCacheTest extends TestCase
         $conn->shouldReceive('sadd')->once()->with('prefix:bar:standard_ref', 'prefix:'.sha1('foo|bar').':key1');
         $store->shouldReceive('push')->with(sha1('foo|bar').':key1', 'key1:value');
 
-        $redis->put('key1', 'key1:value');
+        $redis->put('key1', 'key1:value', 0);
     }
 
     public function testRedisCacheTagsCanBeFlushed()


### PR DESCRIPTION
This PR does a couple of things:

- It fixes some types on certain method signatures indicating that null can be passed as well 
- Fixes the return type of the `add` method in the cache repository when a call cascaded to the `put` method.
- Allows for cache drivers to implement a default TTL

The PSR spec for the TTL value goes as follows:

> Optional. The TTL value of this item. If no value is sent and the driver supports TTL then the library may set a default value for it or let the driver take care of that.

The way we currently handle `null` TTLs in our own cache repository is that we return false and don't save anything. But according to the PSR cache repository spec there should be support for handling defaults in drivers. At the moment the `null` TTL isn't cascaded to the cache stores so there's no way for them to implement a default. This commit allows for the TTL to be passed to the cache stores so they may set their default TTL is they have done so. I've updated our own cache stores to return `false` immediately when they receive a `null` TTL because they don't offer a default at the moment.

It also still makes sure that for any TTL below or equal to 0 nothing will be set.

No tests were adjusted (just a really minor adjustment to a Redis test) and more tests have been added to verify the new behavior.

All in all this PR should make us conform to the PSR spec better. This PR may later be extended to allow Laravel to offer a default from its own but that's a different PR.

Fixes https://github.com/laravel/framework/issues/27160

PS.: there seems to be an additional problem that the TTL according to the PSR spec should be in seconds while we handle it in minutes. We should maybe have a look at that as wel.