### PR TITLE
[5.8] Provide a simple debug info in compiled views (path to view)

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\View\Compilers;
 
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -106,6 +107,29 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $rawBlocks = [];
 
     /**
+     * Provide debug info in the compiled views.
+     *
+     * @var boolean
+     */
+    protected $debugInfo;
+
+    /**
+     * Create a new compiler instance.
+     *
+     * @param  Filesystem  $files
+     * @param  string  $cachePath
+     * @param  boolean  $debugInfo
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(Filesystem $files, $cachePath, $debugInfo = false)
+    {
+        parent::__construct($files, $cachePath);
+        $this->debugInfo = $debugInfo;
+    }
+
+    /**
      * Compile the view at the given path.
      *
      * @param  string  $path
@@ -119,7 +143,9 @@ class BladeCompiler extends Compiler implements CompilerInterface
 
         if (! is_null($this->cachePath)) {
             $contents = $this->compileString($this->files->get($this->getPath()));
-
+            if ($this->debugInfo) {
+                $contents .= $this->generateDebugInfo();
+            }
             $this->files->put($this->getCompiledPath($this->getPath()), $contents);
         }
     }
@@ -520,5 +546,15 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function withoutDoubleEncoding()
     {
         $this->setEchoFormat('e(%s, false)');
+    }
+
+    /**
+     * Generate debug info for the file.
+     *
+     * @return string
+     */
+    protected function generateDebugInfo()
+    {
+        return "\n /* {$this->getPath()} */";
     }
 }

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -138,7 +138,7 @@ class ViewServiceProvider extends ServiceProvider
         // instance to pass into the engine so it can compile the views properly.
         $this->app->singleton('blade.compiler', function () {
             return new BladeCompiler(
-                $this->app['files'], $this->app['config']['view.compiled']
+                $this->app['files'], $this->app['config']['view.compiled'], $this->app['config']['view.debugInfo']
             );
         });
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -93,6 +93,14 @@ class ViewBladeCompilerTest extends TestCase
         }}'));
     }
 
+    public function testIncludeDebugInfo()
+    {
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__, true);
+        $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', "Hello World\n /* foo */");
+        $compiler->compile('foo');
+    }
+
     protected function getFiles()
     {
         return m::mock(Filesystem::class);


### PR DESCRIPTION
This PR fixes https://github.com/laravel/ideas/issues/1480 by adding very simple debug info to compiled views namely the path to the view in order to provide a possibility of Blade debugging in PhpStorm.

Also, I'm going to submit a PR with adding a new default option to view config if this PR is accepted: https://github.com/bzixilu/laravel/commit/a17462b15435eb16ef3f1d10f8604aefd4090aa9
