### PR TITLE
[5.9] Add sortKeysByPrimary to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1653,26 +1653,28 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @param  int  $options
      * @param  bool  $descending
+     * @param  array $priorityKeys
      * @return static
      */
-    public function sortKeys($options = SORT_REGULAR, $descending = false)
+    public function sortKeys($options = SORT_REGULAR, $descending = false, $priorityKeys = [])
     {
         $items = $this->items;
 
         $descending ? krsort($items, $options) : ksort($items, $options);
 
-        return new static($items);
+        return new static(array_merge(Arr::only($items, $priorityKeys), $items));
     }
 
     /**
      * Sort the collection keys in descending order.
      *
      * @param  int $options
+     * @param  array $priorityKeys
      * @return static
      */
-    public function sortKeysDesc($options = SORT_REGULAR)
+    public function sortKeysDesc($options = SORT_REGULAR, $priorityKeys = [])
     {
-        return $this->sortKeys($options, true);
+        return $this->sortKeys($options, true, $priorityKeys);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1653,28 +1653,41 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @param  int  $options
      * @param  bool  $descending
-     * @param  array $priorityKeys
      * @return static
      */
-    public function sortKeys($options = SORT_REGULAR, $descending = false, $priorityKeys = [])
+    public function sortKeys($options = SORT_REGULAR, $descending = false)
     {
         $items = $this->items;
 
         $descending ? krsort($items, $options) : ksort($items, $options);
 
-        return new static(array_merge(Arr::only($items, $priorityKeys), $items));
+        return new static($items);
     }
 
     /**
      * Sort the collection keys in descending order.
      *
      * @param  int $options
-     * @param  array $priorityKeys
      * @return static
      */
-    public function sortKeysDesc($options = SORT_REGULAR, $priorityKeys = [])
+    public function sortKeysDesc($options = SORT_REGULAR)
     {
-        return $this->sortKeys($options, true, $priorityKeys);
+        return $this->sortKeys($options, true);
+    }
+
+    /**
+     * Sort the collection keys by example priority.
+     *
+     * @param  array $priority
+     * @param  int  $options
+     * @param  bool  $descending
+     * @return static
+     */
+    public function sortKeysByPrimary($priority, $options = SORT_REGULAR, $descending = false)
+    {
+        $items = $this->sortKeys($options, $descending)->items;
+
+        return new static(array_merge(Arr::only($items, $priority), $items));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1041,7 +1041,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new Collection(['b' => 'dayle', 'z' => 'zorro', 'a' => 'taylor']);
 
-        $sortData = $data->sortKeys(SORT_REGULAR, false, ['z','t'])->all();
+        $sortData = $data->sortKeys(SORT_REGULAR, false, ['z', 't'])->all();
 
         $this->assertEquals(['z' => 'zorro', 'a' => 'taylor', 'b' => 'dayle'], $sortData);
         $this->assertEquals(['z', 'a', 'b'], array_keys($sortData));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1041,7 +1041,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new Collection(['b' => 'dayle', 'z' => 'zorro', 'a' => 'taylor']);
 
-        $sortData = $data->sortKeys(SORT_REGULAR, false, ['z', 't'])->all();
+        $sortData = $data->sortKeysByPrimary(['z', 't'])->all();
 
         $this->assertEquals(['z' => 'zorro', 'a' => 'taylor', 'b' => 'dayle'], $sortData);
         $this->assertEquals(['z', 'a', 'b'], array_keys($sortData));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1037,6 +1037,16 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['b', 'a'], array_keys($sortData));
     }
 
+    public function testSortKeysWidthPrimaryKeys()
+    {
+        $data = new Collection(['b' => 'dayle', 'z' => 'zorro', 'a' => 'taylor']);
+
+        $sortData = $data->sortKeys(SORT_REGULAR, false, ['z','t'])->all();
+
+        $this->assertEquals(['z' => 'zorro', 'a' => 'taylor', 'b' => 'dayle'], $sortData);
+        $this->assertEquals(['z', 'a', 'b'], array_keys($sortData));
+    }
+
     public function testReverse()
     {
         $data = new Collection(['zaeed', 'alan']);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
If you need to place keys in your order in sorting
```
collect([
    'size' => 10,
    'name' => 'Desk',
    'price' => 100,
    'orders' => 10,
])->only(['name', 'price', 'size'])->sortKeysByPrimary(['size'])->all()
// [
//     "size" => 10,
//     "name" => "Desk",
//     "price" => 100,
// ]
```
The idea of ​​a functional from https://github.com/laravel/framework/pull/27926
However, placing this functionality in Arr :: only, in my opinion, violates the principle of single responsibility