### PR TITLE
[5.8] Allow Macroable::mixin to only add macros that do not exist yet

### DIFF
--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -33,20 +33,22 @@ trait Macroable
      * Mix another object into the class.
      *
      * @param  object  $mixin
+     * @param  bool    $replace
      * @return void
      *
      * @throws \ReflectionException
      */
-    public static function mixin($mixin)
+    public static function mixin($mixin, $replace = true)
     {
         $methods = (new ReflectionClass($mixin))->getMethods(
             ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED
         );
 
         foreach ($methods as $method) {
-            $method->setAccessible(true);
-
-            static::macro($method->name, $method->invoke($mixin));
+            if ($replace || ! static::hasMacro($method->name)) {
+                $method->setAccessible(true);
+                static::macro($method->name, $method->invoke($mixin));
+            }
         }
     }
 

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -60,6 +60,19 @@ class SupportMacroableTest extends TestCase
         $instance = new TestMacroable;
         $this->assertEquals('instance-Adam', $instance->methodOne('Adam'));
     }
+
+    public function testClassBasedMacrosNoReplace()
+    {
+        TestMacroable::macro('methodThree', function () {
+            return 'bar';
+        });
+        TestMacroable::mixin(new TestMixin, false);
+        $instance = new TestMacroable;
+        $this->assertEquals('bar', $instance->methodThree());
+
+        TestMacroable::mixin(new TestMixin);
+        $this->assertEquals('foo', $instance->methodThree());
+    }
 }
 
 class EmptyMacroable
@@ -92,6 +105,13 @@ class TestMixin
     {
         return function ($value) {
             return $this->protectedVariable.'-'.$value;
+        };
+    }
+
+    protected function methodThree()
+    {
+        return function () {
+            return 'foo';
         };
     }
 }


### PR DESCRIPTION
This PR allows class-based macros to be added without overwriting existing macros. A second parameter `$replace` has been added to the `Macroable::mixin` method, a boolean set to `true` by default to indicate if existing macros should be overwritten.