### PR TITLE
[5.7] Update vue preset to exclude @babel/preset-react

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/Vue.php
+++ b/src/Illuminate/Foundation/Console/Presets/Vue.php
@@ -31,7 +31,7 @@ class Vue extends Preset
     protected static function updatePackageArray(array $packages)
     {
         return ['vue' => '^2.5.17'] + Arr::except($packages, [
-            'babel-preset-react',
+            '@babel/preset-react',
             'react',
             'react-dom',
         ]);


### PR DESCRIPTION
Laravel Mix v3+ is using babel 7 which has a new name for this preset

https://www.npmjs.com/package/@babel/preset-react

React preset is already using new name
https://github.com/laravel/framework/blob/8107fe1d3769fdef35a8ccb85d9ff0d942380394/src/Illuminate/Foundation/Console/Presets/React.php#L34
