### PR TITLE
[5.8] Method on EloquentUserProvider to create query builder instance

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -47,7 +47,7 @@ class EloquentUserProvider implements UserProvider
     {
         $model = $this->createModel();
 
-        return $model->newQuery()
+        return $this->modelQuery($model)
             ->where($model->getAuthIdentifierName(), $identifier)
             ->first();
     }
@@ -111,7 +111,7 @@ class EloquentUserProvider implements UserProvider
         // First we will add each credential element to the query as a where clause.
         // Then we can execute the query and, if we found a user, return it in a
         // Eloquent User "model" that will be utilized by the Guard instances.
-        $query = $this->createModel()->newQuery();
+        $query = $this->modelQuery();
 
         foreach ($credentials as $key => $value) {
             if (Str::contains($key, 'password')) {
@@ -152,6 +152,20 @@ class EloquentUserProvider implements UserProvider
         $class = '\\'.ltrim($this->model, '\\');
 
         return new $class;
+    }
+
+    /**
+     * Get a new query builder for the model instance.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function modelQuery($model = null)
+    {
+        if (is_null($model)) {
+            $model = $this->createModel();
+        }
+
+        return $model->newQuery();
     }
 
     /**

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -63,15 +63,15 @@ class EloquentUserProvider implements UserProvider
     {
         $model = $this->createModel();
 
-        $model = $model->where($model->getAuthIdentifierName(), $identifier)->first();
+        $retrievedModel = $this->modelQuery($model)->where($model->getAuthIdentifierName(), $identifier)->first();
 
-        if (! $model) {
+        if (! $retrievedModel) {
             return null;
         }
 
-        $rememberToken = $model->getRememberToken();
+        $rememberToken = $retrievedModel->getRememberToken();
 
-        return $rememberToken && hash_equals($rememberToken, $token) ? $model : null;
+        return $rememberToken && hash_equals($rememberToken, $token) ? $retrievedModel : null;
     }
 
     /**

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -157,6 +157,7 @@ class EloquentUserProvider implements UserProvider
     /**
      * Get a new query builder for the model instance.
      *
+     * @param  \Illuminate\Database\Eloquent\Model|null  $model
      * @return \Illuminate\Database\Eloquent\Builder
      */
     protected function modelQuery($model = null)

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -37,6 +37,7 @@ class AuthEloquentUserProviderTest extends TestCase
 
         $provider = $this->getProviderMock();
         $mock = m::mock(stdClass::class);
+        $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
         $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
         $mock->shouldReceive('first')->once()->andReturn($mockUser);
@@ -50,6 +51,7 @@ class AuthEloquentUserProviderTest extends TestCase
     {
         $provider = $this->getProviderMock();
         $mock = m::mock(stdClass::class);
+        $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
         $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
         $mock->shouldReceive('first')->once()->andReturn(null);
@@ -66,6 +68,7 @@ class AuthEloquentUserProviderTest extends TestCase
 
         $provider = $this->getProviderMock();
         $mock = m::mock(stdClass::class);
+        $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
         $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
         $mock->shouldReceive('first')->once()->andReturn($mockUser);


### PR DESCRIPTION
Reason: allows easy extension for a custom eloquent based auth provider in case, for example, you'd only need to have an extra constraint on the backing model applied. Prevents the need to fully implement the UserProvider interface.

Explanation of changes in EloquentUserProvider: instead of calling newQuery() on the model instance directly, now done through a protected method that can easily be overriden.

Example implementation where someone would have an "admin" guard that should only validate when a extra criteria (a field on the users table) is set:

```php
<?php

namespace App\Extensions;

use Illuminate\Auth\EloquentUserProvider;

class MyEloquentAdminProvider extends EloquentUserProvider
{
    protected function modelQuery($model = null)
    {
        return parent::modelQuery($model)->where('role', 'admin');
    }
}
```
