### PR TITLE
[5.7] Fix an issue when using Mail::queue to queue Mailables

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -380,7 +380,11 @@ class Mailer implements MailerContract, MailQueueContract
             throw new InvalidArgumentException('Only mailables may be queued.');
         }
 
-        return $view->queue(is_null($queue) ? $this->queue : $queue);
+        if (is_string($queue)) {
+            $view->onQueue($queue);
+        }
+
+        return $view->queue($this->queue);
     }
 
     /**


### PR DESCRIPTION
The issue was found on the `Illuminate\Mail\Mailer::queue` method. The given queue name and the queue manager where used indistinctly which caused the error when calling the `Illuminate\Mail\Mailable::queue` method as it expected an `Illuminate\Contracts\Queue\Factory` object.

Fixes #27612