### PR TITLE
[5.8] Throw exception on registering non exists observer

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use RuntimeException;
 use Illuminate\Support\Arr;
 use Illuminate\Contracts\Events\Dispatcher;
 
@@ -30,6 +31,8 @@ trait HasEvents
      *
      * @param  object|array|string  $classes
      * @return void
+     *
+     * @throws \RuntimeException
      */
     public static function observe($classes)
     {
@@ -45,10 +48,16 @@ trait HasEvents
      *
      * @param  object|string $class
      * @return void
+     *
+     * @throws \RuntimeException
      */
     protected function registerObserver($class)
     {
         $className = is_string($class) ? $class : get_class($class);
+
+        if (! class_exists($className)) {
+            throw new RuntimeException('Given observer class not exists.');
+        }
 
         // When registering a model observer, we will spin through the possible events
         // and determine if this observer has that method. If it does, we will hook

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -53,11 +53,7 @@ trait HasEvents
      */
     protected function registerObserver($class)
     {
-        $className = is_string($class) ? $class : get_class($class);
-
-        if (! class_exists($className)) {
-            throw new RuntimeException('Given observer class not exists.');
-        }
+        $className = $this->resolveObserverClassName($class);
 
         // When registering a model observer, we will spin through the possible events
         // and determine if this observer has that method. If it does, we will hook
@@ -380,5 +376,26 @@ trait HasEvents
                 static::setEventDispatcher($dispatcher);
             }
         }
+    }
+
+    /**
+     * Resolve observer class name from object or string.
+     *
+     * @param  object|string $class
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    private function resolveObserverClassName($class)
+    {
+        if (is_object($class)) {
+            return get_class($class);
+        }
+
+        if (class_exists($class)) {
+            return $class;
+        }
+
+        throw new RuntimeException('Given observer class not exists.');
     }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -8,6 +8,7 @@ use Exception;
 use Mockery as m;
 use LogicException;
 use ReflectionClass;
+use RuntimeException;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Illuminate\Support\Carbon;
@@ -1308,6 +1309,18 @@ class DatabaseEloquentModelTest extends TestCase
         $events->shouldReceive('forget');
         EloquentModelStub::observe([EloquentTestObserverStub::class]);
         EloquentModelStub::flushEventListeners();
+    }
+
+    public function testThrowExceptionOnAttachingNotExistsModelObserverWithString()
+    {
+        $this->expectException(RuntimeException::class);
+        EloquentModelStub::observe(NotExistClass::class);
+    }
+
+    public function testThrowExceptionOnAttachingNotExistsModelObserversThroughAnArray()
+    {
+        $this->expectException(RuntimeException::class);
+        EloquentModelStub::observe([NotExistClass::class]);
     }
 
     public function testModelObserversCanBeAttachedToModelsThroughCallingObserveMethodOnlyOnce()


### PR DESCRIPTION
Based on #27614

I've experienced an issue when observer was registered, but never used. The problem was hidden in wrong observer namespace, but despite the fact that observer class wasn't exists - it was successfully registered.

This PR throws exception on registering not existing model observer.