### PR TITLE
[5.8] Job-based retry delay

### DIFF
--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -100,6 +100,13 @@ interface Job
     public function maxTries();
 
     /**
+     * Get the time delay before retrying a job.
+     *
+     * @return int|null
+     */
+    public function retriesIn();
+
+    /**
      * Get the number of seconds the job can run.
      *
      * @return int|null

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -234,6 +234,16 @@ abstract class Job
     }
 
     /**
+     * Get the time delay before retrying a job.
+     *
+     * @return int|null
+     */
+    public function retriesIn()
+    {
+        return $this->payload()['retriesIn'] ?? null;
+    }
+
+    /**
      * Get the number of seconds the job can run.
      *
      * @return int|null

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -125,6 +125,7 @@ abstract class Queue
             'job' => 'Illuminate\Queue\CallQueuedHandler@call',
             'maxTries' => $job->tries ?? null,
             'timeout' => $job->timeout ?? null,
+            'retriesIn' => $job->retriesIn ?? null,
             'timeoutAt' => $this->getJobExpiration($job),
             'data' => [
                 'commandName' => $job,
@@ -185,6 +186,7 @@ abstract class Queue
             'job' => $job,
             'maxTries' => null,
             'timeout' => null,
+            'retriesIn' => null,
             'data' => $data,
         ]);
     }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -322,9 +322,7 @@ class Worker
             );
 
             // Here we will check if there's a delay before retrying a job.
-            $this->delayJobAttemptExecution(
-              $job
-            );
+            $this->delayJobAttemptExecution($job);
 
             // Here we will fire off the job and let it process. We will catch any exceptions so
             // they can be reported to the developers logs, etc. Once the job is finished the
@@ -491,7 +489,7 @@ class Worker
      * Delay a job retry if defined.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
-     * @return  void
+     * @return void
      */
     protected function delayJobAttemptExecution($job)
     {


### PR DESCRIPTION
#### Related links
This pull request implements the feature requested  [here](https://github.com/laravel/ideas/issues/537)

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
#### What does this feature do?
If a `$retriesIn` property is defined on a job, then if that job fails the retry will be delayed for `$retriesIn` amount of time.

#### How will this feature be useful to users?
Let's take an example. An application that  creates `Digital Ocean` droplets using the API. 

The application then tries to `SSH` into the droplet using a job `SshIntoDroplet` once it's active. Even though the droplet is marked as `active` sometimes `SSH` is just not ready, and the job fails. 

With the current functionality, this job is retried immediately. This probably isn't the best way to handle this specific job. 

To fix this, this pull request adds a `$retriesIn` property on a job, and the job is only re-attempted after the defined amount of time.

#### How to use?

Here's an example job that implements this feature:

```php
<?php

namespace App\Jobs;

use App\Droplet;
use Illuminate\Bus\Queueable;
use Illuminate\Queue\SerializesModels;
use Illuminate\Queue\InteractsWithQueue;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Foundation\Bus\Dispatchable;

class SshIntoDroplet implements ShouldQueue
{
    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

    /**
     * The droplet to ssh into.
     *
     * @var Droplet
     */
    public $droplet;

    /**
     * The delay before attempting job again
     * 
     * @var integer
     */
    public $retriesIn = 5;

    /**
     * Create a new job instance.
     *
     * @return void
     */
    public function __construct(Droplet $droplet)
    {
        $this->droplet = $droplet;
    }

    /**
     * Execute the job.
     *
     * @return void
     */
    public function handle()
    {
        // job fails when droplet is active but still booting.
        // If it fails, the Queue worker waits for 5 seconds before retrying.
        $this->droplet->ssh();
    }
}

```