### PR TITLE
[5.7] Show displayable values for relative dates in validation error messages

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -385,11 +385,11 @@ trait ReplacesAttributes
      */
     protected function replaceBefore($message, $attribute, $rule, $parameters)
     {
-        if (! (strtotime($parameters[0]))) {
+        if (! strtotime($parameters[0])) {
             return str_replace(':date', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 
-        return str_replace(':date', $parameters[0], $message);
+        return str_replace(':date', $this->getDisplayableValue($attribute, $parameters[0]), $message);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -429,6 +429,15 @@ class ValidationValidatorTest extends TestCase
         $v->messages()->setFormat(':message');
         $this->assertEquals('type must be included in Short, Long.', $v->messages()->first('type'));
 
+        //date_equals:tomorrow
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.date_equals' => 'The :attribute must be a date equal to :date.'], 'en');
+        $trans->addLines(['validation.values.date.tomorrow' => 'the day after today'], 'en');
+        $v = new Validator($trans, ['date' => date('Y-m-d')], ['date' => 'date_equals:tomorrow']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('The date must be a date equal to the day after today.', $v->messages()->first('date'));
+
         // test addCustomValues
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.in' => ':attribute must be included in :values.'], 'en');


### PR DESCRIPTION
Currently the `after`, `after_or_equal`, `before`, `before_or_equal` and `date_equals` validation rules allow us to use relative keywords in english to compare dates, e.g. `date_equals:tomorrow`.

When the placeholders are replaced in the validation messages, the `:date` parameter is normally replaced if it references another attribute, e.g. `after:start_date` but not when it's a relative keyword.

This is an issue when the locale is other than english: e.g. the `date_equals:tomorrow` in french is translated to `Le champ date doit être une date égale à tomorrow.`

This commit allows for developers to specify custom translation for these values.

E.g. in `fr/validation.php`:
```php
'values' => [
    'date' => [
        'tomorrow' => 'demain',
    ],
],
```

So now the validation message will be translated to `Le champ date doit être une date égale à demain.`

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
