### PR TITLE
[5.8] Adds even and odd flags to the Loop variable

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -33,6 +33,8 @@ trait ManagesLoops
             'count' => $length,
             'first' => true,
             'last' => isset($length) ? $length == 1 : null,
+            'odd' => false,
+            'even' => true,
             'depth' => count($this->loopsStack) + 1,
             'parent' => $parent ? (object) $parent : null,
         ];
@@ -51,6 +53,8 @@ trait ManagesLoops
             'iteration' => $loop['iteration'] + 1,
             'index' => $loop['iteration'],
             'first' => $loop['iteration'] == 0,
+            'odd' => ! $loop['odd'],
+            'even' => ! $loop['even'],
             'remaining' => isset($loop['count']) ? $loop['remaining'] - 1 : null,
             'last' => isset($loop['count']) ? $loop['iteration'] == $loop['count'] - 1 : null,
         ]);

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -539,6 +539,8 @@ class ViewFactoryTest extends TestCase
             'count' => 3,
             'first' => true,
             'last' => false,
+            'odd' => false,
+            'even' => true,
             'depth' => 1,
             'parent' => null,
         ];
@@ -554,6 +556,8 @@ class ViewFactoryTest extends TestCase
             'count' => 4,
             'first' => true,
             'last' => false,
+            'odd' => false,
+            'even' => true,
             'depth' => 2,
             'parent' => (object) $expectedLoop,
         ];
@@ -597,6 +601,8 @@ class ViewFactoryTest extends TestCase
             'count' => null,
             'first' => true,
             'last' => null,
+            'odd' => false,
+            'even' => true,
             'depth' => 1,
             'parent' => null,
         ];
@@ -612,11 +618,19 @@ class ViewFactoryTest extends TestCase
 
         $factory->incrementLoopIndices();
 
+        $this->assertEquals(1, $factory->getLoopStack()[0]['iteration']);
+        $this->assertEquals(0, $factory->getLoopStack()[0]['index']);
+        $this->assertEquals(3, $factory->getLoopStack()[0]['remaining']);
+        $this->assertTrue($factory->getLoopStack()[0]['odd']);
+        $this->assertFalse($factory->getLoopStack()[0]['even']);
+
         $factory->incrementLoopIndices();
 
         $this->assertEquals(2, $factory->getLoopStack()[0]['iteration']);
         $this->assertEquals(1, $factory->getLoopStack()[0]['index']);
         $this->assertEquals(2, $factory->getLoopStack()[0]['remaining']);
+        $this->assertFalse($factory->getLoopStack()[0]['odd']);
+        $this->assertTrue($factory->getLoopStack()[0]['even']);
     }
 
     public function testReachingEndOfLoop()


### PR DESCRIPTION
The _Loop Variable_ is an exceptionally helpful and underutilized feature within Blade. This adds a few convenience properties of `even` and `odd`.

Having these explicit variables is beneficial when designing repeated UI elements (e.g. zebra stripes), and prevents using otherwise dense syntax (e.g. `$loop->iteration % 2`) providing that smooth artisan flow Laravel is known for.

If merged, will open a PR to update the Docs as well.