### PR TITLE
[5.8] Constant pivot data in saveMany & createMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -862,7 +862,7 @@ class BelongsToMany extends Relation
     public function saveMany($models, array $pivotAttributes = [])
     {
         foreach ($models as $key => $model) {
-            $this->save($model, (array) ($pivotAttributes[$key] ?? []), false);
+            $this->save($model, (array) ($pivotAttributes[$key] ?? $pivotAttributes), false);
         }
 
         $this->touchIfTouching();
@@ -904,7 +904,7 @@ class BelongsToMany extends Relation
         $instances = [];
 
         foreach ($records as $key => $record) {
-            $instances[] = $this->create($record, (array) ($joinings[$key] ?? []), false);
+            $instances[] = $this->create($record, (array) ($joinings[$key] ?? $joinings), false);
         }
 
         $this->touchIfTouching();


### PR DESCRIPTION
Allows one-dimensional arrays in the second argument of both `saveMany` & `createMany`. Useful for applying the same pivot data, regardless of `$key`. Default argument is already an empty array, and an empty array is currently used for pivot data if `$key` doesn't exist in the array—shouldn't break anything.