### PR TITLE
[5.8] Add migrate option to session:table command

### DIFF
--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Session\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Composer;
 use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Input\InputOption;
 
 class SessionTableCommand extends Command
 {
@@ -62,6 +63,8 @@ class SessionTableCommand extends Command
 
         $this->info('Migration created successfully!');
 
+        $this->migrateSessionTable($fullPath);
+
         $this->composer->dumpAutoloads();
     }
 
@@ -77,5 +80,32 @@ class SessionTableCommand extends Command
         $path = $this->laravel->databasePath().'/migrations';
 
         return $this->laravel['migration.creator']->create($name, $path);
+    }
+
+    /**
+     * Migrate the session table.
+     *
+     * @param string $fullPath
+     * @return void
+     */
+    protected function migrateSessionTable($fullPath)
+    {
+        if ($this->option('migrate')) {
+            $path = str_replace(getcwd(), '', $fullPath);
+
+            $this->call('migrate', ['--path' => $path]);
+        }
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['migrate', 'm', InputOption::VALUE_NONE, 'Migrate the session table.'],
+        ];
     }
 }


### PR DESCRIPTION
Almost every time you generate the session table you are going to be migrating it, so adding the ability to generate and migrate the table with one command is a better workflow.

This PR adds an option to the `php artisan session:table` command and can be used like this:

```console
php artisan session:table -m
php artisan session:table --migrate
```
