### PR TITLE
[5.9] Better handling for wildcards in validation message keys

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -149,7 +149,7 @@ class Str
      *
      * @param  string|array  $pattern
      * @param  string  $value
-     * @param  string $wildcard
+     * @param  string  $wildcard
      * @return bool
      */
     public static function is($pattern, $value, $wildcard = '.*')

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -149,9 +149,10 @@ class Str
      *
      * @param  string|array  $pattern
      * @param  string  $value
+     * @param  string $wildcard
      * @return bool
      */
-    public static function is($pattern, $value)
+    public static function is($pattern, $value, $wildcard = '.*')
     {
         $patterns = Arr::wrap($pattern);
 
@@ -172,7 +173,7 @@ class Str
             // Asterisks are translated into zero-or-more regular expression wildcards
             // to make it convenient to check if the strings starts with the given
             // pattern such as "library/*", making any string check convenient.
-            $pattern = str_replace('\*', '.*', $pattern);
+            $pattern = str_replace('\*', $wildcard, $pattern);
 
             if (preg_match('#^'.$pattern.'\z#u', $value) === 1) {
                 return true;

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -98,7 +98,7 @@ trait FormatsMessages
         // that is not attribute specific. If we find either we'll return it.
         foreach ($keys as $key) {
             foreach (array_keys($source) as $sourceKey) {
-                if (Str::is($sourceKey, $key)) {
+                if (Str::is($sourceKey, $key, '[^.]*')) {
                     return $source[$sourceKey];
                 }
             }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -193,7 +193,7 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::is($patternObject, $valueObject));
 
         // Tests the wildcard parameter
-        $this->assertFalse(Str::is('foo.*.baz', 'test.bar.bar.baz', '[^.]*'));
+        $this->assertFalse(Str::is('foo.*.baz', 'foo.bar.bar.baz', '[^.]*'));
         $this->assertTrue(Str::is('foo.*.baz', 'foo.bar.baz', '[^.]*'));
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -191,6 +191,10 @@ class SupportStrTest extends TestCase
 
         $this->assertTrue(Str::is('foo/bar/baz', $valueObject));
         $this->assertTrue(Str::is($patternObject, $valueObject));
+
+        // Tests the wildcard parameter
+        $this->assertFalse(Str::is('test.*.test', 'test.something', '[^.]*'));
+        $this->assertTrue(Str::is('test.*.test', 'test.something.test', '[^.]*'));
     }
 
     public function testKebab()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -193,8 +193,8 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::is($patternObject, $valueObject));
 
         // Tests the wildcard parameter
-        $this->assertFalse(Str::is('test.*.test', 'test.something', '[^.]*'));
-        $this->assertTrue(Str::is('test.*.test', 'test.something.test', '[^.]*'));
+        $this->assertFalse(Str::is('foo.*.baz', 'test.bar.bar.baz', '[^.]*'));
+        $this->assertTrue(Str::is('foo.*.baz', 'foo.bar.baz', '[^.]*'));
     }
 
     public function testKebab()


### PR DESCRIPTION
Breaking change as may change the behaviour of validation (to be correct)

See #22499 
