### PR TITLE
[5.7] Test correct $user is passed to gates

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -658,25 +658,25 @@ class AuthAccessGateTest extends TestCase
 
 class AccessGateTestStaticClass
 {
-    public static function foo()
+    public static function foo($user)
     {
-        return true;
+        return $user->id === 1;
     }
 }
 
 class AccessGateTestClass
 {
-    public function foo()
+    public function foo($user)
     {
-        return true;
+        return $user->id === 1;
     }
 }
 
 class AccessGateTestInvokableClass
 {
-    public function __invoke()
+    public function __invoke($user)
     {
-        return true;
+        return $user->id === 1;
     }
 }
 


### PR DESCRIPTION
This straightens the tests, by making sure that the correct user variable is passed to the gates.
If the gate forgets to pass the user variable to the methods something should, warn us.
Currently everything just passes.