### PR TITLE
[5.7] Fix return of add method in Cache Repository

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -272,9 +272,7 @@ class Repository implements CacheContract, ArrayAccess
         // so it exists for subsequent requests. Then, we will return true so it is
         // easy to know if the value gets added. Otherwise, we will return false.
         if (is_null($this->get($key))) {
-            $this->put($key, $value, $minutes);
-
-            return true;
+            return $this->put($key, $value, $minutes);
         }
 
         return false;

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -154,6 +154,15 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testAddWithStoreFailureReturnsFalse()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('add')->never();
+        $repo->getStore()->shouldReceive('get')->andReturn(null);
+        $repo->getStore()->shouldReceive('put')->andReturn(false);
+        $this->assertFalse($repo->add('foo', 'bar', 60));
+    }
+
     public function testCacheAddCallsRedisStoreAdd()
     {
         $store = m::mock(RedisStore::class);


### PR DESCRIPTION
The success should depend on the result of the put method call. This is a bug fix and therefor the change in behavior shouldn't be considered a breaking change.