### PR TITLE
[5.8] Container make method throws exception

### DIFF
--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -130,6 +130,8 @@ interface Container extends ArrayAccess, ContainerInterface
      * @param  string  $abstract
      * @param  array  $parameters
      * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function make($abstract, array $parameters = []);
 


### PR DESCRIPTION
See https://github.com/laravel/framework/pull/26856 for a little bit more information!

If the container can resolve an abstract type, it just simply returns it. Otherwise, it raises an exception that "I can't resolve this abstract type". This logic is reasonable for the IOC container and each implementation should follow.