### PR TITLE
[5.9] getNamespace is independent

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1174,11 +1174,11 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             return $this->namespace;
         }
 
-        $composer = json_decode(file_get_contents(base_path('composer.json')), true);
+        $composer = json_decode(file_get_contents($this->basePath('composer.json')), true);
 
         foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path) {
             foreach ((array) $path as $pathChoice) {
-                if (realpath(app_path()) == realpath(base_path().'/'.$pathChoice)) {
+                if (realpath($this->path()) === realpath($this->basePath($pathChoice))) {
                     return $this->namespace = $namespace;
                 }
             }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -310,6 +310,15 @@ class FoundationApplicationTest extends TestCase
 
         $this->assertEquals(4, $counter);
     }
+
+    public function testGetNamespace()
+    {
+        $app1 = new Application(realpath(__DIR__.'/fixtures/laravel1'));
+        $app2 = new Application(realpath(__DIR__.'/fixtures/laravel2'));
+
+        $this->assertSame('Laravel\\One\\', $app1->getNamespace());
+        $this->assertSame('Laravel\\Two\\', $app2->getNamespace());
+    }
 }
 
 class ApplicationBasicServiceProviderStub extends ServiceProvider

--- a/tests/Foundation/fixtures/laravel1/composer.json
+++ b/tests/Foundation/fixtures/laravel1/composer.json
@@ -1,0 +1,7 @@
+{
+    "autoload": {
+        "psr-4": {
+            "Laravel\\One\\": "app/"
+        }
+    }
+}

--- a/tests/Foundation/fixtures/laravel2/composer.json
+++ b/tests/Foundation/fixtures/laravel2/composer.json
@@ -1,0 +1,7 @@
+{
+    "autoload": {
+        "psr-4": {
+            "Laravel\\Two\\": "app/"
+        }
+    }
+}


### PR DESCRIPTION
`Application::getNamespace()` currently uses global helpers in which the first call to this method is the call to global container instance only because `Application` constructor sets it via `Application::registerBaseBindings()`. `Application::getNamespace()` is independent and returns the namespace itself. This pull request solves by using the exact methods of Application rather than global helpers.

See the example below for more details:

- Step 1: The application laravel1/composer.json
```json
{
    "autoload": {
        "psr-4": {
            "Laravel\\One\\": "app/"
        }
    }
}
```

- Step 2: The application laravel2/composer.json
```json
{
    "autoload": {
        "psr-4": {
            "Laravel\\Two\\": "app/"
        }
    }
}
```

- Step 3: Create 2 application instances in a single process:
```php
$app1 = new Application(realpath(__DIR__.'/path/to/laravel1'));
$app2 = new Application(realpath(__DIR__.'/path/to/laravel2'));
// Initialize but I haven't called getNamespace() from them.
```

### Expected
```php
$app1->getNamespace(); // "Laravel\\One\\"
$app2->getNamespace(); // "Laravel\\Two\\"
```

### Actual
```php
$app1->getNamespace(); // "Laravel\\Two\\"
$app2->getNamespace(); // "Laravel\\Two\\"
```