### PR TITLE
[5.8] Return fake objects from facades

### DIFF
--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -20,11 +20,13 @@ class Bus extends Facade
     /**
      * Replace the bound instance with a fake.
      *
-     * @return void
+     * @return BusFake
      */
     public static function fake()
     {
-        static::swap(new BusFake);
+        static::swap($fake = new BusFake);
+
+        return $fake;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -20,7 +20,7 @@ class Bus extends Facade
     /**
      * Replace the bound instance with a fake.
      *
-     * @return BusFake
+     * @return \Illuminate\Support\Testing\Fakes\BusFake
      */
     public static function fake()
     {

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -24,7 +24,7 @@ class Event extends Facade
      * Replace the bound instance with a fake.
      *
      * @param  array|string  $eventsToFake
-     * @return EventFake
+     * @return \Illuminate\Support\Testing\Fakes\EventFake
      */
     public static function fake($eventsToFake = [])
     {

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -24,13 +24,15 @@ class Event extends Facade
      * Replace the bound instance with a fake.
      *
      * @param  array|string  $eventsToFake
-     * @return void
+     * @return EventFake
      */
     public static function fake($eventsToFake = [])
     {
         static::swap($fake = new EventFake(static::getFacadeRoot(), $eventsToFake));
 
         Model::setEventDispatcher($fake);
+
+        return $fake;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -31,11 +31,13 @@ class Mail extends Facade
     /**
      * Replace the bound instance with a fake.
      *
-     * @return void
+     * @return MailFake
      */
     public static function fake()
     {
-        static::swap(new MailFake);
+        static::swap($fake = new MailFake);
+
+        return $fake;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -31,7 +31,7 @@ class Mail extends Facade
     /**
      * Replace the bound instance with a fake.
      *
-     * @return MailFake
+     * @return \Illuminate\Support\Testing\Fakes\MailFake
      */
     public static function fake()
     {

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -24,7 +24,7 @@ class Queue extends Facade
     /**
      * Replace the bound instance with a fake.
      *
-     * @return QueueFake
+     * @return \Illuminate\Support\Testing\Fakes\QueueFake
      */
     public static function fake()
     {

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -24,11 +24,13 @@ class Queue extends Facade
     /**
      * Replace the bound instance with a fake.
      *
-     * @return void
+     * @return QueueFake
      */
     public static function fake()
     {
-        static::swap(new QueueFake(static::getFacadeApplication()));
+        static::swap($fake = new QueueFake(static::getFacadeApplication()));
+
+        return $fake;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -16,7 +16,7 @@ class Storage extends Facade
      *
      * @param  string|null  $disk
      *
-     * @return void
+     * @return Filesystem
      */
     public static function fake($disk = null)
     {
@@ -26,22 +26,26 @@ class Storage extends Facade
             $root = storage_path('framework/testing/disks/'.$disk)
         );
 
-        static::set($disk, self::createLocalDriver(['root' => $root]));
+        static::set($disk, $fake = self::createLocalDriver(['root' => $root]));
+
+        return $fake;
     }
 
     /**
      * Replace the given disk with a persistent local testing disk.
      *
      * @param  string|null  $disk
-     * @return void
+     * @return Filesystem
      */
     public static function persistentFake($disk = null)
     {
         $disk = $disk ?: self::$app['config']->get('filesystems.default');
 
-        static::set($disk, self::createLocalDriver([
+        static::set($disk, $fake = self::createLocalDriver([
             'root' => storage_path('framework/testing/disks/'.$disk),
         ]));
+
+        return $fake;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -16,7 +16,7 @@ class Storage extends Facade
      *
      * @param  string|null  $disk
      *
-     * @return Filesystem
+     * @return \Illuminate\Filesystem\Filesystem
      */
     public static function fake($disk = null)
     {
@@ -35,7 +35,7 @@ class Storage extends Facade
      * Replace the given disk with a persistent local testing disk.
      *
      * @param  string|null  $disk
-     * @return Filesystem
+     * @return \Illuminate\Filesystem\Filesystem
      */
     public static function persistentFake($disk = null)
     {


### PR DESCRIPTION
For [consistency](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Support/Facades/Notification.php#L28) in facade fakes I have added the fakes a return type. That way I can create a property for the fake in the test's `setUp` method.

**Current**
```php
public function setUp()
{
    parent::setUp();

    Bus::fake();
    $this->eventBus = $this->app->make(Dispatcher::class);
}
```

**New**
```php
public function setUp()
{
    parent::setUp();

    $this->eventBus = Bus::fake();
}
```