### PR TITLE
[5.8] Fix guessed policy names when using Gate::forUser

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -703,7 +703,8 @@ class Gate implements GateContract
 
         return new static(
             $this->container, $callback, $this->abilities,
-            $this->policies, $this->beforeCallbacks, $this->afterCallbacks, $this->guessPolicyNamesUsingCallback
+            $this->policies, $this->beforeCallbacks, $this->afterCallbacks,
+            $this->guessPolicyNamesUsingCallback
         );
     }
 

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -80,10 +80,12 @@ class Gate implements GateContract
      * @param  array  $policies
      * @param  array  $beforeCallbacks
      * @param  array  $afterCallbacks
+     * @param  callable  $guessPolicyNamesUsingCallback
      * @return void
      */
     public function __construct(Container $container, callable $userResolver, array $abilities = [],
-                                array $policies = [], array $beforeCallbacks = [], array $afterCallbacks = [])
+                                array $policies = [], array $beforeCallbacks = [], array $afterCallbacks = [],
+                                callable $guessPolicyNamesUsingCallback = null)
     {
         $this->policies = $policies;
         $this->container = $container;
@@ -91,6 +93,7 @@ class Gate implements GateContract
         $this->userResolver = $userResolver;
         $this->afterCallbacks = $afterCallbacks;
         $this->beforeCallbacks = $beforeCallbacks;
+        $this->guessPolicyNamesUsingCallback = $guessPolicyNamesUsingCallback;
     }
 
     /**
@@ -700,7 +703,7 @@ class Gate implements GateContract
 
         return new static(
             $this->container, $callback, $this->abilities,
-            $this->policies, $this->beforeCallbacks, $this->afterCallbacks
+            $this->policies, $this->beforeCallbacks, $this->afterCallbacks, $this->guessPolicyNamesUsingCallback
         );
     }
 


### PR DESCRIPTION
## Overview 
When using the `Gate` facade to create a new instance for a specific user with `forUser` the `guessPolicyNameUsingCallback` is not passed on to the new instance. This results in the policies *no* policies being loaded when using just the policy name guesser.  

## Reproduction
```php
Gate::guessPolicyNamesUsing(function ($class) {
    return 'foo';
});

dump(app(Gate::class));
// #guessPolicyNamesUsingCallback: Closure($class) {#371

dump(app(Gate::class)->forUser($user));
// #guessPolicyNamesUsingCallback: null
```

## Proposed Solution
Add the `guessPolicyNameUsingCallback` nullable argument to the constructor and pass it in the `forUser` method. 