### PR TITLE
[5.8] Fix docblock

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -65,7 +65,7 @@ class Rule
     /**
      * Get a required_if constraint builder instance.
      *
-     * @param  callable  $callback
+     * @param  callable|bool  $callback
      * @return \Illuminate\Validation\Rules\RequiredIf
      */
     public static function requiredIf($callback)


### PR DESCRIPTION
RequiredIf class allows both callback and bool in constructor:

```
    /**
     * Create a new required validation rule based on a condition.
     *
     * @param  callable|bool  $condition
     * @return void
     */
    public function __construct($condition)
    {
        $this->condition = $condition;
    }
```

so here it should be also bool included