### PR TITLE
[5.7] Remove type hint against UrlGenerator

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -30,7 +30,7 @@ class Redirector
      * @param  \Illuminate\Routing\UrlGenerator  $generator
      * @return void
      */
-    public function __construct(UrlGenerator $generator)
+    public function __construct($generator)
     {
         $this->generator = $generator;
     }


### PR DESCRIPTION
This follows `\Illuminate\Routing\RouteUrlGenerator::__construct()`. By dropping the type hint, the `'url'` service may be overridden by the app to use an app-specific `UrlGenerator`.

At present, if a custom `UrlGenerator` is used in place of `'url'`, implementing `Illuminate\Contracts\Routing\UrlGenerator`, instantiating the `Redirector` class will fail as the type hint requires Laravel's `UrlGenerator`.

Example (currently failing):

```php
$this->app->extend('url', function ($generator) {
    return new \App\Routing\LocaleUrlGeneratorDecorator($generator);
});
```

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
