### PR TITLE
[5.8] Bugfix in migrating expired jobs

### DIFF
--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -117,7 +117,7 @@ if(next(val) ~= nil) then
     for i = 1, #val, 100 do
         redis.call('rpush', KEYS[2], unpack(val, i, math.min(i+99, #val)))
         -- Push a notification for every job that was migrated...
-        for j = 1, math.min(i+99, #val) do
+        for j = i, math.min(i+99, #val) do
             redis.call('rpush', KEYS[3], 1)
         end
     end

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -93,6 +93,23 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
+     * @param  string  $driver
+     */
+    public function testMigrateMoreThan100Jobs($driver)
+    {
+        $this->setQueue($driver);
+        for ($i = -1; $i >= -201; $i--) {
+            $this->queue->later($i, new RedisQueueIntegrationTestJob($i));
+        }
+        for ($i = -201; $i <= -1; $i++) {
+            $this->assertEquals($i, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command)->i);
+            $this->assertEquals(-$i - 1, $this->redis[$driver]->llen('queues:default:notify'));
+        }
+    }
+
+    /**
+     * @dataProvider redisDriverProvider
+     *
      * @param string $driver
      */
     public function testPopProperlyPopsJobOffOfRedis($driver)


### PR DESCRIPTION
After migrating 201 expired jobs, `llen queues:default:notify` should be 201. Currently it is 500.