### PR TITLE
[5.8] Create getter for the http route middlewares

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -337,6 +337,16 @@ class Kernel implements KernelContract
     }
 
     /**
+     * Get the application's route middleware.
+     *
+     * @return array
+     */
+    public function getRouteMiddleware()
+    {
+        return $this->routeMiddleware;
+    }
+
+    /**
      * Get the Laravel application instance.
      *
      * @return \Illuminate\Contracts\Foundation\Application

--- a/tests/Foundation/Http/KernelTest.php
+++ b/tests/Foundation/Http/KernelTest.php
@@ -17,6 +17,13 @@ class KernelTest extends TestCase
         $this->assertEquals([], $kernel->getMiddlewareGroups());
     }
 
+    public function testGetRouteMiddleware()
+    {
+        $kernel = new Kernel($this->getApplication(), $this->getRouter());
+
+        $this->assertEquals([], $kernel->getRouteMiddleware());
+    }
+
     /**
      * @return \Illuminate\Contracts\Foundation\Application
      */


### PR DESCRIPTION
This getter allows to create tests for the route middlewares, which is currently not possible because the property is protected.

For example, if you want to ensure that a route middleware has been registered, with this getter you can write:

```php
/** @test */
public function it_registers_a_custom_route_middleware()
{
    $middlewares = resolve(\App\Http\Kernel::class)->getRouteMiddleware();

    $this->assertArrayHasKey('custom', $middlewares);
    $this->assertEquals(\App\Http\Middleware\Custom::class, $middlewares['custom']);
}
```

This is similar to https://github.com/laravel/framework/pull/26268 but for the `$routeMiddleware` property.