### PR TITLE
[5.8] Adds phpDoc for $factory in factory stub

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -2,6 +2,8 @@
 
 use Faker\Generator as Faker;
 
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
 $factory->define(DummyModel::class, function (Faker $faker) {
     return [
         //


### PR DESCRIPTION
Why has it been removed previously? 