### PR TITLE
[5.8] RefreshDatabase trait: Only refresh the database when migrations change

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -50,16 +50,81 @@ trait RefreshDatabase
     protected function refreshTestDatabase()
     {
         if (! RefreshDatabaseState::$migrated) {
-            $this->artisan('migrate:fresh', $this->shouldDropViews() ? [
+            // Fall back to "migrate" in case the test database was deleted
+            $command = $this->shouldRefreshTestDatabase() ? 'migrate:fresh' : 'migrate';
+
+            $this->artisan($command, $this->shouldDropViews() ? [
                 '--drop-views' => true,
             ] : []);
 
             $this->app[Kernel::class]->setArtisan(null);
 
+            $this->updateCachedMigrationHash();
+
             RefreshDatabaseState::$migrated = true;
         }
 
         $this->beginDatabaseTransaction();
+    }
+
+    /**
+     * Determine if the database should be refreshed.
+     *
+     * @return bool
+     */
+    protected function shouldRefreshTestDatabase()
+    {
+        return $this->getCachedMigrationHash() !== $this->getMigrationHash();
+    }
+
+    /**
+     * Calculate a hash based on the contents of each migration file.
+     *
+     * @return string
+     */
+    protected function getMigrationHash()
+    {
+        $migrationPath = $this->app->databasePath().DIRECTORY_SEPARATOR.'migrations';
+
+        $migrationFiles = collect($this->app['migrator']->getMigrationFiles($migrationPath));
+
+        return $migrationFiles->reduce(function ($hash, $file) {
+            return md5($hash.file_get_contents($file));
+        });
+    }
+
+    /**
+     * Get the path to the migration cache file.
+     *
+     * @return string
+     */
+    protected function getCachedMigrationPath()
+    {
+        return storage_path('framework/testing/migrationhash');
+    }
+
+    /**
+     * Get the current cached migration hash value.
+     *
+     * @return string
+     */
+    protected function getCachedMigrationHash()
+    {
+        $path = $this->getCachedMigrationPath();
+
+        if (file_exists($path)) {
+            return file_get_contents($path);
+        }
+    }
+
+    /**
+     * Update the cached migration hash value with the current migration hash.
+     *
+     * @return void
+     */
+    protected function updateCachedMigrationHash()
+    {
+        file_put_contents($this->getCachedMigrationPath(), $this->getMigrationHash());
     }
 
     /**


### PR DESCRIPTION
Refreshing the database can be relatively slow in projects with a lot of migrations (100+). This can be especially annoying when using the RefreshDatabase trait as it adds an initial 15+ second delay (or possibly significantly more) each time you run your tests.

Since the RefreshDatabase trait starts and rolls back a transaction during each test, it's not really necessary to completely refresh the database every single time phpunit runs unless the migration files have actually changed.

This change modifies RefreshDatabase to calculate a hash based on the contents of all the migration files and uses that to determine whether the database should actually be refreshed. If the hash hasn't changed, it runs `migrate` instead of `migrate:fresh` just in case you cleared out the database tables, etc.

The hash is stored in a file called `/storage/framework/testing/migrationhash` (which is .gitignore'd by default in new projects).

(Some reference: I found [this blog post](https://alexvanderbist.com/posts/2019/how-migrations-might-be-slowing-down-your-laravel-tests) which describes the issue and provides an alternate solution.)