### PR TITLE
[5.8] Assist code-completion with `@var $factory` PHPDoc

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -2,6 +2,10 @@
 
 use Faker\Generator as Faker;
 
+/**
+ * @var $factory \Illuminate\Database\Eloquent\Factory
+ */
+
 $factory->define(DummyModel::class, function (Faker $faker) {
     return [
         //


### PR DESCRIPTION
This makes code-completion work out of the box with many IDEs when generating factories.

[Laravel PR](https://github.com/laravel/laravel/pull/4960)

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
