### PR TITLE
[5.8] Add firstAfter and firstBefore Collection Methods

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -779,7 +779,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 return $value;
             }
         }
-        if($grabNext && $wrap) {
+        if ($grabNext && $wrap) {
             return Arr::first($this->items, null, $default);
         }
         return $default;
@@ -798,7 +798,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $lastKey = null;
         foreach ($this->items as $key => $value) {
             if ($callback($value, $key)) {
-                if($lastKey === null) {
+                if ($lastKey === null) {
                     return $wrap ? Arr::last($this->items, null, $default) : $default;
                 }
                 return $this->items[$lastKey];

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -764,18 +764,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @param  callable|null  $callback
      * @param  mixed  $default
-     * @param  boolean $wrap
+     * @param  bool $wrap
      * @return mixed
      */
     public function firstAfter(callable $callback, $default = null, $wrap = false)
     {
         $grabNext = false;
         foreach ($this->items as $key => $value) {
-            if($callback($value, $key)) {
+            if ($callback($value, $key)) {
                 $grabNext = true;
                 continue;
             }
-            if($grabNext) {
+            if ($grabNext) {
                 return $value;
             }
         }
@@ -790,14 +790,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @param  callable|null  $callback
      * @param  mixed  $default
-     * @param  boolean $wrap
+     * @param  bool $wrap
      * @return mixed
      */
     public function firstBefore(callable $callback, $default = null, $wrap = false)
     {
         $lastKey = null;
         foreach ($this->items as $key => $value) {
-            if($callback($value, $key)) {
+            if ($callback($value, $key)) {
                 if($lastKey === null) {
                     return $wrap ? Arr::last($this->items, null, $default) : $default;
                 }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -782,6 +782,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         if ($grabNext && $wrap) {
             return Arr::first($this->items, null, $default);
         }
+
         return $default;
     }
 
@@ -801,10 +802,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 if ($lastKey === null) {
                     return $wrap ? Arr::last($this->items, null, $default) : $default;
                 }
+                
                 return $this->items[$lastKey];
             }
             $lastKey = $key;
         }
+
         return $default;
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -760,6 +760,55 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the next item from the collection after a truth test is passed.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @param  boolean $wrap
+     * @return mixed
+     */
+    public function firstAfter(callable $callback, $default = null, $wrap = false)
+    {
+        $grabNext = false;
+        foreach ($this->items as $key => $value) {
+            if($callback($value, $key)) {
+                $grabNext = true;
+                continue;
+            }
+            if($grabNext) {
+                return $value;
+            }
+        }
+        if($grabNext && $wrap) {
+            return Arr::first($this->items, null, $default);
+        }
+        return $default;
+    }
+
+    /**
+     * Get the previous item from the collection after a truth test is passed.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @param  boolean $wrap
+     * @return mixed
+     */
+    public function firstBefore(callable $callback, $default = null, $wrap = false)
+    {
+        $lastKey = null;
+        foreach ($this->items as $key => $value) {
+            if($callback($value, $key)) {
+                if($lastKey === null) {
+                    return $wrap ? Arr::last($this->items, null, $default) : $default;
+                }
+                return $this->items[$lastKey];
+            }
+            $lastKey = $key;
+        }
+        return $default;
+    }
+
+    /**
      * Get the first item by the given key value pair.
      *
      * @param  string  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -51,6 +51,68 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('default', $result);
     }
 
+    public function testFirstAfterWithoutDefaultAndWithoutWrap()
+    {
+        $data = new Collection(['foo', 'bar', 'baz']);
+        $result = $data->firstAfter(function ($value) {
+            return $value === 'bar';
+        });
+        $this->assertEquals('baz', $result);
+    }
+
+    public function testFirstAfterWithDefaultAndWithoutWrap()
+    {
+        $data = new Collection(['foo', 'bar', 'baz']);
+        $result = $data->firstAfter(function ($value) {
+            return $value === 'not_present';
+        }, 'default');
+        $this->assertEquals('default', $result);
+        $result = $data->firstAfter(function ($value) {
+            return $value === 'baz';
+        }, 'default');
+        $this->assertEquals('default', $result);
+    }
+
+    public function testFirstAfterWithDefaultAndWithWrap()
+    {
+        $data = new Collection(['foo', 'bar', 'baz']);
+        $result = $data->firstAfter(function ($value) {
+            return $value === 'baz';
+        }, 'default', true);
+        $this->assertEquals('foo', $result);
+    }
+
+    public function testFirstBeforeWithoutDefaultAndWithoutWrap()
+    {
+        $data = new Collection(['foo', 'bar', 'baz']);
+        $result = $data->firstBefore(function ($value) {
+            return $value === 'bar';
+        });
+        $this->assertEquals('foo', $result);
+    }
+
+    public function testFirstBeforeWithDefaultAndWithoutWrap()
+    {
+        $data = new Collection(['foo', 'bar', 'baz']);
+        $result = $data->firstBefore(function ($value) {
+            return $value === 'not_present';
+        }, 'default');
+        $this->assertEquals('default', $result);
+        $result = $data->firstBefore(function ($value) {
+            return $value === 'foo';
+        }, 'default');
+        $this->assertEquals('default', $result);
+    }
+
+    public function testFirstBeforeWithDefaultAndWithWrap()
+    {
+        $data = new Collection(['foo', 'bar', 'baz']);
+        $result = $data->firstBefore(function ($value) {
+            return $value === 'foo';
+        }, 'default', true);
+        $this->assertEquals('baz', $result);
+    }
+
     public function testFirstWhere()
     {
         $data = new Collection([


### PR DESCRIPTION
Multiple times I have run into scenarios where I need to get the next item of a particular item in a list. For example, determining the next user in a list given the previous user's id in a round robin scenario. These methods are a clean way of solving it.

An example:
```
$result = new Collection(['foo', 'bar', 'baz'])->firstAfter(function ($value) {
    return $value === 'bar';
});
dd($result); // will be "baz"
```

You can also use the third "wrap" parameter which will return the first item in the list if the last item passes the truth test:
```
$result = new Collection(['foo', 'bar', 'baz'])->firstAfter(function ($value) {
    return $value === 'baz';
}, null, true);
dd($result); // will be "foo"
```

And all of the above applies to the `firstBefore` method except that it will return the item preceding the item that passes the truth test. And the wrap parameter will return the last item in the list if the first item in the list passes the truth test.