### PR TITLE
[5.8] setUp and tearDown parent call

### DIFF
--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -15,6 +15,8 @@ class AuthDatabaseUserProviderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -13,6 +13,8 @@ class AuthEloquentUserProviderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -25,6 +25,8 @@ class AuthGuardTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -17,6 +17,8 @@ class AuthPasswordBrokerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -12,6 +12,8 @@ class AuthTokenGuardTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -33,6 +33,8 @@ class AuthenticateMiddlewareTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -20,6 +20,8 @@ class AuthenticateMiddlewareTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $container = Container::setInstance(new Container);
 
         $this->auth = new AuthManager($container);

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -46,6 +46,8 @@ class AuthorizeMiddlewareTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -11,6 +11,8 @@ class BroadcastEventTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -27,6 +27,8 @@ class BroadcasterTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -23,6 +23,8 @@ class RedisBroadcasterTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -23,6 +23,8 @@ class UsePusherChannelConventionsTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -17,6 +17,8 @@ class BusDispatcherTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -15,6 +15,8 @@ class CacheDatabaseStoreTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -17,6 +17,8 @@ class CacheEventsTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -11,6 +11,8 @@ class CacheManagerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -11,6 +11,8 @@ class CacheMemcachedConnectorTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -11,6 +11,8 @@ class CacheRateLimiterTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -11,6 +11,8 @@ class CacheRedisStoreTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -19,6 +19,8 @@ class CacheRepositoryTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
         Carbon::setTestNow();
     }

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -16,6 +16,8 @@ class CacheTableCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -16,6 +16,8 @@ class CacheTaggedCacheTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -54,6 +54,8 @@ class ClearCommandTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -15,6 +15,7 @@ class RedisCacheIntegrationTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->setUpRedis();
     }
 

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -22,6 +22,7 @@ class RedisCacheIntegrationTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
+
         m::close();
         $this->tearDownRedis();
     }

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -38,7 +38,6 @@ class RepositoryTest extends TestCase
                 'z' => 'zoo',
             ],
         ]);
-
     }
 
     public function testConstruct()

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -19,6 +19,8 @@ class RepositoryTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->repository = new Repository($this->config = [
             'foo' => 'bar',
             'bar' => 'baz',
@@ -37,7 +39,6 @@ class RepositoryTest extends TestCase
             ],
         ]);
 
