### PR TITLE
[5.8] Nested keys for Higher Order Proxy

### DIFF
--- a/src/Illuminate/Support/HigherOrderCollectionProxy.php
+++ b/src/Illuminate/Support/HigherOrderCollectionProxy.php
@@ -43,7 +43,7 @@ class HigherOrderCollectionProxy
     public function __get($key)
     {
         return $this->collection->{$this->method}(function ($value) use ($key) {
-            return is_array($value) ? $value[$key] : $value->{$key};
+            return is_array($value) ? Arr::get($value, $key) : $value->{$key};
         });
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1840,6 +1840,25 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([2 => ['rating' => 1, 'name' => '1'], 4 => ['rating' => 2, 'name' => '2'], 6 => ['rating' => 3, 'name' => '3']], $result->all());
     }
 
+    public function testKeyByNestedAttribute()
+    {
+        $data = new Collection([
+            ['id' => 1, 'person' => ['first_name' => 'foo', 'last_name' => 'bar']],
+            ['id' => 2, 'person' => ['first_name' => 'foo', 'last_name' => 'baz']]
+        ]);
+
+        $result = $data->keyBy('person.last_name');
+
+        $this->assertEquals([
+            'bar' => ['id' => 1, 'person' => ['first_name' => 'foo', 'last_name' => 'bar']],
+            'baz' => ['id' => 2, 'person' => ['first_name' => 'foo', 'last_name' => 'baz']]
+        ], $result->all());
+
+        $result = $data->keyBy('person.last_name')->map->id;
+
+        $this->assertEquals(['bar' => 1, 'baz' => 2], $result->all());
+    }
+
     public function testKeyByClosure()
     {
         $data = new Collection([

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -346,6 +346,16 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['id1' => 'first', 'id2' => 'second'], $c->keyBy->id->map->name->all());
     }
 
+    public function testHigherOrderNestedKeyBy()
+    {
+        $c = new Collection([
+            ['value'  => 'foo 1', 'bar' => ['baz' => 'first']],
+            ['value'  => 'foo 2', 'bar' => ['baz' => 'second']],
+        ]);
+
+        $this->assertEquals(['first' => 'foo 1', 'second' => 'foo 2'], $c->keyBy->{'bar.baz'}->map->value->all());
+    }
+
     public function testHigherOrderUnique()
     {
         $c = new Collection([
@@ -354,6 +364,16 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertCount(1, $c->unique->id);
+    }
+
+    public function testHigherOrderNestedUnique()
+    {
+        $c = new Collection([
+            ['id' => '1', 'person' => ['first_name' => 'foo', 'last_name' => 'bar']],
+            ['id' => '2', 'person' => ['first_name' => 'foo', 'last_name' => 'baz']],
+        ]);
+
+        $this->assertCount(1, $c->unique->{'person.first_name'});
     }
 
     public function testHigherOrderFilter()
@@ -379,6 +399,17 @@ class SupportCollectionTest extends TestCase
 
         $this->assertCount(1, $c->filter->active());
     }
+
+    public function testHigherOrderNestedFilter()
+    {
+        $c = new Collection([
+            ['name' => 'bob', 'dinner' => [ 'main_course' => 'salad', 'starter' => 'soup']],
+            ['name' => 'eve', 'dinner' => [ 'main_course' => 'burger', 'desert' => 'ice cream']]
+        ]);
+
+        $this->assertCount(1, $c->filter->{'dinner.starter'});
+    }
+
 
     public function testWhere()
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -403,13 +403,12 @@ class SupportCollectionTest extends TestCase
     public function testHigherOrderNestedFilter()
     {
         $c = new Collection([
-            ['name' => 'bob', 'dinner' => [ 'main_course' => 'salad', 'starter' => 'soup']],
-            ['name' => 'eve', 'dinner' => [ 'main_course' => 'burger', 'desert' => 'ice cream']]
+            ['name' => 'bob', 'dinner' => ['main_course' => 'salad', 'starter' => 'soup']],
+            ['name' => 'eve', 'dinner' => ['main_course' => 'burger', 'desert' => 'ice cream']],
         ]);
 
         $this->assertCount(1, $c->filter->{'dinner.starter'});
     }
-
 
     public function testWhere()
     {
@@ -1844,14 +1843,14 @@ class SupportCollectionTest extends TestCase
     {
         $data = new Collection([
             ['id' => 1, 'person' => ['first_name' => 'foo', 'last_name' => 'bar']],
-            ['id' => 2, 'person' => ['first_name' => 'foo', 'last_name' => 'baz']]
+            ['id' => 2, 'person' => ['first_name' => 'foo', 'last_name' => 'baz']],
         ]);
 
         $result = $data->keyBy('person.last_name');
 
         $this->assertEquals([
             'bar' => ['id' => 1, 'person' => ['first_name' => 'foo', 'last_name' => 'bar']],
-            'baz' => ['id' => 2, 'person' => ['first_name' => 'foo', 'last_name' => 'baz']]
+            'baz' => ['id' => 2, 'person' => ['first_name' => 'foo', 'last_name' => 'baz']],
         ], $result->all());
 
         $result = $data->keyBy('person.last_name')->map->id;


### PR DESCRIPTION
Hey all,

I ran into a minor issue earlier this morning. I wanted to consume an JSON API response in the following format:

`[
[
'values' => ['value' => 100],
'time_range' => ['date' => '04-03-2019']
],
[
'values' => ['value' => 200], 
'time_range' => ['date' => '04-02-2019']
]
]`

I assumed I could keyBy using dot notation in Higher Order Proxy, because you can using the normal collection. I wrote an extra test to confirm this, but the relevant code is in line 1781 of Collection. Collection uses data_get, and HigherOrderCollectionProxy uses direct array access.

Obviously I could just use $collection->keyBy('time_range.date') here, but I deeply enjoy the brevity HAP provides and I'd love to see it used more.

Long story short, this PR should make HAP and regular Collections more consistent, and I feel that consuming deeply nested arrays is a regular enough use-case to warrant this, it shouldn't break any existing behaviour, so I targeted 5.8, let me know if that's wrong.