### PR TITLE
[5.7] Update preset to use @babel/preset-react

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/None.php
+++ b/src/Illuminate/Foundation/Console/Presets/None.php
@@ -38,7 +38,7 @@ class None extends Preset
             $packages['jquery'],
             $packages['popper.js'],
             $packages['vue'],
-            $packages['babel-preset-react'],
+            $packages['@babel/preset-react'],
             $packages['react'],
             $packages['react-dom']
         );

--- a/src/Illuminate/Foundation/Console/Presets/React.php
+++ b/src/Illuminate/Foundation/Console/Presets/React.php
@@ -31,7 +31,7 @@ class React extends Preset
     protected static function updatePackageArray(array $packages)
     {
         return [
-            'babel-preset-react' => '^6.23.0',
+            '@babel/preset-react' => '^7.0.0',
             'react' => '^16.2.0',
             'react-dom' => '^16.2.0',
         ] + Arr::except($packages, ['vue']);


### PR DESCRIPTION
Hi,

This PR will update the react preset to use the [@babel/preset-react](https://www.npmjs.com/package/@babel/preset-react) package.

Laravel Mix v3.0+ is now using babel 7.x. See 

https://github.com/JeffreyWay/laravel-mix/blob/cc816bb799cdd9b3900aaa60cf416b51b223e5ba/src/components/React.js#L8
