### PR TITLE
[5.8] Removed useless return

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -310,7 +310,7 @@ class Factory implements ArrayAccess
      */
     public function offsetSet($offset, $value)
     {
-        return $this->define($offset, $value);
+        $this->define($offset, $value);
     }
 
     /**


### PR DESCRIPTION
This was raised by https://github.com/laravel/framework/pull/27312.