### PR TITLE
[5.8] Support bindings with type hints if type matches resolved instance

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -175,7 +175,7 @@ class BoundMethod
     }
     
     /**
-     * Get the dependecy for the call parameter by type hinted class
+     * Get the dependecy for the call parameter by type hinted class.
      * 
      * @param  string $class
      * @param  array $parameters

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -173,10 +173,10 @@ class BoundMethod
             $dependencies[] = $parameter->getDefaultValue();
         }
     }
-    
+
     /**
      * Get the dependecy for the call parameter by type hinted class.
-     * 
+     *
      * @param  string $class
      * @param  array $parameters
      * @return int|string|null

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -163,11 +163,33 @@ class BoundMethod
             $dependencies[] = $parameters[$parameter->getClass()->name];
 
             unset($parameters[$parameter->getClass()->name]);
+        } elseif ($parameter->getClass() && $parameterKey = static::findParameterKeyByClass($parameter->getClass()->name, $parameters)) {
+            $dependencies[] = $parameters[$parameterKey];
+
+            unset($parameters[$parameterKey]);
         } elseif ($parameter->getClass()) {
             $dependencies[] = $container->make($parameter->getClass()->name);
         } elseif ($parameter->isDefaultValueAvailable()) {
             $dependencies[] = $parameter->getDefaultValue();
         }
+    }
+    
+    /**
+     * Get the dependecy for the call parameter by type hinted class
+     * 
+     * @param  string $class
+     * @param  array $parameters
+     * @return int|string|null
+     */
+    protected static function findParameterKeyByClass(string $class, array $parameters)
+    {
+        foreach ($parameters as $key => $value) {
+            if ($value instanceof $class) {
+                return $key;
+            }
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Suppose we have this custom resolution logic:
```php
Route::bind('page', function ($value) {
    return App\Page::findOrFail($value);
});

Route::bind('pageSlug', function ($value) {
    return App\Page::where('slug', $value)->firstOrFail();
});
```
Routes like so:
```php
Route::get('/api/pages/{page}', 'PageController@show'); // Notice we have same controller methods here
Route::get('/page/{pageSlug}', 'PageController@show');
```

And a controller method:
```php
public function show(Page $page) // type hinted
{
    return $page;
}
```
if we hit the first route, parameter is resolved with matching route parameter name and controller method parameter name.

But if we hit the second route, binding is resolved as expected, but as we have type hinted our parameter in controller method and names do not match new instance of type hinted class is resolved from container and passed. This means we receive data which we do not expect in controller, as in this case new model's attributes are empty.

This minor feature fixes problem when controller parameter names are dependent on route parameters, enforces method reusability and type hinting, and it does not contain breaking changes.
