### PR TITLE
[5.8] Add validateRequest method

### DIFF
--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -48,6 +48,22 @@ trait ValidatesRequests
     }
 
     /**
+     * Validate the HTTP request with the given rules
+     *
+     * @param  array  $rules
+     * @param  array  $messages
+     * @param  array  $customAttributes
+     * @return array
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function validateRequest(array $rules, array $messages = [],
+                                    array $customAttributes = [])
+    {
+        return $this->validate(request(), $rules, $messages, $customAttributes);
+    }
+
+    /**
      * Validate the given request with the given rules.
      *
      * @param  string  $errorBag

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -48,7 +48,7 @@ trait ValidatesRequests
     }
 
     /**
-     * Validate the HTTP request with the given rules
+     * Validate the HTTP request with the given rules.
      *
      * @param  array  $rules
      * @param  array  $messages


### PR DESCRIPTION
Within controllers I often find that I am calling the validator as follows:

```php
$this->validate(request(), [...]);
```

This PR allows you to use the following method call instead:

```php
$this->validateRequest([...]);
```

This is minimal risk as it just defers to the `validate` method, but passing in the request automatically, rather than the user having to specify it.