### PR TITLE
[5.7] Fix several misspellings concerning mailer contract

### DIFF
--- a/src/Illuminate/Contracts/Mail/Mailer.php
+++ b/src/Illuminate/Contracts/Mail/Mailer.php
@@ -21,7 +21,7 @@ interface Mailer
     public function bcc($users);
 
     /**
-     * Send a new message when only a raw text part.
+     * Send a new message with only a raw text part.
      *
      * @param  string  $text
      * @param  mixed  $callback

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -160,7 +160,7 @@ class Mailer implements MailerContract, MailQueueContract
     }
 
     /**
-     * Send a new message with only an HTML part.
+     * Send a new message with only a HTML part.
      *
      * @param  string  $html
      * @param  mixed  $callback
@@ -172,7 +172,7 @@ class Mailer implements MailerContract, MailQueueContract
     }
 
     /**
-     * Send a new message when only a raw text part.
+     * Send a new message with only a raw text part.
      *
      * @param  string  $text
      * @param  mixed  $callback
@@ -184,7 +184,7 @@ class Mailer implements MailerContract, MailQueueContract
     }
 
     /**
-     * Send a new message when only a plain part.
+     * Send a new message with only a plain part.
      *
      * @param  string  $view
      * @param  array  $data

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -160,7 +160,7 @@ class Mailer implements MailerContract, MailQueueContract
     }
 
     /**
-     * Send a new message with only a HTML part.
+     * Send a new message with only an HTML part.
      *
      * @param  string  $html
      * @param  mixed  $callback

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -263,7 +263,7 @@ class MailFake implements Mailer, MailQueue
     }
 
     /**
-     * Send a new message when only a raw text part.
+     * Send a new message with only a raw text part.
      *
      * @param  string  $text
      * @param  \Closure|string  $callback


### PR DESCRIPTION
Because a [nearly 50k :star: framework](https://twitter.com/taylorotwell/status/1093268600406925313) should have correct doc blocks. :grinning: 
