### PR TITLE
[5.8] Send LogoutOtherDevices event when request is made.

### DIFF
--- a/src/Illuminate/Auth/Events/LogoutOtherDevices.php
+++ b/src/Illuminate/Auth/Events/LogoutOtherDevices.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Auth\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class LogoutOtherDevices
+{
+    use SerializesModels;
+
+    /**
+     * The authentication guard name.
+     *
+     * @var string
+     */
+    public $guard;
+
+    /**
+     * The authenticated user.
+     *
+     * @var \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $guard
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return void
+     */
+    public function __construct($guard, $user)
+    {
+        $this->user = $user;
+        $this->guard = $guard;
+    }
+}

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -552,6 +552,8 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
 
         $this->queueRecallerCookie($this->user());
 
+        $this->fireLogoutOtherDevicesEvent($this->user());
+
         return $result;
     }
 
@@ -610,6 +612,21 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Events\Authenticated(
+                $this->name, $user
+            ));
+        }
+    }
+
+    /**
+     * Fire the logout other devices event if the dispatcher is set.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return void
+     */
+    protected function fireLogoutOtherDevicesEvent($user)
+    {
+        if (isset($this->events)) {
+            $this->events->dispatch(new Events\LogoutOtherDevices(
                 $this->name, $user
             ));
         }

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Auth\Events\LogoutOtherDevices;
 use Illuminate\Tests\Integration\Auth\Fixtures\AuthenticationTestUser;
 
 /**
@@ -178,6 +179,27 @@ class AuthenticationTest extends TestCase
         $this->app['auth']->logout();
         $this->assertNull($this->app['auth']->user());
         Event::assertDispatched(Logout::class, function ($event) {
+            $this->assertEquals('web', $event->guard);
+            $this->assertEquals(1, $event->user->id);
+
+            return true;
+        });
+    }
+
+    public function test_logging_out_other_devices()
+    {
+        Event::fake();
+
+        $this->app['auth']->loginUsingId(1);
+
+        $user = $this->app['auth']->user();
+
+        $this->assertEquals(1, $user->id);
+
+        $this->app['auth']->logoutOtherDevices('adifferentpassword');
+        $this->assertEquals(1, $user->id);
+
+        Event::assertDispatched(LogoutOtherDevices::class, function ($event) {
             $this->assertEquals('web', $event->guard);
             $this->assertEquals(1, $event->user->id);
 


### PR DESCRIPTION
This would allow developers to manages other authentications to react to this request
such as `Passport`, where the application may choose to revoke all users access_token etc.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
