### PR TITLE
[5.9] Slightly simplified user provider

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -61,9 +61,7 @@ class EloquentUserProvider implements UserProvider
      */
     public function retrieveByToken($identifier, $token)
     {
-        $model = $this->createModel();
-
-        $model = $model->where($model->getAuthIdentifierName(), $identifier)->first();
+        $model = $this->retrieveById($identifier);
 
         if (! $model) {
             return null;


### PR DESCRIPTION
Might cause backward compatibility issues in projects overriding the retrieveById function.

Makes extending EloquentUserProvider easier as only the retrieveById function must be reimplmeneted. The retrieveByToken has a common behavior.