### PR TITLE
[5.7] Add getCollection to Paginator contract.

### DIFF
--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -114,7 +114,7 @@ interface Paginator
      * @return string
      */
     public function render($view = null, $data = []);
-    
+
     /**
      * Get the paginator's underlying collection.
      *

--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -114,4 +114,11 @@ interface Paginator
      * @return string
      */
     public function render($view = null, $data = []);
+    
+    /**
+     * Get the paginator's underlying collection.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getCollection();
 }


### PR DESCRIPTION
This is a useful method which is found in `AbstractPaginator` class and the contract should show it (useful for IDEs). This change doesn't break anything since the method is already implemented in `illuminate/pagination/AbstractPaginator.php`.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
