### PR TITLE
[5.8] Fix seeding logic in Arr::shuffle

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -541,11 +541,12 @@ class Arr
         if (is_null($seed)) {
             shuffle($array);
         } else {
-            srand($seed);
-
-            usort($array, function () {
-                return rand(-1, 1);
-            });
+            // Seed the random number generator to guarantee the order in which the
+            // array is shuffled.  Then, after the shuffling is done, reset the
+            // seed randomly to prevent biases in future random methods.
+            mt_srand($seed);
+            shuffle($array);
+            mt_srand();
         }
 
         return $array;


### PR DESCRIPTION
The random comparator logic used -- `return rand(-1, 1)` -- is not really that random, as it's biased 2:1 in favour of not swapping the two elements.

| values before | random comparator | result after |
|--------|------------|--------|
| a, b | -1 | a, b |
| a, b | 0 | a, b |
| a, b | 1 | b, a |

This can be illustrated with the following code, which checks what the first element of a "randomized" array is when using the same logic as `Arr::shuffle()` when a seed is passed (assuming the seeds in this case are randomized as well).

```php
$k = [ 'a', 'b', 'c', 'd', 'e' ];
$r = array_fill_keys($k, 0);

for ($i=0; $i<1000000; $i++) {
    $array = $k;

    usort($array, function () {
        return rand(-1, 1);
    });

    $r[ $array[0] ] ++;
}

print_r($r);
```

Results:

```
Array
(
    [a] => 564137
    [b] => 105554
    [c] => 281362
    [d] => 36514
    [e] => 12433
)
```

So, when that random logic runs, more than half the time the shuffled array still has the first element in the first position.

Changing the logic to use `return rand(0,1)` helps a bit, but is still biased:

```
Array
(
    [a] => 307937
    [b] => 204875
    [c] => 308190
    [d] => 116441
    [e] => 62557
)
```

I think the basic fix for this is to simply use PHP's `shuffle()` which returns a much more evenly randomized array.  If the randomization needs to be seeded, we can just set that before calling `shuffle()` (and then set it again afterwards, with a random seed, to prevent later logic in the code from being biased).

This PR does this.
