### PR TITLE
[5.7] Add missing tests for Facades

### DIFF
--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -70,6 +70,37 @@ class SupportFacadeTest extends TestCase
         FacadeStub::shouldReceive('foo')->once()->andReturn('bar');
         $this->assertEquals('bar', FacadeStub::foo());
     }
+
+    public function testFacadesAreStateful()
+    {
+        $app = new ApplicationStub;
+        $app->setAttributes(['foo' => new StateFulFacadeStub()]);
+
+        FacadeStub::setFacadeApplication($app);
+
+        $this->assertEquals(1, FacadeStub::increment());
+        $this->assertEquals(2, FacadeStub::increment());
+        $this->assertEquals(3, FacadeStub::increment());
+        $this->assertEquals(4, FacadeStub::increment());
+        $this->assertEquals(3, FacadeStub::decrement());
+        $this->assertEquals(2, FacadeStub::decrement());
+        $this->assertEquals(1, FacadeStub::decrement());
+    }
+}
+
+class StatefulFacadeStub
+{
+    protected $counter = 0;
+
+    public function increment()
+    {
+        return ++$this->counter;
+    }
+
+    public function decrement()
+    {
+        return --$this->counter;
+    }
 }
 
 class FacadeStub extends Facade


### PR DESCRIPTION
Following a discussion in laravel/ideas about facades at last I stumbled upon the Facades tests and saw that there is no test covering the fact that facades cache the resolved abstract in memory and reuse the object.

But I am not sure whether it is desired or documented behavior.
Maybe the facade should ask the container with each call and let the container decide to resolve the same instance or create a new instance.

Currently in only calls the container once and memoizes the result