### PR TITLE
Fix Cache::remember() for ArrayStore

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Cache;
 
+use Illuminate\Support\InteractsWithTime;
+
 class ArrayStore extends TaggableStore
 {
-    use RetrievesMultipleKeys;
+    use RetrievesMultipleKeys, InteractsWithTime;
 
     /**
      * The array of stored values.
@@ -21,7 +23,18 @@ class ArrayStore extends TaggableStore
      */
     public function get($key)
     {
-        return $this->storage[$key] ?? null;
+        if (! isset($this->storage[$key])) {
+            return null;
+        }
+
+        $item = $this->storage[$key];
+        if ($item['expiresAt'] !== 0 && $this->currentTime() > $item['expiresAt']) {
+            $this->forget($key);
+
+            return null;
+        }
+
+        return $item['value'];
     }
 
     /**
@@ -34,7 +47,10 @@ class ArrayStore extends TaggableStore
      */
     public function put($key, $value, $minutes)
     {
-        $this->storage[$key] = $value;
+        $this->storage[$key] = [
+            'value' => $value,
+            'expiresAt' => $this->calculateExpiration($minutes)
+        ];
 
         return true;
     }
@@ -48,10 +64,15 @@ class ArrayStore extends TaggableStore
      */
     public function increment($key, $value = 1)
     {
-        $this->storage[$key] = ! isset($this->storage[$key])
-                ? $value : ((int) $this->storage[$key]) + $value;
+        if (! isset($this->storage[$key])) {
+            $this->forever($key, $value);
 
-        return $this->storage[$key];
+            return $this->storage[$key]['value'];
+        }
+
+        $this->storage[$key]['value'] = ((int) $this->storage[$key]['value']) + $value;
+
+        return $this->storage[$key]['value'];
     }
 
     /**
@@ -111,5 +132,27 @@ class ArrayStore extends TaggableStore
     public function getPrefix()
     {
         return '';
+    }
+
+    /**
+     * Get the expiration time of the key.
+     *
+     * @param  int  $minutes
+     * @return int
+     */
+    protected function calculateExpiration($minutes)
+    {
+        return $this->toTimestamp($minutes);
+    }
+
+    /**
+     * Get the UNIX timestamp for the given number of minutes.
+     *
+     * @param  int  $minutes
+     * @return int
+     */
+    protected function toTimestamp($minutes)
+    {
+        return $minutes > 0 ? $this->availableAt($minutes * 60) : 0;
     }
 }

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Cache;
 
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\ArrayStore;
 
@@ -33,6 +34,19 @@ class CacheArrayStoreTest extends TestCase
         ], $store->many(['foo', 'fizz', 'quz', 'norf']));
     }
 
+    public function testItemsCanExpire(): void
+    {
+        Carbon::setTestNow(Carbon::now());
+        $store = new ArrayStore;
+
+        $store->put('foo', 'bar', 10);
+        Carbon::setTestNow(Carbon::now()->addMinutes(10)->addSecond());
+        $result = $store->get('foo');
+
+        $this->assertNull($result);
+        Carbon::setTestNow(null);
+    }
+
     public function testStoreItemForeverProperlyStoresInArray()
     {
         $mock = $this->getMockBuilder(ArrayStore::class)->setMethods(['put'])->getMock();
@@ -47,14 +61,16 @@ class CacheArrayStoreTest extends TestCase
     {
         $store = new ArrayStore;
         $store->put('foo', 1, 10);
-        $store->increment('foo');
+        $result = $store->increment('foo');
+        $this->assertEquals(2, $result);
         $this->assertEquals(2, $store->get('foo'));
     }
 
     public function testNonExistingKeysCanBeIncremented()
     {
         $store = new ArrayStore;
-        $store->increment('foo');
+        $result = $store->increment('foo');
+        $this->assertEquals(1, $result);
         $this->assertEquals(1, $store->get('foo'));
     }
 
@@ -62,7 +78,8 @@ class CacheArrayStoreTest extends TestCase
     {
         $store = new ArrayStore;
         $store->put('foo', 1, 10);
-        $store->decrement('foo');
+        $result = $store->decrement('foo');
+        $this->assertEquals(0, $result);
         $this->assertEquals(0, $store->get('foo'));
     }
 


### PR DESCRIPTION
This fixes a (potential) bug where `Cache::remember` isn't working as expected when using the `ArrayStore` driver.

I'm entirely assuming here, but my guess is that at some point it was decided that the `ArrayStore` caching driver doesn't really need a full implementation of `::remember` method, since it stores values entirely in-memory during a request that will finish in mere (milli)seconds.

However, this functionality ceases to do what is expected when we're doing something like the following in our tests (and it just so happens that the array driver is the default caching driver in Laravel's phpunit.xml):

```php
...
    /** @test */
    public function it_should_refresh_the_statistics_after_five_minutes(): void
    {
        $page = factory(Page::class)->create();

        Carbon::setTestNow(Carbon::today());
        $visitOne = $this->get(route('pages.view',  $page));
        $visitOne->assertSeeText(now()->toDateTimeString());

        Carbon::setTestNow(Carbon::today()->addMinutes(5));
        $visitTwo = $this->get(route('pages.view',  $page));
        $visitTwo->assertSeeText(now()->toDateTimeString());

        Carbon::setTestNow(null);
    }
```

If this is in fact intended behaviour and I'm just _holding it wrong_, then please let me know :)