### PR TITLE
[5.8] Allow retrieving env variables with getenv

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use Dotenv\Environment\DotenvFactory;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HigherOrderTapProxy;
+use Dotenv\Environment\Adapter\PutenvAdapter;
 use Dotenv\Environment\Adapter\EnvConstAdapter;
 use Dotenv\Environment\Adapter\ServerConstAdapter;
 
@@ -642,7 +643,7 @@ if (! function_exists('env')) {
         static $variables;
 
         if ($variables === null) {
-            $variables = (new DotenvFactory([new EnvConstAdapter, new ServerConstAdapter]))->createImmutable();
+            $variables = (new DotenvFactory([new EnvConstAdapter, new PutEnvAdapter, new ServerConstAdapter]))->createImmutable();
         }
 
         return Option::fromValue($variables->get($key))

--- a/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
+++ b/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
@@ -37,6 +37,9 @@ class LoadEnvironmentVariablesTest extends TestCase
         (new LoadEnvironmentVariables)->bootstrap($this->getAppMock('.env'));
 
         $this->assertSame('BAR', env('FOO'));
+        $this->assertSame('BAR', getenv('FOO'));
+        $this->assertSame('BAR', $_ENV['FOO']);
+        $this->assertSame('BAR', $_SERVER['FOO']);
     }
 
     public function testCanFailSilent()


### PR DESCRIPTION
This PR makes it possible to retrieve `.env` values with `getenv`, which is necessary for some third party libraries to work as expected.

This restores the 5.7 behavior.  See https://github.com/vlucas/phpdotenv#upgrading-from-v2 for more info.

Resolves #27949 and #27913 .