### PR TITLE
[5.8] Allow belongsToMany to take Model/Pivot class name as a second parameter

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -198,17 +198,17 @@ class BelongsToMany extends Relation
         if (! class_exists($class)) {
             return $class;
         }
-        
+
         $object = new $class;
-        
+
         if ($object instanceof Model) {
             if ($object instanceof Pivot) {
                 $this->using($class);
             }
-            
+
             return $object->getTable();
         }
-        
+
         return $class;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -141,7 +141,7 @@ class BelongsToMany extends Relation
     public function __construct(Builder $query, Model $parent, $table, $foreignPivotKey,
                                 $relatedPivotKey, $parentKey, $relatedKey, $relationName = null)
     {
-        $this->table = $table;
+        $this->table = $this->resolveTableName($table);
         $this->parentKey = $parentKey;
         $this->relatedKey = $relatedKey;
         $this->relationName = $relationName;
@@ -185,6 +185,31 @@ class BelongsToMany extends Relation
         $query->join($this->table, $key, '=', $this->getQualifiedRelatedPivotKeyName());
 
         return $this;
+    }
+
+    /**
+     * Resolves table name from a given string.
+     *
+     * @param  string  $class
+     * @return string
+     */
+    protected function resolveTableName($class)
+    {
+        if (! class_exists($class)) {
+            return $class;
+        }
+        
+        $object = new $class;
+        
+        if ($object instanceof Model) {
+            if ($object instanceof Pivot) {
+                $this->using($class);
+            }
+            
+            return $object->getTable();
+        }
+        
+        return $class;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -188,28 +188,28 @@ class BelongsToMany extends Relation
     }
 
     /**
-     * Resolves table name from a given string.
+     * Attempt to resolve the table name from a given string.
      *
-     * @param  string  $class
+     * @param  string  $table
      * @return string
      */
-    protected function resolveTableName($class)
+    protected function resolveTableName($table)
     {
-        if (! class_exists($class)) {
-            return $class;
+        if (! class_exists($table)) {
+            return $table;
         }
 
-        $object = new $class;
+        $model = new $table;
 
-        if ($object instanceof Model) {
-            if ($object instanceof Pivot) {
-                $this->using($class);
-            }
-
-            return $object->getTable();
+        if (! ($model instanceof Model)) {
+            return $table;
         }
 
-        return $class;
+        if ($model instanceof Pivot) {
+            $this->using($table);
+        }
+
+        return $model->getTable();
     }
 
     /**

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -122,6 +122,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertInstanceOf(CustomPivot::class, $post->tagsWithCustomPivot[0]->pivot);
         $this->assertEquals('1507630210', $post->tagsWithCustomPivot[0]->pivot->getAttributes()['created_at']);
 
+        $this->assertInstanceOf(CustomPivot::class, $post->tagsWithCustomPivotClass[0]->pivot);
+        $this->assertEquals('posts_tags', $post->tagsWithCustomPivotClass()->getTable());
+
         $this->assertEquals([
             'post_id' => '1',
             'tag_id' => '1',
@@ -635,6 +638,11 @@ class Post extends Model
         return $this->belongsToMany(TagWithCustomPivot::class, 'posts_tags', 'post_id', 'tag_id')
             ->using(CustomPivot::class)
             ->withTimestamps();
+    }
+
+    public function tagsWithCustomPivotClass()
+    {
+        return $this->belongsToMany(TagWithCustomPivot::class, CustomPivot::class, 'post_id', 'tag_id');
     }
 
     public function tagsWithCustomAccessor()


### PR DESCRIPTION
## Overview
The motivation behind this RP is to allow a non-hardcoded intermediate table name assignments in belongsToMany relationship. The proposed PR does not alter old behavior but improves and provides more integrity for people using Pivot models.

## Example

```php
namespace App\Models;

class Customer extends Model
{
    protected $table = 'customers';
}

class CustomerProfile extends Pivot
{
    protected $table = 'customers_profiles';
}
```

Example of current usage (hardcoded):
```php
return $this->belongsToMany(Profile::class, 'customers_profiles')->using(CustomerProfile::class);
```

Example of current usage (dynamic):
```php
$pivotClass = CustomerProfile::class; 
return $this->belongsToMany(Profile::class, (new $pivotClass)->getTable())->using($pivotClass);
```

Example of (possible) usage after PR (improved behavior does not require to define Pivot through using):
```php
return $this->belongsToMany(Profile::class, CustomerProfile::class);
```