### PR TITLE
[5.8] Allow to use group option in Auth::routes()

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1148,26 +1148,30 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function auth(array $options = [])
     {
-        // Authentication Routes...
-        $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
-        $this->post('login', 'Auth\LoginController@login');
-        $this->post('logout', 'Auth\LoginController@logout')->name('logout');
+        $group = $options['group'] ?? [];
 
-        // Registration Routes...
-        if ($options['register'] ?? true) {
-            $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
-            $this->post('register', 'Auth\RegisterController@register');
-        }
+        $this->group($group, function () {
+            // Authentication Routes...
+            $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
+            $this->post('login', 'Auth\LoginController@login');
+            $this->post('logout', 'Auth\LoginController@logout')->name('logout');
 
-        // Password Reset Routes...
-        if ($options['reset'] ?? true) {
-            $this->resetPassword();
-        }
+            // Registration Routes...
+            if ($options['register'] ?? true) {
+                $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
+                $this->post('register', 'Auth\RegisterController@register');
+            }
 
-        // Email Verification Routes...
-        if ($options['verify'] ?? false) {
-            $this->emailVerification();
-        }
+            // Password Reset Routes...
+            if ($options['reset'] ?? true) {
+                $this->resetPassword();
+            }
+
+            // Email Verification Routes...
+            if ($options['verify'] ?? false) {
+                $this->emailVerification();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
This PR. allows to use `group` option in `Auth::routes()`

For example :
```
Auth::routes(['group' => ['prefix' => 'auth']]);

// Instead of

Route::group(['prefix' => 'auth'], function () {
    Auth::routes();
});
```