### PR TITLE
[5.7] Add middleware disable feature with specified middleware group name o…

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -111,6 +111,32 @@ trait MakesHttpRequests
     }
 
     /**
+     * Disable middleware by group name for the test.
+     *
+     * @param string[] $groups
+     * @return $this
+     */
+    public function withoutMiddlewareGroups($groups = null)
+    {
+        if (is_null($groups) || !is_array($groups)) {
+            return $this;
+        }
+
+        $kernel = $this->app->make(HttpKernel::class);
+        $middlewares = $kernel->getMiddlewareGroups();
+
+        foreach ($groups as $group) {
+            if (!isset($middlewares[$group])) {
+                continue;
+            }
+
+            $this->withoutMiddleware($middlewares[$group]);
+        }
+
+        return $this;
+    }
+
+    /**
      * Enable the given middleware for the test.
      *
      * @param  string|array  $middleware

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -118,7 +118,7 @@ trait MakesHttpRequests
      */
     public function withoutMiddlewareGroups($groups = null)
     {
-        if (is_null($groups) || !is_array($groups)) {
+        if (is_null($groups) || ! is_array($groups)) {
             return $this;
         }
 
@@ -126,7 +126,7 @@ trait MakesHttpRequests
         $middlewares = $kernel->getMiddlewareGroups();
 
         foreach ($groups as $group) {
-            if (!isset($middlewares[$group])) {
+            if (! isset($middlewares[$group])) {
                 continue;
             }
 


### PR DESCRIPTION
Current method `withoutMiddleware` defined in `Illuminate\Foundation\Testing\Concerns\MakesHttpRequests` cannot disable middleware by specified middleware group name when testing.

We could list up all middleware class name and pass it to this method, such as
```php
$middlewares = $this->app->make(Kernel::class)->getMiddlewareGroups();
$this->withoutMiddleware($middlewares['group_name']);
```

However, I'll be happy if this prepared method is ready on `TestCase`. thanks!

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
