### PR TITLE
Add third parameter's sortByKeysParameter to Arr::only

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -358,10 +358,18 @@ class Arr
      *
      * @param  array  $array
      * @param  array|string  $keys
+     * @param  bool $sortByKeysParameter
      * @return array
      */
-    public static function only($array, $keys)
+    public static function only($array, $keys, $sortByKeysParameter = false)
     {
+        if ($sortByKeysParameter) {
+            $keysFlip = array_flip((array) $keys);
+            $result = array_intersect_key($array, $keysFlip);
+
+            return array_merge($keysFlip, $result);
+        }
+
         return array_intersect_key($array, array_flip((array) $keys));
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -379,9 +379,11 @@ class SupportArrTest extends TestCase
 
     public function testOnly()
     {
-        $array = ['name' => 'Desk', 'price' => 100, 'orders' => 10];
-        $array = Arr::only($array, ['name', 'price']);
-        $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
+        $array = ['size' => 10, 'name' => 'Desk', 'price' => 100, 'orders' => 10];
+        $array = Arr::only($array, ['name', 'price', 'size'], true);
+
+        $this->assertEquals(['name' => 'Desk', 'price' => 100, 'size' => 10], $array);
+        $this->assertEquals('{"name":"Desk","price":100,"size":10}', json_encode($array));
         $this->assertEmpty(Arr::only($array, ['nonExistingKey']));
     }
 


### PR DESCRIPTION
Haven't third parameter
```
$array = ['size' => 10, 'name' => 'Desk', 'price' => 100, 'orders' => 10];
$array = Arr::only($array, ['name', 'price', 'size']);

array:3 [
  "size" => 10
  "name" => "Desk"
  "price" => 100
]
```

Have third parameter
```
$array = ['size' => 10, 'name' => 'Desk', 'price' => 100, 'orders' => 10];
$array = Arr::only($array, ['name', 'price', 'size'], true);

array:3 [
  "name" => "Desk"
  "price" => 100
  "size" => 10
]
```