### PR TITLE
Fix sendResetFailedResponse to redirect with the right message

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -135,9 +135,17 @@ trait ResetsPasswords
      */
     protected function sendResetFailedResponse(Request $request, $response)
     {
+        $errorType = 'email';
+
+        if($response == Password::INVALID_PASSWORD) {
+            $errorType = 'password';
+        } else if($response == Password::INVALID_TOKEN) {
+            $errorType = 'token';
+        }
+
         return redirect()->back()
                     ->withInput($request->only('email'))
-                    ->withErrors(['email' => trans($response)]);
+                    ->withErrors([$errorType => trans($response)]);
     }
 
     /**


### PR DESCRIPTION
Currently, if $this->broker()->reset() returns and error message, this message will always be sent back to the previous location under the key 'email'. This way the error messages will be shown in reset.blade.php as an 'email' error, even if the error is a 'passwords.password' or a 'passwords.token'. This simple fix will check wich is the type of the error message and change the key name accordingly.
