### PR TITLE
[5.8] bugfix if columns is null

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2084,12 +2084,12 @@ class Builder
      */
     public function get($columns = ['*'])
     {
-        if (empty($columns)) {
+        if (is_null($columns)) {
             $columns = ['*'];
         } else {
             $columns = Arr::wrap($columns);
         }
-        
+
         return collect($this->onceWithColumns($columns, function () {
             return $this->processor->processSelect($this, $this->runSelect());
         }));

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2084,7 +2084,13 @@ class Builder
      */
     public function get($columns = ['*'])
     {
-        return collect($this->onceWithColumns(Arr::wrap($columns), function () {
+        if (empty($columns)) {
+            $columns = ['*'];
+        } else {
+            $columns = Arr::wrap($columns);
+        }
+        
+        return collect($this->onceWithColumns($columns, function () {
             return $this->processor->processSelect($this, $this->runSelect());
         }));
     }


### PR DESCRIPTION
Arr::wrap($columns) make null columns return []
so after check $columns is null never return true

if we call User::get(null) Will be throw exception:

Illuminate/Database/QueryException with message 'SQLSTATE[HY000]: General error: 1 near "from": syntax error (SQL: select  from "users")'

is 5.7 it's normal, so need check columns value first