### PR TITLE
[5.9] Add nullableMorphsAfter and MorphsAfter for database migrations

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1213,6 +1213,40 @@ class Blueprint
     }
 
     /**
+     * Add nullable morph columns after a specified column.
+     *
+     * @param  string  $name
+     * @param  string  $afterColumn
+     * @param  string|null  $indexName
+     * @return void
+     */
+    public function nullableMorphsAfter($name, $afterColumn, $indexName = null)
+    {
+        $this->string("{$name}_type")->after("$afterColumn")->nullable();
+
+        $this->unsignedBigInteger("{$name}_id")->after("$afterColumn")->nullable();
+
+        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+    }
+
+    /**
+     * Add morphs after column for a polymorphic table.
+     *
+     * @param  string  $name
+     * @param  string  $afterColumn
+     * @param  string|null  $indexName
+     * @return void
+     */
+    public function morphsAfter($name, $afterColumn, $indexName = null)
+    {
+        $this->string("{$name}_type")->after("$afterColumn");
+
+        $this->unsignedBigInteger("{$name}_id")->after("$afterColumn");
+
+        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+    }
+
+    /**
      * Adds the `remember_token` column to the table.
      *
      * @return \Illuminate\Database\Schema\ColumnDefinition


### PR DESCRIPTION
**This is the first PR that I've ever submitted - please forgive errors or mistakes...**

**Description**
Add Nullable Morphs After function to Database Schema Blueprint. I have tested this function but I'm unsure if you require unit tests?

**End User Benefits**
Recently I've had to create nullable morphs after a particular column in a production database. I think that writing something like this in the migrations files...

```php
    public function up()
    {
        Schema::table('testing', function (Blueprint $table) {
            $table->nullableMorphsAfter('tested', 'name');
        });
    }

    public function down()
    {
        Schema::table('testing', function (Blueprint $table) {
          $table->dropMorphs('tested');
        });
    }
```
Seems like a cleaner way to achieve nullable morphs columns after specified column. This is much easier for the end user to understand rather than the current working method...

```php
  public function up()
  {
    Schema::table('user_goal', function (Blueprint $table) {
      $table->string('assigned_type')->after('goal_id')->nullable();
      $table->unsignedBigInteger('assigned_id')->after('goal_id')->nullable();

      $table->index(['assigned_id', 'assigned_type'], 'user_goal_assigned_type_assigned_id_index');
    });
  }

  public function down()
  {
    Schema::table('user_goal', function (Blueprint $table) {
      $table->dropMorphs('assigned');
    });
  }
```
After testing this with existing functionality I am unable to find any conflicts...