### PR TITLE
[5.8] Fix stack channel's bug

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -335,6 +335,8 @@ class LogManager implements LoggerInterface
             $config['handler_with'] ?? []
         );
 
+        $with['level'] = $this->level($config);
+
         return new Monolog($this->parseChannel($config), [$this->prepareHandler(
             $this->app->make($config['handler'], $with), $config
         )]);


### PR DESCRIPTION
This simply fixes the https://github.com/laravel/framework/issues/27669 issue.

I found that stack channel had no tests.
I was always working with the default log level since it was assumed that the 'level' is coming as a key in the 'with' array, but it is not documented that way on the laravel.com

https://laravel.com/docs/5.7/logging#building-log-stacks

now the tests are modified to conform to laravel docs.
