### PR TITLE
[5.7] Fix issue fake dispatcher (other way)

### DIFF
--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -86,5 +86,13 @@ class AuthServiceProvider extends ServiceProvider
                 return call_user_func($app['auth']->userResolver(), $guard);
             });
         });
+
+        $this->app->rebinding('events', function ($app, $dispatcher) {
+            $guard = $app['auth']->guard();
+
+            if (method_exists($guard, 'setDispatcher')) {
+                $guard->setDispatcher($dispatcher);
+            }
+        });
     }
 }

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -31,8 +31,6 @@ class Event extends Facade
         static::swap($fake = new EventFake(static::getFacadeRoot(), $eventsToFake));
 
         Model::setEventDispatcher($fake);
-
-        self::setDispatcherOnAuth($fake);
     }
 
     /**
@@ -52,7 +50,6 @@ class Event extends Facade
             static::swap($originalDispatcher);
 
             Model::setEventDispatcher($originalDispatcher);
-            self::setDispatcherOnAuth($originalDispatcher);
         });
     }
 
@@ -64,16 +61,5 @@ class Event extends Facade
     protected static function getFacadeAccessor()
     {
         return 'events';
-    }
-
-    /**
-     * @param $fake
-     */
-    protected static function setDispatcherOnAuth($fake)
-    {
-        $guard = Auth::guard();
-        if (method_exists($guard, 'setDispatcher')) {
-            $guard->setDispatcher($fake);
-        }
     }
 }

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -31,6 +31,8 @@ class Event extends Facade
         static::swap($fake = new EventFake(static::getFacadeRoot(), $eventsToFake));
 
         Model::setEventDispatcher($fake);
+
+        self::setDispatcherOnAuth($fake);
     }
 
     /**
@@ -50,6 +52,7 @@ class Event extends Facade
             static::swap($originalDispatcher);
 
             Model::setEventDispatcher($originalDispatcher);
+            self::setDispatcherOnAuth($originalDispatcher);
         });
     }
 
@@ -61,5 +64,16 @@ class Event extends Facade
     protected static function getFacadeAccessor()
     {
         return 'events';
+    }
+
+    /**
+     * @param $fake
+     */
+    protected static function setDispatcherOnAuth($fake)
+    {
+        $guard = Auth::guard();
+        if (method_exists($guard, 'setDispatcher')) {
+            $guard->setDispatcher($fake);
+        }
     }
 }

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Auth\AuthManager;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
 use Illuminate\Support\Facades\Event;
@@ -15,14 +16,27 @@ class SupportFacadesEventTest extends TestCase
 {
     private $events;
 
+    private $auth;
+
+    private $guard;
+
     protected function setUp()
     {
         parent::setUp();
 
         $this->events = m::spy(Dispatcher::class);
+        $this->auth = m::spy(AuthManager::class);
 
         $container = new Container;
         $container->instance('events', $this->events);
+        $container->instance('auth', $this->auth);
+        $container->rebinding('events', function ($app, $dispatcher) {
+            $guard = $app['auth']->guard();
+
+            if (method_exists($guard, 'setDispatcher')) {
+                $guard->setDispatcher($dispatcher);
+            }
+        });
 
         Facade::setFacadeApplication($container);
     }
@@ -49,13 +63,28 @@ class SupportFacadesEventTest extends TestCase
 
     public function testFakeForSwapsDispatchers()
     {
+        $this->guard = new SessionGuardStub;
+        $this->auth->shouldReceive('guard')->andReturn($this->guard);
+
         Event::fakeFor(function () {
             $this->assertInstanceOf(EventFake::class, Event::getFacadeRoot());
             $this->assertInstanceOf(EventFake::class, Model::getEventDispatcher());
+            $this->assertInstanceOf(EventFake::class, $this->guard->getDispatcher());
         });
 
         $this->assertSame($this->events, Event::getFacadeRoot());
         $this->assertSame($this->events, Model::getEventDispatcher());
+        $this->assertSame($this->events, $this->guard->getDispatcher());
+    }
+
+    public function testFakeForSwapsDispatchersHasNoProblemWithStateLessGuards()
+    {
+        $this->auth->shouldReceive('guard')->once()->andReturn(new TokenGuardStub);
+
+        Event::fake();
+
+        $this->assertInstanceOf(EventFake::class, Model::getEventDispatcher());
+        $this->assertInstanceOf(EventFake::class, Event::getFacadeRoot());
     }
 }
 
@@ -65,4 +94,23 @@ class FakeForStub
     {
         Event::dispatch(EventStub::class);
     }
+}
+
+class SessionGuardStub
+{
+    private $events;
+
+    public function setDispatcher($events)
+    {
+        $this->events = $events;
+    }
+
+    public function getDispatcher()
+    {
+        return $this->events;
+    }
+}
+
+class TokenGuardStub
+{
 }


### PR DESCRIPTION
Following https://github.com/laravel/framework/pull/27473
As Taylor suggested, now it uses the rebinding callbacks of the container to solve the issue.
Which I think is a more robust way of solving it and it solves an other not yet reported issue.
(when an other implementation of event dispatcher got rebound to the 'events' on the container, the AuthManager was not getting updated to use the new one.)

- But unit testing a piece of code within a service provider is somewhat tricky. 👀 
(Any suggestion about tests?)

- Maybe we also need to do the same approach for the EloquentModels event dispatcher.

- Let me mention that `SessionGuardStub` and `TokenGuardStub` are representatives of two kinds of guard found in laravel, and not the specific implementations.
`SessionGuardStub` here means any guard that can accept a dispatcher.


### the third way

- An other way of doing that is to delay the resolution of the dispatcher instance to the moment that the event is going to be fired and avoid injecting the dispatcher instance directly, instead we pass it a dispatcher resolver.



So this gets injected into the constructor of the SessionGuard class :
```php
$dispatcher = function () use($app) {
   return $app['events'];
}

$guard->setDispatcher($dispatcher);
```
![image](https://user-images.githubusercontent.com/6961695/52541457-7f9a0000-2daa-11e9-84d4-a1f7fae8bd37.png)

Pros:

Easier To test

Cons:

As Taylor mentioned in the laravel snippet 5 changes in the type-hints of method signature create an infinitesimally weak probability of backward incompatibility.