### PR TITLE
[5.7] Fix PDO param casting when using floats with PDO::ATTR_EMULATE_PREPARES

### DIFF
--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -76,8 +76,9 @@ class MySqlConnection extends Connection
     {
         foreach ($bindings as $key => $value) {
             $statement->bindValue(
-                is_string($key) ? $key : $key + 1, $value,
-                is_int($value) || is_float($value) ? PDO::PARAM_INT : PDO::PARAM_STR
+                is_string($key) ? $key : $key + 1,
+                $value,
+                is_int($value) || (is_float($value) && $value === floor($value)) ? PDO::PARAM_INT : PDO::PARAM_STR
             );
         }
     }

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database;
 
-use PDO;
 use Illuminate\Database\Schema\MySqlBuilder;
 use Illuminate\Database\Query\Processors\MySqlProcessor;
 use Doctrine\DBAL\Driver\PDOMySql\Driver as DoctrineDriver;
@@ -63,23 +62,5 @@ class MySqlConnection extends Connection
     protected function getDoctrineDriver()
     {
         return new DoctrineDriver;
-    }
-
-    /**
-     * Bind values to their parameters in the given statement.
-     *
-     * @param  \PDOStatement $statement
-     * @param  array  $bindings
-     * @return void
-     */
-    public function bindValues($statement, $bindings)
-    {
-        foreach ($bindings as $key => $value) {
-            $statement->bindValue(
-                is_string($key) ? $key : $key + 1,
-                $value,
-                is_int($value) || (is_float($value) && $value === floor($value)) ? PDO::PARAM_INT : PDO::PARAM_STR
-            );
-        }
     }
 }

--- a/tests/Integration/Database/MySqlConnectionTest.php
+++ b/tests/Integration/Database/MySqlConnectionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @group integration
+ */
+class MySqlConnectionTest extends DatabaseTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'mysql',
+            'host' => '127.0.0.1',
+            'username' => 'root',
+            'password' => '',
+            'database' => 'forge',
+            'prefix' => '',
+            'options' => [
+                \PDO::ATTR_EMULATE_PREPARES => true,
+            ],
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function ($table) {
+            $table->decimal('rating', 5, 1);
+        });
+    }
+
+    public function tearDown()
+    {
+        Schema::drop('posts');
+
+        parent::tearDown();
+    }
+
+    public function testFloatBindingsMaintainDecimals()
+    {
+        DB::table('posts')->insert([
+            'rating' => 5.2,
+        ]);
+
+        $this->assertEquals(5.2, DB::table('posts')->value('rating'));
+    }
+}


### PR DESCRIPTION
This PR fixes #23850 

### Background
Starting  PHP 7.2, there's a breaking change in the way PDO handles `PDO::PARAM_INT` attributes.
Prior to 7.2, a float that was set as `PDO::PARAM_INT` would be casted as a float.
In PHP 7.2, a float set as `PDO::PARAM_INT` gets casted to an int.

```php
// Example:
DB::table('posts')->insert(['rating' => 5.2]);

// PHP <= 7.1
DB::table('posts')->pluck('rating');
=> [5.2]

// PHP >= 7.2
DB::table('posts')->pluck('rating');
=> [5]
```

There are various reasons for using `PDO::ATTR_EMULATE_PREPARES => true`. In my case I am running multiple database clusters behind ProxySQL, which requires emulate prepares turned on.

### The fix

Cast the float to an integer only when the float is a real integer, eg: `2.0 === 2`, otherwise keep the bindings as strings.

Tests provided to cover this case.