### PR TITLE
[5.7] Translate from fallback locale when using Json translations

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -144,9 +144,10 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  string  $key
      * @param  array  $replace
      * @param  string  $locale
+     * @param  bool  $useFallbackLocale
      * @return string|array
      */
-    public function getFromJson($key, array $replace = [], $locale = null)
+    public function getFromJson($key, array $replace = [], $locale = null, $useFallbackLocale = false)
     {
         $locale = $locale ?: $this->locale;
 
@@ -161,6 +162,11 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // using the typical translation file. This way developers can always just use a
         // helper such as __ instead of having to pick between trans or __ with views.
         if (! isset($line)) {
+            // Attempt to translate from fallback JSON key
+            if ($useFallbackLocale) {
+                return $this->getFromJson($key, $replace, $this->fallback, false);
+            }
+
             $fallback = $this->get($key, $replace, $locale);
 
             if ($fallback !== $key) {

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -178,6 +178,16 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('foo baz', $t->getFromJson('foo :message', ['message' => 'baz']));
     }
 
+    public function testGetJsonMethodFallbackJsonLocale()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->setFallback('lv');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('lv', '*', '*')->andReturn(['foo' => 'foo', 'bar' => 'bar']);
+        $this->assertEquals('foo', $t->getFromJson('foo', [], null, true));
+        $this->assertEquals('bar', $t->getFromJson('bar', [], null, true));
+    }
+
     protected function getLoader()
     {
         return m::mock(Loader::class);


### PR DESCRIPTION
Currently when translation is missing from from json translations, it defaults to the missing key or tries to find translation in php files instead of first checking for translation in fallback locale. This pull request adds a parameter to `getFromJson` method to check for fallback json files.

If this behavior is accepted, I'll update `__()` helper function.