### PR TITLE
[5.9] Lines returns removal in resetPassword

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -103,13 +103,9 @@ trait ResetsPasswords
     protected function resetPassword($user, $password)
     {
         $user->password = Hash::make($password);
-
         $user->setRememberToken(Str::random(60));
-
         $user->save();
-
         event(new PasswordReset($user));
-
         $this->guard()->login($user);
     }
 


### PR DESCRIPTION
Economise a bit of server treatment for empty lines.
Nothing breaks, it's just milliseconds of treatments.
