### PR TITLE
[5.7] Add an exception when column parameter is empty

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -595,6 +595,12 @@ class Builder
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
+        // Check if column parameter is not empty, to avoid that Builder brings all
+        // rows from a table
+        if (empty($column)) {
+            throw new InvalidArgumentException('Columns must not be empty');
+        }
+        
         // If the column is an array, we will assume it is an array of key-value pairs
         // and can add them each as a where clause. We will maintain the boolean we
         // received when the method was called and pass it into the nested where.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -600,7 +600,7 @@ class Builder
         if (empty($column)) {
             throw new InvalidArgumentException('Columns must not be empty');
         }
-        
+
         // If the column is an array, we will assume it is an array of key-value pairs
         // and can add them each as a where clause. We will maintain the boolean we
         // received when the method was called and pass it into the nested where.


### PR DESCRIPTION
This PR avoid the case bellow:

```
$companies = Companies::where([])
               ->get();
```

When an empty array is passed on where method, the Builder ignores it and brings all rows from a table. This PR forces you to pass a filled parameter to avoid this case.