### PR TITLE
[5.8] Serve command will try 10 ports by default if the previous port is occupied

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -24,6 +24,12 @@ class ServeCommand extends Command
     protected $description = 'Serve the application on the PHP development server';
 
     /**
+     * The current addition to the port (used with maxTries)
+     * @var int
+     */
+    protected $addPort = 0;
+
+    /**
      * Execute the console command.
      *
      * @return int
@@ -37,6 +43,13 @@ class ServeCommand extends Command
         $this->line("<info>Laravel development server started:</info> <http://{$this->host()}:{$this->port()}>");
 
         passthru($this->serverCommand(), $status);
+
+        if ($status && $this->canTryAnotherPort()) {
+            $this->addPort += 1;
+            return $this->handle();
+        }
+
+        echo $status;
 
         return $status;
     }
@@ -73,7 +86,17 @@ class ServeCommand extends Command
      */
     protected function port()
     {
-        return $this->input->getOption('port');
+        return $this->input->getOption('port') + $this->addPort;
+    }
+
+    /**
+     * Check if command has reached its max amount of port tries
+     *
+     * @return bool
+     */
+    protected function canTryAnotherPort()
+    {
+        return $this->input->getOption('maxTries') > $this->addPort;
     }
 
     /**
@@ -87,6 +110,8 @@ class ServeCommand extends Command
             ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on', '127.0.0.1'],
 
             ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on', 8000],
+
+            ['maxTries', null, InputOption::VALUE_OPTIONAL, 'The max number of times to try connecting to a port', 10],
         ];
     }
 }


### PR DESCRIPTION
Often, I find myself having to restart my `serve` command with a specified port, this PR would let it try 10 ports before finally exiting if the previous ports are occupied.

The inspiration for this addition comes from `vue-cli`, if you try to run a project (with `npm run serve`) it starts on port 8080 and if it in-use it'll go to the next port and try it until it comes up with an open port.
