### PR TITLE
[5.8-wip] Add support for nullable unique indexes in SQL Server

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -109,7 +109,7 @@ class SqlServerGrammar extends Grammar
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
             $this->columnize($command->columns),
-            $this->wrap($command->index)
+            implode(' is not null and ', $command->columns)
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -105,10 +105,11 @@ class SqlServerGrammar extends Grammar
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('create unique index %s on %s (%s)',
+        return sprintf('create unique index %s on %s (%s) where %s is not null',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
-            $this->columnize($command->columns)
+            $this->columnize($command->columns),
+            $this->wrap($command->index)
         );
     }
 

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -233,7 +233,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create unique index "bar" on "users" ("foo") where "bar" is not null', $statements[0]);
+        $this->assertEquals('create unique index "bar" on "users" ("foo") where "foo" is not null', $statements[0]);
     }
 
     public function testAddingIndex()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -233,7 +233,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create unique index "bar" on "users" ("foo")', $statements[0]);
+        $this->assertEquals('create unique index "bar" on "users" ("foo") where "bar" is not null', $statements[0]);
     }
 
     public function testAddingIndex()


### PR DESCRIPTION
see https://stackoverflow.com/a/767702/620141
Note: Supports SQL Server 2008 & up (11 years, should be safe)