### PR TITLE
[5.8] Add `countBy` method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1891,6 +1891,28 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Count the number of items in the collection by some predicate.
+     *
+     * @param callable|null
+     * @return static
+     */
+    public function countBy($predicate = null)
+    {
+        if (is_null($predicate)) {
+            $predicate = function ($val, $key) {
+                return $val;
+            };
+        }
+
+        return new static(
+            $this->groupBy($predicate)
+                ->map(function ($val, $key) {
+                    return $val->count();
+                })
+        );
+    }
+
+    /**
      * Add an item to the collection.
      *
      * @param  mixed  $item

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1899,14 +1899,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function countBy($predicate = null)
     {
         if (is_null($predicate)) {
-            $predicate = function ($val, $key) {
+            $predicate = function ($val) {
                 return $val;
             };
         }
 
         return new static(
             $this->groupBy($predicate)
-                ->map(function ($val, $key) {
+                ->map(function ($val) {
                     return $val->count();
                 })
         );

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -307,6 +307,31 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(2, $c);
     }
 
+    public function testCountableByWithoutPredicate()
+    {
+        $c = new Collection([ 'foo', 'foo', 'foo', 'bar', 'bar', 'foobar' ]);
+        $this->assertEquals([ 'foo' => 3, 'bar' => 2, 'foobar' => 1 ], $c->countBy()->all());
+
+        $c = new Collection([ true, true, false, false, false ]);
+        $this->assertEquals([ true => 2, false => 3, ], $c->countBy()->all());
+
+        $c = new Collection([ 1, 5, 1, 5, 5, 1 ]);
+        $this->assertEquals([ 1 => 3, 5 => 3, ], $c->countBy()->all());
+    }
+
+    public function testCountableByWithPredicate()
+    {
+        $c = new Collection([ 'alice', 'aaron', 'bob', 'carla' ]);
+        $this->assertEquals([ 'a' => 2, 'b' => 1, 'c' => 1 ], $c->countBy(function ($name) {
+            return substr($name, 0, 1);
+        })->all());
+
+        $c = new Collection([ 1, 2, 3, 4, 5 ]);
+        $this->assertEquals([ true => 2, false => 3 ], $c->countBy(function ($i) {
+            return $i % 2 === 0;
+        })->all());
+    }
+
     public function testIterable()
     {
         $c = new Collection(['foo']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -313,10 +313,10 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo' => 3, 'bar' => 2, 'foobar' => 1], $c->countBy()->all());
 
         $c = new Collection([true, true, false, false, false]);
-        $this->assertEquals([true => 2, false => 3,], $c->countBy()->all());
+        $this->assertEquals([true => 2, false => 3], $c->countBy()->all());
 
         $c = new Collection([1, 5, 1, 5, 5, 1]);
-        $this->assertEquals([1 => 3, 5 => 3,], $c->countBy()->all());
+        $this->assertEquals([1 => 3, 5 => 3], $c->countBy()->all());
     }
 
     public function testCountableByWithPredicate()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -309,25 +309,25 @@ class SupportCollectionTest extends TestCase
 
     public function testCountableByWithoutPredicate()
     {
-        $c = new Collection([ 'foo', 'foo', 'foo', 'bar', 'bar', 'foobar' ]);
-        $this->assertEquals([ 'foo' => 3, 'bar' => 2, 'foobar' => 1 ], $c->countBy()->all());
+        $c = new Collection(['foo', 'foo', 'foo', 'bar', 'bar', 'foobar']);
+        $this->assertEquals(['foo' => 3, 'bar' => 2, 'foobar' => 1], $c->countBy()->all());
 
-        $c = new Collection([ true, true, false, false, false ]);
-        $this->assertEquals([ true => 2, false => 3, ], $c->countBy()->all());
+        $c = new Collection([true, true, false, false, false]);
+        $this->assertEquals([true => 2, false => 3,], $c->countBy()->all());
 
-        $c = new Collection([ 1, 5, 1, 5, 5, 1 ]);
-        $this->assertEquals([ 1 => 3, 5 => 3, ], $c->countBy()->all());
+        $c = new Collection([1, 5, 1, 5, 5, 1]);
+        $this->assertEquals([1 => 3, 5 => 3,], $c->countBy()->all());
     }
 
     public function testCountableByWithPredicate()
     {
-        $c = new Collection([ 'alice', 'aaron', 'bob', 'carla' ]);
-        $this->assertEquals([ 'a' => 2, 'b' => 1, 'c' => 1 ], $c->countBy(function ($name) {
+        $c = new Collection(['alice', 'aaron', 'bob', 'carla']);
+        $this->assertEquals(['a' => 2, 'b' => 1, 'c' => 1], $c->countBy(function ($name) {
             return substr($name, 0, 1);
         })->all());
 
-        $c = new Collection([ 1, 2, 3, 4, 5 ]);
-        $this->assertEquals([ true => 2, false => 3 ], $c->countBy(function ($i) {
+        $c = new Collection([1, 2, 3, 4, 5]);
+        $this->assertEquals([true => 2, false => 3], $c->countBy(function ($i) {
             return $i % 2 === 0;
         })->all());
     }


### PR DESCRIPTION
Adds a `countBy` method to `Illuminate\Support\Collection`.

By default, this method counts each appearance of a given value:

    collect([ 1, 2, 2, 2, 3 ])->countBy(); // == collect([ 1 => 1, 2 => 3, 3 => 1 ])

It also accepts a predicate:

    collect([ 1, 2, 2, 3, 4 ])->countBy(function ($i) {
        return $i % 2 === 0;
    }); // == collect([ true => 3, false => 2 ])

    collect([ 'alice@gmail.com', 'bob@yahoo.fr', 'carlos@gmail.com' ])
        ->countBy(function ($email) {
            return substr(strrchr($email, "@"), 1);
        }); // == collect([ 'gmail.com' => 2, 'yahoo.fr' => 1 ])