### PR TITLE
[5.8] Check for all values in the "Accept" HTTP header

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -53,7 +53,13 @@ trait InteractsWithContentTypes
     {
         $acceptable = $this->getAcceptableContentTypes();
 
-        return isset($acceptable[0]) && Str::contains($acceptable[0], ['/json', '+json']);
+        foreach ($acceptable as $value) {
+            if (Str::contains($value, ['/json', '+json'])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Hello,
this pull request will update the wantsJson method to check for all the values in the Accept HTTP header instead of only the first one.

It would correctly handle cases like: `Accept: */*, application/json`, which right now are treated as "non-JSON" requests, but might create issues in situations where incompatible types are specified: `Accept: application/json, application/xml`.

Looking forward to your feedback.