### PR TITLE
[5.7] Add Model::withoutEventDispatcher() method to temporarily bypass model events

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -351,4 +351,27 @@ trait HasEvents
     {
         static::$dispatcher = null;
     }
+
+    /**
+     * Execute a callback without the event dispatcher.
+     *
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public static function withoutEventDispatcher(callable $callback)
+    {
+        $dispatcher = static::getEventDispatcher();
+
+        static::unsetEventDispatcher();
+
+        try {
+            $result = $callback();
+        } finally {
+            if ($dispatcher) {
+                static::setEventDispatcher($dispatcher);
+            }
+        }
+
+        return $result;
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -353,7 +353,7 @@ trait HasEvents
     }
 
     /**
-     * Execute a callback without the event dispatcher.
+     * Execute a callback without firing any model events for this model type.
      *
      * @param  callable  $callback
      * @return mixed

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -365,13 +365,11 @@ trait HasEvents
         static::unsetEventDispatcher();
 
         try {
-            $result = $callback();
+            return $callback();
         } finally {
             if ($dispatcher) {
                 static::setEventDispatcher($dispatcher);
             }
         }
-
-        return $result;
     }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1342,9 +1342,15 @@ class DatabaseEloquentModelTest extends TestCase
         });
 
         $model->withoutEventDispatcher(function () use ($model) {
-            $model->name = 'Taylor';
+            $model->first_name = 'Taylor';
             $model->save();
         });
+
+        $events->shouldReceive('until')->once()->with('eloquent.saving: Illuminate\Tests\Database\EloquentModelSaveStub', $model);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelSaveStub', $model);
+
+        $model->last_name = 'Otwell';
+        $model->save();
 
         EloquentModelSaveStub::flushEventListeners();
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1338,6 +1338,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = EloquentModelSaveStub::withoutEventDispatcher(function () {
             $model = new EloquentModelSaveStub;
             $model->save();
+
             return $model;
         });
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1325,6 +1325,30 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelStub::flushEventListeners();
     }
 
+    public function testWithoutEventDispatcher()
+    {
+        EloquentModelSaveStub::setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelSaveStub', EloquentTestObserverStub::class.'@creating');
+        $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelSaveStub', EloquentTestObserverStub::class.'@saved');
+        $events->shouldNotReceive('until');
+        $events->shouldNotReceive('dispatch');
+        $events->shouldReceive('forget');
+        EloquentModelSaveStub::observe(EloquentTestObserverStub::class);
+
+        $model = EloquentModelSaveStub::withoutEventDispatcher(function () {
+            $model = new EloquentModelSaveStub;
+            $model->save();
+            return $model;
+        });
+
+        $model->withoutEventDispatcher(function () use ($model) {
+            $model->name = 'Taylor';
+            $model->save();
+        });
+
+        EloquentModelSaveStub::flushEventListeners();
+    }
+
     public function testSetObservableEvents()
     {
         $class = new EloquentModelStub;
@@ -1976,7 +2000,13 @@ class EloquentModelSaveStub extends Model
 
     public function save(array $options = [])
     {
+        if ($this->fireModelEvent('saving') === false) {
+            return false;
+        }
+
         $_SERVER['__eloquent.saved'] = true;
+
+        $this->fireModelEvent('saved', false);
     }
 
     public function setIncrementing($value)


### PR DESCRIPTION
It is sometimes desirable to temporarily bypass model events. For example, when seeding - imagine your model has a `created` listener and a `saved` listener. You are trying to test the `saved` listener, but the `created` listener is also firing when seeding the data for the test.

While it is already possible to do this, the code is verbose and requires either muddying up the test with implementation details, or by creating a base model or trait to add the functionality directly to the model (my current workaround). This aims to simplify that by creating an intuitively named helper method to execute a callback with the event dispatcher temporarily disabled, returning the result of the callback.

As this is a new method, it should not break anything. It just enhances the existing API around getting, setting, and unsetting the event dispatcher.

Before:
```php
$dispatcher = User::getEventDispatcher();
User::unsetEventDispatcher();
$user = factory(User::class)->create();
User::setEventDispatcher($dispatcher);

$user->doSomethingWhereEventsShouldFire();
```

After:
```php
$user = User::withoutEventDispatcher(function () {
    return factory(User::class)->create();
});

$user->doSomethingWhereEventsShouldFire();
```

I realise that a [similar PR](https://github.com/laravel/framework/pull/22136) was rejected in the past, but I feel this PR is different for the following reasons:

1. The method name matches the existing `Model::unsetEventDispatcher()` API so I believe it achieves the same clarity about what it is doing.
2. The use case seems quite common.
2. This method allows you to return the result of the callback
3. This method handles the situation where an event dispatcher was never defined
4. This PR has tests