### PR TITLE
[6.0] Make LengthAwarePaginator respect distinct columns

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -347,14 +347,17 @@ class Builder
     /**
      * Force the query to only return distinct results.
      *
-     * @param array|mixed $column
      * @return $this
      */
-    public function distinct($column = true)
+    public function distinct()
     {
-        $column = is_array($column) || is_bool($column) ? $column : func_get_args();
+        $columns = func_get_args();
 
-        $this->distinct = $column;
+        if (count($columns) > 0) {
+            $this->distinct = is_array($columns[0]) || is_bool($columns[0]) ? $columns[0] : $columns;
+        } else {
+            $this->distinct = true;
+        }
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -78,7 +78,7 @@ class Builder
     /**
      * Indicates if the query returns distinct results.
      *
-     * @var bool
+     * @var array|bool
      */
     public $distinct = false;
 
@@ -347,11 +347,14 @@ class Builder
     /**
      * Force the query to only return distinct results.
      *
+     * @param array|mixed $column
      * @return $this
      */
-    public function distinct()
+    public function distinct($column = true)
     {
-        $this->distinct = true;
+        $column = is_array($column) || is_bool($column) ? $column : func_get_args();
+
+        $this->distinct = $column;
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -109,7 +109,9 @@ class Grammar extends BaseGrammar
         // If the query has a "distinct" constraint and we're not asking for all columns
         // we need to prepend "distinct" onto the column name so that the query takes
         // it into account when it performs the aggregating operations on the data.
-        if ($query->distinct && $column !== '*') {
+        if (is_array($query->distinct)) {
+            $column = 'distinct ('.$this->columnize($query->distinct).')';
+        } elseif ($query->distinct && $column !== '*') {
             $column = 'distinct '.$column;
         }
 
@@ -132,7 +134,13 @@ class Grammar extends BaseGrammar
             return;
         }
 
-        $select = $query->distinct ? 'select distinct ' : 'select ';
+        if (is_array($query->distinct)) {
+            $select = 'select distinct ('.$this->columnize($query->distinct).'), ';
+        } elseif ($query->distinct) {
+            $select = 'select distinct ';
+        } else {
+            $select = 'select ';
+        }
 
         return $select.$this->columnize($columns);
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -110,7 +110,7 @@ class Grammar extends BaseGrammar
         // we need to prepend "distinct" onto the column name so that the query takes
         // it into account when it performs the aggregating operations on the data.
         if (is_array($query->distinct)) {
-            $column = 'distinct ('.$this->columnize($query->distinct).')';
+            $column = 'distinct '.$this->columnize($query->distinct).'';
         } elseif ($query->distinct && $column !== '*') {
             $column = 'distinct '.$column;
         }
@@ -134,9 +134,7 @@ class Grammar extends BaseGrammar
             return;
         }
 
-        if (is_array($query->distinct)) {
-            $select = 'select distinct ('.$this->columnize($query->distinct).'), ';
-        } elseif ($query->distinct) {
+        if ($query->distinct) {
             $select = 'select distinct ';
         } else {
             $select = 'select ';

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -126,6 +126,33 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile the "select *" portion of the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $columns
+     * @return string|null
+     */
+    protected function compileColumns(Builder $query, $columns)
+    {
+        // If the query is actually performing an aggregating select, we will let that
+        // compiler handle the building of the select clauses, as it will need some
+        // more syntax that is best handled by that function to keep things neat.
+        if (! is_null($query->aggregate)) {
+            return;
+        }
+
+        if (is_array($query->distinct)) {
+            $select = 'select distinct on ('.$this->columnize($query->distinct).') ';
+        } elseif ($query->distinct) {
+            $select = 'select distinct ';
+        } else {
+            $select = 'select ';
+        }
+
+        return $select.$this->columnize($columns);
+    }
+
+    /**
      * Compile a single union statement.
      *
      * @param  array  $union

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -119,6 +119,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select distinct "foo", "bar" from "users"', $builder->toSql());
     }
 
+    public function testBasicSelectDistinctWithColumns()
+    {
+        $builder = $this->getBuilder();
+        $builder->distinct('foo')->select('foo', 'bar')->from('users');
+        $this->assertEquals('select distinct ("foo"), "foo", "bar" from "users"', $builder->toSql());
+    }
+
     public function testBasicAlias()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -119,11 +119,15 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select distinct "foo", "bar" from "users"', $builder->toSql());
     }
 
-    public function testBasicSelectDistinctWithColumns()
+    public function testBasicSelectDistinctOnColumns()
     {
         $builder = $this->getBuilder();
         $builder->distinct('foo')->select('foo', 'bar')->from('users');
-        $this->assertEquals('select distinct ("foo"), "foo", "bar" from "users"', $builder->toSql());
+        $this->assertEquals('select distinct "foo", "bar" from "users"', $builder->toSql());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->distinct('foo')->select('foo', 'bar')->from('users');
+        $this->assertEquals('select distinct on ("foo") "foo", "bar" from "users"', $builder->toSql());
     }
 
     public function testBasicAlias()

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -49,6 +49,7 @@ class EloquentPaginateTest extends DatabaseTestCase
         $query = Post::query()->distinct();
 
         $this->assertEquals(6, $query->get()->count());
+        $this->assertEquals(6, $query->count());
         $this->assertEquals(6, $query->paginate()->total());
     }
 
@@ -63,6 +64,7 @@ class EloquentPaginateTest extends DatabaseTestCase
         $query = Post::query()->distinct()->select('title');
 
         $this->assertEquals(2, $query->get()->count());
+        $this->assertEquals(6, $query->count());
         $this->assertEquals(6, $query->paginate()->total());
     }
 
@@ -76,6 +78,7 @@ class EloquentPaginateTest extends DatabaseTestCase
         $query = Post::query()->distinct('title')->select('title');
 
         $this->assertEquals(2, $query->get()->count());
+        $this->assertEquals(2, $query->count());
         $this->assertEquals(2, $query->paginate()->total());
     }
 
@@ -95,6 +98,7 @@ class EloquentPaginateTest extends DatabaseTestCase
             ->distinct('users.id')->select('users.*');
 
         $this->assertEquals(5, $query->get()->count());
+        $this->assertEquals(5, $query->count());
         $this->assertEquals(5, $query->paginate()->total());
     }
 }

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -18,6 +18,12 @@ class EloquentPaginateTest extends DatabaseTestCase
         Schema::create('posts', function ($table) {
             $table->increments('id');
             $table->string('title')->nullable();
+            $table->unsignedInteger('user_id')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
             $table->timestamps();
         });
     }
@@ -32,9 +38,61 @@ class EloquentPaginateTest extends DatabaseTestCase
 
         $this->assertCount(15, Post::paginate(15, ['id', 'title']));
     }
+
+    public function test_pagination_with_distinct()
+    {
+        for ($i = 1; $i <= 3; $i++) {
+            Post::create(['title' => 'Hello world']);
+            Post::create(['title' => 'Goodbye world']);
+        }
+
+        $query = Post::query()->distinct();
+
+        $this->assertEquals(6, $query->count());
+        $this->assertEquals(6, $query->paginate()->total());
+    }
+
+    public function test_pagination_with_distinct_and_select()
+    {
+        for ($i = 1; $i <= 3; $i++) {
+            Post::create(['title' => 'Hello world']);
+            Post::create(['title' => 'Goodbye world']);
+        }
+
+        $query = Post::query()->distinct('title')
+            ->select('title');
+
+        $this->assertEquals(2, $query->count());
+        $this->assertEquals(2, $query->paginate()->total());
+    }
+
+    public function test_pagination_with_distinct_and_select_and_join()
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $user = User::create();
+            for ($j = 1; $j <= 10; $j++) {
+                Post::create([
+                    'title' => 'Title '.$i,
+                    'user_id' => $user->id,
+                ]);
+            }
+        }
+
+        $query = User::query()->join('posts', 'posts.user_id', '=', 'users.id')
+            ->distinct('users.id')
+            ->select('users.*');
+
+        $this->assertEquals(5, $query->get()->count());
+        $this->assertEquals(5, $query->paginate()->total());
+    }
 }
 
 class Post extends Model
+{
+    protected $guarded = [];
+}
+
+class User extends Model
 {
     protected $guarded = [];
 }

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -48,25 +48,38 @@ class EloquentPaginateTest extends DatabaseTestCase
 
         $query = Post::query()->distinct();
 
-        $this->assertEquals(6, $query->count());
+        $this->assertEquals(6, $query->get()->count());
         $this->assertEquals(6, $query->paginate()->total());
     }
 
     public function test_pagination_with_distinct_and_select()
+    {
+        // This is the 'broken' behaviour, but this test is added to show backwards compatibility.
+        for ($i = 1; $i <= 3; $i++) {
+            Post::create(['title' => 'Hello world']);
+            Post::create(['title' => 'Goodbye world']);
+        }
+
+        $query = Post::query()->distinct()->select('title');
+
+        $this->assertEquals(2, $query->get()->count());
+        $this->assertEquals(6, $query->paginate()->total());
+    }
+
+    public function test_pagination_with_distinct_columns_and_select()
     {
         for ($i = 1; $i <= 3; $i++) {
             Post::create(['title' => 'Hello world']);
             Post::create(['title' => 'Goodbye world']);
         }
 
-        $query = Post::query()->distinct('title')
-            ->select('title');
+        $query = Post::query()->distinct('title')->select('title');
 
-        $this->assertEquals(2, $query->count());
+        $this->assertEquals(2, $query->get()->count());
         $this->assertEquals(2, $query->paginate()->total());
     }
 
-    public function test_pagination_with_distinct_and_select_and_join()
+    public function test_pagination_with_distinct_columns_and_select_and_join()
     {
         for ($i = 1; $i <= 5; $i++) {
             $user = User::create();
@@ -79,8 +92,7 @@ class EloquentPaginateTest extends DatabaseTestCase
         }
 
         $query = User::query()->join('posts', 'posts.user_id', '=', 'users.id')
-            ->distinct('users.id')
-            ->select('users.*');
+            ->distinct('users.id')->select('users.*');
 
         $this->assertEquals(5, $query->get()->count());
         $this->assertEquals(5, $query->paginate()->total());


### PR DESCRIPTION
## Overview 
This PR demonstrates the bug that was reported in #21242. There have been _many_ previous PR attempts (#18186, #21899, #23209, #23214, #23255, #25126, #25973, #26014, #27107) to solve this issue, however, none succeeded.

## Reproduction
When using `paginate` on a `Builder` instance that has a `distinct` column, the actual amount of results from `$query->get()->count()` differ from `$query->paginate()->total()`.

_The issue has also been reproduced in `tests/Integration/Database/EloquentPaginateTest.php`._

## Proposed Solution
In #26014 it was proposed to allow to specify which columns the distinct should be on, and this PR implements that proposal. This solution gives a flexible way of building the query while not breaking existing behaviour.

The `distinct` property on `Builder` now can be a boolean or an array. When an `array` is passed, these denote the columns to be used in the distinct. If an argument is omitted or `true` is passed, the original behaviour should be used.

## Considerations
1. One other solution considered was to pass the columns from `$query->select()` to be directly passed to `getCountForPagination`, however, this would break existing behaviour and not work in SQLite when passing a wildcard or multiple columns to the select.

```php
$query->paginate(15, ['users.*'])
// Illuminate\Database\QueryException : SQLSTATE[HY000]: General error: 1 near "*": syntax error (SQL: select count(distinct "users".*) as aggregate from "users" inner join "posts" on "posts"."user_id" = "users"."id")
```