### PR TITLE
[5.7] Encode unicode characters in JSON validation errors

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -672,7 +672,7 @@ class TestResponse
         if (is_null($keys) && count($errors) > 0) {
             PHPUnit::fail(
                 'Response has unexpected validation errors: '.PHP_EOL.PHP_EOL.
-                json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+                json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
             );
         }
 
@@ -942,7 +942,7 @@ class TestResponse
         PHPUnit::assertFalse(
             $hasErrors,
             'Session has unexpected errors: '.PHP_EOL.PHP_EOL.
-            json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+            json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
         );
 
         return $this;


### PR DESCRIPTION
Validation errors which have translated messages with unicode characters were escaped as \uXXXX when assertions are failing in TestResponse.

Using `JSON_UNESCAPED_UNICODE` will encode these characters literally when PHPUnit displays the assertion messages, which will render these `$errors` human-readable instead of gibberish unicode soup.

Before:

```json
{
    "foo": [
        "La valeur du champ foo est d\u00e9j\u00e0 utilis\u00e9e."
    ]
}
```

After:
```json
{
    "foo": [
        "La valeur du champ foo est déjà utilisée."
    ]
}
```

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
