### PR TITLE
[5.8] Require vlucas/phpdotenv

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -19,6 +19,7 @@
         "ext-mbstring": "*",
         "doctrine/inflector": "^1.1",
         "illuminate/contracts": "5.8.*",
+        "vlucas/phpdotenv": "^3.0",
         "nesbot/carbon": "^1.26.3 || ^2.0"
     },
     "conflict": {


### PR DESCRIPTION
I have error after updates on 5.8
PHP Fatal error: Uncaught Error: Class 'Dotenv\Environment\DotenvFactory' not found in vendor/illuminate/support/helpers.php:645
