### PR TITLE
[5.8] Fix unique validation without ignored column

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -712,7 +712,9 @@ trait ValidatesAttributes
         if (isset($parameters[2])) {
             [$idColumn, $id] = $this->getUniqueIds($parameters);
 
-            $id = stripslashes($id);
+            if (! is_null($id)) {
+                $id = stripslashes($id);
+            }
         }
 
         // The presence verifier is responsible for counting rows within this store

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1889,7 +1889,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,NULL,id_col,foo,bar']);
         $mock = m::mock(PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
-        $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', null, 'id_col', ['foo' => 'bar'])->andReturn(2);
+        $mock->shouldReceive('getCount')->once()->withArgs(function () {
+            return func_get_args() === ['users', 'email_addr', 'foo', null, 'id_col', ['foo' => 'bar']];
+        })->andReturn(2);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
     }


### PR DESCRIPTION
#27940 broke `unique` validation without an ignored column:

```php
$v = Validator::make(['email' => 'test@example.com'], ['email' => Rule::unique('users')]);
$v->passes();

// expected
select count(*) as aggregate from "users" where "email" = 'test@example.com'

// actual
select count(*) as aggregate from "users" where "email" = 'test@example.com' and "id" <> ''
```

We can only apply `stripslashes()` to non-null values.

The tests didn't catch this because Mockery only uses loose comparison.

Fixes #27986.
