### PR TITLE
[5.8] Fix updateOrInsert method for query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2678,6 +2678,10 @@ class Builder
             return $this->insert(array_merge($attributes, $values));
         }
 
+        if (empty($values)) {
+            return true;
+        }
+
         return (bool) $this->take(1)->update($values);
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2005,19 +2005,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testUpdateOrInsertMethodWorksWithEmptyUpdateValues()
     {
-        $builder = m::mock(Builder::class.'[where,exists,insert]', [
-            m::mock(ConnectionInterface::class),
-            new Grammar,
-            m::mock(Processor::class),
-        ]);
-
-        $builder->shouldReceive('where')->once()->with(['email' => 'foo'])->andReturn(m::self());
-        $builder->shouldReceive('exists')->once()->andReturn(false);
-        $builder->shouldReceive('insert')->once()->with(['email' => 'foo', 'name' => 'bar'])->andReturn(true);
-
-        $this->assertTrue($builder->updateOrInsert(['email' => 'foo'], ['name' => 'bar']));
-
-        $builder = m::mock(Builder::class.'[where,exists,update]', [
+        $builder = m::spy(Builder::class.'[where,exists,update]', [
             m::mock(ConnectionInterface::class),
             new Grammar,
             m::mock(Processor::class),
@@ -2025,10 +2013,9 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder->shouldReceive('where')->once()->with(['email' => 'foo'])->andReturn(m::self());
         $builder->shouldReceive('exists')->once()->andReturn(true);
-        $builder->shouldReceive('take')->andReturnSelf();
-        $builder->shouldNotReceive('update')->with([]);
 
         $this->assertTrue($builder->updateOrInsert(['email' => 'foo']));
+        $builder->shouldNotHaveReceived('update');
     }
 
     public function testDeleteMethod()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2003,6 +2003,34 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($builder->updateOrInsert(['email' => 'foo'], ['name' => 'bar']));
     }
 
+    public function testUpdateOrInsertMethodWorksWithEmptyUpdateValues()
+    {
+        $builder = m::mock(Builder::class.'[where,exists,insert]', [
+            m::mock(ConnectionInterface::class),
+            new Grammar,
+            m::mock(Processor::class),
+        ]);
+
+        $builder->shouldReceive('where')->once()->with(['email' => 'foo'])->andReturn(m::self());
+        $builder->shouldReceive('exists')->once()->andReturn(false);
+        $builder->shouldReceive('insert')->once()->with(['email' => 'foo', 'name' => 'bar'])->andReturn(true);
+
+        $this->assertTrue($builder->updateOrInsert(['email' => 'foo'], ['name' => 'bar']));
+
+        $builder = m::mock(Builder::class.'[where,exists,update]', [
+            m::mock(ConnectionInterface::class),
+            new Grammar,
+            m::mock(Processor::class),
+        ]);
+
+        $builder->shouldReceive('where')->once()->with(['email' => 'foo'])->andReturn(m::self());
+        $builder->shouldReceive('exists')->once()->andReturn(true);
+        $builder->shouldReceive('take')->andReturnSelf();
+        $builder->shouldNotReceive('update')->with([]);
+
+        $this->assertTrue($builder->updateOrInsert(['email' => 'foo']));
+    }
+
     public function testDeleteMethod()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Fixes #27890 

Now updateOrInsert meethod correctly works with empty values array.
Before it created syntactically wrong update SQL, now it doesn't trigger any update Query and simply returns 'true'.

I have also added the test cehcking the new behaviour of method.




