### PR TITLE
[5.9] createMany should accept collections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -895,11 +895,11 @@ class BelongsToMany extends Relation
     /**
      * Create an array of new instances of the related models.
      *
-     * @param  array  $records
+     * @param  iterable  $records
      * @param  array  $joinings
      * @return array
      */
-    public function createMany(array $records, array $joinings = [])
+    public function createMany(iterable $records, array $joinings = [])
     {
         $instances = [];
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -285,10 +285,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create a Collection of new instances of the related model.
      *
-     * @param  array  $records
+     * @param  iterable  $records
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function createMany(array $records)
+    public function createMany(iterable $records)
     {
         $instances = $this->related->newCollection();
 


### PR DESCRIPTION
Currently if you have a collection of many items and chunk them to allow bulk-inserts to a database, you have to convert the collection to an array before you can use it with `createMany`.

```php
collect([1,2,3])->chunk(2)->each(function($set) {
    $table1->table2->createMany($set->toArray());
});
```

This can be simplified to 

```php
collect([1,2,3])->chunk(2)->each(function($set) {
    $table1->table2->createMany($set);
});
```