### PR TITLE
[5.8] Add methods to test collection data

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithCollections.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithCollections.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+use Illuminate\Foundation\Testing\TestCollection;
+
+trait InteractsWithCollections
+{
+    /**
+     * Assert that the given value is a collection or a paginator.
+     *
+     * @param  mixed  $collection
+     * @return TestCollection
+     */
+    protected function assertCollection($collection)
+    {
+        return new TestCollection($collection);
+    }
+}

--- a/src/Illuminate/Foundation/Testing/FallbackToParent.php
+++ b/src/Illuminate/Foundation/Testing/FallbackToParent.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use BadMethodCallException;
+
+trait FallbackToParent
+{
+    /**
+     * Object to fallback to if a method is not found in the current class.
+     *
+     * @var mixed
+     */
+    private $fallback;
+
+    /**
+     * Set object to fallback to if the method is not found in the current class.
+     *
+     * @param  mixed  $fallback
+     */
+    public function setFallback($fallback)
+    {
+        $this->fallback = $fallback;
+    }
+
+    /**
+     * Redirect the call to the fallback object.
+     *
+     * @param  string  $method
+     * @param  array  $params
+     * @return mixed
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $params = [])
+    {
+        if (method_exists($this->fallback, $method)) {
+            return $this->fallback->$method(...$params);
+        }
+
+        throw new BadMethodCallException("The method [{$method}] does not exist.");
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -19,6 +19,7 @@ abstract class TestCase extends BaseTestCase
         Concerns\InteractsWithDatabase,
         Concerns\InteractsWithExceptionHandling,
         Concerns\InteractsWithSession,
+        Concerns\InteractsWithCollections,
         Concerns\MocksApplicationServices;
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCollection.php
+++ b/src/Illuminate/Foundation/Testing/TestCollection.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Assert as PHPUnit;
+use SebastianBergmann\Exporter\Exporter;
+use Illuminate\Pagination\AbstractPaginator;
+
+class TestCollection
+{
+    use FallbackToParent;
+
+    /**
+     * The collection to test.
+     *
+     * @var \Illuminate\Support\Collection|\Illuminate\Pagination\AbstractPaginator
+     */
+    protected $collection;
+
+    /**
+     * Create a new test collection instance.
+     *
+     * @param  mixed  $collection
+     * @param null $fallback
+     * @return void
+     */
+    public function __construct($collection, $fallback = null)
+    {
+        if (! ($collection instanceof Collection || $collection instanceof AbstractPaginator)) {
+            $this->fail('"%s" is not a collection', $collection);
+        }
+
+        $this->collection = $collection;
+        $this->setFallback($fallback);
+    }
+
+    /**
+     * Assert the collection contains the expected value.
+     *
+     * @param  mixed  $expected
+     * @return $this
+     */
+    public function contains($expected)
+    {
+        if (! $this->collection->contains($expected)) {
+            $this->fail('The collection does not contain the expected value "%s"', $expected);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert the collection does not contain the unexpected value.
+     *
+     * @param  mixed  $expected
+     * @return $this
+     */
+    public function notContains($expected)
+    {
+        if ($this->collection->contains($expected)) {
+            $this->fail('The collection contains the unexpected value "%s"', $expected);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert the collection has the expected amount of elements.
+     *
+     * @param  int  $expected
+     * @return $this
+     */
+    public function counts(int $expected)
+    {
+        $count = $this->collection->count();
+
+        if ($count !== $expected) {
+            $this->fail('The collection does not contain %s elements (%s found instead)', $expected, $count);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Fails the test with the given message.
+     *
+     * @param  string  $message
+     * @param  mixed  $expected
+     * @param  mixed|null  $found
+     *
+     * @throws \PHPUnit\Framework\AssertionFailedError
+     */
+    protected function fail($message, $expected, $found = null)
+    {
+        PHPUnit::fail(sprintf($message, $this->export($expected), $this->export($found)));
+    }
+
+    /**
+     * Exports a value into a single-line string
+     *
+     * @param  mixed  $value
+     * @return string
+     */
+    protected function export($value)
+    {
+        return (new Exporter)->shortenedExport($value);
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestCollection.php
+++ b/src/Illuminate/Foundation/Testing/TestCollection.php
@@ -97,7 +97,7 @@ class TestCollection
     }
 
     /**
-     * Exports a value into a single-line string
+     * Exports a value into a single-line string.
      *
      * @param  mixed  $value
      * @return string

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -790,6 +790,19 @@ class TestResponse
     }
 
     /**
+     * Assert that the response view has a collection or paginator.
+     *
+     * @param  string  $key
+     * @return $this
+     */
+    public function assertViewCollection($key)
+    {
+        $this->assertViewHas($key);
+
+        return new TestCollection($this->viewData($key));
+    }
+
+    /**
      * Get a piece of data from the original view.
      *
      * @param  string  $key

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -799,7 +799,7 @@ class TestResponse
     {
         $this->assertViewHas($key);
 
-        return new TestCollection($this->viewData($key));
+        return new TestCollection($this->viewData($key), $this);
     }
 
     /**

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use Illuminate\Support\Collection;
 use Mockery as m;
 use JsonSerializable;
 use Illuminate\Http\Response;
@@ -35,6 +36,19 @@ class FoundationTestResponseTest extends TestCase
         ]);
 
         $response->assertViewHas('foo');
+    }
+
+    public function testAssertViewCollection()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'hello world',
+            'getData' => ['myCollection' => new Collection([1, 2, 3, 4])],
+        ]);
+
+        $response->assertViewCollection('myCollection')
+            ->contains(1)
+            ->notContains(5)
+            ->counts(4);
     }
 
     public function testAssertViewHasModel()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -42,13 +42,17 @@ class FoundationTestResponseTest extends TestCase
     {
         $response = $this->makeMockResponse([
             'render' => 'hello world',
-            'getData' => ['myCollection' => new Collection([1, 2, 3, 4])],
+            'getData' => [
+                'myCollection' => new Collection([1, 2, 3, 4]),
+                'foo' => 'bar',
+            ],
         ]);
 
         $response->assertViewCollection('myCollection')
-            ->contains(1)
-            ->notContains(5)
-            ->counts(4);
+                ->contains(1)
+                ->notContains(5)
+                ->counts(4)
+            ->assertViewHas('foo', 'bar');
     }
 
     public function testAssertViewHasModel()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Foundation;
 
-use Illuminate\Support\Collection;
 use Mockery as m;
 use JsonSerializable;
 use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Collection;
 use Illuminate\Contracts\View\View;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Database\Eloquent\Model;

--- a/tests/Foundation/Testing/TestCollectionTest.php
+++ b/tests/Foundation/Testing/TestCollectionTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing;
+
+use stdClass;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Collection;
+use Illuminate\Pagination\Paginator;
+use PHPUnit\Framework\AssertionFailedError;
+use Illuminate\Foundation\Testing\TestCollection;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithCollections;
+
+class TestCollectionTest extends TestCase
+{
+    use InteractsWithCollections;
+
+    public function testItCanBeInstantiatedWithACollection()
+    {
+        $testCollection = new TestCollection(new Collection);
+
+        $this->assertInstanceOf(TestCollection::class, $testCollection);
+    }
+
+    public function testItCanBeInstantiatedWithAPaginator()
+    {
+        $testCollection = new TestCollection(new Paginator([], 10));
+
+        $this->assertInstanceOf(TestCollection::class, $testCollection);
+    }
+
+    public function testFailsIfTheValueGivenIsNotACollection()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('"stdClass Object ()" is not a collection');
+
+        new TestCollection(new stdClass());
+    }
+
+    public function testPassesIfTheCollectionContainsTheExpectedValue()
+    {
+        $testCollection = new TestCollection(new Collection([1, 2, 3]));
+
+        $testCollection->contains(2);
+    }
+
+    public function testFailsIfTheCollectionDoesNotContainTheExpectedValue()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The collection does not contain the expected value "5"');
+
+        $testCollection = new TestCollection(new Collection([1, 2, 3]));
+
+        $testCollection->contains(5);
+    }
+
+    public function testPassesIfTheCollectionDoesNotContainTheUnexpectedValue()
+    {
+        $testCollection = new TestCollection(new Collection([1, 2, 3]));
+
+        $testCollection->notContains(5);
+    }
+
+    public function testFailsIfTheCollectionContainsTheUnexpectedValue()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The collection contains the unexpected value "2"');
+
+        $testCollection = new TestCollection(new Collection([1, 2, 3]));
+
+        $testCollection->notContains(2);
+    }
+
+    public function testPassesIfTheCollectionHasTheExpectedAmountOfElements()
+    {
+        $testCollection = new TestCollection(new Collection([1, 2, 3]));
+
+        $testCollection->counts(3);
+    }
+
+    public function testFailsIfTheCollectionDoesNotHaveTheExpectedAmountOfElements()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The collection does not contain 4 elements (3 found instead)');
+
+        $testCollection = new TestCollection(new Collection([1, 2, 3]));
+
+        $testCollection->counts(4);
+    }
+
+    public function testItCanChainMethods()
+    {
+        $testCollection = new TestCollection(new Collection([1, 2, 3]));
+
+        $testCollection->contains(2)
+            ->notContains(4)
+            ->counts(3);
+    }
+
+    public function testItHasACustomHelper()
+    {
+        $testCollection = $this->assertCollection(new Collection());
+
+        $this->assertInstanceOf(TestCollection::class, $testCollection);
+    }
+
+    public function testFallbacksToTheParentClass()
+    {
+        $fallback = new class {
+            public $called = false;
+
+            public function parentMethod()
+            {
+                $this->called = true;
+            }
+        };
+
+        $testCollection = new TestCollection(new Collection, $fallback);
+
+        $testCollection->parentMethod();
+
+        $this->assertTrue($fallback->called);
+    }
+}


### PR DESCRIPTION
Laravel has a custom assertion to test view data (`assertViewHas`) that works well with simple values or models, but gets messy if you want to test data in a collection, for example:

Let's test a collection contains 3 not 5 and has a length of 4:

```
$response->assertViewHas($collection, function ($collection) {
    return $collection->contains(1) 
                   && ! $collection->contains(5)
                   && $collection->count() == 4;
});
```

This is both complicated to write and doesn't provide a helpful message in case of failure. 

This PR adds a method to test the view has a collection and then few extra helpers that will provide a better way to test the data in a collection with a fluent interface, so the above now becomes:

```
        $response->assertViewCollection('myCollection')
            ->contains(1)
            ->notContains(5)
            ->counts(4);
```

Alt syntax if the collection is in a variable and not in a view:

```
       $this->assertCollection($myCollection)
            ->contains(1)
            ->notContains(5)
            ->counts(4);
```

Also it doesn't break the chain of the methods in the `TestResponse` object, so this is possible:

```
        $response->assertViewCollection('myCollection')
                ->contains(1)
                ->notContains(5)
                ->counts(4)
         ->assertViewHas('myModel', $aModel);
```