### PR TITLE
[5.8] Specify a global storage directory prefix dynamically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
-    - php: 7.1
-      env: SETUP=lowest
     - php: 7.2
     - php: 7.2
       env: SETUP=lowest

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -9,7 +9,7 @@ then
     exit 1
 fi
 
-CURRENT_BRANCH="5.8"
+CURRENT_BRANCH="5.9"
 VERSION=$1
 
 # Always prepend with "v"

--- a/bin/split.sh
+++ b/bin/split.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-CURRENT_BRANCH="5.8"
+CURRENT_BRANCH="master"
 
 function split()
 {

--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "league/flysystem-cached-adapter": "^1.0",
         "mockery/mockery": "^1.0",
         "moontoast/math": "^1.1",
-        "orchestra/testbench-core": "3.8.*",
+        "orchestra/testbench-core": "3.9.*",
         "pda/pheanstalk": "^4.0",
         "phpunit/phpunit": "^7.5|^8.0",
         "predis/predis": "^1.1.1",

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.9.*",
         "illuminate/http": "5.9.*",
         "illuminate/queue": "5.9.*",

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/http": "5.8.*",
-        "illuminate/queue": "5.8.*",
-        "illuminate/support": "5.8.*"
+        "illuminate/contracts": "5.9.*",
+        "illuminate/http": "5.9.*",
+        "illuminate/queue": "5.9.*",
+        "illuminate/support": "5.9.*"
     },
     "autoload": {
         "psr-4": {
@@ -27,13 +27,13 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "suggest": {
-        "illuminate/console": "Required to use the auth:clear-resets command (5.8.*).",
-        "illuminate/queue": "Required to fire login / logout events (5.8.*).",
-        "illuminate/session": "Required to use the session based guard (5.8.*)."
+        "illuminate/console": "Required to use the auth:clear-resets command (5.9.*).",
+        "illuminate/queue": "Required to fire login / logout events (5.9.*).",
+        "illuminate/session": "Required to use the session based guard (5.9.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -17,10 +17,10 @@
         "php": "^7.1.3",
         "ext-json": "*",
         "psr/log": "^1.0",
-        "illuminate/bus": "5.8.*",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/queue": "5.8.*",
-        "illuminate/support": "5.8.*"
+        "illuminate/bus": "5.9.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/queue": "5.9.*",
+        "illuminate/support": "5.9.*"
     },
     "autoload": {
         "psr-4": {
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "suggest": {

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "psr/log": "^1.0",
         "illuminate/bus": "5.9.*",

--- a/src/Illuminate/Bus/composer.json
+++ b/src/Illuminate/Bus/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/pipeline": "5.8.*",
-        "illuminate/support": "5.8.*"
+        "illuminate/contracts": "5.9.*",
+        "illuminate/pipeline": "5.9.*",
+        "illuminate/support": "5.9.*"
     },
     "autoload": {
         "psr-4": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Bus/composer.json
+++ b/src/Illuminate/Bus/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.9.*",
         "illuminate/pipeline": "5.9.*",
         "illuminate/support": "5.9.*"

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.9.*",
         "illuminate/support": "5.9.*"
     },

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*"
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,13 +25,13 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "suggest": {
-        "illuminate/database": "Required to use the database cache driver (5.8.*).",
-        "illuminate/filesystem": "Required to use the file cache driver (5.8.*).",
-        "illuminate/redis": "Required to use the redis cache driver (5.8.*)."
+        "illuminate/database": "Required to use the database cache driver (5.9.*).",
+        "illuminate/filesystem": "Required to use the file cache driver (5.9.*).",
+        "illuminate/redis": "Required to use the redis cache driver (5.9.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Config/composer.json
+++ b/src/Illuminate/Config/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.9.*",
         "illuminate/support": "5.9.*"
     },

--- a/src/Illuminate/Config/composer.json
+++ b/src/Illuminate/Config/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*"
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*",
         "symfony/console": "^4.2",
         "symfony/process": "^4.2"
     },
@@ -27,13 +27,13 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "suggest": {
         "dragonmantank/cron-expression": "Required to use scheduling component (^2.0).",
         "guzzlehttp/guzzle": "Required to use the ping methods on schedules (^6.0).",
-        "illuminate/filesystem": "Required to use the generator command (5.8.*)"
+        "illuminate/filesystem": "Required to use the generator command (5.9.*)"
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.9.*",
         "illuminate/support": "5.9.*",
         "symfony/console": "^4.2",

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*",
         "psr/container": "^1.0"
     },
     "autoload": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.9.*",
         "illuminate/support": "5.9.*",
         "psr/container": "^1.0"

--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -202,7 +202,7 @@ interface Filesystem
      * @return string
      */
     public function getPathPrefix();
-    
+
     /**
      * Set a new path prefix.
      *

--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -195,4 +195,19 @@ interface Filesystem
      * @return bool
      */
     public function deleteDirectory($directory);
+
+    /**
+     * Get the current path prefix.
+     *
+     * @return string
+     */
+    public function getPathPrefix();
+    
+    /**
+     * Set a new path prefix.
+     *
+     * @param  string  $path
+     * @return bool
+     */
+    public function setPathPrefix($path);
 }

--- a/src/Illuminate/Contracts/composer.json
+++ b/src/Illuminate/Contracts/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "psr/container": "^1.0",
         "psr/simple-cache": "^1.0"
     },

--- a/src/Illuminate/Contracts/composer.json
+++ b/src/Illuminate/Contracts/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.9.*",
         "illuminate/support": "5.9.*",
         "symfony/http-foundation": "^4.2",

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*",
         "symfony/http-foundation": "^4.2",
         "symfony/http-kernel": "^4.2"
     },
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -368,15 +368,4 @@ class BelongsTo extends Relation
     {
         return $this->relationName;
     }
