### PR TITLE
[5.8] Update JSON Blade Directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -19,24 +19,15 @@ trait CompilesJson
      */
     protected function compileJson($expression)
     {
-        $expression = '<?php ' . $this->stripParentheses($expression);
-
-        $tokens = token_get_all($expression);
+        $tokens = token_get_all('<?php ' . $this->stripParentheses($expression));
 
         $openExpressions = 0;
 
-        $arguments = [
-            null,
-            null,
-            null,
-        ];
+        $arguments = [null, null, null];
 
         $currentArgument = 0;
 
-        //remove the first
-        unset($tokens[0]);
-
-        foreach ($tokens as $token) {
+        foreach (array_slice($tokens, 1) as $token) {
 
             //increment if we have an opening character
             if (is_string($token) && in_array($token, ['(', '['])) {
@@ -62,12 +53,10 @@ trait CompilesJson
             }
         }
 
-        $output = [
-            trim($arguments[0]),
-            trim($arguments[1] ?? $this->encodingOptions),
-            trim($arguments[2] ?? 512),
-        ];
+        $value = trim($arguments[0]);
+        $options = trim($arguments[1] ?? $this->encodingOptions);
+        $depth = trim($arguments[2] ?? 512);
 
-        return "<?php echo json_encode($output[0], $output[1], $output[2]) ?>";
+        return "<?php echo json_encode($value, $options, $depth) ?>";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -19,7 +19,7 @@ trait CompilesJson
      */
     protected function compileJson($expression)
     {
-        $tokens = token_get_all('<?php ' . $this->stripParentheses($expression));
+        $tokens = token_get_all('<?php '.$this->stripParentheses($expression));
 
         $openExpressions = 0;
 
@@ -42,13 +42,9 @@ trait CompilesJson
             //we have no open expressions, and the token is a comma, move to the next argument
             if ($openExpressions === 0 && is_string($token) && $token === ',') {
                 $currentArgument++;
-            }
-
-            elseif (is_array($token)) {
+            } elseif (is_array($token)) {
                 $arguments[$currentArgument] .= $token[1];
-            }
-
-            else {
+            } else {
                 $arguments[$currentArgument] .= $token;
             }
         }

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeJsonTest extends AbstractBladeTestCase
 {
-    public function testStatementIsCompiledWithSafeDefaultEncodingOptions()
+    public function testStatementIsCompiledWithDefaultOptionsAndDepth()
     {
         $string = '@json($var);';
         $expected = '<?php echo json_encode($var, 15, 512) ?>;';

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -12,38 +12,28 @@ class BladeJsonTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testEncodingOptionsCanBeOverwritten()
-    {
-        $string = 'var foo = @json($var, JSON_HEX_TAG);';
-        $expected = 'var foo = <?php echo json_encode($var, JSON_HEX_TAG, 512) ?>;';
-
-        $this->assertEquals($expected, $this->compiler->compileString($string));
-    }
-
-    public function testBasicStatementIsCompiled()
-    {
-        $string = 'var foo = @json($var);';
-        $expected = 'var foo = <?php echo json_encode($var, 15, 512) ?>;';
-        $this->assertEquals($expected, $this->compiler->compileString($string));
-    }
     public function testOptionsArgumentCanBeSpecified()
     {
         $string = 'var foo = @json($var, JSON_HEX_TAG);';
         $expected = 'var foo = <?php echo json_encode($var, JSON_HEX_TAG, 512) ?>;';
+
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
     public function testDepthArgumentCanBeSpecified()
     {
         $string = 'var foo = @json($var, 0, 128);';
         $expected = 'var foo = <?php echo json_encode($var, 0, 128) ?>;';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
     public function testValueArgumentCanContainCommas()
     {
         $string = 'var foo = @json(["value1", "value2", "value3"], JSON_HEX_TAG, 512);';
         $expected = 'var foo = <?php echo json_encode(["value1", "value2", "value3"], JSON_HEX_TAG, 512) ?>;';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
     public function testValueArgumentCanContainFunctions()
     {
         $string = 'var foo = @json(array_merge(["value1", "value2"], ["value3", "value4"]), JSON_HEX_TAG, 512);';

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -6,38 +6,38 @@ class BladeJsonTest extends AbstractBladeTestCase
 {
     public function testStatementIsCompiledWithSafeDefaultEncodingOptions()
     {
-        $string = 'var foo = @json($var);';
-        $expected = 'var foo = <?php echo json_encode($var, 15, 512) ?>;';
+        $string = '@json($var);';
+        $expected = '<?php echo json_encode($var, 15, 512) ?>;';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testOptionsArgumentCanBeSpecified()
     {
-        $string = 'var foo = @json($var, JSON_HEX_TAG);';
-        $expected = 'var foo = <?php echo json_encode($var, JSON_HEX_TAG, 512) ?>;';
+        $string = '@json($var, JSON_HEX_TAG);';
+        $expected = '<?php echo json_encode($var, JSON_HEX_TAG, 512) ?>;';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testDepthArgumentCanBeSpecified()
     {
-        $string = 'var foo = @json($var, 0, 128);';
-        $expected = 'var foo = <?php echo json_encode($var, 0, 128) ?>;';
+        $string = '@json($var, 0, 128);';
+        $expected = '<?php echo json_encode($var, 0, 128) ?>;';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testValueArgumentCanContainCommas()
     {
-        $string = 'var foo = @json(["value1", "value2", "value3"], JSON_HEX_TAG, 512);';
-        $expected = 'var foo = <?php echo json_encode(["value1", "value2", "value3"], JSON_HEX_TAG, 512) ?>;';
+        $string = '@json(["value1", "value2", "value3"], JSON_HEX_TAG, 512);';
+        $expected = '<?php echo json_encode(["value1", "value2", "value3"], JSON_HEX_TAG, 512) ?>;';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testValueArgumentCanContainFunctions()
     {
-        $string = 'var foo = @json(array_merge(["value1", "value2"], ["value3", "value4"]), JSON_HEX_TAG, 512);';
-        $expected = 'var foo = <?php echo json_encode(array_merge(["value1", "value2"], ["value3", "value4"]), JSON_HEX_TAG, 512) ?>;';
+        $string = '@json(array_merge(["value1", "value2"], ["value3", "value4"]), JSON_HEX_TAG, 512);';
+        $expected = '<?php echo json_encode(array_merge(["value1", "value2"], ["value3", "value4"]), JSON_HEX_TAG, 512) ?>;';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -19,4 +19,35 @@ class BladeJsonTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testBasicStatementIsCompiled()
+    {
+        $string = 'var foo = @json($var);';
+        $expected = 'var foo = <?php echo json_encode($var, 15, 512) ?>;';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+    public function testOptionsArgumentCanBeSpecified()
+    {
+        $string = 'var foo = @json($var, JSON_HEX_TAG);';
+        $expected = 'var foo = <?php echo json_encode($var, JSON_HEX_TAG, 512) ?>;';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+    public function testDepthArgumentCanBeSpecified()
+    {
+        $string = 'var foo = @json($var, 0, 128);';
+        $expected = 'var foo = <?php echo json_encode($var, 0, 128) ?>;';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+    public function testValueArgumentCanContainCommas()
+    {
+        $string = 'var foo = @json(["value1", "value2", "value3"], JSON_HEX_TAG, 512);';
+        $expected = 'var foo = <?php echo json_encode(["value1", "value2", "value3"], JSON_HEX_TAG, 512) ?>;';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+    public function testValueArgumentCanContainFunctions()
+    {
+        $string = 'var foo = @json(array_merge(["value1", "value2"], ["value3", "value4"]), JSON_HEX_TAG, 512);';
+        $expected = 'var foo = <?php echo json_encode(array_merge(["value1", "value2"], ["value3", "value4"]), JSON_HEX_TAG, 512) ?>;';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
continuation of #27802 

please be gentle, code is a little ugly. This is an attempt to use "tokenization" rather than `explode()` to extract arguments from a Blade directive. The `explode()` is lacking because it cannot handle situations when the delimiter character also exists in one of the argument expressions.

The PR will correctly identify when an argument contains opening characters (`(` and `[`) in an argument and not move onto the next argument when a delimiter character is met until all the opening characters have been closed.

All current tests pass, and I have added some extras in for the additional behavior.

Currently, it is very easy to incorrectly use the `@json` directive with the assumption of the default 'safe encoding' options, and this PR fixes that as well.
