### PR TITLE
[5.8] Do not wait for the application to finish boot to load cached routes

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -71,9 +71,7 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function loadCachedRoutes()
     {
-        $this->app->booted(function () {
-            require $this->app->getCachedRoutesPath();
-        });
+        require $this->app->getCachedRoutesPath();
     }
 
     /**


### PR DESCRIPTION
When there is no cached routes it's possible to use `route('route.name')` within a `boot()` method of a service provider.
Once the routes are cached, calling a route from the boot method of a service provider will throw a `not defined route` error.

Being able to use the `route()` helper should be the same for both cases cached and not cached.
When there is no cached routes, we are not waiting for the framework to be booted to load routes, so it should be the same for the cached routes.