### PR TITLE
[5.8] Rename cache seconds to TTL

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -22,18 +22,18 @@ class RedisTaggedCache extends TaggedCache
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTimeInterface|\DateInterval|int|null  $seconds
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
-    public function put($key, $value, $seconds = null)
+    public function put($key, $value, $ttl = null)
     {
-        if ($seconds === null) {
+        if ($ttl === null) {
             return $this->forever($key, $value);
         }
 
         $this->pushStandardKeys($this->tags->getNamespace(), $key);
 
-        return parent::put($key, $value, $seconds);
+        return parent::put($key, $value, $ttl);
     }
 
     /**

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -35,16 +35,16 @@ class TaggedCache extends Repository
      * Store multiple items in the cache for a given number of seconds.
      *
      * @param  array  $values
-     * @param  int|null  $seconds
+     * @param  int|null  $ttl
      * @return bool
      */
-    public function putMany(array $values, $seconds = null)
+    public function putMany(array $values, $ttl = null)
     {
-        if ($seconds === null) {
+        if ($ttl === null) {
             return $this->putManyForever($values);
         }
 
-        return $this->putManyAlias($values, $seconds);
+        return $this->putManyAlias($values, $ttl);
     }
 
     /**

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -21,20 +21,20 @@ interface Repository extends CacheInterface
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTimeInterface|\DateInterval|int|null  $seconds
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
-    public function put($key, $value, $seconds = null);
+    public function put($key, $value, $ttl = null);
 
     /**
      * Store an item in the cache if the key does not exist.
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTimeInterface|\DateInterval|int|null  $seconds
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
-    public function add($key, $value, $seconds = null);
+    public function add($key, $value, $ttl = null);
 
     /**
      * Increment the value of an item in the cache.
@@ -67,11 +67,11 @@ interface Repository extends CacheInterface
      * Get an item from the cache, or execute the given Closure and store the result.
      *
      * @param  string  $key
-     * @param  \DateTimeInterface|\DateInterval|int|null  $seconds
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @param  \Closure  $callback
      * @return mixed
      */
-    public function remember($key, $seconds, Closure $callback);
+    public function remember($key, $ttl, Closure $callback);
 
     /**
      * Get an item from the cache, or execute the given Closure and store the result forever.


### PR DESCRIPTION
This is a mere suggestion at better naming so please see fit to close it if you disagree.

These changes will rename the cache seconds on the `Repository` interface and its implementations to `$ttl` rather than `$seconds`. The reason behind this is because the TTL can be more than seconds. It can be an instance of `DateTimeInterface` and `DateInterval` as well.

Overall it also makes the internals a bit clearer so a call like this:

```php
$seconds = $this->getSeconds($seconds);
```

Becomes the following which makes more sense:

```php
$seconds = $this->getSeconds($ttl);
```

No changes were made to the cache stores themselves because these always accept integers/seconds so it's more appropriate to leave those as is.