-        parent::setUp();
     }
 
     public function testConstruct()

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -14,6 +14,8 @@ class ConsoleApplicationTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -34,6 +34,8 @@ class ConsoleEventSchedulerTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -28,6 +28,8 @@ class ConsoleScheduledEventTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         date_default_timezone_set($this->defaultTimezone);
         Carbon::setTestNow(null);
         m::close();

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -20,6 +20,8 @@ class ConsoleScheduledEventTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->defaultTimezone = date_default_timezone_get();
         date_default_timezone_set('UTC');
     }

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -11,6 +11,8 @@ class EventTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -16,6 +16,8 @@ class FrequencyTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->event = new Event(
             m::mock(EventMutex::class),
             'php foo'

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -12,6 +12,8 @@ class CookieTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -17,6 +17,8 @@ class DatabaseConnectionFactoryTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->db = new DB;
 
         $this->db->addConnection([

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -41,6 +41,8 @@ class DatabaseConnectionFactoryTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -27,6 +27,8 @@ class DatabaseConnectionTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -15,6 +15,8 @@ class DatabaseConnectorTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
@@ -74,6 +74,8 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->schema()->drop('users');
         $this->schema()->drop('articles');
         $this->schema()->drop('article_user');

--- a/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
@@ -12,6 +12,8 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -60,6 +60,8 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->schema()->drop('users');
         $this->schema()->drop('articles');
         $this->schema()->drop('article_user');

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -11,6 +11,8 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -12,6 +12,8 @@ class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -17,6 +17,8 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -25,6 +25,8 @@ class DatabaseEloquentBuilderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentCollectionQueueableTest.php
+++ b/tests/Database/DatabaseEloquentCollectionQueueableTest.php
@@ -12,6 +12,8 @@ class DatabaseEloquentCollectionQueueableTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         Mockery::close();
     }
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -13,6 +13,8 @@ class DatabaseEloquentCollectionTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -23,6 +23,8 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
 
         Model::unsetConnectionResolver();

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -14,6 +14,8 @@ class DatabaseEloquentHasManyTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -12,6 +12,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -67,6 +67,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->schema()->drop('users');
         $this->schema()->drop('posts');
         $this->schema()->drop('countries');

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -21,6 +21,8 @@ class DatabaseEloquentHasOneTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -12,6 +12,8 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -67,6 +67,8 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->schema()->drop('users');
         $this->schema()->drop('contracts');
         $this->schema()->drop('positions');

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -134,6 +134,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         foreach (['default', 'second_connection'] as $connection) {
             $this->schema($connection)->drop('users');
             $this->schema($connection)->drop('friends');

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -32,6 +32,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -17,6 +17,8 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -70,6 +70,8 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         foreach (['default'] as $connection) {
             $this->schema($connection)->drop('users');
             $this->schema($connection)->drop('friends');

--- a/tests/Database/DatabaseEloquentIrregularPluralTest.php
+++ b/tests/Database/DatabaseEloquentIrregularPluralTest.php
@@ -57,6 +57,8 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->schema()->drop('irregular_plural_tokens');
         $this->schema()->drop('irregular_plural_humans');
         $this->schema()->drop('irregular_plural_human_irregular_plural_token');

--- a/tests/Database/DatabaseEloquentIrregularPluralTest.php
+++ b/tests/Database/DatabaseEloquentIrregularPluralTest.php
@@ -11,6 +11,8 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -15,6 +15,8 @@ class DatabaseEloquentMorphTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         Relation::morphMap([], false);
 
         m::close();

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -12,6 +12,8 @@ class DatabaseEloquentMorphToManyTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -16,6 +16,8 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -11,6 +11,8 @@ class DatabaseEloquentPivotTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -10,6 +10,8 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -70,6 +70,8 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->schema()->drop('users');
         $this->schema()->drop('posts');
         $this->schema()->drop('comments');

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -62,6 +62,8 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         foreach (['default'] as $connection) {
             $this->schema($connection)->drop('posts');
             $this->schema($connection)->drop('images');

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -16,6 +16,8 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -16,6 +16,8 @@ class DatabaseEloquentRelationTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -89,6 +89,8 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         Carbon::setTestNow(null);
 
         $this->schema()->drop('users');

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -16,6 +16,8 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         Carbon::setTestNow(Carbon::now());
 
         $db = new DB;

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -60,6 +60,8 @@ class DatabaseEloquentTimestampsTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->schema()->drop('users');
         $this->schema()->drop('users_created_at');
         $this->schema()->drop('users_updated_at');

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -11,6 +11,8 @@ class DatabaseEloquentTimestampsTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -12,6 +12,8 @@ class DatabaseMigrationCreatorTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -14,6 +14,8 @@ class DatabaseMigrationInstallCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -15,6 +15,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -14,6 +14,8 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -18,6 +18,8 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -15,6 +15,8 @@ class DatabaseMigrationRepositoryTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -14,6 +14,8 @@ class DatabaseMigrationResetCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -14,6 +14,8 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -63,6 +63,8 @@ class DatabaseMigratorIntegrationTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
     }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -25,6 +25,8 @@ class DatabaseMigratorIntegrationTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->db = $db = new DB;
 
         $db->addConnection([

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -13,6 +13,8 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -12,6 +12,8 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -13,6 +13,8 @@ class DatabaseProcessorTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -26,6 +26,8 @@ class DatabaseQueryBuilderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -15,6 +15,8 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -41,6 +41,8 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
     }

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -23,6 +23,8 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->db = $db = new DB;
 
         $db->addConnection([

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -15,6 +15,8 @@ class DatabaseSchemaBlueprintTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -36,6 +36,8 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
     }

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -18,6 +18,8 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->db = $db = new DB;
 
         $db->addConnection([

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -12,6 +12,8 @@ class DatabaseSchemaBuilderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -30,6 +30,8 @@ class DatabaseSeederTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -17,6 +17,8 @@ class DatabaseSoftDeletingScopeTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -11,6 +11,8 @@ class DatabaseSoftDeletingTraitTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -12,6 +12,8 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -47,6 +47,8 @@ class SeedCommandTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -16,6 +16,8 @@ class EventsDispatcherTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -18,6 +18,8 @@ class FilesystemAdapterTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->tempDir = __DIR__.'/tmp';
         $this->filesystem = new Filesystem(new Local($this->tempDir));
     }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -26,6 +26,8 @@ class FilesystemAdapterTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $filesystem = new Filesystem(new Local(dirname($this->tempDir)));
         $filesystem->deleteDir(basename($this->tempDir));
     }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -25,6 +25,8 @@ class FilesystemTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
 
         $files = new Filesystem;

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -17,6 +17,8 @@ class FilesystemTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->tempDir = __DIR__.'/tmp';
         mkdir($this->tempDir);
     }

--- a/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
+++ b/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
@@ -11,6 +11,8 @@ class LoadEnvironmentVariablesTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -14,6 +14,8 @@ class FoundationApplicationTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Foundation/FoundationAuthenticationTest.php
+++ b/tests/Foundation/FoundationAuthenticationTest.php
@@ -51,6 +51,8 @@ class FoundationAuthenticationTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -11,6 +11,8 @@ class FoundationComposerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -10,6 +10,8 @@ class FoundationEnvironmentDetectorTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -55,6 +55,8 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -31,6 +31,8 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->config = m::mock(Config::class);
 
         $this->request = m::mock(stdClass::class);

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -23,6 +23,8 @@ class FoundationFormRequestTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
 
         $this->mocks = [];

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -14,6 +14,8 @@ class FoundationHelpersTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -29,6 +29,8 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -22,6 +22,8 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->connection = m::mock(Connection::class);
     }
 

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -14,6 +14,8 @@ class FoundationProviderRepositoryTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
+++ b/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
@@ -29,6 +29,8 @@ class CheckForMaintenanceModeTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         if (is_null($this->files)) {
             $this->files = new Filesystem;
         }

--- a/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
+++ b/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
@@ -43,6 +43,8 @@ class CheckForMaintenanceModeTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->files->deleteDirectory($this->storagePath);
 
         m::close();

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -17,6 +17,8 @@ class HttpRedirectResponseTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -16,6 +16,8 @@ class HttpRequestTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -24,6 +24,8 @@ class HttpResponseTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Integration/Database/EloquentModelStringCastingTest.php
+++ b/tests/Integration/Database/EloquentModelStringCastingTest.php
@@ -15,6 +15,8 @@ class EloquentModelStringCastingTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Integration/Database/EloquentModelStringCastingTest.php
+++ b/tests/Integration/Database/EloquentModelStringCastingTest.php
@@ -53,6 +53,8 @@ class EloquentModelStringCastingTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->schema()->drop('casting_table');
     }
 

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -55,9 +55,9 @@ class EventFakeTest extends TestCase
      */
     protected function tearDown(): void
     {
-        Schema::dropIfExists('posts');
-
         parent::tearDown();
+
+        Schema::dropIfExists('posts');
     }
 
     public function testNonFakedEventGetsProperlyDispatched()

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -17,6 +17,7 @@ class ThrottleRequestsTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
+
         Carbon::setTestNow(null);
     }
 

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -19,6 +19,7 @@ class ThrottleRequestsWithRedisTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
+
         Carbon::setTestNow(null);
     }
 

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -46,11 +46,6 @@ class SendingMailWithLocaleTest extends TestCase
         ]);
     }
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function test_mail_is_sent_with_default_locale()
     {
         Mail::to('test@mail.com')->send(new TestMail);

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -31,6 +31,8 @@ class JobChainingTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         JobChainingTestFirstJob::$ran = false;
         JobChainingTestSecondJob::$ran = false;
         JobChainingTestThirdJob::$ran = false;

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -15,6 +15,8 @@ class LogLoggerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -20,6 +20,8 @@ class MailMailerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -11,6 +11,8 @@ class MailMarkdownTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -30,6 +30,8 @@ class MailMessageTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -21,6 +21,8 @@ class MailableQueuedTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -15,6 +15,8 @@ class NotificationBroadcastChannelTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -20,6 +20,8 @@ class NotificationChannelManagerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -12,6 +12,8 @@ class NotificationDatabaseChannelTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -13,6 +13,8 @@ class NotificationRoutesNotificationsTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -11,6 +11,8 @@ class NotificationSendQueuedNotificationTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -19,6 +19,8 @@ class LengthAwarePaginatorTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->options = ['onEachSide' => 5];
         $this->p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2, $this->options);
     }

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -27,6 +27,8 @@ class LengthAwarePaginatorTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         unset($this->p);
     }
 

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -17,6 +17,8 @@ class QueueBeanstalkdJobTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -14,6 +14,8 @@ class QueueBeanstalkdQueueTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -99,6 +99,8 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->schema()->drop('jobs');
     }
 

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -29,6 +29,8 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -14,6 +14,8 @@ class QueueDatabaseQueueUnitTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -12,6 +12,8 @@ class QueueListenerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -12,6 +12,8 @@ class QueueManagerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -13,6 +13,8 @@ class QueueRedisJobTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -13,6 +13,8 @@ class QueueRedisQueueTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -54,6 +54,8 @@ class QueueSqsJobTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -14,6 +14,8 @@ class QueueSqsJobTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->key = 'AMAZONSQSKEY';
         $this->secret = 'AmAz0n+SqSsEcReT+aLpHaNuM3R1CsTr1nG';
         $this->service = 'sqs';

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -15,6 +15,8 @@ class QueueSqsQueueTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -20,6 +20,8 @@ class QueueSqsQueueTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         // Use Mockery to mock the SqsClient
         $this->sqs = m::mock(SqsClient::class);
 

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -15,6 +15,8 @@ class QueueSyncQueueTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -25,6 +25,8 @@ class QueueWorkerTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->events = m::spy(Dispatcher::class);
         $this->exceptionHandler = m::spy(ExceptionHandler::class);
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -38,6 +38,8 @@ class QueueWorkerTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         Container::setInstance();
     }
 

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -30,8 +30,9 @@ class RedisQueueIntegrationTest extends TestCase
 
     protected function tearDown(): void
     {
-        Carbon::setTestNow(null);
         parent::tearDown();
+
+        Carbon::setTestNow(null);
         $this->tearDownRedis();
         m::close();
     }

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -22,8 +22,9 @@ class RedisQueueIntegrationTest extends TestCase
 
     protected function setUp(): void
     {
-        Carbon::setTestNow(Carbon::now());
         parent::setUp();
+
+        Carbon::setTestNow(Carbon::now());
         $this->setUpRedis();
     }
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -32,6 +32,7 @@ class RedisConnectionTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
+
         $this->tearDownRedis();
     }
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -17,6 +17,7 @@ class RedisConnectionTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->setUpRedis();
 
         if (! isset($this->redis['phpredis'])) {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -26,6 +26,8 @@ class RouteRegistrarTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -49,6 +49,8 @@ class RoutingRedirectorTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -21,6 +21,8 @@ class RoutingRedirectorTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->headers = m::mock(HeaderBag::class);
 
         $this->request = m::mock(Request::class);

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -13,6 +13,8 @@ class EncryptedSessionStoreTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -15,6 +15,8 @@ class SessionStoreTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -16,6 +16,8 @@ class SessionTableCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Support/DateFacadeTest.php
+++ b/tests/Support/DateFacadeTest.php
@@ -16,6 +16,7 @@ class DateFacadeTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
+
         DateFactory::use(Carbon::class);
     }
 

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -15,6 +15,8 @@ class SupportCapsuleManagerTraitTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -26,10 +26,10 @@ class SupportCarbonTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         Carbon::setTestNow();
         Carbon::serializeUsing(null);
