### PR TITLE
[5.8] Call the "report" method on Exceptions through the Container

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -99,8 +99,9 @@ class Handler implements ExceptionHandlerContract
             return;
         }
 
-        if (method_exists($e, 'report')) {
-            return $e->report();
+        $reportMethod = [$e, 'report'];
+        if (is_callable($reportMethod)) {
+            return $this->container->call($reportMethod);
         }
 
         try {

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -65,6 +65,15 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->handler->report(new RuntimeException('Exception message'));
     }
 
+    public function testHandlerCallsReportMethodWithDependencies()
+    {
+        $reporter = m::mock(ReportingService::class);
+        $this->container->instance(ReportingService::class, $reporter);
+        $reporter->shouldReceive('send')->withArgs(['Exception message']);
+
+        $this->handler->report(new ReportableException('Exception message'));
+    }
+
     public function testReturnsJsonWithStackTraceWhenAjaxRequestAndDebugTrue()
     {
         $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(true);
@@ -138,4 +147,17 @@ class CustomException extends Exception implements Responsable
     {
         return response()->json(['response' => 'My custom exception response']);
     }
+}
+
+class ReportableException extends Exception
+{
+    public function report(ReportingService $reportingService)
+    {
+        $reportingService->send($this->getMessage());
+    }
+}
+
+interface ReportingService
+{
+    public function send($message);
 }


### PR DESCRIPTION
This is useful if you use a custom error reporting service but still want to keep
your Exceptions self-contained.

Backwards compatibility is ensured, as previously the report method was simply
called without any arguments, which is still possible if no type hints are added.

See https://github.com/laravel/docs/pull/4931 for the Docs update.