### PR TITLE
[5.7] Lenient log stacks

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -15,6 +15,7 @@ use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Handler\RotatingFileHandler;
 use Monolog\Handler\SlackWebhookHandler;
+use Monolog\Handler\WhatFailureGroupHandler;
 
 class LogManager implements LoggerInterface
 {
@@ -215,6 +216,10 @@ class LogManager implements LoggerInterface
         $handlers = collect($config['channels'])->flatMap(function ($channel) {
             return $this->channel($channel)->getHandlers();
         })->all();
+
+        if ($config['lenient'] ?? false) {
+            $handlers = [new WhatFailureGroupHandler($handlers)];
+        }
 
         return new Monolog($this->parseChannel($config), $handlers);
     }


### PR DESCRIPTION
A simple yet powerful addition to the `stack` log driver: whenever a log stack is marked as `lenient`, the stack gets wrapped in the `WhatFailureGroupHandler`. Taken from [Monolog's documentation](https://github.com/Seldaek/monolog/blob/master/doc/02-handlers-formatters-processors.md#wrappers--special-handlers):

> This handler extends the GroupHandler ignoring exceptions raised by each child handler. This allows you to ignore issues where a remote tcp connection may have died but you do not want your entire application to crash and may wish to continue to log to other handlers.

So in this case log handlers throwing exceptions themselves are gracefully ignored, allowing the stack to continue. Highly useful to prevent white screens in production when for instance Slack cannot be reached.

I had a hard time choosing the right keyword (lenient, tolerant, continue, ignore_exceptions, ...), so please adjust as desired.

Disclaimer: I know this can be accomplished by tapping into the Monolog instance (`tap`) and rebinding the handler, but since it is such a useful thing I figured suggesting it as a config would be appropriate and helpful to many that are unaware of the possibility.