### PR TITLE
[5.7] Add line about expiring password reset in notification email

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -60,6 +60,7 @@ class ResetPassword extends Notification
             ->subject(Lang::getFromJson('Reset Password Notification'))
             ->line(Lang::getFromJson('You are receiving this email because we received a password reset request for your account.'))
             ->action(Lang::getFromJson('Reset Password'), url(config('app.url').route('password.reset', $this->token, false)))
+            ->line(Lang::transChoice('Your password reset link will expire in :count minute.|Your password reset link will expire in :count minutes.', config('auth.passwords.users.expire')))
             ->line(Lang::getFromJson('If you did not request a password reset, no further action is required.'));
     }
 


### PR DESCRIPTION
I've recently started using the password resets in one of our apps at work, and the most common feedback we receive is that "it doesn't work". This is always because the link is expired.

Per suggestions from [Postmark](https://postmarkapp.com/guides/password-reset-email-best-practices), I've added a line that pulls the expiry config value in to the notification email.

I'm not sure of the significance of using `transChoice` over `getFromJson` here, but I couldn't get the choice to work otherwise.

Happy to make changes if anybody else (ping @themsaid) has feedback on another approach; I don't want to have a line that doesn't work for those using JSON language files if the `transChoice` method doesn't work with that properly.