### PR TITLE
[5.8] Replace deprecated shouldDeferMissing usages

### DIFF
--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -76,7 +76,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
             m::mock(Processor::class)
         ));
         $model = m::mock(Model::class);
-        $model->shouldDeferMissing();
+        $model->makePartial();
         $scope = m::mock(SoftDeletingScope::class.'[remove]');
         $scope->extend($builder);
         $callback = $builder->getMacro('onlyTrashed');
@@ -99,7 +99,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
             m::mock(Processor::class)
         ));
         $model = m::mock(Model::class);
-        $model->shouldDeferMissing();
+        $model->makePartial();
         $scope = m::mock(SoftDeletingScope::class.'[remove]');
         $scope->extend($builder);
         $callback = $builder->getMacro('withoutTrashed');

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -17,7 +17,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
     public function testDeleteSetsSoftDeletedColumn()
     {
         $model = m::mock(DatabaseSoftDeletingTraitStub::class);
-        $model->shouldDeferMissing();
+        $model->makePartial();
         $model->shouldReceive('newModelQuery')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('id', 1)->andReturn($query);
         $query->shouldReceive('update')->once()->with([
@@ -32,7 +32,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
     public function testRestore()
     {
         $model = m::mock(DatabaseSoftDeletingTraitStub::class);
-        $model->shouldDeferMissing();
+        $model->makePartial();
         $model->shouldReceive('fireModelEvent')->with('restoring')->andReturn(true);
         $model->shouldReceive('save')->once();
         $model->shouldReceive('fireModelEvent')->with('restored', false)->andReturn(true);
@@ -45,7 +45,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
     public function testRestoreCancel()
     {
         $model = m::mock(DatabaseSoftDeletingTraitStub::class);
-        $model->shouldDeferMissing();
+        $model->makePartial();
         $model->shouldReceive('fireModelEvent')->with('restoring')->andReturn(false);
         $model->shouldReceive('save')->never();
 


### PR DESCRIPTION
Replaced some deprecated mockery methods.