### PR TITLE
[5.7] Fix BelongsToMany pivot relationship child with loaded relations wakeup

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1408,9 +1408,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $relations = [];
 
         foreach ($this->getRelations() as $key => $relation) {
-            if (method_exists($this, $key)) {
-                $relations[] = $key;
+            if (! method_exists($this, $key)) {
+                continue;
             }
+
+            $relations[] = $key;
 
             if ($relation instanceof QueueableCollection) {
                 foreach ($relation->getQueueableRelations() as $collectionValue) {

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -7,6 +7,7 @@ use Orchestra\Testbench\TestCase;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
  * @group integration
@@ -58,6 +59,15 @@ class ModelSerializationTest extends TestCase
 
         Schema::create('products', function ($table) {
             $table->increments('id');
+        });
+
+        Schema::create('roles', function ($table) {
+            $table->increments('id');
+        });
+
+        Schema::create('role_user', function ($table) {
+            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('role_id');
         });
     }
 
@@ -176,6 +186,31 @@ class ModelSerializationTest extends TestCase
         $this->assertEquals($nestedUnSerialized->order->getRelations(), $order->getRelations());
     }
 
+    /**
+     * Regression test for https://github.com/laravel/framework/issues/23068
+     */
+    public function test_it_can_unserialize_nested_relationships_without_pivot()
+    {
+        $user = tap(User::create([
+            'email' => 'taylor@laravel.com',
+        ]), function (User $user) {
+            $user->wasRecentlyCreated = false;
+        });
+
+        $role1 = Role::create();
+        $role2 = Role::create();
+
+        RoleUser::create(['user_id' => $user->id, 'role_id' => $role1->id]);
+        RoleUser::create(['user_id' => $user->id, 'role_id' => $role2->id]);
+
+        $user->roles->each(function ($role) {
+            $role->pivot->load('user', 'role');
+        });
+
+        $serialized = serialize(new ModelSerializationTestClass($user));
+        unserialize($serialized);
+    }
+
     public function test_it_serializes_an_empty_collection()
     {
         $serialized = serialize(new ModelSerializationTestClass(
@@ -229,6 +264,46 @@ class Product extends Model
 {
     public $guarded = ['id'];
     public $timestamps = false;
+}
+
+class User extends Model
+{
+    public $guarded = ['id'];
+    public $timestamps = false;
+
+    public function roles()
+    {
+        return $this->belongsToMany(Role::class)
+            ->using(RoleUser::class);
+    }
+}
+
+class Role extends Model
+{
+    public $guarded = ['id'];
+    public $timestamps = false;
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class)
+            ->using(RoleUser::class);
+    }
+}
+
+class RoleUser extends Pivot
+{
+    public $guarded = ['id'];
+    public $timestamps = false;
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function role()
+    {
+        return $this->belongsTo(Role::class);
+    }
 }
 
 class ModelSerializationTestClass

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -187,7 +187,7 @@ class ModelSerializationTest extends TestCase
     }
 
     /**
-     * Regression test for https://github.com/laravel/framework/issues/23068
+     * Regression test for https://github.com/laravel/framework/issues/23068.
      */
     public function test_it_can_unserialize_nested_relationships_without_pivot()
     {


### PR DESCRIPTION
## Overview 
This PR demonstrates the bug that was reported in #23068. Although a previous PR (#23081) was submitted and merged to fix the issue, another edge case caused the bug to persist.

## Reproduction
Whenever a model is serialized that has a loaded pivot relation that is using a `Pivot` class, and that pivot class has loaded relations, the following exception is thrown:

```
Illuminate\Database\Eloquent\RelationNotFoundException : Call to undefined relationship [pivot] on model [Illuminate\Tests\Integration\Queue\Role].
```

The bug persists because in the case that there are loaded relations within the pivot, they are still appended to the result of `getQueueableRelations()` as `relation.pivot.child`, even if the relation method `pivot` does not exist.

https://github.com/laravel/framework/blob/a0ba83d25eeff4e904f230755225be473f97d8b5/src/Illuminate/Database/Eloquent/Model.php#L1410-L1426

## Proposed Solution
In order to prevent any children from a pivot (or non-existing relationship) to be serialized, the `foreach` in `getQueueableRelations()` should `continue` when the relationship method does not exist. 