### PR TITLE
[5.6] Use consistentCarbon versioning across 5.5, 5.6 and 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "erusev/parsedown": "~1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "~1.12",
-        "nesbot/carbon": "1.26.*",
+        "nesbot/carbon": "^1.26",
         "psr/container": "~1.0",
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^3.7",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -18,7 +18,7 @@
         "ext-mbstring": "*",
         "doctrine/inflector": "~1.1",
         "illuminate/contracts": "5.6.*",
-        "nesbot/carbon": "1.26.*"
+        "nesbot/carbon": "^1.26"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"


### PR DESCRIPTION
Rather than upgrading from only 1.25 to 1.26 (https://github.com/laravel/framework/commit/b12feabda70f136cb2d7081af41441a0bf22edc7), version should be aligned on 5.5, 5.6 and 5.7 with `^1.26`.

`1.26.*` is no longer maintained, far from last version `1` and even more from `2` (current state of documentation).

And version `1` only receive security/language fixes. All new features are added only in version `2`.

This means you can safely use the current 1 (`1.36.2`) as `^1` release frequency is now very slow, and will now have no method added, and no test changed.