### PR TITLE
[5.8] Check for preserveKeys when serializing a collection from a resource

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -75,7 +75,11 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public static function collection($resource)
     {
-        return new AnonymousResourceCollection($resource, static::class);
+        $collection = new AnonymousResourceCollection($resource, static::class);
+
+        $collection->preserveKeys = property_exists(static::class, 'preserveKeys') && (new static([]))->preserveKeys === true;
+
+        return $collection;
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -75,11 +75,11 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public static function collection($resource)
     {
-        $collection = new AnonymousResourceCollection($resource, static::class);
-
-        $collection->preserveKeys = property_exists(static::class, 'preserveKeys') && (new static([]))->preserveKeys === true;
-
-        return $collection;
+        return tap(new AnonymousResourceCollection($resource, static::class), function ($collection) {
+            if (property_exists(static::class, 'preserveKeys')) {
+                $collection->preserveKeys = (new static([]))->preserveKeys === true;
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
As [commented](https://github.com/laravel/framework/pull/27394#issuecomment-475833765) by @staudenmeir, when setting the `preserveKeys` in a resource, but generating a collection from it, the keys are not preserved.

Before this PR the example in the docs should not work:

```php
use App\User;
use App\Http\Resources\User as UserResource;

Route::get('/user', function () {
    return UserResource::collection(User::all()->keyBy->id);
});
```

As the `JsonResource::collection` returns a `AnonymousResourceCollection` and this class does not have a `preserveKeys` attribute, it fails on keeping the keys when serializing as currently we only check the `$preserveKeys` property in the object being serialized.

This PR adds a method to the `ConditionallyLoadsAttributes` trait to handle both the cases of serializing a Resoruce or a Collection of resources.

I used reflection to accomplish this, maybe to 5.9 we could change to using an Interface, I think it would clearer.

Worth noticing that @staudenmeir found this bug while working on issue #27950