### PR TITLE
[5.7] clean some classes of cache directory includes PHPDoc and code refactoring

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -123,7 +123,7 @@ class CacheManager implements FactoryContract
      * Create an instance of the APC cache driver.
      *
      * @param  array $config
-     * @return Repository
+     * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function createApcDriver(array $config)
     {
@@ -135,7 +135,7 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the array cache driver.
      *
-     * @return Repository
+     * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function createArrayDriver()
     {
@@ -146,7 +146,7 @@ class CacheManager implements FactoryContract
      * Create an instance of the file cache driver.
      *
      * @param  array $config
-     * @return Repository
+     * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function createFileDriver(array $config)
     {
@@ -157,7 +157,7 @@ class CacheManager implements FactoryContract
      * Create an instance of the Memcached cache driver.
      *
      * @param  array $config
-     * @return Repository
+     * @return \Illuminate\Contracts\Cache\Repository
      * @throws \ReflectionException
      */
     protected function createMemcachedDriver(array $config)
@@ -174,7 +174,7 @@ class CacheManager implements FactoryContract
 
     /**
      * Create an instance of the Null cache driver.
-     * @return Repository
+     * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function createNullDriver()
     {
@@ -185,7 +185,7 @@ class CacheManager implements FactoryContract
      * Create an instance of the Redis cache driver.
      *
      * @param  array $config
-     * @return Repository
+     * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function createRedisDriver(array $config)
     {
@@ -200,7 +200,7 @@ class CacheManager implements FactoryContract
      * Create an instance of the database cache driver.
      *
      * @param  array $config
-     * @return Repository
+     * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function createDatabaseDriver(array $config)
     {
@@ -217,7 +217,7 @@ class CacheManager implements FactoryContract
      * Create a new cache repository with the given implementation.
      *
      * @param  \Illuminate\Contracts\Cache\Store  $store
-     * @return \Illuminate\Cache\Repository
+     * @return \Illuminate\Contracts\Cache\Repository
      */
     public function repository(Store $store)
     {

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -106,7 +106,6 @@ class CacheManager implements FactoryContract
             return $this->{$driverMethod}($config);
         }
         throw new InvalidArgumentException("Driver [{$config['driver']}] is not supported.");
-
     }
 
     /**

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -98,15 +98,15 @@ class CacheManager implements FactoryContract
 
         if (isset($this->customCreators[$config['driver']])) {
             return $this->callCustomCreator($config);
-        } else {
-            $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
-
-            if (method_exists($this, $driverMethod)) {
-                return $this->{$driverMethod}($config);
-            } else {
-                throw new InvalidArgumentException("Driver [{$config['driver']}] is not supported.");
-            }
         }
+
+        $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
+
+        if (method_exists($this, $driverMethod)) {
+            return $this->{$driverMethod}($config);
+        }
+        throw new InvalidArgumentException("Driver [{$config['driver']}] is not supported.");
+
     }
 
     /**
@@ -123,8 +123,8 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the APC cache driver.
      *
-     * @param  array  $config
-     * @return \Illuminate\Cache\ApcStore
+     * @param  array $config
+     * @return Repository
      */
     protected function createApcDriver(array $config)
     {
@@ -136,7 +136,7 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the array cache driver.
      *
-     * @return \Illuminate\Cache\ArrayStore
+     * @return Repository
      */
     protected function createArrayDriver()
     {
@@ -146,8 +146,8 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the file cache driver.
      *
-     * @param  array  $config
-     * @return \Illuminate\Cache\FileStore
+     * @param  array $config
+     * @return Repository
      */
     protected function createFileDriver(array $config)
     {
@@ -157,13 +157,12 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the Memcached cache driver.
      *
-     * @param  array  $config
-     * @return \Illuminate\Cache\MemcachedStore
+     * @param  array $config
+     * @return Repository
+     * @throws \ReflectionException
      */
     protected function createMemcachedDriver(array $config)
     {
-        $prefix = $this->getPrefix($config);
-
         $memcached = $this->app['memcached.connector']->connect(
             $config['servers'],
             $config['persistent_id'] ?? null,
@@ -171,13 +170,12 @@ class CacheManager implements FactoryContract
             array_filter($config['sasl'] ?? [])
         );
 
-        return $this->repository(new MemcachedStore($memcached, $prefix));
+        return $this->repository(new MemcachedStore($memcached, $this->getPrefix($config)));
     }
 
     /**
      * Create an instance of the Null cache driver.
-     *
-     * @return \Illuminate\Cache\NullStore
+     * @return Repository
      */
     protected function createNullDriver()
     {
@@ -187,8 +185,8 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the Redis cache driver.
      *
-     * @param  array  $config
-     * @return \Illuminate\Cache\RedisStore
+     * @param  array $config
+     * @return Repository
      */
     protected function createRedisDriver(array $config)
     {
@@ -202,8 +200,8 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the database cache driver.
      *
-     * @param  array  $config
-     * @return \Illuminate\Cache\DatabaseStore
+     * @param  array $config
+     * @return Repository
      */
     protected function createDatabaseDriver(array $config)
     {

--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -53,6 +53,7 @@ class CacheTableCommand extends Command
      * Execute the console command.
      *
      * @return void
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
     public function handle()
     {

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -109,9 +109,10 @@ class DatabaseStore implements Store
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  string  $key
-     * @param  mixed   $value
+     * @param  string $key
+     * @param  mixed $value
      * @return int|bool
+     * @throws \Throwable
      */
     public function increment($key, $value = 1)
     {
@@ -123,9 +124,10 @@ class DatabaseStore implements Store
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  string  $key
-     * @param  mixed   $value
+     * @param  string $key
+     * @param  mixed $value
      * @return int|bool
+     * @throws \Throwable
      */
     public function decrement($key, $value = 1)
     {
@@ -137,10 +139,11 @@ class DatabaseStore implements Store
     /**
      * Increment or decrement an item in the cache.
      *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @param  \Closure  $callback
+     * @param  string $key
+     * @param  mixed $value
+     * @param  \Closure $callback
      * @return int|bool
+     * @throws \Throwable
      */
     protected function incrementOrDecrement($key, $value, Closure $callback)
     {

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -127,11 +127,11 @@ class FileStore implements Store
      */
     public function forget($key)
     {
-        if ($this->files->exists($file = $this->path($key))) {
-            return $this->files->delete($file);
+        if (! $this->files->exists($file = $this->path($key))) {
+            return false;
         }
 
-        return false;
+        return $this->files->delete($file);
     }
 
     /**

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -43,8 +43,9 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
     /**
      * Create a new Memcached store.
      *
-     * @param  \Memcached  $memcached
-     * @param  string      $prefix
+     * @param  \Memcached $memcached
+     * @param  string $prefix
+     * @throws \ReflectionException
      * @return void
      */
     public function __construct($memcached, $prefix = '')
@@ -64,10 +65,8 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
      */
     public function get($key)
     {
-        $value = $this->memcached->get($this->prefix.$key);
-
         if ($this->memcached->getResultCode() == 0) {
-            return $value;
+            return $this->memcached->get($this->prefix.$key);
         }
     }
 

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -65,8 +65,10 @@ class MemcachedStore extends TaggableStore implements LockProvider, Store
      */
     public function get($key)
     {
+        $value = $this->memcached->get($this->prefix.$key);
+
         if ($this->memcached->getResultCode() == 0) {
-            return $this->memcached->get($this->prefix.$key);
+            return $value;
         }
     }
 

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -102,9 +102,7 @@ class RateLimiter
      */
     public function retriesLeft($key, $maxAttempts)
     {
-        $attempts = $this->attempts($key);
-
-        return $maxAttempts - $attempts;
+        return $maxAttempts - $this->attempts($key);
     }
 
     /**


### PR DESCRIPTION
This PR changes includes:
1. correct all PHPDoc problems caused to show error in editor like return types or throws
2. some code refactoring for better readability like decrease indentation. 