### PR TITLE
[5.8] Use orchestra/testbench-core 3.8.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "league/flysystem-cached-adapter": "^1.0",
         "mockery/mockery": "^1.0",
         "moontoast/math": "^1.1",
-        "orchestra/testbench-core": "dev-phpunit8 as 3.8.x-dev",
+        "orchestra/testbench-core": "3.8.*",
         "pda/pheanstalk": "^3.0",
         "phpunit/phpunit": "^7.5|^8.0",
         "predis/predis": "^1.1.1",


### PR DESCRIPTION
PHPUnit 8 support has been made available.
