### PR TITLE
[5.7] add 'assertJsonDoesntHaveValidationErrors' to TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -679,6 +679,24 @@ class TestResponse
     }
 
     /**
+     * Assert that the response does not have JSON validation errors.
+     *
+     * @return $this
+     */
+    public function assertJsonDoesntHaveValidationErrors()
+    {
+        $errors = $this->json('errors') ?? [];
+
+        PHPUnit::assertEmpty(
+            $errors,
+            'Response has unexpected validation errors: '.PHP_EOL.PHP_EOL.
+            json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        return $this;
+    }
+
+    /**
      * Validate and return the decoded response JSON.
      *
      * @param  string|null  $key

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -11,6 +11,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\AssertionFailedError;
 use Illuminate\Foundation\Testing\TestResponse;
+use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class FoundationTestResponseTest extends TestCase
@@ -355,6 +356,41 @@ class FoundationTestResponseTest extends TestCase
         $response = TestResponse::fromBaseResponse($baseResponse);
 
         $response->assertJsonMissingValidationErrors('bar');
+    }
+
+    public function testAssertJsonDoesntHaveValidationErrors()
+    {
+        $data = ['status' => 'ok'];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonDoesntHaveValidationErrors();
+    }
+
+    public function testAssertJsonDoesntHaveValidationErrorsPassesWhenErrorsIsEmpty()
+    {
+        $data = ['status' => 'ok', 'errors' => []];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonDoesntHaveValidationErrors();
+    }
+
+    public function testAssertJsonDoesntHaveValidationErrorsCanFail()
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        $data = ['errors' => ['foo' => []]];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonDoesntHaveValidationErrors();
     }
 
     public function testMacroable()


### PR DESCRIPTION
This PR adds a `assertJsonDoesntHaveValidationErrors()` method to the `TestResponse`. It is basically the same assertion as `assertSessionHasNoErrors()`, but it works for Json responses (since they don't store their errors in session).

Example:
```php
$this->post(route('api.users.store'), $data)
    ->assertJsonDoesntHaveValidationErrors()
    ->assertStatus(201);
```

If this test has validation errors, it will print them to the console. If you would write the same test without the `assertJsonDoesntHaveValidationErrors()` and you get validation errors, the test will only print an unhelpful "expected status 201 but received 422".
