### PR TITLE
[5.8] Remove workaround for https://bugs.php.net/bug.php?id=75577 if PHP > 7.3

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -792,12 +792,17 @@ trait HasAttributes
             return Date::instance(Carbon::createFromFormat('Y-m-d', $value)->startOfDay());
         }
 
+        $format = $this->getDateFormat();
+
+        // Work-around for https://bugs.php.net/bug.php?id=75577
+        if (version_compare(PHP_VERSION, '7.3.0-dev', '<')) {
+            $format = str_replace('.v', '.u', $format);
+        }
+
         // Finally, we will just assume this date is in the format used by default on
         // the database connection and use that format to create the Carbon object
         // that is returned back out to the developers after we convert it here.
-        return Date::createFromFormat(
-            str_replace('.v', '.u', $this->getDateFormat()), $value
-        );
+        return Date::createFromFormat($format, $value);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -484,6 +484,22 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($model->fromDateTime(null));
     }
 
+    public function testFromDateTimeMilliseconds()
+    {
+        if (version_compare(PHP_VERSION, '7.3.0-dev', '<')) {
+            $this->markTestSkipped('Due to https://bugs.php.net/bug.php?id=75577, proper "v" format support can only works since PHP 7.3.');
+        }
+
+        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentDateModelStub')->setMethods(['getDateFormat'])->getMock();
+        $model->expects($this->any())->method('getDateFormat')->will($this->returnValue('Y-m-d H:s.vi'));
+        $model->setRawAttributes([
+            'created_at' => '2012-12-04 22:59.32130',
+        ]);
+
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->created_at);
+        $this->assertEquals('22:30:59.321000', $model->created_at->format('H:i:s.u'));
+    }
+
     public function testInsertProcess()
     {
         $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();


### PR DESCRIPTION
.v bug is fixed in PHP 7.3 and the work-around prevent using some
custom formats so the workaround should only be called for PHP < 7.3

The test `testFromDateTimeMilliseconds` below has no reason to fail because data and format are valid (`echo DateTime::createFromFormat('Y-m-d H:s.vi', '2012-12-04 22:59.32130')->format('H:i:s.v');` works fine with PHP 7.3).

So the fix `str_replace('.v', '.u'` applied to fix the bug https://bugs.php.net/bug.php?id=75577 should only be applied for PHP versions that have the bug. And a comment should mention this bug link to explain why this replacement is done.