### PR TITLE
[5.7] Updated Illuminate\Mail\Mailer queue method docblock

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -368,7 +368,7 @@ class Mailer implements MailerContract, MailQueueContract
     /**
      * Queue a new e-mail message for sending.
      *
-     * @param  string|array|\Illuminate\Contracts\Mail\Mailable  $view
+     * @param  \Illuminate\Contracts\Mail\Mailable  $view
      * @param  string|null  $queue
      * @return mixed
      *


### PR DESCRIPTION
`$view` should only, really, be a `Mailable`. Caused a little confusion when using PHPStorm which read the DocBock and told me `$view` could be things that it wasn't.