### PR TITLE
[5.8] Adding support for class@method notation for guest friendly gates (the other way)

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -58,6 +58,13 @@ class Gate implements GateContract
     protected $afterCallbacks = [];
 
     /**
+     * All of the defined abilities with class@method notation.
+     *
+     * @var array
+     */
+    protected $atNotation = [];
+
+    /**
      * Create a new gate instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
@@ -112,6 +119,7 @@ class Gate implements GateContract
         if (is_callable($callback)) {
             $this->abilities[$ability] = $callback;
         } elseif (is_string($callback)) {
+            $this->atNotation[$ability] = $callback;
             $this->abilities[$ability] = $this->buildAbilityCallback($ability, $callback);
         } else {
             throw new InvalidArgumentException("Callback must be a callable or a 'Class@method' string.");
@@ -482,6 +490,13 @@ class Gate implements GateContract
             ! is_null($policy = $this->getPolicyFor($arguments[0])) &&
             $callback = $this->resolvePolicyCallback($user, $ability, $arguments, $policy)) {
             return $callback;
+        }
+
+        if (isset($this->atNotation[$ability])) {
+            [$class, $method] = Str::parseCallback($this->atNotation[$ability]);
+            if ($this->canBeCalledWithUser($user, $class, $method)) {
+                return $this->abilities[$ability];
+            }
         }
 
         if (isset($this->abilities[$ability]) &&

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -654,6 +654,43 @@ class AuthAccessGateTest extends TestCase
             [$noAbilities, [], true],
         ];
     }
+
+    public function test_classes_can_be_defined_as_callbacks_using_at_notation_for_guests()
+    {
+        $gate = new Gate(new Container, function () {
+            return null;
+        });
+
+        $gate->define('foo', AccessGateTestClassForGuest::class.'@foo');
+        $gate->define('bar', AccessGateTestClassForGuest::class.'@bar');
+
+        AccessGateTestClassForGuest::$calledMethod = '';
+
+        $this->assertTrue($gate->check('foo'));
+        $this->assertEquals('foo', AccessGateTestClassForGuest::$calledMethod);
+
+        $this->assertTrue($gate->check('bar'));
+        $this->assertEquals('bar', AccessGateTestClassForGuest::$calledMethod);
+    }
+}
+
+class AccessGateTestClassForGuest
+{
+    public static $calledMethod = '';
+
+    public function foo($user = null)
+    {
+        static::$calledMethod = 'foo';
+
+        return true;
+    }
+
+    public function bar(?stdClass $user)
+    {
+        static::$calledMethod = 'bar';
+
+        return true;
+    }
 }
 
 class AccessGateTestStaticClass


### PR DESCRIPTION
Following my previous try which was involving some reflection to figure out what to do.
This is an other was of adding support for class@method notation for guest friendly gates.
Passing the exact same test.
I was reluctant to add a new property on the class, but no way, we need it.