### PR TITLE
[5.7] Fix collections mapInto - do not pass key as second argument to constructor

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1136,8 +1136,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function mapInto($class)
     {
-        return $this->map(function ($value, $key) use ($class) {
-            return new $class($value, $key);
+        return $this->map(function ($value) use ($class) {
+            return new $class($value);
         });
     }
 


### PR DESCRIPTION
For some reason, `mapInto()` passes the key of the collection as second argument to the constructor of the created instance.

In may case, this caused unexpected results. As this behaviour is [not documented](https://laravel.com/docs/5.7/collections#method-mapinto) and [not checked by any test](https://github.com/laravel/framework/blob/5.7/tests/Support/SupportCollectionTest.php#L1589), I am considering this as a bug.

Example Code
---

```php
class Currency
{
     function __construct(string $code, string $secondArg = "default", string $thirdArg="default2")
     {
         dump("Currency code: " . $code . ", secondArg: " . $secondArg  . ", thirdArg: " . $thirdArg);
     }
}

$collection = collect(['USD', 'EUR', 'GBP']);
$currencies = $collection->mapInto(Currency::class);

```


Current Output
---
```
"Currency code: USD, secondArg: 0, thirdArg: default2"
"Currency code: EUR, secondArg: 1, thirdArg: default2"
"Currency code: GBP, secondArg: 2, thirdArg: default2"
```

Expected Output
---
```
"Currency code: USD, secondArg: default, thirdArg: default2"
"Currency code: EUR, secondArg: default, thirdArg: default2"
"Currency code: GBP, secondArg: default, thirdArg: default2"
```