### PR TITLE
createMany should accept collections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -924,7 +924,7 @@ class BelongsToMany extends Relation
      * @param  array  $joinings
      * @return array
      */
-    public function createMany(array $records, array $joinings = [])
+    public function createMany(iterable $records, array $joinings = [])
     {
         $instances = [];
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -288,7 +288,7 @@ abstract class HasOneOrMany extends Relation
      * @param  array  $records
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function createMany(array $records)
+    public function createMany(iterable $records)
     {
         $instances = $this->related->newCollection();
 


### PR DESCRIPTION
Currently if you have a collection of many items and chunk them to allow bulk-inserts to a database, you have to convert the collection to an array before you can use it with `createMany`.

```php
collect([1,2,3])->chunk(2)->each(function($set) {
    $table1->table2->createMany($set->toArray());
});
```

This can be simplified to 

```php
collect([1,2,3])->chunk(2)->each(function($set) {
    $table1->table2->createMany($set);
});
```