### PR TITLE
[5.7] Cache view in optimize command

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -27,6 +27,7 @@ class OptimizeCommand extends Command
      */
     public function handle()
     {
+        $this->call('view:cache');
         $this->call('config:cache');
         $this->call('route:cache');
 


### PR DESCRIPTION
Laravel allows to cache views, so why not add this command here.

`optimize:clear` command already clears the cached views
https://github.com/laravel/framework/blob/8107fe1d3769fdef35a8ccb85d9ff0d942380394/src/Illuminate/Foundation/Console/OptimizeClearCommand.php#L30