### PR TITLE
[5.8] PHPUnit 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "league/flysystem-cached-adapter": "^1.0",
         "mockery/mockery": "^1.0",
         "moontoast/math": "^1.1",
-        "orchestra/testbench-core": "3.8.*",
+        "orchestra/testbench-core": "dev-phpunit8 as 3.8.x-dev",
         "pda/pheanstalk": "^3.0",
         "phpunit/phpunit": "^7.5|^8.0",
         "predis/predis": "^1.1.1",

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "moontoast/math": "^1.1",
         "orchestra/testbench-core": "3.8.*",
         "pda/pheanstalk": "^3.0",
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^7.5|^8.0",
         "predis/predis": "^1.1.1",
         "symfony/css-selector": "^4.2",
         "symfony/dom-crawler": "^4.2",

--- a/src/Illuminate/Foundation/Testing/Assert.php
+++ b/src/Illuminate/Foundation/Testing/Assert.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use ArrayAccess;
+use PHPUnit\Util\InvalidArgumentHelper;
+use PHPUnit\Framework\Assert as PHPUnit;
+use PHPUnit\Framework\Constraint\ArraySubset;
+
+/**
+ * @internal This class is not meant to be used or overwritten outside the framework itself.
+ */
+abstract class Assert extends PHPUnit
+{
+    /**
+     * Asserts that an array has a specified subset.
+     *
+     * This method was taken over from PHPUnit where it was deprecated. See link for more info.
+     *
+     * @param  array|\ArrayAccess  $subset
+     * @param  array|\ArrayAccess  $array
+     * @param  bool  $checkForObjectIdentity
+     * @param  string  $message
+     * @return void
+     *
+     * @link https://github.com/sebastianbergmann/phpunit/issues/3494
+     */
+    public static function assertArraySubset($subset, $array, bool $checkForObjectIdentity = false, string $message = ''): void
+    {
+        if (! (is_array($subset) || $subset instanceof ArrayAccess)) {
+            throw InvalidArgumentHelper::factory(1, 'array or ArrayAccess');
+        }
+
+        if (! (is_array($array) || $array instanceof ArrayAccess)) {
+            throw InvalidArgumentHelper::factory(2, 'array or ArrayAccess');
+        }
+
+        $constraint = new ArraySubset($subset, $checkForObjectIdentity);
+
+        static::assertThat($array, $constraint, $message);
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -63,7 +63,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! $this->app) {
             $this->refreshApplication();
@@ -133,7 +133,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->app) {
             foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -342,7 +342,7 @@ class TestResponse
      */
     public function assertSee($value)
     {
-        PHPUnit::assertContains((string) $value, $this->getContent());
+        PHPUnit::assertStringContainsString((string) $value, $this->getContent());
 
         return $this;
     }
@@ -368,7 +368,7 @@ class TestResponse
      */
     public function assertSeeText($value)
     {
-        PHPUnit::assertContains((string) $value, strip_tags($this->getContent()));
+        PHPUnit::assertStringContainsString((string) $value, strip_tags($this->getContent()));
 
         return $this;
     }
@@ -394,7 +394,7 @@ class TestResponse
      */
     public function assertDontSee($value)
     {
-        PHPUnit::assertNotContains((string) $value, $this->getContent());
+        PHPUnit::assertStringNotContainsString((string) $value, $this->getContent());
 
         return $this;
     }
@@ -407,7 +407,7 @@ class TestResponse
      */
     public function assertDontSeeText($value)
     {
-        PHPUnit::assertNotContains((string) $value, strip_tags($this->getContent()));
+        PHPUnit::assertStringNotContainsString((string) $value, strip_tags($this->getContent()));
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
-use PHPUnit\Framework\Assert as PHPUnit;
+use Illuminate\Foundation\Testing\Assert as PHPUnit;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Illuminate\Foundation\Testing\Constraints\SeeInOrder;
 

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -587,7 +587,7 @@ class TestResponse
 
         foreach ($structure as $key => $value) {
             if (is_array($value) && $key === '*') {
-                PHPUnit::assertInternalType('array', $responseData);
+                PHPUnit::assertIsArray($responseData);
 
                 foreach ($responseData as $responseDataItem) {
                     $this->assertJsonStructure($structure['*'], $responseDataItem);

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -56,4 +56,14 @@ class LogTransport extends Transport
 
         return $string;
     }
+
+    /**
+     * Get the logger for the LogTransport instance.
+     *
+     * @return \Psr\Log\LoggerInterface
+     */
+    public function logger()
+    {
+        return $this->logger;
+    }
 }

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -60,6 +60,16 @@ class SesTransport extends Transport
     }
 
     /**
+     * Get the Amazon SES client for the SesTransport instance.
+     *
+     * @return \Aws\Ses\SesClient
+     */
+    public function ses()
+    {
+        return $this->ses;
+    }
+
+    /**
      * Get the transmission options being used by the transport.
      *
      * @return array

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -3,11 +3,13 @@
 namespace Illuminate\Tests\Auth;
 
 use stdClass;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Container\Container;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class AuthAccessGateTest extends TestCase
 {
@@ -507,10 +509,11 @@ class AuthAccessGateTest extends TestCase
 
     /**
      * @dataProvider notCallableDataProvider
-     * @expectedException \InvalidArgumentException
      */
     public function test_define_second_parameter_should_be_string_or_callable($callback)
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $gate = $this->getBasicGate();
 
         $gate->define('foo', $callback);
@@ -529,12 +532,11 @@ class AuthAccessGateTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\Access\AuthorizationException
-     * @expectedExceptionMessage You are not an admin.
-     */
     public function test_authorize_throws_unauthorized_exception()
     {
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('You are not an admin.');
+
         $gate = $this->getBasicGate();
 
         $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -13,14 +13,14 @@ use Illuminate\Auth\Passwords\DatabaseTokenRepository;
 
 class AuthDatabaseTokenRepositoryTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         Carbon::setTestNow(Carbon::now());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -13,7 +13,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 
 class AuthDatabaseUserProviderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 
 class AuthEloquentUserProviderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -21,7 +21,7 @@ use Illuminate\Contracts\Encryption\Encrypter;
 
 class AuthGuardTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -14,10 +14,12 @@ use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Auth\AuthenticationException;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Encryption\Encrypter;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class AuthGuardTest extends TestCase
 {
@@ -50,11 +52,10 @@ class AuthGuardTest extends TestCase
         $guard->basic('email');
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
-     */
     public function testBasicReturnsResponseOnFailure()
     {
+        $this->expectException(UnauthorizedHttpException::class);
+
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $guard = m::mock(SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
         $guard->shouldReceive('check')->once()->andReturn(false);
@@ -188,12 +189,11 @@ class AuthGuardTest extends TestCase
         $guard->setUser($user);
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     * @expectedExceptionMessage Unauthenticated.
-     */
     public function testAuthenticateThrowsWhenUserIsNull()
     {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Unauthenticated.');
+
         $guard = $this->getGuard();
         $guard->getSession()->shouldReceive('get')->once()->andReturn(null);
 

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Auth;
 
 use Mockery as m;
 use Illuminate\Support\Arr;
+use UnexpectedValueException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Auth\UserProvider;
@@ -28,12 +29,11 @@ class AuthPasswordBrokerTest extends TestCase
         $this->assertEquals(PasswordBrokerContract::INVALID_USER, $broker->sendResetLink(['credentials']));
     }
 
-    /**
-     * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage User must implement CanResetPassword interface.
-     */
     public function testGetUserThrowsExceptionIfUserDoesntImplementCanResetPassword()
     {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('User must implement CanResetPassword interface.');
+
         $broker = $this->getBroker($mocks = $this->getMocks());
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn('bar');
 

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -14,7 +14,7 @@ use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
 
 class AuthPasswordBrokerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -10,7 +10,7 @@ use Illuminate\Contracts\Auth\UserProvider;
 
 class AuthTokenGuardTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -18,12 +18,7 @@ class AuthenticateMiddlewareTest extends TestCase
 {
     protected $auth;
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
-    public function setUp()
+    public function setUp(): void
     {
         $container = Container::setInstance(new Container);
 
@@ -32,6 +27,11 @@ class AuthenticateMiddlewareTest extends TestCase
         $container->singleton('config', function () {
             return $this->createConfig();
         });
+    }
+
+    public function tearDown(): void
+    {
+        m::close();
     }
 
     /**

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -34,12 +34,11 @@ class AuthenticateMiddlewareTest extends TestCase
         m::close();
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     * @expectedExceptionMessage Unauthenticated.
-     */
     public function testDefaultUnauthenticatedThrows()
     {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Unauthenticated.');
+
         $this->registerAuthDriver('default', false);
 
         $this->authenticate();
@@ -80,12 +79,11 @@ class AuthenticateMiddlewareTest extends TestCase
         $this->assertSame($secondary, $this->auth->guard());
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     * @expectedExceptionMessage Unauthenticated.
-     */
     public function testMultipleDriversUnauthenticatedThrows()
     {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Unauthenticated.');
+
         $this->registerAuthDriver('default', false);
 
         $this->registerAuthDriver('secondary', false);

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -22,12 +22,7 @@ class AuthorizeMiddlewareTest extends TestCase
     protected $user;
     protected $router;
 
-    public function tearDown()
-    {
-        m::close();
-    }
-
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -46,6 +41,11 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->container->singleton(Registrar::class, function () {
             return $this->router;
         });
+    }
+
+    public function tearDown(): void
+    {
+        m::close();
     }
 
     /**

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -13,6 +13,7 @@ use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 
@@ -48,12 +49,11 @@ class AuthorizeMiddlewareTest extends TestCase
         m::close();
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\Access\AuthorizationException
-     * @expectedExceptionMessage This action is unauthorized.
-     */
     public function testSimpleAbilityUnauthorized()
     {
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('This action is unauthorized.');
+
         $this->gate()->define('view-dashboard', function ($user, $additional = null) {
             $this->assertNull($additional);
 
@@ -176,12 +176,11 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertEquals($response->content(), 'success');
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\Access\AuthorizationException
-     * @expectedExceptionMessage This action is unauthorized.
-     */
     public function testModelTypeUnauthorized()
     {
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('This action is unauthorized.');
+
         $this->gate()->define('create', function ($user, $model) {
             $this->assertEquals($model, 'App\User');
 
@@ -218,12 +217,11 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertEquals($response->content(), 'success');
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\Access\AuthorizationException
-     * @expectedExceptionMessage This action is unauthorized.
-     */
     public function testModelUnauthorized()
     {
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('This action is unauthorized.');
+
         $post = new stdClass;
 
         $this->router->bind('post', function () use ($post) {

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Broadcasting\Broadcaster;
 
 class BroadcastEventTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -2,12 +2,14 @@
 
 namespace Illuminate\Tests\Broadcasting;
 
+use Exception;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Routing\BindingRegistrar;
 use Illuminate\Broadcasting\Broadcasters\Broadcaster;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class BroadcasterTest extends TestCase
 {
@@ -78,11 +80,10 @@ class BroadcasterTest extends TestCase
         $this->assertEquals(['model.1.instance', 'something'], $parameters);
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testUnknownChannelAuthHandlerTypeThrowsException()
     {
+        $this->expectException(Exception::class);
+
         $this->broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', 123);
     }
 
@@ -95,11 +96,10 @@ class BroadcasterTest extends TestCase
         $this->broadcaster->channel('somethingelse', DummyBroadcastingChannel::class);
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
-     */
     public function testNotFoundThrowsHttpException()
     {
+        $this->expectException(HttpException::class);
+
         $callback = function ($user, BroadcasterTestEloquentModelNotFoundStub $model) {
             //
         };

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -16,14 +16,14 @@ class BroadcasterTest extends TestCase
      */
     public $broadcaster;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->broadcaster = new FakeBroadcaster;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Broadcasting;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Broadcasting\Broadcasters\PusherBroadcaster;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class PusherBroadcasterTest extends TestCase
 {
@@ -37,11 +38,10 @@ class PusherBroadcasterTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
-     */
     public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenCallbackReturnFalse()
     {
+        $this->expectException(AccessDeniedHttpException::class);
+
         $this->broadcaster->channel('test', function () {
             return false;
         });
@@ -51,11 +51,10 @@ class PusherBroadcasterTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
-     */
     public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenRequestUserNotFound()
     {
+        $this->expectException(AccessDeniedHttpException::class);
+
         $this->broadcaster->channel('test', function () {
             return true;
         });
@@ -80,11 +79,10 @@ class PusherBroadcasterTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
-     */
     public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenCallbackReturnNull()
     {
+        $this->expectException(AccessDeniedHttpException::class);
+
         $this->broadcaster->channel('test', function () {
         });
 
@@ -93,11 +91,10 @@ class PusherBroadcasterTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
-     */
     public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenRequestUserNotFound()
     {
+        $this->expectException(AccessDeniedHttpException::class);
+
         $this->broadcaster->channel('test', function () {
             return [1, 2, 3, 4];
         });

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -15,7 +15,7 @@ class PusherBroadcasterTest extends TestCase
 
     public $pusher;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Broadcasting;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Broadcasting\Broadcasters\RedisBroadcaster;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class RedisBroadcasterTest extends TestCase
 {
@@ -39,11 +40,10 @@ class RedisBroadcasterTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
-     */
     public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenCallbackReturnFalse()
     {
+        $this->expectException(AccessDeniedHttpException::class);
+
         $this->broadcaster->channel('test', function () {
             return false;
         });
@@ -53,11 +53,10 @@ class RedisBroadcasterTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
-     */
     public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenRequestUserNotFound()
     {
+        $this->expectException(AccessDeniedHttpException::class);
+
         $this->broadcaster->channel('test', function () {
             return true;
         });
@@ -82,11 +81,10 @@ class RedisBroadcasterTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
-     */
     public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenCallbackReturnNull()
     {
+        $this->expectException(AccessDeniedHttpException::class);
+
         $this->broadcaster->channel('test', function () {
         });
 
@@ -95,11 +93,10 @@ class RedisBroadcasterTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
-     */
     public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenRequestUserNotFound()
     {
+        $this->expectException(AccessDeniedHttpException::class);
+
         $this->broadcaster->channel('test', function () {
             return [1, 2, 3, 4];
         });

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -13,14 +13,14 @@ class RedisBroadcasterTest extends TestCase
      */
     public $broadcaster;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->broadcaster = m::mock(RedisBroadcaster::class)->makePartial();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -14,14 +14,14 @@ class UsePusherChannelConventionsTest extends TestCase
      */
     public $broadcaster;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->broadcaster = new FakeBroadcasterUsingPusherChannelsNames();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -15,7 +15,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 
 class BusDispatcherTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\PostgresConnection;
 
 class CacheDatabaseStoreTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -15,7 +15,7 @@ use Illuminate\Cache\Events\KeyForgotten;
 
 class CacheEventsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -10,14 +10,14 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class CacheFileStoreTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         Carbon::setTestNow(Carbon::now());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -9,7 +9,7 @@ use Illuminate\Cache\CacheManager;
 
 class CacheManagerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -9,7 +9,7 @@ use Illuminate\Cache\MemcachedConnector;
 
 class CacheMemcachedConnectorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 
 class CacheRateLimiterTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Redis\Factory;
 
 class CacheRedisStoreTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -17,7 +17,7 @@ use Illuminate\Contracts\Cache\Store;
 
 class CacheRepositoryTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         m::close();
         Carbon::setTestNow();

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Migrations\MigrationCreator;
 
 class CacheTableCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -14,7 +14,7 @@ use Illuminate\Cache\RedisTaggedCache;
 
 class CacheTaggedCacheTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -38,7 +38,7 @@ class ClearCommandTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -52,7 +52,7 @@ class ClearCommandTest extends TestCase
         $this->command->setLaravel($app);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -79,11 +79,10 @@ class ClearCommandTest extends TestCase
         $this->runCommand($this->command, ['store' => 'foo']);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testClearWithInvalidStoreArgument()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $this->files->shouldReceive('files')->andReturn([]);
 
         $this->cacheManager->shouldReceive('store')->once()->with('bar')->andThrow(InvalidArgumentException::class);

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -12,13 +12,13 @@ class RedisCacheIntegrationTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->setUpRedis();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         m::close();

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -17,7 +17,7 @@ class RepositoryTest extends TestCase
      */
     protected $config;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->repository = new Repository($this->config = [
             'foo' => 'bar',

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
 class ConsoleApplicationTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -19,7 +19,7 @@ class ConsoleEventSchedulerTest extends TestCase
      */
     private $schedule;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -32,7 +32,7 @@ class ConsoleEventSchedulerTest extends TestCase
         $container->instance(Schedule::class, $this->schedule = new Schedule(m::mock(EventMutex::class)));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -18,13 +18,13 @@ class ConsoleScheduledEventTest extends TestCase
      */
     protected $defaultTimezone;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->defaultTimezone = date_default_timezone_get();
         date_default_timezone_set('UTC');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         date_default_timezone_set($this->defaultTimezone);
         Carbon::setTestNow(null);

--- a/tests/Console/Scheduling/CacheEventMutexTest.php
+++ b/tests/Console/Scheduling/CacheEventMutexTest.php
@@ -31,7 +31,7 @@ class CacheEventMutexTest extends TestCase
      */
     protected $cacheRepository;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Console/Scheduling/CacheSchedulingMutexTest.php
+++ b/tests/Console/Scheduling/CacheSchedulingMutexTest.php
@@ -38,7 +38,7 @@ class CacheSchedulingMutexTest extends TestCase
      */
     protected $cacheRepository;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -9,7 +9,7 @@ use Illuminate\Console\Scheduling\EventMutex;
 
 class EventTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -14,7 +14,7 @@ class FrequencyTest extends TestCase
      */
     protected $event;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->event = new Event(
             m::mock(EventMutex::class),

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -4,17 +4,17 @@ namespace Illuminate\Tests\Container;
 
 use Closure;
 use stdClass;
+use ReflectionException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 
 class ContainerCallTest extends TestCase
 {
-    /**
-     * @expectedException \ReflectionException
-     * @expectedExceptionMessage Function ContainerTestCallStub() does not exist
-     */
     public function testCallWithAtSignBasedClassReferencesWithoutMethodThrowsException()
     {
+        $this->expectException(ReflectionException::class);
+        $this->expectExceptionMessage('Function ContainerTestCallStub() does not exist');
+
         $container = new Container;
         $container->call('ContainerTestCallStub');
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -5,6 +5,9 @@ namespace Illuminate\Tests\Container;
 use stdClass;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
+use Psr\Container\ContainerExceptionInterface;
+use Illuminate\Container\EntryNotFoundException;
+use Illuminate\Contracts\Container\BindingResolutionException;
 
 class ContainerTest extends TestCase
 {
@@ -239,32 +242,29 @@ class ContainerTest extends TestCase
         $this->assertFalse($_SERVER['__test.rebind']);
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Container\BindingResolutionException
-     * @expectedExceptionMessage Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class Illuminate\Tests\Container\ContainerMixedPrimitiveStub
-     */
     public function testInternalClassWithDefaultParameters()
     {
+        $this->expectException(BindingResolutionException::class);
+        $this->expectExceptionMessage('Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class Illuminate\Tests\Container\ContainerMixedPrimitiveStub');
+
         $container = new Container;
         $container->make(ContainerMixedPrimitiveStub::class, []);
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Container\BindingResolutionException
-     * @expectedExceptionMessage Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable.
-     */
     public function testBindingResolutionExceptionMessage()
     {
+        $this->expectException(BindingResolutionException::class);
+        $this->expectExceptionMessage('Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable.');
+
         $container = new Container;
         $container->make(IContainerContractStub::class, []);
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Container\BindingResolutionException
-     * @expectedExceptionMessage Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable while building [Illuminate\Tests\Container\ContainerDependentStub].
-     */
     public function testBindingResolutionExceptionMessageIncludesBuildStack()
     {
+        $this->expectException(BindingResolutionException::class);
+        $this->expectExceptionMessage('Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable while building [Illuminate\Tests\Container\ContainerDependentStub].');
+
         $container = new Container;
         $container->make(ContainerDependentStub::class, []);
     }
@@ -476,20 +476,18 @@ class ContainerTest extends TestCase
         $this->assertSame('Taylor', $container['name']);
     }
 
-    /**
-     * @expectedException \Illuminate\Container\EntryNotFoundException
-     */
     public function testUnknownEntryThrowsException()
     {
+        $this->expectException(EntryNotFoundException::class);
+
         $container = new Container;
         $container->get('Taylor');
     }
 
-    /**
-     * @expectedException \Psr\Container\ContainerExceptionInterface
-     */
     public function testBoundEntriesThrowsContainerExceptionWhenNotResolvable()
     {
+        $this->expectException(ContainerExceptionInterface::class);
+
         $container = new Container;
         $container->bind('Taylor', IContainerContractStub::class);
 

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class CookieTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -26,7 +26,7 @@ class EncryptCookiesTest extends TestCase
     protected $setCookiePath = 'cookie/set';
     protected $queueCookiePath = 'cookie/queue';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Database;
 
-use InvalidArgumentException;
 use PDO;
 use Mockery as m;
 use ReflectionProperty;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Database\Capsule\Manager as DB;

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use InvalidArgumentException;
 use PDO;
 use Mockery as m;
 use ReflectionProperty;
@@ -73,22 +74,20 @@ class DatabaseConnectionFactoryTest extends TestCase
         $this->assertNotInstanceOf(PDO::class, $readPdo->getValue($connection));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage A driver must be specified.
-     */
     public function testIfDriverIsntSetExceptionIsThrown()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A driver must be specified.');
+
         $factory = new ConnectionFactory($container = m::mock(Container::class));
         $factory->createConnector(['foo']);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unsupported driver [foo]
-     */
     public function testExceptionIsThrownOnUnsupportedDriver()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported driver [foo]');
+
         $factory = new ConnectionFactory($container = m::mock(Container::class));
         $container->shouldReceive('bound')->once()->andReturn(false);
         $factory->createConnector(['driver' => 'foo']);

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -14,7 +14,7 @@ class DatabaseConnectionFactoryTest extends TestCase
 {
     protected $db;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->db = new DB;
 
@@ -36,7 +36,7 @@ class DatabaseConnectionFactoryTest extends TestCase
         $this->db->setAsGlobal();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -25,7 +25,7 @@ use Illuminate\Database\Query\Builder as BaseBuilder;
 
 class DatabaseConnectionTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -240,12 +240,11 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals($mock, $result);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\QueryException
-     * @expectedExceptionMessage Deadlock found when trying to get lock (SQL: )
-     */
     public function testTransactionMethodRetriesOnDeadlock()
     {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('Deadlock found when trying to get lock (SQL: )');
+
         $pdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)->setMethods(['beginTransaction', 'commit', 'rollBack'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
         $pdo->expects($this->exactly(3))->method('beginTransaction');
@@ -272,12 +271,11 @@ class DatabaseConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Illuminate\Database\QueryException
-     * @expectedExceptionMessage server has gone away (SQL: foo)
-     */
     public function testOnLostConnectionPDOIsNotSwappedWithinATransaction()
     {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('server has gone away (SQL: foo)');
+
         $pdo = m::mock(PDO::class);
         $pdo->shouldReceive('beginTransaction')->once();
         $statement = m::mock(PDOStatement::class);
@@ -326,12 +324,11 @@ class DatabaseConnectionTest extends TestCase
         }]);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\QueryException
-     * @expectedExceptionMessage  (SQL: ) (SQL: )
-     */
     public function testRunMethodNeverRetriesIfWithinTransaction()
     {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('(SQL: ) (SQL: )');
+
         $method = (new ReflectionClass(Connection::class))->getMethod('run');
         $method->setAccessible(true);
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Connectors\SqlServerConnector;
 
 class DatabaseConnectorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -70,7 +70,7 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('articles');

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -56,7 +56,7 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('articles');

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -15,7 +15,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     protected $related;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -6,6 +6,7 @@ use Closure;
 use stdClass;
 use Mockery as m;
 use Carbon\Carbon;
+use BadMethodCallException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
@@ -17,6 +18,8 @@ use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Query\Builder as BaseBuilder;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\RelationNotFoundException;
 
 class DatabaseEloquentBuilderTest extends TestCase
 {
@@ -67,11 +70,10 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertInstanceOf(Model::class, $result);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
     public function testFindOrFailMethodThrowsModelNotFoundException()
     {
+        $this->expectException(ModelNotFoundException::class);
+
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($this->getMockModel());
         $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
@@ -79,11 +81,10 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->findOrFail('bar', ['column']);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
     public function testFindOrFailMethodWithManyThrowsModelNotFoundException()
     {
+        $this->expectException(ModelNotFoundException::class);
+
         $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $builder->setModel($this->getMockModel());
         $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', [1, 2]);
@@ -91,11 +92,10 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->findOrFail([1, 2], ['column']);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
     public function testFirstOrFailMethodThrowsModelNotFoundException()
     {
+        $this->expectException(ModelNotFoundException::class);
+
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($this->getMockModel());
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
@@ -416,12 +416,11 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder->bam(), $builder->getQuery());
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Call to undefined method Illuminate\Database\Eloquent\Builder::missingMacro()
-     */
     public function testMissingStaticMacrosThrowsProperException()
     {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Call to undefined method Illuminate\Database\Eloquent\Builder::missingMacro()');
+
         Builder::missingMacro();
     }
 
@@ -508,11 +507,10 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getRelation('ordersGroups');
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\RelationNotFoundException
-     */
     public function testGetRelationThrowsException()
     {
+        $this->expectException(RelationNotFoundException::class);
+
         $builder = $this->getBuilder();
         $builder->setModel($this->getMockModel());
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -879,7 +879,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $sql = preg_replace($aliasRegex, $alias, $sql);
 
-        $this->assertContains('"self_alias_hash"."id" = "self_related_stubs"."parent_id"', $sql);
+        $this->assertStringContainsString('"self_alias_hash"."id" = "self_related_stubs"."parent_id"', $sql);
     }
 
     public function testDoesntHave()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -20,7 +20,7 @@ use Illuminate\Database\Query\Builder as BaseBuilder;
 
 class DatabaseEloquentBuilderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
+++ b/tests/Database/DatabaseEloquentCastsDatabaseStringTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentCastsDatabaseStringTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -45,7 +45,7 @@ class DatabaseEloquentCastsDatabaseStringTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema()->drop('casting_table');
     }

--- a/tests/Database/DatabaseEloquentCollectionQueueableTest.php
+++ b/tests/Database/DatabaseEloquentCollectionQueueableTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class DatabaseEloquentCollectionQueueableTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Database;
 
-use LogicException;
 use Mockery as m;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Collection as BaseCollection;
 
 class DatabaseEloquentCollectionTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use LogicException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
@@ -352,12 +353,11 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(TestEloquentCollectionModel::class, $c->getQueueableClass());
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Queueing collections with multiple model types is not supported.
-     */
     public function testQueueableCollectionImplementationThrowsExceptionOnMultipleModelTypes()
     {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Queueing collections with multiple model types is not supported.');
+
         $c = new Collection([new TestEloquentCollectionModel, (object) ['id' => 'something']]);
         $c->getQueueableClass();
     }

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Capsule\Manager as DB;
 
 class DatabaseEloquentGlobalScopesTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -21,7 +21,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         ])->bootEloquent();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class DatabaseEloquentHasManyTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -62,7 +62,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('posts');

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Capsule\Manager as DB;
@@ -118,24 +119,22 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertCount(1, $country);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].
-     */
     public function testFirstOrFailThrowsAnException()
     {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].');
+
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
 
         HasManyThroughTestCountry::first()->posts()->firstOrFail();
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1
-     */
     public function testFindOrFailThrowsAnException()
     {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1');
+
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
                                  ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
 

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 {

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -19,7 +19,7 @@ class DatabaseEloquentHasOneTest extends TestCase
 
     protected $parent;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
 {

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Capsule\Manager as DB;
@@ -115,23 +116,21 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         $this->assertCount(1, $position);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasOneThroughTestContract].
-     */
     public function testFirstOrFailThrowsAnException()
     {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasOneThroughTestContract].');
+
         HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
             ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);
 
         HasOneThroughTestPosition::first()->contract()->firstOrFail();
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
     public function testFindOrFailThrowsAnException()
     {
+        $this->expectException(ModelNotFoundException::class);
+
         HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
             ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);
 

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -62,7 +62,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('contracts');

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -26,7 +26,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -126,7 +126,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach (['default', 'second_connection'] as $connection) {
             $this->schema($connection)->drop('users');

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -3,9 +3,12 @@
 namespace Illuminate\Tests\Database;
 
 use Exception;
+use RuntimeException;
+use InvalidArgumentException;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\QueryException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -17,6 +20,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Pagination\AbstractPaginator as Paginator;
 
 class DatabaseEloquentIntegrationTest extends TestCase
@@ -439,21 +443,19 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf(EloquentTestUser::class, $multiple[1]);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1
-     */
     public function testFindOrFailWithSingleIdThrowsModelNotFoundException()
     {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1');
+
         EloquentTestUser::findOrFail(1);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1, 2
-     */
     public function testFindOrFailWithMultipleIdsThrowsModelNotFoundException()
     {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1, 2');
+
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::findOrFail([1, 2]);
     }
@@ -718,11 +720,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals($questionMarksCount, $bindingsCount);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testHasOnMorphToRelationship()
     {
+        $this->expectException(RuntimeException::class);
+
         EloquentTestPhoto::has('imageable')->get();
     }
 
@@ -923,12 +924,11 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(['x' => 0, 'y' => 1, 'a' => ['b' => 3]], $model->json);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\QueryException
-     * @expectedExceptionMessage SQLSTATE[23000]:
-     */
     public function testSaveOrFailWithDuplicatedEntry()
     {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('SQLSTATE[23000]:');
+
         $date = '1970-01-01';
         EloquentTestPost::create([
             'id' => 1, 'user_id' => 1, 'name' => 'Post', 'created_at' => $date, 'updated_at' => $date,
@@ -1244,11 +1244,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('2017-11-14 08:23:19.000', $model->fromDateTime($model->getAttribute('created_at')));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testTimestampsUsingOldSqlServerDateFormatFailInEdgeCases()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $model = new EloquentTestUser;
         $model->setDateFormat('Y-m-d H:i:s.000'); // Old SQL Server date format
         $model->setRawAttributes([

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -15,7 +15,7 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -66,7 +66,7 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach (['default'] as $connection) {
             $this->schema($connection)->drop('users');

--- a/tests/Database/DatabaseEloquentIrregularPluralTest.php
+++ b/tests/Database/DatabaseEloquentIrregularPluralTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Capsule\Manager as DB;
 
 class DatabaseEloquentIrregularPluralTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -53,7 +53,7 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
         });
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema()->drop('irregular_plural_tokens');
         $this->schema()->drop('irregular_plural_humans');

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -6,6 +6,7 @@ use DateTime;
 use stdClass;
 use Exception;
 use Mockery as m;
+use LogicException;
 use ReflectionClass;
 use DateTimeImmutable;
 use DateTimeInterface;
@@ -25,6 +26,8 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Query\Builder as BaseBuilder;
+use Illuminate\Database\Eloquent\JsonEncodingException;
+use Illuminate\Database\Eloquent\MassAssignmentException;
 
 class DatabaseEloquentModelTest extends TestCase
 {
@@ -964,12 +967,11 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('bar', $model->foo);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\MassAssignmentException
-     * @expectedExceptionMessage name
-     */
     public function testGlobalGuarded()
     {
+        $this->expectException(MassAssignmentException::class);
+        $this->expectExceptionMessage('name');
+
         $model = new EloquentModelStub;
         $model->guard(['*']);
         $model->fill(['name' => 'foo', 'age' => 'bar', 'votes' => 'baz']);
@@ -1402,12 +1404,11 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNotContains('bar', $class->getObservableEvents());
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Illuminate\Tests\Database\EloquentModelStub::incorrectRelationStub must return a relationship instance.
-     */
     public function testGetModelAttributeMethodThrowsExceptionIfNotRelation()
     {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Illuminate\Tests\Database\EloquentModelStub::incorrectRelationStub must return a relationship instance.');
+
         $model = new EloquentModelStub;
         $model->incorrectRelationStub;
     }
@@ -1656,12 +1657,11 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($array['timestampAttribute']);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\JsonEncodingException
-     * @expectedExceptionMessage Unable to encode attribute [objectAttribute] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.
-     */
     public function testModelAttributeCastingFailsOnUnencodableData()
     {
+        $this->expectException(JsonEncodingException::class);
+        $this->expectExceptionMessage('Unable to encode attribute [objectAttribute] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.');
+
         $model = new EloquentModelCastingStub;
         $model->objectAttribute = ['foo' => "b\xF8r"];
         $obj = new stdClass;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -30,14 +30,14 @@ class DatabaseEloquentModelTest extends TestCase
 {
     use InteractsWithTime;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         Carbon::setTestNow(Carbon::now());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 class DatabaseEloquentMorphTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Relation::morphMap([], false);
 

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 class DatabaseEloquentMorphToManyTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -14,7 +14,7 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     protected $related;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class DatabaseEloquentPivotTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -66,7 +66,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('posts');

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -14,7 +14,7 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -58,7 +58,7 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach (['default'] as $connection) {
             $this->schema($connection)->drop('posts');

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 
 class DatabaseEloquentRelationTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -84,7 +84,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         Carbon::setTestNow(null);
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use BadMethodCallException;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Pagination\Paginator;
@@ -621,11 +622,10 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals($abigail->email, $comment->owner->email);
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testMorphToWithBadMethodCall()
     {
+        $this->expectException(BadMethodCallException::class);
+
         $this->createUsers();
 
         $abigail = SoftDeletesTestUser::where('email', 'abigailotwell@gmail.com')->first();

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentTimestampsTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -56,7 +56,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema()->drop('users');
         $this->schema()->drop('users_created_at');

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Migrations\MigrationCreator;
 
 class DatabaseMigrationCreatorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Database;
 
-use InvalidArgumentException;
 use Mockery as m;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Database\Migrations\MigrationCreator;

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Filesystem\Filesystem;
@@ -66,12 +67,11 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->create('create_bar', 'foo', 'baz', true);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage A MigrationCreatorFakeMigration class already exists.
-     */
     public function testTableUpdateMigrationWontCreateDuplicateClass()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A MigrationCreatorFakeMigration class already exists.');
+
         $creator = $this->getCreator();
 
         $creator->create('migration_creator_fake_migration', 'foo');

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Migrations\MigrationRepositoryInterface;
 
 class DatabaseMigrationInstallCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
 
 class DatabaseMigrationMakeCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Console\Migrations\MigrateCommand;
 
 class DatabaseMigrationMigrateCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Application as ConsoleApplication;
 
 class DatabaseMigrationRefreshCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 
 class DatabaseMigrationRepositoryTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Console\Migrations\ResetCommand;
 
 class DatabaseMigrationResetCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Console\Migrations\RollbackCommand;
 
 class DatabaseMigrationRollbackCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -23,7 +23,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->db = $db = new DB;
 
@@ -59,7 +59,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 
 class DatabaseMySqlSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Schema\Grammars\PostgresGrammar;
 
 class DatabasePostgresSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Query\Processors\Processor;
 
 class DatabaseProcessorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4,6 +4,8 @@ namespace Illuminate\Tests\Database;
 
 use stdClass;
 use Mockery as m;
+use RuntimeException;
+use BadMethodCallException;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Query\Builder;
@@ -2363,11 +2365,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertCount(2, $builder->wheres);
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testBuilderThrowsExpectedExceptionWithUndefinedMethod()
     {
+        $this->expectException(BadMethodCallException::class);
+
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select');
         $builder->getProcessor()->shouldReceive('processSelect')->andReturn([]);
@@ -2874,11 +2875,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([1], $builder->getBindings());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testWhereJsonContainsSqlite()
     {
+        $this->expectException(RuntimeException::class);
+
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereJsonContains('options->languages', ['en'])->toSql();
     }
@@ -2927,11 +2927,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([1], $builder->getBindings());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testWhereJsonDoesntContainSqlite()
     {
+        $this->expectException(RuntimeException::class);
+
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereJsonDoesntContain('options->languages', ['en'])->toSql();
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -22,7 +22,7 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class DatabaseQueryBuilderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
 
 class DatabaseSQLiteSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use Mockery as m;
+use RuntimeException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Capsule\Manager;
@@ -125,12 +126,11 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertFalse($schema->hasColumn('users', 'name'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The database driver in use does not support spatial indexes.
-     */
     public function testDropSpatialIndex()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
+
         $blueprint = new Blueprint('geo');
         $blueprint->dropSpatialIndex(['coordinates']);
         $blueprint->toSql($this->getConnection(), $this->getGrammar());
@@ -231,23 +231,21 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The database driver in use does not support spatial indexes.
-     */
     public function testAddingSpatialIndex()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
+
         $blueprint = new Blueprint('geo');
         $blueprint->spatialIndex('coordinates');
         $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The database driver in use does not support spatial indexes.
-     */
     public function testAddingFluentSpatialIndex()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
+
         $blueprint = new Blueprint('geo');
         $blueprint->point('coordinates')->spatialIndex();
         $blueprint->toSql($this->getConnection(), $this->getGrammar());

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -21,7 +21,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->db = $db = new DB;
 
@@ -37,7 +37,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         Facade::setFacadeApplication($container);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 
 class DatabaseSchemaBlueprintTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -16,7 +16,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->db = $db = new DB;
 
@@ -32,7 +32,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         Facade::setFacadeApplication($container);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Schema\Builder;
 
 class DatabaseSchemaBuilderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -28,7 +28,7 @@ class TestDepsSeeder extends Seeder
 
 class DatabaseSeederTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -15,7 +15,7 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class DatabaseSoftDeletingScopeTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class DatabaseSoftDeletingTraitTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 
 class DatabaseSqlServerSchemaGrammarTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -45,7 +45,7 @@ class SeedCommandTest extends TestCase
         $container->shouldHaveReceived('call')->with([$command, 'handle']);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Tests\Encryption;
 
+use RuntimeException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Encryption\Encrypter;
+use Illuminate\Contracts\Encryption\DecryptException;
 
 class EncrypterTest extends TestCase
 {
@@ -44,71 +46,64 @@ class EncrypterTest extends TestCase
         $this->assertEquals('foo', $e->decrypt($encrypted));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
-     */
     public function testDoNoAllowLongerKey()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+
         new Encrypter(str_repeat('z', 32));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
-     */
     public function testWithBadKeyLength()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+
         new Encrypter(str_repeat('a', 5));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
-     */
     public function testWithBadKeyLengthAlternativeCipher()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+
         new Encrypter(str_repeat('a', 16), 'AES-256-CFB8');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
-     */
     public function testWithUnsupportedCipher()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+
         new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Encryption\DecryptException
-     * @expectedExceptionMessage The payload is invalid.
-     */
     public function testExceptionThrownWhenPayloadIsInvalid()
     {
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('The payload is invalid.');
+
         $e = new Encrypter(str_repeat('a', 16));
         $payload = $e->encrypt('foo');
         $payload = str_shuffle($payload);
         $e->decrypt($payload);
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Encryption\DecryptException
-     * @expectedExceptionMessage The MAC is invalid.
-     */
     public function testExceptionThrownWithDifferentKey()
     {
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('The MAC is invalid.');
+
         $a = new Encrypter(str_repeat('a', 16));
         $b = new Encrypter(str_repeat('b', 16));
         $b->decrypt($a->encrypt('baz'));
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Encryption\DecryptException
-     * @expectedExceptionMessage The payload is invalid.
-     */
     public function testExceptionThrownWhenIvIsTooLong()
     {
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('The payload is invalid.');
+
         $e = new Encrypter(str_repeat('a', 16));
         $payload = $e->encrypt('foo');
         $data = json_decode(base64_decode($payload), true);

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -14,7 +14,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 class EventsDispatcherTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -16,13 +16,13 @@ class FilesystemAdapterTest extends TestCase
     private $tempDir;
     private $filesystem;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->tempDir = __DIR__.'/tmp';
         $this->filesystem = new Filesystem(new Local($this->tempDir));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $filesystem = new Filesystem(new Local(dirname($this->tempDir)));
         $filesystem->deleteDir(basename($this->tempDir));

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Filesystem;
 
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use SplFileInfo;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -259,11 +260,10 @@ class FilesystemTest extends TestCase
         $this->assertFalse($files->moveDirectory($this->tempDir.'/tmp', $this->tempDir.'/tmp2', true));
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Filesystem\FileNotFoundException
-     */
     public function testGetThrowsExceptionNonexisitingFile()
     {
+        $this->expectException(FileNotFoundException::class);
+
         $files = new Filesystem;
         $files->get($this->tempDir.'/unknown-file.txt');
     }
@@ -275,11 +275,10 @@ class FilesystemTest extends TestCase
         $this->assertEquals('Howdy?', $files->getRequire($this->tempDir.'/file.php'));
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Filesystem\FileNotFoundException
-     */
-    public function testGetRequireThrowsExceptionNonexisitingFile()
+    public function testGetRequireThrowsExceptionNonExistingFile()
     {
+        $this->expectException(FileNotFoundException::class);
+
         $files = new Filesystem;
         $files->getRequire($this->tempDir.'/file.php');
     }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Filesystem;
 
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use SplFileInfo;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -10,6 +9,7 @@ use League\Flysystem\Adapter\Ftp;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
 use Illuminate\Filesystem\FilesystemManager;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class FilesystemTest extends TestCase
 {

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -14,13 +14,13 @@ class FilesystemTest extends TestCase
 {
     private $tempDir;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->tempDir = __DIR__.'/tmp';
         mkdir($this->tempDir);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
 

--- a/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
+++ b/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 
 class LoadEnvironmentVariablesTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -12,7 +12,7 @@ use Illuminate\Foundation\Bootstrap\RegisterFacades;
 
 class FoundationApplicationTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationAuthenticationTest.php
+++ b/tests/Foundation/FoundationAuthenticationTest.php
@@ -49,7 +49,7 @@ class FoundationAuthenticationTest extends TestCase
         return $guard;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Container\Container;
 use Illuminate\Auth\Access\Response;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 
@@ -29,12 +30,11 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
         $this->assertTrue($_SERVER['_test.authorizes.trait']);
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\Access\AuthorizationException
-     * @expectedExceptionMessage This action is unauthorized.
-     */
     public function test_exception_is_thrown_if_gate_check_fails()
     {
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('This action is unauthorized.');
+
         $gate = $this->getBasicGate();
 
         $gate->define('baz', function () {

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -9,7 +9,7 @@ use Illuminate\Filesystem\Filesystem;
 
 class FoundationComposerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\EnvironmentDetector;
 
 class FoundationEnvironmentDetectorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -29,7 +29,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     protected $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->config = m::mock(Config::class);
 
@@ -51,7 +51,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->handler = new Handler($this->container);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -81,11 +81,11 @@ class FoundationExceptionsHandlerTest extends TestCase
 
         $response = $this->handler->render($this->request, new Exception('My custom error message'))->getContent();
 
-        $this->assertNotContains('<!DOCTYPE html>', $response);
-        $this->assertContains('"message": "My custom error message"', $response);
-        $this->assertContains('"file":', $response);
-        $this->assertContains('"line":', $response);
-        $this->assertContains('"trace":', $response);
+        $this->assertStringNotContainsString('<!DOCTYPE html>', $response);
+        $this->assertStringContainsString('"message": "My custom error message"', $response);
+        $this->assertStringContainsString('"file":', $response);
+        $this->assertStringContainsString('"line":', $response);
+        $this->assertStringContainsString('"trace":', $response);
     }
 
     public function testReturnsCustomResponseWhenExceptionImplementsResponsable()
@@ -102,12 +102,12 @@ class FoundationExceptionsHandlerTest extends TestCase
 
         $response = $this->handler->render($this->request, new Exception('This error message should not be visible'))->getContent();
 
-        $this->assertContains('"message": "Server Error"', $response);
-        $this->assertNotContains('<!DOCTYPE html>', $response);
-        $this->assertNotContains('This error message should not be visible', $response);
-        $this->assertNotContains('"file":', $response);
-        $this->assertNotContains('"line":', $response);
-        $this->assertNotContains('"trace":', $response);
+        $this->assertStringContainsString('"message": "Server Error"', $response);
+        $this->assertStringNotContainsString('<!DOCTYPE html>', $response);
+        $this->assertStringNotContainsString('This error message should not be visible', $response);
+        $this->assertStringNotContainsString('"file":', $response);
+        $this->assertStringNotContainsString('"line":', $response);
+        $this->assertStringNotContainsString('"trace":', $response);
     }
 
     public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalseAndHttpExceptionErrorIsShown()
@@ -117,12 +117,12 @@ class FoundationExceptionsHandlerTest extends TestCase
 
         $response = $this->handler->render($this->request, new HttpException(403, 'My custom error message'))->getContent();
 
-        $this->assertContains('"message": "My custom error message"', $response);
-        $this->assertNotContains('<!DOCTYPE html>', $response);
-        $this->assertNotContains('"message": "Server Error"', $response);
-        $this->assertNotContains('"file":', $response);
-        $this->assertNotContains('"line":', $response);
-        $this->assertNotContains('"trace":', $response);
+        $this->assertStringContainsString('"message": "My custom error message"', $response);
+        $this->assertStringNotContainsString('<!DOCTYPE html>', $response);
+        $this->assertStringNotContainsString('"message": "Server Error"', $response);
+        $this->assertStringNotContainsString('"file":', $response);
+        $this->assertStringNotContainsString('"line":', $response);
+        $this->assertStringNotContainsString('"trace":', $response);
     }
 
     public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalseAndAccessDeniedHttpExceptionErrorIsShown()
@@ -132,12 +132,12 @@ class FoundationExceptionsHandlerTest extends TestCase
 
         $response = $this->handler->render($this->request, new AccessDeniedHttpException('My custom error message'))->getContent();
 
-        $this->assertContains('"message": "My custom error message"', $response);
-        $this->assertNotContains('<!DOCTYPE html>', $response);
-        $this->assertNotContains('"message": "Server Error"', $response);
-        $this->assertNotContains('"file":', $response);
-        $this->assertNotContains('"line":', $response);
-        $this->assertNotContains('"trace":', $response);
+        $this->assertStringContainsString('"message": "My custom error message"', $response);
+        $this->assertStringNotContainsString('<!DOCTYPE html>', $response);
+        $this->assertStringNotContainsString('"message": "Server Error"', $response);
+        $this->assertStringNotContainsString('"file":', $response);
+        $this->assertStringNotContainsString('"line":', $response);
+        $this->assertStringNotContainsString('"trace":', $response);
     }
 }
 

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -11,7 +11,9 @@ use Illuminate\Routing\UrlGenerator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\Validation\Factory as ValidationFactoryContract;
 
@@ -80,11 +82,10 @@ class FoundationFormRequestTest extends TestCase
         $this->assertEquals(1, FoundationTestFormRequestTwiceStub::$count);
     }
 
-    /**
-     * @expectedException \Illuminate\Validation\ValidationException
-     */
     public function test_validate_throws_when_validation_fails()
     {
+        $this->expectException(ValidationException::class);
+
         $request = $this->createRequest(['no' => 'name']);
 
         $this->mocks['redirect']->shouldReceive('withInput->withErrors');
@@ -92,12 +93,11 @@ class FoundationFormRequestTest extends TestCase
         $request->validateResolved();
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\Access\AuthorizationException
-     * @expectedExceptionMessage This action is unauthorized.
-     */
     public function test_validate_method_throws_when_authorization_fails()
     {
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('This action is unauthorized.');
+
         $this->createRequest([], FoundationTestFormRequestForbiddenStub::class)->validateResolved();
     }
 

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -19,7 +19,7 @@ class FoundationFormRequestTest extends TestCase
 {
     protected $mocks = [];
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
 

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation;
 
 use stdClass;
+use Exception;
 use Mockery as m;
 use Illuminate\Support\Str;
 use Illuminate\Foundation\Mix;
@@ -41,12 +42,11 @@ class FoundationHelpersTest extends TestCase
         $this->assertEquals('default', cache('baz', 'default'));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage You must specify an expiration time when setting a value in the cache.
-     */
     public function testCacheThrowsAnExceptionIfAnExpirationIsNotProvided()
     {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('You must specify an expiration time when setting a value in the cache.');
+
         cache(['foo' => 'bar']);
     }
 
@@ -98,12 +98,11 @@ class FoundationHelpersTest extends TestCase
         unlink($manifest);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The Mix manifest does not exist.
-     */
     public function testMixMissingManifestThrowsException()
     {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('The Mix manifest does not exist.');
+
         mix('unversioned.css', 'missing');
     }
 

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -11,7 +11,7 @@ use Illuminate\Foundation\Application;
 
 class FoundationHelpersTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -19,12 +19,12 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     protected $connection;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->connection = m::mock(Connection::class);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\ExpectationFailedException;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase;
 
 class FoundationInteractsWithDatabaseTest extends TestCase
@@ -36,12 +37,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The table is empty.
-     */
     public function testSeeInDatabaseDoesNotFindResults()
     {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The table is empty.');
+
         $builder = $this->mockCountBuilder(0);
 
         $builder->shouldReceive('get')->andReturn(collect());
@@ -49,11 +49,10 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
-     */
     public function testSeeInDatabaseFindsNotMatchingResults()
     {
+        $this->expectException(ExpectationFailedException::class);
+
         $this->expectExceptionMessage('Found: '.json_encode([['title' => 'Forge']], JSON_PRETTY_PRINT));
 
         $builder = $this->mockCountBuilder(0);
@@ -64,11 +63,10 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
-     */
     public function testSeeInDatabaseFindsManyNotMatchingResults()
     {
+        $this->expectException(ExpectationFailedException::class);
+
         $this->expectExceptionMessage('Found: '.json_encode(['data', 'data', 'data'], JSON_PRETTY_PRINT).' and 2 others.');
 
         $builder = $this->mockCountBuilder(0);
@@ -88,11 +86,10 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseMissing($this->table, $this->data);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
-     */
     public function testDontSeeInDatabaseFindsResults()
     {
+        $this->expectException(ExpectationFailedException::class);
+
         $builder = $this->mockCountBuilder(1);
 
         $builder->shouldReceive('take')->andReturnSelf();
@@ -108,12 +105,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertSoftDeleted($this->table, $this->data);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The table is empty.
-     */
     public function testAssertSoftDeletedInDatabaseDoesNotFindResults()
     {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The table is empty.');
+
         $builder = $this->mockCountBuilder(0);
 
         $builder->shouldReceive('get')->andReturn(collect());
@@ -121,12 +117,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertSoftDeleted($this->table, $this->data);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage The table is empty.
-     */
     public function testAssertSoftDeletedInDatabaseDoesNotFindModelResults()
     {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The table is empty.');
+
         $this->data = ['id' => 1];
 
         $builder = $this->mockCountBuilder(0);

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
 class FoundationProviderRepositoryTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -11,6 +11,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\AssertionFailedError;
 use Illuminate\Foundation\Testing\TestResponse;
+use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class FoundationTestResponseTest extends TestCase
@@ -143,12 +144,11 @@ class FoundationTestResponseTest extends TestCase
         $response->assertHeader('Location', '/bar');
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
-     * @expectedExceptionMessage Unexpected header [Location] is present on response.
-     */
     public function testAssertHeaderMissing()
     {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Unexpected header [Location] is present on response.');
+
         $baseResponse = tap(new Response, function ($response) {
             $response->header('Location', '/foo');
         });

--- a/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
+++ b/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
@@ -26,7 +26,7 @@ class CheckForMaintenanceModeTest extends TestCase
      */
     protected $files;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (is_null($this->files)) {
             $this->files = new Filesystem;
@@ -38,7 +38,7 @@ class CheckForMaintenanceModeTest extends TestCase
         $this->files->makeDirectory($this->storagePath.'/framework', 0755, true);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->files->deleteDirectory($this->storagePath);
 

--- a/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
+++ b/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode;
+use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
 
 class CheckForMaintenanceModeTest extends TestCase
 {
@@ -88,12 +89,11 @@ class CheckForMaintenanceModeTest extends TestCase
         $this->assertSame('Allowing [2001:0db8:85a3:0000:0000:8a2e:0370:7334]', $result);
     }
 
-    /**
-     * @expectedException \Illuminate\Foundation\Http\Exceptions\MaintenanceModeException
-     * @expectedExceptionMessage This application is down for maintenance.
-     */
     public function testApplicationDeniesSomeIPs()
     {
+        $this->expectException(MaintenanceModeException::class);
+        $this->expectExceptionMessage('This application is down for maintenance.');
+
         $middleware = new CheckForMaintenanceMode($this->createMaintenanceApplication());
 
         $result = $middleware->handle(Request::create('/'), function ($request) {
@@ -120,12 +120,11 @@ class CheckForMaintenanceModeTest extends TestCase
         $this->assertSame('Excepting /foo/bar', $result);
     }
 
-    /**
-     * @expectedException \Illuminate\Foundation\Http\Exceptions\MaintenanceModeException
-     * @expectedExceptionMessage This application is down for maintenance.
-     */
     public function testApplicationDeniesSomeURIs()
     {
+        $this->expectException(MaintenanceModeException::class);
+        $this->expectExceptionMessage('This application is down for maintenance.');
+
         $middleware = new CheckForMaintenanceMode($this->createMaintenanceApplication());
 
         $result = $middleware->handle(Request::create('/foo/bar'), function ($request) {

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Hashing;
 
+use RuntimeException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Hashing\ArgonHasher;
 use Illuminate\Hashing\BcryptHasher;
@@ -50,11 +51,10 @@ class HasherTest extends TestCase
         $this->assertSame('argon2id', password_get_info($value)['algoName']);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testBasicBcryptVerification()
     {
+        $this->expectException(RuntimeException::class);
+
         if (! defined('PASSWORD_ARGON2I')) {
             $this->markTestSkipped('PHP not compiled with Argon2i hashing support.');
         }
@@ -64,21 +64,19 @@ class HasherTest extends TestCase
         (new BcryptHasher(['verify' => true]))->check('password', $argonHashed);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testBasicArgon2iVerification()
     {
+        $this->expectException(RuntimeException::class);
+
         $bcryptHasher = new BcryptHasher(['verify' => true]);
         $bcryptHashed = $bcryptHasher->make('password');
         (new ArgonHasher(['verify' => true]))->check('password', $bcryptHashed);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testBasicArgon2idVerification()
     {
+        $this->expectException(RuntimeException::class);
+
         $bcryptHasher = new BcryptHasher(['verify' => true]);
         $bcryptHashed = $bcryptHasher->make('password');
         (new Argon2IdHasher(['verify' => true]))->check('password', $bcryptHashed);

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Http;
 
 use stdClass;
 use JsonSerializable;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Contracts\Support\Jsonable;
@@ -68,14 +69,12 @@ class HttpJsonResponseTest extends TestCase
     }
 
     /**
-     * @param mixed $data
-     *
-     * @expectedException \InvalidArgumentException
-     *
      * @dataProvider jsonErrorDataProvider
      */
     public function testInvalidArgumentExceptionOnJsonError($data)
     {
+        $this->expectException(InvalidArgumentException::class);
+
         new JsonResponse(['data' => $data]);
     }
 

--- a/tests/Http/HttpMimeTypeTest.php
+++ b/tests/Http/HttpMimeTypeTest.php
@@ -30,7 +30,8 @@ class HttpMimeTypeTest extends TestCase
     public function testGetAllMimeTypes()
     {
         $this->assertIsArray(MimeType::get());
-        $this->assertArraySubset(['jpg' => 'image/jpeg'], MimeType::get());
+        $this->assertArrayHasKey('jpg', MimeType::get());
+        $this->assertEquals('image/jpeg', MimeType::get()['jpg']);
     }
 
     public function testSearchExtensionFromMimeType()

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -14,7 +14,7 @@ use Illuminate\Contracts\Support\MessageProvider;
 
 class HttpRedirectResponseTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Http;
 
 use Mockery as m;
+use BadMethodCallException;
 use Illuminate\Http\Request;
 use Illuminate\Session\Store;
 use PHPUnit\Framework\TestCase;
@@ -124,12 +125,11 @@ class HttpRedirectResponseTest extends TestCase
         $response->withFoo('bar');
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Call to undefined method Illuminate\Http\RedirectResponse::doesNotExist()
-     */
     public function testMagicCallException()
     {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Call to undefined method Illuminate\Http\RedirectResponse::doesNotExist()');
+
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 
 class HttpRequestTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Http;
 
 use Mockery as m;
+use RuntimeException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Session\Store;
@@ -844,12 +845,11 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->accepts('text/html'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Session store not set on request.
-     */
     public function testSessionMethod()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Session store not set on request.');
+
         $request = Request::create('/', 'GET');
         $request->session();
     }
@@ -876,12 +876,11 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(40, mb_strlen($request->fingerprint()));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unable to generate fingerprint. Route unavailable.
-     */
     public function testFingerprintWithoutRoute()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to generate fingerprint. Route unavailable.');
+
         $request = Request::create('/', 'GET', [], [], [], []);
         $request->fingerprint();
     }

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class HttpResponseTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Http;
 
 use Mockery as m;
 use JsonSerializable;
+use BadMethodCallException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Session\Store;
@@ -196,12 +197,11 @@ class HttpResponseTest extends TestCase
         $response->withFoo('bar');
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Call to undefined method Illuminate\Http\RedirectResponse::doesNotExist()
-     */
     public function testMagicCallException()
     {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Call to undefined method Illuminate\Http\RedirectResponse::doesNotExist()');
+
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');
     }

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Http\Middleware;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Http\Middleware\SetCacheHeaders as Cache;
 
@@ -73,11 +74,10 @@ class CacheTest extends TestCase
         $this->assertSame(304, $response->getStatusCode());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidOption()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         (new Cache)->handle(new Request, function () {
             return new Response('some content');
         }, 'invalid');

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -34,7 +34,7 @@ class AuthenticationTest extends TestCase
         $app['config']->set('hashing', ['driver' => 'bcrypt']);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Cache;
  */
 class DynamoDbStoreTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Cache/MemcachedCacheLockTest.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Cache;
 use Memcached;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Contracts\Cache\LockTimeoutException;
 
 /**
  * @group integration
@@ -43,11 +44,10 @@ class MemcachedCacheLockTest extends MemcachedIntegrationTest
         }));
     }
 
-    /**
-     * @expectedException \Illuminate\Contracts\Cache\LockTimeoutException
-     */
     public function test_locks_throw_timeout_if_block_expires()
     {
+        $this->expectException(LockTimeoutException::class);
+
         Carbon::setTestNow();
 
         Cache::store('memcached')->lock('foo')->release();

--- a/tests/Integration/Cache/MemcachedIntegrationTest.php
+++ b/tests/Integration/Cache/MemcachedIntegrationTest.php
@@ -10,7 +10,7 @@ use Orchestra\Testbench\TestCase;
  */
 abstract class MemcachedIntegrationTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -14,14 +14,14 @@ class RedisCacheLockTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->setUpRedis();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Console\Kernel;
 
 class ConsoleApplicationTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 /**
@@ -228,11 +229,10 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals($tag->name, $post->tags()->first()->name);
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
     public function test_firstOrFail_method()
     {
+        $this->expectException(ModelNotFoundException::class);
+
         $post = Post::create(['title' => Str::random()]);
 
         $post->tags()->firstOrFail(['id' => 10]);
@@ -251,11 +251,10 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertCount(2, $post->tags()->findMany([$tag->id, $tag2->id]));
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
     public function test_findOrFail_method()
     {
+        $this->expectException(ModelNotFoundException::class);
+
         $post = Post::create(['title' => Str::random()]);
 
         Tag::create(['name' => Str::random()]);

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -16,7 +16,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentBelongsToManyTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentBelongsToTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/EloquentCollectionFreshTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class EloquentCollectionFreshTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -15,7 +15,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentCollectionLoadCountTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentCollectionLoadMissingTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
  */
 class EloquentCustomPivotCastTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -25,7 +25,7 @@ class EloquentDeleteTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -103,7 +103,7 @@ class EloquentFactoryBuilderTest extends TestCase
         });
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentHasManyThroughTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentLazyEagerLoadingTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelConnectionsTest.php
+++ b/tests/Integration/Database/EloquentModelConnectionsTest.php
@@ -31,7 +31,7 @@ class EloquentModelConnectionsTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelCustomEventsTest.php
+++ b/tests/Integration/Database/EloquentModelCustomEventsTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelCustomEventsTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelDateCastingTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelDecimalCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDecimalCastingTest.php
@@ -11,7 +11,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelDecimalCastingTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelJsonCastingTest.php
+++ b/tests/Integration/Database/EloquentModelJsonCastingTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelJsonCastingTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelLoadCountTest.php
+++ b/tests/Integration/Database/EloquentModelLoadCountTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelLoadCountTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMissingTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelLoadMissingTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelRefreshTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class EloquentModelTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentMorphManyTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
+++ b/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
@@ -14,7 +14,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentMorphToGlobalScopesTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentMorphToLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphToLazyEagerLoadingTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentMorphToLazyEagerLoadingTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentMorphToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphToSelectTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentMorphToSelectTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentMorphToTouchesTest.php
+++ b/tests/Integration/Database/EloquentMorphToTouchesTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentMorphToTouchesTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -11,7 +11,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentPaginateTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Eloquent\Collection as DatabaseCollection;
  */
 class EloquentPivotSerializationTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentPushTest.php
+++ b/tests/Integration/Database/EloquentPushTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Schema\Blueprint;
  */
 class EloquentPushTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -13,7 +13,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentTouchParentWithGlobalScopeTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -26,7 +26,7 @@ class EloquentUpdateTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentWhereHasTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Schema\Blueprint;
  */
 class EloquentWhereTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -11,7 +11,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentWithCountTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/MigrateWithRealpathTest.php
+++ b/tests/Integration/Database/MigrateWithRealpathTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 
 class MigrateWithRealpathTest extends DatabaseTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class QueryBuilderTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -36,7 +36,7 @@ class EventFakeTest extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -53,7 +53,7 @@ class EventFakeTest extends TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Schema::dropIfExists('posts');
 

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -66,12 +66,11 @@ class FoundationHelpersTest extends TestCase
     //     unlink($manifest);
     // }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Unable to locate Mix file: /missing.js.
-     */
     // public function testMixThrowsExceptionWhenAssetIsMissingFromManifestWhenInDebugMode()
     // {
+    //     $this->expectException(Exception::class);
+    //     $this->expectExceptionMessage('Unable to locate Mix file: /missing.js.');
+
     //     $this->app['config']->set('app.debug', true);
     //     $manifest = $this->makeManifest();
 

--- a/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
+++ b/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
@@ -23,7 +23,7 @@ class InteractsWithAuthenticationTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -11,7 +11,7 @@ class VerifyCsrfTokenExceptTest extends TestCase
     private $stub;
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -14,7 +14,7 @@ use Illuminate\Http\Exceptions\ThrottleRequestsException;
  */
 class ThrottleRequestsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         Carbon::setTestNow(null);

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -16,7 +16,7 @@ class ThrottleRequestsWithRedisTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         Carbon::setTestNow(null);

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -55,7 +55,7 @@ class SendingMailWithLocaleTest extends TestCase
     {
         Mail::to('test@mail.com')->send(new TestMail);
 
-        $this->assertContains('name',
+        $this->assertStringContainsString('name',
             app('swift.transport')->messages()[0]->getBody()
         );
     }
@@ -64,7 +64,7 @@ class SendingMailWithLocaleTest extends TestCase
     {
         Mail::to('test@mail.com')->locale('ar')->send(new TestMail);
 
-        $this->assertContains('esm',
+        $this->assertStringContainsString('esm',
             app('swift.transport')->messages()[0]->getBody()
         );
     }
@@ -95,7 +95,7 @@ class SendingMailWithLocaleTest extends TestCase
 
         Mail::to($recipient)->send(new TestMail);
 
-        $this->assertContains('esm',
+        $this->assertStringContainsString('esm',
             app('swift.transport')->messages()[0]->getBody()
         );
     }
@@ -109,7 +109,7 @@ class SendingMailWithLocaleTest extends TestCase
 
         Mail::to($recipient)->locale('ar')->send(new TestMail);
 
-        $this->assertContains('esm',
+        $this->assertStringContainsString('esm',
             app('swift.transport')->messages()[0]->getBody()
         );
     }
@@ -128,7 +128,7 @@ class SendingMailWithLocaleTest extends TestCase
 
         Mail::to($toRecipient)->cc($ccRecipient)->send(new TestMail);
 
-        $this->assertContains('esm',
+        $this->assertStringContainsString('esm',
             app('swift.transport')->messages()[0]->getBody()
         );
     }
@@ -148,7 +148,7 @@ class SendingMailWithLocaleTest extends TestCase
 
         Mail::to($recipients)->send(new TestMail);
 
-        $this->assertContains('name',
+        $this->assertStringContainsString('name',
             app('swift.transport')->messages()[0]->getBody()
         );
     }
@@ -160,11 +160,11 @@ class SendingMailWithLocaleTest extends TestCase
 
         $this->assertEquals('en', app('translator')->getLocale());
 
-        $this->assertContains('esm',
+        $this->assertStringContainsString('esm',
             app('swift.transport')->messages()[0]->getBody()
         );
 
-        $this->assertContains('name',
+        $this->assertStringContainsString('name',
             app('swift.transport')->messages()[1]->getBody()
         );
     }

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -18,7 +18,7 @@ use Illuminate\Contracts\Translation\HasLocalePreference;
  */
 class SendingMailWithLocaleTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -46,7 +46,7 @@ class SendingMailWithLocaleTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -23,7 +23,7 @@ class SendingMailNotificationsTest extends TestCase
     public $mailer;
     public $markdown;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -54,7 +54,7 @@ class SendingMailNotificationsTest extends TestCase
         });
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -73,7 +73,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
 
         NotificationFacade::send($user, new GreetingMailNotification);
 
-        $this->assertContains('hello',
+        $this->assertStringContainsString('hello',
             app('swift.transport')->messages()[0]->getBody()
         );
     }
@@ -87,7 +87,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
 
         NotificationFacade::locale('fr')->send($user, new GreetingMailNotification);
 
-        $this->assertContains('bonjour',
+        $this->assertStringContainsString('bonjour',
             app('swift.transport')->messages()[0]->getBody()
         );
     }
@@ -107,11 +107,11 @@ class SendingNotificationsWithLocaleTest extends TestCase
 
         NotificationFacade::send($users, (new GreetingMailNotification)->locale('fr'));
 
-        $this->assertContains('bonjour',
+        $this->assertStringContainsString('bonjour',
             app('swift.transport')->messages()[0]->getBody()
         );
 
-        $this->assertContains('bonjour',
+        $this->assertStringContainsString('bonjour',
             app('swift.transport')->messages()[1]->getBody()
         );
     }
@@ -125,7 +125,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
 
         NotificationFacade::locale('fr')->send($user, new GreetingMailNotificationWithMailable);
 
-        $this->assertContains('bonjour',
+        $this->assertStringContainsString('bonjour',
             app('swift.transport')->messages()[0]->getBody()
         );
     }
@@ -145,7 +145,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
 
         $user->notify((new GreetingMailNotification)->locale('fr'));
 
-        $this->assertContains('bonjour',
+        $this->assertStringContainsString('bonjour',
             app('swift.transport')->messages()[0]->getBody()
         );
 
@@ -167,7 +167,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
 
         $recipient->notify(new GreetingMailNotification);
 
-        $this->assertContains('bonjour',
+        $this->assertStringContainsString('bonjour',
             app('swift.transport')->messages()[0]->getBody()
         );
     }
@@ -192,13 +192,13 @@ class SendingNotificationsWithLocaleTest extends TestCase
             $recipients, new GreetingMailNotification
         );
 
-        $this->assertContains('bonjour',
+        $this->assertStringContainsString('bonjour',
             app('swift.transport')->messages()[0]->getBody()
         );
-        $this->assertContains('hola',
+        $this->assertStringContainsString('hola',
             app('swift.transport')->messages()[1]->getBody()
         );
-        $this->assertContains('hi',
+        $this->assertStringContainsString('hi',
             app('swift.transport')->messages()[2]->getBody()
         );
     }
@@ -214,7 +214,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
             (new GreetingMailNotification)->locale('fr')
         );
 
-        $this->assertContains('bonjour',
+        $this->assertStringContainsString('bonjour',
             app('swift.transport')->messages()[0]->getBody()
         );
     }
@@ -230,7 +230,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
             $recipient, new GreetingMailNotification
         );
 
-        $this->assertContains('bonjour',
+        $this->assertStringContainsString('bonjour',
             app('swift.transport')->messages()[0]->getBody()
         );
     }

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -53,7 +53,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -17,7 +17,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
  */
 class CallQueuedHandlerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -29,7 +29,7 @@ class JobChainingTest extends TestCase
         ]);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         JobChainingTestFirstJob::$ran = false;
         JobChainingTestSecondJob::$ran = false;

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -33,7 +33,7 @@ class ModelSerializationTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Queue;
 
 use Schema;
+use LogicException;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Database\Eloquent\Model;
@@ -125,12 +126,11 @@ class ModelSerializationTest extends TestCase
         $this->assertEquals('taylor@laravel.com', $unSerialized->user[1]->email);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage  Queueing collections with multiple model connections is not supported.
-     */
     public function test_it_fails_if_models_on_multi_connections()
     {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Queueing collections with multiple model connections is not supported.');
+
         $user = ModelSerializationTestUser::on('custom')->create([
             'email' => 'mohamed@laravel.com',
         ]);

--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -20,8 +20,8 @@ class FallbackRouteTest extends TestCase
             return 'one';
         });
 
-        $this->assertContains('one', $this->get('/one')->getContent());
-        $this->assertContains('fallback', $this->get('/non-existing')->getContent());
+        $this->assertStringContainsString('one', $this->get('/one')->getContent());
+        $this->assertStringContainsString('fallback', $this->get('/non-existing')->getContent());
         $this->assertEquals(404, $this->get('/non-existing')->getStatusCode());
     }
 
@@ -37,10 +37,10 @@ class FallbackRouteTest extends TestCase
             });
         });
 
-        $this->assertContains('one', $this->get('/prefix/one')->getContent());
-        $this->assertContains('fallback', $this->get('/prefix/non-existing')->getContent());
-        $this->assertContains('fallback', $this->get('/prefix/non-existing/with/multiple/segments')->getContent());
-        $this->assertContains('Not Found', $this->get('/non-existing')->getContent());
+        $this->assertStringContainsString('one', $this->get('/prefix/one')->getContent());
+        $this->assertStringContainsString('fallback', $this->get('/prefix/non-existing')->getContent());
+        $this->assertStringContainsString('fallback', $this->get('/prefix/non-existing/with/multiple/segments')->getContent());
+        $this->assertStringContainsString('Not Found', $this->get('/non-existing')->getContent());
     }
 
     public function test_fallback_with_wildcards()
@@ -57,8 +57,8 @@ class FallbackRouteTest extends TestCase
             return 'wildcard';
         })->where('any', '.*');
 
-        $this->assertContains('one', $this->get('/one')->getContent());
-        $this->assertContains('wildcard', $this->get('/non-existing')->getContent());
+        $this->assertStringContainsString('one', $this->get('/one')->getContent());
+        $this->assertStringContainsString('wildcard', $this->get('/non-existing')->getContent());
         $this->assertEquals(200, $this->get('/non-existing')->getStatusCode());
     }
 
@@ -68,7 +68,7 @@ class FallbackRouteTest extends TestCase
             return response('fallback', 404);
         });
 
-        $this->assertContains('fallback', $this->get('/non-existing')->getContent());
+        $this->assertStringContainsString('fallback', $this->get('/non-existing')->getContent());
         $this->assertEquals(404, $this->get('/non-existing')->getStatusCode());
     }
 
@@ -82,8 +82,8 @@ class FallbackRouteTest extends TestCase
             return Route::respondWithRoute('testFallbackRoute');
         });
 
-        $this->assertContains('fallback', $this->get('/non-existing')->getContent());
-        $this->assertContains('fallback', $this->get('/one')->getContent());
+        $this->assertStringContainsString('fallback', $this->get('/non-existing')->getContent());
+        $this->assertStringContainsString('fallback', $this->get('/one')->getContent());
     }
 
     public function test_no_fallbacks()
@@ -92,7 +92,7 @@ class FallbackRouteTest extends TestCase
             return 'one';
         });
 
-        $this->assertContains('one', $this->get('/one')->getContent());
+        $this->assertStringContainsString('one', $this->get('/one')->getContent());
         $this->assertEquals(200, $this->get('/one')->getStatusCode());
     }
 }

--- a/tests/Integration/Routing/RouteViewTest.php
+++ b/tests/Integration/Routing/RouteViewTest.php
@@ -17,7 +17,7 @@ class RouteViewTest extends TestCase
 
         View::addLocation(__DIR__.'/Fixtures');
 
-        $this->assertContains('Test bar', $this->get('/route')->getContent());
+        $this->assertStringContainsString('Test bar', $this->get('/route')->getContent());
     }
 
     public function test_route_view_with_params()
@@ -26,7 +26,7 @@ class RouteViewTest extends TestCase
 
         View::addLocation(__DIR__.'/Fixtures');
 
-        $this->assertContains('Test bar', $this->get('/route/value1/value2')->getContent());
-        $this->assertContains('Test bar', $this->get('/route/value1')->getContent());
+        $this->assertStringContainsString('Test bar', $this->get('/route/value1/value2')->getContent());
+        $this->assertStringContainsString('Test bar', $this->get('/route/value1')->getContent());
     }
 }

--- a/tests/Integration/Support/ManagerTest.php
+++ b/tests/Integration/Support/ManagerTest.php
@@ -2,15 +2,15 @@
 
 namespace Illuminate\Tests\Integration\Support;
 
+use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
 
 class ManagerTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testDefaultDriverCannotBeNull()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         (new Fixtures\NullableManager($this->app))->driver();
     }
 }

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -12,7 +12,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class ValidatorTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Log;
 
 use Mockery as m;
+use RuntimeException;
 use Illuminate\Log\Logger;
 use Monolog\Logger as Monolog;
 use PHPUnit\Framework\TestCase;
@@ -48,12 +49,11 @@ class LogLoggerTest extends TestCase
         unset($_SERVER['__log.context']);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Events dispatcher has not been set.
-     */
     public function testListenShortcutFailsWithNoDispatcher()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Events dispatcher has not been set.');
+
         $writer = new Logger($monolog = m::mock(Monolog::class));
         $writer->listen(function () {
             //

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
 class LogLoggerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Mail/MailLogTransportTest.php
+++ b/tests/Mail/MailLogTransportTest.php
@@ -24,7 +24,7 @@ class MailLogTransportTest extends TestCase
         $transport = $manager->driver('log');
         $this->assertInstanceOf(LogTransport::class, $transport);
 
-        $logger = $this->readAttribute($transport, 'logger');
+        $logger = $transport->logger();
         $this->assertInstanceOf(LoggerInterface::class, $logger);
 
         $this->assertInstanceOf(Logger::class, $monolog = $logger->getLogger());
@@ -38,6 +38,6 @@ class MailLogTransportTest extends TestCase
 
         $manager = $this->app['swift.transport'];
 
-        $this->assertAttributeEquals($logger, 'logger', $manager->driver('log'));
+        $this->assertEquals($logger, $manager->driver('log')->logger());
     }
 }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -18,7 +18,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 
 class MailMailerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class MailMarkdownTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -20,7 +20,7 @@ class MailMessageTest extends TestCase
      */
     protected $message;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -28,7 +28,7 @@ class MailMessageTest extends TestCase
         $this->message = new Message($this->swift);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -32,7 +32,7 @@ class MailSesTransportTest extends TestCase
         $transport = $manager->driver('ses');
 
         /** @var SesClient $ses */
-        $ses = $this->readAttribute($transport, 'ses');
+        $ses = $transport->ses();
 
         $this->assertEquals('us-east-1', $ses->getRegion());
     }

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
 
 class MailableQueuedTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -13,7 +13,7 @@ use Illuminate\Notifications\Events\BroadcastNotificationCreated;
 
 class NotificationBroadcastChannelTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -18,7 +18,7 @@ use Illuminate\Notifications\Events\NotificationSending;
 
 class NotificationChannelManagerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -10,7 +10,7 @@ use Illuminate\Notifications\Messages\DatabaseMessage;
 
 class NotificationDatabaseChannelTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Notifications\Dispatcher;
 
 class NotificationRoutesNotificationsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -9,7 +9,7 @@ use Illuminate\Notifications\SendQueuedNotifications;
 
 class NotificationSendQueuedNotificationTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -17,13 +17,13 @@ class LengthAwarePaginatorTest extends TestCase
      */
     private $options;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->options = ['onEachSide' => 5];
         $this->p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2, $this->options);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->p);
     }

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Pipeline;
 
+use RuntimeException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Container\Container;
@@ -150,12 +151,11 @@ class PipelineTest extends TestCase
         $this->assertEquals('data', $result);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage A container instance has not been passed to the Pipeline.
-     */
     public function testPipelineThrowsExceptionOnResolveWithoutContainer()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('A container instance has not been passed to the Pipeline.');
+
         (new Pipeline)->send('data')
             ->through(PipelineTestPipeOne::class)
             ->then(function ($piped) {

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -15,7 +15,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 
 class QueueBeanstalkdJobTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -12,7 +12,7 @@ use Illuminate\Queue\Jobs\BeanstalkdJob;
 
 class QueueBeanstalkdQueueTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -27,7 +27,7 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
      */
     protected $container;
 
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -95,7 +95,7 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema()->drop('jobs');
     }

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -12,7 +12,7 @@ use Illuminate\Queue\DatabaseQueue;
 
 class QueueDatabaseQueueUnitTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Process\Process;
 
 class QueueListenerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -10,7 +10,7 @@ use Illuminate\Contracts\Encryption\Encrypter;
 
 class QueueManagerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -11,7 +11,7 @@ use Illuminate\Queue\Jobs\RedisJob;
 
 class QueueRedisJobTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Redis\Factory;
 
 class QueueRedisQueueTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -12,7 +12,7 @@ use Illuminate\Container\Container;
 
 class QueueSqsJobTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->key = 'AMAZONSQSKEY';
         $this->secret = 'AmAz0n+SqSsEcReT+aLpHaNuM3R1CsTr1nG';
@@ -50,7 +50,7 @@ class QueueSqsJobTest extends TestCase
         ];
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -13,12 +13,12 @@ use Illuminate\Container\Container;
 
 class QueueSqsQueueTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         // Use Mockery to mock the SqsClient
         $this->sqs = m::mock(SqsClient::class);

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -13,7 +13,7 @@ use Illuminate\Contracts\Queue\QueueableEntity;
 
 class QueueSyncQueueTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -23,7 +23,7 @@ class QueueWorkerTest extends TestCase
     public $events;
     public $exceptionHandler;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->events = m::spy(Dispatcher::class);
         $this->exceptionHandler = m::spy(ExceptionHandler::class);
@@ -34,7 +34,7 @@ class QueueWorkerTest extends TestCase
         $container->instance(ExceptionHandler::class, $this->exceptionHandler);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Container::setInstance();
     }

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -190,6 +190,7 @@ class RedisQueueIntegrationTest extends TestCase
             $command = unserialize(json_decode($payload)->data->command);
             $this->assertInstanceOf(RedisQueueIntegrationTestJob::class, $command);
             $this->assertContains($command->i, [10, -20]);
+
             if ($command->i == 10) {
                 $this->assertLessThanOrEqual($score, $before);
                 $this->assertGreaterThanOrEqual($score, $after);

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -20,14 +20,14 @@ class RedisQueueIntegrationTest extends TestCase
      */
     private $queue;
 
-    public function setUp()
+    public function setUp(): void
     {
         Carbon::setTestNow(Carbon::now());
         parent::setUp();
         $this->setUpRedis();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Carbon::setTestNow(null);
         parent::tearDown();

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -15,7 +15,7 @@ class ConcurrentLimiterTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -15,7 +15,7 @@ class DurationLimiterTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -14,7 +14,7 @@ class RedisConnectionTest extends TestCase
 {
     use InteractsWithRedis;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->setUpRedis();
@@ -28,7 +28,7 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         $this->tearDownRedis();

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -14,7 +14,7 @@ class RouteCollectionTest extends TestCase
      */
     protected $routeCollection;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -16,14 +16,14 @@ class RouteRegistrarTest extends TestCase
      */
     protected $router;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->router = new Router(m::mock(Dispatcher::class), Container::getInstance());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -479,8 +479,8 @@ class RouteRegistrarTest extends TestCase
         $this->router->resource('posts', RouteRegistrarControllerStub::class)
                      ->parameter('posts', 'topic');
 
-        $this->assertContains('admin_user', $this->router->getRoutes()->getByName('users.show')->uri);
-        $this->assertContains('topic', $this->router->getRoutes()->getByName('posts.show')->uri);
+        $this->assertStringContainsString('admin_user', $this->router->getRoutes()->getByName('users.show')->uri);
+        $this->assertStringContainsString('topic', $this->router->getRoutes()->getByName('posts.show')->uri);
     }
 
     public function testCanSetMiddlewareOnRegisteredResource()

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Routing;
 
-use BadMethodCallException;
 use Mockery as m;
+use BadMethodCallException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\TestCase;

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Routing;
 
+use BadMethodCallException;
 use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
@@ -210,12 +211,11 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals('api.users', $this->getRoute()->getName());
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method Illuminate\Routing\RouteRegistrar::missing does not exist.
-     */
     public function testRegisteringNonApprovedAttributesThrows()
     {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Method Illuminate\Routing\RouteRegistrar::missing does not exist.');
+
         $this->router->domain('foo')->missing('bar')->group(function ($router) {
             //
         });

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -19,7 +19,7 @@ class RoutingRedirectorTest extends TestCase
     protected $session;
     protected $redirect;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->headers = m::mock(HeaderBag::class);
 
@@ -45,7 +45,7 @@ class RoutingRedirectorTest extends TestCase
         $this->redirect->setSession($this->session);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use UnexpectedValueException;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\TestCase;
@@ -27,7 +28,6 @@ use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RoutingRouteTest extends TestCase
 {
@@ -837,7 +837,7 @@ class RoutingRouteTest extends TestCase
 
     public function testModelBindingWithNullReturn()
     {
-        $this->expectException(NotFoundHttpException::class);
+        $this->expectException(ModelNotFoundException::class);
         $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Routing\RouteModelBindingNullStub].');
 
         $router = $this->getRouter();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -5,10 +5,12 @@ namespace Illuminate\Tests\Routing;
 use DateTime;
 use stdClass;
 use Exception;
+use LogicException;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
+use UnexpectedValueException;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Events\Dispatcher;
@@ -25,6 +27,7 @@ use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RoutingRouteTest extends TestCase
 {
@@ -247,12 +250,11 @@ class RoutingRouteTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Route for [foo/bar] has no action.
-     */
     public function testFluentRouting()
     {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Route for [foo/bar] has no action.');
+
         $router = $this->getRouter();
         $router->get('foo/bar')->uses(function () {
             return 'hello';
@@ -562,11 +564,10 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foo/bar/baz', $router->dispatch(Request::create('/foo/bar/baz', 'GET'))->getContent());
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
     public function testRoutesDontMatchNonMatchingPathsWithLeadingOptionals()
     {
+        $this->expectException(NotFoundHttpException::class);
+
         $router = $this->getRouter();
         $router->get('{baz?}', function ($age = 25) {
             return $age;
@@ -574,11 +575,10 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('25', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
     public function testRoutesDontMatchNonMatchingDomain()
     {
+        $this->expectException(NotFoundHttpException::class);
+
         $router = $this->getRouter();
         $router->get('foo/bar', ['domain' => 'api.foo.bar', function () {
             return 'hello';
@@ -835,12 +835,11 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Routing\RouteModelBindingNullStub].
-     */
     public function testModelBindingWithNullReturn()
     {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Routing\RouteModelBindingNullStub].');
+
         $router = $this->getRouter();
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
@@ -1149,12 +1148,11 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('Namespace\\Controller@action', $action['controller']);
     }
 
-    /**
-     * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage Invalid route action: [Illuminate\Tests\Routing\RouteTestControllerStub].
-     */
     public function testInvalidActionException()
     {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Invalid route action: [Illuminate\Tests\Routing\RouteTestControllerStub].');
+
         $router = $this->getRouter();
         $router->get('/', ['uses' => RouteTestControllerStub::class]);
 
@@ -1488,11 +1486,10 @@ class RoutingRouteTest extends TestCase
         $router->dispatch(Request::create('foo', 'GET'))->getContent();
     }
 
-    /**
-     * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
     public function testImplicitBindingsWithOptionalParameterWithNonExistingKeyInUri()
     {
+        $this->expectException(ModelNotFoundException::class);
+
         $phpunit = $this;
         $router = $this->getRouter();
         $router->get('foo/{bar?}', [

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use UnexpectedValueException;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\TestCase;
@@ -28,6 +27,7 @@ use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RoutingRouteTest extends TestCase
 {

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class RoutingUrlGeneratorTest extends TestCase
@@ -485,11 +486,10 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('http://sub.foo.com/foo/bar', $url->route('foo'));
     }
 
-    /**
-     * @expectedException \Illuminate\Routing\Exceptions\UrlGenerationException
-     */
     public function testUrlGenerationForControllersRequiresPassingOfRequiredParameters()
     {
+        $this->expectException(UrlGenerationException::class);
+
         $url = new UrlGenerator(
             $routes = new RouteCollection,
             $request = Request::create('http://www.foo.com:8080/')
@@ -551,12 +551,11 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals($url->to('/foo'), $url->previous('/foo'));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Route [not_exists_route] not defined.
-     */
     public function testRouteNotDefinedException()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Route [not_exists_route] not defined.');
+
         $url = new UrlGenerator(
             $routes = new RouteCollection,
             $request = Request::create('http://www.foo.com/')

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Encryption\Encrypter;
 
 class EncryptedSessionStoreTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SessionStoreTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Migrations\MigrationCreator;
 
 class SessionTableCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Support/DateFacadeTest.php
+++ b/tests/Support/DateFacadeTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use DateTime;
 use Carbon\Factory;
 use Carbon\CarbonImmutable;
+use InvalidArgumentException;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\DateFactory;
@@ -85,11 +86,10 @@ class DateFacadeTest extends TestCase
         DateFactory::use(Carbon::class);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testUseInvalidHandler()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         DateFactory::use(42);
     }
 }

--- a/tests/Support/DateFacadeTest.php
+++ b/tests/Support/DateFacadeTest.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Date;
 
 class DateFacadeTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         DateFactory::use(Carbon::class);

--- a/tests/Support/ForwardsCallsTest.php
+++ b/tests/Support/ForwardsCallsTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Support;
 
+use Error;
+use BadMethodCallException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Traits\ForwardsCalls;
 
@@ -21,39 +23,35 @@ class ForwardsCallsTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $results);
     }
 
-    /**
-     * @expectedException  \BadMethodCallException
-     * @expectedExceptionMessage  Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::missingMethod()
-     */
     public function testMissingForwardedCallThrowsCorrectError()
     {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::missingMethod()');
+
         (new ForwardsCallsOne)->missingMethod('foo', 'bar');
     }
 
-    /**
-     * @expectedException  \BadMethodCallException
-     * @expectedExceptionMessage  Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::this1_shouldWork_too()
-     */
     public function testMissingAlphanumericForwardedCallThrowsCorrectError()
     {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::this1_shouldWork_too()');
+
         (new ForwardsCallsOne)->this1_shouldWork_too('foo', 'bar');
     }
 
-    /**
-     * @expectedException  \Error
-     * @expectedExceptionMessage  Call to undefined method Illuminate\Tests\Support\ForwardsCallsBase::missingMethod()
-     */
     public function testNonForwardedErrorIsNotTamperedWith()
     {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Call to undefined method Illuminate\Tests\Support\ForwardsCallsBase::missingMethod()');
+
         (new ForwardsCallsOne)->baseError('foo', 'bar');
     }
 
-    /**
-     * @expectedException  \BadMethodCallException
-     * @expectedExceptionMessage  Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::test()
-     */
     public function testThrowBadMethodCallException()
     {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Call to undefined method Illuminate\Tests\Support\ForwardsCallsOne::test()');
+
         (new ForwardsCallsOne)->throwTestException('test');
     }
 }

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -13,7 +13,7 @@ class SupportCapsuleManagerTraitTest extends TestCase
 {
     use CapsuleManagerTrait;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use DateTime;
 use DateTimeInterface;
+use BadMethodCallException;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
@@ -57,21 +58,19 @@ class SupportCarbonTest extends TestCase
         $this->assertSame('2017-06-25 12:00:00', Carbon::twoDaysAgoAtNoon()->toDateTimeString());
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage nonExistingStaticMacro does not exist.
-     */
     public function testCarbonRaisesExceptionWhenStaticMacroIsNotFound()
     {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('nonExistingStaticMacro does not exist.');
+
         Carbon::nonExistingStaticMacro();
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage nonExistingMacro does not exist.
-     */
     public function testCarbonRaisesExceptionWhenMacroIsNotFound()
     {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('nonExistingMacro does not exist.');
+
         Carbon::now()->nonExistingMacro();
     }
 

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -16,14 +16,14 @@ class SupportCarbonTest extends TestCase
      */
     protected $now;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         Carbon::setTestNow($this->now = Carbon::create(2017, 6, 27, 13, 14, 15, 'UTC'));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Carbon::setTestNow();
         Carbon::serializeUsing(null);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -11,6 +11,7 @@ use ArrayIterator;
 use CachingIterator;
 use ReflectionClass;
 use JsonSerializable;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
@@ -2384,11 +2385,10 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRandomThrowsAnExceptionUsingAmountBiggerThanCollectionSize()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $data = new Collection([1, 2, 3]);
         $data->random(4);
     }

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -11,13 +11,13 @@ use Illuminate\Support\Facades\Facade;
 
 class SupportFacadeTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Facade::clearResolvedInstances();
         FacadeStub::setFacadeApplication(null);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -15,7 +15,7 @@ class SupportFacadesEventTest extends TestCase
 {
     private $events;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -27,7 +27,7 @@ class SupportFacadesEventTest extends TestCase
         Facade::setFacadeApplication($container);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Event::clearResolvedInstances();
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -751,11 +751,10 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals($mock, tap($mock)->foo());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testThrow()
     {
+        $this->expectException(RuntimeException::class);
+
         throw_if(true, new RuntimeException);
     }
 
@@ -764,12 +763,11 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('foo', throw_unless('foo', new RuntimeException));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Test Message
-     */
     public function testThrowWithString()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Test Message');
+
         throw_if(true, RuntimeException::class, 'Test Message');
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -14,7 +14,7 @@ use Illuminate\Contracts\Support\Htmlable;
 
 class SupportHelpersTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -9,7 +9,7 @@ class SupportMacroableTest extends TestCase
 {
     private $macroable;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->macroable = $this->createObjectForTrait();
     }

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\MessageBag;
 
 class SupportMessageBagTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\ServiceProvider;
 
 class SupportServiceProviderTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         ServiceProvider::$publishes = [];
         ServiceProvider::$publishGroups = [];
@@ -21,7 +21,7 @@ class SupportServiceProviderTest extends TestCase
         $two->boot();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\Constraint\ExceptionMessage;
 
 class SupportTestingEventFakeTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fake = new EventFake(m::mock(Dispatcher::class));

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -23,7 +23,7 @@ class SupportTestingMailFakeTest extends TestCase
      */
     private $mailable;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fake = new MailFake;

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -27,7 +27,7 @@ class SupportTestingNotificationFakeTest extends TestCase
      */
     private $user;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fake = new NotificationFake;

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -21,7 +21,7 @@ class SupportTestingQueueFakeTest extends TestCase
      */
     private $job;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fake = new QueueFake(new Application);

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -9,7 +9,7 @@ use Illuminate\Translation\FileLoader;
 
 class TranslationFileLoaderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Translation\Loader;
 
 class TranslationTranslatorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\ConnectionResolverInterface;
 
 class ValidationDatabasePresenceVerifierTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -18,7 +18,7 @@ class ValidationExistsRuleTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $db = new DB;
 
@@ -159,7 +159,7 @@ class ValidationExistsRuleTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->schema('default')->drop('users');
     }

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Translation\Translator as TranslatorInterface;
 
 class ValidationFactoryTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6,6 +6,7 @@ use DateTime;
 use Mockery as m;
 use DateTimeImmutable;
 use Illuminate\Support\Arr;
+use InvalidArgumentException;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
@@ -16,6 +17,7 @@ use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Validation\ValidationData;
+use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpFoundation\File\File;
 use Illuminate\Contracts\Validation\ImplicitRule;
 use Illuminate\Validation\PresenceVerifierInterface;
@@ -73,11 +75,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    /**
-     * @expectedException \Illuminate\Validation\ValidationException
-     */
     public function testValidateThrowsOnFail()
     {
+        $this->expectException(ValidationException::class);
+
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar'], ['baz' => 'required']);
 
@@ -3262,12 +3263,11 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Validation rule required_if requires at least 2 parameters.
-     */
     public function testExceptionThrownOnIncorrectParameterCount()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Validation rule required_if requires at least 2 parameters.');
+
         $trans = $this->getTranslator();
         $v = new Validator($trans, [], ['foo' => 'required_if:foo']);
         $v->passes();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -24,7 +24,7 @@ use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 
 class ValidationValidatorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Carbon::setTestNow();
         m::close();

--- a/tests/View/Blade/AbstractBladeTestCase.php
+++ b/tests/View/Blade/AbstractBladeTestCase.php
@@ -11,13 +11,13 @@ abstract class AbstractBladeTestCase extends TestCase
 {
     protected $compiler;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->compiler = new BladeCompiler(m::mock(Filesystem::class), __DIR__);
         parent::setUp();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
 

--- a/tests/View/Blade/BladeElseAuthStatementsTest.php
+++ b/tests/View/Blade/BladeElseAuthStatementsTest.php
@@ -9,7 +9,7 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeElseAuthStatementsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/Blade/BladeElseGuestStatementsTest.php
+++ b/tests/View/Blade/BladeElseGuestStatementsTest.php
@@ -9,7 +9,7 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeElseGuestStatementsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/Blade/BladeIfAuthStatementsTest.php
+++ b/tests/View/Blade/BladeIfAuthStatementsTest.php
@@ -9,7 +9,7 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeIfAuthStatementsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/Blade/BladeIfGuestStatementsTest.php
+++ b/tests/View/Blade/BladeIfGuestStatementsTest.php
@@ -9,7 +9,7 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeIfGuestStatementsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -9,7 +9,7 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class ViewBladeCompilerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\View;
 
 use Mockery as m;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\BladeCompiler;
@@ -21,12 +22,11 @@ class ViewBladeCompilerTest extends TestCase
         $this->assertTrue($compiler->isExpired('foo'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Please provide a valid cache path.
-     */
     public function testCannotConstructWithBadCachePath()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please provide a valid cache path.');
+
         new BladeCompiler($this->getFiles(), null);
     }
 

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -9,7 +9,7 @@ use Illuminate\View\Compilers\CompilerInterface;
 
 class ViewCompilerEngineTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/ViewEngineResolverTest.php
+++ b/tests/View/ViewEngineResolverTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\View;
 
 use stdClass;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\View\Engines\EngineResolver;
 
@@ -19,11 +20,10 @@ class ViewEngineResolverTest extends TestCase
         $this->assertEquals(spl_object_hash($result), spl_object_hash($resolver->resolve('foo')));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testResolverThrowsExceptionOnUnknownEngine()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $resolver = new EngineResolver;
         $resolver->resolve('foo');
     }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\View;
 use Closure;
 use stdClass;
 use Mockery as m;
+use ErrorException;
 use ReflectionFunction;
 use Illuminate\View\View;
 use Illuminate\View\Factory;
@@ -80,11 +81,10 @@ class ViewFactoryTest extends TestCase
         unset($_SERVER['__test.view']);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testFirstThrowsInvalidArgumentExceptionIfNoneFound()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->once()->with('view')->andThrow(InvalidArgumentException::class);
         $factory->getFinder()->shouldReceive('find')->once()->with('bar')->andThrow(InvalidArgumentException::class);
@@ -474,22 +474,20 @@ class ViewFactoryTest extends TestCase
         $factory->make('vendor/package::foo.bar');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testExceptionIsThrownForUnknownExtension()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->once()->with('view')->andReturn('view.foo');
         $factory->make('view');
     }
 
-    /**
-     * @expectedException \ErrorException
-     * @expectedExceptionMessage section exception message
-     */
     public function testExceptionsInSectionsAreThrown()
     {
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage('section exception message');
+
         $engine = new CompilerEngine(m::mock(CompilerInterface::class));
         $engine->getCompiler()->shouldReceive('getCompiledPath')->andReturnUsing(function ($path) {
             return $path;
@@ -504,12 +502,11 @@ class ViewFactoryTest extends TestCase
         $factory->make('view')->render();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Cannot end a section without first starting one.
-     */
     public function testExtraStopSectionCallThrowsException()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot end a section without first starting one.');
+
         $factory = $this->getFactory();
         $factory->startSection('foo');
         $factory->stopSection();
@@ -517,12 +514,11 @@ class ViewFactoryTest extends TestCase
         $factory->stopSection();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Cannot end a section without first starting one.
-     */
     public function testExtraAppendSectionCallThrowsException()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot end a section without first starting one.');
+
         $factory = $this->getFactory();
         $factory->startSection('foo');
         $factory->stopSection();

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -22,7 +22,7 @@ use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
 class ViewFactoryTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\View;
 
 use Mockery as m;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\View\FileViewFinder;
 use Illuminate\Filesystem\Filesystem;
@@ -74,11 +75,10 @@ class ViewFileViewFinderTest extends TestCase
         $this->assertEquals(__DIR__.'/bar/bar/baz.blade.php', $finder->find('foo::bar.baz'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testExceptionThrownWhenViewNotFound()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $finder = $this->getFinder();
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(false);
@@ -87,22 +87,20 @@ class ViewFileViewFinderTest extends TestCase
         $finder->find('foo');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage No hint path defined for [name].
-     */
     public function testExceptionThrownOnInvalidViewName()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No hint path defined for [name].');
+
         $finder = $this->getFinder();
         $finder->find('name::');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage No hint path defined for [name].
-     */
     public function testExceptionThrownWhenNoHintPathIsRegistered()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No hint path defined for [name].');
+
         $finder = $this->getFinder();
         $finder->find('name::foo');
     }

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -9,7 +9,7 @@ use Illuminate\Filesystem\Filesystem;
 
 class ViewFileViewFinderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -8,7 +8,7 @@ use Illuminate\View\Engines\PhpEngine;
 
 class ViewPhpEngineTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\View;
 
+use BadMethodCallException;
 use Closure;
 use ArrayAccess;
 use Mockery as m;
@@ -170,12 +171,11 @@ class ViewTest extends TestCase
         $this->assertFalse($view->offsetExists('foo'));
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Method Illuminate\View\View::badMethodCall does not exist.
-     */
     public function testViewBadMethod()
     {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Method Illuminate\View\View::badMethodCall does not exist.');
+
         $view = $this->getView();
         $view->badMethodCall();
     }

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -15,7 +15,7 @@ use Illuminate\Contracts\Support\Renderable;
 
 class ViewTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\View;
 
-use BadMethodCallException;
 use Closure;
 use ArrayAccess;
 use Mockery as m;
 use Illuminate\View\View;
+use BadMethodCallException;
 use Illuminate\View\Factory;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\MessageBag;


### PR DESCRIPTION
**This PR needs to wait until orchestra/testbench-core has PHPUnit 8 support: https://github.com/orchestral/testbench-core/pull/19**

This adds support for PHPUnit 8 to the next release while keeping backwards compatibility with PHPUnit 7. The only necessary changes made which will affect user land are the now required return types on the `setUp` and `tearDown` methods. This will affect both PHPUnit 7 and PHPUnit 8 users and cannot be avoided.

This PR also replaces all deprecated methods which will be removed in PHPUnit 9. The only call that remains is the `assertArraySubset` call in the `assertJson` method (which other methods depend on). We'll have to either take over te method from PHPUnit or deprecate and remove these.