### PR TITLE
[5.7] Pass second argument to Lang::getFromJson as an array.

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -60,7 +60,7 @@ class ResetPassword extends Notification
             ->subject(Lang::getFromJson('Reset Password Notification'))
             ->line(Lang::getFromJson('You are receiving this email because we received a password reset request for your account.'))
             ->action(Lang::getFromJson('Reset Password'), url(config('app.url').route('password.reset', $this->token, false)))
-            ->line(Lang::getFromJson('This password reset link will expire in :count minutes.', [config('auth.passwords.users.expire')]))
+            ->line(Lang::getFromJson('This password reset link will expire in :count minutes.', ['count' => config('auth.passwords.users.expire')]))
             ->line(Lang::getFromJson('If you did not request a password reset, no further action is required.'));
     }
 

--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -60,7 +60,7 @@ class ResetPassword extends Notification
             ->subject(Lang::getFromJson('Reset Password Notification'))
             ->line(Lang::getFromJson('You are receiving this email because we received a password reset request for your account.'))
             ->action(Lang::getFromJson('Reset Password'), url(config('app.url').route('password.reset', $this->token, false)))
-            ->line(Lang::getFromJson('This password reset link will expire in :count minutes.', config('auth.passwords.users.expire')))
+            ->line(Lang::getFromJson('This password reset link will expire in :count minutes.', [config('auth.passwords.users.expire')]))
             ->line(Lang::getFromJson('If you did not request a password reset, no further action is required.'));
     }
 


### PR DESCRIPTION
Fix for https://github.com/laravel/framework/issues/27349

* Passes the expiration minutes as an array instead of an integer.

I'm willing to add tests, but I don't know where/how they should be structured.

Edit:

Another change I considered was to change the `getFromJson()` method to accept any type of argument, and then make sure it is transformed into an array before being used.