### PR TITLE
[5.7] "Go Home" link update on exception page

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/illustrated-layout.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/illustrated-layout.blade.php
@@ -470,7 +470,7 @@
                         @yield('message')
                     </p>
 
-                    <a href="{{ url('/') }}">
+                    <a href="{{ app('router')->has('home') ? route('home') : url('/') }}">
                         <button class="bg-transparent text-grey-darkest font-bold uppercase tracking-wide py-3 px-6 border-2 border-grey-light hover:border-grey rounded-lg">
                             {{ __('Go Home') }}
                         </button>


### PR DESCRIPTION
If route with name "home" exists, then "Go Home" button will point this route.
Otherwise, it will contain a link to the root of the website.