### PR TITLE
[5.7] Test cache has method with false value

### DIFF
--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -66,9 +66,11 @@ class CacheRepositoryTest extends TestCase
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
         $repo->getStore()->shouldReceive('get')->once()->with('bar')->andReturn('bar');
+        $repo->getStore()->shouldReceive('get')->once()->with('baz')->andReturn(false);
 
         $this->assertTrue($repo->has('bar'));
         $this->assertFalse($repo->has('foo'));
+        $this->assertTrue($repo->has('baz'));
     }
 
     public function testMissingMethod()


### PR DESCRIPTION
An issue was filed which caused some confusion about false being a valid cache value with the has method. Turns out that the current implementation is the correct one but the behavior wasn't tested yet. This extra test makes it clear.

More on valid data values: https://www.php-fig.org/psr/psr-16/#14-data

Referenced issue: https://github.com/laravel/framework/issues/27630