### PR TITLE
Added whereLike wrapper methods for simplifying calls to where() using the like operator

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -240,7 +240,7 @@ class Builder
 
     public function whereLLike($column, $value)
     {
-        return $this->query->where($column, 'like', '%'. $value);
+        return $this->query->where($column, 'like', '%'.$value);
     }
 
     public function whereRLike($column, $value)

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -235,17 +235,17 @@ class Builder
 
     public function whereLike($column, $value)
     {
-        return $this->query->where($column, 'like', '%' . $value . '%');
+        return $this->query->where($column, 'like', '%'.$value.'%');
     }
 
     public function whereLLike($column, $value)
     {
-        return $this->query->where($column, 'like', '%' . $value);
+        return $this->query->where($column, 'like', '%'. $value);
     }
 
     public function whereRLike($column, $value)
     {
-        return $this->query->where($column, 'like', $value . '%');
+        return $this->query->where($column, 'like', $value.'%');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -233,6 +233,21 @@ class Builder
         return $this;
     }
 
+    public function whereLike($column, $value)
+    {
+        return $this->query->where($column, 'like', '%' . $value . '%');
+    }
+
+    public function whereLLike($column, $value)
+    {
+        return $this->query->where($column, 'like', '%' . $value);
+    }
+
+    public function whereRLike($column, $value)
+    {
+        return $this->query->where($column, 'like', $value . '%');
+    }
+
     /**
      * Add an "or where" clause to the query.
      *

--- a/tests/Integration/Database/EloquentWhereLikeTest.php
+++ b/tests/Integration/Database/EloquentWhereLikeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentWhereLikeTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentWhereLikeTest extends DatabaseTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+        });
+
+        User::create([
+            'email' => 'test_email@laravel.com'
+        ]);
+        User::create([
+            'email' => 'taylor.otwell@laravel.com'
+        ]);
+    }
+
+    public function test_with_like()
+    {
+        $users = User::whereLike('email', 'otwell')->get();
+
+        $this->assertEquals(['taylor.otwell@laravel.com'], $users->pluck('email')->all());
+    }
+
+    public function test_with_l_like()
+    {
+        $users = User::whereLLike('email', '@laravel.com')->get();
+
+        $this->assertEquals(['test_email@laravel.com', 'taylor.otwell@laravel.com'], $users->pluck('email')->all());
+    }
+
+    public function test_with_r_like()
+    {
+        $users = User::whereRLike('email', 'taylor')->get();
+
+        $this->assertEquals(['taylor.otwell@laravel.com'], $users->pluck('email')->all());
+    }
+}
+
+class User extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = ['email'];
+}

--- a/tests/Integration/Database/EloquentWhereLikeTest.php
+++ b/tests/Integration/Database/EloquentWhereLikeTest.php
@@ -22,10 +22,10 @@ class EloquentWhereLikeTest extends DatabaseTestCase
         });
 
         User::create([
-            'email' => 'test_email@laravel.com'
+            'email' => 'test_email@laravel.com',
         ]);
         User::create([
-            'email' => 'taylor.otwell@laravel.com'
+            'email' => 'taylor.otwell@laravel.com',
         ]);
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch
PR made against 5.7 which is the currently latest LTS version.

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
The reason for this PR is to clean up how calls to `Model::where($column, 'like', $value)` is used.

Currently, if a user wanted to build a query to match a pattern, say all users whose emails contains some generated value, they would have to do the following:
`User::where('email', 'like', '%' . $value)`

With this PR, they could instead use `User::whereLike('email', $value)` which will simply execute the following:
`return $this->query->where($column, 'like', '%' . $value . '%');`

Additionally, there is a `whereLLike` and `whereRLike` method that will place the wildcard character before and after the value, respectively.

One problem I see is the naming and confusion with the current `rlike` operator value, so comments/naming conventions are welcome.