### PR TITLE
[5.8] Refactoring add() method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1947,9 +1947,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function add($item)
     {
-        $this->items[] = $item;
-
-        return $this;
+        return $this->push($item);
     }
 
     /**


### PR DESCRIPTION
The `Collection::add()` method is just an alias of an existed method `Collection::push()`