### PR TITLE
[5.7] Add wildcard prefix to Resource Routes names option

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -405,7 +405,7 @@ class ResourceRegistrar
 
             if (Str::contains($prefix, '*')) {
                 $prefix = trim($prefix, '*');
-            };
+            }
         }
 
         return trim(sprintf('%s%s.%s', $prefix, $name, $method), '.');

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -398,6 +398,16 @@ class ResourceRegistrar
         // the resource action. Otherwise we'll just use an empty string for here.
         $prefix = isset($options['as']) ? $options['as'].'.' : '';
 
+        // If a star is set as the key in the names array
+        // we will prefix all the routes with that value
+        if (isset($options['names']['*'])) {
+            $prefix = $options['names']['*'];
+
+            if (Str::contains($prefix, '*')) {
+                $prefix = trim($prefix, '*');
+            };
+        }
+
         return trim(sprintf('%s%s.%s', $prefix, $name, $method), '.');
     }
 


### PR DESCRIPTION
This feature would allow resource routes prefixes to be written with shorter syntax, making use of the already existing names option.

Currently you would have to use this syntax to append a prefix to all routes in a resource route. I feel this can start to look pretty messy if you already have a lot of nested route groups.
```
    Route::group(['as' => 'accounts.'], function () {
        Route::apiResource('accounts/tags', 'AccountTagController');
    });
```

However this pull request would allow this syntax which works with the existing names option
```
Route::apiResource('accounts/tags', 'AccountTagController')->names(['*' => 'accounts.']);
Route::resource('accounts/tags', 'AccountTagController')->names(['*' => 'accounts.']);
```

It would also work as
```
Route::apiResource('accounts/tags', 'AccountTagController')->names(['*' => 'accounts.*']);
Route::resource('accounts/tags', 'AccountTagController')->names(['*' => 'accounts.*']);
```

All of the tests inside the routing directory passed with this, and it seems to cause no errors in my current project where I have already implemented it.