### PR TITLE
[5.8] Add createTest() to make:model

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -117,7 +117,7 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Create a Feature Test and Unit Test for the model
+     * Create a Feature Test and Unit Test for the model.
      *
      * @return void
      */
@@ -126,10 +126,10 @@ class ModelMakeCommand extends GeneratorCommand
         $test = Str::studly(class_basename($this->argument('name')));
 
         $this->call('make:test', [
-            'name' => "{$test}Test"
+            'name' => "{$test}Test",
         ]);
         $this->call('make:test --unit', [
-            'name' => "{$test}Test"
+            'name' => "{$test}Test",
         ]);
     }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -45,6 +45,7 @@ class ModelMakeCommand extends GeneratorCommand
             $this->input->setOption('migration', true);
             $this->input->setOption('controller', true);
             $this->input->setOption('resource', true);
+            $this->input->setOption('test', true);
         }
 
         if ($this->option('factory')) {
@@ -57,6 +58,10 @@ class ModelMakeCommand extends GeneratorCommand
 
         if ($this->option('controller') || $this->option('resource')) {
             $this->createController();
+        }
+
+        if ($this->option('test')) {
+            $this->createTest();
         }
     }
 
@@ -112,6 +117,23 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Create a Feature Test and Unit Test for the model
+     *
+     * @return void
+     */
+    protected function createTest()
+    {
+        $test = Str::studly(class_basename($this->argument('name')));
+
+        $this->call('make:test', [
+            'name' => "{$test}Test"
+        ]);
+        $this->call('make:test --unit', [
+            'name' => "{$test}Test"
+        ]);
+    }
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string
@@ -146,6 +168,8 @@ class ModelMakeCommand extends GeneratorCommand
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
 
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
+
+            ['test', 't', InputOption::VALUE_NONE, 'Create a new feature test and a new unit test for the model'],
         ];
     }
 }


### PR DESCRIPTION
There are few instances when you don't need to write tests for a model you've created.  This modification simplifies that process by automating the creation of both the unit and feature test for your model, which if you're asking for "all" (aka: everything) should be expected to be included.