-
-        parent::tearDown();
     }
 
     public function testInstance()

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -13,6 +13,8 @@ class SupportFacadeTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         Facade::clearResolvedInstances();
         FacadeStub::setFacadeApplication(null);
     }

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -21,6 +21,8 @@ class SupportFacadeTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -29,6 +29,8 @@ class SupportFacadesEventTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         Event::clearResolvedInstances();
 
         m::close();

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -16,6 +16,8 @@ class SupportHelpersTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -11,6 +11,8 @@ class SupportMacroableTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->macroable = $this->createObjectForTrait();
     }
 

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -11,6 +11,8 @@ class SupportMessageBagTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -25,6 +25,8 @@ class SupportServiceProviderTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -11,6 +11,8 @@ class SupportServiceProviderTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         ServiceProvider::$publishes = [];
         ServiceProvider::$publishGroups = [];
 

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -14,6 +14,7 @@ class SupportTestingEventFakeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->fake = new EventFake(m::mock(Dispatcher::class));
     }
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -26,6 +26,7 @@ class SupportTestingMailFakeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->fake = new MailFake;
         $this->mailable = new MailableStub;
     }

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -30,6 +30,7 @@ class SupportTestingNotificationFakeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->fake = new NotificationFake;
         $this->notification = new NotificationStub;
         $this->user = new UserStub;

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -24,6 +24,7 @@ class SupportTestingQueueFakeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->fake = new QueueFake(new Application);
         $this->job = new JobStub;
     }

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -11,6 +11,8 @@ class TranslationFileLoaderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -13,6 +13,8 @@ class TranslationTranslatorTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -13,6 +13,8 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -163,6 +163,8 @@ class ValidationExistsRuleTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->schema('default')->drop('users');
     }
 

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -20,6 +20,8 @@ class ValidationExistsRuleTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -13,6 +13,8 @@ class ValidationFactoryTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -28,6 +28,8 @@ class ValidationValidatorTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         Carbon::setTestNow();
         m::close();
     }

