### PR TITLE
[5.8] Email notification view: pass subcopy as a slot

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -48,7 +48,7 @@
 
 {{-- Subcopy --}}
 @isset($actionText)
-@component('mail::subcopy')
+@slot('subcopy')
 @lang(
     "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
     'into your web browser: [:actionURL](:actionURL)',
@@ -57,6 +57,6 @@
         'actionURL' => $actionUrl,
     ]
 )
-@endcomponent
+@endslot
 @endisset
 @endcomponent


### PR DESCRIPTION
Both the `mail::message` and `mail::layout` default components contain unused code to support the email subcopy to be passed through as `$subcopy`. The email subcopy is instead passed through, along with the rest of the email body, via the `$slot` in `mail::layout`. This is not how I believe it was intended to function due to the existence of the `$subcopy` variables in `mail::message` and `mail::layout`.

This pull request fixes the issue by passing the email subcopy as a slot to the `mail::message` component to fill the already existing `$subcopy` there, which then passes the subcopy component as a slot to the `mail::layout` view for final insertion as `$subcopy` instead of using the email body's `$slot`. The benefit of this is that the email subcopy is now decoupled from the email body and does not have to immediately follow it in customized versions of `mail::layout` to be inserted correctly.

Since this could be a potentially breaking change in the case of the `$subcopy` variables being removed in custom versions of `mail::message` and `mail::layout` due to it not being used, it is being submitted to the master branch.

See [message.blade.php](https://github.com/laravel/framework/blob/master/src/Illuminate/Mail/resources/views/html/message.blade.php) as `mail::message` and [layout.blade.php](https://github.com/laravel/framework/blob/master/src/Illuminate/Mail/resources/views/html/layout.blade.php) as `mail::layout`.
