### PR TITLE
[5.8] Move Str tests to the right location

### DIFF
--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -209,48 +209,6 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten([['#foo', '#bar'], ['#baz']]));
     }
 
-    public function testStrIs()
-    {
-        $this->assertTrue(Str::is('*.dev', 'localhost.dev'));
-        $this->assertTrue(Str::is('a', 'a'));
-        $this->assertTrue(Str::is('/', '/'));
-        $this->assertTrue(Str::is('*dev*', 'localhost.dev'));
-        $this->assertTrue(Str::is('foo?bar', 'foo?bar'));
-        $this->assertFalse(Str::is('*something', 'foobar'));
-        $this->assertFalse(Str::is('foo', 'bar'));
-        $this->assertFalse(Str::is('foo.*', 'foobar'));
-        $this->assertFalse(Str::is('foo.ar', 'foobar'));
-        $this->assertFalse(Str::is('foo?bar', 'foobar'));
-        $this->assertFalse(Str::is('foo?bar', 'fobar'));
-
-        $this->assertTrue(Str::is([
-            '*.dev',
-            '*oc*',
-        ], 'localhost.dev'));
-
-        $this->assertFalse(Str::is([
-            '/',
-            'a*',
-        ], 'localhost.dev'));
-
-        $this->assertFalse(Str::is([], 'localhost.dev'));
-    }
-
-    public function testStrRandom()
-    {
-        $result = Str::random(20);
-        $this->assertIsString($result);
-        $this->assertEquals(20, strlen($result));
-    }
-
-    public function testStartsWith()
-    {
-        $this->assertTrue(Str::startsWith('jason', 'jas'));
-        $this->assertTrue(Str::startsWith('jason', ['jas']));
-        $this->assertFalse(Str::startsWith('jason', 'day'));
-        $this->assertFalse(Str::startsWith('jason', ['day']));
-    }
-
     public function testE()
     {
         $str = 'A \'quote\' is <b>bold</b>';
@@ -258,80 +216,6 @@ class SupportHelpersTest extends TestCase
         $html = m::mock(Htmlable::class);
         $html->shouldReceive('toHtml')->andReturn($str);
         $this->assertEquals($str, e($html));
-    }
-
-    public function testEndsWith()
-    {
-        $this->assertTrue(Str::endsWith('jason', 'on'));
-        $this->assertTrue(Str::endsWith('jason', ['on']));
-        $this->assertFalse(Str::endsWith('jason', 'no'));
-        $this->assertFalse(Str::endsWith('jason', ['no']));
-    }
-
-    public function testStrAfter()
-    {
-        $this->assertEquals('nah', Str::after('hannah', 'han'));
-        $this->assertEquals('nah', Str::after('hannah', 'n'));
-        $this->assertEquals('hannah', Str::after('hannah', 'xxxx'));
-    }
-
-    public function testStrContains()
-    {
-        $this->assertTrue(Str::contains('taylor', 'ylo'));
-        $this->assertTrue(Str::contains('taylor', ['ylo']));
-        $this->assertFalse(Str::contains('taylor', 'xxx'));
-        $this->assertFalse(Str::contains('taylor', ['xxx']));
-        $this->assertTrue(Str::contains('taylor', ['xxx', 'taylor']));
-    }
-
-    public function testStrFinish()
-    {
-        $this->assertEquals('test/string/', Str::finish('test/string', '/'));
-        $this->assertEquals('test/string/', Str::finish('test/string/', '/'));
-        $this->assertEquals('test/string/', Str::finish('test/string//', '/'));
-    }
-
-    public function testStrStart()
-    {
-        $this->assertEquals('/test/string', Str::start('test/string', '/'));
-        $this->assertEquals('/test/string', Str::start('/test/string', '/'));
-        $this->assertEquals('/test/string', Str::start('//test/string', '/'));
-    }
-
-    public function testSnakeCase()
-    {
-        $this->assertEquals('foo_bar', Str::snake('fooBar'));
-        $this->assertEquals('foo_bar', Str::snake('fooBar')); // test cache
-    }
-
-    public function testStrLimit()
-    {
-        $string = 'The PHP framework for web artisans.';
-        $this->assertEquals('The PHP...', Str::limit($string, 7));
-        $this->assertEquals('The PHP', Str::limit($string, 7, ''));
-        $this->assertEquals('The PHP framework for web artisans.', Str::limit($string, 100));
-
-        $nonAsciiString = '这是一段中文';
-        $this->assertEquals('这是一...', Str::limit($nonAsciiString, 6));
-        $this->assertEquals('这是一', Str::limit($nonAsciiString, 6, ''));
-    }
-
-    public function testCamelCase()
-    {
-        $this->assertEquals('fooBar', Str::camel('FooBar'));
-        $this->assertEquals('fooBar', Str::camel('foo_bar'));
-        $this->assertEquals('fooBar', Str::camel('foo_bar')); // test cache
-        $this->assertEquals('fooBarBaz', Str::camel('Foo-barBaz'));
-        $this->assertEquals('fooBarBaz', Str::camel('foo-bar_baz'));
-    }
-
-    public function testStudlyCase()
-    {
-        $this->assertEquals('FooBar', Str::studly('fooBar'));
-        $this->assertEquals('FooBar', Str::studly('foo_bar'));
-        $this->assertEquals('FooBar', Str::studly('foo_bar')); // test cache
-        $this->assertEquals('FooBarBaz', Str::studly('foo-barBaz'));
-        $this->assertEquals('FooBarBaz', Str::studly('foo-bar_baz'));
     }
 
     public function testClassBasename()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -7,7 +7,6 @@ use ArrayAccess;
 use Mockery as m;
 use RuntimeException;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Optional;
 use Illuminate\Contracts\Support\Htmlable;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -145,6 +145,13 @@ class SupportStrTest extends TestCase
         $this->assertEquals('سلام-دنیا', Str::slug('سلام دنیا', '-', null));
     }
 
