### PR TITLE
[5.8] Validate container alias registration

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -477,9 +477,15 @@ class Container implements ContainerContract
      * @param  string  $abstract
      * @param  string  $alias
      * @return void
+     *
+     * @throws \LogicException
      */
     public function alias($abstract, $alias)
     {
+        if ($alias === $abstract) {
+            throw new LogicException("[{$abstract}] is aliased to itself.");
+        }
+
         $this->aliases[$alias] = $abstract;
 
         $this->abstractAliases[$abstract][] = $alias;
@@ -1095,17 +1101,11 @@ class Container implements ContainerContract
      *
      * @param  string  $abstract
      * @return string
-     *
-     * @throws \LogicException
      */
     public function getAlias($abstract)
     {
         if (! isset($this->aliases[$abstract])) {
             return $abstract;
-        }
-
-        if ($this->aliases[$abstract] === $abstract) {
-            throw new LogicException("[{$abstract}] is aliased to itself.");
         }
 
         return $this->getAlias($this->aliases[$abstract]);

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -22,6 +22,8 @@ interface Container extends ArrayAccess, ContainerInterface
      * @param  string  $abstract
      * @param  string  $alias
      * @return void
+     *
+     * @throws \LogicException
      */
     public function alias($abstract, $alias);
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -342,13 +342,11 @@ class ContainerTest extends TestCase
 
     public function testItThrowsExceptionWhenAbstractIsSameAsAlias()
     {
-        $container = new Container;
-        $container->alias('name', 'name');
-
         $this->expectException('LogicException');
         $this->expectExceptionMessage('[name] is aliased to itself.');
 
-        $container->getAlias('name');
+        $container = new Container;
+        $container->alias('name', 'name');
     }
 
     public function testContainerGetFactory()


### PR DESCRIPTION

The Container::getAlias() method currently throws LogicException. This exception is forwarded to many other container methods that call getAlias() and there are a lot of conflicts with the container interface.
- \Illuminate\Container\Container::when() >>> breaks container interface.
- \Illuminate\Container\Container::resolved() >>> breaks container interface.
- \Illuminate\Container\Container::addContextualBinding() >>> breaks container interface
- \Illuminate\Container\Container::extend() >>> breaks container interface
- \Illuminate\Container\Container::rebinding()
- \Illuminate\Container\Container::resolve()
- \Illuminate\Container\Container::resolving() >>> breaks container interface
- \Illuminate\Container\Container::afterResolving() >>> breaks container interface
- \Illuminate\Container\Container::getExtenders()
- \Illuminate\Container\Container::forgetExtenders()

Let's validate container alias registration to avoid these conflicts. And I think it's reasonable to add `@throws \LogicException` to \Illuminate\Contracts\Container\Container::alias(). Each class has to implement this logic.