### PR TITLE
[5.8] Add `join` method to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -297,6 +297,34 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Join all items from the collection using a string. The final items can use a separate glue string.
+     *
+     * @param  string  $glue
+     * @param  string  $finalGlue
+     * @return string
+     */
+    public function join($glue, $finalGlue = '')
+    {
+        if ($finalGlue === '') {
+            return $this->implode($glue);
+        }
+
+        if ($this->count() === 0) {
+            return '';
+        }
+
+        if ($this->count() === 1) {
+            return $this->last();
+        }
+
+        $collection = new static($this->items);
+
+        $finalItem = $collection->pop();
+
+        return $collection->implode($glue).$finalGlue.$finalItem;
+    }
+
+    /**
      * Cross join with the given lists, returning all possible permutations.
      *
      * @param  mixed  ...$lists

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -309,11 +309,13 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return $this->implode($glue);
         }
 
-        if ($this->count() === 0) {
+        $count = $this->count();
+
+        if ($count === 0) {
             return '';
         }
 
-        if ($this->count() === 1) {
+        if ($count === 1) {
             return $this->last();
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -878,6 +878,19 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1, 2, 3, 4, 5, 6], $data->collapse()->all());
     }
 
+    public function testJoin()
+    {
+        $this->assertEquals('a, b, c', (new Collection(['a', 'b', 'c']))->join(', '));
+
+        $this->assertEquals('a, b and c', (new Collection(['a', 'b', 'c']))->join(', ', ' and '));
+
+        $this->assertEquals('a and b', (new Collection(['a', 'b']))->join(', ', ' and '));
+
+        $this->assertEquals('a', (new Collection(['a']))->join(', ', ' and '));
+
+        $this->assertEquals('', (new Collection([]))->join(', ', ' and '));
+    }
+
     public function testCrossJoin()
     {
         // Cross join with an array


### PR DESCRIPTION
This PR adds a function to easily use a separate "glue" for the final item.

```php
collect(['a', 'b', 'c']))->join(', ')); // returns 'a, b, c'
 
collect(['a', 'b', 'c']))->join(', ', ' and ')); // returns 'a, b and c'
 
collect(['a', 'b']))->join(', ', ' and ')); // returns 'a and b'
 
collect(['a']))->join(', ', ' and ')); // returns 'a'
 
collect([]))->join(', ', ' and ')); // returns ''
```