### PR TITLE
[5.8] Fix return types null store

### DIFF
--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -42,11 +42,11 @@ class NullStore extends TaggableStore
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return int
+     * @return int|bool
      */
     public function increment($key, $value = 1)
     {
-        //
+        return false;
     }
 
     /**
@@ -54,11 +54,11 @@ class NullStore extends TaggableStore
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return int
+     * @return int|bool
      */
     public function decrement($key, $value = 1)
     {
-        //
+        return false;
     }
 
     /**

--- a/tests/Cache/CacheNullStoreTest.php
+++ b/tests/Cache/CacheNullStoreTest.php
@@ -26,4 +26,11 @@ class CacheNullStoreTest extends TestCase
             'bar',
         ]));
     }
+
+    public function testIncrementAndDecrementReturnFalse()
+    {
+        $store = new NullStore;
+        $this->assertFalse($store->increment('foo'));
+        $this->assertFalse($store->decrement('foo'));
+    }
 }


### PR DESCRIPTION
The increment and decrement methods should also be able to return booleans according to their interface equivalents. This means the increment and decrement of the NullStore can always return false as they don't do anything.
