### PR TITLE
[5.8] Container `build` method catch ReflectionException

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -7,6 +7,7 @@ use Exception;
 use ArrayAccess;
 use LogicException;
 use ReflectionClass;
+use ReflectionException;
 use ReflectionParameter;
 use Illuminate\Support\Arr;
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -791,7 +792,11 @@ class Container implements ArrayAccess, ContainerContract
             return $concrete($this, $this->getLastParameterOverride());
         }
 
-        $reflector = new ReflectionClass($concrete);
+        try {
+            $reflector = new ReflectionClass($concrete);
+        } catch (ReflectionException $e) {
+            throw new BindingResolutionException("Target class [$concrete] does not exist.");
+        }
 
         // If the type is not instantiable, the developer is attempting to resolve
         // an abstract type such as an Interface or Abstract Class and there is

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -274,6 +274,15 @@ class ContainerTest extends TestCase
         $container->make(ContainerDependentStub::class, []);
     }
 
+    public function testBindingResolutionExceptionMessageWhenClassDoesNotExist()
+    {
+        $this->expectException(BindingResolutionException::class);
+        $this->expectExceptionMessage('Target class [Foo\Bar\Baz\DummyClass] does not exist.');
+
+        $container = new Container;
+        $container->make('Foo\Bar\Baz\DummyClass', []);
+    }
+
     public function testForgetInstanceForgetsInstance()
     {
         $container = new Container;


### PR DESCRIPTION
This pull-request was discussed at #27959 and laravel/ideas#1573.

It updates the `Illuminate\Container\Container` (~ line 795) to catch the `ReflectionException` thrown by the `new ReflectionClass($concrete)` call. This catch will throw a `BindingResolutionException`.

This is a small breaking change, since people who are catching `ReflectionException` on `make` or `build` call will now have a `BindingResolutionException` instead.