### PR TITLE
[5.8] Add support for app->call() using a sequential array as parameters

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -5,6 +5,7 @@ namespace Illuminate\Container;
 use Closure;
 use ReflectionMethod;
 use ReflectionFunction;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
 class BoundMethod
@@ -115,6 +116,10 @@ class BoundMethod
      */
     protected static function getMethodDependencies($container, $callback, array $parameters = [])
     {
+        if (! Arr::isAssoc($parameters)) {
+            return static::addDependencyForCallParameterSeq($container, $callback, $parameters);
+        }
+
         $dependencies = [];
 
         foreach (static::getCallReflector($callback)->getParameters() as $parameter) {
@@ -171,6 +176,36 @@ class BoundMethod
     }
 
     /**
+     * Get the dependency for the given call parameter.
+     *
+     * @param  \Illuminate\Container\Container $container
+     * @param $callback
+     * @param  array $inputData
+     * @return mixed
+     *
+     * @throws \ReflectionException
+     */
+    protected static function addDependencyForCallParameterSeq($container, $callback, array $inputData)
+    {
+        $signature = static::getCallReflector($callback)->getParameters();
+        // In case the method has no explicit input parameters we will
+        // call that with whatever input data available to us since
+        // they may have used func_get_args() to catch the input.
+        if (count($signature) === 0) {
+            return $inputData;
+        }
+
+        // When we receive the input as an indexed array and the count of passed arguments
+        // is not less than the declared parameters, it means that we are provided with
+        // everything needed, So the IOC container should not bother about injection.
+        if (count($signature) <= count($inputData)) {
+            return $inputData;
+        }
+
+        return self::resolveDependencies($container, $inputData, $signature);
+    }
+
+    /**
      * Determine if the given string is in Class@method syntax.
      *
      * @param  mixed  $callback
@@ -179,5 +214,36 @@ class BoundMethod
     protected static function isCallableWithAtSign($callback)
     {
         return is_string($callback) && strpos($callback, '@') !== false;
+    }
+
+    /**
+     * @param $container
+     * @param array $inputData
+     * @param array $signature
+     * @return array
+     */
+    protected static function resolveDependencies($container, array $inputData, array $signature)
+    {
+        $i = 0;
+        $parameters = [];
+        // Here we iterate through the list of declared parameters (in the method signature) and decide
+        // whether it should be invoked with the provided input data, or we should resolve an object
+        // for it (according to it's type-hint) or just call it with it's defined "default" value.
+        foreach ($signature as $parameter) {
+            if ($class = $parameter->getClass()) {
+                if (array_key_exists($i, $inputData) && is_a($inputData[$i], $class->name)) {
+                    // gets from indexed array input data
+                    $parameters[] = $inputData[$i++];
+                } else {
+                    $parameters[] = $container->make($class->name);
+                }
+            } elseif (array_key_exists($i, $inputData)) {
+                $parameters[] = $inputData[$i++];
+            } elseif ($parameter->isDefaultValueAvailable()) {
+                $parameters[] = $parameter->getDefaultValue();
+            }
+        }
+
+        return $parameters;
     }
 }

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -178,31 +178,31 @@ class BoundMethod
     /**
      * Get the dependency for the given call parameter.
      *
-     * @param  \Illuminate\Container\Container $container
-     * @param $callback
-     * @param  array $inputData
+     * @param  \Illuminate\Container\Container  $container
+     * @param  callable|string  $callback
+     * @param  array  $inputData
      * @return mixed
      *
      * @throws \ReflectionException
      */
     protected static function addDependencyForCallParameterSeq($container, $callback, array $inputData)
     {
-        $signature = static::getCallReflector($callback)->getParameters();
+        $signatureParams = static::getCallReflector($callback)->getParameters();
         // In case the method has no explicit input parameters we will
         // call that with whatever input data available to us since
         // they may have used func_get_args() to catch the input.
-        if (count($signature) === 0) {
+        if (count($signatureParams) === 0) {
             return $inputData;
         }
 
         // When we receive the input as an indexed array and the count of passed arguments
         // is not less than the declared parameters, it means that we are provided with
         // everything needed, So the IOC container should not bother about injection.
-        if (count($signature) <= count($inputData)) {
+        if (count($signatureParams) <= count($inputData)) {
             return $inputData;
         }
 
-        return self::resolveDependencies($container, $inputData, $signature);
+        return self::resolveDependencies($container, $inputData, $signatureParams);
     }
 
     /**
@@ -217,19 +217,19 @@ class BoundMethod
     }
 
     /**
-     * @param $container
-     * @param array $inputData
-     * @param array $signature
+     * @param  \Illuminate\Container\Container  $container
+     * @param array  $inputData
+     * @param array  $signatureParams
      * @return array
      */
-    protected static function resolveDependencies($container, array $inputData, array $signature)
+    protected static function resolveDependencies($container, array $inputData, array $signatureParams)
     {
         $i = 0;
         $parameters = [];
         // Here we iterate through the list of declared parameters (in the method signature) and decide
         // whether it should be invoked with the provided input data, or we should resolve an object
         // for it (according to it's type-hint) or just call it with it's defined "default" value.
-        foreach ($signature as $parameter) {
+        foreach ($signatureParams as $parameter) {
             if ($class = $parameter->getClass()) {
                 if (array_key_exists($i, $inputData) && is_a($inputData[$i], $class->name)) {
                     // gets from indexed array input data

--- a/tests/Container/BoundMethodTest.php
+++ b/tests/Container/BoundMethodTest.php
@@ -14,12 +14,18 @@ class BoundMethodTest extends TestCase
         };
         $args = BoundMethodAccessor::getMethodDependencies(new Container(), $defaulty, ['a', 'b', 'c']);
         $this->assertSame(['a', 'b', 'c'], $args);
+
         $args = BoundMethodAccessor::getMethodDependencies(new Container(), $defaulty, ['a', 'b']);
         $this->assertSame(['a', 'b', 'default c'], $args);
+
         $args = BoundMethodAccessor::getMethodDependencies(new Container(), $defaulty, ['a', 'b', null]);
         $this->assertSame(['a', 'b', null], $args);
+
         $args = BoundMethodAccessor::getMethodDependencies(new Container(), $defaulty, ['a', null]);
         $this->assertSame(['a', null, 'default c'], $args);
+
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $defaulty, ['a']);
+        $this->assertSame(['a', 'default b', 'default c'], $args);
     }
 
     public function testEndInjection()
@@ -99,6 +105,7 @@ class BoundMethodTest extends TestCase
         $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
         $this->assertEquals('value c', $c);
         $this->assertArrayNotHasKey(4, $args);
+
         $obj = new ContainerBoundMethodStub;
         [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', $obj]);
         $this->assertEquals('passed a', $a);
@@ -110,6 +117,7 @@ class BoundMethodTest extends TestCase
         $this->assertSame($obj, $b);
         $this->assertEquals('passed c', $c);
         $this->assertArrayNotHasKey(4, $args);
+
         $stub2 = new ContainerBoundMethodStub2;
         [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', $stub2]);
         $this->assertEquals('passed a', $a);

--- a/tests/Container/BoundMethodTest.php
+++ b/tests/Container/BoundMethodTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Illuminate\Tests\Container;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+use Illuminate\Container\BoundMethod;
+
+class BoundMethodTest extends TestCase
+{
+    public function testBoundMethodAccessor()
+    {
+        $defaulty = function ($a, $b = 'default b', $c = 'default c') {
+        };
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $defaulty, ['a', 'b', 'c']);
+        $this->assertSame(['a', 'b', 'c'], $args);
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $defaulty, ['a', 'b']);
+        $this->assertSame(['a', 'b', 'default c'], $args);
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $defaulty, ['a', 'b', null]);
+        $this->assertSame(['a', 'b', null], $args);
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $defaulty, ['a', null]);
+        $this->assertSame(['a', null, 'default c'], $args);
+    }
+
+    public function testEndInjection()
+    {
+        $injected = function ($a, $b = 'default b', ContainerBoundMethodStub $c) {
+        };
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $injected, ['a']);
+        $this->assertEquals('a', $a);
+        $this->assertEquals('default b', $b);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
+        $this->assertArrayNotHasKey(4, $args);
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $injected, [null, null]);
+        $this->assertNull($a);
+        $this->assertNull($b);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
+        $this->assertArrayNotHasKey(4, $args);
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $injected, [null, null, null]);
+        $this->assertSame([null, null, null], $args);
+        $this->assertArrayNotHasKey(4, $args);
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $injected, ['a', 'b', 'c']);
+        $this->assertEquals(['a', 'b', 'c'], $args);
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $injected, [
+            'a' => 'passed a',
+            'b' => 'value b',
+            'junk' => 'junk',
+        ]);
+        $this->assertEquals('passed a', $a);
+        $this->assertEquals('value b', $b);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
+        $this->assertArrayNotHasKey(4, $args);
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $injected, [
+            'a' => 'passed a',
+            'junk' => 'junk',
+        ]);
+        $this->assertEquals('passed a', $a);
+        $this->assertEquals('default b', $b);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
+        $this->assertArrayNotHasKey(4, $args);
+    }
+
+    public function testExtraNumberOfInputArePassedIntoMethod()
+    {
+        $callable = function ($a, $b) {
+        };
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callable, ['a', 'b', 'c', 'd']);
+        $this->assertEquals(['a', 'b', 'c', 'd'], $args);
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callable, ['a', 'b', 'c', null]);
+        $this->assertEquals(['a', 'b', 'c', null], $args);
+    }
+
+    public function testCallingWithNoArgs()
+    {
+        $callee = function () {
+        };
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['a', 'b', 'c']);
+        $this->assertSame(['a', 'b', 'c'], $args);
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['key_a' => 'value_a', 'key_b' => 'value_b']);
+        $this->assertSame(['key_a' => 'value_a', 'key_b' => 'value_b'], $args);
+    }
+
+    public function testCanInjectAtMiddle()
+    {
+        $callee = function ($a, ContainerBoundMethodStub $b, $c = 'default c') {
+        };
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['a' => 'passed a', 'junk' => 'junk']);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertEquals('default c', $c);
+        $this->assertArrayNotHasKey(4, $args);
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['c' => 'value c', 'junk' => 'junk', 'a' => 'passed a']);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertEquals('value c', $c);
+        $this->assertArrayNotHasKey(4, $args);
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', 'value c']);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertEquals('value c', $c);
+        $this->assertArrayNotHasKey(4, $args);
+        $obj = new ContainerBoundMethodStub;
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', $obj]);
+        $this->assertEquals('passed a', $a);
+        $this->assertSame($obj, $b);
+        $this->assertEquals('default c', $c);
+        $this->assertArrayNotHasKey(4, $args);
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', $obj, 'passed c']);
+        $this->assertEquals('passed a', $a);
+        $this->assertSame($obj, $b);
+        $this->assertEquals('passed c', $c);
+        $this->assertArrayNotHasKey(4, $args);
+        $stub2 = new ContainerBoundMethodStub2;
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', $stub2]);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertSame($stub2, $c);
+        $this->assertArrayNotHasKey(4, $args);
+    }
+
+    public function testIsCallableWithAtSign()
+    {
+        $this->assertTrue(BoundMethodAccessor::isCallableWithAtSign('@'));
+        $this->assertTrue(BoundMethodAccessor::isCallableWithAtSign('a@'));
+        $this->assertTrue(BoundMethodAccessor::isCallableWithAtSign('@a'));
+        $this->assertTrue(BoundMethodAccessor::isCallableWithAtSign('a@a'));
+        $this->assertTrue(BoundMethodAccessor::isCallableWithAtSign('1@'));
+        $this->assertTrue(BoundMethodAccessor::isCallableWithAtSign('@1'));
+        $this->assertTrue(BoundMethodAccessor::isCallableWithAtSign('1@1'));
+        $this->assertFalse(BoundMethodAccessor::isCallableWithAtSign('I_HaveNoAtSign'));
+        $this->assertFalse(BoundMethodAccessor::isCallableWithAtSign(''));
+        $this->assertFalse(BoundMethodAccessor::isCallableWithAtSign([]));
+        $this->assertFalse(BoundMethodAccessor::isCallableWithAtSign(null));
+    }
+}
+
+class BoundMethodAccessor extends BoundMethod
+{
+    public static function getMethodDependencies($container, $callback, array $inputData = [])
+    {
+        return parent::getMethodDependencies($container, $callback, $inputData);
+    }
+
+    public static function isCallableWithAtSign($callback)
+    {
+        return parent::isCallableWithAtSign($callback);
+    }
+}
+
+class ContainerBoundMethodStub
+{
+}
+
+class ContainerBoundMethodStub2
+{
+}
+
+class BoundMethodAccessorStub
+{
+    public function injectedAtMiddle($a, ContainerBoundMethodStub $b, $c = 'default c')
+    {
+    }
+}

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -46,6 +46,11 @@ class ContainerCallTest extends TestCase
         $stub = new ContainerTestCallStub;
         $result = $container->call([$stub, 'work'], ['foo', 'bar']);
         $this->assertEquals(['foo', 'bar'], $result);
