### PR TITLE
[5.8] Make concurrency limiter lock release safe

### DIFF
--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Redis\Limiters;
 
 use Exception;
+use Illuminate\Support\Str;
 use Illuminate\Contracts\Redis\LimiterTimeoutException;
 
 class ConcurrencyLimiter
@@ -65,8 +66,9 @@ class ConcurrencyLimiter
     public function block($timeout, $callback = null)
     {
         $starting = time();
+        $id = Str::random(20);
 
-        while (! $slot = $this->acquire()) {
+        while (! $slot = $this->acquire($id)) {
             if (time() - $timeout >= $starting) {
                 throw new LimiterTimeoutException;
             }
@@ -76,11 +78,11 @@ class ConcurrencyLimiter
 
         if (is_callable($callback)) {
             try {
-                return tap($callback(), function () use ($slot) {
-                    $this->release($slot);
+                return tap($callback(), function () use ($slot, $id) {
+                    $this->release($slot, $id);
                 });
             } catch (Exception $exception) {
-                $this->release($slot);
+                $this->release($slot, $id);
 
                 throw $exception;
             }
@@ -92,17 +94,19 @@ class ConcurrencyLimiter
     /**
      * Attempt to acquire the lock.
      *
+     * @param string $id A unique identifier for this lock
+     *
      * @return mixed
      */
-    protected function acquire()
+    protected function acquire($id)
     {
         $slots = array_map(function ($i) {
             return $this->name.$i;
         }, range(1, $this->maxLocks));
 
         return $this->redis->eval(...array_merge(
-            [$this->luaScript(), count($slots)],
-            array_merge($slots, [$this->name, $this->releaseAfter])
+            [$this->lockScript(), count($slots)],
+            array_merge($slots, [$this->name, $this->releaseAfter, $id])
         ));
     }
 
@@ -112,15 +116,16 @@ class ConcurrencyLimiter
      * KEYS    - The keys that represent available slots
      * ARGV[1] - The limiter name
      * ARGV[2] - The number of seconds the slot should be reserved
+     * ARGV[3] - The unique identifier for this lock
      *
      * @return string
      */
-    protected function luaScript()
+    protected function lockScript()
     {
         return <<<'LUA'
 for index, value in pairs(redis.call('mget', unpack(KEYS))) do
     if not value then
-        redis.call('set', ARGV[1]..index, "1", "EX", ARGV[2])
+        redis.call('set', ARGV[1]..index, ARGV[3], "EX", ARGV[2])
         return ARGV[1]..index
     end
 end
@@ -130,11 +135,32 @@ LUA;
     /**
      * Release the lock.
      *
-     * @param  string  $key
+     * @param  string $key
+     * @param  string $id
      * @return void
      */
-    protected function release($key)
+    protected function release($key, $id)
     {
-        $this->redis->command('del', [$key]);
+        $this->redis->eval($this->releaseScript(), 1, $key, $id);
+    }
+
+    /**
+     * Get the Lua script to atomically release a lock.
+     *
+     * KEYS[1] - The name of the lock
+     * ARGV[1] - The unique identifier for this lock
+     *
+     * @return string
+     */
+    protected function releaseScript()
+    {
+        return <<<'LUA'
+if redis.call('get', KEYS[1]) == ARGV[1]
+then
+    return redis.call('del', KEYS[1])
+else
+    return 0
+end
+LUA;
     }
 }

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -141,7 +141,7 @@ class ConcurrentLimiterTest extends TestCase
 
 class ConcurrencyLimiterMockThatDoesntRelease extends ConcurrencyLimiter
 {
-    protected function release($Key)
+    protected function release($key, $id)
     {
         //
     }


### PR DESCRIPTION
This PR changes the concurrency limiter to use a random unique token for each lock instance.  If the token no longer matches the lock is not released.  This prevents the possiblity of releasing a lock you no longer hold.  The problem and solution are described [in the Redis docs](https://redis.io/topics/distlock).  This resolves #27224.