### PR TITLE
[5.7] Remove duplicate code

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -416,16 +416,6 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Determine if the grammar supports savepoints.
-     *
-     * @return bool
-     */
-    public function supportsSavepoints()
-    {
-        return true;
-    }
-
-    /**
      * Compile the SQL statement to define a savepoint.
      *
      * @param  string  $name


### PR DESCRIPTION
Since #19439, `supportsSavepoints()` has been equivalent to its [parent](https://github.com/laravel/framework/blob/8216b4607152f9b01f26efba6b045add5382c625/src/Illuminate/Database/Query/Grammars/Grammar.php#L988).