### PR TITLE
[5.9] Add the migrated_at column to the migrations table

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Database\Migrations;
 
-use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Support\Carbon;
+use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 class DatabaseMigrationRepository implements MigrationRepositoryInterface
 {
@@ -109,8 +109,8 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
 
         try {
             $this->table()->insert($record);
-        } catch ( \Throwable $throwable) {
-            if (!$this->repositoryIsCompleted()) {
+        } catch (\Throwable $throwable) {
+            if (! $this->repositoryIsCompleted()) {
                 $this->addMissingColumns();
                 return $this->log($file, $batch);
             }
@@ -223,7 +223,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
-     * Validate if the migrations table is complete
+     * Validate if the migrations table is complete.
      *
      * @return bool
      */
@@ -239,7 +239,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
-     * Add the missing columns to the table
+     * Add the missing columns to the table.
      *
      * @return void
      */

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Tests\Database;
 
 use Closure;
-use Illuminate\Support\Carbon;
 use stdClass;
 use Mockery as m;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Connection;
@@ -89,9 +89,8 @@ class DatabaseMigrationRepositoryTest extends TestCase
         ->andReturnUsing(function () {
             // we first get an exception because the table isn't complete
             throw new \Exception('test');
-        }, function() {
+        }, function () {
             // the second call will be successful
-            return;
         });
         $query->shouldReceive('useWritePdo')->twice()->andReturn($query);
 


### PR DESCRIPTION
I did mention this idea in https://github.com/laravel/ideas/issues/1522 

It is in basic an addition for logging. It is useful to track the moment that a migration has been executed. Especially if on another moment you want to know when a table or column is added that may result in problems you didn't suspect.

During a new installation the migrated_at column will be added.

For backward compatible it will catch any error during the logging and check of all the columns exist, if not it will add the migrated_at column and try again to add the log record. If the columns exist it will throw the catched Throwable. I did it this way because I couldn't found a generic way to decide if the error is because the migrated_at column doesn't exist. And validating the table before each log insert did sound a little slower then this procedure. (That will effect the speed for testing more then the speed of deploying)

I decided to create a generic named addMissingColumns method. If on another moment there need to be more columns added it is possible to do that in the same function.

It is possible to add this status to the migrate:status command but I thought that it will create a breaking change so I didn't add it.

I'm happy to receive feedback if I need to change anything.