### PR TITLE
If no value is supplied to where(), assume non-false instead of null

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -602,6 +602,11 @@ class Builder
             return $this->addArrayOfWheres($column, $boolean);
         }
 
+        // If only the column is passed, we will assume that it has to be true.
+        if (func_num_args() === 1) {
+            [$value, $operator] = [true, '='];
+        }
+
         // Here we will make some assumptions about the operator. If only 2 values are
         // passed to the method, we will assume that the operator is an equals sign
         // and keep going. Otherwise, we'll require the operator to be passed in.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -602,9 +602,9 @@ class Builder
             return $this->addArrayOfWheres($column, $boolean);
         }
 
-        // If only the column is passed, we will assume that it has to be true.
+        // If only the column is passed, we will assume that it must not be false.
         if (func_num_args() === 1) {
-            [$value, $operator] = [true, '='];
+            [$value, $operator] = [false, '!='];
         }
 
         // Here we will make some assumptions about the operator. If only 2 values are

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -595,6 +595,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2014], $builder->getBindings());
     }
 
+    public function testWhereWithoutAValue()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->where('id');
+        $builder->assertEquals('select * from [users] where id', $builder->toSql());
+    }
+
     public function testWhereBetweens()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -599,7 +599,8 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->where('id');
-        $builder->assertEquals('select * from [users] where id', $builder->toSql());
+        $builder->assertEquals('select * from [users] where id != ?', $builder->toSql());
+        $this->assertEquals([0 => false], $builder->getBindings());
     }
 
     public function testWhereBetweens()


### PR DESCRIPTION
Fixes #26333

When `where('enabled')` is called, the query builder shouldn't assume read that as `where enabled is null` but rather `where enabled != false`.

I didn't manage to find a way to do

```sql
select * from users where foo
```

So I went with

```sql
select * from users where foo != false
```

Since that produces results closer to the "conditionless" where than `where foo = true`.
