### PR TITLE
[5.8] 1. Add an assertion for jsonp response 2. Add test cases for the asse…

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -429,7 +429,7 @@ class TestResponse
     }
 
     /**
-     * Assert that the response is a superset of given JSONP
+     * Assert that the response is a superset of given JSONP.
      *
      * @param  string  $callback
      * @param  array  $data
@@ -440,7 +440,7 @@ class TestResponse
     {
         PHPUnit::assertEquals($callback, $this->getCallback());
         $this->assertJson($data, $strict);
-        
+
         return $this;
     }
 

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -429,6 +429,22 @@ class TestResponse
     }
 
     /**
+     * Assert that the response is a superset of given JSONP
+     *
+     * @param  string  $callback
+     * @param  array  $data
+     * @param  bool  $strict
+     * @return $this
+     */
+    public function assertJsonp(string $callback, array $data, $strict = false)
+    {
+        PHPUnit::assertEquals($callback, $this->getCallback());
+        $this->assertJson($data, $strict);
+        
+        return $this;
+    }
+
+    /**
      * Get the assertion message for assertJson.
      *
      * @param  array  $data
@@ -703,7 +719,11 @@ class TestResponse
      */
     public function decodeResponseJson($key = null)
     {
-        $decodedResponse = json_decode($this->getContent(), true);
+        if (is_null($this->getCallback())) {
+            $decodedResponse = json_decode($this->getContent(), true);
+        } else {
+            $decodedResponse = $this->getOriginalContent();
+        }
 
         if (is_null($decodedResponse) || $decodedResponse === false) {
             if ($this->exception) {

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Foundation;
 
 use Mockery as m;
 use JsonSerializable;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\View\View;
@@ -186,6 +187,34 @@ class FoundationTestResponseTest extends TestCase
         $resource = new JsonSerializableMixedResourcesStub;
 
         $response->assertExactJson($resource->jsonSerialize());
+    }
+
+    public function testAssertJsonpWithArray()
+    {
+        $resource = new JsonSerializableSingleResourceStub;
+        $response = TestResponse::fromBaseResponse(
+            (new JsonResponse($resource->jsonSerialize()))->withCallback('callbackMethodName')
+        );
+
+        $response->assertJsonp('callbackMethodName', $resource->jsonSerialize());
+        $this->assertEquals(
+            '/**/callbackMethodName(' . json_encode($resource->jsonSerialize()) . ');',
+            $response->getContent()
+        );
+    }
+
+    public function testAssertJsonpWithMixed()
+    {
+        $resource = new JsonSerializableMixedResourcesStub; 
+        $response = TestResponse::fromBaseResponse(
+            (new JsonResponse($resource->jsonSerialize()))->withCallback('callbackMethodName')
+        );
+
+        $response->assertJsonp('callbackMethodName', $resource->jsonSerialize());
+        $this->assertEquals(
+            '/**/callbackMethodName(' . json_encode($resource->jsonSerialize()) . ');',
+            $response->getContent()
+        );
     }
 
     public function testAssertJsonFragment()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -4,9 +4,9 @@ namespace Illuminate\Tests\Foundation;
 
 use Mockery as m;
 use JsonSerializable;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Contracts\View\View;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Database\Eloquent\Model;
@@ -198,21 +198,21 @@ class FoundationTestResponseTest extends TestCase
 
         $response->assertJsonp('callbackMethodName', $resource->jsonSerialize());
         $this->assertEquals(
-            '/**/callbackMethodName(' . json_encode($resource->jsonSerialize()) . ');',
+            '/**/callbackMethodName('.json_encode($resource->jsonSerialize()).');',
             $response->getContent()
         );
     }
 
     public function testAssertJsonpWithMixed()
     {
-        $resource = new JsonSerializableMixedResourcesStub; 
+        $resource = new JsonSerializableMixedResourcesStub;
         $response = TestResponse::fromBaseResponse(
             (new JsonResponse($resource->jsonSerialize()))->withCallback('callbackMethodName')
         );
 
         $response->assertJsonp('callbackMethodName', $resource->jsonSerialize());
         $this->assertEquals(
-            '/**/callbackMethodName(' . json_encode($resource->jsonSerialize()) . ');',
+            '/**/callbackMethodName('.json_encode($resource->jsonSerialize()).');',
             $response->getContent()
         );
     }


### PR DESCRIPTION
In `TestResponse`, added an assertion for jsonp format response. It checks the `callback` property which is always set when trying to fetch jsonp response.