### PR TITLE
[5.8] Path of the view in compiled template causes regression with declare(strict_types=1) in templates #27704

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -118,8 +118,8 @@ class BladeCompiler extends Compiler implements CompilerInterface
         }
 
         if (! is_null($this->cachePath)) {
-            $contents = "<?php /* {$this->getPath()} */ ?>\n".
-                        $this->compileString($this->files->get($this->getPath()));
+            $contents = $this->compileString($this->files->get($this->getPath())).
+                        "\n<?php /* {$this->getPath()} */ ?>";
 
             $this->files->put($this->getCompiledPath($this->getPath()), $contents);
         }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -49,7 +49,7 @@ class ViewBladeCompilerTest extends TestCase
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', "<?php /* foo */ ?>\nHello World");
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', "Hello World\n<?php /* foo */ ?>");
         $compiler->compile('foo');
     }
 
@@ -57,7 +57,7 @@ class ViewBladeCompilerTest extends TestCase
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', "<?php /* foo */ ?>\nHello World");
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', "Hello World\n<?php /* foo */ ?>");
         $compiler->compile('foo');
         $this->assertEquals('foo', $compiler->getPath());
     }
@@ -73,7 +73,7 @@ class ViewBladeCompilerTest extends TestCase
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', "<?php /* foo */ ?>\nHello World");
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', "Hello World\n<?php /* foo */ ?>");
         // set path before compilation
         $compiler->setPath('foo');
         // trigger compilation with null $path
@@ -97,7 +97,7 @@ class ViewBladeCompilerTest extends TestCase
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', "<?php /* foo */ ?>\nHello World");
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', "Hello World\n<?php /* foo */ ?>");
         $compiler->compile('foo');
     }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -101,6 +101,14 @@ class ViewBladeCompilerTest extends TestCase
         $compiler->compile('foo');
     }
 
+    public function testShouldStartFromStrictTypesDeclaration()
+    {
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $strictTypeDecl = "<?php\ndeclare(strict_types = 1);";
+        $this->assertTrue(substr($compiler->compileString("<?php\ndeclare(strict_types = 1);\nHello World"),
+            0, strlen($strictTypeDecl)) === $strictTypeDecl);
+    }
+
     protected function getFiles()
     {
         return m::mock(Filesystem::class);


### PR DESCRIPTION
The pull-request contains the fix for [5.8] Path of the view in compiled template causes regression with declare(strict_types=1) in templates #27704