### PR TITLE
[5.8] Fix the key to a number using $value

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -607,7 +607,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 
         if (property_exists($provider, 'singletons')) {
             foreach ($provider->singletons as $key => $value) {
-                $this->singleton($key, $value);
+                $this->singleton(is_numeric($key) ? $value : $key, $value);
             }
         }
 


### PR DESCRIPTION
```php
/**
	 * The singleton bindings.
	 *
	 * @var array
	 */
	public $singletons = [Foo::class]

```

At this point, $key is a number to ensure proper binding.

Looks like this:

```php
$this->singleton(Foo::class, Foo::class);

// OR
$this->singleton(Foo::class);
```
