### PR TITLE
[5.8] Remove the useless router property

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -27,13 +27,6 @@ class RouteListCommand extends Command
     protected $description = 'List all registered routes';
 
     /**
-     * The router instance.
-     *
-     * @var \Illuminate\Routing\Router
-     */
-    protected $router;
-
-    /**
      * An array of all the registered routes.
      *
      * @var \Illuminate\Routing\RouteCollection
@@ -64,7 +57,6 @@ class RouteListCommand extends Command
     {
         parent::__construct();
 
-        $this->router = $router;
         $this->routes = $router->getRoutes();
     }
 


### PR DESCRIPTION
The $router property of \Illuminate\Foundation\Console\RouteListCommand class has been set for a very long time but it hasn't ever been used.

Let's remove this useless property.