### PR TITLE
PHPUnit 8.x requires that setUp() and tearDown() be declared as void

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -62,7 +62,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! $this->app) {
             $this->refreshApplication();
@@ -132,7 +132,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->app) {
             foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {


### PR DESCRIPTION
Errors when running PHPUnit 8.0.1:

`PHP Fatal error:  Declaration of Illuminate\Foundation\Testing\TestCase::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in /[path]/vendor/laravel/framework/src/Illuminate/Foundation/Testing/TestCase.php on line 12`

`PHP Fatal error:  Declaration of Illuminate\Foundation\Testing\TestCase::tearDown() must be compatible with PHPUnit\Framework\TestCase::tearDown(): void in /[path]/vendor/laravel/framework/src/Illuminate/Foundation/Testing/TestCase.php on line 12`