### PR TITLE
[5.8] don't add the path if it's null or empty

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -118,9 +118,10 @@ class BladeCompiler extends Compiler implements CompilerInterface
         }
 
         if (! is_null($this->cachePath)) {
-            $contents = $this->compileString($this->files->get($this->getPath())).
-                        "\n<?php /* {$this->getPath()} */ ?>";
-
+            $contents = $this->compileString($this->files->get($this->getPath()));
+            if (! empty($this->getPath())) {
+                $contents .= "\n<?php /* {$this->getPath()} */ ?>";
+            }
             $this->files->put($this->getCompiledPath($this->getPath()), $contents);
         }
     }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -118,11 +118,17 @@ class BladeCompiler extends Compiler implements CompilerInterface
         }
 
         if (! is_null($this->cachePath)) {
-            $contents = $this->compileString($this->files->get($this->getPath()));
+            $contents = $this->compileString(
+                $this->files->get($this->getPath())
+            );
+
             if (! empty($this->getPath())) {
                 $contents .= "\n<?php /* {$this->getPath()} */ ?>";
             }
-            $this->files->put($this->getCompiledPath($this->getPath()), $contents);
+
+            $this->files->put(
+                $this->getCompiledPath($this->getPath()), $contents
+            );
         }
     }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -105,8 +105,8 @@ class ViewBladeCompilerTest extends TestCase
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('')->andReturn('Hello World');
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('').'.php', "Hello World");
-        $compiler->setPath("");
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('').'.php', 'Hello World');
+        $compiler->setPath('');
         $compiler->compile();
     }
 
@@ -114,7 +114,7 @@ class ViewBladeCompilerTest extends TestCase
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with(null)->andReturn('Hello World');
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1(null).'.php', "Hello World");
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1(null).'.php', 'Hello World');
         $compiler->setPath(null);
         $compiler->compile();
     }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -101,6 +101,24 @@ class ViewBladeCompilerTest extends TestCase
         $compiler->compile('foo');
     }
 
+    public function testDontIncludeEmptyPath()
+    {
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $files->shouldReceive('get')->once()->with('')->andReturn('Hello World');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('').'.php', "Hello World");
+        $compiler->setPath("");
+        $compiler->compile();
+    }
+
+    public function testDontIncludeNullPath()
+    {
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $files->shouldReceive('get')->once()->with(null)->andReturn('Hello World');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1(null).'.php', "Hello World");
+        $compiler->setPath(null);
+        $compiler->compile();
+    }
+
     public function testShouldStartFromStrictTypesDeclaration()
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);


### PR DESCRIPTION
The pull-request relates to recent feature: https://github.com/laravel/framework/pull/27544
As it's discussed in #27704 it makes sense to add the path to view only if it's specified and not empty.
Please take a look.