--- a/tests/View/Blade/AbstractBladeTestCase.php
+++ b/tests/View/Blade/AbstractBladeTestCase.php
@@ -20,8 +20,8 @@ abstract class AbstractBladeTestCase extends TestCase
 
     protected function tearDown(): void
     {
-        m::close();
-
         parent::tearDown();
+
+        m::close();
     }
 }

--- a/tests/View/Blade/AbstractBladeTestCase.php
+++ b/tests/View/Blade/AbstractBladeTestCase.php
@@ -13,8 +13,9 @@ abstract class AbstractBladeTestCase extends TestCase
 
     protected function setUp(): void
     {
-        $this->compiler = new BladeCompiler(m::mock(Filesystem::class), __DIR__);
         parent::setUp();
+
+        $this->compiler = new BladeCompiler(m::mock(Filesystem::class), __DIR__);
     }
 
     protected function tearDown(): void

--- a/tests/View/Blade/BladeElseAuthStatementsTest.php
+++ b/tests/View/Blade/BladeElseAuthStatementsTest.php
@@ -11,6 +11,8 @@ class BladeElseAuthStatementsTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/View/Blade/BladeElseGuestStatementsTest.php
+++ b/tests/View/Blade/BladeElseGuestStatementsTest.php
@@ -11,6 +11,8 @@ class BladeElseGuestStatementsTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/View/Blade/BladeIfAuthStatementsTest.php
+++ b/tests/View/Blade/BladeIfAuthStatementsTest.php
@@ -11,6 +11,8 @@ class BladeIfAuthStatementsTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/View/Blade/BladeIfGuestStatementsTest.php
+++ b/tests/View/Blade/BladeIfGuestStatementsTest.php
@@ -12,7 +12,7 @@ class BladeIfGuestStatementsTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
-        
+
         m::close();
     }
 

--- a/tests/View/Blade/BladeIfGuestStatementsTest.php
+++ b/tests/View/Blade/BladeIfGuestStatementsTest.php
@@ -11,6 +11,8 @@ class BladeIfGuestStatementsTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+        
         m::close();
     }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -12,6 +12,8 @@ class ViewBladeCompilerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -11,6 +11,8 @@ class ViewCompilerEngineTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -25,6 +25,8 @@ class ViewFactoryTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -12,6 +12,8 @@ class ViewFileViewFinderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -10,6 +10,8 @@ class ViewPhpEngineTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -18,6 +18,8 @@ class ViewTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This is a good practice to always call `parent::tearDown` and `parent::setup`.
It was already the case in many test classes.
This PR ensures that this is done everywhere.
