### PR TITLE
[5.8] Correct console application test

### DIFF
--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -54,20 +54,27 @@ class ConsoleApplicationTest extends TestCase
     {
         $app = new Application(
             $app = m::mock(ApplicationContract::class, ['version' => '5.8']),
-            $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            $events = m::mock(Dispatcher::class, ['dispatch' => null]),
             'testing'
         );
 
-        $outputOfCallArrayInput = $app->call('help', [
+        $codeOfCallingArrayInput = $app->call('help', [
             '--raw' => true,
             '--format' => 'txt',
             '--no-interaction' => true,
             '--env' => 'testing',
         ]);
 
-        $outputOfCallStringInput = $app->call('help --raw --format=txt --no-interaction --env=testing');
+        $outputOfCallingArrayInput = $app->output();
 
-        $this->assertSame($outputOfCallArrayInput, $outputOfCallStringInput);
+        $codeOfCallingStringInput = $app->call(
+            'help --raw --format=txt --no-interaction --env=testing'
+        );
+
+        $outputOfCallingStringInput = $app->output();
+
+        $this->assertSame($codeOfCallingArrayInput, $codeOfCallingStringInput);
+        $this->assertSame($outputOfCallingArrayInput, $outputOfCallingStringInput);
     }
 
     protected function getMockConsole(array $methods)


### PR DESCRIPTION
I had a mistake. \Illuminate\Console\Application::call() doesn't return a command output, it returns a command exit code. To get the command output, we have to use \Illuminate\Console\Application::output().

Therefore, I submit this pull request to correct the console application test.

https://github.com/laravel/framework/pull/26388
