### PR TITLE
[5.8] Revert "[5.8] Allow retrieving env variables with getenv"

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Collection;
 use Dotenv\Environment\DotenvFactory;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HigherOrderTapProxy;
-use Dotenv\Environment\Adapter\PutenvAdapter;
 use Dotenv\Environment\Adapter\EnvConstAdapter;
 use Dotenv\Environment\Adapter\ServerConstAdapter;
 
@@ -643,7 +642,7 @@ if (! function_exists('env')) {
         static $variables;
 
         if ($variables === null) {
-            $variables = (new DotenvFactory([new EnvConstAdapter, new PutEnvAdapter, new ServerConstAdapter]))->createImmutable();
+            $variables = (new DotenvFactory([new EnvConstAdapter, new ServerConstAdapter]))->createImmutable();
         }
 
         return Option::fromValue($variables->get($key))

--- a/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
+++ b/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
@@ -37,9 +37,6 @@ class LoadEnvironmentVariablesTest extends TestCase
         (new LoadEnvironmentVariables)->bootstrap($this->getAppMock('.env'));
 
         $this->assertSame('BAR', env('FOO'));
-        $this->assertSame('BAR', getenv('FOO'));
-        $this->assertSame('BAR', $_ENV['FOO']);
-        $this->assertSame('BAR', $_SERVER['FOO']);
     }
 
     public function testCanFailSilent()


### PR DESCRIPTION
Reverts laravel/framework#27958. People can already configure their apps to do this, without changing the core.