### PR TITLE
[5.8] [WIP] Path getters and helpers uniformity

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -383,31 +383,36 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the language files.
      *
+     * @param  string  $path Optionally, a path to append to the language files path
      * @return string
      */
-    public function langPath()
+    public function langPath($path = '')
     {
-        return $this->resourcePath().DIRECTORY_SEPARATOR.'lang';
+        return $this->resourcePath().DIRECTORY_SEPARATOR.'lang'.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**
      * Get the path to the public / web directory.
      *
+     * @param  string  $path Optionally, a path to append to the public path
      * @return string
      */
-    public function publicPath()
+    public function publicPath($path = '')
     {
-        return $this->basePath.DIRECTORY_SEPARATOR.'public';
+        return $this->basePath.DIRECTORY_SEPARATOR.'public'.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**
      * Get the path to the storage directory.
      *
+     * @param  string  $path Optionally, a path to append to the storage path
      * @return string
      */
-    public function storagePath()
+    public function storagePath($path = '')
     {
-        return $this->storagePath ?: $this->basePath.DIRECTORY_SEPARATOR.'storage';
+        $storagePath = $this->storagePath ?: $this->basePath.DIRECTORY_SEPARATOR.'storage';
+
+        return $storagePath.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**
@@ -439,11 +444,14 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the environment file directory.
      *
+     * @param  string  $path Optionally, a path to append to the environment path
      * @return string
      */
-    public function environmentPath()
+    public function environmentPath($path = '')
     {
-        return $this->environmentPath ?: $this->basePath;
+        $environmentPath = $this->environmentPath ?: $this->basePath;
+
+        return $environmentPath.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -399,7 +399,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function publicPath($path = '')
     {
-        return $this->basePath.DIRECTORY_SEPARATOR.'public'.($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return $this->basePath.DIRECTORY_SEPARATOR.'public'.($path ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -131,7 +131,7 @@ if (! function_exists('app_path')) {
      */
     function app_path($path = '')
     {
-        return app('path').($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return app()->path($path);
     }
 }
 
@@ -190,7 +190,7 @@ if (! function_exists('base_path')) {
      */
     function base_path($path = '')
     {
-        return app()->basePath().($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return app()->basePath($path);
     }
 }
 
@@ -293,7 +293,7 @@ if (! function_exists('config_path')) {
      */
     function config_path($path = '')
     {
-        return app()->make('path.config').($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return app()->configPath($path);
     }
 }
 
@@ -631,7 +631,7 @@ if (! function_exists('public_path')) {
      */
     function public_path($path = '')
     {
-        return app()->make('path.public').($path ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : $path);
+        return app()->publicPath($path);
     }
 }
 
@@ -839,7 +839,7 @@ if (! function_exists('storage_path')) {
      */
     function storage_path($path = '')
     {
-        return app('path.storage').($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return app()->storagePath($path);
     }
 }
 


### PR DESCRIPTION
I noticed that not all path getter functions in Illuminate\Foundation\Application use the same uniformity and not all getters allow to have a suffix path passed as optional variable. Then I noticed in the helpers.php file that the path helper functions also don't have any uniformity and some use the Service Container to get the paths and some call the functions directly and some do a mix of both. This results into extra code for appending a suffix to the path in the helper function and might result into unexpected behaviour on function changes.

What this pull request does is fix these issues. It adds an optional path suffix variable to all directory path getters and makes the helper functions uniform by changing them all to call the associated Illuminate\Foundation\Application function directly with the $path passed. Which allow the following new functions:

```
app()->environmentPath('some/suffix');
app()->langPath('some/suffix');
app()->publicPath('some/suffix');
app()->storagePath('some/suffix');
```
