### PR TITLE
Fix: fill fields before set foreign attributes when make a instance with HasOneOrMany relationshihp

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -54,8 +54,10 @@ abstract class HasOneOrMany extends Relation
      */
     public function make(array $attributes = [])
     {
-        return tap($this->related->newInstance($attributes), function ($instance) {
+        return tap($this->related->newInstance(), function ($instance) use($attributes) {
             $this->setForeignAttributesForCreate($instance);
+
+            $instance->fill($attributes);
         });
     }
 


### PR DESCRIPTION
### Example
Here is two models related with a simple HasMany-BelongsTo relationship.
And there is a setter in the child model that accesses the parent model.
```php
class User extends Model
{
    public function posts():HasMany
    {...}
}

class Post extends Model
{
    public function user():BelongsTo
    {...}
    
    public function setLinkAttribute(string $link)
    {
        $this->attributes['link'] = LinkMaker::makePrivateLInk($this->user, $link);
    }
}
```
When we call the `HasOneOrMany::make()`, the setter cannot access the parent model.
```php
$user->posts()->make(['link'=>'...']);
$user->posts()->create(['link'=>'...']);
$user->posts()->createMany([['link'=>'...'], ['link'=>'...'],]);

// Exception $this->user is null
```

### Reason

In `HasOneOrMany::make()`, we do this:
1. create a empty instance.
2. fill the given fields.
3. set the foreign attributes.

So, when we fill the fields, we call the setters, but at that time, the foreign attributes are empty.
That's the problem. Switch step 2 and step 3 will fix the bug.
