### PR TITLE
[5.8] WIP: Use an app's Pivot classes when defined in using() for write M2M operations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
-use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
 trait AsPivot
 {

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -187,7 +187,7 @@ trait InteractsWithPivotTable
         if ($this->using) {
             $updated = $this->newPivot([
                 $this->foreignPivotKey => $this->parent->getKey(),
-                $this->relatedPivotKey => $this->parseId($id)
+                $this->relatedPivotKey => $this->parseId($id),
             ], true)->fill($attributes)->save();
 
             if ($touch) {
@@ -382,7 +382,7 @@ trait InteractsWithPivotTable
             foreach ($this->parseIds($ids) as $id) {
                 $results += $this->newPivot([
                     $this->foreignPivotKey => $this->parent->getKey(),
-                    $this->relatedPivotKey => $id
+                    $this->relatedPivotKey => $id,
                 ], true)->delete();
             }
         } else {

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -209,12 +209,21 @@ trait InteractsWithPivotTable
      */
     public function attach($id, array $attributes = [], $touch = true)
     {
-        // Here we will insert the attachment records into the pivot table. Once we have
-        // inserted the records, we will touch the relationships if necessary and the
-        // function will return. We can parse the IDs before inserting the records.
-        $this->newPivotStatement()->insert($this->formatAttachRecords(
-            $this->parseIds($id), $attributes
-        ));
+        if ($this->using) {
+            $records = $this->formatAttachRecords(
+                $this->parseIds($id), $attributes
+            );
+            foreach ($records as $record) {
+                $this->newPivot($record, false)->save();
+            }
+        } else {
+            // Here we will insert the attachment records into the pivot table. Once we have
+            // inserted the records, we will touch the relationships if necessary and the
+            // function will return. We can parse the IDs before inserting the records.
+            $this->newPivotStatement()->insert($this->formatAttachRecords(
+                $this->parseIds($id), $attributes
+            ));
+        }
 
         if ($touch) {
             $this->touchIfTouching();
@@ -355,25 +364,32 @@ trait InteractsWithPivotTable
      */
     public function detach($ids = null, $touch = true)
     {
-        $query = $this->newPivotQuery();
+        if ($this->using) {
+            $results = 0;
+            foreach ($this->parseIds($ids) as $id) {
+                $results += $this->newPivot([$this->relatedPivotKey => $id], true)->delete();
+            }
+        } else {
+            $query = $this->newPivotQuery();
 
-        // If associated IDs were passed to the method we will only delete those
-        // associations, otherwise all of the association ties will be broken.
-        // We'll return the numbers of affected rows when we do the deletes.
-        if (! is_null($ids)) {
-            $ids = $this->parseIds($ids);
+            // If associated IDs were passed to the method we will only delete those
+            // associations, otherwise all of the association ties will be broken.
+            // We'll return the numbers of affected rows when we do the deletes.
+            if (! is_null($ids)) {
+                $ids = $this->parseIds($ids);
 
-            if (empty($ids)) {
-                return 0;
+                if (empty($ids)) {
+                    return 0;
+                }
+
+                $query->whereIn($this->relatedPivotKey, (array) $ids);
             }
 
-            $query->whereIn($this->relatedPivotKey, (array) $ids);
+            // Once we have all of the conditions set on the statement, we are ready
+            // to run the delete on the pivot table. Then, if the touch parameter
+            // is true, we will go ahead and touch all related models to sync.
+            $results = $query->delete();
         }
-
-        // Once we have all of the conditions set on the statement, we are ready
-        // to run the delete on the pivot table. Then, if the touch parameter
-        // is true, we will go ahead and touch all related models to sync.
-        $results = $query->delete();
 
         if ($touch) {
             $this->touchIfTouching();

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -184,6 +184,19 @@ trait InteractsWithPivotTable
      */
     public function updateExistingPivot($id, array $attributes, $touch = true)
     {
+        if ($this->using) {
+            $updated = $this->newPivot([
+                $this->foreignPivotKey => $this->parent->getKey(),
+                $this->relatedPivotKey => $this->parseId($id)
+            ], true)->fill($attributes)->save();
+
+            if ($touch) {
+                $this->touchIfTouching();
+            }
+
+            return (int) $updated;
+        }
+
         if (in_array($this->updatedAt(), $this->pivotColumns)) {
             $attributes = $this->addTimestampsToAttachment($attributes, true);
         }
@@ -367,7 +380,10 @@ trait InteractsWithPivotTable
         if ($this->using) {
             $results = 0;
             foreach ($this->parseIds($ids) as $id) {
-                $results += $this->newPivot([$this->relatedPivotKey => $id], true)->delete();
+                $results += $this->newPivot([
+                    $this->foreignPivotKey => $this->parent->getKey(),
+                    $this->relatedPivotKey => $id
+                ], true)->delete();
             }
         } else {
             $query = $this->newPivotQuery();

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -9,6 +9,8 @@ class Pivot extends Model
 {
     use AsPivot;
 
+    public $incrementing = false;
+
     /**
      * The attributes that aren't mass assignable.
      *


### PR DESCRIPTION
# Overview

This PR adds additional support to `InteractsWithPivotTable` (used by `Relations\BelongsToMany|MorphToMany`) such that write operations to a pivot table (specifically: `attach`, `detach`, `updateExistingPivot`) will use the defined `$this->belongsToMany()->using(MyPivot::class)` when performing these operations. By using the Pivot (through `AsPivot` trait methods) as an eloquent model, you gain the ability to utilize the eloquent lifecycle events when Pivot's are saved/deleted.

As a sidenote use case: one prominent use case is the ability to audit changes to models inside an application. Currently it is easy to audit Models but impossible to audit pivot operations since they take place directly on the connection and outside of Eloquent's perview.

I believe there are other use cases for supporting Pivot tables at true Models, I feel like there is a use case for treating Pivot's as first class Models inside Nova.

# Example

In a situation where there exist a `Category`, `Post`, and a `Pivots\CategoryPost` inside an application:
```php
namespace App\Models {
  class Category extends Model
  {
    public function posts()
    {
      return $this->belongsToMany(Post::class);
    }
  }

  class Post extends Model
  {
    public function categories()
    {
      return $this->belongsToMany(Category::class)->using(Pivots\CategoryPost::class);
    }
  }
}

namespace App\Models\Pivots {
  class CategoryPost extends Pivot
  {
    public static function boot()
    {
      parent::boot();

      static::saving(function (Model $model) {
        echo "In [{$model->getMorphClass()}|{$model->getQueueableId()}] - SAVING\n";
      });

      static::saved(function (Model $model) {
        echo "In [{$model->getMorphClass()}|{$model->getQueueableId()}] - SAVED\n";
      });

      static::deleting(function (Model $model) {
        echo "IN [{$model->getMorphClass()}|{$model->getQueueableId()}] - DELETING\n";
      });

      static::deleted(function (Model $model) {
        echo "IN [{$model->getMorphClass()}|{$model->getQueueableId()}] - DELETED\n";
      });
    }

    public function setOrderAttribute($value)
    {
      $this->attributes['order'] = ((int) $value) * 10;
    }
  }
}
```

A sync method might look like, and its output:

```php
$category1 = Models\Category::create(['name' => 'One']);
$category2 = Models\Category::create(['name' => 'Two']);
$category3 = Models\Category::create(['name' => 'Three']);
$post = new Models\Post(['name' => 'My Post']);
$post->save();
$post->categories()->sync([$category1->id => ['order' => 1], $category2->id => ['order' => 2]]);
$post->categories()->sync([$category3->id => ['order' => 5], $category1->id => ['order' => 9]]);

// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:1] - SAVING
// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:1] - SAVED
// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:2] - SAVING
// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:2] - SAVED
// IN [App\Models\Pivots\CategoryPost|post_id:1:category_id:2] - DELETING
// IN [App\Models\Pivots\CategoryPost|post_id:1:category_id:2] - DELETED
// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:3] - SAVING
// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:3] - SAVED
// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:1] - SAVING
// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:1] - SAVED
```


# Implementation Notes

At first, I thought it woudl be a good idea to simply add model events to `InteractsWithPivotTable`. This ended up being a bad idea because the remote/foreign side of the relationship would not be able to see the fired events and if it did, you'd be fireing off 2 events instead of 1 for each signification action (an event for the model on the local/near side, and an event for the foreign/remote side).  Then each subscribing model would have to be able to distinguish the direction the fired event is coming in from (either remote realtion to self, or from self to remote relation). Put in real terms, it would confusing to figure out (in an event handler) what woudl happen in `$post->categories()->sync(...)` vs. `$categories->posts()->sync(...)` as the same event would fire either way in a different context.  This was abandoned due to complexity.

It also appeared that recently (last year or so) the framework wanted to promote the Pivot to a first class Model (thus the `Pivot extends Model`, and the `AsPivot` trait).  Using a model would allow developers a single place to put their accessors/mutators for Pivot attributes, but also a single place where operations to the underlying table can have notifications.

This current implementation assumes that this is opt-in to using the `Pivot` via `->using()` method.  When not using the `->using()` declaration, operations continue to happen as they always did (that means issuing SQL directly to the connection, not through an Eloquent Model: INSERT/Batch INSERTs/DELETE/UPDATE).

Note: when using the Pivot method, there are no more "batch" INSERT's being performed. Simply put, there will always be a `$pivot->save()` for each row being inserted/updated.

In an ideal world, I think that `InteractsWithPivotTable` would purely use either a base Pivot (if one was not provided by `->using()` or use the one provided in the definintion of the `$this->belongsToMany()`). That said, I am unsure the benefits of sticking to non-eloquent based Pivot operations, have to defer to you on that one.

# TODO

If this is something you'd want to explore furture, I can take it in any number of directions and/or start writing tests and documentation.

# Inspiration & Research

https://github.com/fico7489/laravel-pivot
https://gitlab.com/altek/eventually/
https://github.com/laravel/framework/issues/8452
https://medium.com/@codebyjeff/custom-pivot-table-models-or-choosing-the-right-technique-in-laravel-fe435ce4e27e
https://github.com/signifly/laravel-pivot-events
https://stackoverflow.com/questions/46358388/laravel-5-5-events-not-fired-on-pivot

Thoughts?