### PR TITLE
[5.7] Allow ENV to control paths of cache files for services, packages and routes

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -885,7 +885,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedServicesPath()
     {
-        return $this->bootstrapPath().'/cache/services.php';
+        return $_ENV['APP_SERVICES_CACHE'] ?? $this->bootstrapPath().'/cache/services.php';
     }
 
     /**
@@ -895,7 +895,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedPackagesPath()
     {
-        return $this->bootstrapPath().'/cache/packages.php';
+        return $_ENV['APP_PACKAGES_CACHE'] ?? $this->bootstrapPath().'/cache/packages.php';
     }
 
     /**
@@ -935,7 +935,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedRoutesPath()
     {
-        return $this->bootstrapPath().'/cache/routes.php';
+        return $_ENV['APP_ROUTES_CACHE'] ?? $this->bootstrapPath().'/cache/routes.php';
     }
 
     /**


### PR DESCRIPTION
In order to override paths of all files in bootstrap/cache, add env vars below:

APP_SERVICES_CACHE
APP_PACKAGES_CACHE
APP_ROUTES_CACHE

env var "APP_CONFIG_CACHE" already defined in commit https://github.com/laravel/framework/commit/578bc83f0247b97ec87fefe39a8da7e9bbfd4a66#diff-7b18a52eceff5eb716c1de268e98d55d