### PR TITLE
[5.8] Refactor caching minutes to seconds

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -49,16 +49,16 @@ class ApcStore extends TaggableStore
     }
 
     /**
-     * Store an item in the cache for a given number of minutes.
+     * Store an item in the cache for a given number of seconds.
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function put($key, $value, $minutes)
+    public function put($key, $value, $seconds)
     {
-        return $this->apc->put($this->prefix.$key, $value, (int) ($minutes * 60));
+        return $this->apc->put($this->prefix.$key, $value, $seconds);
     }
 
     /**

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -41,18 +41,18 @@ class ArrayStore extends TaggableStore
     }
 
     /**
-     * Store an item in the cache for a given number of minutes.
+     * Store an item in the cache for a given number of seconds.
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function put($key, $value, $minutes)
+    public function put($key, $value, $seconds)
     {
         $this->storage[$key] = [
             'value' => $value,
-            'expiresAt' => $this->calculateExpiration($minutes),
+            'expiresAt' => $this->calculateExpiration($seconds),
         ];
 
         return true;
@@ -140,22 +140,22 @@ class ArrayStore extends TaggableStore
     /**
      * Get the expiration time of the key.
      *
-     * @param  int  $minutes
+     * @param  int  $seconds
      * @return int
      */
-    protected function calculateExpiration($minutes)
+    protected function calculateExpiration($seconds)
     {
-        return $this->toTimestamp($minutes);
+        return $this->toTimestamp($seconds);
     }
 
     /**
-     * Get the UNIX timestamp for the given number of minutes.
+     * Get the UNIX timestamp for the given number of seconds.
      *
-     * @param  int  $minutes
+     * @param  int  $seconds
      * @return int
      */
-    protected function toTimestamp($minutes)
+    protected function toTimestamp($seconds)
     {
-        return $minutes > 0 ? $this->availableAt($minutes * 60) : 0;
+        return $seconds > 0 ? $this->availableAt($seconds) : 0;
     }
 }

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -84,20 +84,20 @@ class DatabaseStore implements Store
     }
 
     /**
-     * Store an item in the cache for a given number of minutes.
+     * Store an item in the cache for a given number of seconds.
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function put($key, $value, $minutes)
+    public function put($key, $value, $seconds)
     {
         $key = $this->prefix.$key;
 
         $value = $this->serialize($value);
 
-        $expiration = $this->getTime() + (int) ($minutes * 60);
+        $expiration = $this->getTime() + $seconds;
 
         try {
             return $this->table()->insert(compact('key', 'value', 'expiration'));

--- a/src/Illuminate/Cache/DynamoDbLock.php
+++ b/src/Illuminate/Cache/DynamoDbLock.php
@@ -35,7 +35,7 @@ class DynamoDbLock extends Lock
     public function acquire()
     {
         return $this->dynamo->add(
-            $this->name, $this->owner, $this->seconds / 60
+            $this->name, $this->owner, $this->seconds
         );
     }
 

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -182,14 +182,14 @@ class DynamoDbStore implements Store
     }
 
     /**
-     * Store an item in the cache for a given number of minutes.
+     * Store an item in the cache for a given number of seconds.
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function put($key, $value, $minutes)
+    public function put($key, $value, $seconds)
     {
         $this->dynamo->putItem([
             'TableName' => $this->table,
@@ -201,7 +201,7 @@ class DynamoDbStore implements Store
                     $this->type($value) => $this->serialize($value),
                 ],
                 $this->expirationAttribute => [
-                    'N' => (string) $this->toTimestamp($minutes),
+                    'N' => (string) $this->toTimestamp($seconds),
                 ],
             ],
         ]);
@@ -210,15 +210,15 @@ class DynamoDbStore implements Store
     }
 
     /**
-     * Store multiple items in the cache for a given number of minutes.
+     * Store multiple items in the cache for a given number of $seconds.
      *
      * @param  array  $values
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function putMany(array $values, $minutes)
+    public function putMany(array $values, $seconds)
     {
-        $expiration = $this->toTimestamp($minutes);
+        $expiration = $this->toTimestamp($seconds);
 
         $this->dynamo->batchWriteItem([
             'RequestItems' => [
@@ -250,10 +250,10 @@ class DynamoDbStore implements Store
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function add($key, $value, $minutes)
+    public function add($key, $value, $seconds)
     {
         try {
             $this->dynamo->putItem([
@@ -266,7 +266,7 @@ class DynamoDbStore implements Store
                         $this->type($value) => $this->serialize($value),
                     ],
                     $this->expirationAttribute => [
-                        'N' => (string) $this->toTimestamp($minutes),
+                        'N' => (string) $this->toTimestamp($seconds),
                     ],
                 ],
                 'ConditionExpression' => 'attribute_not_exists(#key) OR #expires_at < :now',
@@ -449,15 +449,15 @@ class DynamoDbStore implements Store
     }
 
     /**
-     * Get the UNIX timestamp for the given number of minutes.
+     * Get the UNIX timestamp for the given number of seconds.
      *
-     * @param  int  $minutes
+     * @param  int  $seconds
      * @return int
      */
