### PR TITLE
[5.8] Make Eloquent::newCollection a static method

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -222,10 +222,10 @@ class FactoryBuilder
         }
 
         if ($this->amount < 1) {
-            return (new $this->class)->newCollection();
+            return $this->class::newCollection();
         }
 
-        $instances = (new $this->class)->newCollection(array_map(function () use ($attributes) {
+        $instances = $this->class::newCollection(array_map(function () use ($attributes) {
             return $this->makeInstance($attributes);
         }, range(1, $this->amount)));
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1053,7 +1053,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  array  $models
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function newCollection(array $models = [])
+    public static function newCollection(array $models = [])
     {
         return new Collection($models);
     }


### PR DESCRIPTION
I stumbled upon #6476 when wondering myself why this wasn't a static method.

This is not a breaking change because static methods may also be called on instances.

Resubmitting for 5.8 per #27491

Update: @GrahamCampbell comment on the PR for 5.7 makes a good point that if this method has been overridden, it would be a breaking change.
