### PR TITLE
[5.7] Pheanstalk class already implements PheanstalkInterface.

### DIFF
--- a/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
+++ b/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
@@ -4,7 +4,6 @@ namespace Illuminate\Queue\Connectors;
 
 use Pheanstalk\Connection;
 use Pheanstalk\Pheanstalk;
-use Pheanstalk\PheanstalkInterface;
 use Illuminate\Queue\BeanstalkdQueue;
 
 class BeanstalkdConnector implements ConnectorInterface
@@ -32,7 +31,7 @@ class BeanstalkdConnector implements ConnectorInterface
     {
         return new Pheanstalk(
             $config['host'],
-            $config['port'] ?? PheanstalkInterface::DEFAULT_PORT,
+            $config['port'] ?? Pheanstalk::DEFAULT_PORT,
             $config['timeout'] ?? Connection::DEFAULT_CONNECT_TIMEOUT,
             $config['persistent'] ?? false
         );


### PR DESCRIPTION
We don't use PheanstalkdInterface anywhere else in the core so this should be a step to support Pheanstalk 4.0.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
