### PR TITLE
[5.8] Let Laravel 5.8 support PHPUnit 8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
@@ -85,7 +85,7 @@
         "moontoast/math": "^1.1",
         "orchestra/testbench-core": "3.8.*",
         "pda/pheanstalk": "^3.0",
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^8.0",
         "predis/predis": "^1.1.1",
         "symfony/css-selector": "^4.2",
         "symfony/dom-crawler": "^4.2",

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -13,14 +13,14 @@ use Illuminate\Auth\Passwords\DatabaseTokenRepository;
 
 class AuthDatabaseTokenRepositoryTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         Carbon::setTestNow(Carbon::now());
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -13,7 +13,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 
 class AuthDatabaseUserProviderTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 
 class AuthEloquentUserProviderTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -21,7 +21,7 @@ use Illuminate\Contracts\Encryption\Encrypter;
 
 class AuthGuardTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -14,7 +14,7 @@ use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
 
 class AuthPasswordBrokerTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -10,7 +10,7 @@ use Illuminate\Contracts\Auth\UserProvider;
 
 class AuthTokenGuardTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -18,12 +18,12 @@ class AuthenticateMiddlewareTest extends TestCase
 {
     protected $auth;
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         $container = Container::setInstance(new Container);
 

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -22,12 +22,12 @@ class AuthorizeMiddlewareTest extends TestCase
     protected $user;
     protected $router;
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Broadcasting\Broadcaster;
 
 class BroadcastEventTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -16,14 +16,14 @@ class BroadcasterTest extends TestCase
      */
     public $broadcaster;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->broadcaster = new FakeBroadcaster;
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -15,7 +15,7 @@ class PusherBroadcasterTest extends TestCase
 
     public $pusher;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -13,14 +13,14 @@ class RedisBroadcasterTest extends TestCase
      */
     public $broadcaster;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->broadcaster = m::mock(RedisBroadcaster::class)->makePartial();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -14,14 +14,14 @@ class UsePusherChannelConventionsTest extends TestCase
      */
     public $broadcaster;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->broadcaster = new FakeBroadcasterUsingPusherChannelsNames();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -15,7 +15,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 
 class BusDispatcherTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\PostgresConnection;
 
 class CacheDatabaseStoreTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -15,7 +15,7 @@ use Illuminate\Cache\Events\KeyForgotten;
 
 class CacheEventsTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -10,14 +10,14 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class CacheFileStoreTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         Carbon::setTestNow(Carbon::now());
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -9,7 +9,7 @@ use Illuminate\Cache\CacheManager;
 
 class CacheManagerTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -9,7 +9,7 @@ use Illuminate\Cache\MemcachedConnector;
 
 class CacheMemcachedConnectorTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 
 class CacheRateLimiterTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Redis\Factory;
 
 class CacheRedisStoreTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -17,7 +17,7 @@ use Illuminate\Contracts\Cache\Store;
 
 class CacheRepositoryTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         m::close();
         Carbon::setTestNow();

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Migrations\MigrationCreator;
 
 class CacheTableCommandTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -14,7 +14,7 @@ use Illuminate\Cache\RedisTaggedCache;
 
 class CacheTaggedCacheTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -38,7 +38,7 @@ class ClearCommandTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -52,7 +52,7 @@ class ClearCommandTest extends TestCase
         $this->command->setLaravel($app);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -12,13 +12,13 @@ class RedisCacheIntegrationTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpRedis();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         m::close();

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -17,7 +17,7 @@ class RepositoryTest extends TestCase
      */
     protected $config;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->repository = new Repository($this->config = [
             'foo' => 'bar',

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
 class ConsoleApplicationTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -19,7 +19,7 @@ class ConsoleEventSchedulerTest extends TestCase
      */
     private $schedule;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -32,7 +32,7 @@ class ConsoleEventSchedulerTest extends TestCase
         $container->instance(Schedule::class, $this->schedule = new Schedule(m::mock(EventMutex::class)));
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -18,13 +18,13 @@ class ConsoleScheduledEventTest extends TestCase
      */
     protected $defaultTimezone;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->defaultTimezone = date_default_timezone_get();
         date_default_timezone_set('UTC');
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         date_default_timezone_set($this->defaultTimezone);
         Carbon::setTestNow(null);

--- a/tests/Console/Scheduling/CacheEventMutexTest.php
+++ b/tests/Console/Scheduling/CacheEventMutexTest.php
@@ -31,7 +31,7 @@ class CacheEventMutexTest extends TestCase
      */
     protected $cacheRepository;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Console/Scheduling/CacheSchedulingMutexTest.php
+++ b/tests/Console/Scheduling/CacheSchedulingMutexTest.php
@@ -38,7 +38,7 @@ class CacheSchedulingMutexTest extends TestCase
      */
     protected $cacheRepository;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -9,7 +9,7 @@ use Illuminate\Console\Scheduling\EventMutex;
 
 class EventTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -14,7 +14,7 @@ class FrequencyTest extends TestCase
      */
     protected $event;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->event = new Event(
             m::mock(EventMutex::class),

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class CookieTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -26,7 +26,7 @@ class EncryptCookiesTest extends TestCase
     protected $setCookiePath = 'cookie/set';
     protected $queueCookiePath = 'cookie/queue';
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -14,7 +14,7 @@ class DatabaseConnectionFactoryTest extends TestCase
 {
     protected $db;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->db = new DB;
 
@@ -36,7 +36,7 @@ class DatabaseConnectionFactoryTest extends TestCase
         $this->db->setAsGlobal();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -25,7 +25,7 @@ use Illuminate\Database\Query\Builder as BaseBuilder;
 
 class DatabaseConnectionTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Connectors\SqlServerConnector;
 
 class DatabaseConnectorTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $db = new DB;
 
@@ -70,7 +70,7 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('articles');

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $db = new DB;
 
@@ -56,7 +56,7 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('articles');

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -15,7 +15,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     protected $related;
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -20,7 +20,7 @@ use Illuminate\Database\Query\Builder as BaseBuilder;
 
 class DatabaseEloquentBuilderTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
+++ b/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentCastsDatabaseStringTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $db = new DB;
 
@@ -45,7 +45,7 @@ class DatabaseEloquentCastsDatabaseStringTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->schema()->drop('casting_table');
     }

--- a/tests/Database/DatabaseEloquentCollectionQueueableTest.php
+++ b/tests/Database/DatabaseEloquentCollectionQueueableTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class DatabaseEloquentCollectionQueueableTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Collection as BaseCollection;
 
 class DatabaseEloquentCollectionTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Capsule\Manager as DB;
 
 class DatabaseEloquentGlobalScopesTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -21,7 +21,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         ])->bootEloquent();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class DatabaseEloquentHasManyTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $db = new DB;
 
@@ -62,7 +62,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('posts');

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -19,7 +19,7 @@ class DatabaseEloquentHasOneTest extends TestCase
 
     protected $parent;
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $db = new DB;
 
@@ -62,7 +62,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('contracts');

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -26,7 +26,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $db = new DB;
 
@@ -126,7 +126,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         foreach (['default', 'second_connection'] as $connection) {
             $this->schema($connection)->drop('users');

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -15,7 +15,7 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $db = new DB;
 
@@ -66,7 +66,7 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         foreach (['default'] as $connection) {
             $this->schema($connection)->drop('users');

--- a/tests/Database/DatabaseEloquentIrregularPluralTest.php
+++ b/tests/Database/DatabaseEloquentIrregularPluralTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Capsule\Manager as DB;
 
 class DatabaseEloquentIrregularPluralTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $db = new DB;
 
@@ -53,7 +53,7 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
         });
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->schema()->drop('irregular_plural_tokens');
         $this->schema()->drop('irregular_plural_humans');

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -30,14 +30,14 @@ class DatabaseEloquentModelTest extends TestCase
 {
     use InteractsWithTime;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         Carbon::setTestNow(Carbon::now());
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 class DatabaseEloquentMorphTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         Relation::morphMap([], false);
 

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 class DatabaseEloquentMorphToManyTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -14,7 +14,7 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     protected $related;
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class DatabaseEloquentPivotTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $db = new DB;
 
@@ -66,7 +66,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('posts');

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -14,7 +14,7 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $db = new DB;
 
@@ -58,7 +58,7 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         foreach (['default'] as $connection) {
             $this->schema($connection)->drop('posts');

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 
 class DatabaseEloquentRelationTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -84,7 +84,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         Carbon::setTestNow(null);
 

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentTimestampsTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $db = new DB;
 
@@ -56,7 +56,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('users_created_at');

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Migrations\MigrationCreator;
 
 class DatabaseMigrationCreatorTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Migrations\MigrationRepositoryInterface;
 
 class DatabaseMigrationInstallCommandTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
 
 class DatabaseMigrationMakeCommandTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Console\Migrations\MigrateCommand;
 
 class DatabaseMigrationMigrateCommandTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Application as ConsoleApplication;
 
 class DatabaseMigrationRefreshCommandTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 
 class DatabaseMigrationRepositoryTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Console\Migrations\ResetCommand;
 
 class DatabaseMigrationResetCommandTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Console\Migrations\RollbackCommand;
 
 class DatabaseMigrationRollbackCommandTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -23,7 +23,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->db = $db = new DB;
 
@@ -59,7 +59,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         }
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 
 class DatabaseMySqlSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Schema\Grammars\PostgresGrammar;
 
 class DatabasePostgresSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Query\Processors\Processor;
 
 class DatabaseProcessorTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -22,7 +22,7 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class DatabaseQueryBuilderTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
 
 class DatabaseSQLiteSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -21,7 +21,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->db = $db = new DB;
 
@@ -37,7 +37,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         Facade::setFacadeApplication($container);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 
 class DatabaseSchemaBlueprintTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -16,7 +16,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->db = $db = new DB;
 
@@ -32,7 +32,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         Facade::setFacadeApplication($container);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Schema\Builder;
 
 class DatabaseSchemaBuilderTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -28,7 +28,7 @@ class TestDepsSeeder extends Seeder
 
 class DatabaseSeederTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -15,7 +15,7 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class DatabaseSoftDeletingScopeTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class DatabaseSoftDeletingTraitTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 
 class DatabaseSqlServerSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -45,7 +45,7 @@ class SeedCommandTest extends TestCase
         $container->shouldHaveReceived('call')->with([$command, 'handle']);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -14,7 +14,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 class EventsDispatcherTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -16,13 +16,13 @@ class FilesystemAdapterTest extends TestCase
     private $tempDir;
     private $filesystem;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->tempDir = __DIR__.'/tmp';
         $this->filesystem = new Filesystem(new Local($this->tempDir));
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         $filesystem = new Filesystem(new Local(dirname($this->tempDir)));
         $filesystem->deleteDir(basename($this->tempDir));

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -14,13 +14,13 @@ class FilesystemTest extends TestCase
 {
     private $tempDir;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->tempDir = __DIR__.'/tmp';
         mkdir($this->tempDir);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
 

--- a/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
+++ b/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 
 class LoadEnvironmentVariablesTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -12,7 +12,7 @@ use Illuminate\Foundation\Bootstrap\RegisterFacades;
 
 class FoundationApplicationTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationAuthenticationTest.php
+++ b/tests/Foundation/FoundationAuthenticationTest.php
@@ -49,7 +49,7 @@ class FoundationAuthenticationTest extends TestCase
         return $guard;
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -9,7 +9,7 @@ use Illuminate\Filesystem\Filesystem;
 
 class FoundationComposerTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\EnvironmentDetector;
 
 class FoundationEnvironmentDetectorTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -29,7 +29,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     protected $request;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->config = m::mock(Config::class);
 
@@ -51,7 +51,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->handler = new Handler($this->container);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -19,7 +19,7 @@ class FoundationFormRequestTest extends TestCase
 {
     protected $mocks = [];
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
 

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -11,7 +11,7 @@ use Illuminate\Foundation\Application;
 
 class FoundationHelpersTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -19,12 +19,12 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     protected $connection;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->connection = m::mock(Connection::class);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
 class FoundationProviderRepositoryTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
+++ b/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
@@ -26,7 +26,7 @@ class CheckForMaintenanceModeTest extends TestCase
      */
     protected $files;
 
-    public function setUp()
+    protected function setUp(): void
     {
         if (is_null($this->files)) {
             $this->files = new Filesystem;
@@ -38,7 +38,7 @@ class CheckForMaintenanceModeTest extends TestCase
         $this->files->makeDirectory($this->storagePath.'/framework', 0755, true);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->files->deleteDirectory($this->storagePath);
 

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -14,7 +14,7 @@ use Illuminate\Contracts\Support\MessageProvider;
 
 class HttpRedirectResponseTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 
 class HttpRequestTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class HttpResponseTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -34,7 +34,7 @@ class AuthenticationTest extends TestCase
         $app['config']->set('hashing', ['driver' => 'bcrypt']);
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Cache;
  */
 class DynamoDbStoreTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Cache/MemcachedIntegrationTest.php
+++ b/tests/Integration/Cache/MemcachedIntegrationTest.php
@@ -10,7 +10,7 @@ use Orchestra\Testbench\TestCase;
  */
 abstract class MemcachedIntegrationTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -14,14 +14,14 @@ class RedisCacheLockTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->setUpRedis();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Console\Kernel;
 
 class ConsoleApplicationTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -16,7 +16,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentBelongsToManyTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentBelongsToTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/EloquentCollectionFreshTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class EloquentCollectionFreshTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -15,7 +15,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentCollectionLoadCountTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentCollectionLoadMissingTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
  */
 class EloquentCustomPivotCastTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -25,7 +25,7 @@ class EloquentDeleteTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -103,7 +103,7 @@ class EloquentFactoryBuilderTest extends TestCase
         });
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentHasManyThroughTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentLazyEagerLoadingTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelConnectionsTest.php
+++ b/tests/Integration/Database/EloquentModelConnectionsTest.php
@@ -31,7 +31,7 @@ class EloquentModelConnectionsTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelCustomEventsTest.php
+++ b/tests/Integration/Database/EloquentModelCustomEventsTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelCustomEventsTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelDateCastingTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelDecimalCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDecimalCastingTest.php
@@ -11,7 +11,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelDecimalCastingTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelLoadCountTest.php
+++ b/tests/Integration/Database/EloquentModelLoadCountTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelLoadCountTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMissingTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelLoadMissingTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelRefreshTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class EloquentModelTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentMorphManyTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
+++ b/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
@@ -14,7 +14,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentMorphToGlobalScopesTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentMorphToLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphToLazyEagerLoadingTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentMorphToLazyEagerLoadingTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentMorphToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphToSelectTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentMorphToSelectTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentMorphToTouchesTest.php
+++ b/tests/Integration/Database/EloquentMorphToTouchesTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentMorphToTouchesTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -11,7 +11,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentPaginateTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Eloquent\Collection as DatabaseCollection;
  */
 class EloquentPivotSerializationTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentPushTest.php
+++ b/tests/Integration/Database/EloquentPushTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Schema\Blueprint;
  */
 class EloquentPushTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentTouchParentWithGlobalScopeTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -26,7 +26,7 @@ class EloquentUpdateTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentWhereHasTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Schema\Blueprint;
  */
 class EloquentWhereTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -11,7 +11,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentWithCountTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/MigrateWithRealpathTest.php
+++ b/tests/Integration/Database/MigrateWithRealpathTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 
 class MigrateWithRealpathTest extends DatabaseTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class QueryBuilderTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -36,7 +36,7 @@ class EventFakeTest extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -53,7 +53,7 @@ class EventFakeTest extends TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Schema::dropIfExists('posts');
 

--- a/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
+++ b/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
@@ -23,7 +23,7 @@ class InteractsWithAuthenticationTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -11,7 +11,7 @@ class VerifyCsrfTokenExceptTest extends TestCase
     private $stub;
     private $request;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -14,7 +14,7 @@ use Illuminate\Http\Exceptions\ThrottleRequestsException;
  */
 class ThrottleRequestsTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         Carbon::setTestNow(null);

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -16,7 +16,7 @@ class ThrottleRequestsWithRedisTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         Carbon::setTestNow(null);

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -18,7 +18,7 @@ use Illuminate\Contracts\Translation\HasLocalePreference;
  */
 class SendingMailWithLocaleTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 
@@ -46,7 +46,7 @@ class SendingMailWithLocaleTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -23,7 +23,7 @@ class SendingMailNotificationsTest extends TestCase
     public $mailer;
     public $markdown;
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 
@@ -54,7 +54,7 @@ class SendingMailNotificationsTest extends TestCase
         });
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -53,7 +53,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -17,7 +17,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
  */
 class CallQueuedHandlerTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -29,7 +29,7 @@ class JobChainingTest extends TestCase
         ]);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         JobChainingTestFirstJob::$ran = false;
         JobChainingTestSecondJob::$ran = false;

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -33,7 +33,7 @@ class ModelSerializationTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class ValidatorTest extends DatabaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
 class LogLoggerTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -18,7 +18,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 
 class MailMailerTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class MailMarkdownTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -20,7 +20,7 @@ class MailMessageTest extends TestCase
      */
     protected $message;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -28,7 +28,7 @@ class MailMessageTest extends TestCase
         $this->message = new Message($this->swift);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
 
 class MailableQueuedTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -13,7 +13,7 @@ use Illuminate\Notifications\Events\BroadcastNotificationCreated;
 
 class NotificationBroadcastChannelTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -18,7 +18,7 @@ use Illuminate\Notifications\Events\NotificationSending;
 
 class NotificationChannelManagerTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -10,7 +10,7 @@ use Illuminate\Notifications\Messages\DatabaseMessage;
 
 class NotificationDatabaseChannelTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Notifications\Dispatcher;
 
 class NotificationRoutesNotificationsTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -9,7 +9,7 @@ use Illuminate\Notifications\SendQueuedNotifications;
 
 class NotificationSendQueuedNotificationTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -17,13 +17,13 @@ class LengthAwarePaginatorTest extends TestCase
      */
     private $options;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->options = ['onEachSide' => 5];
         $this->p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2, $this->options);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         unset($this->p);
     }

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -15,7 +15,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 
 class QueueBeanstalkdJobTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -12,7 +12,7 @@ use Illuminate\Queue\Jobs\BeanstalkdJob;
 
 class QueueBeanstalkdQueueTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -27,7 +27,7 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
      */
     protected $container;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $db = new DB;
 
