### PR TITLE
[5.8] Update blade JSON directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -5,13 +5,6 @@ namespace Illuminate\View\Compilers\Concerns;
 trait CompilesJson
 {
     /**
-     * The default JSON encoding options.
-     *
-     * @var int
-     */
-    private $encodingOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
-
-    /**
      * Compile the JSON statement into valid PHP.
      *
      * @param  string  $expression
@@ -19,12 +12,6 @@ trait CompilesJson
      */
     protected function compileJson($expression)
     {
-        $parts = explode(',', $this->stripParentheses($expression));
-
-        $options = isset($parts[1]) ? trim($parts[1]) : $this->encodingOptions;
-
-        $depth = isset($parts[2]) ? trim($parts[2]) : 512;
-
-        return "<?php echo json_encode($parts[0], $options, $depth) ?>";
+        return "<?php echo json_encode(" . $this->stripParentheses($expression) . ") ?>";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -12,6 +12,6 @@ trait CompilesJson
      */
     protected function compileJson($expression)
     {
-        return "<?php echo json_encode(" . $this->stripParentheses($expression) . ") ?>";
+        return '<?php echo json_encode('.$this->stripParentheses($expression).') ?>';
     }
 }

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -4,18 +4,42 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeJsonTest extends AbstractBladeTestCase
 {
-    public function testStatementIsCompiledWithSafeDefaultEncodingOptions()
+    public function testBasicStatementIsCompiled()
     {
         $string = 'var foo = @json($var);';
-        $expected = 'var foo = <?php echo json_encode($var, 15, 512) ?>;';
+        $expected = 'var foo = <?php echo json_encode($var) ?>;';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testEncodingOptionsCanBeOverwritten()
+    public function testOptionsArgumentCanBeSpecified()
     {
         $string = 'var foo = @json($var, JSON_HEX_TAG);';
-        $expected = 'var foo = <?php echo json_encode($var, JSON_HEX_TAG, 512) ?>;';
+        $expected = 'var foo = <?php echo json_encode($var, JSON_HEX_TAG) ?>;';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testDepthArgumentCanBeSpecified()
+    {
+        $string = 'var foo = @json($var, 0, 128);';
+        $expected = 'var foo = <?php echo json_encode($var, 0, 128) ?>;';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testValueArgumentCanContainCommas()
+    {
+        $string = 'var foo = @json(["value1", "value2", "value3"], JSON_HEX_TAG, 512);';
+        $expected = 'var foo = <?php echo json_encode(["value1", "value2", "value3"], JSON_HEX_TAG, 512) ?>;';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testValueArgumentCanContainFunctions()
+    {
+        $string = 'var foo = @json(array_merge(["value1", "value2"], ["value3", "value4"]), JSON_HEX_TAG, 512);';
+        $expected = 'var foo = <?php echo json_encode(array_merge(["value1", "value2"], ["value3", "value4"]), JSON_HEX_TAG, 512) ?>;';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }


### PR DESCRIPTION
The `@json` directive does not compile properly if there are 3 or more commas in the expression. For example:

```
@json([
    'value1',
    'value2',
    'value3',
])
```

This is due to the Blade compiler exploding the expression by commas, and assuming the 2nd and 3rd segments are the 'options' and 'depth', respectively.

This change takes what is given in the "expression" and passes it through unaltered to compile to PHP.  This gives the user full control over what ends up in the compiled output, and does not limit what they can put in the first argument.

This does, however, remove the default encoding options if a user fails to pass a second argument through. This is an undocumented feature.

Tests are updated to reflect the change, and new tests are added to make sure the "value" argument can contain commas and functions.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
