### PR TITLE
[5.9] Delegate to php native type casting

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -8,7 +8,6 @@ use ArrayAccess;
 use LogicException;
 use ReflectionClass;
 use ReflectionParameter;
-use Illuminate\Support\Arr;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 
@@ -143,7 +142,7 @@ class Container implements ArrayAccess, ContainerContract
     {
         $aliases = [];
 
-        foreach (Arr::wrap($concrete) as $c) {
+        foreach ((array) $concrete as $c) {
             $aliases[] = $this->getAlias($c);
         }
 


### PR DESCRIPTION
No need to call a library API, since the concrete is not going be a object type. 
(string or an array of strings.)