### PR TITLE
[5.8] Allow belongsToMany to take Model/Pivot class name as a second parameter

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -141,7 +141,7 @@ class BelongsToMany extends Relation
     public function __construct(Builder $query, Model $parent, $table, $foreignPivotKey,
                                 $relatedPivotKey, $parentKey, $relatedKey, $relationName = null)
     {
-        $this->table = $table;
+        $this->table = $this->resolveTableName($table);
         $this->parentKey = $parentKey;
         $this->relatedKey = $relatedKey;
         $this->relationName = $relationName;
@@ -163,6 +163,31 @@ class BelongsToMany extends Relation
         if (static::$constraints) {
             $this->addWhereConstraints();
         }
+    }
+
+    /**
+     * Resolves table name from a given string.
+     *
+     * @param  string  $class
+     * @return string
+     */
+    protected function resolveTableName($class)
+    {
+        if (! class_exists($class)) {
+            return $class;
+        }
+
+        $object = new $class;
+
+        if ($object instanceof Model) {
+            if ($object instanceof Pivot) {
+                $this->using($class);
+            }
+
+            return $object->getTable();
+        }
+
+        return $class;
     }
 
     /**


### PR DESCRIPTION
## Overview
The motivation behind this RP is to allow a non-hardcoded intermediate table names in belongsToMany relationship. The proposed PR does not alter old behavior but improves and provides more integrity for people using Pivot models.

## Example

```php
class Customer extends Model
{
    protected $table = 'customers';
}

class CustomerProfile extends Pivot
{
    protected $table = 'customers_profiles';
}
```

Current behavior:
```php
return $this->belongsToMany(Profile::class, 'customers_profiles')->using(CustomerProfile::class);
```

Same behavior after PR (improved behavior does not require to separately define Pivot through using):
```php
return $this->belongsToMany(Profile::class, CustomerProfile::class);
```

