### PR TITLE
[5.8] Locks acquired with block() are not immediately released if the callback fails

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -115,9 +115,11 @@ abstract class Lock implements LockContract
         }
 
         if (is_callable($callback)) {
-            return tap($callback(), function () {
+            try {
+                return $callback();
+            } finally {
                 $this->release();
-            });
+            }
         }
 
         return true;

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
+use Exception;
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Cache;
@@ -80,9 +81,9 @@ class RedisCacheLockTest extends TestCase
 
         try {
             $firstLock->block(1, function () {
-                throw new \Exception('failed');
+                throw new Exception('failed');
             });
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             // Not testing the exception, just testing the lock
             // is released regardless of the how the exception
             // thrown by the callback was handled.

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -79,7 +79,7 @@ class RedisCacheLockTest extends TestCase
         $firstLock = Cache::store('redis')->lock('foo', 10);
         try {
             $firstLock->block(1, function () {
-                throw new \Exception("failed");
+                throw new \Exception('failed');
             });
         } catch (\Exception $e) {
             // Not testing the exception, just testing the lock

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -77,6 +77,7 @@ class RedisCacheLockTest extends TestCase
         Cache::store('redis')->lock('foo')->forceRelease();
 
         $firstLock = Cache::store('redis')->lock('foo', 10);
+
         try {
             $firstLock->block(1, function () {
                 throw new \Exception('failed');
@@ -86,7 +87,9 @@ class RedisCacheLockTest extends TestCase
             // is released regardless of the how the exception
             // thrown by the callback was handled.
         }
+
         $secondLock = Cache::store('redis')->lock('foo', 1);
+
         $this->assertTrue($secondLock->get());
     }
 


### PR DESCRIPTION
Currently, after block() successfully acquires a lock, tap() releases the lock _only if_ $callback() is a success. However this won't happen if $callback fails in some way; the lock will only release when it was set to expire since there is nothing ensuring it on $callback's failure.

Contrast this with the behavior of get() which wraps $callback in a try/finally, so the lock is released immediately regardless of the outcome of the callback. This PR ensures block() exhibits the same behavior after successful lock acquisition.

Added redis integration test for this case.
