### PR TITLE
[5.7] Add missing type to param in docblock

### DIFF
--- a/src/Illuminate/Http/Resources/MergeValue.php
+++ b/src/Illuminate/Http/Resources/MergeValue.php
@@ -17,7 +17,7 @@ class MergeValue
     /**
      * Create new merge value instance.
      *
-     * @param  \Illuminate\Support\Collection|array  $data
+     * @param  \Illuminate\Support\Collection|JsonSerializable|array  $data
      * @return void
      */
     public function __construct($data)

--- a/src/Illuminate/Http/Resources/MergeValue.php
+++ b/src/Illuminate/Http/Resources/MergeValue.php
@@ -17,7 +17,7 @@ class MergeValue
     /**
      * Create new merge value instance.
      *
-     * @param  \Illuminate\Support\Collection|JsonSerializable|array  $data
+     * @param  \Illuminate\Support\Collection|\JsonSerializable|array  $data
      * @return void
      */
     public function __construct($data)


### PR DESCRIPTION
Adds `JsonSerializable` to the `$data` param docblock at `Illuminate\Http\Resources\MergeValue` constructor.

While working on PR's #27384 and #27394 I noticed that it as missing.