### PR TITLE
[5.8] Get Eloquent base query builder from connection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -15,7 +15,6 @@ use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
@@ -1045,11 +1044,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function newBaseQueryBuilder()
     {
-        $connection = $this->getConnection();
-
-        return new QueryBuilder(
-            $connection, $connection->getQueryGrammar(), $connection->getPostProcessor()
-        );
+        return $this->getConnection()->query();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1140,6 +1140,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $grammar = new $grammarClass;
         $processor = new $processorClass;
         $connection = m::mock(ConnectionInterface::class, ['getQueryGrammar' => $grammar, 'getPostProcessor' => $processor]);
+        $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
+            return new BaseBuilder($connection, $grammar, $processor);
+        });
         $resolver = m::mock(ConnectionResolverInterface::class, ['connection' => $connection]);
         $class = get_class($model);
         $class::setConnectionResolver($resolver);


### PR DESCRIPTION
`Model::newBaseQueryBuilder()` doesn't call [`Connection::query()`](https://github.com/laravel/framework/blob/4349fe3d1ac7e75042cfefe69b980188b23dc3a8/src/Illuminate/Database/Connection.php#L273), but creates its query builder using the same code. We can get the query builder from the connection and remove the duplicate code.

I stumbled upon this while working on a package. The package's service provider registers a custom connection factory that returns connections with a custom query builder. As expected, `DB::query()` now returns the package's query builder. But due to the current implementation of `newBaseQueryBuilder()`, `User::query()` still uses Laravel's default query builder. IMO, it should also use the package's query builder.