### PR TITLE
[5.8] Prevent host header attacks.

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrustHosts.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Middleware;
+
+use Closure;
+use Exception;
+use Illuminate\Http\Request;
+
+class TrustHosts
+{
+    /**
+     * The trusted host names.
+     *
+     * @var array
+     */
+    protected $trustedHosts = [];
+
+    /**
+     * Gets the trusted host names.
+     *
+     * @return array
+     */
+    public function getTrustedHosts()
+    {
+        return $this->trustedHosts;
+    }
+
+    /**
+     * Sets trusted host names.
+     *
+     * @param array $trustedHosts
+     */
+    public function setTrustedHosts($trustedHosts)
+    {
+        $this->trustedHosts = $trustedHosts;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     * @return mixed
+     * 
+     * @throws \Exception
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if(empty($hosts = $this->getTrustedHosts())){
+            throw new Exception('trusted hosts are not set.');
+        }
+
+        $request->setTrustedHosts($hosts);
+
+        return $next($request);
+    }
+}

--- a/src/Illuminate/Foundation/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrustHosts.php
@@ -41,12 +41,12 @@ class TrustHosts
      * @param \Illuminate\Http\Request $request
      * @param \Closure                 $next
      * @return mixed
-     * 
+     *
      * @throws \Exception
      */
     public function handle(Request $request, Closure $next)
     {
-        if(empty($hosts = $this->getTrustedHosts())){
+        if (empty($hosts = $this->getTrustedHosts())) {
             throw new Exception('trusted hosts are not set.');
         }
 

--- a/tests/Foundation/Http/Middleware/TrustHostsTest.php
+++ b/tests/Foundation/Http/Middleware/TrustHostsTest.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Tests\Foundation\Http\Middleware;
 
-use Illuminate\Foundation\Http\Middleware\TrustHosts;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
-use Illuminate\Routing\RouteCollection;
-use Illuminate\Routing\UrlGenerator;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Routing\UrlGenerator;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Foundation\Http\Middleware\TrustHosts;
 
 class TrustHostsTest extends TestCase
 {
@@ -63,7 +63,7 @@ class TrustHostsTest extends TestCase
         $headers = ['HOST' => 'laravel.com'];
         $servers = [];
         $urlGenerator = $this->createUrlGenerator($trustedHosts, $headers, $servers);
-        $this->assertEquals("http://laravel.com", $urlGenerator->to('/'));
+        $this->assertEquals('http://laravel.com', $urlGenerator->to('/'));
     }
 
     /**
@@ -76,10 +76,10 @@ class TrustHostsTest extends TestCase
         $headers = ['HOST' => 'laravel.com'];
         $servers = [];
         $urlGenerator = $this->createUrlGenerator($trustedHosts, $headers, $servers);
-        $this->assertEquals("http://laravel.com", $urlGenerator->to('/'));
+        $this->assertEquals('http://laravel.com', $urlGenerator->to('/'));
     }
 
-    protected function createUrlGenerator($trustedHosts = array(), $headers = array(), $servers = array())
+    protected function createUrlGenerator($trustedHosts = [], $headers = [], $servers = [])
     {
         $middleware = new TrustHosts;
         $middleware->setTrustedHosts($trustedHosts);
@@ -94,7 +94,8 @@ class TrustHostsTest extends TestCase
             $request->server->set($key, $val);
         }
 
-        $middleware->handle($request, function () {});
+        $middleware->handle($request, function () {
+        });
 
         $routes = new RouteCollection;
         $routes->add(new Route('GET', 'foo', [

--- a/tests/Foundation/Http/Middleware/TrustHostsTest.php
+++ b/tests/Foundation/Http/Middleware/TrustHostsTest.php
@@ -11,6 +11,16 @@ use Illuminate\Foundation\Http\Middleware\TrustHosts;
 
 class TrustHostsTest extends TestCase
 {
+    protected static $orignalTrustHosts;
+
+    public static function setUpBeforeClass(){
+        self::$orignalTrustHosts = Request::getTrustedHosts();
+    }
+
+    public static function tearDownAfterClass(){
+        Request::setTrustedHosts(self::$orignalTrustHosts);
+    }
+
     /**
      * @expectedException  Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException
      */

--- a/tests/Foundation/Http/Middleware/TrustHostsTest.php
+++ b/tests/Foundation/Http/Middleware/TrustHostsTest.php
@@ -13,11 +13,13 @@ class TrustHostsTest extends TestCase
 {
     protected static $orignalTrustHosts;
 
-    public static function setUpBeforeClass(){
+    public static function setUpBeforeClass()
+    {
         self::$orignalTrustHosts = Request::getTrustedHosts();
     }
 
-    public static function tearDownAfterClass(){
+    public static function tearDownAfterClass()
+    {
         Request::setTrustedHosts(self::$orignalTrustHosts);
     }
 

--- a/tests/Foundation/Http/Middleware/TrustHostsTest.php
+++ b/tests/Foundation/Http/Middleware/TrustHostsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\TrustHosts;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Routing\UrlGenerator;
+use PHPUnit\Framework\TestCase;
+
+class TrustHostsTest extends TestCase
+{
+    /**
+     * @expectedException  Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException
+     */
+    public function testToMethodThrowExceptionForUntrustedHosts()
+    {
+        $trustedHosts = ['laravel.com'];
+        $headers = ['HOST' => 'malicious.com'];
+        $urlGenerator = $this->createUrlGenerator($trustedHosts, $headers);
+        $urlGenerator->to('/');
+    }
+
+    /**
+     * @expectedException  Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException
+     */
+    public function testToMethodThrowExceptionForUntrustedServerName()
+    {
+        $trustedHosts = ['laravel.com'];
+        $headers = [];
+        $servers = ['SERVER_NAME' => 'malicious.com'];
+        $urlGenerator = $this->createUrlGenerator($trustedHosts, $headers, $servers);
+        $urlGenerator->to('/');
+    }
+
+    /**
+     * @expectedException  Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException
+     */
+    public function testToMethodThrowExceptionForUntrustedServerAddr()
+    {
+        $trustedHosts = ['laravel.com'];
+        $headers = [];
+        $servers = ['SERVER_ADDR' => 'malicious.com'];
+        $urlGenerator = $this->createUrlGenerator($trustedHosts, $headers, $servers);
+        $urlGenerator->to('/');
+    }
+
+    /**
+     * @expectedException  Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException
+     */
+    public function testRouteMethodThrowExceptionForUntrustedHosts()
+    {
+        $trustedHosts = ['laravel.com'];
+        $headers = ['HOST' => 'malicious.com'];
+        $urlGenerator = $this->createUrlGenerator($trustedHosts, $headers);
+        $urlGenerator->route('foo_index');
+    }
+
+    public function testItDoesNotThrowExceptionForTrustedHost()
+    {
+        $trustedHosts = ['laravel.com'];
+        $headers = ['HOST' => 'laravel.com'];
+        $servers = [];
+        $urlGenerator = $this->createUrlGenerator($trustedHosts, $headers, $servers);
+        $this->assertEquals("http://laravel.com", $urlGenerator->to('/'));
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage trusted hosts are not set.
+     */
+    public function testItThrowExceptionWhenNoTrustedHostsAreSpecified()
+    {
+        $trustedHosts = [];
+        $headers = ['HOST' => 'laravel.com'];
+        $servers = [];
+        $urlGenerator = $this->createUrlGenerator($trustedHosts, $headers, $servers);
+        $this->assertEquals("http://laravel.com", $urlGenerator->to('/'));
+    }
+
+    protected function createUrlGenerator($trustedHosts = array(), $headers = array(), $servers = array())
+    {
+        $middleware = new TrustHosts;
+        $middleware->setTrustedHosts($trustedHosts);
+
+        $request = new Request;
+
+        foreach ($headers as $key => $val) {
+            $request->headers->set($key, $val);
+        }
+
+        foreach ($servers as $key => $val) {
+            $request->server->set($key, $val);
+        }
+
+        $middleware->handle($request, function () {});
+
+        $routes = new RouteCollection;
+        $routes->add(new Route('GET', 'foo', [
+            'uses' => 'FooController@index',
+            'as' => 'foo_index',
+        ]));
+
+        return new UrlGenerator($routes, $request);
+    }
+}


### PR DESCRIPTION
# What this PR is for?

## 1. Provide an easy way to prevent host header attacks.

Since the url helper functions such as url(), route() get host names from server variables, there is a risk of introducing host header attack vulnerability into applications.

This PR add a feature to set trusted hosts to request class so that untrusted hosts are rejected when url helpers are called.

Even though users can prevent host header attacks with proper web server setting or proper coding, it is nice to have an easier way.

Also, I think it would be better if trusted hosts are set by default.
Therefore, I am going to submit this PR for laravel app later. (this PR is in progress. the code is not complete)
This will prevent users from introducing the vulnerability by default.

Since the middleware is just settng trusted host to symfony request class, please refer to symfony's document: https://symfony.com/doc/current/reference/configuration/framework.html#trusted-hosts

## 2. Fix password reset link issue with sub domain.

Currently, config('app.url') is used to generate password reset link in order to prevent host header attack.
https://github.com/laravel/framework/blob/78505345f2a34b865a980cefbd103d8eb839eedf/src/Illuminate/Auth/Notifications/ResetPassword.php#L62

However, due to this code, password resets email ignore subdomains.

If this PR is merged, we can remove config('app.url') from the code since we don't need to worry about host header attacks.

This PR is resubmit of https://github.com/laravel/framework/pull/27173 .