### PR TITLE
[5.7] Add thenReturn method to Pipeline

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -105,6 +105,18 @@ class Pipeline implements PipelineContract
     }
 
     /**
+     * Run the pipeline and return the result.
+     *
+     * @return mixed
+     */
+    public function thenReturn()
+    {
+        return $this->then(function ($passable) {
+            return $passable;
+        });
+    }
+
+    /**
      * Get the final piece of the Closure onion.
      *
      * @param  \Closure  $destination

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -162,6 +162,19 @@ class PipelineTest extends TestCase
                 return $piped;
             });
     }
+
+    public function testPipelineThenReturnMethodRunsPipelineThenReturnsPassable()
+    {
+        $result = (new Pipeline(new Container))
+                    ->send('foo')
+                    ->through([PipelineTestPipeOne::class])
+                    ->thenReturn();
+
+        $this->assertEquals('foo', $result);
+        $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
+
+        unset($_SERVER['__test.pipe.one']);
+    }
 }
 
 class PipelineTestPipeOne


### PR DESCRIPTION
Often when using a pipeline there is additional work to be done to the object passed through. A good example of this is using the Pipeline to apply *additional* filters to a query builder, perhaps based off a request's query parameters. Current you could do the following...

```php
$users = app(Pipeline::class)
    ->send(User::query())
    ->through($pipes)
    ->then(function ($query) {
        return $query
            ->whereConfirmedEmail()
            ->whereAccountActive()
            ->get();
    });
```
or...
```php
app(Pipeline::class)
    ->send($query = User::query())
    ->through($pipes)
    ->then(function () {});

$users = $query->whereConfirmedEmail()->whereAccountActive()->get();
```
or...
```php
$query = User::whereConfirmedEmail()->whereAccountActive();

$users = app(Pipeline::class)
    ->send($query)
    ->through($pipes)
    ->then(function ($query) {
        return $query->get();
    });
```
or you could merge in a closure based pipe, and so on.


Adding a helper method to return the `$passable` allows for continued chaining in the same scope, so the above examples become...

```php
$users = app(Pipeline::class)
    ->send(User::query())
    ->through($pipes)
    ->thenReturn()
    ->whereConfirmedEmail()
    ->whereAccountActive()
    ->get();
```

which I personally think feels nice when simple running the pipeline does not complete the preparation/manipulation of the `$passable`.

There are also scenarios where you just wanna run something through a pipeline and you don't need to do any additional work to it...

```php
return app(Pipeline::class)
    ->send($thing)
    ->through($pipes)
    // ->then(function ($thing) {
    //     return $thing;
    // });
    ->thenReturn();
```

Although I have named the method `thenReturn`, it may not be the best name for this. I thought `run` might also be an option, as you are _running_ the passable through the pipeline.

```php
app(Pipeline::class)
    ->send($thing)
    ->through($pipes)
    ->run()
    ...
```