### PR TITLE
[5.8] Use config for verification expire time

### DIFF
--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -59,7 +59,7 @@ class VerifyEmail extends Notification
     protected function verificationUrl($notifiable)
     {
         return URL::temporarySignedRoute(
-            'verification.verify', Carbon::now()->addMinutes(60), ['id' => $notifiable->getKey()]
+            'verification.verify', Carbon::now()->addMinutes(config('auth.verification.expire', 60)), ['id' => $notifiable->getKey()]
         );
     }
 


### PR DESCRIPTION
The expire time for the verification email can now be read from the auth config. It still defaults to 60 minutes so it wont break anything.
