### PR TITLE
[5.8] Arr::get() to support path as array in addition to dot-notation string

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -268,10 +268,10 @@ class Arr
     }
 
     /**
-     * Get an item from an array using "dot" notation.
+     * Get an item from an array using "dot" notation or array of keys.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string  $key
+     * @param  array|string  $key
      * @param  mixed   $default
      * @return mixed
      */
@@ -283,6 +283,8 @@ class Arr
 
         if (is_null($key)) {
             return $array;
+        } elseif (is_array($key)) {
+            $key = implode('.', $key);
         }
 
         if (static::exists($array, $key)) {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -160,10 +160,10 @@ if (! function_exists('array_forget')) {
 
 if (! function_exists('array_get')) {
     /**
-     * Get an item from an array using "dot" notation.
+     * Get an item from an array using "dot" notation or array of keys.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string  $key
+     * @param  array|string  $key
      * @param  mixed   $default
      * @return mixed
      *

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -281,7 +281,7 @@ class SupportArrTest extends TestCase
                 ['name' => '1st product'],
                 ['name' => '2nd product'],
                 ['name' => '3rd product'],
-            ]
+            ],
         ];
         $this->assertEquals('2nd product', Arr::get($array, 'products.1.name'));
         $this->assertEquals('2nd product', Arr::get($array, ['products', '1', 'name']));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -211,26 +211,35 @@ class SupportArrTest extends TestCase
     {
         $array = ['products.desk' => ['price' => 100]];
         $this->assertEquals(['price' => 100], Arr::get($array, 'products.desk'));
+        $this->assertEquals(['price' => 100], Arr::get($array, ['products', 'desk']));
 
         $array = ['products' => ['desk' => ['price' => 100]]];
         $value = Arr::get($array, 'products.desk');
+        $this->assertEquals(['price' => 100], $value);
+        $value = Arr::get($array, ['products', 'desk']);
         $this->assertEquals(['price' => 100], $value);
 
         // Test null array values
         $array = ['foo' => null, 'bar' => ['baz' => null]];
         $this->assertNull(Arr::get($array, 'foo', 'default'));
+        $this->assertNull(Arr::get($array, ['foo'], 'default'));
         $this->assertNull(Arr::get($array, 'bar.baz', 'default'));
+        $this->assertNull(Arr::get($array, ['bar', 'baz'], 'default'));
 
         // Test direct ArrayAccess object
         $array = ['products' => ['desk' => ['price' => 100]]];
         $arrayAccessObject = new ArrayObject($array);
         $value = Arr::get($arrayAccessObject, 'products.desk');
         $this->assertEquals(['price' => 100], $value);
+        $value = Arr::get($arrayAccessObject, ['products', 'desk']);
+        $this->assertEquals(['price' => 100], $value);
 
         // Test array containing ArrayAccess object
         $arrayAccessChild = new ArrayObject(['products' => ['desk' => ['price' => 100]]]);
         $array = ['child' => $arrayAccessChild];
         $value = Arr::get($array, 'child.products.desk');
+        $this->assertEquals(['price' => 100], $value);
+        $value = Arr::get($array, ['child', 'products', 'desk']);
         $this->assertEquals(['price' => 100], $value);
 
         // Test array containing multiple nested ArrayAccess objects
@@ -239,6 +248,8 @@ class SupportArrTest extends TestCase
         $array = ['parent' => $arrayAccessParent];
         $value = Arr::get($array, 'parent.child.products.desk');
         $this->assertEquals(['price' => 100], $value);
+        $value = Arr::get($array, ['parent', 'child', 'products', 'desk']);
+        $this->assertEquals(['price' => 100], $value);
 
         // Test missing ArrayAccess object field
         $arrayAccessChild = new ArrayObject(['products' => ['desk' => ['price' => 100]]]);
@@ -246,17 +257,39 @@ class SupportArrTest extends TestCase
         $array = ['parent' => $arrayAccessParent];
         $value = Arr::get($array, 'parent.child.desk');
         $this->assertNull($value);
+        $value = Arr::get($array, ['parent', 'child', 'desk']);
+        $this->assertNull($value);
 
         // Test missing ArrayAccess object field
         $arrayAccessObject = new ArrayObject(['products' => ['desk' => null]]);
         $array = ['parent' => $arrayAccessObject];
         $value = Arr::get($array, 'parent.products.desk.price');
         $this->assertNull($value);
+        $value = Arr::get($array, ['parent', 'products', 'desk', 'price']);
+        $this->assertNull($value);
 
         // Test null ArrayAccess object fields
         $array = new ArrayObject(['foo' => null, 'bar' => new ArrayObject(['baz' => null])]);
         $this->assertNull(Arr::get($array, 'foo', 'default'));
+        $this->assertNull(Arr::get($array, ['foo'], 'default'));
         $this->assertNull(Arr::get($array, 'bar.baz', 'default'));
+        $this->assertNull(Arr::get($array, ['bar', 'baz'], 'default'));
+
+        // Test numeric keys
+        $array = [
+            'products' => [
+                ['name' => '1st product'],
+                ['name' => '2nd product'],
+                ['name' => '3rd product']
+            ]
+        ];
+        $this->assertEquals('2nd product', Arr::get($array, 'products.1.name'));
+        $this->assertEquals('2nd product', Arr::get($array, ['products', '1', 'name']));
+
+        // Test combination of dot-notation + array of keys
+        $array = ['products' => ['desk' => ['price' => 100]]];
+        $value = Arr::get($array, ['products.desk', 'price']);
+        $this->assertEquals(100, $value);
 
         // Test null key returns the whole array
         $array = ['foo', 'bar'];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -280,7 +280,7 @@ class SupportArrTest extends TestCase
             'products' => [
                 ['name' => '1st product'],
                 ['name' => '2nd product'],
-                ['name' => '3rd product']
+                ['name' => '3rd product'],
             ]
         ];
         $this->assertEquals('2nd product', Arr::get($array, 'products.1.name'));


### PR DESCRIPTION
## Summary

`Arr::get($array, 'dot.notation.key')` is a very useful method. Sometimes the nested property I'm fetching is based on a variable. This allows you to pass them as an array instead of concatenating into dot-notation.

## Example

```php
// This PR allows you to now do this
Arr::get($array, [ $a, $b ])

// Before, you had to something like these
Arr::get($array, "$a.$b")
Arr::get($array, $a . '.' . $b)
Arr::get($array, implode('.', [ $a, $b ]))
// ... or any other concatentation method
```

## In other languages/frameworks

Lodash's `_.get()` behaves like this: https://lodash.com/docs/4.17.11#get

It's also similar to `Hash#dig` in Ruby >2.3.0: https://ruby-doc.org/core-2.3.0_preview1/Hash.html#method-i-dig

## Real-world example

For a real-world example, see the `Arr::get()` uses in `HasGlobalScopes` trait in Laravel below. I won't make the change as part of this PR but those would be able to be changed.

https://github.com/laravel/framework/blob/1fb4ef72655e91b27d8d7177d02c81a25325f2f1/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php#L51-L60