+    public function testStrStart()
+    {
+        $this->assertEquals('/test/string', Str::start('test/string', '/'));
+        $this->assertEquals('/test/string', Str::start('/test/string', '/'));
+        $this->assertEquals('/test/string', Str::start('//test/string', '/'));
+    }
+
     public function testFinish()
     {
         $this->assertEquals('abbc', Str::finish('ab', 'bc'));
@@ -207,6 +214,15 @@ class SupportStrTest extends TestCase
     {
         $this->assertEquals('Laravel is...', Str::limit('Laravel is a free, open source PHP web application framework.', 10));
         $this->assertEquals('这是一...', Str::limit('这是一段中文', 6));
+
+        $string = 'The PHP framework for web artisans.';
+        $this->assertEquals('The PHP...', Str::limit($string, 7));
+        $this->assertEquals('The PHP', Str::limit($string, 7, ''));
+        $this->assertEquals('The PHP framework for web artisans.', Str::limit($string, 100));
+
+        $nonAsciiString = '这是一段中文';
+        $this->assertEquals('这是一...', Str::limit($nonAsciiString, 6));
+        $this->assertEquals('这是一', Str::limit($nonAsciiString, 6, ''));
     }
 
     public function testLength()
@@ -274,6 +290,12 @@ class SupportStrTest extends TestCase
         $this->assertEquals('LaravelPhpFramework', Str::studly('laravel_php_framework'));
         $this->assertEquals('LaravelPhPFramework', Str::studly('laravel-phP-framework'));
         $this->assertEquals('LaravelPhpFramework', Str::studly('laravel  -_-  php   -_-   framework   '));
+
+        $this->assertEquals('FooBar', Str::studly('fooBar'));
+        $this->assertEquals('FooBar', Str::studly('foo_bar'));
+        $this->assertEquals('FooBar', Str::studly('foo_bar')); // test cache
+        $this->assertEquals('FooBarBaz', Str::studly('foo-barBaz'));
+        $this->assertEquals('FooBarBaz', Str::studly('foo-bar_baz'));
     }
 
     public function testCamel()
@@ -282,6 +304,12 @@ class SupportStrTest extends TestCase
         $this->assertEquals('laravelPhpFramework', Str::camel('Laravel_php_framework'));
         $this->assertEquals('laravelPhPFramework', Str::camel('Laravel-phP-framework'));
         $this->assertEquals('laravelPhpFramework', Str::camel('Laravel  -_-  php   -_-   framework   '));
+
+        $this->assertEquals('fooBar', Str::camel('FooBar'));
+        $this->assertEquals('fooBar', Str::camel('foo_bar'));
+        $this->assertEquals('fooBar', Str::camel('foo_bar')); // test cache
+        $this->assertEquals('fooBarBaz', Str::camel('Foo-barBaz'));
+        $this->assertEquals('fooBarBaz', Str::camel('foo-bar_baz'));
     }
 
     public function testSubstr()


### PR DESCRIPTION
`tests/Support/SupporStrTest.php` file is created to organize all tests related to \Illuminate\Support\Str class but some tests are still located at `tests/Support/SupporHelperTest.php`.

Therefore, I want to help to move these tests to the right location `tests/Support/SupporStrTest.php` and later tests should be held here.

1 test is moved:
- SupportHelperTest::testStrStart() -> SupportStrTest::testStart()

6 tests are deleted:
- SupportHelperTest::testStrIs() is deleted because SupportStrTest::testIs() exists and covers all cases.
- SupportHelperTest::testStartsWith() is deleted because SupportStrTest::testStartsWith() exists and covers all cases.
- SupportHelperTest::testEndsWith() is deleted because SupportStrTest::testEndsWith() exists and covers all cases.
- SupportHelperTest::testStrAfter() is deleted because SupportStrTest::testStrAfter() exists and covers all cases.
- SupportHelperTest::testStrContains() is deleted because SupporStrTest::testStrContains() exists and covers all cases.
- SupportHelperTest::testStrFinish() is deleted because SupportStrTest::testFinish() exists and covers all cases.
- SupporHelperTest::testSnakeCase() is deleted because SupportStrTest::testSnake() exists and covers all cases.

4 test cases (aserrtions) are moved:
- SupportHelperTest::testStrRandom() -> SupportStrTest::testRandom()
- SupportHelperTest::testStrLimit() -> SupporStr::testLimit()
- SupportHelperTest::testCamelCase() -> SupporStrTest::testCamel()
- SupportHelperTest::testStudlyCase() -> SupportStrTest::testStudly()

