### PR TITLE
[5.9] Correct collection sortKeys test

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -983,14 +983,20 @@ class SupportCollectionTest extends TestCase
     {
         $data = new Collection(['b' => 'dayle', 'a' => 'taylor']);
 
-        $this->assertEquals(['a' => 'taylor', 'b' => 'dayle'], $data->sortKeys()->all());
+        $sortData = $data->sortKeys()->all();
+
+        $this->assertEquals(['a' => 'taylor', 'b' => 'dayle'], $sortData);
+        $this->assertEquals(['a', 'b'], array_keys($sortData));
     }
 
     public function testSortKeysDesc()
     {
         $data = new Collection(['a' => 'taylor', 'b' => 'dayle']);
 
-        $this->assertEquals(['b' => 'dayle', 'a' => 'taylor'], $data->sortKeys()->all());
+        $sortData = $data->sortKeysDesc()->all();
+
+        $this->assertEquals(['b' => 'dayle', 'a' => 'taylor'], $sortData);
+        $this->assertEquals(['b', 'a'], array_keys($sortData));
     }
 
     public function testReverse()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
In the sorting tests, an assertion is added which keys are in the correct order
- assertEquals does not check that the array keys are in the correct order
- testSortKeysDesc called the method sortKeys

I left a check on the similarity of arrays. 
It seems to me that you need to make sure that the values ​​do not change
So I just added a check on the correct order of keys and corrected the check sortKeysDesc