### PR TITLE
[5.7] Allow the reject method on Collection to be called without an argument

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1420,16 +1420,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  callable|mixed  $callback
      * @return static
      */
-    public function reject($callback)
+    public function reject($callback = true)
     {
-        if ($this->useAsCallable($callback)) {
-            return $this->filter(function ($value, $key) use ($callback) {
-                return ! $callback($value, $key);
-            });
-        }
+        $useAsCallable = $this->useAsCallable($callback);
 
-        return $this->filter(function ($item) use ($callback) {
-            return $item != $callback;
+        return $this->filter(function ($value, $key) use ($callback, $useAsCallable) {
+            return $useAsCallable
+                ? ! $callback($value, $key)
+                : $value != $callback;
         });
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2055,6 +2055,26 @@ class SupportCollectionTest extends TestCase
         })->all());
     }
 
+    public function testRejectWithoutAnArgumentRemovesTruthyValues()
+    {
+        $collection1 = new Collection([
+            false,
+            true,
+            new Collection(),
+            0,
+        ]);
+        $this->assertSame([0 => false, 3 => 0], $collection1->reject()->all());
+
+        $collection2 = new Collection([
+            'a' => true,
+            'b' => true,
+            'c' => true,
+        ]);
+        $this->assertTrue(
+            $collection2->reject()->isEmpty()
+        );
+    }
+
     public function testSearchReturnsIndexOfFirstFoundItem()
     {
         $c = new Collection([1, 2, 3, 4, 5, 2, 5, 'foo' => 'bar']);


### PR DESCRIPTION
the `reject` method on the Collection is the inverse of `filter`, but unlike filter, it can not be called without an argument. This PR makes calling reject without an argument remove all truthy values from the collection, in the same way that calling filter without an argument removes all falsy values. I've also refactored the reject method to be slightly shorter.

Example: I had a key-value collection where the key was the name of a safety check, and the value a boolean if the check passed or not. In my view i wanted to check if all safety checks had passed (i.e. if they were all true). With this PR you an do that like this:
```php
@if($safetyChecks->reject()->isEmpty())
```

Instead of having to write it like this:
```php
@if($safetyChecks->filter()->count() === $safetyChecks->count())

// or

@if($safetyChecks->reject(true)->isEmpty())
```