### PR TITLE
[5.7] 1. Add a accessor for 'callback' property, 2. Add a assertion method …

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -429,6 +429,22 @@ class TestResponse
     }
 
     /**
+     * Assert that the response is a superset of given JSONP.
+     *
+     * @param  string  $callback
+     * @param  array  $data
+     * @param  bool  $strict
+     * @return $this
+     */
+    public function assertJsonp(string $callback, array $data, $strict = false)
+    {
+        PHPUnit::assertEquals($callback, $this->getCallback());
+        $this->assertJson($data, $strict);
+
+        return $this;
+    }
+
+    /**
      * Get the assertion message for assertJson.
      *
      * @param  array  $data
@@ -694,7 +710,11 @@ class TestResponse
      */
     public function decodeResponseJson($key = null)
     {
-        $decodedResponse = json_decode($this->getContent(), true);
+        if (is_null($this->getCallback())) {
+            $decodedResponse = json_decode($this->getContent(), true);
+        } else {
+            $decodedResponse = $this->getOriginalContent();
+        }
 
         if (is_null($decodedResponse) || $decodedResponse === false) {
             if ($this->exception) {

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -43,6 +43,16 @@ trait ResponseTrait
     }
 
     /**
+     * Get the callback of the response.
+     *
+     * @return string|null
+     */
+    public function getCallback()
+    {
+        return $this->callback ?? null;
+    }
+
+    /**
      * Get the original response content.
      *
      * @return mixed


### PR DESCRIPTION
I would like to suggest to have an assertion method for JSONP response as well.
As an assertion it's checking callback name and json format, but there was no method to access protected property `callback` so that added the one.

I'll appreciate your feedback. thank you.
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
