### PR TITLE
Redirect to intented URL after registration

### DIFF
--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -35,7 +35,7 @@ trait RegistersUsers
         $this->guard()->login($user);
 
         return $this->registered($request, $user)
-                        ?: redirect($this->redirectPath());
+                        ?: redirect()->intended($this->redirectPath());
     }
 
     /**


### PR DESCRIPTION
Hi there 👋 

I'm not sure if this is done on purpose but the redirection post-registration differs from the redirection post-authentication in the following way:

```php
redirect()->intended($this->redirectPath()); // Authentication
redirect($this->redirectPath()); // Registration
```

This issue [has been mentioned a few years ago](https://github.com/laravel/framework/issues/16423) and a PR was welcomed but I couldn't find any PR related to this.

I apologise in advance if a written decision has been made about this and I wasn't able to find it.

Let me know if you need any more work from me.