### PR TITLE
[5.7] 1. Add a accessor for 'callback' property, 2. Add a assertion method …

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -429,6 +429,22 @@ class TestResponse
     }
 
     /**
+     * Assert that the response is a superset of given JSONP
+     *
+     * @param  string  $callback
+     * @param  array  $data
+     * @param  bool  $strict
+     * @return $this
+     */
+    public function assertJsonp(string $callback, array $data, $strict = false)
+    {
+        PHPUnit::assertEquals($callback, $this->getCallback());
+        $this->assertJson($data, $strict);
+
+        return $this;
+    }
+
+    /**
      * Get the assertion message for assertJson.
      *
      * @param  array  $data
@@ -694,7 +710,11 @@ class TestResponse
      */
     public function decodeResponseJson($key = null)
     {
-        $decodedResponse = json_decode($this->getContent(), true);
+        if (is_null($this->getCallback())) {
+            $decodedResponse = json_decode($this->getContent(), true);
+        } else {
+            $decodedResponse = $this->getOriginalContent();
+        }
 
         if (is_null($decodedResponse) || $decodedResponse === false) {
             if ($this->exception) {

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Illuminate\Foundation\Testing\Constraints\SeeInOrder;
 
 /**
- * @mixin \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+ * @mixin \Illuminate\Http\Response
  */
 class TestResponse
 {
@@ -25,7 +25,7 @@ class TestResponse
     /**
      * The response to delegate to.
      *
-     * @var \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+     * @var \Illuminate\Http\Response
      */
     public $baseResponse;
 
@@ -39,7 +39,7 @@ class TestResponse
     /**
      * Create a new test response instance.
      *
-     * @param  \Illuminate\Http\Response|\Illuminate\Http\JsonResponse  $response
+     * @param  \Illuminate\Http\Response  $response
      * @return void
      */
     public function __construct($response)

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Illuminate\Foundation\Testing\Constraints\SeeInOrder;
 
 /**
- * @mixin \Illuminate\Http\Response
+ * @mixin \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
  */
 class TestResponse
 {

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -25,7 +25,7 @@ class TestResponse
     /**
      * The response to delegate to.
      *
-     * @var \Illuminate\Http\Response
+     * @var \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
      */
     public $baseResponse;
 
@@ -39,7 +39,7 @@ class TestResponse
     /**
      * Create a new test response instance.
      *
-     * @param  \Illuminate\Http\Response  $response
+     * @param  \Illuminate\Http\Response|\Illuminate\Http\JsonResponse  $response
      * @return void
      */
     public function __construct($response)

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -429,7 +429,7 @@ class TestResponse
     }
 
     /**
-     * Assert that the response is a superset of given JSONP
+     * Assert that the response is a superset of given JSONP.
      *
      * @param  string  $callback
      * @param  array  $data

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -43,6 +43,16 @@ class JsonResponse extends BaseJsonResponse
     }
 
     /**
+     * Get the JSONP callback.
+     *
+     * @return  string|null
+     */
+    public function getCallback()
+    {
+        return $this->callback;
+    }
+
+    /**
      * Get the json_decoded data from the response.
      *
      * @param  bool  $assoc

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -43,16 +43,6 @@ class JsonResponse extends BaseJsonResponse
     }
 
     /**
-     * Get the JSONP callback.
-     *
-     * @return  string|null
-     */
-    public function getCallback()
-    {
-        return $this->callback;
-    }
-
-    /**
      * Get the json_decoded data from the response.
      *
      * @param  bool  $assoc

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -43,6 +43,17 @@ trait ResponseTrait
     }
 
     /**
+     * Get the callback of the response.
+     *
+     * @return string|null
+     */
+    public function getCallback()
+    {
+        return $this->callback ?? null;
+    }
+
+
+    /**
      * Get the original response content.
      *
      * @return mixed


### PR DESCRIPTION
I would like to suggest to have an assertion method for JSONP response as well.
As an assertion it's checking callback name and json format, but there was no method to access protected property `callback` so that added the one.

I'll appreciate your feedback. thank you.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
