### PR TITLE
[5.7] Fix registering not exists observers

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -55,7 +55,7 @@ trait HasEvents
     {
         $className = is_string($class) ? $class : get_class($class);
 
-        if (!class_exists($class)) {
+        if (! class_exists($class)) {
             throw new RuntimeException('Given observer class not exists.');
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use RuntimeException;
 use Illuminate\Support\Arr;
 use Illuminate\Contracts\Events\Dispatcher;
-use RuntimeException;
 
 trait HasEvents
 {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -55,7 +55,7 @@ trait HasEvents
     {
         $className = is_string($class) ? $class : get_class($class);
 
-        if (! class_exists($class)) {
+        if (! class_exists($className)) {
             throw new RuntimeException('Given observer class not exists.');
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent\Concerns;
 
 use Illuminate\Support\Arr;
 use Illuminate\Contracts\Events\Dispatcher;
+use RuntimeException;
 
 trait HasEvents
 {
@@ -30,6 +31,8 @@ trait HasEvents
      *
      * @param  object|array|string  $classes
      * @return void
+     *
+     * @throws \RuntimeException
      */
     public static function observe($classes)
     {
@@ -45,13 +48,15 @@ trait HasEvents
      *
      * @param  object|string $class
      * @return void
+     *
+     * @throws \RuntimeException
      */
     protected function registerObserver($class)
     {
         $className = is_string($class) ? $class : get_class($class);
 
         if (!class_exists($class)) {
-            throw new \RuntimeException('Given observer class not exists.');
+            throw new RuntimeException('Given observer class not exists.');
         }
 
         // When registering a model observer, we will spin through the possible events

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -50,6 +50,10 @@ trait HasEvents
     {
         $className = is_string($class) ? $class : get_class($class);
 
+        if (!class_exists($class)) {
+            throw new \RuntimeException('Given observer class not exists.');
+        }
+
         // When registering a model observer, we will spin through the possible events
         // and determine if this observer has that method. If it does, we will hook
         // it into the model's event system, making it convenient to watch these.

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -7,6 +7,7 @@ use stdClass;
 use Exception;
 use Mockery as m;
 use ReflectionClass;
+use RuntimeException;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Illuminate\Support\Carbon;
@@ -1308,14 +1309,14 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testThrowExceptionOnAttachingNotExistsModelObserverWithString()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         EloquentModelStub::observe(NotExistClass::class);
         EloquentModelStub::flushEventListeners();
     }
 
     public function testThrowExceptionOnAttachingNotExistsModelObserversThroughAnArray()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         EloquentModelStub::observe([NotExistClass::class]);
         EloquentModelStub::flushEventListeners();
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1306,6 +1306,20 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelStub::flushEventListeners();
     }
 
+    public function testThrowExceptionOnAttachingNotExistsModelObserverWithString()
+    {
+        $this->expectException(\RuntimeException::class);
+        EloquentModelStub::observe(NotExistClass::class);
+        EloquentModelStub::flushEventListeners();
+    }
+
+    public function testThrowExceptionOnAttachingNotExistsModelObserversThroughAnArray()
+    {
+        $this->expectException(\RuntimeException::class);
+        EloquentModelStub::observe([NotExistClass::class]);
+        EloquentModelStub::flushEventListeners();
+    }
+
     public function testModelObserversCanBeAttachedToModelsThroughCallingObserveMethodOnlyOnce()
     {
         EloquentModelStub::setEventDispatcher($events = m::mock(Dispatcher::class));

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1311,14 +1311,12 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         EloquentModelStub::observe(NotExistClass::class);
-        EloquentModelStub::flushEventListeners();
     }
 
     public function testThrowExceptionOnAttachingNotExistsModelObserversThroughAnArray()
     {
         $this->expectException(RuntimeException::class);
         EloquentModelStub::observe([NotExistClass::class]);
-        EloquentModelStub::flushEventListeners();
     }
 
     public function testModelObserversCanBeAttachedToModelsThroughCallingObserveMethodOnlyOnce()


### PR DESCRIPTION
I've experienced an issue when observer was registered, but never used. The problem was hidden in wrong observer namespace, but despite the fact that observer class wasn't exists - it was successfully registered.

This PR throws exception on registering not existing model observer.