### PR TITLE
[5.7] Add command to generate controllers from routes list

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -53,6 +53,7 @@ use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Foundation\Console\PackageDiscoverCommand;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Foundation\Console\NotificationMakeCommand;
+use Illuminate\Routing\Console\GenerateControllersCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
 use Illuminate\Queue\Console\WorkCommand as QueueWorkCommand;
 use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
@@ -138,6 +139,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'ChannelMake' => 'command.channel.make',
         'ConsoleMake' => 'command.console.make',
         'ControllerMake' => 'command.controller.make',
+        'ControllerGenerate' => 'command.controllers.generate',
         'EventGenerate' => 'command.event.generate',
         'EventMake' => 'command.event.make',
         'ExceptionMake' => 'command.exception.make',
@@ -1008,6 +1010,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.view.clear', function ($app) {
             return new ViewClearCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerControllerGenerateCommand()
+    {
+        $this->app->singleton('command.controllers.generate', function () {
+            return new GenerateControllersCommand();
         });
     }
 

--- a/src/Illuminate/Routing/Console/GenerateControllersCommand.php
+++ b/src/Illuminate/Routing/Console/GenerateControllersCommand.php
@@ -44,7 +44,7 @@ class GenerateControllersCommand extends Command
         )->getActionList();
 
         // No route are found
-        if(count($allRoutes) === 0){
+        if (count($allRoutes) === 0) {
             $this->warn('No Routes are found');
             return;
         }
@@ -57,14 +57,14 @@ class GenerateControllersCommand extends Command
         $cachedControllers = [];
 
         // Loop over all actions
-        foreach ($controllers as $controller){
-            $controller = explode("@", $controller);
+        foreach ($controllers as $controller) {
+            $controller = explode('@', $controller);
             // Only parse Controllers that are not parsed before
-            if(!in_array($controller[0], $cachedControllers)){
+            if (! in_array($controller[0], $cachedControllers)) {
                 $cachedControllers [] = $controller[0];
 
-                if(!class_exists($controller[0])){
-                    \Illuminate\Support\Facades\Artisan::call("make:controller", [
+                if(! class_exists($controller[0])) {
+                    \Illuminate\Support\Facades\Artisan::call('make:controller', [
                         'name' => $controller[0]
                     ]);
 

--- a/src/Illuminate/Routing/Console/GenerateControllersCommand.php
+++ b/src/Illuminate/Routing/Console/GenerateControllersCommand.php
@@ -46,6 +46,7 @@ class GenerateControllersCommand extends Command
         // No route are found
         if (count($allRoutes) === 0) {
             $this->warn('No Routes are found');
+
             return;
         }
 
@@ -63,9 +64,9 @@ class GenerateControllersCommand extends Command
             if (! in_array($controller[0], $cachedControllers)) {
                 $cachedControllers [] = $controller[0];
 
-                if(! class_exists($controller[0])) {
+                if (! class_exists($controller[0])) {
                     \Illuminate\Support\Facades\Artisan::call('make:controller', [
-                        'name' => $controller[0]
+                        'name' => $controller[0],
                     ]);
 
                     $this->info("{$controller[0]} Controller has been created.");

--- a/src/Illuminate/Routing/Console/GenerateControllersCommand.php
+++ b/src/Illuminate/Routing/Console/GenerateControllersCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Illuminate\Routing\Console;
+
+use Illuminate\Console\Command;
+
+class GenerateControllersCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'generate:controller';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate controllers from the routes list';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $allRoutes = optional(
+            optional(
+                app('router')->getRoutes()
+            )
+        )->getActionList();
+
+        // No route are found
+        if(count($allRoutes) === 0){
+            $this->warn('No Routes are found');
+            return;
+        }
+
+        $controllers = array_keys(
+            $allRoutes
+        );
+
+
+        $cachedControllers = [];
+
+        // Loop over all actions
+        foreach ($controllers as $controller){
+            $controller = explode("@", $controller);
+            // Only parse Controllers that are not parsed before
+            if(!in_array($controller[0], $cachedControllers)){
+                $cachedControllers [] = $controller[0];
+
+                if(!class_exists($controller[0])){
+                    \Illuminate\Support\Facades\Artisan::call("make:controller", [
+                        'name' => $controller[0]
+                    ]);
+
+                    $this->info("{$controller[0]} Controller has been created.");
+                }
+            }
+        }
+    }
+}

--- a/src/Illuminate/Routing/Console/GenerateControllersCommand.php
+++ b/src/Illuminate/Routing/Console/GenerateControllersCommand.php
@@ -54,7 +54,6 @@ class GenerateControllersCommand extends Command
             $allRoutes
         );
 
-
         $cachedControllers = [];
 
         // Loop over all actions

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -348,4 +348,14 @@ class RouteCollection implements Countable, IteratorAggregate
     {
         return count($this->getRoutes());
     }
+
+    /**
+     * Get the list of Actions.
+     *
+     * @return array
+     */
+    public function getActionList()
+    {
+        return $this->actionList;
+    }
 }


### PR DESCRIPTION
The idea behind the command is to make the development as fast as possible.
Having in the following routes 

```
Route::get('/', 'HomesController@index');
```

After the command

`php artisan generate:controller`

A App\Http\Controllers\HomesController Controller will be created for you directly based on the routes you have.

The same as the event:generate command.

