### PR TITLE
[5.8] Call `afterMigrate` when it exists after migration.

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -39,6 +39,10 @@ trait RefreshDatabase
     {
         $this->artisan('migrate');
 
+        if (method_exists($this, 'afterMigrate')) {
+            $this->afterMigrate();
+        }
+
         $this->app[Kernel::class]->setArtisan(null);
     }
 
@@ -57,6 +61,10 @@ trait RefreshDatabase
             $this->app[Kernel::class]->setArtisan(null);
 
             RefreshDatabaseState::$migrated = true;
+
+            if (method_exists($this, 'afterMigrate')) {
+                $this->afterMigrate();
+            }
         }
 
         $this->beginDatabaseTransaction();


### PR DESCRIPTION
This gives the possibility to do some modifications to the database before the transaction is started, but only when the database is just migrated.
For example this allows importing a large dataset once, and depend on the transaction rollbacks during the rest of the test-suite.

