### PR TITLE
[5.7] More accurate validated data for nested arrays

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -470,7 +470,7 @@ class Validator implements ValidatorContract
      *
      * @param  object|string  $rule
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function isValidatable($rule, $attribute, $value)
@@ -486,7 +486,7 @@ class Validator implements ValidatorContract
      *
      * @param  object|string  $rule
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function presentOrRuleIsImplicit($rule, $attribute, $value)
@@ -526,7 +526,7 @@ class Validator implements ValidatorContract
         $data = ValidationData::initializeAndGatherData($attribute, $this->data);
 
         return array_key_exists($attribute, $data)
-                    || array_key_exists($attribute, $this->data);
+            || array_key_exists($attribute, $this->data);
     }
 
     /**
@@ -612,7 +612,7 @@ class Validator implements ValidatorContract
      *
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return void
      */
     public function addFailure($attribute, $rule, $parameters = [])
@@ -931,7 +931,7 @@ class Validator implements ValidatorContract
     /**
      * Register a custom implicit validator extension.
      *
-     * @param  string   $rule
+     * @param  string  $rule
      * @param  \Closure|string  $extension
      * @return void
      */
@@ -945,7 +945,7 @@ class Validator implements ValidatorContract
     /**
      * Register a custom dependent validator extension.
      *
-     * @param  string   $rule
+     * @param  string  $rule
      * @param  \Closure|string  $extension
      * @return void
      */
@@ -1139,7 +1139,7 @@ class Validator implements ValidatorContract
      * Call a custom validator extension.
      *
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return bool|null
      */
     protected function callExtension($rule, $parameters)
@@ -1157,7 +1157,7 @@ class Validator implements ValidatorContract
      * Call a class based validator extension.
      *
      * @param  string  $callback
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return bool
      */
     protected function callClassBasedExtension($callback, $parameters)
@@ -1171,7 +1171,7 @@ class Validator implements ValidatorContract
      * Handle dynamic calls to class methods.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      *
      * @throws \BadMethodCallException

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -319,7 +319,7 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Return validated value.
+     * Return validated data.
      *
      * @return array
      *
@@ -335,7 +335,7 @@ class Validator implements ValidatorContract
 
         $missingValue = Str::random(10);
 
-        foreach (array_keys($this->getRules()) as $key) {
+        foreach ($this->validatedKeys() as $key) {
             $value = data_get($this->data, $key, $missingValue);
 
             if ($value !== $missingValue) {
@@ -344,6 +344,35 @@ class Validator implements ValidatorContract
         }
 
         return $results;
+    }
+
+    /**
+     * Compose an array of the validated data keys.
+     *
+     * @return array
+     */
+    protected function validatedKeys()
+    {
+        $keys = array_keys($this->rules);
+
+        return array_filter($keys, function ($key) {
+            return ! $this->validatedKeyHasNestedKeys($key);
+        });
+    }
+
+    /**
+     * Check if the specified validated key has nested keys.
+     *
+     * @param  string  $inspected
+     * @return bool
+     */
+    protected function validatedKeyHasNestedKeys($inspected)
+    {
+        $keys = array_keys($this->rules);
+
+        return (bool) array_first($keys, function ($key) use ($inspected) {
+            return starts_with($key, "{$inspected}.");
+        });
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -336,7 +336,7 @@ class Validator implements ValidatorContract
         $missingValue = Str::random(10);
 
         foreach (array_keys($this->getRules()) as $key) {
-            $value = data_get($this->getData(), $key, $missingValue);
+            $value = data_get($this->data, $key, $missingValue);
 
             if ($value !== $missingValue) {
                 Arr::set($results, $key, $value);
@@ -858,7 +858,7 @@ class Validator implements ValidatorContract
      */
     public function sometimes($attribute, $rules, callable $callback)
     {
-        $payload = new Fluent($this->getData());
+        $payload = new Fluent($this->data);
 
         if (call_user_func($callback, $payload)) {
             foreach ((array) $attribute as $key) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4292,6 +4292,19 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['nested' => [['bar' => 'baz'], ['bar' => 'baz2']]], $data);
     }
 
+    public function testValidateReturnsValidatedDataNestedArrayRulesWithParentRule()
+    {
+        $post = ['nested' => [['bar' => 'baz', 'with' => 'extras', 'type' => 'admin'], ['bar' => 'baz2', 'with' => 'extras', 'type' => 'admin']]];
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), $post, ['nested' => 'required', 'nested.*.bar' => 'required']);
+        $v->sometimes('nested.*.type', 'required', function () {
+            return false;
+        });
+        $data = $v->validate();
+
+        $this->assertEquals(['nested' => [['bar' => 'baz'], ['bar' => 'baz2']]], $data);
+    }
+
     public function testValidateAndValidatedData()
     {
         $post = ['first' => 'john',  'preferred'=>'john', 'last' => 'doe', 'type' => 'admin'];


### PR DESCRIPTION
This PR fixes #27049.

**If** you're using rules for validating nested arrays (f.e. `items.*.product.id`) with rules of a more "higher level" (f.e. `items`),

 **Then**, your validated data would be the full set from the `items` array.

It may be a bit confusing because those rules are intersecting with each other, and validated data may be more accurate in that case.

Here is the code example for convenience:

```php
$data = [
    'items' => [
        ['product' => ['id' => 1, 'name' => 'One']],
        ['product' => ['id' => 2, 'name' => 'Two']],
    ],
];

$rules = [
    'items' => 'required',
    'items.*.product.id' => 'required',
];

$validator = Validator::make($data, $rules);

$validated = $validator->validate();

dd($validated);
```

Before:

```php
[
    'items' => [
        ['product' => ['id' => 1, 'name' => 'One']],
        ['product' => ['id' => 2, 'name' => 'Two']],
    ],
]
```

After:

```php
[
    'items' => [
        ['product' => ['id' => 1]],
        ['product' => ['id' => 2]],
    ],
]
```

PS: #27049 was initially considered as a `bug`, so I've made a PR in `5.7`.