### PR TITLE
[5.7] Use config to resolve the database value during tests.

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -25,9 +25,9 @@ trait RefreshDatabase
      */
     protected function usingInMemoryDatabase()
     {
-        return config('database.connections')[
-            config('database.default')
-        ]['database'] === ':memory:';
+        $default = config('database.default');
+
+        return config("database.connections.$default.database") === ':memory:';
     }
 
     /**


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Laravel comes with a handy ["read/write"](https://laravel.com/docs/5.7/database#read-and-write-connections) feature.
Unfortunatelly it is impossible to keep and test this feature alike during tests, when using `RefreshDatabase`. 

In this situation, `usingInMemoryDatabase` method will never resolve the `database` key as it's embedded under either the `read` either the `write` section, and will raise an error during tests.

This PR fix this problem.
