### PR TITLE
[5.5] Add a get method to access protected property 'middlewareGroups' in K…

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -327,6 +327,16 @@ class Kernel implements KernelContract
     }
 
     /**
+     * Get the application's route middleware groups.
+     *
+     * @return array
+     */
+    public function getMiddlewareGroups()
+    {
+        return $this->middlewareGroups;
+    }
+
+    /**
      * Get the Laravel application instance.
      *
      * @return \Illuminate\Contracts\Foundation\Application


### PR DESCRIPTION
I found that the accessor `getMiddlewareGroups` in `src/Illuminate/Foundation/Http/Kernel.php` is defined in `5.7` branch, but it's great if the updated is integrated in LTS version too.

thank you, 

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
