### PR TITLE
[5.8] Remove first page from Pagination URL

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -166,10 +166,14 @@ abstract class AbstractPaginator implements Htmlable
         // If we have any extra query string key / value pairs that need to be added
         // onto the URL, we will put them in query string form and then attach it
         // to the URL. This allows for extra information like sortings storage.
-        $parameters = [$this->pageName => $page];
+        $parameters = $page > 1 ? [$this->pageName => $page] : [];
 
         if (count($this->query) > 0) {
             $parameters = array_merge($this->query, $parameters);
+        }
+
+        if (count($parameters) === 0) {
+            return $this->path.$this->buildFragment();
         }
 
         return $this->path

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -468,8 +468,8 @@ class ResourceTest extends TestCase
                 ],
             ],
             'links' => [
-                'first' => '/?page=1',
-                'last' => '/?page=1',
+                'first' => '/',
+                'last' => '/',
                 'prev' => null,
                 'next' => null,
             ],
@@ -509,8 +509,8 @@ class ResourceTest extends TestCase
                 ],
             ],
             'links' => [
-                'first' => '/?page=1',
-                'last' => '/?page=1',
+                'first' => '/',
+                'last' => '/',
                 'prev' => null,
                 'next' => null,
             ],

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -64,10 +64,10 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEquals('http://website.com?foo=2',
                             $this->p->url($this->p->currentPage()));
 
-        $this->assertEquals('http://website.com?foo=1',
+        $this->assertEquals('http://website.com',
                             $this->p->url($this->p->currentPage() - 1));
 
-        $this->assertEquals('http://website.com?foo=1',
+        $this->assertEquals('http://website.com',
                             $this->p->url($this->p->currentPage() - 2));
     }
 
@@ -88,10 +88,10 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEquals('http://website.com/test?foo=2',
                             $this->p->url($this->p->currentPage()));
 
-        $this->assertEquals('http://website.com/test?foo=1',
+        $this->assertEquals('http://website.com/test',
                             $this->p->url($this->p->currentPage() - 1));
 
-        $this->assertEquals('http://website.com/test?foo=1',
+        $this->assertEquals('http://website.com/test',
                             $this->p->url($this->p->currentPage() - 2));
     }
 

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -19,9 +19,9 @@ class PaginatorTest extends TestCase
         $pageInfo = [
             'per_page' => 2,
             'current_page' => 2,
-            'first_page_url' => '/?page=1',
+            'first_page_url' => '/',
             'next_page_url' => '/?page=3',
-            'prev_page_url' => '/?page=1',
+            'prev_page_url' => '/',
             'from' => 3,
             'to' => 4,
             'data' => ['item3', 'item4'],
@@ -36,7 +36,7 @@ class PaginatorTest extends TestCase
         $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test/']);
 
-        $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
+        $this->assertEquals('http://website.com/test?page=3', $p->nextPageUrl());
     }
 
     public function testPaginatorGeneratesUrlsWithoutTrailingSlash()
@@ -44,7 +44,7 @@ class PaginatorTest extends TestCase
         $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test']);
 
-        $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
+        $this->assertEquals('http://website.com/test?page=3', $p->nextPageUrl());
     }
 
     public function testItRetrievesThePaginatorOptions()

--- a/tests/Pagination/UrlWindowTest.php
+++ b/tests/Pagination/UrlWindowTest.php
@@ -19,7 +19,7 @@ class UrlWindowTest extends TestCase
     {
         $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
         $window = new UrlWindow($p);
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => null, 'last' => null], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => null, 'last' => null], $window->get());
     }
 
     public function testPresenterCanGetAUrlRangeForAWindowOfLinks()
@@ -35,7 +35,7 @@ class UrlWindowTest extends TestCase
             $slider[$i] = '/?page='.$i;
         }
 
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => $slider, 'last' => [12 => '/?page=12', 13 => '/?page=13']], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => $slider, 'last' => [12 => '/?page=12', 13 => '/?page=13']], $window->get());
 
         /*
          * Test Being Near The End Of The List
@@ -47,7 +47,7 @@ class UrlWindowTest extends TestCase
             $last[$i] = '/?page='.$i;
         }
 
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => null, 'last' => $last], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => null, 'last' => $last], $window->get());
     }
 
     public function testCustomUrlRangeForAWindowOfLinks()
@@ -66,6 +66,6 @@ class UrlWindowTest extends TestCase
             $slider[$i] = '/?page='.$i;
         }
 
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => $slider, 'last' => [12 => '/?page=12', 13 => '/?page=13']], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => $slider, 'last' => [12 => '/?page=12', 13 => '/?page=13']], $window->get());
     }
 }


### PR DESCRIPTION
The current Pagination generates `?page=1` for the first page, however this is a minor issue from an SEO perspective as this page is now accessible via `/` and `?page=1` causing duplicate content.

This PR removes the first page query from the URL and instead generates the url to the base path instead. It is backwards compatible in that it doesn't break anything and accessing the URL manually with `?page=1` will still work.

I have updated the tests to check for all existing functionality as well as the first page URLs.

Lastly, I initially thought of this as a minor feature but because of the page duplication issue for search engines would this be considered a bug? I was also unsure if this PR should be send to 5.8, 5.5 (LTS) or master. Happy to amend as required, thanks.