### PR TITLE
[5.7] Always prepend versions with v character

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -10,6 +10,13 @@ then
 fi
 
 CURRENT_BRANCH="5.7"
+VERSION=$1
+
+# Always prepend with "v"
+if [[ $VERSION != v*  ]]
+then
+    VERSION="v$VERSION"
+fi
 
 for REMOTE in auth broadcasting bus cache config console container contracts cookie database encryption events filesystem hashing http log mail notifications pagination pipeline queue redis routing session support translation validation view
 do
@@ -29,7 +36,7 @@ do
         git clone $REMOTE_URL .
         git checkout "$CURRENT_BRANCH";
 
-        git tag $1
+        git tag $VERSION
         git push origin --tags
     )
 done


### PR DESCRIPTION
So it doesn't matter if you write "5.7.15" or "v5.7.15".

Tested here: https://repl.it/repls/GoldEnchantedGoal