### PR TITLE
[5.8] Fix how resources handle arrays with mixed numeric and string keys

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -79,14 +79,13 @@ trait ConditionallyLoadsAttributes
                 $value->resource instanceof PotentiallyMissing &&
                 $value->isMissing())) {
                 unset($data[$key]);
+            } else {
+                $numericKeys = $numericKeys && is_numeric($key);
             }
-            $numericKeys = $numericKeys && is_numeric($key);
         }
 
         if (property_exists($this, 'preserveKeys') && $this->preserveKeys === true) {
-            $values = array_values($data);
-
-            return $values === $data ? $values : $data;
+            return $data;
         }
 
         return $numericKeys ? array_values($data) : $data;

--- a/tests/Integration/Http/Fixtures/ResourceWithPreservedKeys.php
+++ b/tests/Integration/Http/Fixtures/ResourceWithPreservedKeys.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+class ResourceWithPreservedKeys extends PostResource
+{
+    protected $preserveKeys = true;
+
+    public function toArray($request)
+    {
+        return $this->resource;
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -878,6 +878,27 @@ class ResourceTest extends TestCase
         ]);
     }
 
+    public function test_it_will_return_as_an_array_when_string_keys_are_stripped()
+    {
+        $this->assertJsonResourceResponse([
+            1 => 'John',
+            2 => 'Hank',
+            'foo' => new MissingValue,
+        ], ['data' => ['John', 'Hank']]);
+
+        $this->assertJsonResourceResponse([
+            1 => 'John',
+            'foo' => new MissingValue,
+            3 => 'Hank',
+        ], ['data' => ['John', 'Hank']]);
+
+        $this->assertJsonResourceResponse([
+            'foo' => new MissingValue,
+            2 => 'John',
+            3 => 'Hank',
+        ], ['data' => ['John', 'Hank']]);
+    }
+
     public function test_it_strips_numeric_keys()
     {
         $this->assertJsonResourceResponse([


### PR DESCRIPTION
Since PR #23414 the way Resources handle payload with numeric keys has changed breaking the way some users expected them to be returned.

After this PR, any array in a Resource that had a numeric value in its first key was converted to a plain JSON array. For example, assume we have this route:

~~~php
Route::get('/', function () {
    return new \Illuminate\Http\Resources\Json\JsonResource([
        1 => 10,
        2 => 20,
        'total' => 30
    ]);
});
~~~

Currently the response would be:

~~~json
{"data":[10,20,30]}
~~~

While as a user might excpect it to be:

~~~json
{"data":{"1": 10, "2": 20, "total": 30}}
~~~
This problem was tried to be solved in some other PR's ( #24339 , #27325 , #27384 ). And some use-cases were described in the comments within these PR's.

The example above (having a `total` key and the payload) was described by @hotmeteor in the PR #23414 comments ( [link to the comment](https://github.com/laravel/framework/pull/23414#issuecomment-374235188) ).

Other valid use case, described by @SethTompkins in the comments of PR #24339 ( [link to the comment](https://github.com/laravel/framework/pull/24339#issuecomment-421446740) ) was to adopt a recommendation from the Redux JavaScript framework to "normalize  frontend state to allow for easy transaction and lookups with api resources". ( Reference: https://redux.js.org/recipes/structuring-reducers/normalizing-state-shape#relationships-and-tables )

In the example from Redux, linked above, it suggests to return a lookup-table shaped like this (simplified):

~~~js
{
    entities: {
        authorBook : {
            byId : {
                1 : { id : 1, authorId : 5, bookId : 22 },
                2 : { id : 2, authorId : 5, bookId : 15 },
                3 : { id : 3, authorId : 42, bookId : 12 }
            },
            allIds : [1, 2, 3]
        }
    }
}
~~~

Note that the `entities.authorBook.byId` property is a JavaScript object with numeric keys.

In the current form we could not return the data shaped like this example. Currently a Resource when serialize its data it only checks if the first key of an array is numeric and, if so, converts all the array to a plain array. The data returned would look like this:

~~~js
{
    entities: {
        authorBook : {
            byId : [
                { id : 1, authorId : 5, bookId : 22 },
                { id : 2, authorId : 5, bookId : 15 },
                { id : 3, authorId : 42, bookId : 12 }
            ],
            allIds : [1, 2, 3]
        }
    }
}
~~~

Which is different than expected.

If this PR gets merged, a user could define a `$preserveKeys = true` property in the Resource returning this data structure and the keys within the `entities.authorBook.byId` would be preserved.

This PR does the following changes:

1.  Change how the `ConditionallyLoadsAttributes@removeMissingValues` methods detects if an array has only numeric keys, by using an sentinel flag while it iterates to the array element.
    
    This is a breaking change, as it would check all keys in a array before converting it to a 'plain' without further modification from a user (see first use-case above).
    
2. A user can now define a `$preserveKeys` to a resource, so only *actual* plain arrays (`array_values($data) === $data`) are converted to a JS array, anything different than that have their keys preserved.

---

Much of the code in this PR was possible summing up on the previous work and comments from @staudenmeir in PR's  #24339 , #27325 . 