### PR TITLE
[5.8] Fix numeric keys in resources

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -28,7 +28,10 @@ trait ConditionallyLoadsAttributes
             }
 
             if (is_numeric($key) && $value instanceof MergeValue) {
-                return $this->mergeData($data, $index, $this->filter($value->data), $numericKeys);
+                return $this->mergeData(
+                    $data, $index, $this->filter($value->data),
+                    array_values($value->data) === $value->data
+                );
             }
 
             if ($value instanceof self && is_null($value->resource)) {
@@ -80,8 +83,7 @@ trait ConditionallyLoadsAttributes
             }
         }
 
-        return ! empty($data) && is_numeric(array_keys($data)[0])
-                        ? array_values($data) : $data;
+        return $numericKeys ? array_values($data) : $data;
     }
 
     /**

--- a/tests/Integration/Http/Fixtures/PostResourceWithNumericKeys.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithNumericKeys.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+class PostResourceWithNumericKeys extends PostResource
+{
+    public function toArray($request)
+    {
+        return [
+            'array' => [1 => 'foo', 2 => 'bar'],
+        ];
+    }
+}


### PR DESCRIPTION
_Re-submit of #24339._

#23414 fixed an issue with `MergeValue` and an associative array. However, this left the `$numericKeys` parameter in `removeMissingValues()` unused and thereby broke associative arrays with numeric keys:

```php
$test = new Test(['array' => [1 => 'foo', 2 => 'bar']]);
return new TestResource($test);

// expected
{"data":{"array":{"1":"foo","2":"bar"}}}

// actual
{"data":{"array":["foo","bar"]}}
```

This PR reverts #23414 and instead fixes the issue in `filter()`: `$numericKeys` has to be determined on the data of `MergeValue`, not on the original `$data`.

We also have to remove the tests from #25269.

> The underlying code seems to have changed between now and then.

The `merge()` method has been renamed to `mergeData()`.

Fixes #23595 and #24302.

