### PR TITLE
[5.7] Fix wrong class being used when eager loading nullable MorphTo with withDefault()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -178,6 +178,17 @@ class MorphTo extends BelongsTo
     }
 
     /**
+     * Make a new related instance for the given model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    protected function newRelatedInstanceFor(Model $parent)
+    {
+        return $parent->{$this->relation}()->getRelated()->newInstance();
+    }
+
+    /**
      * Associate the model instance to the given parent.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model


### PR DESCRIPTION
Fixes #27369 

Currently, MorphTo inherits the `newRelatedInstanceFor()` method from BelongsTo, which ignores the passed `$parent` argument and instantiates a related model based on the generalized relationship instance (without constraints) produced by the query builder . However, in the case of MorphTo relations, the no-constraint relationship instance does not know anything about related classes, and wrongly defaults to the parent model class. This commit simply makes use of the `$parent` argument to produce a related instance that is appropriate for the parent model instance.
