### PR TITLE
[5.8] Add PascalCase method to Str class.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -27,6 +27,13 @@ class Str
     protected static $camelCache = [];
 
     /**
+     * The cache of pascal-cased words.
+     *
+     * @var array
+     */
+    protected static $pascalCache = [];
+
+    /**
      * The cache of studly-cased words.
      *
      * @var array
@@ -92,6 +99,21 @@ class Str
         }
 
         return static::$camelCache[$value] = lcfirst(static::studly($value));
+    }
+
+    /**
+     * Convert a value to pascal case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function pascal($value)
+    {
+        if (isset(static::$pascalCache[$value])) {
+            return static::$pascalCache[$value];
+        }
+
+        return static::$pascalCache[$value] = ucfirst(static::studly($value));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -316,6 +316,20 @@ class SupportStrTest extends TestCase
         $this->assertEquals('fooBarBaz', Str::camel('foo-bar_baz'));
     }
 
+    public function testPascal()
+    {
+        $this->assertSame('LaravelPHPFramework', Str::pascal('Laravel_p_h_p_framework'));
+        $this->assertSame('LaravelPhpFramework', Str::pascal('Laravel_php_framework'));
+        $this->assertSame('LaravelPhPFramework', Str::pascal('Laravel-phP-framework'));
+        $this->assertSame('LaravelPhpFramework', Str::pascal('Laravel  -_-  php   -_-   framework   '));
+
+        $this->assertSame('FooBar', Str::pascal('FooBar'));
+        $this->assertSame('FooBar', Str::pascal('foo_bar'));
+        $this->assertSame('FooBar', Str::pascal('foo_bar')); // test cache
+        $this->assertSame('FooBarBaz', Str::pascal('Foo-barBaz'));
+        $this->assertSame('FooBarBaz', Str::pascal('foo-bar_baz'));
+    }
+
     public function testSubstr()
     {
         $this->assertEquals('Ё', Str::substr('БГДЖИЛЁ', -1));


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds `PascalCase` method to `\Illuminate\Support\Str` class. 
