### PR TITLE
[5.8] Adds the ability to set the reconnector created by a `DatabaseManager`.

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -42,6 +42,13 @@ class DatabaseManager implements ConnectionResolverInterface
     protected $extensions = [];
 
     /**
+     * When creating connections, the default reconnector to call when a connection need to be recreated.
+     *
+     * @var callable
+     */
+    protected $reconnector;
+
+    /**
      * Create a new database manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -52,6 +59,9 @@ class DatabaseManager implements ConnectionResolverInterface
     {
         $this->app = $app;
         $this->factory = $factory;
+        $this->reconnector = function (Connection $connection) {
+            $this->reconnect($connection->getName());
+        };
     }
 
     /**
@@ -164,9 +174,7 @@ class DatabaseManager implements ConnectionResolverInterface
         // Here we'll set a reconnector callback. This reconnector can be any callable
         // so we will set a Closure to reconnect from this manager with the name of
         // the connection, which will allow us to reconnect from the connections.
-        $connection->setReconnector(function ($connection) {
-            $this->reconnect($connection->getName());
-        });
+        $connection->setReconnector($this->reconnector);
 
         return $connection;
     }
@@ -313,6 +321,16 @@ class DatabaseManager implements ConnectionResolverInterface
     public function getConnections()
     {
         return $this->connections;
+    }
+
+    /**
+     * Set the reconnect instance on connections created by this manager.
+     *
+     * @param  callable  $reconnector
+     */
+    public function setReconnector(callable $reconnector): void
+    {
+        $this->reconnector = $reconnector;
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -327,8 +327,9 @@ class DatabaseManager implements ConnectionResolverInterface
      * Set the reconnect instance on connections created by this manager.
      *
      * @param  callable  $reconnector
+     * @return void
      */
-    public function setReconnector(callable $reconnector): void
+    public function setReconnector(callable $reconnector)
     {
         $this->reconnector = $reconnector;
     }


### PR DESCRIPTION
Implements https://github.com/laravel/ideas/issues/1557.

Our current use-case for wanting to customize the reconnector is wanting to add a "maximum retries" setting. When experiencing some edge-case database issues, they were exacerbated by the default reconnector "infinitely" trying to reconnect (infinitely in quotes because eventually something times out, but still has the tendency to turn a minor blip into a feedback loop).