### PR TITLE
[5.7] Clarify the unit of delay

### DIFF
--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -28,6 +28,8 @@ interface Job
     /**
      * Release the job back into the queue.
      *
+     * Accepts a delay specified in seconds.
+     *
      * @param  int   $delay
      * @return void
      */


### PR DESCRIPTION
The unit of delay is not exactly clear from the interface. 
An implementation should know the unit of _delay_.
The `Cache/Repository` interface, for example, specified a `ttl` in minutes. 

Solution: explicit units improve clarity.


