### PR TITLE
[5.8] Use only validated data for user creation

### DIFF
--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -28,9 +28,9 @@ trait RegistersUsers
      */
     public function register(Request $request)
     {
-        $this->validator($request->all())->validate();
+        $validated = $this->validator($request->all())->validate();
 
-        event(new Registered($user = $this->create($request->all())));
+        event(new Registered($user = $this->create($validated)));
 
         $this->guard()->login($user);
 


### PR DESCRIPTION
At the moment we pass all request data for user creation. It can cause potentials security issues when someone would override default `create` method with custom code for example like this:

```
protected function create(array $data)
{
    return User::create(array_merge($data, [
         'password' => Hash::make($data['password']),
     ]);
}
```

Is someone send for example `admin` field in request then it's possible any user could get admin permissions.

In my opinion it's much safer to use only validated data by default and if someone would really like to use all of them (probably there is no point to do that), they could override default implementation with custom code.

If approved, this should be added to migration guide as it can change applications behaviour if some input data was not validated before and used during user creation.