### PR TITLE
[5.7] Allow configuration of token guard keys

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -154,7 +154,9 @@ class AuthManager implements FactoryContract
         // user in the database or another persistence layer where users are.
         $guard = new TokenGuard(
             $this->createUserProvider($config['provider'] ?? null),
-            $this->app['request']
+            $this->app['request'],
+            $config['input_key'] ?? 'api_token',
+            $config['storage_key'] ?? 'api_token'
         );
 
         $this->app->refresh('request', $guard, 'setRequest');


### PR DESCRIPTION
This change allows users to configure the token guard input and storage keys in the auth guard configuration. It's useful if they want something else than the default `api_token` name.

No breaking changes.