### PR TITLE
Do not force host on password reset notification

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -59,7 +59,7 @@ class ResetPassword extends Notification
         return (new MailMessage)
             ->subject(Lang::getFromJson('Reset Password Notification'))
             ->line(Lang::getFromJson('You are receiving this email because we received a password reset request for your account.'))
-            ->action(Lang::getFromJson('Reset Password'), url(config('app.url').route('password.reset', ['token' => $this->token], false)))
+            ->action(Lang::getFromJson('Reset Password'), route('password.reset', ['token' => $this->token]))
             ->line(Lang::getFromJson('If you did not request a password reset, no further action is required.'));
     }
 


### PR DESCRIPTION
This PR revert this [commit](https://github.com/laravel/framework/commit/cef10551820530632a86fa6f1306fee95c5cac43) in order to solve sub domain link issue
This PR needs to be merged after  https://github.com/laravel/framework/pull/27173 since this PR introduce security risk of host injection attack without https://github.com/laravel/framework/pull/27173 .
