### PR TITLE
[5.8] Add the `any` method to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -56,7 +56,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @var array
      */
     protected static $proxies = [
-        'average', 'avg', 'contains', 'each', 'every', 'filter', 'first',
+        'average', 'avg', 'contains', 'each', 'every', 'any', 'filter', 'first',
         'flatMap', 'groupBy', 'keyBy', 'map', 'max', 'min', 'partition',
         'reject', 'some', 'sortBy', 'sortByDesc', 'sum', 'unique',
     ];
@@ -462,6 +462,31 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         return $this->every($this->operatorForWhere(...func_get_args()));
+    }
+
+    /**
+     * Determine if an item in the collection pass the given test.
+     *
+     * @param  string|callable  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function any($key, $operator = null, $value = null)
+    {
+        if (func_num_args() === 1) {
+            $callback = $this->valueRetriever($key);
+
+            foreach ($this->items as $k => $v) {
+                if ($callback($v, $k)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return $this->any($this->operatorForWhere(...func_get_args()));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1111,6 +1111,38 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse($c->push(['active' => false])->every->active);
     }
 
+    public function testAny()
+    {
+        $c = new Collection([]);
+        $this->assertFalse($c->any('key', 'value'));
+        $this->assertFalse($c->any(function () {
+            return false;
+        }));
+
+        $c = new Collection([['age' => 18], ['age' => 20], ['age' => 20]]);
+        $this->assertTrue($c->any('age', 18));
+        $this->assertTrue($c->any('age', '>=', 18));
+        $this->assertTrue($c->any(function ($item) {
+            return $item['age'] >= 18;
+        }));
+        $this->assertFalse($c->any(function ($item) {
+            return $item['age'] > 20;
+        }));
+
+        $c = new Collection([null, null]);
+        $this->assertTrue($c->any(function ($item) {
+            return $item === null;
+        }));
+        $this->assertTrue($c->push('not null')->any(function ($item) {
+            return $item === null;
+        }));
+
+        $c = new Collection([]);
+        $this->assertFalse($c->any('active'));
+        $this->assertFalse($c->any->active);
+        $this->assertTrue($c->push(['active' => true])->any->active);
+    }
+
     public function testExcept()
     {
         $data = new Collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
Hello,

This PR add the `any` method to collection, to easly check if one of the items pass a given test.
The method is based on the `every` method, and will return false if the collection is empty.

```php
collect([])->any('name', 'Jane'); // returns false.
collect([['name' => 'Jane']])->any('name', 'Jane'); // returns true.
collect([['name' => 'Jane'], ['name' => 'John']])->any('name', 'Jane'); // returns true.
collect([1, 2, 3])->any(function ($item) {
    return $item === 2;
}); // returns true.
```