### PR TITLE
[5.8] Shorter when conditionals

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -85,9 +85,13 @@ trait BuildsQueries
      * @param  callable  $default
      * @return mixed|$this
      */
-    public function when($value, $callback, $default = null)
+    public function when($value, $callback = null, $default = null)
     {
-        if ($value) {
+        if (is_array($value) && $callback == null) {
+            foreach ($value as $key => $value) {
+                return $value ? $this->where($key, $value) : $this;
+            }
+        } elseif ($value) {
             return $callback($this, $value) ?: $this;
         } elseif ($default) {
             return $default($this, $value) ?: $this;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -211,12 +211,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when(['key'=>true])->where('email', 'foo');
         $this->assertEquals('select * from "users" where "key" = ? and "email" = ?', $builder->toSql());
-        $this->assertEquals([true,'foo'], $builder->getBindings());
-        
+        $this->assertEquals([true, 'foo'], $builder->getBindings());
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when(['key'=>'key'])->where('email', 'foo');
         $this->assertEquals('select * from "users" where "key" = ? and "email" = ?', $builder->toSql());
-        $this->assertEquals(['key','foo'], $builder->getBindings());
+        $this->assertEquals(['key', 'foo'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when(['key'=>false])->where('email', 'foo');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -206,6 +206,24 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2, 1 => 'foo'], $builder->getBindings());
     }
 
+    public function testWhenShort()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(['key'=>true])->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "key" = ? and "email" = ?', $builder->toSql());
+        $this->assertEquals([true,'foo'], $builder->getBindings());
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(['key'=>'key'])->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "key" = ? and "email" = ?', $builder->toSql());
+        $this->assertEquals(['key','foo'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(['key'=>false])->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
+        $this->assertEquals(['foo'], $builder->getBindings());
+    }
+
     public function testUnlessCallback()
     {
         $callback = function ($query, $condition) {


### PR DESCRIPTION
This pull request adds the ability to shorten 'when' conditionals on the query builder, so for example, if you wanted a simple when condition, you'd need the following:

```php
Destination::whereLocation($region)
            ->when($type,function($query,$type){
                     return $query->where('type',$type);
             ))
            ->first();
```

But by safely checking if the first parameter is an array and the second parameter is null, we could check the first variable for truthiness and then use the key/value to create a default where.

It's probably a little bit overreaching to default to a where conditional but maybe someone much smarter than I can see the glory in the following code and propose a better solution. Here is the shortened conditional:

```php
Destination::whereLocation($region)
            ->when(['type' => $type])
            ->first();
```

Or `whenTypeWhere($type)`/`whenType($type)` might be interesting.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
