### PR TITLE
[5.9] Fix sendResetFailedResponse to return the error message with the right key name

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -135,9 +135,17 @@ trait ResetsPasswords
      */
     protected function sendResetFailedResponse(Request $request, $response)
     {
+        $errorKey = 'email';
+
+        if ($response == Password::INVALID_PASSWORD) {
+            $errorKey = 'password';
+        } elseif ($response == Password::INVALID_TOKEN) {
+            $errorKey = 'token';
+        }
+
         return redirect()->back()
                     ->withInput($request->only('email'))
-                    ->withErrors(['email' => trans($response)]);
+                    ->withErrors([$errorKey => trans($response)]);
     }
 
     /**


### PR DESCRIPTION
Resubmitting PR [#27601](https://github.com/laravel/framework/pull/27601), previously submitted to branch 5.7 and closed because of potential breaking changes. 
Please let me know if you need more info or a different solution.

Currently, if $this->broker()->reset() returns and error message, this message will always be sent back to the previous location under the key 'email'. This way the error messages will be shown in reset.blade.php as an 'email' error, even if the error is a 'passwords.password' or a 'passwords.token'. This simple fix will check wich is the type of the error message and change the key name accordingly.