### PR TITLE
[5.7] Implement title casing

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -90,6 +90,18 @@ abstract class GeneratorCommand extends Command
         if (Str::startsWith($name, $rootNamespace)) {
             return $name;
         }
+        
+        if (strtolower($name) === $name) {
+            $segments = preg_split('/\\\\/', $name);
+            $name = '';
+            
+            foreach ($segments as $bit) {
+                $name .= title_case($bit);
+                $name .= '\\';
+            }
+
+            $name = substr($name, 0, -1);
+        }
 
         $name = str_replace('/', '\\', $name);
 

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -90,11 +90,11 @@ abstract class GeneratorCommand extends Command
         if (Str::startsWith($name, $rootNamespace)) {
             return $name;
         }
-        
+
         if (strtolower($name) === $name) {
             $segments = preg_split('/\\\\/', $name);
             $name = '';
-            
+
             foreach ($segments as $bit) {
                 $name .= title_case($bit);
                 $name .= '\\';


### PR DESCRIPTION
When passing a lowercase class into a console command it does not automatically titlecase the class. This resolves this issue.

##### Original behaviour examples:
```
php artisan make:factory ExampleFactory --model=namespace\\example
// > ExampleFactory
// > namespace\\example

php artisan make:factory ExampleFactory --model=example
// > ExampleFactory
// > example
```

##### New behaviour examples:
```
php artisan make:factory ExampleFactory --model=namespace\\example
// > ExampleFactory
// > Namespace\\Example

php artisan make:factory ExampleFactory --model=example
// > ExampleFactory
// > Example
```

🎉 

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
