### PR TITLE
[5.7] Bug fix for Request cloning

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -393,7 +393,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             $from->getContent()
         );
 
-        $request->setJson($from->json());
+        $request->setJson(clone $from->json());
 
         if ($session = $from->getSession()) {
             $request->setLaravelSession($session);


### PR DESCRIPTION
When cloning a Request there is a bug that just copies over the JSON ParameterBag instead of cloning it. So when you update the content of the cloned Request you inadvertently change the content in the original Request object.