### PR TITLE
[5.8] Fix mix exception handling

### DIFF
--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -52,10 +52,14 @@ class Mix
         $manifest = $manifests[$manifestPath];
 
         if (! isset($manifest[$path])) {
-            report(new Exception("Unable to locate Mix file: {$path}."));
+            $exception = new Exception("Unable to locate Mix file: {$path}.");
 
             if (! app('config')->get('app.debug')) {
+                report($exception);
+
                 return $path;
+            } else {
+                throw $exception;
             }
         }
 

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Foundation;
 use Exception;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 
 /**
@@ -54,51 +55,51 @@ class FoundationHelpersTest extends TestCase
         unlink($manifest);
     }
 
-    // public function testMixSilentlyFailsWhenAssetIsMissingFromManifestWhenNotInDebugMode()
-    // {
-    //     $this->app['config']->set('app.debug', false);
-    //     $manifest = $this->makeManifest();
+    public function testMixSilentlyFailsWhenAssetIsMissingFromManifestWhenNotInDebugMode()
+    {
+        $this->app['config']->set('app.debug', false);
+        $manifest = $this->makeManifest();
 
-    //     $path = mix('missing.js');
+        $path = mix('missing.js');
 
-    //     $this->assertSame('/missing.js', $path);
+        $this->assertSame('/missing.js', $path);
 
-    //     unlink($manifest);
-    // }
+        unlink($manifest);
+    }
 
-    // public function testMixThrowsExceptionWhenAssetIsMissingFromManifestWhenInDebugMode()
-    // {
-    //     $this->expectException(Exception::class);
-    //     $this->expectExceptionMessage('Unable to locate Mix file: /missing.js.');
+    public function testMixThrowsExceptionWhenAssetIsMissingFromManifestWhenInDebugMode()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unable to locate Mix file: /missing.js.');
 
-    //     $this->app['config']->set('app.debug', true);
-    //     $manifest = $this->makeManifest();
+        $this->app['config']->set('app.debug', true);
+        $manifest = $this->makeManifest();
 
-    //     try {
-    //         mix('missing.js');
-    //     } catch (\Exception $e) {
-    //         throw $e;
-    //     } finally { // make sure we can cleanup the file
-    //         unlink($manifest);
-    //     }
-    // }
+        try {
+            mix('missing.js');
+        } catch (\Exception $e) {
+            throw $e;
+        } finally { // make sure we can cleanup the file
+            unlink($manifest);
+        }
+    }
 
-    // public function testMixOnlyThrowsAndReportsOneExceptionWhenAssetIsMissingFromManifestWhenInDebugMode()
-    // {
-    //     $handler = new FakeHandler;
-    //     $this->app->instance(ExceptionHandler::class, $handler);
-    //     $this->app['config']->set('app.debug', true);
-    //     $manifest = $this->makeManifest();
-    //     Route::get('test-route', function () {
-    //         mix('missing.js');
-    //     });
+    public function testMixOnlyThrowsAndReportsOneExceptionWhenAssetIsMissingFromManifestWhenInDebugMode()
+    {
+        $handler = new FakeHandler;
+        $this->app->instance(ExceptionHandler::class, $handler);
+        $this->app['config']->set('app.debug', true);
+        $manifest = $this->makeManifest();
+        Route::get('test-route', function () {
+            mix('missing.js');
+        });
 
-    //     $this->get('/test-route');
+        $this->get('/test-route');
 
-    //     $this->assertCount(1, $handler->reported);
+        $this->assertCount(1, $handler->reported);
 
-    //     unlink($manifest);
-    // }
+        unlink($manifest);
+    }
 
     protected function makeManifest($directory = '')
     {


### PR DESCRIPTION
I noticed that these tests were uncommented so I did some investigating into why. It turns out that two prs referenced below were merged on either the 5.7 and 5.8 branches. I believe that due to a merge gone wrong some of the functionality from the PR sent to 5.7 was removed again causing the tests to fail (which is why they were commented out). I've re-added the changes and re-enable the commented out tests which now pass again.

5.7 PR: https://github.com/laravel/framework/pull/26431
5.8 PR: https://github.com/laravel/framework/pull/26289
