### PR TITLE
[5.8] add createIfNotExists method.

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -166,6 +166,18 @@ class Builder
     }
 
     /**
+     * Create a new table from the schema if it not exists.
+     *
+     * @param string $table
+     * @param \Closure $callback
+     * @return void
+     */
+    public function createIfNotExists($table, Closure $callback)
+    {
+        $this->hasTable($table) === false && $this->create($table, $callback);
+    }
+
+    /**
      * Drop a table from the schema.
      *
      * @param  string  $table


### PR DESCRIPTION
When creating a migration of an existing system, it may be necessary to execute create after using the hasTable method.

```php
public function up()
{
    if (!Schema::hasTable('users')) {
        Schema::create('users', function(Blueprint $table) {
            //
        });
    }
}
```

With the addition of this method we can write:
```php
public function up()
{
    Schema::createIfNotExists('users', function(Blueprint $table) {
        //
    });
}
```