### PR TITLE
[5.8] Custom route with EnsureEmailIsVerified

### DIFF
--- a/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
+++ b/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
@@ -13,16 +13,17 @@ class EnsureEmailIsVerified
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
+     * @param  string  $route  The route where to redirect users with unverified email
      * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
      */
-    public function handle($request, Closure $next)
+    public function handle($request, Closure $next, $route = null)
     {
         if (! $request->user() ||
             ($request->user() instanceof MustVerifyEmail &&
             ! $request->user()->hasVerifiedEmail())) {
             return $request->expectsJson()
                     ? abort(403, 'Your email address is not verified.')
-                    : Redirect::route('verification.notice');
+                    : Redirect::route($route ?? 'verification.notice');
         }
 
         return $next($request);


### PR DESCRIPTION
I have three types of users (different database tables), each of them should verify emails, with this I can do it without overriding ```EnsureEmailIsVerified```:
```php
// UserController.php
...
$this->middleware('verified:users.verification.notice');
...
```

```php
// ManagersController.php
...
$this->middleware('verified:managers.verification.notice');
...
```

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
