### PR TITLE
[5.7] Set relation on parent for HasOne and HasMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -49,9 +49,10 @@ trait HasRelationships
      * @param  string  $related
      * @param  string  $foreignKey
      * @param  string  $localKey
+     * @param  string  $relation
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
-    public function hasOne($related, $foreignKey = null, $localKey = null)
+    public function hasOne($related, $foreignKey = null, $localKey = null, $relation = null)
     {
         $instance = $this->newRelatedInstance($related);
 
@@ -59,7 +60,11 @@ trait HasRelationships
 
         $localKey = $localKey ?: $this->getKeyName();
 
-        return $this->newHasOne($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey);
+        $relation = $relation ?: $this->guessBelongsToRelation();
+
+        return $this->newHasOne(
+            $instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey, $relation
+        );
     }
 
     /**
@@ -69,11 +74,12 @@ trait HasRelationships
      * @param  \Illuminate\Database\Eloquent\Model  $parent
      * @param  string  $foreignKey
      * @param  string  $localKey
+     * @param  string  $relation
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
-    protected function newHasOne(Builder $query, Model $parent, $foreignKey, $localKey)
+    protected function newHasOne(Builder $query, Model $parent, $foreignKey, $localKey, $relation)
     {
-        return new HasOne($query, $parent, $foreignKey, $localKey);
+        return new HasOne($query, $parent, $foreignKey, $localKey, $relation);
     }
 
     /**
@@ -84,9 +90,10 @@ trait HasRelationships
      * @param  string  $type
      * @param  string  $id
      * @param  string  $localKey
+     * @param  string  $relation
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    public function morphOne($related, $name, $type = null, $id = null, $localKey = null)
+    public function morphOne($related, $name, $type = null, $id = null, $localKey = null, $relation = null)
     {
         $instance = $this->newRelatedInstance($related);
 
@@ -96,7 +103,11 @@ trait HasRelationships
 
         $localKey = $localKey ?: $this->getKeyName();
 
-        return $this->newMorphOne($instance->newQuery(), $this, $table.'.'.$type, $table.'.'.$id, $localKey);
+        $relation = $relation ?: $this->guessBelongsToRelation();
+
+        return $this->newMorphOne(
+            $instance->newQuery(), $this, $table.'.'.$type, $table.'.'.$id, $localKey, $relation
+        );
     }
 
     /**
@@ -107,11 +118,12 @@ trait HasRelationships
      * @param  string  $type
      * @param  string  $id
      * @param  string  $localKey
+     * @param  string  $relation
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    protected function newMorphOne(Builder $query, Model $parent, $type, $id, $localKey)
+    protected function newMorphOne(Builder $query, Model $parent, $type, $id, $localKey, $relation)
     {
-        return new MorphOne($query, $parent, $type, $id, $localKey);
+        return new MorphOne($query, $parent, $type, $id, $localKey, $relation);
     }
 
     /**
@@ -276,9 +288,10 @@ trait HasRelationships
      * @param  string  $related
      * @param  string  $foreignKey
      * @param  string  $localKey
+     * @param  string  $relation
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function hasMany($related, $foreignKey = null, $localKey = null)
+    public function hasMany($related, $foreignKey = null, $localKey = null, $relation = null)
     {
         $instance = $this->newRelatedInstance($related);
 
@@ -286,8 +299,10 @@ trait HasRelationships
 
         $localKey = $localKey ?: $this->getKeyName();
 
+        $relation = $relation ?: $this->guessBelongsToRelation();
+
         return $this->newHasMany(
-            $instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey
+            $instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey, $relation
         );
     }
 
@@ -298,11 +313,12 @@ trait HasRelationships
      * @param  \Illuminate\Database\Eloquent\Model  $parent
      * @param  string  $foreignKey
      * @param  string  $localKey
+     * @param  string  $relation
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    protected function newHasMany(Builder $query, Model $parent, $foreignKey, $localKey)
+    protected function newHasMany(Builder $query, Model $parent, $foreignKey, $localKey, $relation)
     {
-        return new HasMany($query, $parent, $foreignKey, $localKey);
+        return new HasMany($query, $parent, $foreignKey, $localKey, $relation);
     }
 
     /**
@@ -356,9 +372,10 @@ trait HasRelationships
      * @param  string  $type
      * @param  string  $id
      * @param  string  $localKey
+     * @param  string  $relation
      * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */
