### PR TITLE
[5.8] Clean global container instance each test

### DIFF
--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -32,6 +32,8 @@ class AuthenticateMiddlewareTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        Container::setInstance(null);
     }
 
     public function testDefaultUnauthenticatedThrows()

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -47,6 +47,8 @@ class AuthorizeMiddlewareTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        Container::setInstance(null);
     }
 
     public function testSimpleAbilityUnauthorized()

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -28,6 +28,8 @@ class BroadcasterTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        Container::setInstance(null);
     }
 
     public function testExtractingParametersWhileCheckingForUserAccess()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -11,6 +11,11 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 
 class ContainerTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     public function testContainerSingleton()
     {
         $container = Container::setInstance(new Container);

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -12,6 +12,11 @@ use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 
 class FoundationAuthorizesRequestsTraitTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
     public function test_basic_gate_check()
     {
         unset($_SERVER['_test.authorizes.trait']);

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -54,6 +54,8 @@ class FoundationExceptionsHandlerTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        Container::setInstance(null);
     }
 
     public function testHandlerReportsExceptionAsContext()

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -21,6 +21,8 @@ class NotificationChannelManagerTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        Container::setInstance(null);
     }
 
     public function testNotificationCanBeDispatchedToDriver()

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -14,6 +14,8 @@ class NotificationRoutesNotificationsTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        Container::setInstance(null);
     }
 
     public function testNotificationCanBeDispatched()

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -16,6 +16,8 @@ class QueueSyncQueueTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        Container::setInstance(null);
     }
 
     public function testPushShouldFireJobInstantly()

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -36,7 +36,7 @@ class QueueWorkerTest extends TestCase
 
     protected function tearDown(): void
     {
-        Container::setInstance();
+        Container::setInstance(null);
     }
 
     public function test_job_can_be_fired()


### PR DESCRIPTION
If the global container instance isn't clean each test, it may effect on the other tests and developers have to care much more about related results.

Therefore, Just clean the global container instance at the end of each test and Feel more comfortable while testing something related to it.