### PR TITLE
[5.7] Improve assertJsonValidationErrors error message, make it fail when no keys given

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -647,7 +647,7 @@ class TestResponse
         $errorMessage = $errors
             ? 'Response has the following JSON validation errors: '.
             PHP_EOL.PHP_EOL.json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
-            : 'Response did not have JSON validation errors';
+            : 'Response does not have JSON validation errors';
 
         foreach ($keys as $key) {
             PHPUnit::assertArrayHasKey(

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -638,13 +638,22 @@ class TestResponse
      */
     public function assertJsonValidationErrors($keys)
     {
+        $keys = Arr::wrap($keys);
+
+        PHPUnit::assertNotEmpty($keys, 'You need to provide at least one expected key');
+
         $errors = $this->json()['errors'] ?? [];
 
-        foreach (Arr::wrap($keys) as $key) {
+        $errorMessage = $errors
+            ? 'Response has the following JSON validation errors: '.
+            PHP_EOL.PHP_EOL.json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+            : 'Response did not have JSON validation errors';
+
+        foreach ($keys as $key) {
             PHPUnit::assertArrayHasKey(
                 $key,
                 $errors,
-                "Failed to find a validation error in the response for key: '{$key}'"
+                "Failed to find a validation error in the response for key: '{$key}'".PHP_EOL.PHP_EOL.$errorMessage
             );
         }
 

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -344,6 +344,17 @@ class FoundationTestResponseTest extends TestCase
         $testResponse->assertJsonValidationErrors('bar');
     }
 
+    public function testAssertJsonValidationErrorsFailsWhenGivenAnEmptyArray()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode(['errors' => ['foo' => 'oops']]))
+        );
+
+        $testResponse->assertJsonValidationErrors([]);
+    }
+
     public function testAssertJsonMissingValidationErrors()
     {
         $baseResponse = tap(new Response, function ($response) {


### PR DESCRIPTION
Currently, when the `assertJsonValidationErrors` assertion fails, it prints the following unhelpful error message:

![image](https://user-images.githubusercontent.com/7202674/52626479-8c564b00-2eb3-11e9-91eb-bac8c90e0fcf.png)

This PR makes it output the validation errors that are present. This makes it easier to figure out what is going on.

![image](https://user-images.githubusercontent.com/7202674/52626622-dc351200-2eb3-11e9-916d-f62f274852ad.png)

If the response has no json validation errors, it will show this instead:

![image](https://user-images.githubusercontent.com/7202674/52626643-ebb45b00-2eb3-11e9-8755-43ba4a303629.png)

This PR also makes the assertion fail if you don't give the assertions any keys to expect. Currently if you pass in an empty array, the method won't make any assertion and just keep going.

