### PR TITLE
[5.8]`ServiceProvider::register()` method auto-registration dependency.

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -595,7 +595,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         }
 
         if (method_exists($provider, 'register')) {
-            $provider->register();
+            $this->call([$provider, 'register']);
         }
 
         // If there are bindings / singletons set as properties on the provider we


### PR DESCRIPTION
```php

FooServiceProvider
{
    public function register(Bar $bar)
    {
         // $bar->register
    }
}
```