### PR TITLE
[5.8]  Make the redis queue blocking pop atomic

### DIFF
--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -76,6 +76,7 @@ LUA;
      *
      * KEYS[1] - The queue we are removing jobs from, for example: queues:foo:reserved
      * KEYS[2] - The queue we are moving jobs to, for example: queues:foo
+     * KEYS[3] - The notification list for the queue we are moving jobs to, for example queues:foo:notify
      * ARGV[1] - The current UNIX timestamp
      *
      * @return string
@@ -94,6 +95,11 @@ if(next(val) ~= nil) then
 
     for i = 1, #val, 100 do
         redis.call('rpush', KEYS[2], unpack(val, i, math.min(i+99, #val)))
+        if KEYS[3] ~= nil then
+            for j = 1, math.min(i+99, #val) do
+                redis.call('rpush', KEYS[3], 1)
+            end
+        end
     end
 end
 

--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -106,4 +106,24 @@ end
 return val
 LUA;
     }
+
+    /**
+     * Get the Lua script for pushing jobs onto the queue.
+     *
+     * KEYS[1] - The queue to push the job onto, for example: queues:foo
+     * KEYS[2] - The notification list fot the queue we are pushing jobs onto, for example: queues:foo:notify
+     * ARGV[1] - The job payload
+     *
+     * @return string
+     */
+    public static function push()
+    {
+        return <<<'LUA'
+redis.call('rpush', KEYS[1], ARGV[1])
+if KEYS[2] ~= nil then
+    redis.call('rpush', KEYS[2], 1)
+end
+return cjson.decode(ARGV[1])['id']
+LUA;
+    }
 }

--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -95,6 +95,7 @@ if(next(val) ~= nil) then
 
     for i = 1, #val, 100 do
         redis.call('rpush', KEYS[2], unpack(val, i, math.min(i+99, #val)))
+        -- Push a notification for every job that was migrated...
         if KEYS[3] ~= nil then
             for j = 1, math.min(i+99, #val) do
                 redis.call('rpush', KEYS[3], 1)
@@ -119,7 +120,9 @@ LUA;
     public static function push()
     {
         return <<<'LUA'
+-- Push the job onto the queue...
 redis.call('rpush', KEYS[1], ARGV[1])
+-- Push a notification onto the "notify" queue...
 if KEYS[2] ~= nil then
     redis.call('rpush', KEYS[2], 1)
 end

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -194,24 +194,27 @@ class RedisQueue extends Queue implements QueueContract
      */
     protected function migrate($queue)
     {
-        $this->migrateExpiredJobs($queue.':delayed', $queue);
+        $notify = $this->blockFor !== null ? $queue.':notify' : null;
+
+        $this->migrateExpiredJobs($queue.':delayed', $queue, $notify);
 
         if (! is_null($this->retryAfter)) {
-            $this->migrateExpiredJobs($queue.':reserved', $queue);
+            $this->migrateExpiredJobs($queue.':reserved', $queue, $notify);
         }
     }
 
     /**
      * Migrate the delayed jobs that are ready to the regular queue.
      *
-     * @param  string  $from
-     * @param  string  $to
+     * @param  string $from
+     * @param  string $to
+     * @param  string $notify
      * @return array
      */
-    public function migrateExpiredJobs($from, $to)
+    public function migrateExpiredJobs($from, $to, $notify = null)
     {
         return $this->getConnection()->eval(
-            LuaScripts::migrateExpiredJobs(), 2, $from, $to, $this->currentTime()
+            LuaScripts::migrateExpiredJobs(), 3, $from, $to, $notify, $this->currentTime()
         );
     }
 

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Queue\LuaScripts;
 use Illuminate\Queue\RedisQueue;
 use Illuminate\Contracts\Redis\Factory;
 
@@ -21,7 +22,7 @@ class QueueRedisQueueTest extends TestCase
         $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
-        $redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]));
+        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', null, json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]))->andReturn('foo');
 
         $id = $queue->push('foo', ['data']);
         $this->assertEquals('foo', $id);
@@ -32,7 +33,7 @@ class QueueRedisQueueTest extends TestCase
         $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
-        $redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0]));
+        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', null, json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0]))->andReturn('foo');
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
             return ['custom' => 'taylor'];
@@ -49,7 +50,7 @@ class QueueRedisQueueTest extends TestCase
         $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
-        $redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0]));
+        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', null, json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0]))->andReturn('foo');
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
             return ['custom' => 'taylor'];


### PR DESCRIPTION
## Overview

This PR changes the redis queue driver's blocking pop implementation to pop jobs atomically, fixing #22939.  The pattern is [explained in the Redis docs](https://redis.io/commands/blpop#pattern-event-notification).

When we push a job we also push a 'notification key'.  The notification list is named using the pattern `queues:{{name}}:notify`.

```
MULTI
RPUSH queues:default {{payload}}
RPUSH queues:default:notify 1
EXEC
```

When the worker attempts to reserve the job it first tries a blocking pop on the notification list.  As soon as a key is aded to the notification list the worker returns and then attempts to pop a job like normal, using the existing Lua script.

```
BLPOP queues:default:notify {{block_for}}
EVAL {{pop_script}} 2 queues:default queues:default:reserved {{available_at}}
```

There is a small chance the worker might crash between popping the notification element and popping the job onto the reserved queue. That is ok - once the worker restarts it will block for `block_for` seconds, then attempt to pop the job again.

## Upgrade Notes

If you upgrade the workers before upgrading the PHP processes pushing the jobs the worker will block waiting for a notification key that is never set.  This means you won't be able to mix pre 5.8 producers with 5.8+ workers without slowing down the workers considerably.

If for some reason you have to upgrade the workers first you can set `block_for` to `null` until you are fully upgraded.