### PR TITLE
[5.8] Fix BelongsToMany::detach() with custom pivot class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -403,7 +403,7 @@ trait InteractsWithPivotTable
      */
     public function detach($ids = null, $touch = true)
     {
-        if ($this->using && ! empty($ids)) {
+        if ($this->using && ! empty($ids) && empty($this->pivotWheres) && empty($this->pivotWhereIns)) {
             $results = $this->detachUsingCustomClass($ids);
         } else {
             $query = $this->newPivotQuery();


### PR DESCRIPTION
#27571 broke `detach()` and `updateExistingPivot()` when the relationship uses a custom pivot class in combination with `wherePivot()`/`wherePivotIn()`:

```php
class User extends Model
{
    public function roles()
    {
        return $this->belongsToMany(Role::class)
            ->using(RoleUserPivot::class)
            ->wherePivot('active', true);
    }
}

$user->roles()->detach(1);

// expected
delete from `role_user` where `active` = 1 and `user_id` = 1 and `role_id` in (1)

// actual
delete from `role_user` where (`user_id` = 1 and `role_id` = 1)
```

cadea88 fixed `updateExistingPivot()`, this PR fixes `detach()` the same way.