### PR TITLE
[5.8] Fix BoundMethod docblock

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -17,6 +17,9 @@ class BoundMethod
      * @param  array  $parameters
      * @param  string|null  $defaultMethod
      * @return mixed
+     *
+     * @throws \ReflectionException
+     * @throws \InvalidArgumentException
      */
     public static function call($container, $callback, array $parameters = [], $defaultMethod = null)
     {
@@ -107,6 +110,8 @@ class BoundMethod
      * @param  callable|string  $callback
      * @param  array  $parameters
      * @return array
+     *
+     * @throws \ReflectionException
      */
     protected static function getMethodDependencies($container, $callback, array $parameters = [])
     {


### PR DESCRIPTION
- `BoundMethod::getMethodDependencies()` may throw a ReflectionException instance from `BoundMethod::getCallReflector()`.

- `BoundMethod::call()` may throw an InvalidArgumentException instance from `BoundMethod::callClass()` or a ReflectionException instance from `BoundMethod::getMethodDependencies()`.