### PR TITLE
[5.7] Reflash the session for the broadcasting auth call.

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastController.php
+++ b/src/Illuminate/Broadcasting/BroadcastController.php
@@ -16,6 +16,10 @@ class BroadcastController extends Controller
      */
     public function authenticate(Request $request)
     {
+        if ($request->hasSession()) {
+            $request->session()->reflash();
+        }
+
         return Broadcast::auth($request);
     }
 }


### PR DESCRIPTION
When using session flash and broadcasting, the flashed message is being aged by the presence channel auth request. The BroadcastController needs the web middleware in order to authenticate the user, however while accessing the session middleware the flashed data is being aged out. Here is how the requests go:

1. Home page <- Flash a "Hello" message. This will show on the current page, as it's in the flash new key.
2. Home page presence request <- checks the user auth and has access to the flash old key. Ages the session and clears out the flashed message.
3. Contact page <- Has no access to the "Hello" message since it was aged out by the "last" request which was the presence auth ajax request.

This is unexpected behavior, and since the auth request is not supposed to touch the session flash, we need to reflash it there to avoid the session flash being aged out one request too early.

I can't think of a reasonable way to write a test for this, so if someone can suggest something I'll be happy to write it.

