### PR TITLE
[5.8] Merge policy callback guesses with default guess

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -560,12 +560,15 @@ class Gate implements GateContract
     protected function guessPolicyName($class)
     {
         if ($this->guessPolicyNamesUsingCallback) {
-            return Arr::wrap(call_user_func($this->guessPolicyNamesUsingCallback, $class));
+            $guesses = Arr::wrap(call_user_func($this->guessPolicyNamesUsingCallback, $class));
         }
 
         $classDirname = str_replace('/', '\\', dirname(str_replace('\\', '/', $class)));
 
-        return [$classDirname.'\\Policies\\'.class_basename($class).'Policy'];
+        return array_merge(
+            $guesses,
+            [$classDirname.'\\Policies\\'.class_basename($class).'Policy']
+        );
     }
 
     /**

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -559,16 +559,17 @@ class Gate implements GateContract
      */
     protected function guessPolicyName($class)
     {
+        $classDirname = str_replace('/', '\\', dirname(str_replace('\\', '/', $class)));
+        $default = [$classDirname.'\\Policies\\'.class_basename($class).'Policy'];
+
         if ($this->guessPolicyNamesUsingCallback) {
-            $guesses = Arr::wrap(call_user_func($this->guessPolicyNamesUsingCallback, $class));
+            return array_merge(
+                Arr::wrap(call_user_func($this->guessPolicyNamesUsingCallback, $class)),
+                $default
+            );
         }
 
-        $classDirname = str_replace('/', '\\', dirname(str_replace('\\', '/', $class)));
-
-        return array_merge(
-            $guesses,
-            [$classDirname.'\\Policies\\'.class_basename($class).'Policy']
-        );
+        return $default;
     }
 
     /**

--- a/tests/Integration/Auth/Fixtures/Policies/AuthenticationCustomTestUserPolicy.php
+++ b/tests/Integration/Auth/Fixtures/Policies/AuthenticationCustomTestUserPolicy.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Auth\Fixtures\Policies;
+
+class AuthenticationCustomTestUserPolicy
+{
+    //
+}

--- a/tests/Integration/Auth/GatePolicyResolutionTest.php
+++ b/tests/Integration/Auth/GatePolicyResolutionTest.php
@@ -6,6 +6,7 @@ use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Tests\Integration\Auth\Fixtures\AuthenticationTestUser;
 use Illuminate\Tests\Integration\Auth\Fixtures\Policies\AuthenticationTestUserPolicy;
+use Illuminate\Tests\Integration\Auth\Fixtures\Policies\AuthenticationCustomTestUserPolicy;
 
 /**
  * @group integration
@@ -23,11 +24,11 @@ class GatePolicyResolutionTest extends TestCase
     public function testPolicyCanBeGuessedUsingCallback()
     {
         Gate::guessPolicyNamesUsing(function () {
-            return AuthenticationTestUserPolicy::class;
+            return AuthenticationCustomTestUserPolicy::class;
         });
 
         $this->assertInstanceOf(
-            AuthenticationTestUserPolicy::class,
+            AuthenticationCustomTestUserPolicy::class,
             Gate::getPolicyFor(AuthenticationTestUser::class)
         );
     }
@@ -37,12 +38,33 @@ class GatePolicyResolutionTest extends TestCase
         Gate::guessPolicyNamesUsing(function () {
             return [
                 'App\\Policies\\TestUserPolicy',
-                AuthenticationTestUserPolicy::class,
+                AuthenticationCustomTestUserPolicy::class,
             ];
         });
 
         $this->assertInstanceOf(
+            AuthenticationCustomTestUserPolicy::class,
+            Gate::getPolicyFor(AuthenticationTestUser::class)
+        );
+    }
+
+    public function testDefaultPolicyGuessWillBeMergedWithCallbackGuesses()
+    {
+        Gate::guessPolicyNamesUsing(function () {
+            return 'App\\Policies\\TestUserPolicy';
+        });
+
+        $this->assertInstanceOf(
             AuthenticationTestUserPolicy::class,
+            Gate::getPolicyFor(AuthenticationTestUser::class)
+        );
+
+        Gate::guessPolicyNamesUsing(function () {
+            return AuthenticationCustomTestUserPolicy::class;
+        });
+
+        $this->assertInstanceOf(
+            AuthenticationCustomTestUserPolicy::class,
             Gate::getPolicyFor(AuthenticationTestUser::class)
         );
     }

--- a/tests/Integration/Auth/GatePolicyResolutionTest.php
+++ b/tests/Integration/Auth/GatePolicyResolutionTest.php
@@ -58,14 +58,5 @@ class GatePolicyResolutionTest extends TestCase
             AuthenticationTestUserPolicy::class,
             Gate::getPolicyFor(AuthenticationTestUser::class)
         );
-
-        Gate::guessPolicyNamesUsing(function () {
-            return AuthenticationCustomTestUserPolicy::class;
-        });
-
-        $this->assertInstanceOf(
-            AuthenticationCustomTestUserPolicy::class,
-            Gate::getPolicyFor(AuthenticationTestUser::class)
-        );
     }
 }


### PR DESCRIPTION
Appends the default guessed policy name to the guesses returned from the guess policy callback.