### PR TITLE
[5.7] Revert "Handle AWS Connection Lost (#25295)"

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -34,7 +34,6 @@ trait DetectsLostConnections
             'reset by peer',
             'Physical connection is not usable',
             'TCP Provider: Error code 0x68',
-            'Name or service not known',
             'ORA-03114',
             'Packets out of order. Expected',
             'Adaptive Server connection failed',

--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -34,7 +34,7 @@ trait DetectsLostConnections
             'reset by peer',
             'Physical connection is not usable',
             'TCP Provider: Error code 0x68',
-            'php_network_getaddresses: getaddrinfo failed: Name or service not known',
+            'getaddrinfo failed: Name or service not known',
             'ORA-03114',
             'Packets out of order. Expected',
             'Adaptive Server connection failed',

--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -34,7 +34,7 @@ trait DetectsLostConnections
             'reset by peer',
             'Physical connection is not usable',
             'TCP Provider: Error code 0x68',
-            'getaddrinfo failed: Name or service not known',
+            'Name or service not known',
             'ORA-03114',
             'Packets out of order. Expected',
             'Adaptive Server connection failed',


### PR DESCRIPTION
Fixes #27053, Refs #25289 & #25295

Queue workers die with userland exception
```
production.ERROR: Error creating resource: [message] fopen(): php_network_getaddresses: getaddrinfo failed: Name or service not known
```

Any failure in userland to fopen will cause the queue worker to kill itself, because it gets detected by "DetectsLostConnections". This is because this string is too generic in the detection of lost connections when it was intended for database lost connections, but instead it falls for random userland exceptions.

I had first opted to fix the DetectsLostConnection to check exception for DB context, but I don't know enough about internals of Laravel to do that. So I opted instead to revert the commits that added this.

See this comment for more details: https://github.com/laravel/framework/issues/27053#issuecomment-451470685