### PR TITLE
[5.8] Add blocking pop support to the Beanstalkd queue driver

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -31,18 +31,27 @@ class BeanstalkdQueue extends Queue implements QueueContract
     protected $timeToRun;
 
     /**
+     * The maximum number of seconds to block for a job.
+     *
+     * @var int
+     */
+    protected $blockFor;
+
+    /**
      * Create a new Beanstalkd queue instance.
      *
      * @param  \Pheanstalk\Pheanstalk  $pheanstalk
      * @param  string  $default
      * @param  int  $timeToRun
+     * @param  int  $blockFor
      * @return void
      */
-    public function __construct(Pheanstalk $pheanstalk, $default, $timeToRun)
+    public function __construct(Pheanstalk $pheanstalk, $default, $timeToRun, $blockFor = 0)
     {
         $this->default = $default;
         $this->timeToRun = $timeToRun;
         $this->pheanstalk = $pheanstalk;
+        $this->blockFor = $blockFor;
     }
 
     /**
@@ -117,7 +126,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     {
         $queue = $this->getQueue($queue);
 
-        $job = $this->pheanstalk->watchOnly($queue)->reserve(0);
+        $job = $this->pheanstalk->watchOnly($queue)->reserve($this->blockFor);
 
         if ($job instanceof PheanstalkJob) {
             return new BeanstalkdJob(

--- a/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
+++ b/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
@@ -19,7 +19,7 @@ class BeanstalkdConnector implements ConnectorInterface
     {
         $retryAfter = $config['retry_after'] ?? Pheanstalk::DEFAULT_TTR;
 
-        return new BeanstalkdQueue($this->pheanstalk($config), $config['queue'], $retryAfter);
+        return new BeanstalkdQueue($this->pheanstalk($config), $config['queue'], $retryAfter, $config['block_for'] ?? 0);
     }
 
     /**

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -48,7 +48,21 @@ class QueueBeanstalkdQueueTest extends TestCase
         $pheanstalk = $queue->getPheanstalk();
         $pheanstalk->shouldReceive('watchOnly')->once()->with('default')->andReturn($pheanstalk);
         $job = m::mock(Job::class);
-        $pheanstalk->shouldReceive('reserve')->once()->andReturn($job);
+        $pheanstalk->shouldReceive('reserve')->once()->with(0)->andReturn($job);
+
+        $result = $queue->pop();
+
+        $this->assertInstanceOf(BeanstalkdJob::class, $result);
+    }
+
+    public function testBlockingPopProperlyPopsJobOffOfBeanstalkd()
+    {
+        $queue = new BeanstalkdQueue(m::mock(Pheanstalk::class), 'default', 60, 60);
+        $queue->setContainer(m::mock(Container::class));
+        $pheanstalk = $queue->getPheanstalk();
+        $pheanstalk->shouldReceive('watchOnly')->once()->with('default')->andReturn($pheanstalk);
+        $job = m::mock(Job::class);
+        $pheanstalk->shouldReceive('reserve')->once()->with(60)->andReturn($job);
 
         $result = $queue->pop();
 


### PR DESCRIPTION
This PR adds blocking pop support for the Beanstalkd queue driver.  The timeout is set using the `block_for` config key, just like the blocking behavior that was recently added to the Redis queue driver.  If the config key is not set it defaults to `0`, which prevents blocking and everything works the same as it does now.

The blocking pop is easier on CPU, results in less network traffic, and allows the job to be processed faster.

If this PR is accepted I can open PRs to update the documentation and default configs.