### PR TITLE
[5.8] Less magick

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -315,14 +315,10 @@ class Builder
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|null
+     * @return \Illuminate\Database\Eloquent\Model|null
      */
     public function find($id, $columns = ['*'])
     {
-        if (is_array($id) || $id instanceof Arrayable) {
-            return $this->findMany($id, $columns);
-        }
-
         return $this->whereKey($id)->first($columns);
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -326,7 +326,7 @@ class Builder
      * Find multiple models by their primary keys.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $ids
-     * @param  array  $columns
+     * @param  array $columns
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function findMany($ids, $columns = ['*'])
@@ -336,6 +336,23 @@ class Builder
         }
 
         return $this->whereKey($ids)->get($columns);
+    }
+
+    /**
+     * Find multiple models by their primary keys or throw an exception.
+     * @param array $ids
+     * @param array $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function findManyOrFail($ids, $columns = ['*'])
+    {
+        $results = $this->findMany($ids, $columns);
+
+        if (count($results) === count(array_unique($ids))) {
+            return $results;
+        }
+
+        throw (new ModelNotFoundException)->setModel(get_class($this->model), $ids);
     }
 
     /**
@@ -351,11 +368,7 @@ class Builder
     {
         $result = $this->find($id, $columns);
 
-        if (is_array($id)) {
-            if (count($result) === count(array_unique($id))) {
-                return $result;
-            }
-        } elseif (! is_null($result)) {
+        if (! is_null($result)) {
             return $result;
         }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -109,7 +109,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel($this->getMockModel());
         $builder->shouldReceive('get')->with(['column'])->andReturn('baz');
 
-        $result = $builder->find([1, 2], ['column']);
+        $result = $builder->findMany([1, 2], ['column']);
         $this->assertEquals('baz', $result);
     }
 
@@ -121,7 +121,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel($this->getMockModel());
         $builder->shouldReceive('get')->with(['column'])->andReturn('baz');
 
-        $result = $builder->find($ids, ['column']);
+        $result = $builder->findMany($ids, ['column']);
         $this->assertEquals('baz', $result);
     }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -430,7 +430,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
 
         $single = EloquentTestUser::findOrFail(1);
-        $multiple = EloquentTestUser::findOrFail([1, 2]);
+        $multiple = EloquentTestUser::findManyOrFail([1, 2]);
 
         $this->assertInstanceOf(EloquentTestUser::class, $single);
         $this->assertEquals('taylorotwell@gmail.com', $single->email);

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -171,8 +171,8 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertInstanceOf(Collection::class, $instances);
         $this->assertCount(3, $users);
         $this->assertCount(3, $instances);
-        $this->assertCount(3, FactoryBuildableUser::find($users->pluck('id')->toArray()));
-        $this->assertCount(0, FactoryBuildableUser::find($instances->pluck('id')->toArray()));
+        $this->assertCount(3, FactoryBuildableUser::findMany($users->pluck('id')->toArray()));
+        $this->assertCount(0, FactoryBuildableUser::findMany($instances->pluck('id')->toArray()));
     }
 
     public function test_creating_models_with_callable_state()


### PR DESCRIPTION
This PR remove magick in Eloquent Builder's find method. It should returns stable only Model instead of sometimes Collection, another ways use findMany. Most IDE's could not understand what returns the method: Collection or Model.
It's the major logick change, only Laravel 5.8 accepted.
Also I added new method findManyOrFail