### PR TITLE
Issue #1499: Add lastWhere() to Collection.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1009,6 +1009,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the last item by the given key value pair.
+     *
+     * @param  string  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public function lastWhere($key, $operator, $value = null)
+    {
+        return $this->last($this->operatorForWhere(...func_get_args()));
+    }
+
+    /**
      * Get the values of a given key.
      *
      * @param  string|array  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -97,6 +97,20 @@ class SupportCollectionTest extends TestCase
         $result = $data->last(null, 'default');
         $this->assertEquals('default', $result);
     }
+    
+    public function testLastWhere()
+    {
+        $data = new Collection([
+            ['material' => 'plastic', 'type' => 'pen'],
+            ['material' => 'paper', 'type' => 'book'],
+            ['material' => 'rubber', 'type' => 'gasket'],
+            ['material' => 'plastic', 'type' => 'trashcan'],
+        ]);
+        $this->assertEquals('trashcan', $data->lastWhere('material', 'plastic')['type']);
+        $this->assertEquals('gasket', $data->lastWhere('material', 'rubber')['type']);
+        $this->assertNull($data->lastWhere('material', 'nonexistant'));
+        $this->assertNull($data->lastWhere('nonexistant', 'key'));
+    }
 
     public function testPopReturnsAndRemovesLastItemInCollection()
     {


### PR DESCRIPTION
Per [issue #1499](https://github.com/laravel/ideas/issues/1499)

There may be a need to use a where clause in conjunction with the last() method. The functions first(), firstWhere(), and last() exist but there is no lastWhere().
