### PR TITLE
[5.9] Add custom errors key to validation test

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -637,7 +637,7 @@ class TestResponse
      * @param string       $responseKey
      * @return $this
      */
-    public function assertJsonValidationErrors($keys, $responseKey = 'errors')
+    public function assertJsonValidationErrors($keys, string $responseKey = 'errors')
     {
         $keys = Arr::wrap($keys);
 
@@ -646,15 +646,15 @@ class TestResponse
         $errors = $this->json()[$responseKey] ?? [];
 
         $errorMessage = $errors
-            ? 'Response has the following JSON validation errors:' .
-            PHP_EOL . PHP_EOL . json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . PHP_EOL
+            ? 'Response has the following JSON validation errors:'.
+            PHP_EOL.PHP_EOL.json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL
             : 'Response does not have JSON validation errors.';
 
         foreach ($keys as $key) {
             PHPUnit::assertArrayHasKey(
                 $key,
                 $errors,
-                "Failed to find a validation error in the response for key: '{$key}'" . PHP_EOL . PHP_EOL . $errorMessage
+                "Failed to find a validation error in the response for key: '{$key}'".PHP_EOL.PHP_EOL.$errorMessage
             );
         }
 
@@ -672,7 +672,7 @@ class TestResponse
     {
         $json = $this->json();
 
-        if (!array_key_exists($responseKey, $json)) {
+        if (! array_key_exists($responseKey, $json)) {
             PHPUnit::assertArrayNotHasKey($responseKey, $json);
 
             return $this;
@@ -682,7 +682,7 @@ class TestResponse
 
         if (is_null($keys) && count($errors) > 0) {
             PHPUnit::fail(
-                'Response has unexpected validation errors: ' . PHP_EOL . PHP_EOL .
+                'Response has unexpected validation errors: '.PHP_EOL.PHP_EOL.
                 json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
             );
         }

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -637,7 +637,7 @@ class TestResponse
      * @param string  $responseKey
      * @return $this
      */
-    public function assertJsonValidationErrors($keys, string $responseKey = 'errors')
+    public function assertJsonValidationErrors($keys, $responseKey = 'errors')
     {
         $keys = Arr::wrap($keys);
 

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -634,7 +634,7 @@ class TestResponse
      * Assert that the response has the given JSON validation errors for the given keys.
      *
      * @param  string|array  $keys
-     * @param string  $responseKey
+     * @param  string  $responseKey
      * @return $this
      */
     public function assertJsonValidationErrors($keys, $responseKey = 'errors')
@@ -665,10 +665,10 @@ class TestResponse
      * Assert that the response has no JSON validation errors for the given keys.
      *
      * @param  string|array  $keys
-     * @param string  $responseKey
+     * @param  string  $responseKey
      * @return $this
      */
-    public function assertJsonMissingValidationErrors($keys = null, string $responseKey = 'errors')
+    public function assertJsonMissingValidationErrors($keys = null, $responseKey = 'errors')
     {
         $json = $this->json();
 

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -646,9 +646,9 @@ class TestResponse
         $errors = $this->json()[$responseKey] ?? [];
 
         $errorMessage = $errors
-            ? 'Response has the following JSON validation errors:'.
-            PHP_EOL.PHP_EOL.json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL
-            : 'Response does not have JSON validation errors.';
+                ? 'Response has the following JSON validation errors:'.
+                        PHP_EOL.PHP_EOL.json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL
+                : 'Response does not have JSON validation errors.';
 
         foreach ($keys as $key) {
             PHPUnit::assertArrayHasKey(

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -633,8 +633,8 @@ class TestResponse
     /**
      * Assert that the response has the given JSON validation errors for the given keys.
      *
-     * @param string|array $keys
-     * @param string       $responseKey
+     * @param  string|array  $keys
+     * @param string  $responseKey
      * @return $this
      */
     public function assertJsonValidationErrors($keys, string $responseKey = 'errors')
@@ -664,8 +664,8 @@ class TestResponse
     /**
      * Assert that the response has no JSON validation errors for the given keys.
      *
-     * @param string|array $keys
-     * @param string       $responseKey
+     * @param  string|array  $keys
+     * @param string  $responseKey
      * @return $this
      */
     public function assertJsonMissingValidationErrors($keys = null, string $responseKey = 'errors')

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -633,27 +633,28 @@ class TestResponse
     /**
      * Assert that the response has the given JSON validation errors for the given keys.
      *
-     * @param  string|array  $keys
+     * @param string|array $keys
+     * @param string       $responseKey
      * @return $this
      */
-    public function assertJsonValidationErrors($keys)
+    public function assertJsonValidationErrors($keys, $responseKey = 'errors')
     {
         $keys = Arr::wrap($keys);
 
         PHPUnit::assertNotEmpty($keys, 'No keys were provided.');
 
-        $errors = $this->json()['errors'] ?? [];
+        $errors = $this->json()[$responseKey] ?? [];
 
         $errorMessage = $errors
-                ? 'Response has the following JSON validation errors:'.
-                        PHP_EOL.PHP_EOL.json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL
-                : 'Response does not have JSON validation errors.';
+            ? 'Response has the following JSON validation errors:' .
+            PHP_EOL . PHP_EOL . json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . PHP_EOL
+            : 'Response does not have JSON validation errors.';
 
         foreach ($keys as $key) {
             PHPUnit::assertArrayHasKey(
                 $key,
                 $errors,
-                "Failed to find a validation error in the response for key: '{$key}'".PHP_EOL.PHP_EOL.$errorMessage
+                "Failed to find a validation error in the response for key: '{$key}'" . PHP_EOL . PHP_EOL . $errorMessage
             );
         }
 
@@ -663,24 +664,25 @@ class TestResponse
     /**
      * Assert that the response has no JSON validation errors for the given keys.
      *
-     * @param  string|array  $keys
+     * @param string|array $keys
+     * @param string       $responseKey
      * @return $this
      */
-    public function assertJsonMissingValidationErrors($keys = null)
+    public function assertJsonMissingValidationErrors($keys = null, string $responseKey = 'errors')
     {
         $json = $this->json();
 
-        if (! array_key_exists('errors', $json)) {
-            PHPUnit::assertArrayNotHasKey('errors', $json);
+        if (!array_key_exists($responseKey, $json)) {
+            PHPUnit::assertArrayNotHasKey($responseKey, $json);
 
             return $this;
         }
 
-        $errors = $json['errors'];
+        $errors = $json[$responseKey];
 
         if (is_null($keys) && count($errors) > 0) {
             PHPUnit::fail(
-                'Response has unexpected validation errors: '.PHP_EOL.PHP_EOL.
+                'Response has unexpected validation errors: ' . PHP_EOL . PHP_EOL .
                 json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
             );
         }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -326,7 +326,7 @@ class FoundationTestResponseTest extends TestCase
             (new Response)->setContent(json_encode($data))
         );
 
-        $testResponse->assertJsonValidationErrors('foo','data');
+        $testResponse->assertJsonValidationErrors('foo', 'data');
     }
 
     public function testAssertJsonValidationErrorsCanFail()
@@ -471,7 +471,7 @@ class FoundationTestResponseTest extends TestCase
             (new Response)->setContent(json_encode($data))
         );
 
-        $testResponse->assertJsonMissingValidationErrors('bar','data');
+        $testResponse->assertJsonMissingValidationErrors('bar', 'data');
     }
 
     public function testMacroable()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -315,6 +315,20 @@ class FoundationTestResponseTest extends TestCase
         $testResponse->assertJsonValidationErrors('foo');
     }
 
+    public function testAssertJsonValidationErrorsCustomErrorsName()
+    {
+        $data = [
+            'status' => 'ok',
+            'data' => ['foo' => 'oops'],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors('foo','data');
+    }
+
     public function testAssertJsonValidationErrorsCanFail()
     {
         $this->expectException(AssertionFailedError::class);
@@ -444,6 +458,20 @@ class FoundationTestResponseTest extends TestCase
         );
 
         $testResponse->assertJsonMissingValidationErrors();
+    }
+
+    public function testAssertJsonMissingValidationErrorsCustomErrorsName()
+    {
+        $data = [
+            'status' => 'ok',
+            'data' => ['foo' => 'oops'],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonMissingValidationErrors('bar','data');
     }
 
     public function testMacroable()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
By default, validation errors are written in an array of errors, but when I write them to another key such as data or validations, you can use the standard test solution after completing the key in which to look for errors

Correct code style for this pull request https://github.com/laravel/framework/pull/27899