### PR TITLE
[5.8] Change return types of renderSections() and render() to array and array|string, respectively

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -80,7 +80,7 @@ class View implements ArrayAccess, ViewContract
      * Get the string contents of the view.
      *
      * @param  callable|null  $callback
-     * @return string
+     * @return array|string
      *
      * @throws \Throwable
      */
@@ -163,7 +163,7 @@ class View implements ArrayAccess, ViewContract
     /**
      * Get the sections of the rendered view.
      *
-     * @return string
+     * @return array
      *
      * @throws \Throwable
      */


### PR DESCRIPTION
The return type of the `View::renderSection()` method is wrongly tagged to be `string`, when in reality it always returns an `array`. 

Likewise, the `View::render()` method is expected to return a `string`, but may return any type the passed in closure returns. In case of the `renderSection()` code, it returns an array.

With the changes in this pull request I propose changing the return type of `renderSection()` to `array`, and the return type of `render()` to either `array|string` or `mixed` (as it can really return anything but `null` depending on the closure return).

The impact should be very low, as the functions never returned strings (only). Instead, modern IDEs correctly mark the type mismatch of `renderSection()` results as issues, which is corrected by the changes within this pull request.