### PR TITLE
[5.8] Allow configuring a default manifest directory

### DIFF
--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -25,6 +25,8 @@ class Mix
             $path = "/{$path}";
         }
 
+        $manifestDirectory = $manifestDirectory ?: app('config')->get('app.manifest_directory');
+
         if ($manifestDirectory && ! Str::startsWith($manifestDirectory, '/')) {
             $manifestDirectory = "/{$manifestDirectory}";
         }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -8,10 +8,19 @@ use Mockery as m;
 use Illuminate\Support\Str;
 use Illuminate\Foundation\Mix;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
 use Illuminate\Foundation\Application;
+use Illuminate\Config\Repository as Config;
 
 class FoundationHelpersTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        app()->singleton('config', function () {
+            return new Config([]);
+        });
+    }
+
     protected function tearDown(): void
     {
         m::close();
@@ -117,6 +126,23 @@ class FoundationHelpersTest extends TestCase
 
         unlink($manifest);
         rmdir($directory);
+    }
+
+    public function testMixWithConfiguredManifestDirectory()
+    {
+        app('config')->set(['app.manifest_directory' => 'mix']);
+
+        mkdir($directory = __DIR__.'/mix');
+        $manifest = $this->makeManifest('mix');
+
+        $result = mix('unversioned.css');
+
+        $this->assertSame('/mix/versioned.css', $result->toHtml());
+
+        unlink($manifest);
+        rmdir($directory);
+
+        app('config')->set(['app.manifest_directory' => '']);
     }
 
     public function testMixManifestDirectoryMissingStartingSlashHasItAdded()

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -8,7 +8,6 @@ use Mockery as m;
 use Illuminate\Support\Str;
 use Illuminate\Foundation\Mix;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Container\Container;
 use Illuminate\Foundation\Application;
 use Illuminate\Config\Repository as Config;
 


### PR DESCRIPTION
This PR depends on laravel/laravel#4957.

This PR enables users to set a default manifest directory for all calls to the `mix` helper, so that they don't have to pass a second parameter to it every time. It also makes it less likely that a user will forget to pass the manifest directory to the `mix` helper. An additional benefit is that, if they would ever change this path, they can now change it in a single location, rather than having to go through all their views. It is also makes it easy to change this path in different environments.

This PR doesn't break any existing features. It only adds one additional line to the `Mix` class and doesn't change its signature. The behaviour of the helper function stays the same if the configuration value isn't set.

Example usage:

In webpack.mix.js
```js
mix.setPublicPath('public/assets');
mix.sass('resources/assets/scss/app.scss', 'public/assets/css')
    .version();
```

In `config/app.php`
```php
<?php

return [
    ...

    'manifest_directory' => env('MANIFEST_DIRECTORY', ''),

    ...
];
```

And then finally, in any view file:
```blade
<link rel="stylesheet" href="{{ mix('css/app.css') }}">
<!-- renders to <link rel="stylesheet" href="/assets/css/app.css?id=123"> -->
```

Previously, you'd have to use the following every time you used a mix asset:
```blade
<link rel="stylesheet" href="{{ mix('css/app.css', 'assets') }}">
```