### PR TITLE
[5.8] Add support for schemas in SqlServer grammar

### DIFF
--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -66,4 +66,17 @@ class SqlServerProcessor extends Processor
             return ((object) $result)->name;
         }, $results);
     }
+
+    /**
+     * Process the results of a default schema query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processDefaultSchema($results)
+    {
+        return array_map(function ($result) {
+            return ((object) $result)->computed;
+        }, $results);
+    }
 }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -35,7 +35,9 @@ class SqlServerGrammar extends Grammar
      */
     public function compileTableExists()
     {
-        return "select * from sysobjects where type = 'U' and name = ?";
+        return "select * from sys.objects as obj
+                join sys.schemas as schemas on obj.schema_id = schemas.schema_id
+                where obj.type = 'U' and schemas.name = ? and obj.name = ?";
     }
 
     /**
@@ -44,11 +46,12 @@ class SqlServerGrammar extends Grammar
      * @param  string  $table
      * @return string
      */
-    public function compileColumnListing($table)
+    public function compileColumnListing()
     {
         return "select col.name from sys.columns as col
                 join sys.objects as obj on col.object_id = obj.object_id
-                where obj.type = 'U' and obj.name = '$table'";
+                join sys.schemas as schemas ON obj.schema_id = schemas.schema_id
+                where obj.type = 'U' and schemas.name = ? and obj.name = ?";
     }
 
     /**
@@ -310,6 +313,16 @@ class SqlServerGrammar extends Grammar
     public function compileDisableForeignKeyConstraints()
     {
         return 'EXEC sp_msforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT all";';
+    }
+
+    /**
+     * Compile the command to get the default schema for a connection.
+     *
+     * @return string
+     */
+    public function compileDefaultSchema()
+    {
+        return "select SCHEMA_NAME()";
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -322,7 +322,7 @@ class SqlServerGrammar extends Grammar
      */
     public function compileDefaultSchema()
     {
-        return "select SCHEMA_NAME()";
+        return 'select SCHEMA_NAME()';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -5,6 +5,23 @@ namespace Illuminate\Database\Schema;
 class SqlServerBuilder extends Builder
 {
     /**
+     * Determine if the given table exists.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    public function hasTable($table)
+    {
+        list($schema, $table) = $this->parseSchemaAndTable($table);
+
+        $table = $this->connection->getTablePrefix().$table;
+
+        return count($this->connection->select(
+                $this->grammar->compileTableExists(), [$schema, $table]
+            )) > 0;
+    }
+
+    /**
      * Drop all tables from the database.
      *
      * @return void
@@ -16,5 +33,52 @@ class SqlServerBuilder extends Builder
         $this->connection->statement($this->grammar->compileDropAllTables());
 
         $this->enableForeignKeyConstraints();
+    }
+
+    /**
+     * Get the column listing for a given table.
+     *
+     * @param  string  $table
+     * @return array
+     */
+    public function getColumnListing($table)
+    {
+        list($schema, $table) = $this->parseSchemaAndTable($table);
+
+        $table = $this->connection->getTablePrefix().$table;
+
+        $results = $this->connection->select(
+            $this->grammar->compileColumnListing(), [$schema, $table]
+        );
+
+        return $this->connection->getPostProcessor()->processColumnListing($results);
+    }
+
+    /**
+     * Parse the table name and extract the schema and table.
+     *
+     * @param  string  $table
+     * @return array
+     */
+    protected function parseSchemaAndTable($table)
+    {
+        $table = explode('.', $table);
+
+        if (is_array($schema = $this->connection->getConfig('schema'))) {
+            if (in_array($table[0], $schema)) {
+                return [array_shift($table), implode('.', $table)];
+            }
+
+            $schema = head($schema);
+        }
+        return [$schema ?: $this->getDefaultSchema(), implode('.', $table)];
+    }
+
+    protected function getDefaultSchema()
+    {
+        $results = $this->connection->select(
+            $this->grammar->compileDefaultSchema()
+        );
+        return head($this->connection->getPostProcessor()->processDefaultSchema($results));
     }
 }

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -71,6 +71,7 @@ class SqlServerBuilder extends Builder
 
             $schema = head($schema);
         }
+
         return [$schema ?: $this->getDefaultSchema(), implode('.', $table)];
     }
 
@@ -79,6 +80,7 @@ class SqlServerBuilder extends Builder
         $results = $this->connection->select(
             $this->grammar->compileDefaultSchema()
         );
+
         return head($this->connection->getPostProcessor()->processDefaultSchema($results));
     }
 }


### PR DESCRIPTION
### Benefit to end user

At this moment it is not get the column listing for a table in a schema different from the default schema. (e.g. *test.Users*)
It is also not possible to check if a table in a different schema exists.

Both the `compileTableExists()` and`compileColumnListing()` functions only check for object name and not for the schema.

### Contents of this pull request

This pull requests adds checks for the schema name in the `compileTableExists()` and
`compileColumnListing()` functions.
The available schemas can be defined in the database configuration.
This is all consistent with the PostgresGrammar and PostgresBuilder.

The default schema is gathered from the database by using
```
select SCHEMA_NAME()
```
Which is available since SQL Server 2008.
See https://docs.microsoft.com/en-us/sql/t-sql/functions/schema-name-transact-sql?view=sql-server-2017

### Breaking
This PR is breaking as it removes the `table` parameter from a public function:
```php
    public function compileColumnListing($table)
```

This is done for consistency reasons with the PostgresGrammar.

This PR could also be done in a non-breaking fashion by adding `$schema` as an optional parameter and either fetching the default schema there or checking for the schema if the parameter is not passed.

```php
    public function compileColumnListing($table, $schema = null)
    ...
```

