### PR TITLE
[5.8] Let the `make:model` command add the new models in `app/Models` if the directory exists.

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -112,6 +112,24 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        $name = Str::replaceFirst($this->rootNamespace(), '', $name);
+        $name = str_replace('\\', '/', $name) . '.php';
+
+        if ($this->hasModelsFolder()) {
+            return $this->laravel['path'] . '/Models/' . $name;
+        }
+
+        return $this->laravel['path'] . '/' . $name;
+    }
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string
@@ -147,5 +165,15 @@ class ModelMakeCommand extends GeneratorCommand
 
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
         ];
+    }
+
+    /**
+     * Check whether the app\Models directory exists.
+     *
+     * @return bool
+     */
+    protected function hasModelsFolder()
+    {
+        return $this->files->exists($this->laravel['path'] . '/Models');
     }
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -112,21 +112,18 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Get the destination class path.
+     * Get the default namespace for the class.
      *
-     * @param  string  $name
+     * @param  string  $rootNamespace
      * @return string
      */
-    protected function getPath($name)
+    protected function getDefaultNamespace($rootNamespace)
     {
-        $name = Str::replaceFirst($this->rootNamespace(), '', $name);
-        $name = str_replace('\\', '/', $name) . '.php';
-
         if ($this->hasModelsFolder()) {
-            return $this->laravel['path'] . '/Models/' . $name;
+            return $rootNamespace . '\Models';
         }
 
-        return $this->laravel['path'] . '/' . $name;
+        return $rootNamespace;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -120,7 +120,7 @@ class ModelMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         if ($this->hasModelsFolder()) {
-            return $rootNamespace . '\Models';
+            return $rootNamespace.'\Models';
         }
 
         return $rootNamespace;
@@ -171,6 +171,6 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function hasModelsFolder()
     {
-        return $this->files->exists($this->laravel['path'] . '/Models');
+        return $this->files->exists($this->laravel['path'].'/Models');
     }
 }


### PR DESCRIPTION
By default the `make:model` command generates the models in the `app/` folder. If you wish to have the models created in the `app/Models` directory for example you'll have to run the command as `php artisan make:model Models\\Post`. 

Although this isn't that hard, it would be good if the `make:model` command automatically added the file in the `app/Models` directory if it exists in the project. 

Having your models in a `app/Models` directory is a convention I've seen many Laravel developers use. 

If developers don't use that folder, and just keep their models loose under the `app/` folder, nothing changes for them. But if they use the `app/Models` folder structure, it'll make their lives just a bit more easier.

🤠