@@ -95,7 +95,7 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->schema()->drop('jobs');
     }

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -12,7 +12,7 @@ use Illuminate\Queue\DatabaseQueue;
 
 class QueueDatabaseQueueUnitTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Process\Process;
 
 class QueueListenerTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -10,7 +10,7 @@ use Illuminate\Contracts\Encryption\Encrypter;
 
 class QueueManagerTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -11,7 +11,7 @@ use Illuminate\Queue\Jobs\RedisJob;
 
 class QueueRedisJobTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Redis\Factory;
 
 class QueueRedisQueueTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -12,7 +12,7 @@ use Illuminate\Container\Container;
 
 class QueueSqsJobTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $this->key = 'AMAZONSQSKEY';
         $this->secret = 'AmAz0n+SqSsEcReT+aLpHaNuM3R1CsTr1nG';
@@ -50,7 +50,7 @@ class QueueSqsJobTest extends TestCase
         ];
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -13,12 +13,12 @@ use Illuminate\Container\Container;
 
 class QueueSqsQueueTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         // Use Mockery to mock the SqsClient
         $this->sqs = m::mock(SqsClient::class);

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -13,7 +13,7 @@ use Illuminate\Contracts\Queue\QueueableEntity;
 
 class QueueSyncQueueTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -23,7 +23,7 @@ class QueueWorkerTest extends TestCase
     public $events;
     public $exceptionHandler;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->events = m::spy(Dispatcher::class);
         $this->exceptionHandler = m::spy(ExceptionHandler::class);
