### PR TITLE
[5.8] Extract registered event and login to registered method

### DIFF
--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -30,9 +30,7 @@ trait RegistersUsers
     {
         $this->validator($request->all())->validate();
 
-        event(new Registered($user = $this->create($request->all())));
-
-        $this->guard()->login($user);
+        $user = $this->create($request->all());
 
         return $this->registered($request, $user)
                         ?: redirect($this->redirectPath());
@@ -57,6 +55,8 @@ trait RegistersUsers
      */
     protected function registered(Request $request, $user)
     {
-        //
+        event(new Registered($user));
+
+        $this->guard()->login($user);
     }
 }


### PR DESCRIPTION
This is another approach to do the same thing as proposed in PR #27795 but without introducing new properties.

We will be able to fire another custom event on user registration (I could return event firing back to `register` method if there is no need) and skip auto-login by just overriding `registered` method with our own logic in application.

The only one bad thing could happen - if user already extended this method in application. Then it will become a breaking change and should be pointed to Laravel 5.9. I could make another PR to master branch if you wish.