### PR TITLE
[5.7] Support retry of failed jobs with a timeout

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -87,6 +87,7 @@ class RetryCommand extends Command
         if (isset($payload['attempts'])) {
             $payload['attempts'] = 0;
         }
+        $payload['timeoutAt'] = null;
 
         return json_encode($payload);
     }


### PR DESCRIPTION
Retrying a failed job with a value for retryUntil() is not possible without resetting the `timeoutAt` value too.

Use Case:

Setting a jobs max tries and a concrete time frame as a limit (maybe 5 minutes) to handle long running external services. If that job failes by the number of attempts you can not retry the job if the timeoutAt value is in the past.

Solution:

Set `timeoutAt` value to null to make a `queue:retry` possible. In most situations it is already null, so everything works fine.

Do you need any information?