### PR TITLE
[5.8] Make the redis queue blocking pop atomic (alternative PR)

### DIFF
--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -76,6 +76,7 @@ LUA;
      *
      * KEYS[1] - The queue we are removing jobs from, for example: queues:foo:reserved
      * KEYS[2] - The queue we are moving jobs to, for example: queues:foo
+     * KEYS[3] - The notification list for the queue we are moving jobs to, for example queues:foo:notify
      * ARGV[1] - The current UNIX timestamp
      *
      * @return string
@@ -94,6 +95,11 @@ if(next(val) ~= nil) then
 
     for i = 1, #val, 100 do
         redis.call('rpush', KEYS[2], unpack(val, i, math.min(i+99, #val)))
+        if KEYS[3] ~= nil then
+            for j = 1, math.min(i+99, #val) do
+                redis.call('rpush', KEYS[3], 1)
+            end
+        end
     end
 end
 

--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -98,10 +98,8 @@ if(next(val) ~= nil) then
     for i = 1, #val, 100 do
         redis.call('rpush', KEYS[2], unpack(val, i, math.min(i+99, #val)))
         -- Push a notification for every job that was migrated...
-        if KEYS[3] ~= nil then
-            for j = 1, math.min(i+99, #val) do
-                redis.call('rpush', KEYS[3], 1)
-            end
+        for j = 1, math.min(i+99, #val) do
+            redis.call('rpush', KEYS[3], 1)
         end
     end
 end

--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -25,6 +25,7 @@ LUA;
      *
      * KEYS[1] - The queue to pop jobs from, for example: queues:foo
      * KEYS[2] - The queue to place reserved jobs on, for example: queues:foo:reserved
+     * KEYS[3] - The notify queue
      * ARGV[1] - The time at which the reserved job will expire
      *
      * @return string
@@ -42,6 +43,7 @@ if(job ~= false) then
     reserved['attempts'] = reserved['attempts'] + 1
     reserved = cjson.encode(reserved)
     redis.call('zadd', KEYS[2], ARGV[1], reserved)
+    redis.call('lpop', KEYS[3])
 end
 
 return {job, reserved}
@@ -123,10 +125,7 @@ LUA;
 -- Push the job onto the queue...
 redis.call('rpush', KEYS[1], ARGV[1])
 -- Push a notification onto the "notify" queue...
-if KEYS[2] ~= nil then
-    redis.call('rpush', KEYS[2], 1)
-end
-return cjson.decode(ARGV[1])['id']
+redis.call('rpush', KEYS[2], 1)
 LUA;
     }
 }

--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -106,4 +106,24 @@ end
 return val
 LUA;
     }
+
+    /**
+     * Get the Lua script for pushing jobs onto the queue.
+     *
+     * KEYS[1] - The queue to push the job onto, for example: queues:foo
+     * KEYS[2] - The notification list fot the queue we are pushing jobs onto, for example: queues:foo:notify
+     * ARGV[1] - The job payload
+     *
+     * @return string
+     */
+    public static function push()
+    {
+        return <<<'LUA'
+redis.call('rpush', KEYS[1], ARGV[1])
+if KEYS[2] ~= nil then
+    redis.call('rpush', KEYS[2], 1)
+end
+return cjson.decode(ARGV[1])['id']
+LUA;
+    }
 }

--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -95,6 +95,7 @@ if(next(val) ~= nil) then
 
     for i = 1, #val, 100 do
         redis.call('rpush', KEYS[2], unpack(val, i, math.min(i+99, #val)))
+        -- Push a notification for every job that was migrated...
         if KEYS[3] ~= nil then
             for j = 1, math.min(i+99, #val) do
                 redis.call('rpush', KEYS[3], 1)
@@ -119,7 +120,9 @@ LUA;
     public static function push()
     {
         return <<<'LUA'
+-- Push the job onto the queue...
 redis.call('rpush', KEYS[1], ARGV[1])
+-- Push a notification onto the "notify" queue...
 if KEYS[2] ~= nil then
     redis.call('rpush', KEYS[2], 1)
 end

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -188,12 +188,10 @@ class RedisQueue extends Queue implements QueueContract
      */
     protected function migrate($queue)
     {
-        $notify = $this->blockFor !== null ? $queue.':notify' : null;
-
-        $this->migrateExpiredJobs($queue.':delayed', $queue, $notify);
+        $this->migrateExpiredJobs($queue.':delayed', $queue);
 
         if (! is_null($this->retryAfter)) {
-            $this->migrateExpiredJobs($queue.':reserved', $queue, $notify);
+            $this->migrateExpiredJobs($queue.':reserved', $queue);
         }
     }
 
@@ -202,13 +200,12 @@ class RedisQueue extends Queue implements QueueContract
      *
      * @param  string $from
      * @param  string $to
-     * @param  string $notify
      * @return array
      */
-    public function migrateExpiredJobs($from, $to, $notify = null)
+    public function migrateExpiredJobs($from, $to)
     {
         return $this->getConnection()->eval(
-            LuaScripts::migrateExpiredJobs(), 3, $from, $to, $notify, $this->currentTime()
+            LuaScripts::migrateExpiredJobs(), 3, $from, $to, $to.':notify', $this->currentTime()
         );
     }
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -194,24 +194,27 @@ class RedisQueue extends Queue implements QueueContract
      */
     protected function migrate($queue)
     {
-        $this->migrateExpiredJobs($queue.':delayed', $queue);
+        $notify = $this->blockFor !== null ? $queue.':notify' : null;
+
+        $this->migrateExpiredJobs($queue.':delayed', $queue, $notify);
 
         if (! is_null($this->retryAfter)) {
-            $this->migrateExpiredJobs($queue.':reserved', $queue);
+            $this->migrateExpiredJobs($queue.':reserved', $queue, $notify);
         }
     }
 
     /**
      * Migrate the delayed jobs that are ready to the regular queue.
      *
-     * @param  string  $from
-     * @param  string  $to
+     * @param  string $from
+     * @param  string $to
+     * @param  string $notify
      * @return array
      */
-    public function migrateExpiredJobs($from, $to)
+    public function migrateExpiredJobs($from, $to, $notify = null)
     {
         return $this->getConnection()->eval(
-            LuaScripts::migrateExpiredJobs(), 2, $from, $to, $this->currentTime()
+            LuaScripts::migrateExpiredJobs(), 3, $from, $to, $notify, $this->currentTime()
         );
     }
 

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Queue\LuaScripts;
 use Illuminate\Queue\RedisQueue;
 use Illuminate\Contracts\Redis\Factory;
 
@@ -21,7 +22,7 @@ class QueueRedisQueueTest extends TestCase
         $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
-        $redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]));
+        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', null, json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]))->andReturn('foo');
 
         $id = $queue->push('foo', ['data']);
         $this->assertEquals('foo', $id);
@@ -32,7 +33,7 @@ class QueueRedisQueueTest extends TestCase
         $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
-        $redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0]));
+        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', null, json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0]))->andReturn('foo');
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
             return ['custom' => 'taylor'];
@@ -49,7 +50,7 @@ class QueueRedisQueueTest extends TestCase
         $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
-        $redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0]));
+        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', null, json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0]))->andReturn('foo');
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
             return ['custom' => 'taylor'];

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -22,7 +22,7 @@ class QueueRedisQueueTest extends TestCase
         $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
-        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', null, json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]))->andReturn('foo');
+        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]));
 
         $id = $queue->push('foo', ['data']);
         $this->assertEquals('foo', $id);
@@ -33,7 +33,7 @@ class QueueRedisQueueTest extends TestCase
         $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
-        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', null, json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0]))->andReturn('foo');
+        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0]));
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
             return ['custom' => 'taylor'];
@@ -50,7 +50,7 @@ class QueueRedisQueueTest extends TestCase
         $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
-        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', null, json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0]))->andReturn('foo');
+        $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0]));
 
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
             return ['custom' => 'taylor'];


### PR DESCRIPTION
This is an alternative to #27227. The main difference is in the way these PRs handle some edge cases especially when mixing blocking & non-blocking workers/pushers.
In #27227 non-blocking operations do not interact with notify queue and a script is run to resize the notify queue on every blocking pop.
In this PR non-blocking pushers/workers push/pop from notify queue as well.