### PR TITLE
[5.7] add support for at notation for termination callbacks

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -970,10 +970,10 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Register a terminating callback with the application.
      *
-     * @param  \Closure  $callback
+     * @param  mixed  $callback
      * @return $this
      */
-    public function terminating(Closure $callback)
+    public function terminating($callback)
     {
         $this->terminatingCallbacks[] = $callback;
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -218,6 +218,14 @@ class FoundationApplicationTest extends TestCase
         $app->afterBootstrapping(RegisterFacades::class, $closure);
         $this->assertArrayHasKey(0, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\RegisterFacades'));
     }
+
+    public function testTerminationCallbacksCanAcceptAtNotation()
+    {
+        $app = new Application;
+        $app->terminating(ConcreteTerminator::class.'@terminate');
+        $app->terminate();
+        $this->assertEquals(1, ConcreteTerminator::$counter);
+    }
 }
 
 class ApplicationBasicServiceProviderStub extends ServiceProvider
@@ -306,4 +314,14 @@ abstract class AbstractClass
 class ConcreteClass extends AbstractClass
 {
     //
+}
+
+class ConcreteTerminator
+{
+    public static $counter = 0;
+
+    public function terminate()
+    {
+        return self::$counter++;
+    }
 }


### PR DESCRIPTION
In fact it is already supported, since it uses the $app->call(... to invoke the callbacks.

we can widen the accepted parameters types to whatever the `call` method accepts.
And this change is going to be backward compatible.