### PR TITLE
[5.8] Test env helper gets data from $_ENV first

### DIFF
--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -962,6 +962,13 @@ class SupportHelpersTest extends TestCase
         $_SERVER['foo'] = '(null)';
         $this->assertNull(env('foo'));
     }
+
+    public function testGetFromENVFirst()
+    {
+        $_ENV['foo'] = 'From $_ENV';
+        $_SERVER['foo'] = 'From $_SERVER';
+        $this->assertSame('From $_ENV', env('foo'));
+    }
 }
 
 trait SupportTestTraitOne


### PR DESCRIPTION
Because the framework reads data from $_ENV first and then $_SERVER, I add a test to ensure env helper get data from $_ENV first. The later change have to be considered.

See https://github.com/laravel/framework/pull/27519 for more details!