### PR TITLE
[5.7] Updates vue preset to use latest stable build.

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/Vue.php
+++ b/src/Illuminate/Foundation/Console/Presets/Vue.php
@@ -30,11 +30,12 @@ class Vue extends Preset
      */
     protected static function updatePackageArray(array $packages)
     {
-        return ['vue' => '^2.5.17'] + Arr::except($packages, [
-            'babel-preset-react',
-            'react',
-            'react-dom',
-        ]);
+        return ['vue' => '^2.6.7', 'vue-template-compiler' => '^2.6.7'] +
+            Arr::except($packages, [
+                'babel-preset-react',
+                'react',
+                'react-dom',
+            ]);
     }
 
     /**


### PR DESCRIPTION
This pull request updates the version of vue to 2.6.7 (latest stable version) in the Vue preset command. I've also explicitly added the `'vue-template-compiler' => '2.6.7'` package to prevent vue and vue-template-compiler version compatibility errors when compiling assets after using this preset.