### PR TITLE
[5.7] Fix unauthenticated() return docblock

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -212,7 +212,7 @@ class Handler implements ExceptionHandlerContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Auth\AuthenticationException  $exception
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     protected function unauthenticated($request, AuthenticationException $exception)
     {


### PR DESCRIPTION
The current docblock specifies a `\Illuminate\Http\Response` return type, however neither `\Illuminate\Http\JsonResponse` or `\Illuminate\Http\RedirectResponse`, both of which are returned by this method, extend that class. They both extend the Symfony response directly.

The `\Illuminate\Http\Response` also extends the Symfony class, so this should cover everything.