### PR TITLE
[5.7] Update migrate:status command to show only failed migrations if needed

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -80,7 +80,7 @@ class StatusCommand extends BaseCommand
         return Collection::make($this->getAllMigrationFiles())
                     ->map(function ($migration) use ($ran, $batches) {
                         $migrationName = $this->migrator->getMigrationName($migration);
-                        if($this->option('failed')) {
+                        if ($this->option('failed')) {
                             return in_array($migrationName, $ran)
                                 ? []
                                 : ['<fg=red>No</fg=red>', $migrationName];
@@ -117,7 +117,7 @@ class StatusCommand extends BaseCommand
 
             ['failed', 'f', InputOption::VALUE_NONE, 'Indicate if only show status of failed migrations'],
 
-            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths']
+            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -84,7 +84,6 @@ class StatusCommand extends BaseCommand
                             return in_array($migrationName, $ran)
                                 ? []
                                 : ['<fg=red>No</fg=red>', $migrationName];
-
                         }
 
                         return in_array($migrationName, $ran)

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -62,7 +62,9 @@ class StatusCommand extends BaseCommand
         if (count($migrations = $this->getStatusFor($ran, $batches)) > 0) {
             $this->table(['Ran?', 'Migration', 'Batch'], $migrations);
         } else {
-            $this->error('No migrations found');
+            $this->option('failed')
+                ? $this->error('No failed migrations found')
+                : $this->error('No migrations found');
         }
     }
 
@@ -78,11 +80,17 @@ class StatusCommand extends BaseCommand
         return Collection::make($this->getAllMigrationFiles())
                     ->map(function ($migration) use ($ran, $batches) {
                         $migrationName = $this->migrator->getMigrationName($migration);
+                        if($this->option('failed')) {
+                            return in_array($migrationName, $ran)
+                                ? []
+                                : ['<fg=red>No</fg=red>', $migrationName];
+
+                        }
 
                         return in_array($migrationName, $ran)
                                 ? ['<info>Yes</info>', $migrationName, $batches[$migrationName]]
                                 : ['<fg=red>No</fg=red>', $migrationName];
-                    });
+                    })->filter();
     }
 
     /**
@@ -107,7 +115,9 @@ class StatusCommand extends BaseCommand
 
             ['path', null, InputOption::VALUE_OPTIONAL, 'The path to the migrations files to use'],
 
-            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
+            ['failed', 'f', InputOption::VALUE_NONE, 'Indicate if only show status of failed migrations'],
+
+            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths']
         ];
     }
 }


### PR DESCRIPTION
The idea behind this PR is to improve user experience and speed up development.

This will help end users in order to see only failed migrations or the ones that are not yet ran. It will be more helpful in case of long list of migrations as users won't need to scroll their terminal window in order to see which migrations are failed or need to re-run.

New command would look like:
`php artisan migrate:status --failed | -f`

Hope it helps out!