### PR TITLE
Found bug in class Builder, method value()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2073,7 +2073,7 @@ class Builder
     {
         $result = (array) $this->first([$column]);
 
-        return count($result) > 0 ? reset($result) : null;
+        return $result[$column] ?? null;
     }
 
     /**


### PR DESCRIPTION
In Builder.php there is a bug according to docs:
https://laravel.com/docs/5.8/queries#retrieving-results

Right now it restarts array to an index of 0.
