### PR TITLE
[5.7] Fix `assertJsonValidationErrors` when there are no errors

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -638,11 +638,12 @@ class TestResponse
      */
     public function assertJsonValidationErrors($keys)
     {
-        $errors = $this->json()['errors'];
+        $errors = $this->json()['errors'] ?? [];
 
         foreach (Arr::wrap($keys) as $key) {
-            PHPUnit::assertTrue(
-                isset($errors[$key]),
+            PHPUnit::assertArrayHasKey(
+                $key,
+                $errors,
                 "Failed to find a validation error in the response for key: '{$key}'"
             );
         }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -301,6 +301,49 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonMissingExact(['id' => 20, 'foo' => 'bar']);
     }
 
+    public function testAssertJsonValidationErrors()
+    {
+        $data = [
+            'status' => 'ok',
+            'errors' => ['foo' => 'oops'],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors('foo');
+    }
+
+    public function testAssertJsonValidationErrorsCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $data = [
+            'status' => 'ok',
+            'errors' => ['foo' => 'oops'],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors('bar');
+    }
+
+    public function testAssertJsonValidationErrorsCanFailWhenThereAreNoErrors()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $data = ['status' => 'ok'];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors('bar');
+    }
+
     public function testAssertJsonMissingValidationErrors()
     {
         $baseResponse = tap(new Response, function ($response) {


### PR DESCRIPTION
When an api response has no errors, `assertJsonValidationErrors` will throw an `ErrorException` because it is trying to access the undefined index `errors`. This PR fixes that. It also changes the `isTrue` assertion to a more descriptive `assertArrayHasKey` assertion.