### PR TITLE
[5.8] Add aliases for foreign key methods

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -376,6 +376,19 @@ class Blueprint
     }
 
     /**
+     * Indicate that the given foreign key should be dropped.
+     *
+     * Alias for self::dropForeign().
+     *
+     * @param  string|array  $index
+     * @return \Illuminate\Support\Fluent
+     */
+    public function dropFk($index)
+    {
+        return $this->dropForeign($index);
+    }
+
+    /**
      * Indicate that the given indexes should be renamed.
      *
      * @param  string  $from
@@ -525,6 +538,20 @@ class Blueprint
     public function foreign($columns, $name = null)
     {
         return $this->indexCommand('foreign', $columns, $name);
+    }
+
+    /**
+     * Specify a foreign key for the table.
+     *
+     * Alias for self::foreign().
+     *
+     * @param  string|array  $columns
+     * @param  string  $name
+     * @return \Illuminate\Support\Fluent
+     */
+    public function fk($columns, $name = null)
+    {
+        return $this->foreign($columns, $name);
     }
 
     /**


### PR DESCRIPTION
## What
this PR goal is to add aliases for foreign key methods
so we could do this:

```php
$table->fk('user_id')...
//
$table->dropFk('foreign_key');
```


## Why
each time I deal with foreign key in my migrations I find myself most of the time flipping the order of `i` and `e` in `foreign`  and I end up writing  `foriegn` instead.

adding the aliases would solve this issue.

and I suppose I am not the only one having the same issue 

## but why add an alias

I noticed that we this class already had an alias 
```php
 /**
     * Add nullable creation and update timestamps to the table.
     *
     * Alias for self::timestamps().
     *
     * @param  int  $precision
     * @return void
     */
    public function nullableTimestamps($precision = 0)
    {
        $this->timestamps($precision);
    }
```
so I figured we can add other aliases as well


