### PR TITLE
Added method for autoloading a routes directory

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -83,7 +83,6 @@ abstract class ServiceProvider
     {
         $routeFiles = (new Filesystem())->allFiles($path);
         if ($routeFiles && !$this->app->routesAreCached()) {
-            $routeFiles = $this->getDirContents($path);
             foreach ($routeFiles as $routeFile) {
                 $this->loadRoutesFrom($routeFile);
             }

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Support;
 
-use Illuminate\Console\Application as Artisan;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Console\Application as Artisan;
 
 abstract class ServiceProvider
 {
@@ -75,7 +75,7 @@ abstract class ServiceProvider
 
     /**
      * Recursively scan the directory at the given path
-     * and load any route files found if not already cached
+     * and load any route files found if not already cached.
      *
      * @param  string  $path
      * @return void
@@ -90,7 +90,7 @@ abstract class ServiceProvider
 
     /**
      * Recursively scan the directory at the given path
-     * and return it's files
+     * and return it's files.
      *
      * @param  string  $path
      * @return array

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -71,6 +71,24 @@ abstract class ServiceProvider
             require $path;
         }
     }
+    
+    /**
+     * Recursively scan the directory at the given path
+     * and load any route files found if not already cached
+     *
+     * @param  string  $path
+     * @return void
+     */
+    protected function loadAllRoutesFrom($path): void
+    {
+        $routeFiles = (new Filesystem())->allFiles($path);
+        if ($routeFiles && !$this->app->routesAreCached()) {
+            $routeFiles = $this->getDirContents($path);
+            foreach ($routeFiles as $routeFile) {
+                $this->loadRoutesFrom($routeFile);
+            }
+        }
+    }
 
     /**
      * Register a view file namespace.

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Illuminate\Console\Application as Artisan;
+use Illuminate\Filesystem\Filesystem;
 
 abstract class ServiceProvider
 {
@@ -71,7 +72,7 @@ abstract class ServiceProvider
             require $path;
         }
     }
-    
+
     /**
      * Recursively scan the directory at the given path
      * and load any route files found if not already cached
@@ -79,14 +80,24 @@ abstract class ServiceProvider
      * @param  string  $path
      * @return void
      */
-    protected function loadAllRoutesFrom($path): void
+    protected function loadAllRoutesFrom($path)
     {
-        $routeFiles = (new Filesystem())->allFiles($path);
-        if ($routeFiles && !$this->app->routesAreCached()) {
-            foreach ($routeFiles as $routeFile) {
-                $this->loadRoutesFrom($routeFile);
-            }
+        $routeFiles = $this->getFilesFromPath($path);
+        foreach ($routeFiles as $routeFile) {
+            $this->loadRoutesFrom($routeFile);
         }
+    }
+
+    /**
+     * Recursively scan the directory at the given path
+     * and return it's files
+     *
+     * @param  string  $path
+     * @return array
+     */
+    protected function getFilesFromPath($path)
+    {
+        return (new Filesystem())->allFiles($path);
     }
 
     /**

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -105,6 +105,28 @@ class SupportServiceProviderTest extends TestCase
         ];
         $this->assertEquals($expected, $toPublish, 'Service provider does not return expected set of published tagged paths.');
     }
+
+    public function testLoadAllRoutesFromLoadsRoutesCorrectly()
+    {
+        $expectedFiles = ['file1.php', 'file2.php'];
+        $app           = m::mock(Application::class)->makePartial();
+        $provider      = m::mock(ServiceProvider::class, [$app])->makePartial();
+        $provider->shouldAllowMockingProtectedMethods();
+
+        $provider->shouldReceive('getFilesFromPath')
+            ->once()
+            ->andReturn($expectedFiles);
+
+        $provider->shouldReceive('loadRoutesFrom')
+            ->times(\count($expectedFiles));
+
+        $provider->loadAllRoutesFrom('some/path');
+
+        // count our expected calls as passed assertions
+        $this->addToAssertionCount(
+            \Mockery::getContainer()->mockery_getExpectationCount()
+        );
+    }
 }
 
 class ServiceProviderForTestingOne extends ServiceProvider

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -109,8 +109,8 @@ class SupportServiceProviderTest extends TestCase
     public function testLoadAllRoutesFromLoadsRoutesCorrectly()
     {
         $expectedFiles = ['file1.php', 'file2.php'];
-        $app           = m::mock(Application::class)->makePartial();
-        $provider      = m::mock(ServiceProvider::class, [$app])->makePartial();
+        $app = m::mock(Application::class)->makePartial();
+        $provider = m::mock(ServiceProvider::class, [$app])->makePartial();
         $provider->shouldAllowMockingProtectedMethods();
 
         $provider->shouldReceive('getFilesFromPath')


### PR DESCRIPTION
### This PR adds three new methods:

#

`src/Illuminate/Support/ServiceProvider.php`

```
loadAllRoutesFrom  // Recursively scan the directory at the given path and load any route files found
getFilesFromPath   // Recursively scan the directory at the given path and return it's files
                   // This helper method was used to make it easier to test loadAllRoutesFrom  
```

#

`tests/Support/SupportServiceProviderTest.php`

```
testLoadAllRoutesFromLoadsRoutesCorrectly // Tests that loadAllRoutesFrom calls getFilesFromPath 1 once
                                          // then calls loadRoutesFrom for each filename returned
```


**Benefit to end users**
- enables users to autoload a directory of route files and avoid having to write code to load each file separately

**Reasons it does not break any existing features**
- PR only adds new methods and no calls to them creating no affect on existing code

**How it makes building web applications easier**
- Makes storing and loading of routes simpler and more organized.

Related to https://github.com/laravel/ideas/issues/1506