### PR TITLE
[5.7] Dispatch event if key not translated in Translation

### DIFF
--- a/src/Illuminate/Translation/Events/KeyNotTranslated.php
+++ b/src/Illuminate/Translation/Events/KeyNotTranslated.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Translation\Events;
+
+class KeyNotTranslated
+{
+    public $key;
+
+    public function __construct($key)
+    {
+        $this->key = $key;
+    }
+}

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Support\NamespacedItemResolver;
 use Illuminate\Contracts\Translation\Translator as TranslatorContract;
+use Illuminate\Translation\Events\KeyNotTranslated;
 
 class Translator extends NamespacedItemResolver implements TranslatorContract
 {
@@ -98,7 +99,11 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function trans($key, array $replace = [], $locale = null)
     {
-        return $this->get($key, $replace, $locale);
+        $fallback = $this->get($key, $replace, $locale);
+        if ($fallback === $key) {
+            event(new KeyNotTranslated($key));
+        }
+        return $fallback;
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -103,6 +103,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         if ($fallback === $key) {
             event(new KeyNotTranslated($key));
         }
+
         return $fallback;
     }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -3,14 +3,14 @@
 namespace Illuminate\Translation;
 
 use Countable;
-use Illuminate\Contracts\Translation\Loader;
-use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
-use Illuminate\Support\NamespacedItemResolver;
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Contracts\Translation\Loader;
+use Illuminate\Support\NamespacedItemResolver;
 use Illuminate\Translation\Events\KeyNotTranslated;
+use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 
 class Translator extends NamespacedItemResolver implements TranslatorContract
 {

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -3,13 +3,13 @@
 namespace Illuminate\Translation;
 
 use Countable;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Translation\Loader;
-use Illuminate\Support\NamespacedItemResolver;
 use Illuminate\Contracts\Translation\Translator as TranslatorContract;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\NamespacedItemResolver;
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Translation\Events\KeyNotTranslated;
 
 class Translator extends NamespacedItemResolver implements TranslatorContract

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -2,13 +2,13 @@
 
 namespace Illuminate\Tests\Translation;
 
-use Illuminate\Contracts\Translation\Loader;
-use Illuminate\Support\Collection;
-use Illuminate\Translation\Events\KeyNotTranslated;
-use Illuminate\Translation\MessageSelector;
-use Illuminate\Translation\Translator;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Collection;
+use Illuminate\Translation\Translator;
+use Illuminate\Translation\MessageSelector;
+use Illuminate\Contracts\Translation\Loader;
+use Illuminate\Translation\Events\KeyNotTranslated;
 
 class TranslationTranslatorTest extends TestCase
 {

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -2,14 +2,13 @@
 
 namespace Illuminate\Tests\Translation;
 
-use Illuminate\Support\Facades\Bus;
+use Illuminate\Contracts\Translation\Loader;
+use Illuminate\Support\Collection;
 use Illuminate\Translation\Events\KeyNotTranslated;
+use Illuminate\Translation\MessageSelector;
+use Illuminate\Translation\Translator;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Support\Collection;
-use Illuminate\Translation\Translator;
-use Illuminate\Translation\MessageSelector;
-use Illuminate\Contracts\Translation\Loader;
 
 class TranslationTranslatorTest extends TestCase
 {


### PR DESCRIPTION
This PR introduces posibility to catch not translated keys in Repository.
It will help to kindly search undefined keys and fix it, for example, in event handlers. 