### PR TITLE
add except method to Eloquent\Concerns\HasAttributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -979,6 +979,25 @@ trait HasAttributes
      * @param  array|mixed  $attributes
      * @return array
      */
+    public function except($attributes)
+    {
+        $results = [];
+
+        foreach (array_keys($this->getAttributes()) as $attribute) {
+            if (! in_array($attribute, is_array($attributes) ? $attributes : func_get_args())) {
+                $results[$attribute] = $this->getAttribute($attribute);
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Get a subset of the model's attributes.
+     *
+     * @param  array|mixed  $attributes
+     * @return array
+     */
     public function only($attributes)
     {
         $results = [];


### PR DESCRIPTION
Make returning a model attributes simple when the situation need to just except one or multiple attributes, for the moment i added this to my shared model, the only method already exist so why not except :)

Example of formatting and returning an api request from a collection (my situation):
```
return $locations->map(function($location) {
    return [
        'id' => $location->id,
        'attributes' => $location->except(['id'])
    ];
});
```