### PR TITLE
[5.8] Support customized notifications

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -3,24 +3,20 @@
 namespace Illuminate\Auth\Notifications;
 
 use Illuminate\Support\Facades\Lang;
+use Illuminate\Notifications\Customizable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\MailMessage;
 
 class ResetPassword extends Notification
 {
+    use Customizable;
+
     /**
      * The password reset token.
      *
      * @var string
      */
     public $token;
-
-    /**
-     * The callback that should be used to build the mail message.
-     *
-     * @var \Closure|null
-     */
-    public static $toMailCallback;
 
     /**
      * Create a notification instance.
@@ -62,16 +58,5 @@ class ResetPassword extends Notification
             ->action(Lang::getFromJson('Reset Password'), url(config('app.url').route('password.reset', ['token' => $this->token], false)))
             ->line(Lang::getFromJson('This password reset link will expire in :count minutes.', ['count' => config('auth.passwords.users.expire')]))
             ->line(Lang::getFromJson('If you did not request a password reset, no further action is required.'));
-    }
-
-    /**
-     * Set a callback that should be used when building the notification mail message.
-     *
-     * @param  \Closure  $callback
-     * @return void
-     */
-    public static function toMailUsing($callback)
-    {
-        static::$toMailCallback = $callback;
     }
 }

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -6,17 +6,13 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Notifications\Customizable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\MailMessage;
 
 class VerifyEmail extends Notification
 {
-    /**
-     * The callback that should be used to build the mail message.
-     *
-     * @var \Closure|null
-     */
-    public static $toMailCallback;
+    use Customizable;
 
     /**
      * Get the notification's channels.
@@ -64,16 +60,5 @@ class VerifyEmail extends Notification
             Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
             ['id' => $notifiable->getKey()]
         );
-    }
-
-    /**
-     * Set a callback that should be used when building the notification mail message.
-     *
-     * @param  \Closure  $callback
-     * @return void
-     */
-    public static function toMailUsing($callback)
-    {
-        static::$toMailCallback = $callback;
     }
 }

--- a/src/Illuminate/Notifications/Customizable.php
+++ b/src/Illuminate/Notifications/Customizable.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Notifications;
+
+trait Customizable
+{
+    /**
+     * The callback that should be used to build the mail message.
+     *
+     * @var \Closure|null
+     */
+    protected static $toMailCallback;
+
+    /**
+     * Set a callback that should be used when building the notification mail message.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function toMailUsing($callback)
+    {
+        static::$toMailCallback = $callback;
+    }
+}


### PR DESCRIPTION
The logic that allows developers to customize the password-reset or email-verified notification is duplicated.

I have a solution for this situation. I create a \Illuminate\Notification\Customizable trait.

- Firstly, this trait doesn't break the existing behavior and avoids duplicated code.
- Secondly, this is also helpful while developers are building their Laravel packages because they can easily support the others to customize notifications.