-    public function morphMany($related, $name, $type = null, $id = null, $localKey = null)
+    public function morphMany($related, $name, $type = null, $id = null, $localKey = null, $relation = null)
     {
         $instance = $this->newRelatedInstance($related);
 
@@ -371,7 +388,11 @@ trait HasRelationships
 
         $localKey = $localKey ?: $this->getKeyName();
 
-        return $this->newMorphMany($instance->newQuery(), $this, $table.'.'.$type, $table.'.'.$id, $localKey);
+        $relation = $relation ?: $this->guessBelongsToRelation();
+
+        return $this->newMorphMany(
+            $instance->newQuery(), $this, $table.'.'.$type, $table.'.'.$id, $localKey, $relation
+        );
     }
 
     /**
@@ -382,11 +403,12 @@ trait HasRelationships
      * @param  string  $type
      * @param  string  $id
      * @param  string  $localKey
+     * @param  string  $relation
      * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */
-    protected function newMorphMany(Builder $query, Model $parent, $type, $id, $localKey)
+    protected function newMorphMany(Builder $query, Model $parent, $type, $id, $localKey, $relation)
     {
-        return new MorphMany($query, $parent, $type, $id, $localKey);
+        return new MorphMany($query, $parent, $type, $id, $localKey, $relation);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -46,4 +46,14 @@ class HasMany extends HasOneOrMany
     {
         return $this->matchMany($models, $results, $relation);
     }
+
+    /**
+     * Set the relationship on the parent model
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     */
+    protected function setRelation($model)
+    {
+        $this->parent->{$this->relation}->add($model);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -48,7 +48,7 @@ class HasMany extends HasOneOrMany
     }
 
     /**
-     * Set the relationship on the parent model
+     * Set the relationship on the parent model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      */

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -67,7 +67,7 @@ class HasOne extends HasOneOrMany
     }
 
     /**
-     * Set the relationship on the parent model
+     * Set the relationship on the parent model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      */

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -65,4 +65,14 @@ class HasOne extends HasOneOrMany
             $this->getForeignKeyName(), $parent->{$this->localKey}
         );
     }
+
+    /**
+     * Set the relationship on the parent model
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     */
+    protected function setRelation($model)
+    {
+        $this->parent->setRelation($this->relation, $model);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -23,6 +23,13 @@ abstract class HasOneOrMany extends Relation
     protected $localKey;
 
     /**
+     * The name of the relationship
+     *
+     * @var string
+     */
+    protected $relation;
+
+    /**
      * The count of self joins.
      *
      * @var int
@@ -36,12 +43,14 @@ abstract class HasOneOrMany extends Relation
      * @param  \Illuminate\Database\Eloquent\Model  $parent
      * @param  string  $foreignKey
      * @param  string  $localKey
+     * @param  string  $relation
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $foreignKey, $localKey)
+    public function __construct(Builder $query, Model $parent, $foreignKey, $localKey, $relation)
     {
         $this->localKey = $localKey;
         $this->foreignKey = $foreignKey;
+        $this->relation = $relation;
 
         parent::__construct($query, $parent);
     }
@@ -249,7 +258,13 @@ abstract class HasOneOrMany extends Relation
     {
         $this->setForeignAttributesForCreate($model);
 
-        return $model->save() ? $model : false;
+        if ($model->save()) {
+            $this->setRelation($model);
+
+            return $model;
+        }
+
+        return false;
     }
 
     /**
@@ -417,4 +432,11 @@ abstract class HasOneOrMany extends Relation
     {
         return $this->localKey;
     }
+
+    /**
+     * Set the relationship on the parent model
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     */
+    abstract protected function setRelation($model);
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -23,7 +23,7 @@ abstract class HasOneOrMany extends Relation
     protected $localKey;
 
     /**
-     * The name of the relationship
+     * The name of the relationship.
      *
      * @var string
      */
@@ -434,7 +434,7 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
-     * Set the relationship on the parent model
+     * Set the relationship on the parent model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      */

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -48,7 +48,7 @@ class MorphMany extends MorphOneOrMany
     }
 
     /**
-     * Set the relationship on the parent model
+     * Set the relationship on the parent model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      */

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -46,4 +46,14 @@ class MorphMany extends MorphOneOrMany
     {
         return $this->matchMany($models, $results, $relation);
     }
