### PR TITLE
Custom reset route in ResetPassword-Notification

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -9,14 +9,14 @@ use Illuminate\Notifications\Messages\MailMessage;
 class ResetPassword extends Notification
 {
     /**
-     * Route to reset password
+     * Route to reset password.
      *
      * @var string
      */
     public $resetPasswordRoute = 'password.reset';
 
     /**
-     * Config path to password's reset link expiration ttl
+     * Config path to password's reset link expiration time.
      *
      * @var string
      */

--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -9,6 +9,20 @@ use Illuminate\Notifications\Messages\MailMessage;
 class ResetPassword extends Notification
 {
     /**
+     * Route to reset password
+     *
+     * @var string
+     */
+    public $resetPasswordRoute = 'password.reset';
+
+    /**
+     * Config path to password's reset link expiration ttl
+     *
+     * @var string
+     */
+    public $resetPasswordLinkTtlConfigPath = 'auth.passwords.users.expire';
+
+    /**
      * The password reset token.
      *
      * @var string
@@ -59,8 +73,8 @@ class ResetPassword extends Notification
         return (new MailMessage)
             ->subject(Lang::getFromJson('Reset Password Notification'))
             ->line(Lang::getFromJson('You are receiving this email because we received a password reset request for your account.'))
-            ->action(Lang::getFromJson('Reset Password'), url(config('app.url').route('password.reset', ['token' => $this->token], false)))
-            ->line(Lang::getFromJson('This password reset link will expire in :count minutes.', ['count' => config('auth.passwords.users.expire')]))
+            ->action(Lang::getFromJson('Reset Password'), url(config('app.url').route($this->resetPasswordRoute, ['token' => $this->token], false)))
+            ->line(Lang::getFromJson('This password reset link will expire in :count minutes.', ['count' => config($this->resetPasswordLinkTtlConfigPath)]))
             ->line(Lang::getFromJson('If you did not request a password reset, no further action is required.'));
     }
 


### PR DESCRIPTION
Similar to https://github.com/laravel/framework/pull/27488, this simplify changing the hardcoded-route:

```
    /**
     * @see CanResetPassword::sendPasswordResetNotification()
     *
     * @param  string  $token
     * @return void
     */
    public function sendPasswordResetNotification($token)
    {
        $notification = new ResetPassword($token);
        $notification->resetPasswordRoute = 'agencies.password.reset';
        $notification->resetPasswordLinkTtlConfigPath = 'auth.passwords.managers.expire';
        $this->notify($notification);
    }
```
