### PR TITLE
[5.7] Update vue preset's vue-stubs for laravel-mix 4 compatibility

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/vue-stubs/ExampleComponent.vue
+++ b/src/Illuminate/Foundation/Console/Presets/vue-stubs/ExampleComponent.vue
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="row justify-content-center">
             <div class="col-md-8">
-                <div class="card">
+                <div class="card card-default">
                     <div class="card-header">Example Component</div>
 
                     <div class="card-body">

--- a/src/Illuminate/Foundation/Console/Presets/vue-stubs/app.js
+++ b/src/Illuminate/Foundation/Console/Presets/vue-stubs/app.js
@@ -10,12 +10,23 @@ require('./bootstrap');
 window.Vue = require('vue');
 
 /**
+ * The following block of code may be used to automatically register your
+ * Vue components. It will recursively scan this directory for the Vue
+ * components and automatically register them with their "basename".
+ *
+ * Eg. ./components/ExampleComponent.vue -> <example-component></example-component>
+ */
+
+// const files = require.context('./', true, /\.vue$/i)
+// files.keys().map(key => Vue.component(key.split('/').pop().split('.')[0], files(key).default))
+
+Vue.component('example-component', require('./components/ExampleComponent.vue').default);
+
+/**
  * Next, we will create a fresh Vue application instance and attach it to
  * the page. Then, you may begin adding components to this application
  * or customize the JavaScript scaffolding to fit your unique needs.
  */
-
-Vue.component('example-component', require('./components/ExampleComponent.vue'));
 
 const app = new Vue({
     el: '#app'


### PR DESCRIPTION
The stubs for app.js and ExampleComponent.vue when issuing the `artisan preset vue` command differ from the laravel project's default app.js and ExampleComponent.vue files. Furthermore, the app.js stub is incompatible with laravel-mix 4 because it does not reference `.default`.

According to the Laravel-Mix 4 upgrade guide [https://laravel-mix.com/docs/4.0/upgrade](url) 

> As part of the vue-loader 15 updates, if your code uses the CommonJS syntax for importing EcmaScript modules, you'll need to append .default...

**How to reproduce**
Using a fresh install of laravel, issue the `php artisan preset vue` command.

I'm thinking this was simply overlooked when upgrading laravel to mix 4, or possibly I'm missing something. Hope this PR helps 👍 