### PR TITLE
Wrong date format for SQL server.

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -454,7 +454,7 @@ class SqlServerGrammar extends Grammar
      */
     public function getDateFormat()
     {
-        return 'Y-m-d H:i:s.v';
+        return 'Y-m-d H:i:s';
     }
 
     /**


### PR DESCRIPTION
Switching from mysql to sql servers I had no little trouble with the timestamps formatting.
This is the correct date format for the sql server, I have tested this on the azure sql server.
