### PR TITLE
[5.8] BUG: Fix quoted environment variable parsing

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -662,7 +662,7 @@ if (! function_exists('env')) {
                         return;
                 }
 
-                if (($valueLength = strlen($value)) > 1 && $value[0] === '"' && $value[$valueLength - 1] === '"') {
+                if (($valueLength = strlen($value)) > 1 && ($value[0] === '"' && $value[$valueLength - 1] === '"' || $value[0] === "'" && $value[$valueLength - 1] === "'")) {
                     return substr($value, 1, -1);
                 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -662,8 +662,8 @@ if (! function_exists('env')) {
                         return;
                 }
 
-                if (($valueLength = strlen($value)) > 1 && ($value[0] === '"' && $value[$valueLength - 1] === '"' || $value[0] === "'" && $value[$valueLength - 1] === "'")) {
-                    return substr($value, 1, -1);
+                if (preg_match('/([\'"])(.*)\1/', $value, $matches)) {
+                    return $matches[2];
                 }
 
                 return $value;

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -662,6 +662,10 @@ if (! function_exists('env')) {
                         return;
                 }
 
+                if (($valueLength = strlen($value)) > 1 && $value[0] === '"' && $value[$valueLength - 1] === '"') {
+                    return substr($value, 1, -1);
+                }
+
                 return $value;
             })
             ->getOrCall(function () use ($default) {

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -576,6 +576,9 @@ class SupportHelpersTest extends TestCase
     {
         $_SERVER['foo'] = '"null"';
         $this->assertSame('null', env('foo'));
+
+        $_SERVER['foo'] = "'null'";
+        $this->assertSame('null', env('foo'));
     }
 
     public function testGetFromENVFirst()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -572,6 +572,12 @@ class SupportHelpersTest extends TestCase
         $this->assertNull(env('foo'));
     }
 
+    public function testEnvEscapedString()
+    {
+        $_SERVER['foo'] = '"null"';
+        $this->assertSame('null', env('foo'));
+    }
+
     public function testGetFromENVFirst()
     {
         $_ENV['foo'] = 'From $_ENV';


### PR DESCRIPTION
For specifying `NullBroadcastDriver` in Laravel 5.7, we need to explicitly quote value like this:

```ini
BROADCAST_DRIVER='"null"'
```

```xml
<env name="BROADCAST_DRIVER" value='"null"' />
```

In Laravel 5.8, I got this error:

<img width="222" alt="2019-02-27 14 50 34" src="https://user-images.githubusercontent.com/1351893/53468826-0d5e3680-3a9f-11e9-9342-7f074d6eaa6a.png">

According to @GrahamCampbell's commit #27462:

> 3\. phpdotenv already natively handles quoted variables, so I don't see the need to strip quotes off again. This is only going to be annoying if you'd escaped the quotes in the env file, then laravel strips then anyway.

I think phpdotenv can natively handle quoted values, however, `NullBroadcastDriver` expects PHP string **`string(4) "null"`**  on configuration, not `string(6) ""null""` or `string(6) "'null'"`.