### PR TITLE
[5.8] URLs from config for custom filesystem drivers

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -398,6 +398,8 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
             return $adapter->getUrl($path);
         } elseif (method_exists($this->driver, 'getUrl')) {
             return $this->driver->getUrl($path);
+        } elseif (! empty($this->driver->getConfig()->get('url'))) {
+            return $this->driver->getConfig()->get('url');
         } elseif ($adapter instanceof AwsS3Adapter) {
             return $this->getAwsUrl($adapter, $path);
         } elseif ($adapter instanceof RackspaceAdapter) {


### PR DESCRIPTION
Some custom filesystem drivers don't include URL support at the adapter level or in the driver but can be added to the driver through config.

For example, [thephpleague/flysystem-sftp](https://github.com/thephpleague/flysystem-sftp) doesn't have the getUrl method, but it will be good if the adapter could get this from filesystems config.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