-
-    /**
-     * Get the name of the relationship.
-     *
-     * @return string
-     * @deprecated The getRelationName() method should be used instead. Will be removed in Laravel 5.9.
-     */
-    public function getRelation()
-    {
-        return $this->relationName;
-    }
 }

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -17,9 +17,9 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
-        "illuminate/container": "5.8.*",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*"
+        "illuminate/container": "5.9.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*"
     },
     "autoload": {
         "psr-4": {
@@ -28,16 +28,16 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "suggest": {
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (^1.4).",
-        "illuminate/console": "Required to use the database commands (5.8.*).",
-        "illuminate/events": "Required to use the observers with Eloquent (5.8.*).",
-        "illuminate/filesystem": "Required to use the migrations (5.8.*).",
-        "illuminate/pagination": "Required to paginate the result set (5.8.*)."
+        "illuminate/console": "Required to use the database commands (5.9.*).",
+        "illuminate/events": "Required to use the observers with Eloquent (5.9.*).",
+        "illuminate/filesystem": "Required to use the migrations (5.9.*).",
+        "illuminate/pagination": "Required to paginate the result set (5.9.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "illuminate/container": "5.9.*",
         "illuminate/contracts": "5.9.*",

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -18,8 +18,8 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*"
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*"
     },
     "autoload": {
         "psr-4": {
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/container": "5.8.*",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*"
+        "illuminate/container": "5.9.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*"
     },
     "autoload": {
         "psr-4": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/container": "5.9.*",
         "illuminate/contracts": "5.9.*",
         "illuminate/support": "5.9.*"

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -658,7 +658,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      */
     public function getPathPrefix()
     {
-        return $this->getDriver()->getAdapter()->getPathPrefix();
+        return $this->driver->getAdapter()->getPathPrefix();
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -663,7 +663,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
 
     /**
      * Set a new path prefix.
-     * 
+     *
      * @param  string  $path
      * @return void
      */

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -652,6 +652,29 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     }
 
     /**
+     * Get the current path prefix.
+     *
+     * @return string
+     */
+    public function getPathPrefix()
+    {
+        return $this->getDriver()->getAdapter()->getPathPrefix();
+    }
+    
+    /**
+     *  Set a new path prefix.
+     * 
+     * @param  string  $path
+     * @return void
+    */
+    public function setPathPrefix($path)
+    {
+        return $this->driver->getAdapter()->setPathPrefix(
+            $this->getPathPrefix().$path
+        );
+    }
+
+    /**
      * Flush the Flysystem cache.
      *
      * @return void

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -660,13 +660,13 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     {
         return $this->getDriver()->getAdapter()->getPathPrefix();
     }
-    
+
     /**
-     *  Set a new path prefix.
+     * Set a new path prefix.
      * 
      * @param  string  $path
      * @return void
-    */
+     */
     public function setPathPrefix($path)
     {
         return $this->driver->getAdapter()->setPathPrefix(

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*",
         "symfony/finder": "^4.2"
     },
     "autoload": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "suggest": {

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.9.*",
         "illuminate/support": "5.9.*",
         "symfony/finder": "^4.2"

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -29,7 +29,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.8-dev';
+    const VERSION = '5.9-dev';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.9.*",
         "illuminate/support": "5.9.*"
     },

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*"
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "illuminate/session": "5.9.*",
         "illuminate/support": "5.9.*",

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
-        "illuminate/session": "5.8.*",
-        "illuminate/support": "5.8.*",
+        "illuminate/session": "5.9.*",
+        "illuminate/support": "5.9.*",
         "symfony/http-foundation": "^4.2",
         "symfony/http-kernel": "^4.2"
     },
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*",
         "monolog/monolog": "^1.11"
     },
     "autoload": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.9.*",
         "illuminate/support": "5.9.*",
         "monolog/monolog": "^1.11"

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -17,9 +17,9 @@
         "php": "^7.1.3",
         "ext-json": "*",
         "erusev/parsedown": "^1.7",
-        "illuminate/container": "5.8.*",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*",
+        "illuminate/container": "5.9.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*",
         "psr/log": "^1.0",
         "swiftmailer/swiftmailer": "^6.0",
         "tijsverkoyen/css-to-inline-styles": "^2.2.1"
@@ -31,7 +31,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "suggest": {

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "erusev/parsedown": "^1.7",
         "illuminate/container": "5.9.*",

--- a/src/Illuminate/Notifications/composer.json
+++ b/src/Illuminate/Notifications/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/broadcasting": "5.9.*",
         "illuminate/bus": "5.9.*",
         "illuminate/container": "5.9.*",

--- a/src/Illuminate/Notifications/composer.json
+++ b/src/Illuminate/Notifications/composer.json
@@ -15,14 +15,14 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/broadcasting": "5.8.*",
-        "illuminate/bus": "5.8.*",
-        "illuminate/container": "5.8.*",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/filesystem": "5.8.*",
-        "illuminate/mail": "5.8.*",
-        "illuminate/queue": "5.8.*",
-        "illuminate/support": "5.8.*"
+        "illuminate/broadcasting": "5.9.*",
+        "illuminate/bus": "5.9.*",
+        "illuminate/container": "5.9.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/filesystem": "5.9.*",
+        "illuminate/mail": "5.9.*",
+        "illuminate/queue": "5.9.*",
+        "illuminate/support": "5.9.*"
     },
     "autoload": {
         "psr-4": {
@@ -31,11 +31,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "suggest": {
-        "illuminate/database": "Required to use the database transport (5.8.*)."
+        "illuminate/database": "Required to use the database transport (5.9.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*"
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*"
     },
     "autoload": {
         "psr-4": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "illuminate/contracts": "5.9.*",
         "illuminate/support": "5.9.*"

--- a/src/Illuminate/Pipeline/composer.json
+++ b/src/Illuminate/Pipeline/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.9.*",
         "illuminate/support": "5.9.*"
     },

--- a/src/Illuminate/Pipeline/composer.json
+++ b/src/Illuminate/Pipeline/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*"
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -16,12 +16,12 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
-        "illuminate/console": "5.8.*",
-        "illuminate/container": "5.8.*",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/database": "5.8.*",
-        "illuminate/filesystem": "5.8.*",
-        "illuminate/support": "5.8.*",
+        "illuminate/console": "5.9.*",
+        "illuminate/container": "5.9.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/database": "5.9.*",
+        "illuminate/filesystem": "5.9.*",
+        "illuminate/support": "5.9.*",
         "opis/closure": "^3.1",
         "symfony/debug": "^4.2",
         "symfony/process": "^4.2"
@@ -33,14 +33,14 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "suggest": {
         "ext-pcntl": "Required to use all features of the queue worker.",
         "ext-posix": "Required to use all features of the queue worker.",
         "aws/aws-sdk-php": "Required to use the SQS queue driver (^3.0).",
-        "illuminate/redis": "Required to use the Redis queue driver (5.8.*).",
+        "illuminate/redis": "Required to use the Redis queue driver (5.9.*).",
         "pda/pheanstalk": "Required to use the Beanstalk queue driver (^4.0)."
     },
     "config": {

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "illuminate/console": "5.9.*",
         "illuminate/container": "5.9.*",

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*",
         "predis/predis": "^1.0"
     },
     "autoload": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/contracts": "5.9.*",
         "illuminate/support": "5.9.*",
         "predis/predis": "^1.0"

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "illuminate/container": "5.9.*",
         "illuminate/contracts": "5.9.*",

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -16,12 +16,12 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
-        "illuminate/container": "5.8.*",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/http": "5.8.*",
-        "illuminate/pipeline": "5.8.*",
-        "illuminate/session": "5.8.*",
-        "illuminate/support": "5.8.*",
+        "illuminate/container": "5.9.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/http": "5.9.*",
+        "illuminate/pipeline": "5.9.*",
+        "illuminate/session": "5.9.*",
+        "illuminate/support": "5.9.*",
         "symfony/debug": "^4.2",
         "symfony/http-foundation": "^4.2",
         "symfony/http-kernel": "^4.2",
@@ -34,11 +34,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "suggest": {
-        "illuminate/console": "Required to use the make commands (5.8.*).",
+        "illuminate/console": "Required to use the make commands (5.9.*).",
         "symfony/psr-http-message-bridge": "Required to psr7 bridging features (^1.1)."
     },
     "config": {

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "illuminate/contracts": "5.9.*",
         "illuminate/filesystem": "5.9.*",

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -16,9 +16,9 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/filesystem": "5.8.*",
-        "illuminate/support": "5.8.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/filesystem": "5.9.*",
+        "illuminate/support": "5.9.*",
         "symfony/finder": "^4.2",
         "symfony/http-foundation": "^4.2"
     },
@@ -29,11 +29,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "suggest": {
-        "illuminate/console": "Required to use the session:table command (5.8.*)."
+        "illuminate/console": "Required to use the session:table command (5.9.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -15,15 +15,6 @@ abstract class ServiceProvider
     protected $app;
 
     /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @deprecated Implement the \Illuminate\Contracts\Support\DeferrableProvider interface instead. Will be removed in Laravel 5.9.
-     *
-     * @var bool
-     */
-    protected $defer = false;
-
-    /**
      * The paths that should be published.
      *
      * @var array
@@ -300,6 +291,6 @@ abstract class ServiceProvider
      */
     public function isDeferred()
     {
-        return $this->defer || $this instanceof DeferrableProvider;
+        return $this instanceof DeferrableProvider;
     }
 }

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -18,7 +18,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "doctrine/inflector": "^1.1",
-        "illuminate/contracts": "5.8.*",
+        "illuminate/contracts": "5.9.*",
         "nesbot/carbon": "^1.26.3 || ^2.0"
     },
     "conflict": {
@@ -34,11 +34,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "suggest": {
-        "illuminate/filesystem": "Required to use the composer class (5.8.*).",
+        "illuminate/filesystem": "Required to use the composer class (5.9.*).",
         "moontoast/math": "Required to use ordered UUIDs (^1.1).",
         "ramsey/uuid": "Required to use Str::uuid() (^3.7).",
         "symfony/process": "Required to use the composer class (^4.2).",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "ext-mbstring": "*",
         "doctrine/inflector": "^1.1",

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -16,9 +16,9 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/filesystem": "5.8.*",
-        "illuminate/support": "5.8.*"
+        "illuminate/contracts": "5.9.*",
+        "illuminate/filesystem": "5.9.*",
+        "illuminate/support": "5.9.*"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "illuminate/contracts": "5.9.*",
         "illuminate/filesystem": "5.9.*",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "egulias/email-validator": "^2.0",
         "illuminate/container": "5.9.*",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -17,10 +17,10 @@
         "php": "^7.1.3",
         "ext-json": "*",
         "egulias/email-validator": "^2.0",
-        "illuminate/container": "5.8.*",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/support": "5.8.*",
-        "illuminate/translation": "5.8.*",
+        "illuminate/container": "5.9.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/support": "5.9.*",
+        "illuminate/translation": "5.9.*",
         "symfony/http-foundation": "^4.2"
     },
     "autoload": {
@@ -30,11 +30,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "suggest": {
-        "illuminate/database": "Required to use the database presence verifier (5.8.*)."
+        "illuminate/database": "Required to use the database presence verifier (5.9.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-json": "*",
         "illuminate/container": "5.9.*",
         "illuminate/contracts": "5.9.*",

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -16,11 +16,11 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
-        "illuminate/container": "5.8.*",
-        "illuminate/contracts": "5.8.*",
-        "illuminate/events": "5.8.*",
-        "illuminate/filesystem": "5.8.*",
-        "illuminate/support": "5.8.*",
+        "illuminate/container": "5.9.*",
+        "illuminate/contracts": "5.9.*",
+        "illuminate/events": "5.9.*",
+        "illuminate/filesystem": "5.9.*",
+        "illuminate/support": "5.9.*",
         "symfony/debug": "^4.2"
     },
     "autoload": {
@@ -30,7 +30,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.8-dev"
+            "dev-master": "5.9-dev"
         }
     },
     "config": {

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -53,7 +53,7 @@ class ConsoleApplicationTest extends TestCase
     public function testCallFullyStringCommandLine()
     {
         $app = new Application(
-            $app = m::mock(ApplicationContract::class, ['version' => '5.8']),
+            $app = m::mock(ApplicationContract::class, ['version' => '5.9']),
             $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
             'testing'
         );
@@ -72,7 +72,7 @@ class ConsoleApplicationTest extends TestCase
 
     protected function getMockConsole(array $methods)
     {
-        $app = m::mock(ApplicationContract::class, ['version' => '5.8']);
+        $app = m::mock(ApplicationContract::class, ['version' => '5.9']);
         $events = m::mock(Dispatcher::class, ['dispatch' => null]);
 
         return $this->getMockBuilder(Application::class)->setMethods($methods)->setConstructorArgs([

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -197,7 +197,7 @@ class FilesystemAdapterTest extends TestCase
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $this->assertEquals($this->tempDir.'/', $filesystemAdapter->getPathPrefix());
     }
-    
+
     public function testSetPathPrefix()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -191,4 +191,17 @@ class FilesystemAdapterTest extends TestCase
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $filesystemAdapter->writeStream('file.txt', 'foo bar');
     }
+
+    public function testGetPathPrefix()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem);
+        $this->assertEquals($this->tempDir.'/', $filesystemAdapter->getPathPrefix());
+    }
+    
+    public function testSetPathPrefix()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem);
+        $filesystemAdapter->setPathPrefix('teams/1');
+        $this->assertEquals($this->tempDir.'/teams/1/', $filesystemAdapter->getPathPrefix());
+    }
 }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Events\LocaleUpdated;
+use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Foundation\Bootstrap\RegisterFacades;
 
 class FoundationApplicationTest extends TestCase
@@ -324,10 +325,8 @@ class ApplicationBasicServiceProviderStub extends ServiceProvider
     }
 }
 
-class ApplicationDeferredSharedServiceProviderStub extends ServiceProvider
+class ApplicationDeferredSharedServiceProviderStub extends ServiceProvider implements DeferrableProvider
 {
-    protected $defer = true;
-
     public function register()
     {
         $this->app->singleton('foo', function () {
@@ -336,10 +335,9 @@ class ApplicationDeferredSharedServiceProviderStub extends ServiceProvider
     }
 }
 
-class ApplicationDeferredServiceProviderCountStub extends ServiceProvider
+class ApplicationDeferredServiceProviderCountStub extends ServiceProvider implements DeferrableProvider
 {
     public static $count = 0;
-    protected $defer = true;
 
     public function register()
     {
@@ -348,10 +346,9 @@ class ApplicationDeferredServiceProviderCountStub extends ServiceProvider
     }
 }
 
-class ApplicationDeferredServiceProviderStub extends ServiceProvider
+class ApplicationDeferredServiceProviderStub extends ServiceProvider implements DeferrableProvider
 {
     public static $initialized = false;
-    protected $defer = true;
 
     public function register()
     {
@@ -360,10 +357,8 @@ class ApplicationDeferredServiceProviderStub extends ServiceProvider
     }
 }
 
-class ApplicationFactoryProviderStub extends ServiceProvider
+class ApplicationFactoryProviderStub extends ServiceProvider implements DeferrableProvider
 {
-    protected $defer = true;
-
     public function register()
     {
         $this->app->bind('foo', function () {
@@ -374,10 +369,8 @@ class ApplicationFactoryProviderStub extends ServiceProvider
     }
 }
 
-class ApplicationMultiProviderStub extends ServiceProvider
+class ApplicationMultiProviderStub extends ServiceProvider implements DeferrableProvider
 {
-    protected $defer = true;
-
     public function register()
     {
         $this->app->singleton('foo', function () {

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -146,7 +146,7 @@ class MailableStub extends Mailable implements MailableContract
 {
     public $framework = 'Laravel';
 
-    protected $version = '5.8';
+    protected $version = '5.9';
 
     /**
      * Build the message.
@@ -164,7 +164,7 @@ class QueueableMailableStub extends Mailable implements ShouldQueue
 {
     public $framework = 'Laravel';
 
-    protected $version = '5.8';
+    protected $version = '5.9';
 
     /**
      * Build the message.


### PR DESCRIPTION
This pull request adds the ability for users to dynamically specify a global storage directory prefix.

Laravel is being used more and more to develop large applications, many of which are multi-tenanted. Users may find it useful to be able to always store files in a specific folder depending on the tenant/team/organisation.

For example, the directory by default could be something like `/assets`. With this PR users would be able to make the filesystem automatically store it in a directory structure such as `/assets/{teamName}`. This could be accomplished by the following:

```php
Storage::setPathPrefix(Auth::user()->team()->name);
```

As this functionality is already available, this PR adds minimal risk as it is just opening up already existing functionality to the user.