+
+        $container = new Container;
+        $stub = new ContainerTestCallStub;
+        $result = $container->call([$stub, 'work'], ['b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['bar', 'foo'], $result);
     }
 
     public function testCallWithStaticMethodNameString()
@@ -54,6 +59,17 @@ class ContainerCallTest extends TestCase
         $result = $container->call('Illuminate\Tests\Container\ContainerStaticMethodStub::inject');
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
+
+        $container = new Container;
+        $result = $container->call([new ContainerTestCallStub, 'inject'], ['baz']);
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
+        $this->assertEquals('baz', $result[1]);
+
+        $container = new Container;
+        $object = new ContainerCallConcreteStub();
+        $result = $container->call([new ContainerTestCallStub, 'inject'], [$object, 'foo']);
+        $this->assertSame($object, $result[0]);
+        $this->assertEquals('foo', $result[1]);
     }
 
     public function testCallWithGlobalMethodName()
@@ -111,11 +127,45 @@ class ContainerCallTest extends TestCase
     public function testClosureCallWithInjectedDependency()
     {
         $container = new Container;
-        $container->call(function (ContainerCallConcreteStub $stub) {
+        $result = $container->call(function (ContainerCallConcreteStub $stub) {
+            return $stub;
         }, ['foo' => 'bar']);
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result);
 
         $container->call(function (ContainerCallConcreteStub $stub) {
         }, ['foo' => 'bar', 'stub' => new ContainerCallConcreteStub]);
+
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result);
+
+        $obj = new ContainerCallConcreteStub;
+        $result = $container->call(function (ContainerCallConcreteStub $stub) {
+            return $stub;
+        }, [$obj]);
+        $this->assertSame($obj, $result);
+
+        $obj = new ContainerCallConcreteStub;
+        $result = $container->call(function (ContainerCallConcreteStub $stub, $baz = 'taylor') {
+            return [$stub, $baz];
+        }, ['foo' => 'bar', 'stub' => $obj]);
+        $this->assertSame($obj, $result[0]);
+        $this->assertEquals('taylor', $result[1]);
+
+        $obj = new ContainerCallConcreteStub;
+        $result = $container->call(function ($foo, ContainerCallConcreteStub $stub) {
+            return [$foo, $stub];
+        }, ['foo', $obj]);
+        $this->assertEquals('foo', $result[0]);
+        $this->assertSame($obj, $result[1]);
+        $result = $container->call(function ($foo = 'default foo', ContainerCallConcreteStub $stub) {
+            return [$foo, $stub];
+        }, ['foo']);
+        $this->assertEquals('foo', $result[0]);
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[1]);
+        $result = $container->call(function ($foo = 'default foo', ContainerCallConcreteStub $stub = null) {
+            return [$foo, $stub];
+        }, []);
+        $this->assertEquals('default foo', $result[0]);
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[1]);
     }
 
     public function testCallWithDependencies()
