### PR TITLE
Issue #27200

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -503,7 +503,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeDateTime(Fluent $column)
     {
-        return $column->precision ? "datetime2($column->precision)" : 'datetime';
+        return $column->precision ? "datetime2($column->precision)" : 'datetime2';
     }
 
     /**

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -497,7 +497,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->dateTime('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetime2 not null', $statements[0]);
     }
 
     public function testAddingDateTimeWithPrecision()


### PR DESCRIPTION
Fix for Issue #27200
Use datetime2 instead of datetime as default
for sql server timestamp columns. 
Date format was already updated in Illuminate\Database\Query\Grammars\Query\SqlServerGrammer
