### PR TITLE
[5.8] Use application instead of container in console

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -5,7 +5,6 @@ namespace Illuminate\Console;
 use Closure;
 use Illuminate\Support\ProcessUtils;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Container\Container;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputOption;
@@ -18,14 +17,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
-use Illuminate\Contracts\Console\Application as ApplicationContract;
+use Illuminate\Contracts\Foundation\Application as ApplicationContract;
+use Illuminate\Contracts\Console\Application as ConsoleApplicationContract;
 
-class Application extends SymfonyApplication implements ApplicationContract
+class Application extends SymfonyApplication implements ConsoleApplicationContract
 {
     /**
      * The Laravel application instance.
      *
-     * @var \Illuminate\Contracts\Container\Container
+     * @var \Illuminate\Contracts\Foundation\Application
      */
     protected $laravel;
 
@@ -53,12 +53,12 @@ class Application extends SymfonyApplication implements ApplicationContract
     /**
      * Create a new Artisan console application.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $laravel
+     * @param  \Illuminate\Contracts\Foundation\Application  $laravel
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @param  string  $version
      * @return void
      */
-    public function __construct(Container $laravel, Dispatcher $events, $version)
+    public function __construct(ApplicationContract $laravel, Dispatcher $events, $version)
     {
         parent::__construct('Laravel Framework', $version);
 


### PR DESCRIPTION

https://github.com/laravel/framework/pull/25241

Inside \Illuminate\Console\Application class:
- The `$laravel` property is commented as a Laravel application and we currently use more functions than just a container.
- The `getLaravel` method is also commented \Illuminate\Contracts\Foundation\Application as the return type.
- The \Illuminate\Tests\Console\ConsoleApplicationTest uses console mock by injecting a Laravel application instead of container instance.

So, I just change a bit at \Illuminate\Console\Application constructor by injecting application instead of container. It will be more clearly for someone who wants to extend this class. For example, building a package.