-    protected function toTimestamp($minutes)
+    protected function toTimestamp($seconds)
     {
-        return $minutes > 0
-                    ? $this->availableAt($minutes * 60)
+        return $seconds > 0
+                    ? $this->availableAt($seconds)
                     : Carbon::now()->getTimestamp();
     }
 

--- a/src/Illuminate/Cache/Events/KeyWritten.php
+++ b/src/Illuminate/Cache/Events/KeyWritten.php
@@ -12,26 +12,26 @@ class KeyWritten extends CacheEvent
     public $value;
 
     /**
-     * The number of minutes the key should be valid.
+     * The number of seconds the key should be valid.
      *
      * @var int|null
      */
-    public $minutes;
+    public $seconds;
 
     /**
      * Create a new event instance.
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @param  int|null  $minutes
+     * @param  int|null  $seconds
      * @param  array  $tags
      * @return void
      */
-    public function __construct($key, $value, $minutes = null, $tags = [])
+    public function __construct($key, $value, $seconds = null, $tags = [])
     {
         parent::__construct($key, $tags);
 
         $this->value = $value;
-        $this->minutes = $minutes;
+        $this->seconds = $seconds;
     }
 }

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -50,19 +50,19 @@ class FileStore implements Store
     }
 
     /**
-     * Store an item in the cache for a given number of minutes.
+     * Store an item in the cache for a given number of seconds.
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function put($key, $value, $minutes)
+    public function put($key, $value, $seconds)
     {
         $this->ensureCacheDirectoryExists($path = $this->path($key));
 
         $result = $this->files->put(
-            $path, $this->expiration($minutes).serialize($value), true
+            $path, $this->expiration($seconds).serialize($value), true
         );
 
         return $result !== false && $result > 0;
@@ -188,10 +188,10 @@ class FileStore implements Store
 
         $data = unserialize(substr($contents, 10));
 
-        // Next, we'll extract the number of minutes that are remaining for a cache
+        // Next, we'll extract the number of seconds that are remaining for a cache
         // so that we can properly retain the time for things like the increment
         // operation that may be performed on this cache on a later operation.
-        $time = ($expire - $this->currentTime()) / 60;
+        $time = $expire - $this->currentTime();
 
         return compact('data', 'time');
     }
@@ -220,16 +220,16 @@ class FileStore implements Store
     }
 
     /**
-     * Get the expiration time based on the given minutes.
+     * Get the expiration time based on the given seconds.
      *
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return int
      */
-    protected function expiration($minutes)
+    protected function expiration($seconds)
     {
-        $time = $this->availableAt((int) ($minutes * 60));
+        $time = $this->availableAt($seconds);
 
-        return $minutes === 0 || $time > 9999999999 ? 9999999999 : (int) $time;
+        return $seconds === 0 || $time > 9999999999 ? 9999999999 : $time;
     }
 
     /**

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -93,28 +93,28 @@ class MemcachedStore extends TaggableStore implements LockProvider
     }
 
     /**
-     * Store an item in the cache for a given number of minutes.
+     * Store an item in the cache for a given number of seconds.
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function put($key, $value, $minutes)
+    public function put($key, $value, $seconds)
     {
         return $this->memcached->set(
-            $this->prefix.$key, $value, $this->calculateExpiration($minutes)
+            $this->prefix.$key, $value, $this->calculateExpiration($seconds)
         );
     }
 
     /**
-     * Store multiple items in the cache for a given number of minutes.
+     * Store multiple items in the cache for a given number of seconds.
      *
      * @param  array  $values
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function putMany(array $values, $minutes)
+    public function putMany(array $values, $seconds)
     {
         $prefixedValues = [];
 
@@ -123,7 +123,7 @@ class MemcachedStore extends TaggableStore implements LockProvider
         }
 
         return $this->memcached->setMulti(
-            $prefixedValues, $this->calculateExpiration($minutes)
+            $prefixedValues, $this->calculateExpiration($seconds)
         );
     }
 
@@ -132,13 +132,13 @@ class MemcachedStore extends TaggableStore implements LockProvider
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function add($key, $value, $minutes)
+    public function add($key, $value, $seconds)
     {
         return $this->memcached->add(
-            $this->prefix.$key, $value, $this->calculateExpiration($minutes)
+            $this->prefix.$key, $value, $this->calculateExpiration($seconds)
         );
     }
 
@@ -227,23 +227,23 @@ class MemcachedStore extends TaggableStore implements LockProvider
     /**
      * Get the expiration time of the key.
      *
-     * @param  int  $minutes
+     * @param  int  $seconds
      * @return int
      */
