### PR TITLE
[5.8] Initial attributes for Eloquent model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -115,6 +115,16 @@ trait HasAttributes
     }
 
     /**
+     * Get an array of initial attributes.
+     *
+     * @return array
+     */
+    protected function initialAttributes()
+    {
+        return [];
+    }
+
+    /**
      * Add the date attributes to the attributes array.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -168,6 +168,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $this->syncOriginal();
 
+        $this->fill($this->initialAttributes());
+
         $this->fill($attributes);
     }
 

--- a/tests/Integration/Database/EloquentModelInitialAttributesTest.php
+++ b/tests/Integration/Database/EloquentModelInitialAttributesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelLoadCountTest;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentModelInitialAttributesTest extends DatabaseTestCase
+{
+    public function testInitialAttributesAreSet()
+    {
+        $model = new ModelWithInitialAttributes;
+
+        $this->assertSame(
+            'Task',
+            $model->getAttribute('title')
+        );
+
+        $this->assertInstanceOf(
+            Carbon::class,
+            $model->getAttribute('deadline_at')
+        );
+    }
+}
+
+class ModelWithInitialAttributes extends Model
+{
+    protected $fillable = [
+        'title',
+        'deadline_at',
+    ];
+
+    protected function initialAttributes()
+    {
+        return [
+            'title' => 'Task',
+            'deadline_at' => now()->addWeek(),
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds `initialAttributes()` method into the base Eloquent model which can be overridden in order to specify the initial attributes for the model.

Example:

```php
class Task extends Model
{
    public function initialAttributes()
    {
        return [
            'name' => 'Task',
            'deadline_at' => now()->addWeek(),
        ];
    }
}
```