### PR TITLE
[5.6] Add paths setter to FileViewFinder

### DIFF
--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -267,6 +267,17 @@ class FileViewFinder implements ViewFinderInterface
     }
 
     /**
+     * Set the active view paths.
+     *
+     * @param  array  $paths
+     * @return array
+     */
+    public function setPaths($paths)
+    {
+        $this->paths = $paths;
+    }
+
+    /**
      * Get the active view paths.
      *
      * @return array


### PR DESCRIPTION
We're in a situation where we want to add file locations. Normally `addLocation` or `prependLocation` would be fine, except we need to add them before each existing configured path.

``` php
// config/views.php

'paths' => [
    resource_path('views'),
    resource_path('who-knows'),
],
```

eg. we need to add paths before `resource_path('views')` and before `resource_path('who-knows')` which might end up looking something like:

```
[
    resource_path('views/one'),
    resource_path('views/two'),
    resource_path('views'),
    resource_path('who-knows/one'),
    resource_path('who-knows/two'),
    resource_path('who-knows'),
]
```

What we ended up doing is using `getPaths()`, adjusting the array manually, then putting it back with `setPaths()`, but the method doesn't exist. This PR adds it.