### PR TITLE
[5.8] Move vlucas/phpdotenv from suggest to required dependency

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -19,7 +19,8 @@
         "ext-mbstring": "*",
         "doctrine/inflector": "^1.1",
         "illuminate/contracts": "5.8.*",
-        "nesbot/carbon": "^1.26.3 || ^2.0"
+        "nesbot/carbon": "^1.26.3 || ^2.0",
+        "vlucas/phpdotenv": "^3.3"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"
@@ -42,8 +43,7 @@
         "moontoast/math": "Required to use ordered UUIDs (^1.1).",
         "ramsey/uuid": "Required to use Str::uuid() (^3.7).",
         "symfony/process": "Required to use the composer class (^4.2).",
-        "symfony/var-dumper": "Required to use the dd function (^4.2).",
-        "vlucas/phpdotenv": "Required to use the env helper (^3.3)."
+        "symfony/var-dumper": "Required to use the dd function (^4.2)."
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
In `helpers.php` in Laravel 5.8, `env` function needs `DotenvFactory` class. If `vlucas/phpdotenv` is not a required dependency, when you call `env` function it will throw an error:

```
Error: Class 'Dotenv\Environment\DotenvFactory' not found
```

Moving `vlucas/phpdotenv` from suggest to required dependency can solve this problem.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
