### PR TITLE
[5.7] Document proper return object for cache store method

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -46,7 +46,7 @@ class CacheManager implements FactoryContract
     }
 
     /**
-     * Get a cache store instance by name.
+     * Get a cache store instance by name, wrapped in a repository.
      *
      * @param  string|null  $name
      * @return \Illuminate\Contracts\Cache\Repository


### PR DESCRIPTION
The store method in the CacheManager is documented in the DocBlock to return an instance of the cache store itself but this isn't true. The store that is passed is wrapped in a cache repository.