### PR TITLE
Fix unit tests - cached user on request globally.

### DIFF
--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -80,7 +80,7 @@ class RequestGuard implements Guard
      */
     public function setRequest(Request $request)
     {
-        if($this->request !== $request){
+        if ($this->request !== $request) {
             $this->user = null;
         }
         $this->request = $request;

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -80,6 +80,9 @@ class RequestGuard implements Guard
      */
     public function setRequest(Request $request)
     {
+        if($this->request !== $request){
+            $this->user = null;
+        }
         $this->request = $request;
 
         return $this;

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -83,6 +83,7 @@ class RequestGuard implements Guard
         if ($this->request !== $request) {
             $this->user = null;
         }
+
         $this->request = $request;
 
         return $this;


### PR DESCRIPTION
Currently you cannot call 2 api calls in 1 unit test with different user authentication. because the user gets cached globally and not refreshed with a new api call.

This problem also exists when you globalize the createApplication process. (for performance/memory issues)

I targeted the problem to a very simple solution (see changes).
