### PR TITLE
[5.7] allow 'assertJsonMissingValidationErrors' to be called without an argument

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -656,7 +656,7 @@ class TestResponse
      * @param  string|array  $keys
      * @return $this
      */
-    public function assertJsonMissingValidationErrors($keys)
+    public function assertJsonMissingValidationErrors($keys = null)
     {
         $json = $this->json();
 
@@ -667,6 +667,13 @@ class TestResponse
         }
 
         $errors = $json['errors'];
+
+        if ($keys === null && count($errors) > 0) {
+            PHPUnit::fail(
+                'Response has unexpected validation errors: '.PHP_EOL.PHP_EOL.
+                json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+            );
+        }
 
         foreach (Arr::wrap($keys) as $key) {
             PHPUnit::assertFalse(

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -668,7 +668,7 @@ class TestResponse
 
         $errors = $json['errors'];
 
-        if ($keys === null && count($errors) > 0) {
+        if (is_null($keys) && count($errors) > 0) {
             PHPUnit::fail(
                 'Response has unexpected validation errors: '.PHP_EOL.PHP_EOL.
                 json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -357,6 +357,41 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonMissingValidationErrors('bar');
     }
 
+    public function testAssertJsonMissingValidationErrorsWithoutArgument()
+    {
+        $data = ['status' => 'ok'];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonMissingValidationErrors();
+    }
+
+    public function testAssertJsonMissingValidationErrorsWithoutArgumentWhenErrorsIsEmpty()
+    {
+        $data = ['status' => 'ok', 'errors' => []];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonMissingValidationErrors();
+    }
+
+    public function testAssertJsonMissingValidationErrorsWithoutArgumentCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $data = ['errors' => ['foo' => []]];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonMissingValidationErrors();
+    }
+
     public function testMacroable()
     {
         TestResponse::macro('foo', function () {


### PR DESCRIPTION
This PR is a different implementation of https://github.com/laravel/framework/pull/27172

This PR makes calling `assertJsonMissingValidationErrors` without an argument behave the same as as `assertSessionHasNoErrors()` (but it works for Json responses, since they don't store their errors in session).

Example:
```php
$this->post(route('api.users.store'), $data)
    ->assertJsonMissingValidationErrors()
    ->assertStatus(201);
```

If this test has validation errors, it will print them to the console. If you would write the same test without the `assertJsonMissingValidationErrors()`, and then you get validation errors, the test will only print an unhelpful "expected status 201 but received 422".