### PR TITLE
Altered the way orders is compiled.

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -698,6 +698,10 @@ class Grammar extends BaseGrammar
      */
     protected function compileOrders(Builder $query, $orders)
     {
+        // Key the array by columns to remove any duplicate columns and keep
+        // only the newest one / one with the highest index.
+        $orders = array_values(array_column($orders, null, 'column'));
+        
         if (! empty($orders)) {
             return 'order by '.implode(', ', $this->compileOrdersToArray($query, $orders));
         }


### PR DESCRIPTION
I have proposed the following edit after reaching an impasse with my relationships.  
I currently have a relationship defined as the following:

    public function users()
    {
        return $this->hasMany(User::class)
                    ->orderBy('name', 'ASC');
    }

The above is just an example of the sort of code I am using.

My issue arose when I tried changing the order of my relationship in my controller.  
Rather than retrieving all records and then sorting the collection, I wanted to do it on the database.  
The controller attempt in question:

    $users = $business->users()->latest('name')->first();

What this results in is the following SQL (snippet):

    order by `name` asc, `name` desc

This led me to learn that SQL takes the first instance of a sort and ignores all others.  
Naturally, I have a problem that I want it to ignore the first sort method.

The two choices are to either remove the `orderBy` call from out of the relationship or to change the source code.  
I chose the latter; hence this PR.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