-    protected function calculateExpiration($minutes)
+    protected function calculateExpiration($seconds)
     {
-        return $this->toTimestamp($minutes);
+        return $this->toTimestamp($seconds);
     }
 
     /**
-     * Get the UNIX timestamp for the given number of minutes.
+     * Get the UNIX timestamp for the given number of seconds.
      *
-     * @param  int  $minutes
+     * @param  int  $seconds
      * @return int
      */
-    protected function toTimestamp($minutes)
+    protected function toTimestamp($seconds)
     {
-        return $minutes > 0 ? $this->availableAt($minutes * 60) : 0;
+        return $seconds > 0 ? $this->availableAt($seconds) : 0;
     }
 
     /**

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -25,14 +25,14 @@ class NullStore extends TaggableStore
     }
 
     /**
-     * Store an item in the cache for a given number of minutes.
+     * Store an item in the cache for a given number of seconds.
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function put($key, $value, $minutes)
+    public function put($key, $value, $seconds)
     {
         return false;
     }

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -51,21 +51,21 @@ class RateLimiter
      * Increment the counter for a given key for a given decay time.
      *
      * @param  string  $key
-     * @param  float|int  $decayMinutes
+     * @param  int  $decaySeconds
      * @return int
      */
-    public function hit($key, $decayMinutes = 1)
+    public function hit($key, $decaySeconds = 60)
     {
         $this->cache->add(
-            $key.':timer', $this->availableAt($decayMinutes * 60), $decayMinutes
+            $key.':timer', $this->availableAt($decaySeconds), $decaySeconds
         );
 
-        $added = $this->cache->add($key, 0, $decayMinutes);
+        $added = $this->cache->add($key, 0, $decaySeconds);
 
         $hits = (int) $this->cache->increment($key);
 
         if (! $added && $hits == 1) {
-            $this->cache->put($key, 1, $decayMinutes);
+            $this->cache->put($key, 1, $decaySeconds);
         }
 
         return $hits;

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -80,35 +80,35 @@ class RedisStore extends TaggableStore implements LockProvider
     }
 
     /**
-     * Store an item in the cache for a given number of minutes.
+     * Store an item in the cache for a given number of seconds.
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function put($key, $value, $minutes)
+    public function put($key, $value, $seconds)
     {
         return (bool) $this->connection()->setex(
-            $this->prefix.$key, (int) max(1, $minutes * 60), $this->serialize($value)
+            $this->prefix.$key, (int) max(1, $seconds), $this->serialize($value)
         );
     }
 
     /**
-     * Store multiple items in the cache for a given number of minutes.
+     * Store multiple items in the cache for a given number of seconds.
      *
      * @param  array  $values
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function putMany(array $values, $minutes)
+    public function putMany(array $values, $seconds)
     {
         $this->connection()->multi();
 
         $manyResult = null;
 
         foreach ($values as $key => $value) {
-            $result = $this->put($key, $value, $minutes);
+            $result = $this->put($key, $value, $seconds);
 
             $manyResult = is_null($manyResult) ? $result : $result && $manyResult;
         }
@@ -123,15 +123,15 @@ class RedisStore extends TaggableStore implements LockProvider
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function add($key, $value, $minutes)
+    public function add($key, $value, $seconds)
     {
         $lua = "return redis.call('exists',KEYS[1])<1 and redis.call('setex',KEYS[1],ARGV[2],ARGV[1])";
 
         return (bool) $this->connection()->eval(
-            $lua, 1, $this->prefix.$key, $this->serialize($value), (int) max(1, $minutes * 60)
+            $lua, 1, $this->prefix.$key, $this->serialize($value), $seconds
         );
     }
 

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -22,18 +22,18 @@ class RedisTaggedCache extends TaggedCache
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTimeInterface|\DateInterval|float|int|null  $minutes
+     * @param  \DateTimeInterface|\DateInterval|int|null  $seconds
      * @return bool
      */
