### PR TITLE
[5.8] Provide a path of the view in compiled view 

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -118,7 +118,8 @@ class BladeCompiler extends Compiler implements CompilerInterface
         }
 
         if (! is_null($this->cachePath)) {
-            $contents = $this->compileString($this->files->get($this->getPath()));
+            $contents = "<?php/* {$this->getPath()} */?>\n";
+            $contents .= $this->compileString($this->files->get($this->getPath()));
 
             $this->files->put($this->getCompiledPath($this->getPath()), $contents);
         }

--- a/tests/Integration/Mail/RenderingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/RenderingMailWithLocaleTest.php
@@ -31,14 +31,14 @@ class RenderingMailWithLocaleTest extends TestCase
     {
         $mail = new RenderedTestMail;
 
-        $this->assertContains('name'.PHP_EOL, $mail->render());
+        $this->assertStringContainsString("name\n", $mail->render());
     }
 
     public function testMailableRendersInSelectedLocale()
     {
         $mail = (new RenderedTestMail)->locale('es');
 
-        $this->assertContains('nombre'.PHP_EOL, $mail->render());
+        $this->assertStringContainsString("nombre\n", $mail->render());
     }
 
     public function testMailableRendersInAppSelectedLocale()
@@ -47,7 +47,7 @@ class RenderingMailWithLocaleTest extends TestCase
 
         $mail = new RenderedTestMail;
 
-        $this->assertContains('nombre'.PHP_EOL, $mail->render());
+        $this->assertStringContainsString("nombre\n", $mail->render());
     }
 }
 

--- a/tests/Integration/Mail/RenderingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/RenderingMailWithLocaleTest.php
@@ -31,14 +31,14 @@ class RenderingMailWithLocaleTest extends TestCase
     {
         $mail = new RenderedTestMail;
 
-        $this->assertEquals('name'.PHP_EOL, $mail->render());
+        $this->assertContains('name'.PHP_EOL, $mail->render());
     }
 
     public function testMailableRendersInSelectedLocale()
     {
         $mail = (new RenderedTestMail)->locale('es');
 
-        $this->assertEquals('nombre'.PHP_EOL, $mail->render());
+        $this->assertContains('nombre'.PHP_EOL, $mail->render());
     }
 
     public function testMailableRendersInAppSelectedLocale()
@@ -47,7 +47,7 @@ class RenderingMailWithLocaleTest extends TestCase
 
         $mail = new RenderedTestMail;
 
-        $this->assertEquals('nombre'.PHP_EOL, $mail->render());
+        $this->assertContains('nombre'.PHP_EOL, $mail->render());
     }
 }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -49,7 +49,7 @@ class ViewBladeCompilerTest extends TestCase
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', 'Hello World');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', "<?php/* foo */?>\nHello World");
         $compiler->compile('foo');
     }
 
@@ -57,7 +57,7 @@ class ViewBladeCompilerTest extends TestCase
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', 'Hello World');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', "<?php/* foo */?>\nHello World");
         $compiler->compile('foo');
         $this->assertEquals('foo', $compiler->getPath());
     }
@@ -73,7 +73,7 @@ class ViewBladeCompilerTest extends TestCase
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', 'Hello World');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', "<?php/* foo */?>\nHello World");
         // set path before compilation
         $compiler->setPath('foo');
         // trigger compilation with null $path
@@ -91,6 +91,14 @@ class ViewBladeCompilerTest extends TestCase
         $this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{
             $name
         }}'));
+    }
+
+    public function testIncludePathToTemplate()
+    {
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', "<?php/* foo */?>\nHello World");
+        $compiler->compile('foo');
     }
 
     protected function getFiles()


### PR DESCRIPTION
This PR fixes [laravel/ideas#1480](https://github.com/laravel/ideas/issues/1480) by adding the path of the view at the first line of compiled view in order to provide a possibility of Blade debugging in PhpStorm. 

This pull-request is a simplified version of the pull-request filed before with fixed shortcomings: https://github.com/laravel/framework/pull/27412 , @taylorotwell please take a look.


