### PR TITLE
[5.7] Revert and fix #26158

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -544,7 +544,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function incrementOrDecrement($column, $amount, $extra, $method)
     {
-        $query = $this->newModelQuery();
+        $query = $this->newQueryWithoutRelationships();
 
         if (! $this->exists) {
             return $query->{$method}($column, $amount, $extra);

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -821,7 +821,7 @@ class BelongsToMany extends Relation
         // the related model's timestamps, to make sure these all reflect the changes
         // to the parent models. This will help us keep any caching synced up here.
         if (count($ids = $this->allRelatedIds()) > 0) {
-            $this->getRelated()->newModelQuery()->whereIn($key, $ids)->update($columns);
+            $this->getRelated()->newQueryWithoutRelationships()->whereIn($key, $ids)->update($columns);
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -124,7 +124,7 @@ trait AsPivot
      */
     protected function getDeleteQuery()
     {
-        return $this->newModelQuery()->where([
+        return $this->newQueryWithoutRelationships()->where([
             $this->foreignKey => $this->getOriginal($this->foreignKey, $this->getAttribute($this->foreignKey)),
             $this->relatedKey => $this->getOriginal($this->relatedKey, $this->getAttribute($this->relatedKey)),
         ]);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1446,13 +1446,13 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testIncrementOnExistingModelCallsQueryAndSetsAttribute()
     {
-        $model = m::mock(EloquentModelStub::class.'[newModelQuery]');
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutRelationships]');
         $model->exists = true;
         $model->id = 1;
         $model->syncOriginalAttribute('id');
         $model->foo = 2;
 
-        $model->shouldReceive('newModelQuery')->andReturn($query = m::mock(stdClass::class));
+        $model->shouldReceive('newQueryWithoutRelationships')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->andReturn($query);
         $query->shouldReceive('increment');
 

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -110,14 +110,14 @@ class DatabaseEloquentPivotTest extends TestCase
 
     public function testDeleteMethodDeletesModelByKeys()
     {
-        $pivot = $this->getMockBuilder(Pivot::class)->setMethods(['newModelQuery'])->getMock();
+        $pivot = $this->getMockBuilder(Pivot::class)->setMethods(['newQueryWithoutRelationships'])->getMock();
         $pivot->setPivotKeys('foreign', 'other');
         $pivot->foreign = 'foreign.value';
         $pivot->other = 'other.value';
         $query = m::mock(stdClass::class);
         $query->shouldReceive('where')->once()->with(['foreign' => 'foreign.value', 'other' => 'other.value'])->andReturn($query);
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $pivot->expects($this->once())->method('newModelQuery')->will($this->returnValue($query));
+        $pivot->expects($this->once())->method('newQueryWithoutRelationships')->will($this->returnValue($query));
 
         $this->assertTrue($pivot->delete());
     }

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -42,6 +42,13 @@ class EloquentUpdateTest extends TestCase
             $table->softDeletes();
             $table->timestamps();
         });
+
+        Schema::create('test_model3', function ($table) {
+            $table->increments('id');
+            $table->unsignedInteger('counter');
+            $table->softDeletes();
+            $table->timestamps();
+        });
     }
 
     public function testBasicUpdate()
@@ -107,6 +114,23 @@ class EloquentUpdateTest extends TestCase
 
         $this->assertCount(0, TestUpdateModel2::all());
     }
+
+    public function testIncrement()
+    {
+        TestUpdateModel3::create([
+            'counter' => 0,
+        ]);
+
+        TestUpdateModel3::create([
+            'counter' => 0,
+        ])->delete();
+
+        TestUpdateModel3::increment('counter');
+
+        $models = TestUpdateModel3::withoutGlobalScopes()->get();
+        $this->assertEquals(1, $models[0]->counter);
+        $this->assertEquals(0, $models[1]->counter);
+    }
 }
 
 class TestUpdateModel1 extends Model
@@ -122,5 +146,14 @@ class TestUpdateModel2 extends Model
 
     public $table = 'test_model2';
     protected $fillable = ['name'];
+    protected $dates = ['deleted_at'];
+}
+
+class TestUpdateModel3 extends Model
+{
+    use SoftDeletes;
+
+    public $table = 'test_model3';
+    protected $fillable = ['counter'];
     protected $dates = ['deleted_at'];
 }


### PR DESCRIPTION
#26158 replaced `newQuery()` with `newModelQuery()` in UPDATE/DELETE queries to remove the unnecessary `$with` and `$withCount` relationships.

That's obviously incorrect, as it also removes global scopes. We have to use `newQueryWithoutRelationships()` instead of `newModelQuery()`.

I added an integration test to prevent this from happening again.

Fixes #27266.