### PR TITLE
[5.8] Prevent host injection attack

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrustHosts.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class TrustHosts
+{
+    /**
+     * The trusted host names.
+     * 
+     * @var array
+     */
+    protected $trustedHosts = [];
+
+    /**
+     * Gets the trusted host names.
+     *
+     * @return array
+     */
+    public function getTrustedHosts()
+    {
+        return $this->trustedHosts;
+    }
+
+    /**
+     * Sets trusted host names.
+     *
+     * @param array $trustedHosts 
+     */
+    public function setTrustedHosts($trustedHosts)
+    {
+        $this->trustedHosts = $trustedHosts;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $request->setTrustedHosts($this->getTrustedHosts());
+        return $next($request);
+    }
+}

--- a/src/Illuminate/Foundation/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrustHosts.php
@@ -9,7 +9,7 @@ class TrustHosts
 {
     /**
      * The trusted host names.
-     * 
+     *
      * @var array
      */
     protected $trustedHosts = [];
@@ -27,7 +27,7 @@ class TrustHosts
     /**
      * Sets trusted host names.
      *
-     * @param array $trustedHosts 
+     * @param array $trustedHosts
      */
     public function setTrustedHosts($trustedHosts)
     {
@@ -44,6 +44,7 @@ class TrustHosts
     public function handle(Request $request, Closure $next)
     {
         $request->setTrustedHosts($this->getTrustedHosts());
+
         return $next($request);
     }
 }

--- a/tests/Foundation/Http/Middleware/TrustHostsTest.php
+++ b/tests/Foundation/Http/Middleware/TrustHostsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Mockery as m;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Http\Middleware\TrustHosts;
+
+class TrustHostsTest extends TestCase
+{
+    public function testItSetTrustHostsToRequest()
+    {
+        $hosts = ['mysites.com'];
+
+        $request = m::mock(Request::class);
+        $request->shouldReceive('setTrustedHosts')->with($hosts)->once();
+
+        $middleware = new TrustHosts();
+        $middleware->setTrustedHosts($hosts);
+        $middleware->handle($request, function(){});
+    }
+}

--- a/tests/Foundation/Http/Middleware/TrustHostsTest.php
+++ b/tests/Foundation/Http/Middleware/TrustHostsTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Foundation\Http\Middleware;
 use Mockery as m;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Http\Middleware\TrustHosts;
 
 class TrustHostsTest extends TestCase
@@ -19,6 +18,7 @@ class TrustHostsTest extends TestCase
 
         $middleware = new TrustHosts();
         $middleware->setTrustedHosts($hosts);
-        $middleware->handle($request, function(){});
+        $middleware->handle($request, function(){
+        });
     }
 }

--- a/tests/Foundation/Http/Middleware/TrustHostsTest.php
+++ b/tests/Foundation/Http/Middleware/TrustHostsTest.php
@@ -18,7 +18,7 @@ class TrustHostsTest extends TestCase
 
         $middleware = new TrustHosts();
         $middleware->setTrustedHosts($hosts);
-        $middleware->handle($request, function(){
+        $middleware->handle($request, function () {
         });
     }
 }


### PR DESCRIPTION
# What this PR is for?

## 1. Provide an easy way to prevent host injection attacks.

Since the url helper functions such as url(), route() get host names from server variables, there is a risk of introducing host injection attack vulnerability into applications.

This PR add a feature to set trusted hosts to request class so that untrusted hosts are rejected when url helpers are called.

Even though users can prevent host injection attacks with proper web server setting or proper coding, it is nice to have an easier way.

Also, I think it would be better if trusted hosts are set by default.
Therefore, I am going to make a PR for laravel app which add a middleware class like below and add this class to http kernels middleware property.
This will prevent users from introducing the vulnerability by default.

app/Http/Middleware/TrustHosts.php
```
<?php
namespace App\Http\Middleware;
use Illuminate\Foundation\Http\Middleware\TrustHosts as Middleware;
class TrustHosts extends Middleware
{
    /**
     * The trusted host names.
     *
     * @var array
     */
    protected $trustedHosts = [];

    public function __construct(Config $config)
    {
        $this->config = $this->config;
        $this->trustedHosts[] = $this->config->get('APP_DOMAIN');
    }
}
```

and in app/Http/Kernel.php:22 add TrustHosts middleware

```
protected $middleware = [
        \App\Http\Middleware\CheckForMaintenanceMode::class,
        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
        \App\Http\Middleware\TrimStrings::class,
        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
        \App\Http\Middleware\TrustProxies::class,
        \App\Http\Middleware\TrustHosts::class,
    ];
```

It might be better to get host name from APP_URL instead of adding new env variable APP_DOMAIN. 

## 2. Fix password reset link issue with sub domain.

Currently, config('app.url') is used to generate password reset link in order to prevent host injection attack.
https://github.com/laravel/framework/blob/78505345f2a34b865a980cefbd103d8eb839eedf/src/Illuminate/Auth/Notifications/ResetPassword.php#L62

However, due to this code, password resets email ignore subdomains.
https://github.com/laravel/framework/issues/27045

If this PR is merged, we can remove config('app.url') from the code since we don't need to worry about host injection attacks.


Related PRs:
https://github.com/laravel/laravel/pull/4908
https://github.com/laravel/framework/pull/27174