### PR TITLE
[5.8] Fix a bug with string via in queued notifications

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -179,7 +179,7 @@ class NotificationSender
         foreach ($notifiables as $notifiable) {
             $notificationId = Str::uuid()->toString();
 
-            foreach ($original->via($notifiable) as $channel) {
+            foreach ((array) $original->via($notifiable) as $channel) {
                 $notification = clone $original;
 
                 $notification->id = $notificationId;

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Notifications;
 
-use Illuminate\Bus\Queueable;
 use Mockery as m;
+use Illuminate\Bus\Queueable;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Tests\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\ChannelManager;
+use Illuminate\Notifications\NotificationSender;
+use Illuminate\Contracts\Bus\Dispatcher as BusDispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
+
+class NotificationSenderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    public function test_it_can_send_queued_notifications_with_a_string_via()
+    {
+        $notifiable = m::mock(Notifiable::class);
+        $manager = m::mock(ChannelManager::class);
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldReceive('dispatch');
+        $events = m::mock(EventDispatcher::class);
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->send($notifiable, new DummyQueuedNotificationWithStringVia());
+    }
+}
+
+class DummyQueuedNotificationWithStringVia extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Get the notification channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array|string
+     * @return array|string
+     */
+    public function via($notifiable)
+    {
+        return 'mail';
+    }
+}


### PR DESCRIPTION
A queued notification with a string via currently fails because it's not converted to an array. I've added a test which proves the failure.

Reported via https://github.com/laravel/docs/pull/5023