### PR TITLE
[5.7] Add message value assertion to assertJsonValidationErrors

### DIFF
--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -362,7 +362,7 @@ class FoundationTestResponseTest extends TestCase
             'errors' => ['foo' => 'one', 'bar' => 'two'],
         ];
 
-         $testResponse = TestResponse::fromBaseResponse(
+        $testResponse = TestResponse::fromBaseResponse(
             (new Response)->setContent(json_encode($data))
         );
 
@@ -376,11 +376,39 @@ class FoundationTestResponseTest extends TestCase
             'errors' => ['key' => 'foo'],
         ];
 
-         $testResponse = TestResponse::fromBaseResponse(
+        $testResponse = TestResponse::fromBaseResponse(
             (new Response)->setContent(json_encode($data))
         );
 
         $testResponse->assertJsonValidationErrors(['key' => 'foo']);
+    }
+
+    public function testAssertJsonValidationErrorMessagesCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $data = [
+            'status' => 'ok',
+            'errors' => ['key' => 'foo'],
+        ];
+
+         $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors(['key' => 'bar']);
+    }
+     public function testAssertJsonValidationErrorMessagesMultipleMessages()
+    {
+        $data = [
+            'status' => 'ok',
+            'errors' => ['one' => 'foo', 'two' => 'bar'],
+        ];
+         $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors(['one' => 'foo', 'two' => 'bar']);
     }
 
     public function testAssertJsonMissingValidationErrors()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -355,6 +355,34 @@ class FoundationTestResponseTest extends TestCase
         $testResponse->assertJsonValidationErrors([]);
     }
 
+    public function testAssertJsonValidationErrorsWithArray()
+    {
+        $data = [
+            'status' => 'ok',
+            'errors' => ['foo' => 'one', 'bar' => 'two'],
+        ];
+
+         $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors(['foo', 'bar']);
+    }
+
+    public function testAssertJsonValidationErrorMessages()
+    {
+        $data = [
+            'status' => 'ok',
+            'errors' => ['key' => 'foo'],
+        ];
+
+         $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors(['key' => 'foo']);
+    }
+
     public function testAssertJsonMissingValidationErrors()
     {
         $baseResponse = tap(new Response, function ($response) {

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -392,19 +392,21 @@ class FoundationTestResponseTest extends TestCase
             'errors' => ['key' => 'foo'],
         ];
 
-         $testResponse = TestResponse::fromBaseResponse(
+        $testResponse = TestResponse::fromBaseResponse(
             (new Response)->setContent(json_encode($data))
         );
 
         $testResponse->assertJsonValidationErrors(['key' => 'bar']);
     }
-     public function testAssertJsonValidationErrorMessagesMultipleMessages()
+
+    public function testAssertJsonValidationErrorMessagesMultipleMessages()
     {
         $data = [
             'status' => 'ok',
             'errors' => ['one' => 'foo', 'two' => 'bar'],
         ];
-         $testResponse = TestResponse::fromBaseResponse(
+
+        $testResponse = TestResponse::fromBaseResponse(
             (new Response)->setContent(json_encode($data))
         );
 


### PR DESCRIPTION
This PR adds the assertion for JSON validation error messages in `assertJsonValidationErrors`. 

Currently, we can only check json validation error keys: 

`$this->assertJsonValidationErrors('key');`
`$this->assertJsonValidationErrors(['foo', 'bar']);`

With this addition, you can check the key and the message:
`$this->assertJsonValidationErrors(['key' => 'validation message']);`

You can still continue to use the normal functionality by just passing a key or an array of keys.