### PR TITLE
when using Eloquent where('column') without a value, it will behave like a Boolean

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -693,6 +693,10 @@ class Builder
      */
     public function prepareValueAndOperator($value, $operator, $useDefault = false)
     {
+        if (is_null($operator)) {
+            return [true, '='];
+        }
+
         if ($useDefault) {
             return [$operator, '='];
         } elseif ($this->invalidOperatorAndValue($operator, $value)) {


### PR DESCRIPTION
when using Eloquent where('column') without a value, it will behave like a Boolean

this is the enhancement discussed here:

https://github.com/laravel/framework/issues/26333
