### PR TITLE
[5.7] Allow the app path to be configured

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -95,6 +95,13 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected $deferredServices = [];
 
     /**
+     * The custom app path defined by the developer.
+     *
+     * @var string
+     */
+    protected $path;
+
+    /**
      * The custom database path defined by the developer.
      *
      * @var string
@@ -295,7 +302,22 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function path($path = '')
     {
-        return $this->basePath.DIRECTORY_SEPARATOR.'app'.($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return ($this->path ?: $this->basePath.DIRECTORY_SEPARATOR.'app').($path ? DIRECTORY_SEPARATOR.$path : $path);
+    }
+
+    /**
+     * Set the app directory.
+     *
+     * @param  string  $path
+     * @return $this
+     */
+    public function usePath($path)
+    {
+        $this->path = $path;
+
+        $this->instance('path', $path);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
In my recents projects I'm using a different structure and I noticed I was not able to change the app path without subclassing the Application class.

This change allows the app path to be configured just like the database, environment and storage paths.

The reason I did not add a test for this method is because I could not find any tests for the other methods. If needed I'm happy to add them.