### PR TITLE
[5.8] do not JSON encode strings for cast model attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -696,7 +696,7 @@ trait HasAttributes
      */
     protected function asJson($value)
     {
-        return json_encode($value);
+        return is_string($value) ? $value : json_encode($value);
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelJsonCastingTest.php
+++ b/tests/Integration/Database/EloquentModelJsonCastingTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentModelJsonCastingTest;
 
+use stdClass;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
-use stdClass;
 
 /**
  * @group integration
@@ -66,7 +66,7 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
             'collection_as_json_field' => new Collection(['key1' => 'value1']),
         ]);
 
-        $this->assertInstanceOf(Collection::class,  $user->toArray()['collection_as_json_field']);
+        $this->assertInstanceOf(Collection::class, $user->toArray()['collection_as_json_field']);
         $this->assertEquals('value1', $user->toArray()['collection_as_json_field']->get('key1'));
     }
 }

--- a/tests/Integration/Database/EloquentModelJsonCastingTest.php
+++ b/tests/Integration/Database/EloquentModelJsonCastingTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelJsonCastingTest;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use stdClass;
+
+/**
+ * @group integration
+ */
+class EloquentModelJsonCastingTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('test_model1', function ($table) {
+            $table->increments('id');
+            $table->json('basic_string_as_json_field')->nullable();
+            $table->json('json_string_as_json_field')->nullable();
+            $table->json('array_as_json_field')->nullable();
+            $table->json('object_as_json_field')->nullable();
+            $table->json('collection_as_json_field')->nullable();
+        });
+    }
+
+    public function test_strings_are_castable()
+    {
+        $user = TestModel1::create([
+            'basic_string_as_json_field' => 'this is a string',
+            'json_string_as_json_field' => '{"key1":"value1"}',
+        ]);
+
+        $this->assertNull($user->toArray()['basic_string_as_json_field']);
+        $this->assertEquals(['key1' => 'value1'], $user->toArray()['json_string_as_json_field']);
+    }
+
+    public function test_arrays_are_castable()
+    {
+        $user = TestModel1::create([
+            'array_as_json_field' => ['key1' => 'value1'],
+        ]);
+
+        $this->assertEquals(['key1' => 'value1'], $user->toArray()['array_as_json_field']);
+    }
+
+    public function test_objects_are_castable()
+    {
+        $object = new stdClass();
+        $object->key1 = 'value1';
+
+        $user = TestModel1::create([
+            'object_as_json_field' => $object,
+        ]);
+
+        $this->assertInstanceOf(stdClass::class, $user->toArray()['object_as_json_field']);
+        $this->assertEquals('value1', $user->toArray()['object_as_json_field']->key1);
+    }
+
+    public function test_collections_are_castable()
+    {
+        $user = TestModel1::create([
+            'collection_as_json_field' => new Collection(['key1' => 'value1']),
+        ]);
+
+        $this->assertInstanceOf(Collection::class,  $user->toArray()['collection_as_json_field']);
+        $this->assertEquals('value1', $user->toArray()['collection_as_json_field']->get('key1'));
+    }
+}
+
+class TestModel1 extends Model
+{
+    public $table = 'test_model1';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+
+    public $casts = [
+        'basic_string_as_json_field' => 'json',
+        'json_string_as_json_field' => 'json',
+        'array_as_json_field' => 'array',
+        'object_as_json_field' => 'object',
+        'collection_as_json_field' => 'collection',
+    ];
+}


### PR DESCRIPTION
if you cast a Model attribute to 'array', 'json', 'object', or 'collection', they are stored as JSON in the database.  To set them on the model, you **must** pass either an array, object, or `Collection`. Currently you **cannot** pass a properly formatted JSON string that would be decoded into one of the types.  This PR allows you set a property to  a JSON string, and to skip the encoding, so when it is decoded it comes out properly.

In 5.7 if we cast a property to an array, and pass an array, everything goes fine.

```php
class User extends Model
{
    protected $casts = [
        'about' => 'array',
    ];
}

$user = new User();
$user->about = [
    'gender' => 'male',
    'height' => '72',
    'eyes' => 'brown',
];
$user->save();

dd($user->about);
```

returns the expected array

```php
[
    'gender' => 'male',
    'height' => '72',
    'eyes' => 'brown',
]
```

However, if we pass a JSON string of the encoded array, we may expect to get the same array back...

```php
$user = new User();
$user->about = '{"gender":"male","height":"72","eyes":"brown"}';

dd($user->about);
```

but it actually returns our original string

```
{"gender":"male","height":"72","eyes":"brown"}
```

What's happening behind the scenes is Laravel is running `json_encode` on the JSON string, which results in it being stored in the database like this: 

```
"{\"gender\":\"male\",\"height\":\"72\",\"eyes\":\"brown\"}"
```

and when we pull it back out, it is getting `json_decode`d back to the original JSON string.

What I'm proposing for 5.8 is a breaking change, and that we not `json_encode` any strings that are passed to an attribute cast to any of the "json castable" values (json, array, object, collection).

Passing an array, object, or `Collection` would still behave identically as before.  However, passing a non-properly formatted JSON string will now result in a `null` value stored in the database.  I would not expect anyone to be storing normal strings as JSON in their database, so I would say this is probably a *low* probability of impact for the upgrade, but definitely something to consider.