### PR TITLE
[5.8] Deny access to user if he has none of these abilities

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -295,7 +295,7 @@ class Gate implements GateContract
         });
     }
 
-     /**
+    /**
      * Determine if any one of the given abilities should be denied for the current user.
      *
      * @param  iterable|string  $abilities
@@ -305,7 +305,7 @@ class Gate implements GateContract
     public function none($abilities, $arguments = [])
     {
         return ! $this->any($abilities, $arguments);
-    }   
+    }     
 
     /**
      * Determine if the given ability should be granted for the current user.

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -305,7 +305,7 @@ class Gate implements GateContract
     public function none($abilities, $arguments = [])
     {
         return ! $this->any($abilities, $arguments);
-    }     
+    }
 
     /**
      * Determine if the given ability should be granted for the current user.

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -295,6 +295,18 @@ class Gate implements GateContract
         });
     }
 
+     /**
+     * Determine if any one of the given abilities should be denied for the current user.
+     *
+     * @param  iterable|string  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function none($abilities, $arguments = [])
+    {
+        return ! $this->any($abilities, $arguments);
+    }   
+
     /**
      * Determine if the given ability should be granted for the current user.
      *


### PR DESCRIPTION
Currently it is only possible to check if a user is 1 of multiple permissions. i.e. `Gate::forUser($user)->denies('update-post', $post)` It not possible to check if a user is authorized for none of multiple abilities.
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
