### PR TITLE
[5.7] Add disable callbacks

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -60,6 +60,13 @@ class FactoryBuilder
     protected $afterCreating = [];
 
     /**
+     * If should run after callbacks
+     *
+     * @var boolean
+     */
+    protected $shouldRunAfterCallbacks = true;
+
+    /**
      * The states to apply.
      *
      * @var array
@@ -150,6 +157,18 @@ class FactoryBuilder
     public function connection($name)
     {
         $this->connection = $name;
+
+        return $this;
+    }
+
+    /**
+     * Disable after callbacks
+     *
+     * @return $this
+     */
+    public function withoutCallbacks()
+    {
+        $this->shouldRunAfterCallbacks = false;
 
         return $this;
     }
@@ -406,13 +425,15 @@ class FactoryBuilder
      */
     protected function callAfter(array $afterCallbacks, $models)
     {
-        $states = array_merge([$this->name], $this->activeStates);
+        if($this->shouldRunAfterCallbacks) {
+            $states = array_merge([$this->name], $this->activeStates);
 
-        $models->each(function ($model) use ($states, $afterCallbacks) {
-            foreach ($states as $state) {
-                $this->callAfterCallbacks($afterCallbacks, $model, $state);
-            }
-        });
+            $models->each(function ($model) use ($states, $afterCallbacks) {
+                foreach ($states as $state) {
+                    $this->callAfterCallbacks($afterCallbacks, $model, $state);
+                }
+            });
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -162,7 +162,7 @@ class FactoryBuilder
     }
 
     /**
-     * Disable after callbacks
+     * Disable after callbacks.
      *
      * @return $this
      */

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -60,9 +60,9 @@ class FactoryBuilder
     protected $afterCreating = [];
 
     /**
-     * If should run after callbacks
+     * If callbacks should run.
      *
-     * @var boolean
+     * @var bool
      */
     protected $shouldRunAfterCallbacks = true;
 
@@ -425,7 +425,7 @@ class FactoryBuilder
      */
     protected function callAfter(array $afterCallbacks, $models)
     {
-        if($this->shouldRunAfterCallbacks) {
+        if ($this->shouldRunAfterCallbacks) {
             $states = array_merge([$this->name], $this->activeStates);
 
             $models->each(function ($model) use ($states, $afterCallbacks) {

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -227,16 +227,14 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertTrue($team->users->contains($team->owner));
     }
 
-    /** @test **/
-    public function can_disable_callbacks_when_creating_models_with_after_callback()
+    public function test_can_disable_callbacks_when_creating_models_with_after_callback()
     {
         $team = factory(FactoryBuildableTeam::class)->withoutCallbacks()->create();
 
         $this->assertFalse($team->users->contains($team->owner));
     }
 
-    /** @test **/
-    public function creating_models_with_after_callback_state()
+    public function test_creating_models_with_after_callback_state()
     {
         $user = factory(FactoryBuildableUser::class)->state('with_callable_server')->create();
 
@@ -244,8 +242,7 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertNotNull($user->servers->where('status', 'callable')->first());
     }
 
-    /** @test **/
-    public function can_disable_callbacks_when_creating_models_with_after_callback_state()
+    public function test_can_disable_callbacks_when_creating_models_with_after_callback_state()
     {
         $user = factory(FactoryBuildableUser::class)->withoutCallbacks()->state('with_callable_server')->create();
 
@@ -254,7 +251,7 @@ class EloquentFactoryBuilderTest extends TestCase
     }
 
     /** @test */
-    public function making_models_with_a_custom_connection()
+    public function test_making_models_with_a_custom_connection()
     {
         $user = factory(FactoryBuildableUser::class)
             ->connection('alternative-connection')
@@ -270,16 +267,14 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertNotNull($user->profile);
     }
 
-    /** @test **/
-    public function can_disable_callbacks_when_making_models_with_after_callback()
+    public function test_can_disable_callbacks_when_making_models_with_after_callback()
     {
         $user = factory(FactoryBuildableUser::class)->withoutCallbacks()->make();
 
         $this->assertNull($user->profile);
     }
 
-    /** @test **/
-    public function making_models_with_after_callback_state()
+    public function test_making_models_with_after_callback_state()
     {
         $user = factory(FactoryBuildableUser::class)->state('with_callable_server')->make();
 
@@ -287,8 +282,7 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertNotNull($user->servers->where('status', 'callable')->first());
     }
 
-    /** @test **/
-    public function can_disable_callbacks_when_making_models_with_after_callback_state()
+    public function test_can_disable_callbacks_when_making_models_with_after_callback_state()
     {
         $user = factory(FactoryBuildableUser::class)->withoutCallbacks()->state('with_callable_server')->make();
 

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -228,7 +228,7 @@ class EloquentFactoryBuilderTest extends TestCase
     }
 
     /** @test **/
-    public function can_disable_callback_when_creating_models_with_after_callback()
+    public function can_disable_callbacks_when_creating_models_with_after_callback()
     {
         $team = factory(FactoryBuildableTeam::class)->withoutCallbacks()->create();
 
@@ -245,7 +245,7 @@ class EloquentFactoryBuilderTest extends TestCase
     }
 
     /** @test **/
-    public function can_disable_callback_when_creating_models_with_after_callback_state()
+    public function can_disable_callbacks_when_creating_models_with_after_callback_state()
     {
         $user = factory(FactoryBuildableUser::class)->withoutCallbacks()->state('with_callable_server')->create();
 
@@ -271,7 +271,7 @@ class EloquentFactoryBuilderTest extends TestCase
     }
 
     /** @test **/
-    public function can_disable_making_models_with_after_callback()
+    public function can_disable_callbacks_when_making_models_with_after_callback()
     {
         $user = factory(FactoryBuildableUser::class)->withoutCallbacks()->make();
 

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -227,7 +227,16 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertTrue($team->users->contains($team->owner));
     }
 
-    public function test_creating_models_with_after_callback_state()
+    /** @test **/
+    public function can_disable_callback_when_creating_models_with_after_callback()
+    {
+        $team = factory(FactoryBuildableTeam::class)->withoutCallbacks()->create();
+
+        $this->assertFalse($team->users->contains($team->owner));
+    }
+
+    /** @test **/
+    public function creating_models_with_after_callback_state()
     {
         $user = factory(FactoryBuildableUser::class)->state('with_callable_server')->create();
 
@@ -235,7 +244,17 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertNotNull($user->servers->where('status', 'callable')->first());
     }
 
-    public function test_making_models_with_a_custom_connection()
+    /** @test **/
+    public function can_disable_callback_when_creating_models_with_after_callback_state()
+    {
+        $user = factory(FactoryBuildableUser::class)->withoutCallbacks()->state('with_callable_server')->create();
+
+        $this->assertNull($user->profile);
+        $this->assertNull($user->servers->where('status', 'callable')->first());
+    }
+
+    /** @test */
+    public function making_models_with_a_custom_connection()
     {
         $user = factory(FactoryBuildableUser::class)
             ->connection('alternative-connection')
@@ -251,12 +270,30 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertNotNull($user->profile);
     }
 
-    public function test_making_models_with_after_callback_state()
+    /** @test **/
+    public function can_disable_making_models_with_after_callback()
+    {
+        $user = factory(FactoryBuildableUser::class)->withoutCallbacks()->make();
+
+        $this->assertNull($user->profile);
+    }
+
+    /** @test **/
+    public function making_models_with_after_callback_state()
     {
         $user = factory(FactoryBuildableUser::class)->state('with_callable_server')->make();
 
         $this->assertNotNull($user->profile);
         $this->assertNotNull($user->servers->where('status', 'callable')->first());
+    }
+
+    /** @test **/
+    public function can_disable_callbacks_when_making_models_with_after_callback_state()
+    {
+        $user = factory(FactoryBuildableUser::class)->withoutCallbacks()->state('with_callable_server')->make();
+
+        $this->assertNull($user->profile);
+        $this->assertNull($user->servers->where('status', 'callable')->first());
     }
 }
 


### PR DESCRIPTION
Adds the `withoutCallbacks` method to disable callbacks when using factories.

eg: `factory(User::class)->withoutCallbacks()->create();`
