### PR TITLE
[5.8] Resubmission of PR #27325 - Fix numeric keys in resources

### DIFF
--- a/tests/Integration/Http/Fixtures/PostResourceWithPreservedKeys.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithPreservedKeys.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+class PostResourceWithPreservedKeys extends PostResource
+{
+    protected $preserveKeys = true;
+
+    public function toArray($request)
+    {
+        return [
+            'array' => [1 => 'foo', 2 => 'bar'],
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -19,6 +19,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\SerializablePostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithExtraData;
 use Illuminate\Tests\Integration\Http\Fixtures\EmptyPostCollectionResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalData;
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithPreservedKeys;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationship;
 use Illuminate\Tests\Integration\Http\Fixtures\AuthorResourceWithOptionalRelationship;
@@ -587,6 +588,25 @@ class ResourceTest extends TestCase
 
         $this->assertCount(2, $collection);
         $this->assertSame(2, count($collection));
+    }
+
+    public function test_keys_are_preserved_if_flagged()
+    {
+        Route::get('/', function () {
+            return new PostResourceWithPreservedKeys(new Post);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'data' => [
+                'array' => [1 => 'foo', 2 => 'bar'],
+            ],
+        ]);
     }
 
     public function test_leading_merge__keyed_value_is_merged_correctly()


### PR DESCRIPTION
This PR is a resubmission of PR #27325 . It adds the ability to preserve the keys of an associative array if it has custom indices.

Currently any array returned in a `Resource` will be converted to a plain JSON array if its first key is numeric.

So assuming you have this Resource:

```php
<?php

namespace App\Http\Resources;

use Illuminate\Http\Resources\Json\JsonResource;

class MyResource extends JsonResource
{
    public function toArray( $request )
    {
        return [
            'data' => $this->resource[ 'data' ],
        ];
    }
}
```

And try to return this resource using the data below:

```php
$router->get('test', function (  ) {
    $data = [ 'data'=> [ '1' => 10, '2' => 20, 'total' => 30 ] ];

    return new \App\Http\Resources\MyResource($data);
});
```

As of 5.7, as the first index is numeric (`1`) the `JsonResource` class would strips all the index and would return only the values as an array:

```json
{"data":[10,20,30]}
```

This PR, adds the ability to define a `$preserveKeys` property in your Resource, so when the JSON output is Serialized the keys are preserved. For example:

```php
<?php

namespace App\Http\Resources;

use Illuminate\Http\Resources\Json\JsonResource;

class MyResource extends JsonResource
{
    public $preserveKeys = true; // flag to preserve keys during JSON serialization

    public function toArray( $request )
    {
        return [
            'data' => $this->resource[ 'data' ],
        ];
    }
}
```
Using the same route as above, the output would be:

```json
{"data":{"1":10,"2":20,"total":30}}
```

If the `$preserveKeys` property is not set, or if it is set to `false` the current behavior is preserved.

Note that if the data is a "plain" array (all indices are sequential and start at zero, i.e. `array_values($arr) === $arr`) , a plain JSON array is returned even when `$preserveKeys = true`

---

Most of the code in this PR is based on previous work from @staudenmeir  in PR's #27325 and #24339 
