### PR TITLE
[5.8] Improve command "route:list" message

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -67,11 +67,15 @@ class RouteListCommand extends Command
      */
     public function handle()
     {
-        if (count($this->routes) === 0) {
+        if (empty($this->routes)) {
             return $this->error("Your application doesn't have any routes.");
         }
 
-        $this->displayRoutes($this->getRoutes());
+        if (empty($routes = $this->getRoutes())) {
+            return $this->info('Could not find any matched routes.');
+        }
+
+        $this->displayRoutes($routes);
     }
 
     /**


### PR DESCRIPTION
For a long time, an empty table (only headers are displayed) has been nothing to me.

| Domain | Method | URI | Name | Action | Middleware |
|--------|--------|-----|------|--------|------------|

Such as the message "Your application doesn't have any routes.", I think a clear message "Could not find any matched routes." looks like more informative and pretty for anyone.
