### PR TITLE
[5.8] Make Str::replaceFirst  suitable insensitive

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -340,7 +340,7 @@ class Str
      * @param  string  $search
      * @param  string  $replace
      * @param  string  $subject
-     * @param  boolean $sensitive
+     * @param  bool $sensitive
      * @return string
      */
     public static function replaceFirst($search, $replace, $subject, $sensitive = true)
@@ -348,7 +348,7 @@ class Str
         if ($search == '') {
             return $subject;
         }
-        
+
         if ($sensitive) {
             $position = strpos($subject, $search);
         } else {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -340,15 +340,20 @@ class Str
      * @param  string  $search
      * @param  string  $replace
      * @param  string  $subject
+     * @param  boolean $sensitive
      * @return string
      */
-    public static function replaceFirst($search, $replace, $subject)
+    public static function replaceFirst($search, $replace, $subject, $sensitive = true)
     {
         if ($search == '') {
             return $subject;
         }
-
-        $position = strpos($subject, $search);
+        
+        if ($sensitive) {
+            $position = strpos($subject, $search);
+        } else {
+            $position = stripos($subject, $search);
+        }
 
         if ($position !== false) {
             return substr_replace($subject, $replace, $position, strlen($search));


### PR DESCRIPTION
```
use Illuminate\Support\Str;

$replaced = Str::replaceFirst('the', 'a', 'The quick brown fox jumps over the lazy dog', false);

// a quick brown fox jumps over the lazy dog
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
