### PR TITLE
[5.8] Restore maintenance message on error page

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/503.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/503.blade.php
@@ -2,4 +2,4 @@
 
 @section('title', __('Service Unavailable'))
 @section('code', '503')
-@section('message', __('Service Unavailable'))
+@section('message', __($exception->getMessage() ?: 'Service Unavailable'))


### PR DESCRIPTION
#25431 added the maintenance message to the 503 error page:

    php artisan down --message="Upgrading Database"

https://github.com/laravel/framework/commit/ece24b56a606474893c7ef7cdfaa8ee1e801876e removed the message (accidentally, I assume), this PR restores it.

Fixes #27892.