### PR TITLE
[5.7] fix gate tests

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -26,7 +26,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->check('bar'));
     }
 
-    public function test_before_can_take_an_array_callback()
+    public function test_before_can_take_an_array_callback_as_object()
     {
         $gate = new Gate(new Container, function () {
             return null;
@@ -37,13 +37,24 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('anything'));
     }
 
+    public function test_before_can_take_an_array_callback_as_object_static()
+    {
+        $gate = new Gate(new Container, function () {
+            return null;
+        });
+
+        $gate->before([new AccessGateTestBeforeCallback, 'allowEverythingStatically']);
+
+        $this->assertTrue($gate->check('anything'));
+    }
+
     public function test_before_can_take_an_array_callback_with_static_method()
     {
         $gate = new Gate(new Container, function () {
             return null;
         });
 
-        $gate->before([AccessGateTestBeforeCallback::class, 'allowEverything']);
+        $gate->before([AccessGateTestBeforeCallback::class, 'allowEverythingStatically']);
 
         $this->assertTrue($gate->check('anything'));
     }
@@ -851,7 +862,7 @@ class AccessGateTestPolicyWithNonGuestBefore
 
 class AccessGateTestBeforeCallback
 {
-    public static function allowEverything($user = null)
+    public function allowEverything($user = null)
     {
         return true;
     }


### PR DESCRIPTION
looking at the tests I found that the `public static allowEverythingStatically` was used nowhere and it had the exact same signature as it's sibling method  `public static allowEverything` . (they were both static)
It was suspicious for me.

Obviously the test tries to check against both an static and a non-static method on a stub class but it didn't. It was only testing against static method call.

Now it is covering all the possible cases. and the unused method is in action.

1 -  $gate->before([object,  'method'])             (newly added)
2 -  $gate->before(['class',  'static_method'])   (as was tested before)
3 -  $gate->before([object,  'static_method'])  (as was tested before)