### PR TITLE
[5.5] Fix for route facade phpdoc to avoid Phan and PHPStorm errors

### DIFF
--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -14,7 +14,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Support\Facades\Route prefix(string  $prefix)
  * @method static \Illuminate\Routing\PendingResourceRegistration resource(string $name, string $controller, array $options = [])
  * @method static \Illuminate\Routing\PendingResourceRegistration apiResource(string $name, string $controller, array $options = [])
- * @method static \Illuminate\Support\Facades\Route middleware(array|string|null $middleware)
+ * @method static \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
  * @method static \Illuminate\Support\Facades\Route substituteBindings(\Illuminate\Support\Facades\Route $route)
  * @method static void substituteImplicitBindings(\Illuminate\Support\Facades\Route $route)
  * @method static \Illuminate\Support\Facades\Route as(string $value)


### PR DESCRIPTION
We are currently in the process of integrating Phan (https://github.com/phan/phan) into our projects and both PHPstorm and Phan are complaining about the Route::middelware annotation:

```
src/Services/Api/Routes/Authentication.php:18 PhanParamTooFew Call with 1 arg(s) to \Illuminate\Support\Facades\Route::group() which requires 2 arg(s) defined at vendor/laravel/framework/src/Illuminate/Support/Facades/Route.php:25
src/Services/Api/Routes/Authentication.php:26 PhanParamTooFew Call with 1 arg(s) to \Illuminate\Support\Facades\Route::group() which requires 2 arg(s) defined at vendor/laravel/framework/src/Illuminate/Support/Facades/Route.php:25
```

I've narrowed it down to a fix that was applied on the 5.6 branch, this is a port of that fix to resolve this issue in the LTS version as well