### PR TITLE
[5.8] Revert "[5.8] BUG: Fix quoted environment variable parsing"

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -662,10 +662,6 @@ if (! function_exists('env')) {
                         return;
                 }
 
-                if (preg_match('/([\'"])(.*)\1/', $value, $matches)) {
-                    return $matches[2];
-                }
-
                 return $value;
             })
             ->getOrCall(function () use ($default) {

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -572,15 +572,6 @@ class SupportHelpersTest extends TestCase
         $this->assertNull(env('foo'));
     }
 
-    public function testEnvEscapedString()
-    {
-        $_SERVER['foo'] = '"null"';
-        $this->assertSame('null', env('foo'));
-
-        $_SERVER['foo'] = "'null'";
-        $this->assertSame('null', env('foo'));
-    }
-
     public function testGetFromENVFirst()
     {
         $_ENV['foo'] = 'From $_ENV';


### PR DESCRIPTION
Reverts laravel/framework#27691 because it is not broken. The example is invalid. You should use double quotes or single quotes to quote something. Not both!