### PR TITLE
[5.8] Add redirectAction to Controller

### DIFF
--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -55,6 +55,20 @@ abstract class Controller
     }
 
     /**
+     * Return a redirect to a method in this Controller.
+     *
+     * @param $method
+     * @param array $parameters
+     * @param int $status
+     * @param array $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    protected function redirectAction($method, $parameters = [], $status = 302, $headers = [])
+    {
+        return redirect()->action([static::class, $method], $parameters, $status, $headers);
+    }
+
+    /**
      * Handle calls to missing methods on the controller.
      *
      * @param  string  $method


### PR DESCRIPTION
This adds a method to simplify returning a redirect to a method in the current class. So basically `return $this->redirectAction('index')` would be equivalent to `return redirect()->action([static::class, 'index']);`

Not sure if the name is best though (could be just `action` or `redirectToAction`)