### PR TITLE
[5.7] Add computed support to SQL Server schema grammar

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -823,15 +823,15 @@ class Blueprint
     }
 
     /**
-     * Create a new generated virtual column on the table.
+     * Create a new generated computed column on the table.
      *
      * @param  string  $column
-     * @param  string  $formula
+     * @param  string  $expression
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function virtual($column, $formula)
+    public function computed($column, $expression)
     {
-        return $this->addColumn('virtual', $column, compact('formula'));
+        return $this->addColumn('computed', $column, compact('expression'));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -823,6 +823,18 @@ class Blueprint
     }
 
     /**
+     * Create a new generated virtual column on the table.
+     *
+     * @param  string  $column
+     * @param  string  $formula
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function virtual($column, $formula)
+    {
+        return $this->addColumn('virtual', $column, compact('formula'));
+    }
+
+    /**
      * Create a new boolean column on the table.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -24,7 +24,7 @@ use Illuminate\Support\Fluent;
  * @method ColumnDefinition unsigned() Set the INTEGER column as UNSIGNED (MySQL)
  * @method ColumnDefinition useCurrent() Set the TIMESTAMP column to use CURRENT_TIMESTAMP as default value
  * @method ColumnDefinition virtualAs(string $expression) Create a virtual generated column (MySQL)
- * @method ColumnDefinition persisted() Mark the virtual generated column as persistent (SQL Server)
+ * @method ColumnDefinition persisted() Mark the computed generated column as persistent (SQL Server)
  */
 class ColumnDefinition extends Fluent
 {

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Fluent;
  * @method ColumnDefinition unsigned() Set the INTEGER column as UNSIGNED (MySQL)
  * @method ColumnDefinition useCurrent() Set the TIMESTAMP column to use CURRENT_TIMESTAMP as default value
  * @method ColumnDefinition virtualAs(string $expression) Create a virtual generated column (MySQL)
+ * @method ColumnDefinition persisted() Mark the virtual generated column as persistent (SQL Server)
  */
 class ColumnDefinition extends Fluent
 {

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use RuntimeException;
 use Illuminate\Support\Fluent;
 use Doctrine\DBAL\Schema\TableDiff;
 use Illuminate\Database\Connection;
@@ -188,6 +189,18 @@ abstract class Grammar extends BaseGrammar
         return array_map(function ($value) use ($prefix) {
             return $prefix.' '.$value;
         }, $values);
+    }
+
+    /**
+     * Create the column definition for a generated computed column type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     *
+     * @throws \RuntimeException
+     */
+    protected function typeComputed(Fluent $column)
+    {
+        throw new RuntimeException('The database driver in use does not support the computed type.');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use RuntimeException;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
@@ -831,6 +832,18 @@ class MySqlGrammar extends Grammar
     public function typeMultiPolygon(Fluent $column)
     {
         return 'multipolygon';
+    }
+
+    /**
+     * Create the column definition for a generated computed column type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     *
+     * @throws \RuntimeException
+     */
+    protected function typeComputed(Fluent $column)
+    {
+        throw new RuntimeException('The database driver in use requires a type, see virtualAs/storedAs modifiers.');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -733,7 +733,6 @@ class SqlServerGrammar extends Grammar
         return 'geography';
     }
 
-
     /**
      * Create the column definition for a generated virtual column type.
      *
@@ -742,7 +741,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeVirtual(Fluent $column)
     {
-        return " as ({$column->formula})";
+        return "as ({$column->formula})";
     }
 
     /**
@@ -768,7 +767,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function modifyNullable(Blueprint $blueprint, Fluent $column)
     {
-        if($column->type !== 'virtual') {
+        if ($column->type !== 'virtual') {
             return $column->nullable ? ' null' : ' not null';
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -19,7 +19,7 @@ class SqlServerGrammar extends Grammar
      *
      * @var array
      */
-    protected $modifiers = ['Increment', 'Collate', 'Nullable', 'Default'];
+    protected $modifiers = ['Increment', 'Collate', 'Nullable', 'Default', 'Persisted'];
 
     /**
      * The columns available as serials.
@@ -733,6 +733,18 @@ class SqlServerGrammar extends Grammar
         return 'geography';
     }
 
+
+    /**
+     * Create the column definition for a generated virtual column type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function typeVirtual(Fluent $column)
+    {
+        return " as ({$column->formula})";
+    }
+
     /**
      * Get the SQL for a collation column modifier.
      *
@@ -756,7 +768,9 @@ class SqlServerGrammar extends Grammar
      */
     protected function modifyNullable(Blueprint $blueprint, Fluent $column)
     {
-        return $column->nullable ? ' null' : ' not null';
+        if($column->type !== 'virtual') {
+            return $column->nullable ? ' null' : ' not null';
+        }
     }
 
     /**
@@ -784,6 +798,20 @@ class SqlServerGrammar extends Grammar
     {
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
             return ' identity primary key';
+        }
+    }
+
+    /**
+     * Get the SQL for a generated stored column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyPersisted(Blueprint $blueprint, Fluent $column)
+    {
+        if ($column->persisted) {
+            return ' persisted';
         }
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -734,14 +734,14 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a generated virtual column type.
+     * Create the column definition for a generated computed column type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string|null
      */
-    protected function typeVirtual(Fluent $column)
+    protected function typeComputed(Fluent $column)
     {
-        return "as ({$column->formula})";
+        return "as ({$column->expression})";
     }
 
     /**
@@ -767,7 +767,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function modifyNullable(Blueprint $blueprint, Fluent $column)
     {
-        if ($column->type !== 'virtual') {
+        if ($column->type !== 'computed') {
             return $column->nullable ? ' null' : ' not null';
         }
     }

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -774,8 +774,8 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('products');
         $blueprint->integer('price');
-        $blueprint->virtual('discounted_virtual', 'price - 5');
-        $blueprint->virtual('discounted_stored', 'price - 5')->persisted();
+        $blueprint->computed('discounted_virtual', 'price - 5');
+        $blueprint->computed('discounted_stored', 'price - 5')->persisted();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "products" add "price" int not null, "discounted_virtual" as (price - 5), "discounted_stored" as (price - 5) persisted', $statements[0]);

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -770,6 +770,17 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
+    public function testAddingGeneratedColumn()
+    {
+        $blueprint = new Blueprint('products');
+        $blueprint->integer('price');
+        $blueprint->virtual('discounted_virtual', 'price - 5');
+        $blueprint->virtual('discounted_stored', 'price - 5')->persisted();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "products" add "price" int not null, add "discounted_virtual" as (price - 5), add "discounted_stored" as (price - 5) persisted', $statements[0]);
+    }
+
     public function testGrammarsAreMacroable()
     {
         // compileReplace macro.

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -778,7 +778,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->virtual('discounted_stored', 'price - 5')->persisted();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "products" add "price" int not null, add "discounted_virtual" as (price - 5), add "discounted_stored" as (price - 5) persisted', $statements[0]);
+        $this->assertEquals('alter table "products" add "price" int not null, "discounted_virtual" as (price - 5), "discounted_stored" as (price - 5) persisted', $statements[0]);
     }
 
     public function testGrammarsAreMacroable()


### PR DESCRIPTION
[SQL Server also supports computed columns (Azure & 2016+)](https://docs.microsoft.com/en-us/sql/relational-databases/tables/specify-computed-columns-in-a-table), but as a type; not a modifier.

inspired by https://github.com/laravel/framework/pull/13430 but for SQL Server
Sadly enough SQL Server defines this instead of a data type, so I couldn't re-use the existing methods.

Instead, a "virtual" type was introduced, with a "persisted" modifier; reflecting the mysql-only virtualAs & storedAs modifiers respectively.