### PR TITLE
[5.7] Add orWhere proxy for scopes to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent;
 
 use Closure;
+use Exception;
 use BadMethodCallException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -10,10 +11,12 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Database\Concerns\BuildsQueries;
+use Illuminate\Support\HigherOrderBuilderProxy;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
 /**
+ * @property-read HigherOrderBuilderProxy $orWhere
  * @mixin \Illuminate\Database\Query\Builder
  */
 class Builder
@@ -1359,5 +1362,22 @@ class Builder
     public function __clone()
     {
         $this->query = clone $this->query;
+    }
+
+    /**
+     * Dynamically access builder proxies.
+     *
+     * @param  string  $key
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    public function __get($key)
+    {
+        if ($key === 'orWhere') {
+            return new HigherOrderBuilderProxy($this, $key);
+        }
+
+        throw new Exception("Property [{$key}] does not exist on this builder instance.");
     }
 }

--- a/src/Illuminate/Support/HigherOrderBuilderProxy.php
+++ b/src/Illuminate/Support/HigherOrderBuilderProxy.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * @mixin \Illuminate\Database\Eloquent\Builder
+ */
+class HigherOrderBuilderProxy
+{
+    /**
+     * The collection being operated on.
+     *
+     * @var \Illuminate\Database\Eloquent\Builder
+     */
+    protected $builder;
+
+    /**
+     * The method being proxied.
+     *
+     * @var string
+     */
+    protected $method;
+
+    /**
+     * Create a new proxy instance.
+     *
+     * @param Builder $builder
+     * @param string $method
+     */
+    public function __construct(Builder $builder, $method)
+    {
+        $this->method = $method;
+        $this->builder = $builder;
+    }
+
+    /**
+     * Proxy a scope call onto the query builder.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->builder->{$this->method}(function ($value) use ($method, $parameters) {
+            return $value->{$method}(...$parameters);
+        });
+    }
+}

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -628,6 +628,22 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['bar', 9000], $query->getBindings());
     }
 
+    public function testRealQueryHigherOrderOrWhereScopes()
+    {
+        $model = new EloquentBuilderTestHigherOrderWhereScopeStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+        $query = $model->newQuery()->one()->orWhere->two();
+        $this->assertEquals('select * from "table" where "one" = ? or ("two" = ?)', $query->toSql());
+    }
+
+    public function testRealQueryChainedHigherOrderOrWhereScopes()
+    {
+        $model = new EloquentBuilderTestHigherOrderWhereScopeStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+        $query = $model->newQuery()->one()->orWhere->two()->orWhere->three();
+        $this->assertEquals('select * from "table" where "one" = ? or ("two" = ?) or ("three" = ?)', $query->toSql());
+    }
+
     public function testSimpleWhere()
     {
         $builder = $this->getBuilder();
@@ -1102,6 +1118,26 @@ class EloquentBuilderTestScopeStub extends Model
     public function scopeApproved($query)
     {
         $query->where('foo', 'bar');
+    }
+}
+
+class EloquentBuilderTestHigherOrderWhereScopeStub extends Model
+{
+    protected $table = 'table';
+
+    public function scopeOne($query)
+    {
+        $query->where('one', 'foo');
+    }
+
+    public function scopeTwo($query)
+    {
+        $query->where('two', 'bar');
+    }
+
+    public function scopeThree($query)
+    {
+        $query->where('three', 'baz');
     }
 }
 


### PR DESCRIPTION
## Overview
This PR adds a shorter way of combining Model query scopes using the same technique applied in Laravel's Collections. Currently, combining model scopes with an `OR` operator adds more complexity in than necessary.

```php
// scopeFoo, scopeBar, scopeBaz on the Model class 
$query->foo()->orWhere(function (Builder $query) {
    $query->bar();
})->orWhere(function (Builder $query) {
    $query->baz();
});
```

This PR allows chaining of `OR`'s without the Closure in user code, like so.
```php
$query->foo()->orWhere->bar()->orWhere->baz();
```

It follows the same logic as combining regular `where` and `orWhere`. The following code examples are thus considered equivalent.

```php
// scopeFoo, scopeBar, scopeBaz on the Model class 
$query->foo()->orWhere(function (Builder $query) {
    $query->bar();
})->baz();
```

```php
$query->foo()->orWhere->bar()->baz();
```

## Considerations
1. This PR does not break any existing functionality as far as I know.

2. I have considered another approach to achieve the same simplicity. It would add the possibility to call query scopes prepended with `or`, like so. But to my knowledge, this seemed more confusing than the proposed change.

```php
$query->foo()->orBar()->orBaz();
```