### PR TITLE
[5.7] Fix QueueableCollection serialization of Eloquent Models when using Binary IDs

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -6,7 +6,7 @@ use LogicException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Support\Collection as BaseCollection;
 
@@ -541,7 +541,7 @@ class Collection extends BaseCollection implements QueueableCollection
             return [];
         }
 
-        return $this->first() instanceof Pivot
+        return $this->first() instanceof QueueableEntity
                     ? $this->map->getQueueableId()->all()
                     : $this->modelKeys();
     }

--- a/tests/Database/DatabaseEloquentCollectionQueueableTest.php
+++ b/tests/Database/DatabaseEloquentCollectionQueueableTest.php
@@ -62,7 +62,7 @@ class DatabaseEloquentCollectionQueueableTest extends TestCase
 
         $this->assertTrue(
             json_encode($payload) !== false,
-            'EloquentCollection is not using the QueueableEntity::queueableId() method.'
+            'EloquentCollection is not using the QueueableEntity::getQueueableId() method.'
         );
     }
 }

--- a/tests/Database/DatabaseEloquentCollectionQueueableTest.php
+++ b/tests/Database/DatabaseEloquentCollectionQueueableTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class DatabaseEloquentCollectionQueueableTest extends TestCase
+{
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+
+    public function testSerializesPivotsEntitiesId()
+    {
+        $spy = Mockery::spy(Pivot::class);
+
+        $c = new Collection([$spy]);
+
+        $c->getQueueableIds();
+
+        $spy->shouldHaveReceived()
+            ->getQueueableId()
+            ->once();
+    }
+
+    public function testSerializesModelEntitiesById()
+    {
+        $spy = Mockery::spy(Model::class);
+
+        $c = new Collection([$spy]);
+
+        $c->getQueueableIds();
+
+        $spy->shouldHaveReceived()
+            ->getQueueableId()
+            ->once();
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testJsonSerializationOfCollectionQueueableIdsWorks()
+    {
+        // When the ID of a Model is binary instead of int or string, the Collection
+        // serialization + JSON encoding breaks because of UTF-8 issues. Encoding
+        // of a QueueableCollection must favor QueueableEntity::queueableId().
+        $mock = Mockery::mock(Model::class, [
+            'getKey' => random_bytes(10),
+            'getQueueableId' => 'mocked',
+        ]);
+
+        $c = new Collection([$mock]);
+
+        $payload = [
+            'ids' => $c->getQueueableIds(),
+        ];
+
+        $this->assertTrue(
+            json_encode($payload) !== false,
+            'EloquentCollection is not using the QueueableEntity::queueableId() method.'
+        );
+    }
+}


### PR DESCRIPTION
Found this issue during development where we have a model that uses binary UUIDs. While the single model serialization works fine, the collection serialization + JSON encoding breaks (UTF-8 issues).

Added a test demonstrating the problem we faced (the `testJsonSerializationOfCollectionQueueableIdsWorks` one) and some other testing that still works for Pivot Models as well as Eloquent Models.