### PR TITLE
[5.7] Add file method to ResponseFactory contract

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -90,6 +90,15 @@ interface ResponseFactory
     public function download($file, $name = null, array $headers = [], $disposition = 'attachment');
 
     /**
+     * Return the raw contents of a binary file.
+     *
+     * @param  \SplFileInfo|string  $file
+     * @param  array  $headers
+     * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+     */
+    public function file($file, array $headers = []);
+
+    /**
      * Create a new redirect response to the given path.
      *
      * @param  string  $path


### PR DESCRIPTION
The official documentation contains the file method, however the contract does not contain this.
https://laravel.com/docs/5.7/responses#other-response-types
