### PR TITLE
[5.7] Add a getter for the tag set in TaggedCache

### DIFF
--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -85,6 +85,16 @@ class TaggedCache extends Repository
     }
 
     /**
+     * Get the tag set instance.
+     *
+     * @return \Illuminate\Cache\TagSet
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    /**
      * Fire an event for this cache instance.
      *
      * @param  string  $event


### PR DESCRIPTION
I'm unable to test a certain part of my package [\[1\]](https://github.com/stancl/tenancy/blob/fceddb8c4d5a0fd1567b51f274df751fdc7d7735/tests/BootstrapsTenancyTest.php#L48) [\[2\]](https://github.com/stancl/tenancy/blob/fceddb8c4d5a0fd1567b51f274df751fdc7d7735/tests/CacheManagerTest.php) because there is no way to get the `tags` property of a `TaggedCache` instance. The property is protected and I didn't want to change that, so I added a getter.

I consider this a minor feature, so as per the docs

> Minor features that are fully backwards compatible with the current Laravel release may be sent to the latest stable branch.

I'm sending this PR to the 5.7 branch. I haven't contributed to this repository yet, so just to make sure, will this change be reflected in the next version as well? I can imagine that 5.7 is merged into master when a new version is released, but I'm not sure.