### PR TITLE
[5.8] Pivot models provided by using() should use model methods for write operations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
-use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
 trait AsPivot
 {

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -43,6 +43,9 @@ trait AsPivot
     {
         $instance = new static;
 
+        // if this factory was presented valid timestamp columns, set th e
+        $instance->timestamps = $instance->hasTimestampAttributes($attributes);
+
         // The pivot model is a "dynamic" model since we will set the tables dynamically
         // for the instance. This allows it work for any intermediate tables for the
         // many to many relationship that are defined by this developer's classes.
@@ -57,12 +60,6 @@ trait AsPivot
         $instance->pivotParent = $parent;
 
         $instance->exists = $exists;
-
-        // If this is a subclassed Pivot class, treat it as a model and respect
-        // the $timestamps property
-        if (get_class($instance) === Pivot::class) {
-            $instance->timestamps = $instance->hasTimestampAttributes();
-        }
 
         return $instance;
     }
@@ -214,13 +211,15 @@ trait AsPivot
     }
 
     /**
-     * Determine if the pivot model has timestamp attributes.
+     * Determine if the pivot model has timestamp attributes in either a provided
+     * array of attributes or the currently tracked attributes inside the model.
      *
+     * @param $attributes array|null Optional,
      * @return bool
      */
-    public function hasTimestampAttributes()
+    public function hasTimestampAttributes($attributes = null)
     {
-        return array_key_exists($this->getCreatedAtColumn(), $this->attributes);
+        return array_key_exists($this->getCreatedAtColumn(), $attributes ?? $this->attributes);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -5,7 +5,6 @@ namespace Illuminate\Database\Eloquent\Relations\Concerns;
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Relations\Pivot;
 
 trait AsPivot
 {
@@ -43,7 +42,8 @@ trait AsPivot
     {
         $instance = new static;
 
-        // if this factory was presented valid timestamp columns, set th e
+        // if this factory was presented valid timestamp columns, set the $timestamps
+        // property accordingly
         $instance->timestamps = $instance->hasTimestampAttributes($attributes);
 
         // The pivot model is a "dynamic" model since we will set the tables dynamically
@@ -77,8 +77,8 @@ trait AsPivot
     {
         $instance = static::fromAttributes($parent, [], $table, $exists);
 
-        // If this is a subclassed Pivot class, treat it as a model and respect
-        // the $timestamps property
+        // if this factory was presented valid timestamp columns, set the $timestamps
+        // property accordingly
         $instance->timestamps = $instance->hasTimestampAttributes($attributes);
 
         $instance->setRawAttributes($attributes, true);
@@ -211,7 +211,7 @@ trait AsPivot
      * Determine if the pivot model has timestamp attributes in either a provided
      * array of attributes or the currently tracked attributes inside the model.
      *
-     * @param $attributes array|null Optional,
+     * @param $attributes array|null Options attributes to check instead of properties
      * @return bool
      */
     public function hasTimestampAttributes($attributes = null)

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -77,14 +77,11 @@ trait AsPivot
     {
         $instance = static::fromAttributes($parent, [], $table, $exists);
 
-        $instance->setRawAttributes($attributes, true);
-
         // If this is a subclassed Pivot class, treat it as a model and respect
         // the $timestamps property
-        if (get_class($instance) === Pivot::class) {
-            $instance->timestamps = $instance->hasTimestampAttributes();
-        }
+        $instance->timestamps = $instance->hasTimestampAttributes($attributes);
 
+        $instance->setRawAttributes($attributes, true);
 
         return $instance;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -125,11 +125,11 @@ trait AsPivot
 
         $this->touchOwners();
 
-        $this->getDeleteQuery()->delete();
+        $affectedRows = $this->getDeleteQuery()->delete();
 
         $this->fireModelEvent('deleted', false);
 
-        return 1;
+        return $affectedRows;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -187,7 +187,7 @@ trait InteractsWithPivotTable
         if ($this->using) {
             $updated = $this->newPivot([
                 $this->foreignPivotKey => $this->parent->getKey(),
-                $this->relatedPivotKey => $this->parseId($id)
+                $this->relatedPivotKey => $this->parseId($id),
             ], true)->fill($attributes)->save();
 
             if ($touch) {
@@ -382,7 +382,7 @@ trait InteractsWithPivotTable
             foreach ($this->parseIds($ids) as $id) {
                 $results += $this->newPivot([
                     $this->foreignPivotKey => $this->parent->getKey(),
-                    $this->relatedPivotKey => $id
+                    $this->relatedPivotKey => $id,
                 ], true)->delete();
             }
         } else {

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -209,12 +209,21 @@ trait InteractsWithPivotTable
      */
     public function attach($id, array $attributes = [], $touch = true)
     {
-        // Here we will insert the attachment records into the pivot table. Once we have
-        // inserted the records, we will touch the relationships if necessary and the
-        // function will return. We can parse the IDs before inserting the records.
-        $this->newPivotStatement()->insert($this->formatAttachRecords(
-            $this->parseIds($id), $attributes
-        ));
+        if ($this->using) {
+            $records = $this->formatAttachRecords(
+                $this->parseIds($id), $attributes
+            );
+            foreach ($records as $record) {
+                $this->newPivot($record, false)->save();
+            }
+        } else {
+            // Here we will insert the attachment records into the pivot table. Once we have
+            // inserted the records, we will touch the relationships if necessary and the
+            // function will return. We can parse the IDs before inserting the records.
+            $this->newPivotStatement()->insert($this->formatAttachRecords(
+                $this->parseIds($id), $attributes
+            ));
+        }
 
         if ($touch) {
             $this->touchIfTouching();
@@ -355,25 +364,32 @@ trait InteractsWithPivotTable
      */
     public function detach($ids = null, $touch = true)
     {
-        $query = $this->newPivotQuery();
+        if ($this->using) {
+            $results = 0;
+            foreach ($this->parseIds($ids) as $id) {
+                $results += $this->newPivot([$this->relatedPivotKey => $id], true)->delete();
+            }
+        } else {
+            $query = $this->newPivotQuery();
 
-        // If associated IDs were passed to the method we will only delete those
-        // associations, otherwise all of the association ties will be broken.
-        // We'll return the numbers of affected rows when we do the deletes.
-        if (! is_null($ids)) {
-            $ids = $this->parseIds($ids);
+            // If associated IDs were passed to the method we will only delete those
+            // associations, otherwise all of the association ties will be broken.
+            // We'll return the numbers of affected rows when we do the deletes.
+            if (! is_null($ids)) {
+                $ids = $this->parseIds($ids);
 
-            if (empty($ids)) {
-                return 0;
+                if (empty($ids)) {
+                    return 0;
+                }
+
+                $query->whereIn($this->relatedPivotKey, (array) $ids);
             }
 
-            $query->whereIn($this->relatedPivotKey, (array) $ids);
+            // Once we have all of the conditions set on the statement, we are ready
+            // to run the delete on the pivot table. Then, if the touch parameter
+            // is true, we will go ahead and touch all related models to sync.
+            $results = $query->delete();
         }
-
-        // Once we have all of the conditions set on the statement, we are ready
-        // to run the delete on the pivot table. Then, if the touch parameter
-        // is true, we will go ahead and touch all related models to sync.
-        $results = $query->delete();
 
         if ($touch) {
             $this->touchIfTouching();

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -184,6 +184,19 @@ trait InteractsWithPivotTable
      */
     public function updateExistingPivot($id, array $attributes, $touch = true)
     {
+        if ($this->using) {
+            $updated = $this->newPivot([
+                $this->foreignPivotKey => $this->parent->getKey(),
+                $this->relatedPivotKey => $this->parseId($id)
+            ], true)->fill($attributes)->save();
+
+            if ($touch) {
+                $this->touchIfTouching();
+            }
+
+            return (int) $updated;
+        }
+
         if (in_array($this->updatedAt(), $this->pivotColumns)) {
             $attributes = $this->addTimestampsToAttachment($attributes, true);
         }
@@ -367,7 +380,10 @@ trait InteractsWithPivotTable
         if ($this->using) {
             $results = 0;
             foreach ($this->parseIds($ids) as $id) {
-                $results += $this->newPivot([$this->relatedPivotKey => $id], true)->delete();
+                $results += $this->newPivot([
+                    $this->foreignPivotKey => $this->parent->getKey(),
+                    $this->relatedPivotKey => $id
+                ], true)->delete();
             }
         } else {
             $query = $this->newPivotQuery();

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -11,8 +11,6 @@ class Pivot extends Model
 
     public $incrementing = false;
 
-    public $timestamps = false;
-
     /**
      * The attributes that aren't mass assignable.
      *

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -11,6 +11,8 @@ class Pivot extends Model
 
     public $incrementing = false;
 
+    public $timestamps = false;
+
     /**
      * The attributes that aren't mass assignable.
      *

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -9,6 +9,8 @@ class Pivot extends Model
 {
     use AsPivot;
 
+    public $incrementing = false;
+
     /**
      * The attributes that aren't mass assignable.
      *

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1524,9 +1524,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testWhenBaseModelIsIgnoredAllChildModelsAreIgnored()
     {
-        // force loading of User model since it exists in a non-autoloadable place
-        class_exists(EloquentCollectionFreshTest::class);
-
         $this->assertFalse(Model::isIgnoringTouch());
         $this->assertFalse(User::isIgnoringTouch());
 
@@ -1541,10 +1538,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testChildModelsAreIgnored()
     {
-        // force loading of User, Post model since it exists in a non-autoloadable place
-        class_exists(EloquentCollectionFreshTest::class);
-        class_exists(EloquentDeleteTest::class);
-
         $this->assertFalse(Model::isIgnoringTouch());
         $this->assertFalse(User::isIgnoringTouch());
         $this->assertFalse(Post::isIgnoringTouch());

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -6,6 +6,8 @@ use Exception;
 use RuntimeException;
 use InvalidArgumentException;
 use Illuminate\Support\Carbon;
+use Illuminate\Tests\Integration\Database\EloquentCollectionFreshTest;
+use Illuminate\Tests\Integration\Database\EloquentDeleteTest;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\QueryException;
@@ -1522,6 +1524,9 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testWhenBaseModelIsIgnoredAllChildModelsAreIgnored()
     {
+        // force loading of User model since it exists in a non-autoloadable place
+        class_exists(EloquentCollectionFreshTest::class);
+
         $this->assertFalse(Model::isIgnoringTouch());
         $this->assertFalse(User::isIgnoringTouch());
 
@@ -1536,6 +1541,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testChildModelsAreIgnored()
     {
+        // force loading of User, Post model since it exists in a non-autoloadable place
+        class_exists(EloquentCollectionFreshTest::class);
+        class_exists(EloquentDeleteTest::class);
+
         $this->assertFalse(Model::isIgnoringTouch());
         $this->assertFalse(User::isIgnoringTouch());
         $this->assertFalse(Post::isIgnoringTouch());

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -6,8 +6,6 @@ use Exception;
 use RuntimeException;
 use InvalidArgumentException;
 use Illuminate\Support\Carbon;
-use Illuminate\Tests\Integration\Database\EloquentCollectionFreshTest;
-use Illuminate\Tests\Integration\Database\EloquentDeleteTest;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\QueryException;

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -2,6 +2,10 @@
 
 namespace Illuminate\Tests\Database;
 
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Grammar;
+use Illuminate\Database\Query\Processors\Processor;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
@@ -17,6 +21,8 @@ class DatabaseEloquentPivotTest extends TestCase
     public function testPropertiesAreSetCorrectly()
     {
         $parent = m::mock(Model::class.'[getConnectionName]');
+        $this->addMockConnection($parent);
+
         $parent->shouldReceive('getConnectionName')->twice()->andReturn('connection');
         $parent->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $parent->setDateFormat('Y-m-d H:i:s');
@@ -150,6 +156,17 @@ class DatabaseEloquentPivotTest extends TestCase
 
         $this->assertEquals($model->getCreatedAtColumn(), $pivotWithoutParent->getCreatedAtColumn());
         $this->assertEquals($model->getUpdatedAtColumn(), $pivotWithoutParent->getUpdatedAtColumn());
+    }
+
+    protected function addMockConnection($model)
+    {
+        $model->setConnectionResolver($resolver = m::mock(ConnectionResolverInterface::class));
+        $resolver->shouldReceive('connection')->andReturn($connection = m::mock(Connection::class));
+        $connection->shouldReceive('getQueryGrammar')->andReturn(m::mock(Grammar::class));
+        // $connection->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
+        // $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
+        //     return new BaseBuilder($connection, $grammar, $processor);
+        // });
     }
 }
 

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -21,8 +21,6 @@ class DatabaseEloquentPivotTest extends TestCase
     public function testPropertiesAreSetCorrectly()
     {
         $parent = m::mock(Model::class.'[getConnectionName]');
-        $this->addMockConnection($parent);
-
         $parent->shouldReceive('getConnectionName')->twice()->andReturn('connection');
         $parent->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $parent->setDateFormat('Y-m-d H:i:s');
@@ -125,7 +123,8 @@ class DatabaseEloquentPivotTest extends TestCase
         $query->shouldReceive('delete')->once()->andReturn(true);
         $pivot->expects($this->once())->method('newQueryWithoutRelationships')->will($this->returnValue($query));
 
-        $this->assertTrue($pivot->delete());
+        $rowsAffected = $pivot->delete();
+        $this->assertEquals(1, $rowsAffected);
     }
 
     public function testPivotModelTableNameIsSingular()
@@ -158,16 +157,10 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertEquals($model->getUpdatedAtColumn(), $pivotWithoutParent->getUpdatedAtColumn());
     }
 
-    protected function addMockConnection($model)
-    {
-        $model->setConnectionResolver($resolver = m::mock(ConnectionResolverInterface::class));
-        $resolver->shouldReceive('connection')->andReturn($connection = m::mock(Connection::class));
-        $connection->shouldReceive('getQueryGrammar')->andReturn(m::mock(Grammar::class));
-        // $connection->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
-        // $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
-        //     return new BaseBuilder($connection, $grammar, $processor);
-        // });
-    }
+    // public function testPivotModelWillFireEvents()
+    // {
+    //
+    // }
 }
 
 class DatabaseEloquentPivotTestDateStub extends Pivot
@@ -206,3 +199,58 @@ class DummyModel extends Model
 {
     //
 }
+//
+// class DummyModelWithExtendedPivot extends Model
+// {
+//     public function
+// }
+//
+// class DatabaseEloquentPivotWithEvents extends Pivot
+// {
+//     public $eventsCalled = [];
+//
+//     public static function boot()
+//     {
+//         parent::boot();
+//
+//         static::creating(function ($model) {
+//             // $model->eventsCalled[]
+//             return true;
+//         });
+//
+//         static::created(function ($model) {
+//             // $model->eventsCalled[]
+//             return true;
+//         });
+//
+//         static::updating(function ($model) {
+//             // $model->eventsCalled[]
+//             return true;
+//         });
+//
+//         static::updated(function ($model) {
+//             // $model->eventsCalled[]
+//             return true;
+//         });
+//
+//         static::saving(function ($model) {
+//             // $model->eventsCalled[]
+//             return true;
+//         });
+//
+//         static::saved(function ($model) {
+//             // $model->eventsCalled[]
+//             return true;
+//         });
+//
+//         static::deleting(function ($model) {
+//             // $model->eventsCalled[]
+//             return true;
+//         });
+//
+//         static::deleted(function ($model) {
+//             // $model->eventsCalled[]
+//             return true;
+//         });
+//     }
+// }

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -2,10 +2,6 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Database\Connection;
-use Illuminate\Database\ConnectionResolverInterface;
-use Illuminate\Database\Grammar;
-use Illuminate\Database\Query\Processors\Processor;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
@@ -156,11 +152,6 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertEquals($model->getCreatedAtColumn(), $pivotWithoutParent->getCreatedAtColumn());
         $this->assertEquals($model->getUpdatedAtColumn(), $pivotWithoutParent->getUpdatedAtColumn());
     }
-
-    // public function testPivotModelWillFireEvents()
-    // {
-    //
-    // }
 }
 
 class DatabaseEloquentPivotTestDateStub extends Pivot
@@ -199,58 +190,3 @@ class DummyModel extends Model
 {
     //
 }
-//
-// class DummyModelWithExtendedPivot extends Model
-// {
-//     public function
-// }
-//
-// class DatabaseEloquentPivotWithEvents extends Pivot
-// {
-//     public $eventsCalled = [];
-//
-//     public static function boot()
-//     {
-//         parent::boot();
-//
-//         static::creating(function ($model) {
-//             // $model->eventsCalled[]
-//             return true;
-//         });
-//
-//         static::created(function ($model) {
-//             // $model->eventsCalled[]
-//             return true;
-//         });
-//
-//         static::updating(function ($model) {
-//             // $model->eventsCalled[]
-//             return true;
-//         });
-//
-//         static::updated(function ($model) {
-//             // $model->eventsCalled[]
-//             return true;
-//         });
-//
-//         static::saving(function ($model) {
-//             // $model->eventsCalled[]
-//             return true;
-//         });
-//
-//         static::saved(function ($model) {
-//             // $model->eventsCalled[]
-//             return true;
-//         });
-//
-//         static::deleting(function ($model) {
-//             // $model->eventsCalled[]
-//             return true;
-//         });
-//
-//         static::deleted(function ($model) {
-//             // $model->eventsCalled[]
-//             return true;
-//         });
-//     }
-// }

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
+use Illuminate\Database\Eloquent\Collection as DatabaseCollection;
+
+/**
+ * @group integration
+ */
+class EloquentPivotEventsTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+            $table->timestamps();
+        });
+
+        Schema::create('projects', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('project_users', function ($table) {
+            $table->integer('user_id');
+            $table->integer('project_id');
+            $table->string('role')->nullable();
+        });
+    }
+
+    public function test_pivot_will_trigger_events_to_be_fired()
+    {
+        $user = PivotEventsTestUser::forceCreate(['email' => 'taylor@laravel.com']);
+        $user2 = PivotEventsTestUser::forceCreate(['email' => 'ralph@ralphschindler.com']);
+        $project = PivotEventsTestProject::forceCreate(['name' => 'Test Project']);
+
+        $project->collaborators()->attach($user);
+        $this->assertEquals(['saving', 'creating', 'created', 'saved'], PivotEventsTestCollaborator::$eventsCalled);
+
+        PivotEventsTestCollaborator::$eventsCalled = [];
+        $project->collaborators()->sync([$user2->id]);
+        $this->assertEquals(['deleting', 'deleted', 'saving', 'creating', 'created', 'saved'], PivotEventsTestCollaborator::$eventsCalled);
+
+        PivotEventsTestCollaborator::$eventsCalled = [];
+        $project->collaborators()->sync([$user->id => ['role' => 'owner'], $user2->id => ['role' => 'contributor']]);
+        $this->assertEquals(['saving', 'creating', 'created', 'saved', 'saving', 'updating', 'updated', 'saved'], PivotEventsTestCollaborator::$eventsCalled);
+    }
+}
+
+class PivotEventsTestUser extends Model
+{
+    public $table = 'users';
+}
+
+class PivotEventsTestProject extends Model
+{
+    public $table = 'projects';
+
+    public function collaborators()
+    {
+        return $this->belongsToMany(
+            PivotEventsTestUser::class, 'project_users', 'project_id', 'user_id'
+        )->using(PivotEventsTestCollaborator::class);
+    }
+}
+
+class PivotEventsTestCollaborator extends Pivot
+{
+    public $table = 'project_users';
+
+    public static $eventsCalled = [];
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            static::$eventsCalled[] = 'creating';
+            return true;
+        });
+
+        static::created(function ($model) {
+            static::$eventsCalled[] = 'created';
+            return true;
+        });
+
+        static::updating(function ($model) {
+            static::$eventsCalled[] = 'updating';
+            return true;
+        });
+
+        static::updated(function ($model) {
+            static::$eventsCalled[] = 'updated';
+            return true;
+        });
+
+        static::saving(function ($model) {
+            static::$eventsCalled[] = 'saving';
+            return true;
+        });
+
+        static::saved(function ($model) {
+            static::$eventsCalled[] = 'saved';
+            return true;
+        });
+
+        static::deleting(function ($model) {
+            static::$eventsCalled[] = 'deleting';
+            return true;
+        });
+
+        static::deleted(function ($model) {
+            static::$eventsCalled[] = 'deleted';
+            return true;
+        });
+    }
+}

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -2,12 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
-use Illuminate\Database\Eloquent\Relations\MorphPivot;
-use Illuminate\Database\Eloquent\Collection as DatabaseCollection;
 
 /**
  * @group integration
@@ -85,42 +82,34 @@ class PivotEventsTestCollaborator extends Pivot
 
         static::creating(function ($model) {
             static::$eventsCalled[] = 'creating';
-            return true;
         });
 
         static::created(function ($model) {
             static::$eventsCalled[] = 'created';
-            return true;
         });
 
         static::updating(function ($model) {
             static::$eventsCalled[] = 'updating';
-            return true;
         });
 
         static::updated(function ($model) {
             static::$eventsCalled[] = 'updated';
-            return true;
         });
 
         static::saving(function ($model) {
             static::$eventsCalled[] = 'saving';
-            return true;
         });
 
         static::saved(function ($model) {
             static::$eventsCalled[] = 'saved';
-            return true;
         });
 
         static::deleting(function ($model) {
             static::$eventsCalled[] = 'deleting';
-            return true;
         });
 
         static::deleted(function ($model) {
             static::$eventsCalled[] = 'deleted';
-            return true;
         });
     }
 }


### PR DESCRIPTION
# Overview

The driving use case behind this PR is to allow Pivot tables/classes/models to be able to trigger model events, which are currently not possible since InteractsWithPivotTable does not go through the Eloquent model.

Changes and tests have been provided.

# Details

This PR adds additional support to `InteractsWithPivotTable` (used by `Relations\BelongsToMany|MorphToMany`) such that write operations to a pivot table (specifically: `attach`, `detach`, `updateExistingPivot`) will use the defined `$this->belongsToMany()->using(MyPivot::class)` when performing these operations. By using the Pivot (through `AsPivot` trait methods) as an eloquent model, you gain the ability to utilize the eloquent lifecycle events when Pivot's are saved/deleted.

(Sidenote: I believe there are other use cases for supporting Pivot tables at true Models, I feel like there is a use case for treating Pivot's as first class Models inside Nova.)

# Example

In a situation where there exist a `Category`, `Post`, and a `Pivots\CategoryPost` inside an application:
```php
namespace App\Models {
  class Category extends Model
  {
    public function posts()
    {
      return $this->belongsToMany(Post::class);
    }
  }

  class Post extends Model
  {
    public function categories()
    {
      return $this->belongsToMany(Category::class)->using(Pivots\CategoryPost::class);
    }
  }
}

namespace App\Models\Pivots {
  class CategoryPost extends Pivot
  {
    public static function boot()
    {
      parent::boot();

      static::saving(function (Model $model) {
        echo "In [{$model->getMorphClass()}|{$model->getQueueableId()}] - SAVING\n";
      });

      static::saved(function (Model $model) {
        echo "In [{$model->getMorphClass()}|{$model->getQueueableId()}] - SAVED\n";
      });

      static::deleting(function (Model $model) {
        echo "IN [{$model->getMorphClass()}|{$model->getQueueableId()}] - DELETING\n";
      });

      static::deleted(function (Model $model) {
        echo "IN [{$model->getMorphClass()}|{$model->getQueueableId()}] - DELETED\n";
      });
    }

    public function setOrderAttribute($value)
    {
      $this->attributes['order'] = ((int) $value) * 10;
    }
  }
}
```

A sync method might look like, and its output:

```php
$category1 = Models\Category::create(['name' => 'One']);
$category2 = Models\Category::create(['name' => 'Two']);
$category3 = Models\Category::create(['name' => 'Three']);
$post = new Models\Post(['name' => 'My Post']);
$post->save();
$post->categories()->sync([$category1->id => ['order' => 1], $category2->id => ['order' => 2]]);
$post->categories()->sync([$category3->id => ['order' => 5], $category1->id => ['order' => 9]]);

// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:1] - SAVING
// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:1] - SAVED
// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:2] - SAVING
// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:2] - SAVED
// IN [App\Models\Pivots\CategoryPost|post_id:1:category_id:2] - DELETING
// IN [App\Models\Pivots\CategoryPost|post_id:1:category_id:2] - DELETED
// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:3] - SAVING
// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:3] - SAVED
// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:1] - SAVING
// In [App\Models\Pivots\CategoryPost|post_id:1:category_id:1] - SAVED
```

# Inspiration & Research

https://github.com/fico7489/laravel-pivot
https://gitlab.com/altek/eventually/
https://github.com/spatie/laravel-activitylog
Laravel Issue: https://github.com/laravel/framework/issues/8452
https://medium.com/@codebyjeff/custom-pivot-table-models-or-choosing-the-right-technique-in-laravel-fe435ce4e27e
https://github.com/signifly/laravel-pivot-events
https://stackoverflow.com/questions/46358388/laravel-5-5-events-not-fired-on-pivot
