### PR TITLE
[5.8] Remove overwritten methods on Repository interface

### DIFF
--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -8,23 +8,6 @@ use Psr\SimpleCache\CacheInterface;
 interface Repository extends CacheInterface
 {
     /**
-     * Determine if an item exists in the cache.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    public function has($key);
-
-    /**
-     * Retrieve an item from the cache by key.
-     *
-     * @param  string  $key
-     * @param  mixed   $default
-     * @return mixed
-     */
-    public function get($key, $default = null);
-
-    /**
      * Retrieve an item from the cache and delete it.
      *
      * @param  string  $key


### PR DESCRIPTION
These methods are already defined on the PSR contract and it's unnecessary to define them twice.

Breaking changes: technically this shouldn't break anything since the methods were just overwritten. I'm not 100% sure so that's why I'm sending this to master.