### PR TITLE
[5.7] Ensure the original paginator options are stored.

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -73,6 +73,13 @@ abstract class AbstractPaginator implements Htmlable
     public $onEachSide = 3;
 
     /**
+     * The paginator options.
+     *
+     * @var array
+     */
+    protected $options;
+
+    /**
      * The current path resolver callback.
      *
      * @var \Closure
@@ -561,6 +568,16 @@ abstract class AbstractPaginator implements Htmlable
         $this->items = $collection;
 
         return $this;
+    }
+
+    /**
+     * Get the paginator options.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
     }
 
     /**

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -40,6 +40,8 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      */
     public function __construct($items, $total, $perPage, $currentPage = null, array $options = [])
     {
+        $this->options = $options;
+
         foreach ($options as $key => $value) {
             $this->{$key} = $value;
         }

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -32,6 +32,8 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      */
     public function __construct($items, $perPage, $currentPage = null, array $options = [])
     {
+        $this->options = $options;
+
         foreach ($options as $key => $value) {
             $this->{$key} = $value;
         }

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -8,13 +8,19 @@ use Illuminate\Pagination\LengthAwarePaginator;
 class LengthAwarePaginatorTest extends TestCase
 {
     /**
-     * @var LengthAwarePaginator
+     * @var \Illuminate\Pagination\LengthAwarePaginator
      */
     private $p;
 
+    /**
+     * @var array
+     */
+    private $options;
+
     public function setUp()
     {
-        $this->p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
+        $this->options = ['onEachSide' => 5];
+        $this->p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2, $this->options);
     }
 
     public function tearDown()
@@ -96,5 +102,10 @@ class LengthAwarePaginatorTest extends TestCase
 
         $this->assertEquals('http://website.com?key=value%20with%20spaces&foo=2',
                             $this->p->url($this->p->currentPage()));
+    }
+
+    public function testItRetrievesPaginatorOptions()
+    {
+        $this->assertSame($this->options, $this->p->getOptions());
     }
 }

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -104,7 +104,7 @@ class LengthAwarePaginatorTest extends TestCase
                             $this->p->url($this->p->currentPage()));
     }
 
-    public function testItRetrievesPaginatorOptions()
+    public function testItRetrievesThePaginatorOptions()
     {
         $this->assertSame($this->options, $this->p->getOptions());
     }

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -46,4 +46,12 @@ class PaginatorTest extends TestCase
 
         $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
     }
+
+    public function testItRetrievesPaginatorOptions()
+    {
+        $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
+            $options = ['path' => 'http://website.com/test']);
+
+        $this->assertSame($p->getOptions(), $options);
+    }
 }

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -47,7 +47,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
     }
 
-    public function testItRetrievesPaginatorOptions()
+    public function testItRetrievesThePaginatorOptions()
     {
         $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
             $options = ['path' => 'http://website.com/test']);


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In some situations, it is useful to have access to the original options passed to a paginator.
Eg. when you want to create an instance of your own custom paginator implementation from an instance of `\Illuminate\Pagination\AbstractPaginator`.

This PR provides this feature.