### PR TITLE
[5.8 ] Adding support for class@method notation for guest friendly gates (re-submittion)

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -494,6 +494,7 @@ class Gate implements GateContract
 
         if (isset($this->atNotation[$ability])) {
             [$class, $method] = Str::parseCallback($this->atNotation[$ability]);
+            $method = $method ?: '__invoke';
             if ($this->canBeCalledWithUser($user, $class, $method)) {
                 return $this->abilities[$ability];
             }

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -58,6 +58,13 @@ class Gate implements GateContract
     protected $afterCallbacks = [];
 
     /**
+     * All of the defined abilities with class@method notation.
+     *
+     * @var array
+     */
+    protected $atNotation = [];
+
+    /**
      * Create a new gate instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
@@ -112,6 +119,7 @@ class Gate implements GateContract
         if (is_callable($callback)) {
             $this->abilities[$ability] = $callback;
         } elseif (is_string($callback)) {
+            $this->atNotation[$ability] = $callback;
             $this->abilities[$ability] = $this->buildAbilityCallback($ability, $callback);
         } else {
             throw new InvalidArgumentException("Callback must be a callable or a 'Class@method' string.");
@@ -482,6 +490,13 @@ class Gate implements GateContract
             ! is_null($policy = $this->getPolicyFor($arguments[0])) &&
             $callback = $this->resolvePolicyCallback($user, $ability, $arguments, $policy)) {
             return $callback;
+        }
+
+        if (isset($this->atNotation[$ability])) {
+            [$class, $method] = Str::parseCallback($this->atNotation[$ability]);
+            if ($this->canBeCalledWithUser($user, $class, $method)) {
+                return $this->abilities[$ability];
+            }
         }
 
         if (isset($this->abilities[$ability]) &&

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -662,32 +662,59 @@ class AuthAccessGateTest extends TestCase
         });
 
         $gate->define('foo', AccessGateTestClassForGuest::class.'@foo');
+        $gate->define('obj_foo', [new AccessGateTestClassForGuest, 'foo']);
+        $gate->define('static_foo', [AccessGateTestClassForGuest::class, 'staticFoo']);
+        $gate->define('static_@foo', AccessGateTestClassForGuest::class.'@staticFoo');
         $gate->define('bar', AccessGateTestClassForGuest::class.'@bar');
+        $gate->define('invokable', AccessGateTestGuestInvokableClass::class);
+        $gate->define('nullable_invokable', AccessGateTestGuestNullableInvokable::class);
+        $gate->define('absent_invokable', 'someAbsentClass');
 
         AccessGateTestClassForGuest::$calledMethod = '';
 
         $this->assertTrue($gate->check('foo'));
-        $this->assertEquals('foo', AccessGateTestClassForGuest::$calledMethod);
+        $this->assertEquals('foo was called', AccessGateTestClassForGuest::$calledMethod);
+
+        $this->assertTrue($gate->check('static_foo'));
+        $this->assertEquals('static foo was invoked', AccessGateTestClassForGuest::$calledMethod);
 
         $this->assertTrue($gate->check('bar'));
-        $this->assertEquals('bar', AccessGateTestClassForGuest::$calledMethod);
+        $this->assertEquals('bar got invoked', AccessGateTestClassForGuest::$calledMethod);
+
+        $this->assertTrue($gate->check('static_@foo'));
+        $this->assertEquals('static foo was invoked', AccessGateTestClassForGuest::$calledMethod);
+
+        $this->assertTrue($gate->check('invokable'));
+        $this->assertEquals('__invoke was called', AccessGateTestGuestInvokableClass::$calledMethod);
+
+        $this->assertTrue($gate->check('nullable_invokable'));
+        $this->assertEquals('Nullable __invoke was called', AccessGateTestGuestNullableInvokable::$calledMethod);
+
+        $this->assertFalse($gate->check('absent_invokable'));
     }
 }
 
 class AccessGateTestClassForGuest
 {
-    public static $calledMethod = '';
+    public static $calledMethod = null;
 
     public function foo($user = null)
     {
-        static::$calledMethod = 'foo';
+        static::$calledMethod = 'foo was called';
+
+        return true;
+    }
+
+    public static function staticFoo($user = null)
+    {
+        static::$calledMethod = 'static foo was invoked';
 
         return true;
     }
 
     public function bar(?stdClass $user)
     {
-        static::$calledMethod = 'bar';
+        static::$calledMethod = 'bar got invoked';
 
         return true;
     }
@@ -713,6 +740,30 @@ class AccessGateTestInvokableClass
 {
     public function __invoke()
     {
+        return true;
+    }
+}
+
+class AccessGateTestGuestInvokableClass
+{
+    public static $calledMethod = null;
+
+    public function __invoke($user = null)
+    {
+        static::$calledMethod = '__invoke was called';
+
+        return true;
+    }
+}
+
+class AccessGateTestGuestNullableInvokable
+{
+    public static $calledMethod = null;
+
+    public function __invoke(?StdClass $user)
+    {
+        static::$calledMethod = 'Nullable __invoke was called';
+
         return true;
     }
 }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -654,6 +654,43 @@ class AuthAccessGateTest extends TestCase
             [$noAbilities, [], true],
         ];
     }
+
+    public function test_classes_can_be_defined_as_callbacks_using_at_notation_for_guests()
+    {
+        $gate = new Gate(new Container, function () {
+            return null;
+        });
+
+        $gate->define('foo', AccessGateTestClassForGuest::class.'@foo');
+        $gate->define('bar', AccessGateTestClassForGuest::class.'@bar');
+
+        AccessGateTestClassForGuest::$calledMethod = '';
+
+        $this->assertTrue($gate->check('foo'));
+        $this->assertEquals('foo', AccessGateTestClassForGuest::$calledMethod);
+
+        $this->assertTrue($gate->check('bar'));
+        $this->assertEquals('bar', AccessGateTestClassForGuest::$calledMethod);
+    }
+}
+
+class AccessGateTestClassForGuest
+{
+    public static $calledMethod = '';
+
+    public function foo($user = null)
+    {
+        static::$calledMethod = 'foo';
+
+        return true;
+    }
+
+    public function bar(?stdClass $user)
+    {
+        static::$calledMethod = 'bar';
+
+        return true;
+    }
 }
 
 class AccessGateTestStaticClass


### PR DESCRIPTION
Following my unsuccessful PRs (https://github.com/laravel/framework/pull/27187 and https://github.com/laravel/framework/pull/27202) to fix a reported issue. (https://github.com/laravel/framework/issues/26221)


I Added support for invokable classes and a lot more tests to be really sure that it will work the way we want it.
If anything is still missing, I would be happy to know about and code for that. 