-    public function put($key, $value, $minutes = null)
+    public function put($key, $value, $seconds = null)
     {
-        if ($minutes === null) {
+        if ($seconds === null) {
             return $this->forever($key, $value);
         }
 
         $this->pushStandardKeys($this->tags->getNamespace(), $key);
 
-        return parent::put($key, $value, $minutes);
+        return parent::put($key, $value, $seconds);
     }
 
     /**

--- a/src/Illuminate/Cache/RetrievesMultipleKeys.php
+++ b/src/Illuminate/Cache/RetrievesMultipleKeys.php
@@ -24,18 +24,18 @@ trait RetrievesMultipleKeys
     }
 
     /**
-     * Store multiple items in the cache for a given number of minutes.
+     * Store multiple items in the cache for a given number of seconds.
      *
      * @param  array  $values
-     * @param  float|int  $minutes
+     * @param  int  $seconds
      * @return bool
      */
-    public function putMany(array $values, $minutes)
+    public function putMany(array $values, $seconds)
     {
         $manyResult = null;
 
         foreach ($values as $key => $value) {
-            $result = $this->put($key, $value, $minutes);
+            $result = $this->put($key, $value, $seconds);
 
             $manyResult = is_null($manyResult) ? $result : $result && $manyResult;
         }

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -32,19 +32,19 @@ class TaggedCache extends Repository
     }
 
     /**
-     * Store multiple items in the cache for a given number of minutes.
+     * Store multiple items in the cache for a given number of seconds.
      *
      * @param  array  $values
-     * @param  float|int|null  $minutes
+     * @param  int|null  $seconds
      * @return bool
      */
-    public function putMany(array $values, $minutes = null)
+    public function putMany(array $values, $seconds = null)
     {
-        if ($minutes === null) {
+        if ($seconds === null) {
             return $this->putManyForever($values);
         }
 
-        return $this->putManyAlias($values, $minutes);
+        return $this->putManyAlias($values, $seconds);
     }
 
     /**

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -21,20 +21,20 @@ interface Repository extends CacheInterface
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTimeInterface|\DateInterval|float|int|null  $minutes
+     * @param  \DateTimeInterface|\DateInterval|int|null  $seconds
      * @return bool
      */
-    public function put($key, $value, $minutes);
+    public function put($key, $value, $seconds);
 
     /**
      * Store an item in the cache if the key does not exist.
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTimeInterface|\DateInterval|float|int|null  $minutes
+     * @param  \DateTimeInterface|\DateInterval|int|null  $seconds
      * @return bool
      */
-    public function add($key, $value, $minutes = null);
+    public function add($key, $value, $seconds = null);
 
     /**
      * Increment the value of an item in the cache.
@@ -67,11 +67,11 @@ interface Repository extends CacheInterface
      * Get an item from the cache, or execute the given Closure and store the result.
      *
      * @param  string  $key
-     * @param  \DateTimeInterface|\DateInterval|float|int|null  $minutes
+     * @param  \DateTimeInterface|\DateInterval|int|null  $seconds
      * @param  \Closure  $callback
      * @return mixed
      */
-    public function remember($key, $minutes, Closure $callback);
+    public function remember($key, $seconds, Closure $callback);
 
     /**
      * Get an item from the cache, or execute the given Closure and store the result forever.

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -47,7 +47,7 @@ class CacheApcStoreTest extends TestCase
             ->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60))
             ->willReturn(true);
         $store = new ApcStore($apc);
-        $result = $store->put('foo', 'bar', 1);
+        $result = $store->put('foo', 'bar', 60);
         $this->assertTrue($result);
     }
 
@@ -66,7 +66,7 @@ class CacheApcStoreTest extends TestCase
             'foo'   => 'bar',
             'baz'   => 'qux',
             'bar'   => 'norf',
-        ], 1);
+        ], 60);
         $this->assertTrue($result);
     }
 

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -40,7 +40,7 @@ class CacheArrayStoreTest extends TestCase
         $store = new ArrayStore;
 
         $store->put('foo', 'bar', 10);
-        Carbon::setTestNow(Carbon::now()->addMinutes(10)->addSecond());
+        Carbon::setTestNow(Carbon::now()->addSeconds(10)->addSecond());
         $result = $store->get('foo');
 
         $this->assertNull($result);

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -71,7 +71,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store->expects($this->once())->method('getTime')->will($this->returnValue(1));
         $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61])->andReturnTrue();
 
-        $result = $store->put('foo', 'bar', 1);
+        $result = $store->put('foo', 'bar', 60);
         $this->assertTrue($result);
     }
 
@@ -87,7 +87,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('update')->once()->with(['value' => serialize('bar'), 'expiration' => 61])->andReturnTrue();
 
-        $result = $store->put('foo', 'bar', 1);
+        $result = $store->put('foo', 'bar', 60);
         $this->assertTrue($result);
     }
 
@@ -99,7 +99,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store->expects($this->once())->method('getTime')->will($this->returnValue(1));
         $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => base64_encode(serialize("\0")), 'expiration' => 61])->andReturnTrue();
 
-        $result = $store->put('foo', "\0", 1);
+        $result = $store->put('foo', "\0", 60);
         $this->assertTrue($result);
     }
 

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -81,10 +81,10 @@ class CacheEventsTest extends TestCase
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
 
-        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'minutes' => 99]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => 99]));
         $repository->put('foo', 'bar', 99);
 
-        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'minutes' => 99, 'tags' => ['taylor']]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => 99, 'tags' => ['taylor']]));
         $repository->tags('taylor')->put('foo', 'bar', 99);
     }
 
@@ -94,11 +94,11 @@ class CacheEventsTest extends TestCase
         $repository = $this->getRepository($dispatcher);
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo']));
-        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'minutes' => 99]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => 99]));
         $this->assertTrue($repository->add('foo', 'bar', 99));
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo', 'tags' => ['taylor']]));
-        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'minutes' => 99, 'tags' => ['taylor']]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => 99, 'tags' => ['taylor']]));
         $this->assertTrue($repository->tags('taylor')->add('foo', 'bar', 99));
     }
 
@@ -107,10 +107,10 @@ class CacheEventsTest extends TestCase
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
 
-        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'minutes' => null]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => null]));
         $repository->forever('foo', 'bar');
 
-        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'minutes' => null, 'tags' => ['taylor']]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => null, 'tags' => ['taylor']]));
         $repository->tags('taylor')->forever('foo', 'bar');
     }
 
@@ -120,13 +120,13 @@ class CacheEventsTest extends TestCase
         $repository = $this->getRepository($dispatcher);
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo']));
-        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'minutes' => 99]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => 99]));
         $this->assertEquals('bar', $repository->remember('foo', 99, function () {
             return 'bar';
         }));
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo', 'tags' => ['taylor']]));
-        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'minutes' => 99, 'tags' => ['taylor']]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => 99, 'tags' => ['taylor']]));
         $this->assertEquals('bar', $repository->tags('taylor')->remember('foo', 99, function () {
             return 'bar';
         }));
@@ -138,13 +138,13 @@ class CacheEventsTest extends TestCase
         $repository = $this->getRepository($dispatcher);
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo']));
-        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'minutes' => null]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => null]));
         $this->assertEquals('bar', $repository->rememberForever('foo', function () {
             return 'bar';
         }));
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo', 'tags' => ['taylor']]));
-        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'minutes' => null, 'tags' => ['taylor']]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => null, 'tags' => ['taylor']]));
         $this->assertEquals('bar', $repository->tags('taylor')->rememberForever('foo', function () {
             return 'bar';
         }));

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -69,7 +69,7 @@ class CacheMemcachedStoreTest extends TestCase
         $memcache = $this->getMockBuilder(Memcached::class)->setMethods(['set'])->getMock();
         $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo($now->timestamp + 60))->willReturn(true);
         $store = new MemcachedStore($memcache);
-        $result = $store->put('foo', 'bar', 1);
+        $result = $store->put('foo', 'bar', 60);
         $this->assertTrue($result);
         Carbon::setTestNow();
     }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -62,7 +62,7 @@ class CacheRedisStoreTest extends TestCase
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
-        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60 * 60, serialize('foo'))->andReturn('OK');
+        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60, serialize('foo'))->andReturn('OK');
         $result = $redis->put('foo', 'foo', 60);
         $this->assertTrue($result);
     }
@@ -74,9 +74,9 @@ class CacheRedisStoreTest extends TestCase
         $connection = $redis->getRedis();
         $connection->shouldReceive('connection')->with('default')->andReturn($redis->getRedis());
         $connection->shouldReceive('multi')->once();
-        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60 * 60, serialize('bar'))->andReturn('OK');
-        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:baz', 60 * 60, serialize('qux'))->andReturn('OK');
-        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:bar', 60 * 60, serialize('norf'))->andReturn('OK');
+        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60, serialize('bar'))->andReturn('OK');
+        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:baz', 60, serialize('qux'))->andReturn('OK');
+        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:bar', 60, serialize('norf'))->andReturn('OK');
         $connection->shouldReceive('exec')->once();
 
         $result = $redis->putMany([
@@ -91,7 +91,7 @@ class CacheRedisStoreTest extends TestCase
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
-        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60 * 60, 1);
+        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60, 1);
         $result = $redis->put('foo', 1, 60);
         $this->assertFalse($result);
     }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -98,8 +98,8 @@ class CacheRepositoryTest extends TestCase
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->times(2)->andReturn(null);
-        $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 602 / 60);
-        $repo->getStore()->shouldReceive('put')->once()->with('baz', 'qux', 598 / 60);
+        $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 602);
+        $repo->getStore()->shouldReceive('put')->once()->with('baz', 'qux', 598);
         $result = $repo->remember('foo', Carbon::now()->addMinutes(10)->addSeconds(2), function () {
             return 'bar';
         });
@@ -198,7 +198,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function dataProviderTestGetMinutes()
+    public function dataProviderTestGetSeconds()
     {
         Carbon::setTestNow(Carbon::parse($this->getTestDate()));
 
@@ -207,20 +207,20 @@ class CacheRepositoryTest extends TestCase
             [(new DateTime($this->getTestDate()))->modify('+5 minutes')],
             [(new DateTimeImmutable($this->getTestDate()))->modify('+5 minutes')],
             [new DateInterval('PT5M')],
-            [5],
+            [300],
         ];
     }
 
     /**
-     * @dataProvider dataProviderTestGetMinutes
+     * @dataProvider dataProviderTestGetSeconds
      * @param mixed $duration
      */
-    public function testGetMinutes($duration)
+    public function testGetSeconds($duration)
     {
         Carbon::setTestNow(Carbon::parse($this->getTestDate()));
 
         $repo = $this->getRepository();
-        $repo->getStore()->shouldReceive('put')->once()->with($key = 'foo', $value = 'bar', 5);
+        $repo->getStore()->shouldReceive('put')->once()->with($key = 'foo', $value = 'bar', 300);
         $repo->put($key, $value, $duration);
     }
 

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -34,8 +34,8 @@ class RedisCacheIntegrationTest extends TestCase
     {
         $store = new RedisStore($this->redis[$driver]);
         $repository = new Repository($store);
-        $this->assertTrue($repository->add('k', 'v', 60));
-        $this->assertFalse($repository->add('k', 'v', 60));
+        $this->assertTrue($repository->add('k', 'v', 3600));
+        $this->assertFalse($repository->add('k', 'v', 3600));
         $this->assertGreaterThan(3500, $this->redis[$driver]->connection()->ttl('k'));
     }
 


### PR DESCRIPTION
These changes will allow developers more finer granular caching. By allowing caching in seconds, developers can set even more specific caching times. 

```php
// This...
Cache::put('foo', 'bar', 60);

// Will change to this...
Cache::put('foo', 'bar', 3600);
```

This also makes the caching TTL conform with PSR-16 which states that:

> Implementing Libraries MUST support at minimum TTL functionality as described below with whole-second granularity.

https://www.php-fig.org/psr/psr-16/

This refactor also simplifies things by removing support for floats and only supporting integers since floats aren't necessary anymore. If you take a look at the refactored tests and internals you'll see that we now do much less calculations.

This will have quite an impact on any app implementing caching and should be indicated in the upgrade guide as a high impact change.