### PR TITLE
[5.8] Allow returning 'break' or 'continue' inside each()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -416,8 +416,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function each(callable $callback)
     {
         foreach ($this->items as $key => $item) {
-            if ($callback($item, $key) === false) {
+            $result = $callback($item, $key);
+            if (in_array($result, [false, 'break'], true)) {
                 break;
+            } elseif ($result === 'continue') {
+                continue;
             }
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -738,7 +738,7 @@ class SupportCollectionTest extends TestCase
             }
         });
         $this->assertEquals([1, 2, 'foo' => 'bar'], $result);
-        
+
         $result = [];
         $c->each(function ($item, $key) use (&$result) {
             $result[$key] = $item;
@@ -747,7 +747,7 @@ class SupportCollectionTest extends TestCase
             }
         });
         $this->assertEquals([1, 2, 'foo' => 'bar'], $result);
-        
+
         $result = [];
         $c->each(function ($item, $key) use (&$result) {
             if ($key === 'foo') {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -738,6 +738,24 @@ class SupportCollectionTest extends TestCase
             }
         });
         $this->assertEquals([1, 2, 'foo' => 'bar'], $result);
+        
+        $result = [];
+        $c->each(function ($item, $key) use (&$result) {
+            $result[$key] = $item;
+            if (is_string($key)) {
+                return 'break';
+            }
+        });
+        $this->assertEquals([1, 2, 'foo' => 'bar'], $result);
+        
+        $result = [];
+        $c->each(function ($item, $key) use (&$result) {
+            if ($key === 'foo') {
+                return 'continue';
+            }
+            $result[$key] = $item;
+        });
+        $this->assertEquals([1, 2, 'bam' => 'baz'], $result);
     }
 
     public function testEachSpread()


### PR DESCRIPTION
It is possible to break out of `Collection::each()` by returning `false`.

This PR introduces the option of `continue`ing the loop by returning `'continue'` and `break`ing out by returning `'break'`, for consistency.

This shouldn't break anything, since the return value of the closure has no meaning except for when breaking it is `false` (this behavior is preserved).