### PR TITLE
[5.7] Fix for EventFake not returning responses

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -211,7 +211,7 @@ class EventFake implements Dispatcher
         if ($this->shouldFakeEvent($name, $payload)) {
             $this->events[$name][] = func_get_args();
         } else {
-            $this->dispatcher->dispatch($event, $payload, $halt);
+            return $this->dispatcher->dispatch($event, $payload, $halt);
         }
     }
 

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -73,6 +73,24 @@ class EventFakeTest extends TestCase
 
         Event::assertNotDispatched(NonImportantEvent::class);
     }
+
+    public function testNonFakedHaltedEventGetsProperlyDispatchedAndReturnsResponse()
+    {
+        Event::fake(NonImportantEvent::class);
+        Event::listen('test', function () {
+            // one
+        });
+        Event::listen('test', function () {
+            return 'two';
+        });
+        Event::listen('test', function () {
+            $this->fail('should not be called');
+        });
+
+        $this->assertEquals('two', Event::until('test'));
+
+        Event::assertNotDispatched(NonImportantEvent::class);
+    }
 }
 
 class Post extends Model

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -74,6 +74,42 @@ class EventFakeTest extends TestCase
         Event::assertNotDispatched(NonImportantEvent::class);
     }
 
+    public function testNonFakedEventGetsProperlyDispatchedAndReturnsResponses()
+    {
+        Event::fake(NonImportantEvent::class);
+        Event::listen('test', function () {
+            // one
+        });
+        Event::listen('test', function () {
+            return 'two';
+        });
+        Event::listen('test', function () {
+            //
+        });
+
+        $this->assertEquals([null, 'two', null], Event::dispatch('test'));
+
+        Event::assertNotDispatched(NonImportantEvent::class);
+    }
+
+    public function testNonFakedEventGetsProperlyDispatchedAndCancelsFutureListeners()
+    {
+        Event::fake(NonImportantEvent::class);
+        Event::listen('test', function () {
+            // one
+        });
+        Event::listen('test', function () {
+            return false;
+        });
+        Event::listen('test', function () {
+            $this->fail('should not be called');
+        });
+
+        $this->assertEquals([null], Event::dispatch('test'));
+
+        Event::assertNotDispatched(NonImportantEvent::class);
+    }
+
     public function testNonFakedHaltedEventGetsProperlyDispatchedAndReturnsResponse()
     {
         Event::fake(NonImportantEvent::class);


### PR DESCRIPTION
We're relying on the responses returned from the dispatcher, but when using the EventFake, nothing gets returned at all. Looks like a simple `return` was left off.

Not sure how far back this PR should go. Docs say bug fixes should go back to the LTS but this class doesn't exist in 5.5.