### PR TITLE
[5.9] Avoid double command name checking

### DIFF
--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -40,10 +40,6 @@ class Parser
      */
     protected static function name($expression)
     {
-        if (trim($expression) === '') {
-            throw new InvalidArgumentException('Console command definition is empty.');
-        }
-
         if (! preg_match('/[^\s]+/', $expression, $matches)) {
             throw new InvalidArgumentException('Unable to determine command name from signature.');
         }

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -159,6 +159,6 @@ class ConsoleParserTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to determine command name from signature.');
 
-        Parser::parse("");
+        Parser::parse('');
     }
 }

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -146,11 +146,19 @@ class ConsoleParserTest extends TestCase
         $this->assertSame('default', $results[2][0]->getDefault());
     }
 
-    public function testNameException()
+    public function testNameIsSpacesException()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to determine command name from signature.');
 
         Parser::parse(" \t\n\r\x0B\f");
+    }
+
+    public function testNameInEmptyException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to determine command name from signature.');
+
+        Parser::parse("");
     }
 }

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Console;
 
+use InvalidArgumentException;
 use Illuminate\Console\Parser;
 use PHPUnit\Framework\TestCase;
 
@@ -143,5 +144,13 @@ class ConsoleParserTest extends TestCase
 
         $results = Parser::parse('command:name {--option=default : The option description.}');
         $this->assertSame('default', $results[2][0]->getDefault());
+    }
+
+    public function testNameException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to determine command name from signature.');
+
+        Parser::parse(" \t\n\r\x0B\f");
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
I deleted the check for **trim**, since the **preg_match** checks only for an empty line