### PR TITLE
[5.8] Make deleteMultiple return false if one delete fails

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -452,11 +452,15 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function deleteMultiple($keys)
     {
+        $result = true;
+
         foreach ($keys as $key) {
-            $this->forget($key);
+            if (! $this->forget($key)) {
+                $result = false;
+            }
         }
 
-        return true;
+        return $result;
     }
 
     /**

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -278,7 +278,17 @@ class CacheRepositoryTest extends TestCase
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('forget')->once()->with('a-key')->andReturn(true);
         $repo->getStore()->shouldReceive('forget')->once()->with('a-second-key')->andReturn(true);
-        $repo->deleteMultiple(['a-key', 'a-second-key']);
+
+        $this->assertTrue($repo->deleteMultiple(['a-key', 'a-second-key']));
+    }
+
+    public function testRemovingMultipleKeysFailsIfOneFails()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('forget')->once()->with('a-key')->andReturn(true);
+        $repo->getStore()->shouldReceive('forget')->once()->with('a-second-key')->andReturn(false);
+
+        $this->assertFalse($repo->deleteMultiple(['a-key', 'a-second-key']));
     }
 
     public function testAllTagsArePassedToTaggableStore()


### PR DESCRIPTION
PSR-16 states for this method that the return result should return `false` if there was an error. This PR fixes that behavior.