### PR TITLE
[5.8] Do not raise KeyForgotten event upon failure

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -432,8 +432,10 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function forget($key)
     {
-        return tap($this->store->forget($this->itemKey($key)), function () use ($key) {
-            $this->event(new KeyForgotten($key));
+        return tap($this->store->forget($this->itemKey($key)), function ($result) use ($key) {
+            if ($result) {
+                $this->event(new KeyForgotten($key));
+            }
         });
     }
 


### PR DESCRIPTION
At the moment when the forgot method on a Cache store returns false a `KeyForgotten` event is still raised. This fix makes sure that the event is only triggered when the key is successfully removed from the cache.

I'm *pretty much* sure this is the way to go. Some cache stores will return false if the key wasn't in the cache store in the first place but it seems to me that in this situation you don't want the event to be raised either. 