### PR TITLE
[5.8] Add message value assertion to assertJsonValidationErrors

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -657,7 +657,12 @@ class TestResponse
                     "Failed to find a validation error in the response for key: '{$value}'".PHP_EOL.PHP_EOL.$errorMessage
                 );
             } else {
-                PHPUnit::assertArraySubset([$key => $value], $jsonErrors, false, 'Failed to find validation errors:');
+                PHPUnit::assertArraySubset(
+                    [$key => $value],
+                    $jsonErrors,
+                    false,
+                    'Failed to find validation errors:'
+                );
             }
         }
 

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -661,7 +661,7 @@ class TestResponse
                     [$key => $value],
                     $jsonErrors,
                     false,
-                    "Failed to find a validation error in the response for key and message:"
+                    'Failed to find a validation error in the response for key and message:'
                 );
             }
         }

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -661,7 +661,7 @@ class TestResponse
                     [$key => $value],
                     $jsonErrors,
                     false,
-                    'Failed to find validation errors:'
+                    "Failed to find a validation error in the response for key and message:"
                 );
             }
         }

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -652,7 +652,7 @@ class TestResponse
                 : 'Response does not have JSON validation errors.';
 
         if ($checkMessages) {
-            PHPUnit::assertArraySubset($errors, $jsonErrors, false, 'Failed to find validation messages:');
+            PHPUnit::assertArraySubset($errors, $jsonErrors, false, 'Failed to find validation errors:');
         } else {
             foreach ($errors as $key) {
                 PHPUnit::assertArrayHasKey(

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -651,16 +651,16 @@ class TestResponse
                         PHP_EOL.PHP_EOL.json_encode($jsonErrors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL
                 : 'Response does not have JSON validation errors.';
 
-        foreach ($errors as $key => $error) {
-            PHPUnit::assertArrayHasKey(
-                $checkMessages ? $key : $error,
-                $jsonErrors,
-                "Failed to find a validation error in the response for key: '{$error}'".PHP_EOL.PHP_EOL.$errorMessage
-            );
-        }
-
         if ($checkMessages) {
             PHPUnit::assertArraySubset($errors, $jsonErrors, false, 'Failed to find validation messages:');
+        } else {
+            foreach ($errors as $key) {
+                PHPUnit::assertArrayHasKey(
+                    $key,
+                    $jsonErrors,
+                    "Failed to find a validation error in the response for key: '{$key}'".PHP_EOL.PHP_EOL.$errorMessage
+                );
+            }
         }
 
         return $this;

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -640,8 +640,6 @@ class TestResponse
     {
         $errors = Arr::wrap($errors);
 
-        $checkMessages = array_keys($errors) !== range(0, count($errors) - 1);
-
         PHPUnit::assertNotEmpty($errors, 'No validation errors were provided.');
 
         $jsonErrors = $this->json()['errors'] ?? [];
@@ -651,15 +649,15 @@ class TestResponse
                         PHP_EOL.PHP_EOL.json_encode($jsonErrors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL
                 : 'Response does not have JSON validation errors.';
 
-        if ($checkMessages) {
-            PHPUnit::assertArraySubset($errors, $jsonErrors, false, 'Failed to find validation errors:');
-        } else {
-            foreach ($errors as $key) {
+        foreach ($errors as $key => $value) {
+            if (is_int($key)) {
                 PHPUnit::assertArrayHasKey(
-                    $key,
+                    $value,
                     $jsonErrors,
-                    "Failed to find a validation error in the response for key: '{$key}'".PHP_EOL.PHP_EOL.$errorMessage
+                    "Failed to find a validation error in the response for key: '{$value}'".PHP_EOL.PHP_EOL.$errorMessage
                 );
+            } else {
+                PHPUnit::assertArraySubset([$key => $value], $jsonErrors, false, 'Failed to find validation errors:');
             }
         }
 

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -369,6 +369,50 @@ class FoundationTestResponseTest extends TestCase
         $testResponse->assertJsonValidationErrors(['foo', 'bar']);
     }
 
+    public function testAssertJsonValidationErrorMessages()
+    {
+        $data = [
+            'status' => 'ok',
+            'errors' => ['key' => 'foo'],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors(['key' => 'foo']);
+    }
+
+    public function testAssertJsonValidationErrorMessagesCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $data = [
+            'status' => 'ok',
+            'errors' => ['key' => 'foo'],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors(['key' => 'bar']);
+    }
+
+    public function testAssertJsonValidationErrorMessagesMultipleMessages()
+    {
+        $data = [
+            'status' => 'ok',
+            'errors' => ['one' => 'foo', 'two' => 'bar'],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors(['one' => 'foo', 'two' => 'bar']);
+    }
+
     public function testAssertJsonMissingValidationErrors()
     {
         $baseResponse = tap(new Response, function ($response) {

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -413,6 +413,36 @@ class FoundationTestResponseTest extends TestCase
         $testResponse->assertJsonValidationErrors(['one' => 'foo', 'two' => 'bar']);
     }
 
+    public function testAssertJsonValidationErrorMessagesMixed()
+    {
+        $data = [
+            'status' => 'ok',
+            'errors' => ['one' => 'foo', 'two' => 'bar'],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors(['one' => 'foo', 'two']);
+    }
+
+    public function testAssertJsonValidationErrorMessagesMixedCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $data = [
+            'status' => 'ok',
+            'errors' => ['one' => 'foo', 'two' => 'bar'],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors(['one' => 'taylor', 'otwell']);
+    }
+
     public function testAssertJsonMissingValidationErrors()
     {
         $baseResponse = tap(new Response, function ($response) {

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -355,6 +355,20 @@ class FoundationTestResponseTest extends TestCase
         $testResponse->assertJsonValidationErrors([]);
     }
 
+    public function testAssertJsonValidationErrorsWithArray()
+    {
+        $data = [
+            'status' => 'ok',
+            'errors' => ['foo' => 'one', 'bar' => 'two'],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors(['foo', 'bar']);
+    }
+
     public function testAssertJsonMissingValidationErrors()
     {
         $baseResponse = tap(new Response, function ($response) {


### PR DESCRIPTION
Moved to 5.8 branch per request (#27640).

This PR adds the assertion for JSON validation error messages in `assertJsonValidationErrors`. 

Currently, we can only check json validation error keys: 

`$this->assertJsonValidationErrors('key');`
`$this->assertJsonValidationErrors(['foo', 'bar']);`

With this addition, you can check the key and the message:
`$this->assertJsonValidationErrors(['key' => 'validation message']);`

You can still continue to use the normal functionality by just passing a key or an array of keys. 