### PR TITLE
[5.8] Unit tests - Fix caching user on request when request changes

### DIFF
--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -80,6 +80,10 @@ class RequestGuard implements Guard
      */
     public function setRequest(Request $request)
     {
+        if ($this->request !== $request) {
+            $this->user = null;
+        }
+
         $this->request = $request;
 
         return $this;


### PR DESCRIPTION
Removes cached user when request changes (fixes unit test with global application using different users).


---
Currently you cannot call 2 api calls in 1 unit test with different user authentication. because the user gets cached globally and not refreshed with a new api call.

This problem also exists when you globalize the createApplication process. (for performance/memory issues)

I targeted the problem to a very simple solution (see changes).