### PR TITLE
[5.8] Fix PSR-16 TTL conformity

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -22,11 +22,15 @@ class RedisTaggedCache extends TaggedCache
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTime|float|int|null  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int|null  $minutes
      * @return bool
      */
     public function put($key, $value, $minutes = null)
     {
+        if ($minutes === null) {
+            return $this->forever($key, $value);
+        }
+
         $this->pushStandardKeys($this->tags->getNamespace(), $key);
 
         return parent::put($key, $value, $minutes);

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -6,7 +6,9 @@ use Illuminate\Contracts\Cache\Store;
 
 class TaggedCache extends Repository
 {
-    use RetrievesMultipleKeys;
+    use RetrievesMultipleKeys {
+        putMany as putManyAlias;
+    }
 
     /**
      * The tag set instance.
@@ -27,6 +29,22 @@ class TaggedCache extends Repository
         parent::__construct($store);
 
         $this->tags = $tags;
+    }
+
+    /**
+     * Store multiple items in the cache for a given number of minutes.
+     *
+     * @param  array  $values
+     * @param  float|int|null  $minutes
+     * @return bool
+     */
+    public function putMany(array $values, $minutes = null)
+    {
+        if ($minutes === null) {
+            return $this->putManyForever($values);
+        }
+
+        return $this->putManyAlias($values, $minutes);
     }
 
     /**

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -21,7 +21,7 @@ interface Repository extends CacheInterface
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int|null  $minutes
      * @return bool
      */
     public function put($key, $value, $minutes);
@@ -31,10 +31,10 @@ interface Repository extends CacheInterface
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int|null  $minutes
      * @return bool
      */
-    public function add($key, $value, $minutes);
+    public function add($key, $value, $minutes = null);
 
     /**
      * Increment the value of an item in the cache.
@@ -67,7 +67,7 @@ interface Repository extends CacheInterface
      * Get an item from the cache, or execute the given Closure and store the result.
      *
      * @param  string  $key
-     * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int|null  $minutes
      * @param  \Closure  $callback
      * @return mixed
      */

--- a/src/Illuminate/Filesystem/Cache.php
+++ b/src/Illuminate/Filesystem/Cache.php
@@ -68,10 +68,6 @@ class Cache extends AbstractCache
     {
         $contents = $this->getForStorage();
 
-        if (! is_null($this->expire)) {
-            $this->repository->put($this->key, $contents, $this->expire);
-        } else {
-            $this->repository->forever($this->key, $contents);
-        }
+        $this->repository->put($this->key, $contents, $this->expire);
     }
 }

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -111,6 +111,23 @@ class CacheTaggedCacheTest extends TestCase
         $conn->shouldReceive('sadd')->once()->with('prefix:foo:standard_ref', 'prefix:'.sha1('foo|bar').':key1');
         $conn->shouldReceive('sadd')->once()->with('prefix:bar:standard_ref', 'prefix:'.sha1('foo|bar').':key1');
         $store->shouldReceive('push')->with(sha1('foo|bar').':key1', 'key1:value');
+        $store->shouldReceive('put')->andReturn(true);
+
+        $redis->put('key1', 'key1:value', 60);
+    }
+
+    public function testRedisCacheTagsPushForeverKeysCorrectlyWithNullTTL()
+    {
+        $store = m::mock(Store::class);
+        $tagSet = m::mock(TagSet::class, [$store, ['foo', 'bar']]);
+        $tagSet->shouldReceive('getNamespace')->andReturn('foo|bar');
+        $tagSet->shouldReceive('getNames')->andReturn(['foo', 'bar']);
+        $redis = new RedisTaggedCache($store, $tagSet);
+        $store->shouldReceive('getPrefix')->andReturn('prefix:');
+        $store->shouldReceive('connection')->andReturn($conn = m::mock(stdClass::class));
+        $conn->shouldReceive('sadd')->once()->with('prefix:foo:forever_ref', 'prefix:'.sha1('foo|bar').':key1');
+        $conn->shouldReceive('sadd')->once()->with('prefix:bar:forever_ref', 'prefix:'.sha1('foo|bar').':key1');
+        $store->shouldReceive('forever')->with(sha1('foo|bar').':key1', 'key1:value');
 
         $redis->put('key1', 'key1:value');
     }


### PR DESCRIPTION
Resend (and a better implementation) for https://github.com/laravel/framework/pull/27166

These changes to the Cache Repository interface and implementation will make our cache implementation compliant with the PSR-16 standard's TTL requirements. It contains some significant changes in how we handle and store cache values.

The main change that was done is that now a TTL with a value of NULL will be considerd an attempt to store the item forever. In addition to this, any value with a TTL equal or lower than zero will be considerd an attempt to remove the item from the cache. The `put`, `putMany` and `add` methods were updated to reflect these changes.

Before these changes a request like `Cache::put('foo', 'bar')` wouldn't do anything since a NULL TTL meant that the call was simply ignored. Now any request without a specified TTL will have the default TTL of NULL and thus the request is considered to attempting to store the item forever.

For the `putMany` call a NULL TTL now means that every single item will be stored forever individually. As there isn't a `putManyForever` equivalent on the Repository or the PSR interface, there was no way to tell a cache store to store the given items in one go.

For the `add` call, the behavior to ignore the call when a zero or less TTL was given is kept but when a NULL TTL is now passed, it's correctly passed to the `put` method. This will ignore a custom `add` method on the cache store as any NULL TTL simply could be considered to re-store the item indefinitely.

No changes were made to the cache stores themselves. Only the Repository was modified. This way, the cache stores keep their current behavior as they aren't implementations of the PSR Simple Cache interface.

All in all these changes will now make us conform with the PSR spec much better.

For reference: https://www.php-fig.org/psr/psr-16/

Fixes https://github.com/laravel/framework/issues/27160

PS. As a proof of concept I was able to simplify a call in the Filesystem component.