+
+    /**
+     * Set the relationship on the parent model
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     */
+    protected function setRelation($model)
+    {
+        $this->parent->{$this->relation}->add($model);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -67,7 +67,7 @@ class MorphOne extends MorphOneOrMany
     }
 
     /**
-     * Set the relationship on the parent model
+     * Set the relationship on the parent model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      */

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -65,4 +65,14 @@ class MorphOne extends MorphOneOrMany
                     ->setAttribute($this->getForeignKeyName(), $parent->{$this->localKey})
                     ->setAttribute($this->getMorphType(), $this->morphClass);
     }
+
+    /**
+     * Set the relationship on the parent model
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     */
+    protected function setRelation($model)
+    {
+        $this->parent->setRelation($this->relation, $model);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -29,15 +29,16 @@ abstract class MorphOneOrMany extends HasOneOrMany
      * @param  string  $type
      * @param  string  $id
      * @param  string  $localKey
+     * @param  string  $relation
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $type, $id, $localKey)
+    public function __construct(Builder $query, Model $parent, $type, $id, $localKey, $relation)
     {
         $this->morphType = $type;
 
         $this->morphClass = $parent->getMorphClass();
 
-        parent::__construct($query, $parent, $id, $localKey);
+        parent::__construct($query, $parent, $id, $localKey, $relation);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -265,7 +265,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
 
-        return new HasMany($builder, $parent, 'table.foreign_key', 'id');
+        return new HasMany($builder, $parent, 'table.foreign_key', 'id', 'relations');
     }
 
     protected function expectNewModel($relation, $attributes = null)

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -210,6 +210,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $this->parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
         $this->parent->shouldReceive('newQueryWithoutScopes')->andReturn($this->builder);
+        $this->parent->shouldReceive('setRelation');
 
         return new HasOne($this->builder, $this->parent, 'table.foreign_key', 'id', 'relation');
     }

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -211,7 +211,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
         $this->parent->shouldReceive('newQueryWithoutScopes')->andReturn($this->builder);
 
-        return new HasOne($this->builder, $this->parent, 'table.foreign_key', 'id');
+        return new HasOne($this->builder, $this->parent, 'table.foreign_key', 'id', 'relation');
     }
 }
 

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -266,7 +266,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
 
-        return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+        return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_id', 'id', 'relation');
     }
 
     protected function getManyRelation()
@@ -281,7 +281,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
 
-        return new MorphMany($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+        return new MorphMany($builder, $parent, 'table.morph_type', 'table.morph_id', 'id', 'relations');
     }
 
     protected function getNamespacedRelation($alias)
@@ -302,7 +302,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $parent->shouldReceive('getMorphClass')->andReturn($alias);
         $builder->shouldReceive('where')->once()->with('table.morph_type', $alias);
 
-        return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+        return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_id', 'id', 'relation');
     }
 }
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -122,7 +122,7 @@ class DatabaseEloquentRelationTest extends TestCase
             $anotherBuilder->shouldReceive('whereNotNull');
             $anotherBuilder->shouldReceive('where');
             $anotherBuilder->shouldReceive('withoutGlobalScopes')->andReturnSelf();
-            $anotherRelation = new HasOne($anotherBuilder, $anotherParent, 'foreign_key', 'id');
+            $anotherRelation = new HasOne($anotherBuilder, $anotherParent, 'foreign_key', 'id', 'relation');
             $now = Carbon::now();
             $anotherRelated->shouldReceive('freshTimestampString')->andReturn($now);
             $anotherBuilder->shouldReceive('update')->once()->with(['updated_at' => $now]);

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -47,7 +47,7 @@ class DatabaseEloquentRelationTest extends TestCase
         $builder->shouldReceive('whereNotNull');
         $builder->shouldReceive('where');
         $builder->shouldReceive('withoutGlobalScopes')->andReturn($builder);
-        $relation = new HasOne($builder, $parent, 'foreign_key', 'id');
+        $relation = new HasOne($builder, $parent, 'foreign_key', 'id', 'relation');
         $related->shouldReceive('getTable')->andReturn('table');
         $related->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
         $now = Carbon::now();
@@ -77,7 +77,7 @@ class DatabaseEloquentRelationTest extends TestCase
             $builder->shouldReceive('whereNotNull');
             $builder->shouldReceive('where');
             $builder->shouldReceive('withoutGlobalScopes')->andReturn($builder);
