### PR TITLE
[5.7] Revert "[5.7] Allow ENV to control paths of cache files for services, packages and routes"

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -885,7 +885,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedServicesPath()
     {
-        return $_ENV['APP_SERVICES_CACHE'] ?? $this->bootstrapPath().'/cache/services.php';
+        return $this->bootstrapPath().'/cache/services.php';
     }
 
     /**
@@ -895,7 +895,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedPackagesPath()
     {
-        return $_ENV['APP_PACKAGES_CACHE'] ?? $this->bootstrapPath().'/cache/packages.php';
+        return $this->bootstrapPath().'/cache/packages.php';
     }
 
     /**
@@ -935,7 +935,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedRoutesPath()
     {
-        return $_ENV['APP_ROUTES_CACHE'] ?? $this->bootstrapPath().'/cache/routes.php';
+        return $this->bootstrapPath().'/cache/routes.php';
     }
 
     /**


### PR DESCRIPTION
I really don't like this implementation. Instead, we should let users call `setCachedServicesPath()` etc when they bootstrap their app, surely? Seems wrong the application is looking at env variables like this - very hacky.