### PR TITLE
[5.8] Check if MessageBag is empty before checking keys exist

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -105,6 +105,10 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     public function has($key)
     {
+        if ($this->isEmpty()) {
+            return false;
+        }
+
         if (is_null($key)) {
             return $this->any();
         }
@@ -128,6 +132,10 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     public function hasAny($keys = [])
     {
+        if ($this->isEmpty()) {
+            return false;
+        }
+
         $keys = is_array($keys) ? $keys : func_get_args();
 
         foreach ($keys as $key) {


### PR DESCRIPTION
Optimization that checks if the message bag has any messages in the first place, to prevent unnecessary looping through all the keys and seeing if each one exists.