### PR TITLE
[5.8] Fix Cache repository getSeconds() when using past CarbonImmutable testNow

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -6,7 +6,7 @@ use Closure;
 use ArrayAccess;
 use DateTimeInterface;
 use BadMethodCallException;
-use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Cache\Events\KeyWritten;
@@ -618,7 +618,7 @@ class Repository implements CacheContract, ArrayAccess
         $duration = $this->parseDateInterval($ttl);
 
         if ($duration instanceof DateTimeInterface) {
-            $duration = Carbon::now()->diffInRealSeconds($duration, false);
+            $duration = Date::now()->diffInRealSeconds($duration, false);
         }
 
         return (int) $duration > 0 ? $duration : 0;


### PR DESCRIPTION
This PR fixes the bug demonstrated by this snippet:

```php
/** @test */
public function test()
{
    // Use CarbonImmutable
    DateFactory::use(CarbonImmutable::class);

    // Freeze date for testing purposes
    Date::setTestNow(Date::create(2019, 1, 1));

    Cache::put('key', 42, now()->addHours(4));

    // This fails
    $this->assertNotNull(Cache::get('key')));
}
```

This is because `Illuminate\Cache\Repository::getSeconds()` hard codes the use of Carbon instead of using the Date class.