### PR TITLE
[5.7] Add passedValidation to manipulate request data after validation successes 

### DIFF
--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -40,7 +40,7 @@ trait ValidatesWhenResolvedTrait
     }
 
     /**
-     * Runs after validation passed
+     * Runs after validation passed.
      *
      * @return void
      */

--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -25,6 +25,8 @@ trait ValidatesWhenResolvedTrait
         if ($instance->fails()) {
             $this->failedValidation($instance);
         }
+
+        $this->passedValidation();
     }
 
     /**
@@ -33,6 +35,16 @@ trait ValidatesWhenResolvedTrait
      * @return void
      */
     protected function prepareForValidation()
+    {
+        // no default action
+    }
+
+    /**
+     * Runs after validation passed
+     *
+     * @return void
+     */
+    protected function passedValidation()
     {
         // no default action
     }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -103,6 +103,15 @@ class FoundationFormRequestTest extends TestCase
         $this->createRequest([], FoundationTestFormRequestHooks::class)->validateResolved();
     }
 
+    public function test_passed_validation_runs_after_validation()
+    {
+        $request = $this->createRequest([], FoundationTestFormRequestHooks::class);
+        
+        $request->validateResolved();
+
+        $this->assertEquals($request->name, 'Taylor Otwel');
+    }
+
     /**
      * Catch the given exception thrown from the executor, and return it.
      *
@@ -301,5 +310,10 @@ class FoundationTestFormRequestHooks extends FormRequest
     public function prepareForValidation()
     {
         $this->replace(['name' => 'Taylor']);
+    }
+
+    public function passedValidation()
+    {
+        $this->replace(['name' => 'Taylor Otwel']);
     }
 }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -106,7 +106,7 @@ class FoundationFormRequestTest extends TestCase
     public function test_passed_validation_runs_after_validation()
     {
         $request = $this->createRequest([], FoundationTestFormRequestHooks::class);
-        
+
         $request->validateResolved();
 
         $this->assertEquals($request->name, 'Taylor Otwel');


### PR DESCRIPTION
Adds **passedValidation** method on **FormRequest** Object , to reuse logic that needs to be done after validation is succeeded  , same like **prepareForValidation** that executes logic before validation is made

example of use case 

```php
class GoogleMapsRequest extends FormRequest
{
 
    public function rules()
    {
        return [
            'google_maps_url' => ['required','url', new GoogleMapsURLIsPlace],
        ];
    }
  
    public function parseLatAndLong()
    {
         $coordinates = //some logic happened then this variable will store the lat & long
          return  $this->merge([
                'latitude' => $coordinates[0],
                'longitude' => $coordinates[1],
            ]);
        }
    }
}

class GoogleMapsController extends Controller 
{
    public function store (GoogleMapsRequest $request)
    {
        $request->parseLatAndLong();
       // rest of logic that depends on latitude & longitude
    }

    public function update (GoogleMapsRequest $request)
    {
        $request->parseLatAndLong();
        // rest of logic that depends on latitude & longitude
    }
}
```
when the PR is accepted , we won't need  **$request->parseLatAndLong()** method at all

```php
class GoogleMapsRequest extends FormRequest
{
 
    public function rules()
    {
        return [
            'google_maps_url' => ['required','url', new GoogleMapsURLIsPlace],
        ];
    }
  
    public function passedValidation()
    {
         $coordinates = //some logic happened then this variable will store the lat & long
          return  $this->merge([
                'latitude' => $coordinates[0],
                'longitude' => $coordinates[1],
            ]);
        }
    }
}

class GoogleMapsController extends Controller 
{
    public function store (GoogleMapsRequest $request)
    {
        //$request object now have the latitude & longitude attributes
    }

    public function update (GoogleMapsRequest $request)
    {
        //$request object now have the latitude & longitude attributes
    }
}
```