### PR TITLE
[5.7] Allow custom message when validate using rule object

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -570,13 +570,15 @@ class Validator implements ValidatorContract
     protected function validateUsingCustomRule($attribute, $value, $rule)
     {
         if (! $rule->passes($attribute, $value)) {
-            $this->failedRules[$attribute][get_class($rule)] = [];
+            $ruleClass = get_class($rule);
+            $this->failedRules[$attribute][$ruleClass] = [];
 
-            $messages = (array) $rule->message();
+            $customMessages = $this->getFromLocalArray($attribute, $ruleClass);
+            $messages = (array) ($customMessages ?: $rule->message());
 
             foreach ($messages as $message) {
                 $this->messages->add($attribute, $this->makeReplacements(
-                    $message, $attribute, get_class($rule), []
+                    $message, $attribute, $ruleClass, []
                 ));
             }
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4281,7 +4281,7 @@ class ValidationValidatorTest extends TestCase
             ['name' => 'adam', 'value' => 'adam'],
             ['name' => $ruleObject, 'value' => $ruleObject],
             [
-                'name.' . get_class($ruleObject) => '[custom] :attribute must be taylor',
+                'name.'.get_class($ruleObject) => '[custom] :attribute must be taylor',
             ]
         );
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4247,6 +4247,49 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($rule->called);
     }
 
+    public function testCustomMessageForCustomRuleObject()
+    {
+        $ruleObject = new class implements Rule {
+            public function passes($attribute, $value)
+            {
+                return $value === 'taylor';
+            }
+
+            public function message()
+            {
+                return ':attribute must be taylor';
+            }
+        };
+
+        // Test custom message for rule class
+        $v = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['name' => 'adam', 'value' => 'adam'],
+            ['name' => $ruleObject, 'value' => $ruleObject],
+            [
+                get_class($ruleObject) => '[custom] :attribute must be taylor',
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals('[custom] name must be taylor', $v->errors()->all()[0]);
+        $this->assertEquals('[custom] value must be taylor', $v->errors()->all()[1]);
+
+        // Test custom message for rule class for specific attribute
+        $v = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['name' => 'adam', 'value' => 'adam'],
+            ['name' => $ruleObject, 'value' => $ruleObject],
+            [
+                'name.' . get_class($ruleObject) => '[custom] :attribute must be taylor',
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals('[custom] name must be taylor', $v->errors()->all()[0]);
+        $this->assertEquals('value must be taylor', $v->errors()->all()[1]);
+    }
+
     public function testValidateReturnsValidatedData()
     {
         $post = ['first' => 'john',  'preferred'=>'john', 'last' => 'doe', 'type' => 'admin'];


### PR DESCRIPTION
All default validation rules are allow to custom message by passing custom message to Validator instance.

This add ability to customize message of Validation Rule object, when using it for different purpose (e.g. custom message for api, cms)... 

E.g.
```php
class CustomValidationRule implements Rule
{
    public function message()
    {
        return __('Default validation message.');
    }
}

$validator = Validator::make(
    $request->all(),
    ['name' => new CustomValidationRule, 'value' => 'required'],
    [
        CustomValidationRule::class => __('Custom validation message'),
        // 'name.' . CustomValidationRule::class => __('Custom validation message'),
    ]
)
```

The PR won't break any functionality and a test is added.