### PR TITLE
[5.8] Create new method named lastWhere() to Illuminate/Support/Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -995,6 +995,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the last item by the given key value pair.
+     *
+     * @param  string  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public function lastWhere($key, $operator, $value = null)
+    {
+        return $this->last($this->operatorForWhere(...func_get_args()));
+    }
+
+    /**
      * Get the values of a given key.
      *
      * @param  string|array  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -98,6 +98,21 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('default', $result);
     }
 
+    public function testLastWhere()
+    {
+        $data = new Collection([
+            ['material' => 'plastic', 'type' => 'pen'],
+            ['material' => 'paper', 'type' => 'book'],
+            ['material' => 'rubber', 'type' => 'gasket'],
+            ['material' => 'plastic', 'type' => 'trashcan'],
+        ]);
+        $this->assertEquals('trashcan', $data->lastWhere('material', 'plastic')['type']);
+        $this->assertEquals('gasket', $data->lastWhere('material', 'rubber')['type']);
+        $this->assertEquals('paper', $data->lastWhere('type', 'book')['material']);
+        $this->assertNull($data->lastWhere('material', 'nonexistant'));
+        $this->assertNull($data->lastWhere('nonexistant', 'key'));
+    }
+
     public function testPopReturnsAndRemovesLastItemInCollection()
     {
         $c = new Collection(['foo', 'bar']);


### PR DESCRIPTION
This PR is related to [laravel/ideas#1499](https://github.com/laravel/ideas/issues/1499) and [laravel/framework#27388](https://github.com/laravel/framework/pull/27388)

In Illuminate/Support/Collection, first() and firstWhere() exists.
Compared to that, last() exists but lastWhere() doesn't exist.
So I suggest I create new method named lastWhere() to Illuminate/Support/Collection.

if this pull request merged, then I"ll open pull request in [laravel/docs](https://github.com/laravel/docs).