-            $relation = new HasOne($builder, $parent, 'foreign_key', 'id');
+            $relation = new HasOne($builder, $parent, 'foreign_key', 'id', 'relation');
             $builder->shouldReceive('update')->never();
 
             $relation->touch();
@@ -109,7 +109,7 @@ class DatabaseEloquentRelationTest extends TestCase
             $builder->shouldReceive('whereNotNull');
             $builder->shouldReceive('where');
             $builder->shouldReceive('withoutGlobalScopes')->andReturnSelf();
-            $relation = new HasOne($builder, $parent, 'foreign_key', 'id');
+            $relation = new HasOne($builder, $parent, 'foreign_key', 'id', 'relation');
             $builder->shouldReceive('update')->never();
 
             $relation->touch();
@@ -159,7 +159,7 @@ class DatabaseEloquentRelationTest extends TestCase
             $builder->shouldReceive('whereNotNull');
             $builder->shouldReceive('where');
             $builder->shouldReceive('withoutGlobalScopes')->andReturnSelf();
-            $relation = new HasOne($builder, $parent, 'foreign_key', 'id');
+            $relation = new HasOne($builder, $parent, 'foreign_key', 'id', 'relation');
             $builder->shouldReceive('update')->never();
 
             $relation->touch();
@@ -172,7 +172,7 @@ class DatabaseEloquentRelationTest extends TestCase
             $anotherBuilder->shouldReceive('whereNotNull');
             $anotherBuilder->shouldReceive('where');
             $anotherBuilder->shouldReceive('withoutGlobalScopes')->andReturnSelf();
-            $anotherRelation = new HasOne($anotherBuilder, $anotherParent, 'foreign_key', 'id');
+            $anotherRelation = new HasOne($anotherBuilder, $anotherParent, 'foreign_key', 'id', 'relation');
             $anotherBuilder->shouldReceive('update')->never();
 
             $anotherRelation->touch();

--- a/tests/Integration/Database/EloquentRelationshipsTest.php
+++ b/tests/Integration/Database/EloquentRelationshipsTest.php
@@ -111,24 +111,24 @@ class CustomPost extends Post
         return new CustomBelongsTo($query, $child, $foreignKey, $ownerKey, $relation);
     }
 
-    protected function newHasMany(Builder $query, Model $parent, $foreignKey, $localKey)
+    protected function newHasMany(Builder $query, Model $parent, $foreignKey, $localKey, $relation)
     {
-        return new CustomHasMany($query, $parent, $foreignKey, $localKey);
+        return new CustomHasMany($query, $parent, $foreignKey, $localKey, $relation);
     }
 
-    protected function newHasOne(Builder $query, Model $parent, $foreignKey, $localKey)
+    protected function newHasOne(Builder $query, Model $parent, $foreignKey, $localKey, $relation)
     {
-        return new CustomHasOne($query, $parent, $foreignKey, $localKey);
+        return new CustomHasOne($query, $parent, $foreignKey, $localKey, $relation);
     }
 
-    protected function newMorphOne(Builder $query, Model $parent, $type, $id, $localKey)
+    protected function newMorphOne(Builder $query, Model $parent, $type, $id, $localKey, $relation)
     {
-        return new CustomMorphOne($query, $parent, $type, $id, $localKey);
+        return new CustomMorphOne($query, $parent, $type, $id, $localKey, $relation);
     }
 
-    protected function newMorphMany(Builder $query, Model $parent, $type, $id, $localKey)
+    protected function newMorphMany(Builder $query, Model $parent, $type, $id, $localKey, $relation)
     {
-        return new CustomMorphMany($query, $parent, $type, $id, $localKey);
+        return new CustomMorphMany($query, $parent, $type, $id, $localKey, $relation);
     }
 
     protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey,


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When you create a parent - child relationship from the child end, the relationship is set on the child:

```
$comment = new Comment;

var_export($comment->post); // --> NULL

$comment->post()->associate(Post::create())->save();

var_export($comment->post instanceof Post); // --> true
```

However, when you create the relationship from the parent end, this is currently not the case:

```
$post = Post::create();

var_export($post->comments->isEmpty()); // --> true

$post->comments()->save(new Comment());

var_export($post->comments->first() instanceof Comment); // false
```

I don't see why we shouldn't have the same behavior in both cases. This pull request adds a line to the `HasOneOrMany::save` method that makes this possible.

Seems that this idea was referenced way back in '13 in Issue #731, but nothing ever came of it.