### PR TITLE
[5.8] Strip slashes for unique rule helper

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -711,6 +711,8 @@ trait ValidatesAttributes
 
         if (isset($parameters[2])) {
             [$idColumn, $id] = $this->getUniqueIds($parameters);
+
+            $id = stripslashes($id);
         }
 
         // The presence verifier is responsible for counting rows within this store

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -35,8 +35,8 @@ class Unique
             return $this->ignoreModel($id, $idColumn);
         }
 
-        $this->ignore = str_replace(',', '', $id);
-        $this->idColumn = str_replace(',', '', $idColumn ?? 'id');
+        $this->ignore = addslashes($id);
+        $this->idColumn = $idColumn ?? 'id';
 
         return $this;
     }
@@ -50,8 +50,8 @@ class Unique
      */
     public function ignoreModel($model, $idColumn = null)
     {
-        $this->idColumn = str_replace(',', '', $idColumn ?? $model->getKeyName());
-        $this->ignore = str_replace(',', '', $model->{$this->idColumn});
+        $this->idColumn = addslashes($idColumn ?? $model->getKeyName());
+        $this->ignore = $model->{$this->idColumn};
 
         return $this;
     }

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -17,7 +17,7 @@ class ValidationUniqueRuleTest extends TestCase
         $rule = new Unique('table', 'column');
         $rule->ignore('Taylor, Otwell', 'id_column');
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,column,"Taylor Otwell",id_column,foo,bar', (string) $rule);
+        $this->assertEquals('unique:table,column,"Taylor, Otwell",id_column,foo,bar', (string) $rule);
 
         $rule = new Unique('table', 'column');
         $rule->ignore(null, 'id_column');


### PR DESCRIPTION
This removes the need to introduce a breaking change while prevents manipulating the generated rule string.