### PR TITLE
[5.8] fix failing tests on windows

### DIFF
--- a/tests/Integration/Mail/RenderingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/RenderingMailWithLocaleTest.php
@@ -31,14 +31,14 @@ class RenderingMailWithLocaleTest extends TestCase
     {
         $mail = new RenderedTestMail;
 
-        $this->assertStringContainsString("name\n", $mail->render());
+        $this->assertStringContainsString('name'.PHP_EOL, $mail->render());
     }
 
     public function testMailableRendersInSelectedLocale()
     {
         $mail = (new RenderedTestMail)->locale('es');
 
-        $this->assertStringContainsString("nombre\n", $mail->render());
+        $this->assertStringContainsString('nombre'.PHP_EOL, $mail->render());
     }
 
     public function testMailableRendersInAppSelectedLocale()
@@ -47,7 +47,7 @@ class RenderingMailWithLocaleTest extends TestCase
 
         $mail = new RenderedTestMail;
 
-        $this->assertStringContainsString("nombre\n", $mail->render());
+        $this->assertStringContainsString('nombre'.PHP_EOL, $mail->render());
     }
 }
 


### PR DESCRIPTION
During a recent change to replace deprecated phpunit methods, PHP_EOL was replaced with unix specific line-endings ( "\n" ). Causing the tests to fail on windows environment.