### PR TITLE
[5.6] Make view finder setter returns this

### DIFF
--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -270,11 +270,13 @@ class FileViewFinder implements ViewFinderInterface
      * Set the active view paths.
      *
      * @param  array  $paths
-     * @return array
+     * @return $this
      */
     public function setPaths($paths)
     {
         $this->paths = $paths;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Please see https://github.com/laravel/framework/pull/27658 for more detail!

FileViewFinder::setPaths() was added and currently has wrong dockblock `@return array`. Instead change into `@return void`, I mark it as `@return $this` for further convenient actions if necessary.