### PR TITLE
[5.8] Add currentRouteGroup()

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1079,6 +1079,16 @@ class Router implements RegistrarContract, BindingRegistrar
     }
 
     /**
+     * Get the current route prefix.
+     *
+     * @return string|null
+     */
+    public function currentRouteGroup()
+    {
+        return $this->current() ? ltrim($this->current()->action['prefix'], '/') : null;
+    }
+
+    /**
      * Alias for the "currentRouteNamed" method.
      *
      * @param  mixed  ...$patterns


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In blade templates, I will often use `Route::currentRouteName()`, but there have been a number of times that I grouped 4 or 5 routes together. Most of the time these are located under a `Route::group()`.

**Here is a route group from a blog integration.**

```
Route::group( [ 'prefix' => 'blog' ], function () {
    Route::get( '/', 'BlogController@index' )->name( 'blog' );
    Route::get( '/categories', 'BlogController@categories' )->name( 'categories' );
    Route::get( '/categories/{category}', 'BlogController@categories' )->name( 'category' );
    Route::get( '/categories/{category}/{page}', 'BlogController@categories' );
    Route::get( '/tags', 'BlogController@tags' )->name( 'tags' );
    Route::get( '/tags/{tag}', 'BlogController@tags' )->name( 'tag' );
    Route::get( '/tags/{tag}/{page}', 'BlogController@tags' );
    Route::get( '/authors', 'BlogController@authors' )->name( 'authors' );
    Route::get( '/authors/{author}', 'BlogController@authors' )->name( 'author' );
    Route::get( '/authors/{author}/{page}', 'BlogController@authors' );
    Route::get( '/{post}', 'BlogController@post' )->name( 'post' );
} );
```

A basic example of this would be including stylesheets on a per page or area basis.

```
@if ( Route::currentRouteName() == 'blog' ?? Route::currentRouteName() == 'categories' ??Route::currentRouteName() == 'tags' ?? Route::currentRouteName() == 'authors')
   // Load the blog CSS
@endif
```

Using `Route::currentRouteGroup()`

```
@if ( Route::currentRouteGroup() == 'blog')
   // Load the blog CSS
@endif
```
**- or -**
```
@if ( Route::currentRouteGroup() == 'blog' && Route::currentRouteName() != 'authors')
   // Load the blog CSS
@endif
```
