### PR TITLE
[5.7] Added missing @param to dd() method on Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -312,6 +312,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Dump the collection and end the script.
      *
+     * @param mixed  ...$args
      * @return void
      */
     public function dd(...$args)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -312,7 +312,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Dump the collection and end the script.
      *
-     * @param mixed  ...$args
+     * @param  mixed  ...$args
      * @return void
      */
     public function dd(...$args)


### PR DESCRIPTION
Added missing `@param` to `dd()`'s docblock on `Collection`

This is such a minor thing it almost seems pointless to do a pull request.

 