### PR TITLE
Added support for relative path in mix

### DIFF
--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -64,7 +64,7 @@ class Mix
         }
 
         $html = $manifestDirectory.$manifest[$path];
-        if($relativePath && Str::startsWith($html, ['/'])){
+        if ($relativePath && Str::startsWith($html, ['/'])) {
             $html = Str::substr($html, 1);
         }
 

--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -17,7 +17,7 @@ class Mix
      * @return HtmlString|string
      * @throws Exception
      */
-    public function __invoke($path, $relativePath = false, $manifestDirectory = '')
+    public function __invoke($path, $manifestDirectory = '', $relativePath = false)
     {
         static $manifests = [];
 

--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -11,13 +11,13 @@ class Mix
     /**
      * Get the path to a versioned Mix file.
      *
-     * @param  string  $path
-     * @param  string  $manifestDirectory
-     * @return \Illuminate\Support\HtmlString|string
-     *
-     * @throws \Exception
+     * @param  string $path
+     * @param  bool $relativePath
+     * @param  string $manifestDirectory
+     * @return HtmlString|string
+     * @throws Exception
      */
-    public function __invoke($path, $manifestDirectory = '')
+    public function __invoke($path, $relativePath = false, $manifestDirectory = '')
     {
         static $manifests = [];
 
@@ -63,6 +63,11 @@ class Mix
             }
         }
 
-        return new HtmlString($manifestDirectory.$manifest[$path]);
+        $html = $manifestDirectory.$manifest[$path];
+        if($relativePath && Str::startsWith($html, array("/"))){
+            $html = Str::substr($html, 1);
+        }
+
+        return new HtmlString($html);
     }
 }

--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -64,7 +64,7 @@ class Mix
         }
 
         $html = $manifestDirectory.$manifest[$path];
-        if($relativePath && Str::startsWith($html, ["/"])){
+        if($relativePath && Str::startsWith($html, ['/'])){
             $html = Str::substr($html, 1);
         }
 

--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -64,7 +64,7 @@ class Mix
         }
 
         $html = $manifestDirectory.$manifest[$path];
-        if($relativePath && Str::startsWith($html, array("/"))){
+        if($relativePath && Str::startsWith($html, ["/"])){
             $html = Str::substr($html, 1);
         }
 


### PR DESCRIPTION
Use Case:
www.mydomain.com/prefix/ - this points to our servers
Now, while including a js file using mix, the path it inserts in html starts with a "/".So the request for js file goes to www.mydomain.com/myscript.js", while it should have been going to www.mydomain.com/prefix/myscript.js.
So the boolean variable $relativePath checks if the request should be going for relative path or absolute path.
This is the best solution I could think of. If any existing solution is there, kindly share.