### PR TITLE
[5.7] add a method to check whether the returned response is a failed validation

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -156,6 +156,18 @@ class TestResponse
     }
 
     /**
+     * Assert whether the validation failed.
+     *
+     * @return $this
+     */
+    public function assertValidationFailed()
+    {
+        PHPUnit::assertEquals($this->getStatusCode(), 422, 'Response status code ['.$this->getStatusCode().'] is not a failed validation status code.');
+
+        return $this;
+    }
+
+    /**
      * Asserts that the response contains the given header and equals the optional value.
      *
      * @param  string  $headerName


### PR DESCRIPTION
The goal of this PR is to make it easy to check whether the returned response of an HTTP request is a failed validation.

before this PR if we want to check if the returned response is a failed validation we would need to check directly the returned status code.

If this is something that could be accepted in the framework, I'm planning to send other PRs related to failed validation (if this is something we want to have in the framework)