@@ -156,6 +206,85 @@ class ContainerCallTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
     }
+
+    public function testTypeErrorHappensWhenWrongDataIsPassed()
+    {
+        $callable = function (ContainerCallConcreteStub $stub) {
+        };
+        $this->expectException(\TypeError::class);
+        (new Container)->call($callable, ['foo']);
+    }
+
+
+    public function testWithDefaultParametersIndexedArraySyntax()
+    {
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar', 'baz']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty');
+        $this->assertEquals(['default a', 'default b', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['foo']);
+        $this->assertEquals(['foo', 'default b', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['foo', null]);
+        $this->assertEquals(['foo', null, 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', [null, null, null]);
+        $this->assertEquals([null, null, null], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['foo', 'bar', 'baz', 'foo2', 'bar2', 'baz2']);
+        $this->assertEquals(['foo', 'bar', 'baz', 'foo2', 'bar2', 'baz2'], $result);
+    }
+    public function testWithDefaultParametersAssociativeSyntax()
+    {
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['a' => 'foo', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['c' => 'baz', 'b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['a' => 'foo', 'c' => 'baz', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['a' => 'foo']);
+        $this->assertEquals(['foo', 'default b', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['a' => 'foo', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+
+        $container = new Container;
+        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['a' => 'foo', 'c' => 'baz', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+    }
+
 }
 
 class ContainerTestCallStub
@@ -189,6 +318,26 @@ function containerTestInject(ContainerCallConcreteStub $stub, $default = 'taylor
 class ContainerStaticMethodStub
 {
     public static function inject(ContainerCallConcreteStub $stub, $default = 'taylor')
+    {
+        return func_get_args();
+    }
+}
+
+class ContainerTestDefaultyParams
+{
+    public function defaulty($a = 'default a', $b = 'default b', $c = 'default c')
+    {
+        return func_get_args();
+    }
+    public function defaultyBandC($a, $b = 'default b', $c = 'default c')
+    {
+        return func_get_args();
+    }
+    public function defaultyOnlyC($a, $b, $c = 'default c')
+    {
+        return func_get_args();
+    }
+    public function noDefault($a, $b, $c)
     {
         return func_get_args();
     }

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -215,7 +215,6 @@ class ContainerCallTest extends TestCase
         (new Container)->call($callable, ['foo']);
     }
 
-
     public function testWithDefaultParametersIndexedArraySyntax()
     {
         $container = new Container;
@@ -246,6 +245,7 @@ class ContainerCallTest extends TestCase
         $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['foo', 'bar', 'baz', 'foo2', 'bar2', 'baz2']);
         $this->assertEquals(['foo', 'bar', 'baz', 'foo2', 'bar2', 'baz2'], $result);
     }
+
     public function testWithDefaultParametersAssociativeSyntax()
     {
         $container = new Container;
@@ -284,7 +284,6 @@ class ContainerCallTest extends TestCase
         $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['a' => 'foo', 'c' => 'baz', 'b' => 'bar']);
         $this->assertEquals(['foo', 'bar', 'baz'], $result);
     }
-
 }
 
 class ContainerTestCallStub
@@ -329,14 +328,17 @@ class ContainerTestDefaultyParams
     {
         return func_get_args();
     }
+
     public function defaultyBandC($a, $b = 'default b', $c = 'default c')
     {
         return func_get_args();
     }
+
     public function defaultyOnlyC($a, $b, $c = 'default c')
     {
         return func_get_args();
     }
+
     public function noDefault($a, $b, $c)
     {
         return func_get_args();


### PR DESCRIPTION
- Trying to fix this issue :
https://github.com/laravel/framework/issues/26851
https://github.com/laravel/framework/pull/27751

- This is a re submission of #26920 but in a way that avoids tampering with the current code as much as possible. Most of the added code is isolated within two new protected methods.

- I can not imagine more tests to proof this PR

- **Side benefit:**  If this gets added to the framework, we can use `$container->call(` in the base facade class to call the intended method. (I will make the subsequent PR then)
currently is it called like this :
https://github.com/laravel/framework/blob/00624592ef044c2ddae5cbc324d39928f5b4bb70/src/Illuminate/Support/Facades/Facade.php#L237

```php
         // can be changed to :
        return static::$app->call($method, $args);

```
(Since the `$args` variable is a sequential array of parameters)

So the end users can enjoy `method injection` on POPOs when they use facades to call methods on classes.

```php
// we use a real-time facade to call MyClass::myMethod
\Facades\MyClass::myMethod();
````

```php
// the POPO which needs method injection
class MyClass {
    public function myMethod(SomeClass $obj) {
        // I have my object injected here...
    }
}
```

- About BoundMethodTest :
This style of unit testing a class ensures that if it works correctly with one type of $callback (e.g closures), it will also work well with other types.

So we need to only test it against Closures and be sure `class@method` notation is also ok.