### PR TITLE
[5.7] Sign the user in only if email verification is not required

### DIFF
--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Auth;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Auth\Events\Registered;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 
 trait RegistersUsers
 {
@@ -32,7 +33,7 @@ trait RegistersUsers
 
         event(new Registered($user = $this->create($request->all())));
 
-        $this->guard()->login($user);
+        $this->login($user);
 
         return $this->registered($request, $user)
                         ?: redirect($this->redirectPath());
@@ -58,5 +59,15 @@ trait RegistersUsers
     protected function registered(Request $request, $user)
     {
         //
+    }
+
+    /**
+     * Signs the user in.
+     *
+     * @param mixed $user
+     */
+    protected function login($user)
+    {
+        $this->guard()->login($user);
     }
 }

--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -5,7 +5,6 @@ namespace Illuminate\Foundation\Auth;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Auth\Events\Registered;
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 
 trait RegistersUsers
 {


### PR DESCRIPTION
Usually, when a user is required to be verified he/she should not be logged in automatically since we need to be sure that the user's email belongs to the right user. 

In my website, the user receives an email verification and is redirected to the home page where a flash message is shown, that says that verification is required (with an email resend link). However, the user sees that the login menu is changed from "Login | Register" to "Profile | Logout". Even if I make additional checks and not show this menu, the user is still not allowed to use the platform anyway if he/she is not verified, so this is unnecessary check. 

If the user tries to go to a page where a login is required by manually typing it, he/she will be redirected to the verification notice page, which is redundant, since it tells the user that he/she can't use the system. This is the same as being not logged in - the user doesn't have access to the system.

We can make that configurable.
