### PR TITLE
[5.8] Support multiple guesses for Policy resolution

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -538,8 +538,10 @@ class Gate implements GateContract
             return $this->resolvePolicy($this->policies[$class]);
         }
 
-        if (class_exists($guessedPolicy = $this->guessPolicyName($class))) {
-            return $this->resolvePolicy($guessedPolicy);
+        foreach ($this->guessPolicyName($class) as $guessedPolicy) {
+            if (class_exists($guessedPolicy)) {
+                return $this->resolvePolicy($guessedPolicy);
+            }
         }
 
         foreach ($this->policies as $expected => $policy) {
@@ -553,17 +555,17 @@ class Gate implements GateContract
      * Guess the policy name for the given class.
      *
      * @param  string  $class
-     * @return string
+     * @return array
      */
     protected function guessPolicyName($class)
     {
         if ($this->guessPolicyNamesUsingCallback) {
-            return call_user_func($this->guessPolicyNamesUsingCallback, $class);
+            return Arr::wrap(call_user_func($this->guessPolicyNamesUsingCallback, $class));
         }
 
         $classDirname = str_replace('/', '\\', dirname(str_replace('\\', '/', $class)));
 
-        return $classDirname.'\\Policies\\'.class_basename($class).'Policy';
+        return [$classDirname.'\\Policies\\'.class_basename($class).'Policy'];
     }
 
     /**

--- a/tests/Integration/Auth/GatePolicyResolutionTest.php
+++ b/tests/Integration/Auth/GatePolicyResolutionTest.php
@@ -19,4 +19,31 @@ class GatePolicyResolutionTest extends TestCase
             Gate::getPolicyFor(AuthenticationTestUser::class)
         );
     }
+
+    public function testPolicyCanBeGuessedUsingCallback()
+    {
+        Gate::guessPolicyNamesUsing(function () {
+            return AuthenticationTestUserPolicy::class;
+        });
+
+        $this->assertInstanceOf(
+            AuthenticationTestUserPolicy::class,
+            Gate::getPolicyFor(AuthenticationTestUser::class)
+        );
+    }
+
+    public function testPolicyCanBeGuessedMultipleTimes()
+    {
+        Gate::guessPolicyNamesUsing(function () {
+            return [
+                'App\\Policies\\TestUserPolicy',
+                AuthenticationTestUserPolicy::class
+            ];
+        });
+
+        $this->assertInstanceOf(
+            AuthenticationTestUserPolicy::class,
+            Gate::getPolicyFor(AuthenticationTestUser::class)
+        );
+    }
 }

--- a/tests/Integration/Auth/GatePolicyResolutionTest.php
+++ b/tests/Integration/Auth/GatePolicyResolutionTest.php
@@ -37,7 +37,7 @@ class GatePolicyResolutionTest extends TestCase
         Gate::guessPolicyNamesUsing(function () {
             return [
                 'App\\Policies\\TestUserPolicy',
-                AuthenticationTestUserPolicy::class
+                AuthenticationTestUserPolicy::class,
             ];
         });
 


### PR DESCRIPTION
Allow users to return an array of strings in the policy guesser callback to try multiple class names to resolve the policy.

```php
Gate::guessPolicyNamesUsing(function ($class) {
   return [
      '\\App\\Policies\\' . str_replace('\\App', '', $class) . 'Policy',
      '\\App\\Policies\\' . class_basename($class) . 'Policy',
   ];
});

Gate::getPolicyFor(\App\Post\Type::class);
// returns \App\Policies\Post\TypePolicy if it exists,
//  otherwise tries \App\Policies\TypePolicy
```
