### PR TITLE
[5.8] Corrects protocol when validating signature in UrlGenerator.php

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -355,7 +355,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function hasValidSignature(Request $request, $absolute = true)
     {
-        $url = $absolute ? $request->url() : '/'.$request->path();
+        $url = $absolute ? url()->current() : '/'.$request->path();
 
         $original = rtrim($url.'?'.Arr::query(
             Arr::except($request->query(), 'signature')

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -355,7 +355,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function hasValidSignature(Request $request, $absolute = true)
     {
-        $url = $absolute ? url()->current() : '/'.$request->path();
+        $url = $absolute ? $this->current() : '/'.$request->path();
 
         $original = rtrim($url.'?'.Arr::query(
             Arr::except($request->query(), 'signature')


### PR DESCRIPTION
fixes #26834 where the URL being generated by $request->url() was not using the enforced url schema, swapped this to url()->current() which does use the enforced url schema.

this means that the signature generated would be valid with the one passed in.
EG: $request->url() generates http://www.example.com
       url()->current() generates https://www.example.com