### PR TITLE
[5.8] Specify a global storage directory prefix dynamically

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -208,6 +208,6 @@ interface Filesystem
      *
      * @param  string  $path
      * @return bool
-    */
+     */
     public function setPathPrefix($path);
 }

--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -195,4 +195,19 @@ interface Filesystem
      * @return bool
      */
     public function deleteDirectory($directory);
+
+    /**
+     * Get the current path prefix.
+     *
+     * @return string
+     */
+    public function getPathPrefix();
+
+    /**
+     * Set a new path prefix.
+     *
+     * @param  string  $path
+     * @return bool
+    */
+    public function setPathPrefix($path);
 }

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -666,7 +666,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      *
      * @param  string  $path
      * @return void
-    */
+     */
     public function setPathPrefix($path)
     {
         return $this->driver->getAdapter()->setPathPrefix(

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -652,6 +652,29 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     }
 
     /**
+     * Get the current path prefix.
+     *
+     * @return string
+     */
+    public function getPathPrefix()
+    {
+        return $this->driver->getAdapter()->getPathPrefix();
+    }
+
+    /**
+     * Set a new path prefix.
+     *
+     * @param  string  $path
+     * @return void
+    */
+    public function setPathPrefix($path)
+    {
+        return $this->driver->getAdapter()->setPathPrefix(
+            $this->getPathPrefix().$path
+        );
+    }
+
+    /**
      * Flush the Flysystem cache.
      *
      * @return void

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -191,4 +191,17 @@ class FilesystemAdapterTest extends TestCase
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $filesystemAdapter->writeStream('file.txt', 'foo bar');
     }
+
+    public function testGetPathPrefix()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem);
+        $this->assertEquals($this->tempDir.'/', $filesystemAdapter->getPathPrefix());
+    }
+
+    public function testSetPathPrefix()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem);
+        $filesystemAdapter->setPathPrefix('teams/1');
+        $this->assertEquals($this->tempDir.'/teams/1/', $filesystemAdapter->getPathPrefix());
+    }
 }


### PR DESCRIPTION
This pull request adds the ability for users to dynamically specify a global storage directory prefix.

Laravel is being used more and more to develop large applications, many of which are multi-tenanted. Users may find it useful to be able to always store files in a specific folder depending on the tenant/team/organisation.

For example, the directory by default could be something like `/assets`. With this PR users would be able to make the filesystem automatically store it in a directory structure such as `/assets/{teamName}`. This could be accomplished by the following:

```php
Storage::setPathPrefix(Auth::user()->team()->name);
```

As this functionality is already available, this PR adds minimal risk as it is just opening up already existing functionality to the user.