### PR TITLE
[5.7] GeneratorCommand requires filesystem

### DIFF
--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -32,6 +32,7 @@
     "suggest": {
         "dragonmantank/cron-expression": "Required to use scheduling component (^2.0).",
         "guzzlehttp/guzzle": "Required to use the ping methods on schedules (^6.0).",
+        "illuminate/filesystem": "Required to use the generator command (5.7.*)",
         "symfony/process": "Required to use scheduling component (^4.1)."
     },
     "config": {


### PR DESCRIPTION
The **GeneratorCommand** constructor needs an instance of `Illuminate\Filesystem\Filesystem`. If a developer use `illuminate/console`, it may be necessary to show the suggestion to notice that `illuminate/filesystem` is required to use GeneratorCommand.

If this pull request is accepted, someone may add the suggestion to the master branch (5.8).