### PR TITLE
[5.7] Remove unused bootstrap class

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/vue-stubs/ExampleComponent.vue
+++ b/src/Illuminate/Foundation/Console/Presets/vue-stubs/ExampleComponent.vue
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="row justify-content-center">
             <div class="col-md-8">
-                <div class="card card-default">
+                <div class="card">
                     <div class="card-header">Example Component</div>
 
                     <div class="card-body">


### PR DESCRIPTION
This class isn't available in Bootstrap 4.