### PR TITLE
[5.7] More accurate validated data for intersecting rules

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -335,7 +335,7 @@ class Validator implements ValidatorContract
 
         $missingValue = Str::random(10);
 
-        foreach (array_keys($this->getRules()) as $key) {
+        foreach ($this->composeValidatedKeys() as $key) {
             $value = data_get($this->getData(), $key, $missingValue);
 
             if ($value !== $missingValue) {
@@ -344,6 +344,39 @@ class Validator implements ValidatorContract
         }
 
         return $results;
+    }
+
+    /**
+     * Compose an array of validated keys.
+     *
+     * @return array
+     */
+    protected function composeValidatedKeys()
+    {
+        $keys = array_keys($this->rules);
+
+        return array_filter($keys, function ($key) {
+            return ! $this->validatedKeyHasNestedKeys($key);
+        });
+    }
+
+    /**
+     * Check if the specified validated key has nested keys.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function validatedKeyHasNestedKeys($key)
+    {
+        $keys = array_keys($this->rules);
+
+        foreach ($keys as $item) {
+            if (starts_with($item, "{$key}.")) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4292,6 +4292,19 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['nested' => [['bar' => 'baz'], ['bar' => 'baz2']]], $data);
     }
 
+    public function testValidateReturnsValidatedDataNestedArrayIntersectingRules()
+    {
+        $post = ['nested' => [['bar' => 'baz', 'with' => 'extras', 'type' => 'admin'], ['bar' => 'baz2', 'with' => 'extras', 'type' => 'admin']]];
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), $post, ['nested' => 'required', 'nested.*.bar' => 'required']);
+        $v->sometimes('nested.*.type', 'required', function () {
+            return false;
+        });
+        $data = $v->validate();
+
+        $this->assertEquals(['nested' => [['bar' => 'baz'], ['bar' => 'baz2']]], $data);
+    }
+
     public function testValidateAndValidatedData()
     {
         $post = ['first' => 'john',  'preferred'=>'john', 'last' => 'doe', 'type' => 'admin'];


### PR DESCRIPTION
This PR is a second part of the closed PR #27205.

Below is just the copy-paste description of the original PR, for convenience.

-------

This PR fixes #27049.

**If** you're using rules for validating nested arrays (f.e. `items.*.product.id`) with rules of a more "higher level" (f.e. `items`),

 **Then**, your validated data would be the full set from the `items` array.

It may be a bit confusing because those rules are intersecting with each other, and validated data may be more accurate in that case.

Here is the code example for convenience:

```php
$data = [
    'items' => [
        ['product' => ['id' => 1, 'name' => 'One']],
        ['product' => ['id' => 2, 'name' => 'Two']],
    ],
];

$rules = [
    'items' => 'required',
    'items.*.product.id' => 'required',
];

$validator = Validator::make($data, $rules);

$validated = $validator->validate();

dd($validated);
```

Before:

```php
[
    'items' => [
        ['product' => ['id' => 1, 'name' => 'One']],
        ['product' => ['id' => 2, 'name' => 'Two']],
    ],
]
```

After:

```php
[
    'items' => [
        ['product' => ['id' => 1]],
        ['product' => ['id' => 2]],
    ],
]
```

PS: #27049 was initially considered as a `bug`, so I've made a PR in `5.7`.