### PR TITLE
[5.7] Use container for Fire app callbacks.

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -823,7 +823,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Register a new boot listener.
      *
-     * @param  callable  $callback
+     * @param  callable|string  $callback
      * @return void
      */
     public function booting($callback)
@@ -834,7 +834,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Register a new "booted" listener.
      *
-     * @param  callable  $callback
+     * @param  callable|string  $callback
      * @return void
      */
     public function booted($callback)
@@ -855,7 +855,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected function fireAppCallbacks(array $callbacks)
     {
         foreach ($callbacks as $callback) {
-            call_user_func($callback, $this);
+            $this->call($callback, [$this]);
         }
     }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -299,6 +299,28 @@ class FoundationApplicationTest extends TestCase
 
         $this->assertEquals(4, $counter);
     }
+
+    public function testBootedCallbacksAtNotation()
+    {
+        $application = new Application;
+
+        $application->booting(ApplicationBootingStub::class.'@method');
+        $application->booted(ApplicationBootingStub::class.'@method');
+
+        $application->boot();
+
+        $this->assertEquals(2, ApplicationBootingStub::$counter);
+    }
+}
+
+class ApplicationBootingStub
+{
+    public static $counter = 0;
+
+    public function method()
+    {
+        self::$counter++;
+    }
 }
 
 class ApplicationBasicServiceProviderStub extends ServiceProvider


### PR DESCRIPTION
We can simply extend the ability of booting and booted methods to accept Class@method notation to be consistent with what the terminating callbacks can accept.