### PR TITLE
[5.8] Fix wrong class being used when eager loading nullable MorphTo with withDefault()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -223,6 +223,17 @@ class MorphTo extends BelongsTo
     }
 
     /**
+     * Make a new related instance for the given model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    protected function newRelatedInstanceFor(Model $parent)
+    {
+        return $parent->{$this->getRelationName()}()->getRelated()->newInstance();
+    }
+
+    /**
      * Get the foreign key "type" name.
      *
      * @return string

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -53,9 +53,7 @@ class DatabaseEloquentMorphToTest extends TestCase
 
         $newModel = new EloquentMorphToModelStub;
 
-        $this->related->shouldReceive('newInstance')->once()->andReturn($newModel);
-
-        $this->assertSame($newModel, $relation->getResults());
+        $this->assertEquals($newModel, $relation->getResults());
     }
 
     public function testMorphToWithDynamicDefault()
@@ -67,12 +65,13 @@ class DatabaseEloquentMorphToTest extends TestCase
         $this->builder->shouldReceive('first')->once()->andReturnNull();
 
         $newModel = new EloquentMorphToModelStub;
+        $newModel->username = 'taylor';
 
-        $this->related->shouldReceive('newInstance')->once()->andReturn($newModel);
+        $result = $relation->getResults();
 
-        $this->assertSame($newModel, $relation->getResults());
+        $this->assertEquals($newModel, $result);
 
-        $this->assertSame('taylor', $newModel->username);
+        $this->assertSame('taylor', $result->username);
     }
 
     public function testMorphToWithArrayDefault()
@@ -82,12 +81,27 @@ class DatabaseEloquentMorphToTest extends TestCase
         $this->builder->shouldReceive('first')->once()->andReturnNull();
 
         $newModel = new EloquentMorphToModelStub;
+        $newModel->username = 'taylor';
 
-        $this->related->shouldReceive('newInstance')->once()->andReturn($newModel);
+        $result = $relation->getResults();
 
-        $this->assertSame($newModel, $relation->getResults());
+        $this->assertEquals($newModel, $result);
 
-        $this->assertSame('taylor', $newModel->username);
+        $this->assertSame('taylor', $result->username);
+    }
+
+    public function testMorphToWithSpecifiedClassDefault()
+    {
+        $parent = new EloquentMorphToModelStub;
+        $parent->relation_type = EloquentMorphToRelatedStub::class;
+
+        $relation = $parent->relation()->withDefault();
+
+        $newModel = new EloquentMorphToRelatedStub;
+
+        $result = $relation->getResults();
+
+        $this->assertEquals($newModel, $result);
     }
 
     public function testAssociateMethodSetsForeignKeyAndTypeOnModel()
@@ -165,4 +179,16 @@ class DatabaseEloquentMorphToTest extends TestCase
 class EloquentMorphToModelStub extends Model
 {
     public $foreign_key = 'foreign.value';
+
+    public $table = 'eloquent_morph_to_model_stubs';
+
+    public function relation()
+    {
+        return $this->morphTo();
+    }
+}
+
+class EloquentMorphToRelatedStub extends Model
+{
+    public $table = 'eloquent_morph_to_related_stubs';
 }


### PR DESCRIPTION
Resubmit of #27411, now without failing tests on master.

Fixes #27369 (and probably #24725)

Currently, MorphTo inherits the `newRelatedInstanceFor()` method from BelongsTo, which ignores the passed `$parent` argument and instantiates a related model based on the generalized relationship instance (without constraints) produced by the query builder . However, in the case of MorphTo relations, the no-constraint relationship instance does not know anything about related classes, and wrongly defaults to the parent model class. This commit simply makes use of the `$parent` argument to produce a related instance that is appropriate for the parent model instance.

Pre-existing tests of MorphTo `withDefault()` had to be modified because they relied on the old behavior of `newRelatedInstanceFor()` where it would always return the same predefined instance of the related model. Additionally, a new test was added to ensure that issue #27369 is really fixed.