### PR TITLE
[5.7] Resolve issue #26527 (key inconsistency between base & eloquent collections)

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -891,7 +891,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $results[$resolvedKey] = $item;
         }
 
-        return new static($results);
+        return new self($results);
     }
 
     /**


### PR DESCRIPTION
This PR solves the problem of issue #26527 

I just set the return of keyBy method as self instead of static, keeping in mind that we use the keyBy, the Eloquent Model in key will be replaced by the given key, so it no longer be more a Eloquent Collection.