### PR TITLE
Added ability to use dotted page name for Paginator

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -163,10 +163,15 @@ abstract class AbstractPaginator implements Htmlable
             $page = 1;
         }
 
+        $parameters = [];
+        Arr::set($parameters, $this->pageName, $page);
+
         // If we have any extra query string key / value pairs that need to be added
         // onto the URL, we will put them in query string form and then attach it
         // to the URL. This allows for extra information like sortings storage.
-        $parameters = [$this->pageName => $page];
+        if (count($this->query) > 0) {
+            $parameters = array_replace_recursive($this->query, $parameters);
+        }
 
         if (count($this->query) > 0) {
             $parameters = array_merge($this->query, $parameters);

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -54,4 +54,29 @@ class PaginatorTest extends TestCase
 
         $this->assertSame($p->getOptions(), $options);
     }
+
+    public function testPaginatorGeneratesUrlsWithDottedPageNameWithoutQuery()
+    {
+        $paginator = new Paginator([1,2], 1, null, [
+            'path' => 'http://website.com/test/',
+            'pageName' => 'page.number',
+        ]);
+
+        $this->assertSame('http://website.com/test?page%5Bnumber%5D=2', $paginator->url(2));
+    }
+
+    public function testPaginatorGeneratesUrlsWithDottedPageNameWithQuery()
+    {
+        $paginator = new Paginator([1,2], 1, null, [
+            'path' => 'http://website.com/test/',
+            'pageName' => 'page.number',
+            'query' => [
+                'page' => [
+                    'size' => '1',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('http://website.com/test?page%5Bsize%5D=1&page%5Bnumber%5D=2', $paginator->url(2));
+    }
 }


### PR DESCRIPTION
JSON API requires to use page.* for pagination purposes (https://jsonapi.org/format/#fetching-pagination), current implementation does not support page names like "page.number", "page.size". The pull request fixes that.
Moreover, currentPageResolver does support dotted-page name already (because `Request->input()` supports dot-notation):
```php
//Illuminate\Pagination\PaginationServiceProvider
...
Paginator::currentPageResolver(function ($pageName = 'page') {
            $page = $this->app['request']->input($pageName);

            if (filter_var($page, FILTER_VALIDATE_INT) !== false && (int) $page >= 1) {
                return (int) $page;
            }

            return 1;
        });
...
```
Tests are provided.
