### PR TITLE
[5.7] Email notification view: pass subcopy as a slot

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -48,7 +48,7 @@
 
 {{-- Subcopy --}}
 @isset($actionText)
-@component('mail::subcopy')
+@slot('subcopy')
 @lang(
     "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
     'into your web browser: [:actionURL](:actionURL)',
@@ -57,6 +57,6 @@
         'actionURL' => $actionUrl,
     ]
 )
-@endcomponent
+@endslot
 @endisset
 @endcomponent


### PR DESCRIPTION
With the current implementation, the notification subcopy skips over the `mail::message` component segment for it and is inserted into `mail::layout` via `$slot` instead of as `$subcopy` with `$subcopy` being empty. This becomes an issue if the `$subcopy` in `mail::layout` is moved anywhere besides directly after `$slot`, as it will not be inserted into the correct location.

The notification subcopy should instead be passed as a slot to the `mail::message` component to fill the `$subcopy` there, which then passes the subcopy component as a slot to `mail::layout` for final insertion as `$subcopy` instead of `$slot`.

See [message.blade.php](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Mail/resources/views/html/message.blade.php) as `mail::message` and [layout.blade.php](https://github.com/laravel/framework/blob/5.7/src/Illuminate/Mail/resources/views/html/layout.blade.php) as `mail::layout`.
