### PR TITLE
[5.7] Fix Memcached skipping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ services:
 
 before_install:
   - phpenv config-rm xdebug.ini || true
-  - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - printf "\n" | pecl install -f redis
+  - printf "\n" | pecl install -f memcached redis
   - travis_retry composer self-update
   - mysql -e 'CREATE DATABASE forge;'
 


### PR DESCRIPTION
For an unknown reason, Travis suddenly stopped providing the Memcached extension. We'll need to install the memcached extension ourselves with PECL.

Reported as an issue to Travis here: https://travis-ci.community/t/unable-to-load-dynamic-library-memcached-so/2232