### PR TITLE
[5.7] Apply parameters to entire localization array

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -244,7 +244,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         if (is_string($line)) {
             return $this->makeReplacements($line, $replace);
         } elseif (is_array($line) && count($line) > 0) {
-            foreach($line as $key => $val) {
+            foreach ($line as $key => $val) {
                 $line[$key] = $this->makeReplacements($val, $replace);
             }
             return $line;

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -247,7 +247,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             foreach ($line as $key => $val) {
                 $line[$key] = $this->makeReplacements($val, $replace);
             }
-            
+
             return $line;
         }
     }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -244,6 +244,9 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         if (is_string($line)) {
             return $this->makeReplacements($line, $replace);
         } elseif (is_array($line) && count($line) > 0) {
+            foreach($line as $key => $val) {
+                $line[$key] = $this->makeReplacements($val, $replace);
+            }
             return $line;
         }
     }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -247,6 +247,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             foreach ($line as $key => $val) {
                 $line[$key] = $this->makeReplacements($val, $replace);
             }
+            
             return $line;
         }
     }


### PR DESCRIPTION
I apologize if this has been addressed somewhere else, though I was unable to find any discussion of this when searching for it. I found a discrepancy when apply parameter replacements to key-based localizations.

When calling
```php
__('foobar', ['foo' => 'bar']);
```
to retrieve an entire localization array, the parameters are not applied. This minor change applies parameters to all lines retrieved.