### PR TITLE
[5.8] Only use $_SERVER for env variables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/routing": "^4.2",
         "symfony/var-dumper": "^4.2",
         "tijsverkoyen/css-to-inline-styles": "^2.2.1",
-        "vlucas/phpdotenv": "^3.0"
+        "vlucas/phpdotenv": "^3.3"
     },
     "replace": {
         "illuminate/auth": "self.version",

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -3,9 +3,11 @@
 namespace Illuminate\Foundation\Bootstrap;
 
 use Dotenv\Dotenv;
+use Dotenv\Environment\DotenvFactory;
 use Dotenv\Exception\InvalidFileException;
 use Symfony\Component\Console\Input\ArgvInput;
 use Illuminate\Contracts\Foundation\Application;
+use Dotenv\Environment\Adapter\ServerConstAdapter;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 class LoadEnvironmentVariables
@@ -25,7 +27,7 @@ class LoadEnvironmentVariables
         $this->checkForSpecificEnvironmentFile($app);
 
         try {
-            Dotenv::create($app->environmentPath(), $app->environmentFile())->safeLoad();
+            $this->createDotenv($app)->safeLoad();
         } catch (InvalidFileException $e) {
             $this->writeErrorAndDie($e);
         }
@@ -72,6 +74,22 @@ class LoadEnvironmentVariables
         }
 
         return false;
+    }
+
+    /**
+     * Create a Dotenv instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     *
+     * @return \Dotenv\Dotenv
+     */
+    protected function createDotenv($app)
+    {
+        return Dotenv::create(
+            $app->environmentPath(),
+            $app->environmentFile(),
+            new DotenvFactory([new ServerConstAdapter])
+        );
     }
 
     /**

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -922,53 +922,47 @@ class SupportHelpersTest extends TestCase
 
     public function testEnv()
     {
-        putenv('foo=bar');
-        $this->assertEquals('bar', env('foo'));
-    }
-
-    public function testEnvWithQuotes()
-    {
-        putenv('foo="bar"');
-        $this->assertEquals('bar', env('foo'));
+        $_SERVER['foo'] = 'bar';
+        $this->assertSame('bar', env('foo'));
     }
 
     public function testEnvTrue()
     {
-        putenv('foo=true');
+        $_SERVER['foo'] = 'true';
         $this->assertTrue(env('foo'));
 
-        putenv('foo=(true)');
+        $_SERVER['foo'] = '(true)';
         $this->assertTrue(env('foo'));
     }
 
     public function testEnvFalse()
     {
-        putenv('foo=false');
+        $_SERVER['foo'] = 'false';
         $this->assertFalse(env('foo'));
 
-        putenv('foo=(false)');
+        $_SERVER['foo'] = '(false)';
         $this->assertFalse(env('foo'));
     }
 
     public function testEnvEmpty()
     {
-        putenv('foo=');
-        $this->assertEquals('', env('foo'));
+        $_SERVER['foo'] = '';
+        $this->assertSame('', env('foo'));
 
-        putenv('foo=empty');
-        $this->assertEquals('', env('foo'));
+        $_SERVER['foo'] = 'empty';
+        $this->assertSame('', env('foo'));
 
-        putenv('foo=(empty)');
-        $this->assertEquals('', env('foo'));
+        $_SERVER['foo'] = '(empty)';
+        $this->assertSame('', env('foo'));
     }
 
     public function testEnvNull()
     {
-        putenv('foo=null');
-        $this->assertEquals('', env('foo'));
+        $_SERVER['foo'] = 'null';
+        $this->assertNull(env('foo'));
 
-        putenv('foo=(null)');
-        $this->assertEquals('', env('foo'));
+        $_SERVER['foo'] = '(null)';
+        $this->assertNull(env('foo'));
     }
 }
 


### PR DESCRIPTION
This change:

1. Tells phpdotenv to only write to $_SERVER and to only read from $_SERVER for resolving nested environment variables.
2. Changes Laravel's `env` function to only look at $_SERVER
3. Stops Laravel's `env` function stripping quotes.

---

Why?

1. In Local development, people are still confused when other websites are interfering with the environment variables. Moreover, the interference is both way, so Laravel variables are leaking out. By instead only reading and writing to the server superglobal, and avoiding putenv and getenv, we avoid this issue.
2. As mentioned in the first point, getenv is also not threadsafe, so variables may leak into Laravel apps even though we're not calling putenv ourselves. The only other consequence of this change I envisage will be case sensitivity of variable resolution, however I don't envisage this being an issue, as I think most people will be getting their case correct when they do the calls, since nearly everyone uses uppercase, and is used to typing it.
3. phpdotenv already natively handles quoted variables, so I don't see the need to strip quotes off again. This is only going to be annoying if you'd escaped the quotes in the env file, then laravel strips then anyway.