### PR TITLE
[5.8] provide a try_data_get method to not need a random string in-existence checking

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -533,6 +533,55 @@ if (! function_exists('data_get')) {
     }
 }
 
+if (! function_exists('try_data_get')) {
+    /**
+     * Try get an item from an array or object using "dot" notation.
+     *
+     * @param  mixed   $target
+     * @param  string|array|int  $key
+     * @param  mixed   $value contains found value.
+     * @return boolean true if array key exists false if not (value was not found).
+     */
+    function try_data_get($target, $key, &$value)
+    {
+        if (is_null($key)) {
+            return $target;
+        }
+
+        $key = is_array($key) ? $key : explode('.', $key);
+
+        while (! is_null($segment = array_shift($key))) {
+            if ($segment === '*') {
+                if ($target instanceof Collection) {
+                    $target = $target->all();
+                } elseif (! is_array($target)) {
+                    return false;
+                }
+
+                $result = [];
+
+                foreach ($target as $item) {
+                    $result[] = data_get($item, $key);
+                }
+
+                $value = in_array('*', $key) ? Arr::collapse($result) : $result;
+                return true;
+            }
+
+            if (Arr::accessible($target) && Arr::exists($target, $segment)) {
+                $target = $target[$segment];
+            } elseif (is_object($target) && isset($target->{$segment})) {
+                $target = $target->{$segment};
+            } else {
+                return false;
+            }
+        }
+
+        $value = $target;
+        return true;
+    }
+}
+
 if (! function_exists('data_set')) {
     /**
      * Set an item on an array or object using dot notation.

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -333,12 +333,8 @@ class Validator implements ValidatorContract
 
         $results = [];
 
-        $missingValue = Str::random(10);
-
         foreach (array_keys($this->getRules()) as $key) {
-            $value = data_get($this->getData(), $key, $missingValue);
-
-            if ($value !== $missingValue) {
+            if(try_data_get($this->getData(), $key, $value)) {
                 Arr::set($results, $key, $value);
             }
         }


### PR DESCRIPTION
Even though it will be very rare the random string will ever hit a real value, it still hurt me looking at it. Very innovative but maybe my solution works better? please criticize it if not, so i can learn 👍 .

I provided this alternative try_data_get method with an out value as a way to get the caught value instead.

Its technically a copy of data_get(), like all the other methods that support the "dot" notation.

Ran the tests but not sure, i get failing tests because of: redis, memcache, mysql etc (is there no docker-compose file to run the tests?).