### PR TITLE
[5.6] Adds Ability to disable callbacks

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -162,7 +162,7 @@ class FactoryBuilder
     }
 
     /**
-     * Disable after callbacks
+     * Disable after callbacks.
      *
      * @return $this
      */

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -60,9 +60,9 @@ class FactoryBuilder
     protected $afterCreating = [];
 
     /**
-     * If should run after callbacks
+     * If callbacks should run.
      *
-     * @var boolean
+     * @var bool
      */
     protected $shouldRunAfterCallbacks = true;
 
@@ -423,7 +423,7 @@ class FactoryBuilder
      */
     protected function callAfter(array $afterCallbacks, $models)
     {
-        if($this->shouldRunAfterCallbacks) {
+        if ($this->shouldRunAfterCallbacks) {
             $states = array_merge([$this->name], $this->activeStates);
 
             $models->each(function ($model) use ($states, $afterCallbacks) {

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -60,6 +60,13 @@ class FactoryBuilder
     protected $afterCreating = [];
 
     /**
+     * If should run after callbacks
+     *
+     * @var boolean
+     */
+    protected $shouldRunAfterCallbacks = true;
+
+    /**
      * The states to apply.
      *
      * @var array
@@ -150,6 +157,18 @@ class FactoryBuilder
     public function connection($name)
     {
         $this->connection = $name;
+
+        return $this;
+    }
+
+    /**
+     * Disable after callbacks
+     *
+     * @return $this
+     */
+    public function withoutCallbacks()
+    {
+        $this->shouldRunAfterCallbacks = false;
 
         return $this;
     }
@@ -404,13 +423,15 @@ class FactoryBuilder
      */
     protected function callAfter(array $afterCallbacks, $models)
     {
-        $states = array_merge([$this->name], $this->activeStates);
+        if($this->shouldRunAfterCallbacks) {
+            $states = array_merge([$this->name], $this->activeStates);
 
-        $models->each(function ($model) use ($states, $afterCallbacks) {
-            foreach ($states as $state) {
-                $this->callAfterCallbacks($afterCallbacks, $model, $state);
-            }
-        });
+            $models->each(function ($model) use ($states, $afterCallbacks) {
+                foreach ($states as $state) {
+                    $this->callAfterCallbacks($afterCallbacks, $model, $state);
+                }
+            });
+        }
     }
 
     /**

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -249,12 +249,29 @@ class EloquentFactoryBuilderTest extends TestCase
     }
 
     /** @test **/
+    public function can_disable_callback_when_creating_models_with_after_callback()
+    {
+        $team = factory(FactoryBuildableTeam::class)->withoutCallbacks()->create();
+
+        $this->assertFalse($team->users->contains($team->owner));
+    }
+
+    /** @test **/
     public function creating_models_with_after_callback_state()
     {
         $user = factory(FactoryBuildableUser::class)->state('with_callable_server')->create();
 
         $this->assertNotNull($user->profile);
         $this->assertNotNull($user->servers->where('status', 'callable')->first());
+    }
+
+    /** @test **/
+    public function can_disable_callback_when_creating_models_with_after_callback_state()
+    {
+        $user = factory(FactoryBuildableUser::class)->withoutCallbacks()->state('with_callable_server')->create();
+
+        $this->assertNull($user->profile);
+        $this->assertNull($user->servers->where('status', 'callable')->first());
     }
 
     /** @test */
@@ -276,12 +293,29 @@ class EloquentFactoryBuilderTest extends TestCase
     }
 
     /** @test **/
+    public function can_disable_making_models_with_after_callback()
+    {
+        $user = factory(FactoryBuildableUser::class)->withoutCallbacks()->make();
+
+        $this->assertNull($user->profile);
+    }
+
+    /** @test **/
     public function making_models_with_after_callback_state()
     {
         $user = factory(FactoryBuildableUser::class)->state('with_callable_server')->make();
 
         $this->assertNotNull($user->profile);
         $this->assertNotNull($user->servers->where('status', 'callable')->first());
+    }
+
+    /** @test **/
+    public function can_disable_callbacks_when_making_models_with_after_callback_state()
+    {
+        $user = factory(FactoryBuildableUser::class)->withoutCallbacks()->state('with_callable_server')->make();
+
+        $this->assertNull($user->profile);
+        $this->assertNull($user->servers->where('status', 'callable')->first());
     }
 }
 

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -249,7 +249,7 @@ class EloquentFactoryBuilderTest extends TestCase
     }
 
     /** @test **/
-    public function can_disable_callback_when_creating_models_with_after_callback()
+    public function can_disable_callbacks_when_creating_models_with_after_callback()
     {
         $team = factory(FactoryBuildableTeam::class)->withoutCallbacks()->create();
 
@@ -266,7 +266,7 @@ class EloquentFactoryBuilderTest extends TestCase
     }
 
     /** @test **/
-    public function can_disable_callback_when_creating_models_with_after_callback_state()
+    public function can_disable_callbacks_when_creating_models_with_after_callback_state()
     {
         $user = factory(FactoryBuildableUser::class)->withoutCallbacks()->state('with_callable_server')->create();
 
@@ -293,7 +293,7 @@ class EloquentFactoryBuilderTest extends TestCase
     }
 
     /** @test **/
-    public function can_disable_making_models_with_after_callback()
+    public function can_disable_callbacks_when_making_models_with_after_callback()
     {
         $user = factory(FactoryBuildableUser::class)->withoutCallbacks()->make();
 


### PR DESCRIPTION
Adds the withoutCallbacks method to disable callbacks when using factories.

eg: `factory(User::class)->withoutCallbacks()->create();`