@@ -34,7 +34,7 @@ class QueueWorkerTest extends TestCase
         $container->instance(ExceptionHandler::class, $this->exceptionHandler);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Container::setInstance();
     }

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -20,14 +20,14 @@ class RedisQueueIntegrationTest extends TestCase
      */
     private $queue;
 
-    public function setUp()
+    protected function setUp(): void
     {
         Carbon::setTestNow(Carbon::now());
         parent::setUp();
         $this->setUpRedis();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Carbon::setTestNow(null);
         parent::tearDown();

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -15,7 +15,7 @@ class ConcurrentLimiterTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -15,7 +15,7 @@ class DurationLimiterTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -14,7 +14,7 @@ class RedisConnectionTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpRedis();
@@ -28,7 +28,7 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->tearDownRedis();

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -14,7 +14,7 @@ class RouteCollectionTest extends TestCase
      */
     protected $routeCollection;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -16,14 +16,14 @@ class RouteRegistrarTest extends TestCase
      */
     protected $router;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->router = new Router(m::mock(Dispatcher::class), Container::getInstance());
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -19,7 +19,7 @@ class RoutingRedirectorTest extends TestCase
     protected $session;
     protected $redirect;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->headers = m::mock(HeaderBag::class);
 
@@ -45,7 +45,7 @@ class RoutingRedirectorTest extends TestCase
         $this->redirect->setSession($this->session);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Encryption\Encrypter;
 
 class EncryptedSessionStoreTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SessionStoreTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Migrations\MigrationCreator;
 
 class SessionTableCommandTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Support/DateFacadeTest.php
+++ b/tests/Support/DateFacadeTest.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Date;
 
 class DateFacadeTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         DateFactory::use(Carbon::class);

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -13,7 +13,7 @@ class SupportCapsuleManagerTraitTest extends TestCase
 {
     use CapsuleManagerTrait;
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -16,14 +16,14 @@ class SupportCarbonTest extends TestCase
      */
     protected $now;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         Carbon::setTestNow($this->now = Carbon::create(2017, 6, 27, 13, 14, 15, 'UTC'));
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Carbon::setTestNow();
         Carbon::serializeUsing(null);

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -11,13 +11,13 @@ use Illuminate\Support\Facades\Facade;
 
 class SupportFacadeTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         Facade::clearResolvedInstances();
         FacadeStub::setFacadeApplication(null);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -15,7 +15,7 @@ class SupportFacadesEventTest extends TestCase
 {
     private $events;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -27,7 +27,7 @@ class SupportFacadesEventTest extends TestCase
         Facade::setFacadeApplication($container);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Event::clearResolvedInstances();
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -14,7 +14,7 @@ use Illuminate\Contracts\Support\Htmlable;
 
 class SupportHelpersTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -9,7 +9,7 @@ class SupportMacroableTest extends TestCase
 {
     private $macroable;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->macroable = $this->createObjectForTrait();
     }

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\MessageBag;
 
 class SupportMessageBagTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\ServiceProvider;
 
 class SupportServiceProviderTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         ServiceProvider::$publishes = [];
         ServiceProvider::$publishGroups = [];
@@ -21,7 +21,7 @@ class SupportServiceProviderTest extends TestCase
         $two->boot();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\Constraint\ExceptionMessage;
 
 class SupportTestingEventFakeTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fake = new EventFake(m::mock(Dispatcher::class));

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -23,7 +23,7 @@ class SupportTestingMailFakeTest extends TestCase
      */
     private $mailable;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fake = new MailFake;

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -27,7 +27,7 @@ class SupportTestingNotificationFakeTest extends TestCase
      */
     private $user;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fake = new NotificationFake;

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -21,7 +21,7 @@ class SupportTestingQueueFakeTest extends TestCase
      */
     private $job;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fake = new QueueFake(new Application);

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -9,7 +9,7 @@ use Illuminate\Translation\FileLoader;
 
 class TranslationFileLoaderTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Translation\Loader;
 
 class TranslationTranslatorTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\ConnectionResolverInterface;
 
 class ValidationDatabasePresenceVerifierTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -18,7 +18,7 @@ class ValidationExistsRuleTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $db = new DB;
 
@@ -159,7 +159,7 @@ class ValidationExistsRuleTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->schema('default')->drop('users');
     }

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Translation\Translator as TranslatorInterface;
 
 class ValidationFactoryTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -24,7 +24,7 @@ use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 
 class ValidationValidatorTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         Carbon::setTestNow();
         m::close();

--- a/tests/View/Blade/AbstractBladeTestCase.php
+++ b/tests/View/Blade/AbstractBladeTestCase.php
@@ -11,13 +11,13 @@ abstract class AbstractBladeTestCase extends TestCase
 {
     protected $compiler;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->compiler = new BladeCompiler(m::mock(Filesystem::class), __DIR__);
         parent::setUp();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
 

--- a/tests/View/Blade/BladeElseAuthStatementsTest.php
+++ b/tests/View/Blade/BladeElseAuthStatementsTest.php
@@ -9,7 +9,7 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeElseAuthStatementsTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/Blade/BladeElseGuestStatementsTest.php
+++ b/tests/View/Blade/BladeElseGuestStatementsTest.php
@@ -9,7 +9,7 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeElseGuestStatementsTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/Blade/BladeIfAuthStatementsTest.php
+++ b/tests/View/Blade/BladeIfAuthStatementsTest.php
@@ -9,7 +9,7 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeIfAuthStatementsTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/Blade/BladeIfGuestStatementsTest.php
+++ b/tests/View/Blade/BladeIfGuestStatementsTest.php
@@ -9,7 +9,7 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeIfGuestStatementsTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -9,7 +9,7 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class ViewBladeCompilerTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -9,7 +9,7 @@ use Illuminate\View\Compilers\CompilerInterface;
 
 class ViewCompilerEngineTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -22,7 +22,7 @@ use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
 class ViewFactoryTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -9,7 +9,7 @@ use Illuminate\Filesystem\Filesystem;
 
 class ViewFileViewFinderTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -8,7 +8,7 @@ use Illuminate\View\Engines\PhpEngine;
 
 class ViewPhpEngineTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -15,7 +15,7 @@ use Illuminate\Contracts\Support\Renderable;
 
 class ViewTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR provides support for PHPUnit 8.

**This requires 2 major changes:**
- upgrade to PHP 7.2 for Laravel 5.8
- upgrade of [Testbench](https://github.com/orchestral/testbench), as `setUp` and `tearDown` methods signatures need to be changed (may happen in 3.9.0)

---

When run locally, no failure occurs.
Only depreciation warnings.

--- 

See 
- https://github.com/laravel/framework/issues/27381
- https://github.com/orchestral/testbench/issues/238