### PR TITLE
[5.7] Clarify missing migration table error message in StatusCommand

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -52,7 +52,7 @@ class StatusCommand extends BaseCommand
         $this->migrator->setConnection($this->option('database'));
 
         if (! $this->migrator->repositoryExists()) {
-            return $this->error('No migrations found.');
+            return $this->error('Migration table not found.');
         }
 
         $ran = $this->migrator->getRepository()->getRan();


### PR DESCRIPTION
`php artisan migrate:status` with a missing migrations table should output a meaningful error message. Replaced "No migrations found" with "Migration table not found." (like in ResetCommand).