### PR TITLE
return the proper count with groupBy

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1823,6 +1823,13 @@ class Builder {
 		$this->aggregate = null;
 
 		$this->columns = $previousColumns;
+		
+		// Fix for returning the proper count with a groupBy clause
+                if ($function == 'count' && !empty($this->groups)) {
+
+                        return $results->count();
+
+                }
 
 		if (isset($results[0]))
 		{


### PR DESCRIPTION
example of the issue:
\App\User::all()->groupBy('id')->count() returns the proper count
\App\User::whereNotNull('email')->groupBy('id')->count() returns the first value of an array of aggregates instead of the count

with this fix the second query returns the proper count
references issue #4306 

I know this is an incomplete but it should be pretty demonstrable with any model.  If there is a better way please go about that.