### PR TITLE
[5.9] Add the option to pass an options array to Storage::url($path, $options) 

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Cloud.php
+++ b/src/Illuminate/Contracts/Filesystem/Cloud.php
@@ -8,7 +8,8 @@ interface Cloud extends Filesystem
      * Get the URL for the file at the given path.
      *
      * @param  string  $path
+     * @param  array  $options  
      * @return string
      */
-    public function url($path);
+    public function url($path, array $options = []);
 }

--- a/src/Illuminate/Contracts/Filesystem/Cloud.php
+++ b/src/Illuminate/Contracts/Filesystem/Cloud.php
@@ -8,7 +8,7 @@ interface Cloud extends Filesystem
      * Get the URL for the file at the given path.
      *
      * @param  string  $path
-     * @param  array  $options  
+     * @param  array  $options
      * @return string
      */
     public function url($path, array $options = []);

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -382,11 +382,12 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      * Get the URL for the file at the given path.
      *
      * @param  string  $path
+     * @param  array  $options
      * @return string
      *
      * @throws \RuntimeException
      */
-    public function url($path)
+    public function url($path, array $options = [])
     {
         $adapter = $this->driver->getAdapter();
 
@@ -395,7 +396,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
         }
 
         if (method_exists($adapter, 'getUrl')) {
-            return $adapter->getUrl($path);
+            return $adapter->getUrl($path, $options);
         } elseif (method_exists($this->driver, 'getUrl')) {
             return $this->driver->getUrl($path);
         } elseif ($adapter instanceof AwsS3Adapter) {


### PR DESCRIPTION
Some services have the option to receive some modifiers when retrieving the url. For example Cloudinary which I am struggling with now has the option to generate a url with transformations.

I tried to find a better way but couldn't find one. I am even opened to overwrite FilesystemAdapter locally but i didn't find a way.

If necessary i will write tests but first i want to know if you approve the idea.