### PR TITLE
[5.7] Check if relation is null before calling `touch()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -616,7 +616,12 @@ trait HasRelationships
     public function touchOwners()
     {
         foreach ($this->touches as $relation) {
-            $this->$relation()->touch();
+            $relation = $this->$relation();
+
+            if (!$relation)
+                continue;
+
+            $relation->touch();
 
             if ($this->$relation instanceof self) {
                 $this->$relation->fireModelEvent('saved', false);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -618,7 +618,7 @@ trait HasRelationships
         foreach ($this->touches as $relation) {
             $relation = $this->$relation();
 
-            if (!$relation) {
+            if (! $relation) {
                 continue;
             }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -618,8 +618,9 @@ trait HasRelationships
         foreach ($this->touches as $relation) {
             $relation = $this->$relation();
 
-            if (!$relation)
+            if (!$relation) {
                 continue;
+            }
 
             $relation->touch();
 


### PR DESCRIPTION
This PR is related to #2638 

If I want to have a child model touch a grandparent when updated, I can do so by creating a relationship on the child like so:

```php
public function grandparent()
{
    return $this->parent->grandparent();
}
```

and adding `'grandparent'` to the `$touches` array of child.

However, if the parent is optional (let's say we have orphans), an exception will be thrown when `$this->parent` is null.

To fix this, we could say

```php
public function grandparent()
{
    return $this->parent ? $this->parent->grandparent() : null;
}
```

But now, `touchOwners` may throw an exception, because the relation might be `null`. This PR adds a `null` check to solve this problem.