### PR TITLE
[5.8] Extract session saving to a method

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -62,7 +62,7 @@ class StartSession
         // Again, if the session has been configured we will need to close out the session
         // so that the attributes may be persisted to some storage medium. We will also
         // add the session identifier cookie to the application response headers now.
-        $this->manager->driver()->save();
+        $this->saveSession();
 
         return $response;
     }
@@ -204,5 +204,15 @@ class StartSession
         $config = $config ?: $this->manager->getSessionConfig();
 
         return ! in_array($config['driver'], [null, 'array']);
+    }
+
+    /**
+     * Save the session data to storage.
+     *
+     * @return void
+     */
+    protected function saveSession()
+    {
+        $this->manager->driver()->save();
     }
 }


### PR DESCRIPTION
This PR simply moves the saving logic into a method so we can override without needing to override the entire handle method.

**Our use case:**

We have a feature in our app that lets you track how long is left in your session from a specific route.

Every request will add a last_activity timestamp to the user's session.

On one route, we want to check the last_activity timestamp without extending the session (which, normally every request would do).

Our SaveSession middleware would end up looking like this:

``` php
protected function saveSession()
{
    if (request()->route()->named('statamic.cp.session.timeout')) {
        return;
    }

    session()->put('last_activity', now()->timestamp);

    parent::saveSession();
}
```