### PR TITLE
[5.8] Merge the cache with the settings in config.cache.stores when extend…

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -354,7 +354,7 @@ class CacheManager implements FactoryContract
      */
     public function saveCustomCreatorConfig($driver) {
         $this->app['config']["cache.stores.{$driver}"] = [
-            "driver" => $driver,
+            'driver' => $driver,
         ];
     }
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -354,7 +354,7 @@ class CacheManager implements FactoryContract
      */
     public function saveCustomCreatorConfig($driver) {
         $this->app['config']["cache.stores.{$driver}"] = [
-            "driver" => $driver
+            "driver" => $driver,
         ];
     }
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -352,7 +352,8 @@ class CacheManager implements FactoryContract
      * @param $driver
      * @return void
      */
-    public function saveCustomCreatorConfig($driver) {
+    public function saveCustomCreatorConfig($driver)
+    {
         $this->app['config']["cache.stores.{$driver}"] = [
             'driver' => $driver,
         ];

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -353,7 +353,7 @@ class CacheManager implements FactoryContract
      * @return void
      */
     public function saveCustomCreatorConfig($driver) {
-        $this->app["config"]["cache.stores.$driver"] = [
+        $this->app['config']["cache.stores.{$driver}"] = [
             "driver" => $driver
         ];
     }

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -341,7 +341,21 @@ class CacheManager implements FactoryContract
     {
         $this->customCreators[$driver] = $callback->bindTo($this, $this);
 
+        $this->saveCustomCreatorConfig($driver);
+
         return $this;
+    }
+
+    /**
+     * Allows you to save the settings of the newly added drive.
+     *
+     * @param $driver
+     * @return void
+     */
+    public function saveCustomCreatorConfig($driver) {
+        $this->app["config"]["cache.stores.$driver"] = [
+            "driver" => $driver
+        ];
     }
 
     /**


### PR DESCRIPTION
When we try to create a new Cache Store like https://laravel.com/docs/5.8/cache#registering-the-driver this store will be added to customCreators protected variable like this.
```php
// https://laravel.com/docs/5.8/cache#writing-the-driver 
Cache::extend('mongo', function ($app) {
     return Cache::repository(new MongoStore);
});

// Illuminate\Cache\CacheManager:307
public function extend($driver, Closure $callback)
{
        $this->customCreators[$driver] = $callback->bindTo($this, $this);
        return $this;
 }

// Illuminate\Cache\CacheManager:97
protected function resolve($name)
{
        $config = $this->getConfig($name);

        if (is_null($config)) {
            throw new InvalidArgumentException("Cache store [{$name}] is not defined.");
        }

        if (isset($this->customCreators[$config['driver']])) {
            return $this->callCustomCreator($config);
        } else {
            $driverMethod = 'create'.ucfirst($config['driver']).'Driver';

            if (method_exists($this, $driverMethod)) {
                return $this->{$driverMethod}($config);
            } else {
                throw new InvalidArgumentException("Driver [{$config['driver']}] is not supported.");
            }
        }
}
// Illuminate\Cache\CacheManager:255
protected function getConfig($name)
{
        return $this->app['config']["cache.stores.{$name}"];
}
```

In this section `is_null($config)` section `getConfig()` function will return empty because the error in a bottom line is the whole process.

The store information for this store that has been added to the application's array of settings for the Cache Store added in this section must be registered.

```php
public function extend($driver, Closure $callback)
{
        $this->customCreators[$driver] = $callback->bindTo($this, $this);

        $this->saveCustomCreatorConfig($driver);

        return $this;
}

public function saveCustomCreatorConfig($driver) {
       $this->app['config']["cache.stores.{$driver}"] = [
            "driver" => $driver
        ];
}
```