### PR TITLE
[5.7] Fix the pagination url slider when $onEachSide is set to 2 or less

### DIFF
--- a/src/Illuminate/Pagination/UrlWindow.php
+++ b/src/Illuminate/Pagination/UrlWindow.php
@@ -73,23 +73,31 @@ class UrlWindow
      */
     protected function getUrlSlider($onEachSide)
     {
-        $window = $onEachSide * 2;
-
         if (! $this->hasPages()) {
             return ['first' => null, 'slider' => null, 'last' => null];
         }
 
+        // Since the number of links on the edges is hardcoded (2), we can't have
+        // $onEachSide <= 2  without making some adjustments.
+
+        $window = max($onEachSide * 2,1); //$window should be at least 1 (in case $onEachSide == 0)
+
+        //Number of pages between the left edge of the $window and the second page
+        $startingGap = $this->currentPage() - $onEachSide - 2;
+        //Number of pages between the right edge of the $window and the second last page.
+        $endingGap = $this->lastPage() - $this->currentPage() - 2 - $onEachSide;
+
         // If the current page is very close to the beginning of the page range, we will
         // just render the beginning of the page range, followed by the last 2 of the
         // links in this list, since we will not have room to create a full slider.
-        if ((in_array($this->currentPage() - $onEachSide - 2, [0,1]) && $this->currentPage() > $window)||$this->currentPage() <= $window) {
+        if ((($startingGap == 0 || $startingGap == 1) && $this->currentPage() > $window)|| $this->currentPage() <= $window) {
             return $this->getSliderTooCloseToBeginning($window);
         }
 
         // If the current page is close to the ending of the page range we will just get
         // this first couple pages, followed by a larger window of these ending pages
         // since we're too close to the end of the list to create a full on slider.
-        elseif ((in_array($this->lastPage() - $this->currentPage() - 2 - $onEachSide, [-1,0]) && $this->currentPage() <= ($this->lastPage() - $window)) || $this->currentPage() > ($this->lastPage() - $window)) {
+        elseif ((($endingGap == -1 || $endingGap == 0) && $this->currentPage() <= ($this->lastPage() - $window)) || $this->currentPage() > ($this->lastPage() - $window)) {
             return $this->getSliderTooCloseToEnding($window);
         }
 

--- a/src/Illuminate/Pagination/UrlWindow.php
+++ b/src/Illuminate/Pagination/UrlWindow.php
@@ -82,14 +82,14 @@ class UrlWindow
         // If the current page is very close to the beginning of the page range, we will
         // just render the beginning of the page range, followed by the last 2 of the
         // links in this list, since we will not have room to create a full slider.
-        if ($this->currentPage() <= $window) {
+        if ((in_array($this->currentPage() - $onEachSide - 2, [0,1]) && $this->currentPage() > $window)||$this->currentPage() <= $window) {
             return $this->getSliderTooCloseToBeginning($window);
         }
 
         // If the current page is close to the ending of the page range we will just get
         // this first couple pages, followed by a larger window of these ending pages
         // since we're too close to the end of the list to create a full on slider.
-        elseif ($this->currentPage() > ($this->lastPage() - $window)) {
+        elseif ((in_array($this->lastPage() - $this->currentPage() - 2 - $onEachSide, [-1,0]) && $this->currentPage() <= ($this->lastPage() - $window)) || $this->currentPage() > ($this->lastPage() - $window)) {
             return $this->getSliderTooCloseToEnding($window);
         }
 

--- a/src/Illuminate/Pagination/UrlWindow.php
+++ b/src/Illuminate/Pagination/UrlWindow.php
@@ -80,7 +80,7 @@ class UrlWindow
         // Since the number of links on the edges is hardcoded (2), we can't have
         // $onEachSide <= 2  without making some adjustments.
 
-        $window = max($onEachSide * 2,1); //$window should be at least 1 (in case $onEachSide == 0)
+        $window = max($onEachSide * 2, 1); //$window should be at least 1 (in case $onEachSide == 0)
 
         //Number of pages between the left edge of the $window and the second page
         $startingGap = $this->currentPage() - $onEachSide - 2;
@@ -90,7 +90,7 @@ class UrlWindow
         // If the current page is very close to the beginning of the page range, we will
         // just render the beginning of the page range, followed by the last 2 of the
         // links in this list, since we will not have room to create a full slider.
-        if ((($startingGap == 0 || $startingGap == 1) && $this->currentPage() > $window)|| $this->currentPage() <= $window) {
+        if ((($startingGap == 0 || $startingGap == 1) && $this->currentPage() > $window) || $this->currentPage() <= $window) {
             return $this->getSliderTooCloseToBeginning($window);
         }
 


### PR DESCRIPTION
As stated in this issue https://github.com/laravel/framework/pull/25580, the url slider doesn't work well when `$onEachSide` is set to two or less (actually the issue only mention < 2, but the same problem occurs when it is equal to 2). This is due to the hardcoded number of links displayed on the edges of the page slider (which is also 2).

This PR fixes that by adding some logic the `getUrlSlider` method.

Here are some examples (not all of course, the list would be too big) of without/with this pr:

**Without:**
onEachSide(0), page 1
![image](https://user-images.githubusercontent.com/15825155/51936350-448de900-2408-11e9-894f-bb719d5308c6.png)


onEachSide(1), page 3
![image](https://user-images.githubusercontent.com/15825155/51935783-004e1900-2407-11e9-857e-aaa62c269202.png)

onEachSide(2), page 5
![image](https://user-images.githubusercontent.com/15825155/51935848-1d82e780-2407-11e9-9687-dda49e687923.png)


**Then with the PR:**
onEachSide(0), page 1
![image](https://user-images.githubusercontent.com/15825155/51935928-5b800b80-2407-11e9-8c99-4d2e25495e83.png)


onEachSide(1), page 3
![image](https://user-images.githubusercontent.com/15825155/51935915-51f6a380-2407-11e9-924b-fe1428daa22c.png)


onEachSide(2), page 5
![image](https://user-images.githubusercontent.com/15825155/51935900-46a37800-2407-11e9-85a1-820fb1060a56.png)

------

The same odd behavior occurs at the other side of the url slider, when we approach the last pages. The PR also fixes it :)