### PR TITLE
[5.7] record command elapsed time and fix doc block

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -86,10 +86,14 @@ class Application extends SymfonyApplication implements ApplicationContract
             )
         );
 
+        $start = microtime(true);
+
         $exitCode = parent::run($input, $output);
 
+        $time = $this->getElapsedTime($start);
+
         $this->events->dispatch(
-            new Events\CommandFinished($commandName, $input, $output, $exitCode)
+            new Events\CommandFinished($commandName, $input, $output, $exitCode, $time)
         );
 
         return $exitCode;
@@ -292,5 +296,16 @@ class Application extends SymfonyApplication implements ApplicationContract
     public function getLaravel()
     {
         return $this->laravel;
+    }
+
+    /**
+     * Get the elapsed time since a given starting point.
+     *
+     * @param  float  $start
+     * @return float
+     */
+    protected function getElapsedTime($start)
+    {
+        return round((microtime(true) - $start) * 1000, 2);
     }
 }

--- a/src/Illuminate/Console/Events/CommandFinished.php
+++ b/src/Illuminate/Console/Events/CommandFinished.php
@@ -49,10 +49,10 @@ class CommandFinished
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @param  int  $exitCode
-     * @param  float  $time
+     * @param  float|null  $time
      * @return void
      */
-    public function __construct($command, InputInterface $input, OutputInterface $output, $exitCode, $time)
+    public function __construct($command, InputInterface $input, OutputInterface $output, $exitCode, $time = null)
     {
         $this->input = $input;
         $this->output = $output;

--- a/src/Illuminate/Console/Events/CommandFinished.php
+++ b/src/Illuminate/Console/Events/CommandFinished.php
@@ -36,19 +36,28 @@ class CommandFinished
     public $exitCode;
 
     /**
+     * The number of milliseconds it took to execute the command.
+     *
+     * @var float
+     */
+    public $time;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $command
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @param  int  $exitCode
+     * @param  float  $time
      * @return void
      */
-    public function __construct($command, InputInterface $input, OutputInterface $output, $exitCode)
+    public function __construct($command, InputInterface $input, OutputInterface $output, $exitCode, $time)
     {
         $this->input = $input;
         $this->output = $output;
         $this->command = $command;
         $this->exitCode = $exitCode;
+        $this->time = $time;
     }
 }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -689,7 +689,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the elapsed time since a given starting point.
      *
-     * @param  int    $start
+     * @param  float  $start
      * @return float
      */
     protected function getElapsedTime($start)


### PR DESCRIPTION
1. Change $start doc block which should be float.
2. Record artisan command duration when finished.
3. Not a breaking change for $time default null.