### PR TITLE
[5.7] Fix issue fake dispatcher #27451

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -31,6 +31,8 @@ class Event extends Facade
         static::swap($fake = new EventFake(static::getFacadeRoot(), $eventsToFake));
 
         Model::setEventDispatcher($fake);
+
+        self::setDispatcherOnAuth($fake);
     }
 
     /**
@@ -50,6 +52,7 @@ class Event extends Facade
             static::swap($originalDispatcher);
 
             Model::setEventDispatcher($originalDispatcher);
+            self::setDispatcherOnAuth($originalDispatcher);
         });
     }
 
@@ -61,5 +64,16 @@ class Event extends Facade
     protected static function getFacadeAccessor()
     {
         return 'events';
+    }
+
+    /**
+     * @param $fake
+     */
+    protected static function setDispatcherOnAuth($fake)
+    {
+        $guard = Auth::guard();
+        if (method_exists($guard, 'setDispatcher')) {
+            $guard->setDispatcher($fake);
+        }
     }
 }

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Auth\AuthManager;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
 use Illuminate\Support\Facades\Event;
@@ -15,14 +16,20 @@ class SupportFacadesEventTest extends TestCase
 {
     private $events;
 
+    private $auth;
+
+    private $guard;
+
     protected function setUp()
     {
         parent::setUp();
 
         $this->events = m::spy(Dispatcher::class);
+        $this->auth = m::spy(AuthManager::class);
 
         $container = new Container;
         $container->instance('events', $this->events);
+        $container->instance('auth', $this->auth);
 
         Facade::setFacadeApplication($container);
     }
@@ -49,13 +56,28 @@ class SupportFacadesEventTest extends TestCase
 
     public function testFakeForSwapsDispatchers()
     {
+        $this->guard = new SessionGuardStub;
+        $this->auth->shouldReceive('guard')->andReturn($this->guard);
+
         Event::fakeFor(function () {
             $this->assertInstanceOf(EventFake::class, Event::getFacadeRoot());
             $this->assertInstanceOf(EventFake::class, Model::getEventDispatcher());
+            $this->assertInstanceOf(EventFake::class, $this->guard->getDispatcher());
         });
 
         $this->assertSame($this->events, Event::getFacadeRoot());
         $this->assertSame($this->events, Model::getEventDispatcher());
+        $this->assertSame($this->events, $this->guard->getDispatcher());
+    }
+
+    public function testFakeForSwapsDispatchersHasNoProblemWithStateLessGuards()
+    {
+        $this->auth->shouldReceive('guard')->once()->andReturn(new TokenGuardStub);
+
+        Event::fake();
+
+        $this->assertInstanceOf(EventFake::class, Model::getEventDispatcher());
+        $this->assertInstanceOf(EventFake::class, Event::getFacadeRoot());
     }
 }
 
@@ -65,4 +87,24 @@ class FakeForStub
     {
         Event::dispatch(EventStub::class);
     }
+}
+
+class SessionGuardStub
+{
+    private $events;
+
+    public function setDispatcher($events)
+    {
+        $this->events = $events;
+    }
+
+    public function getDispatcher()
+    {
+        return $this->events;
+    }
+}
+
+class TokenGuardStub
+{
+
 }


### PR DESCRIPTION
https://github.com/laravel/framework/issues/27451

The added code mimics the AuthManager approach when sets a dispatcher on the guard.
Maybe the duplicated logic can be extracted out into a public method on a class to be reused.

![image](https://user-images.githubusercontent.com/6961695/52527190-c835b880-2cd9-11e9-995c-698a9535bb1d.png)
