### PR TITLE
[5.8] Fix incorrect event namespace in generated listener.

### DIFF
--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -52,7 +52,7 @@ class ListenerMakeCommand extends GeneratorCommand
         );
 
         return str_replace(
-            'DummyFullEvent', $event, $stub
+            'DummyFullEvent', trim($event, '\\'), $stub
         );
     }
 


### PR DESCRIPTION
## Problem Summary
See #27468
The issue arises when running ```event:generate``` for events in third-party namespaces (non-App and non-Illuminate). 
The FQCN of the event (in the "use" statement at the top of the Listener class) has a preceding '\\'.

## Before
```php
<?php

namespace App\Listeners;

use \GreatLaravelPackages\GreatePackage\GreatEvent;

class MyGreatListener
{
}
```

## After
```php
<?php

namespace App\Listeners;

use GreatLaravelPackages\GreatePackage\GreatEvent;

class MyGreatListener
{
}
```

## Details
In ```ListenerMakeCommand```, there is a check to see if the given event namespace starts with: 
(1) your project namespace(App) 
(2)"Illuminate"
(3)"\\"

So it looks like the ```event:generate``` command expects 3 situations:
1. Your event is somewhere in your project's namespace (App).
2. Your event is in the Illuminate namespace.
3. Your event is elsewhere and you are showing that by starting with a '\\'.

If those assumptions are true, then you should be able to generate listeners from events in third party namespaces by adding a starting '\\' to your event in the ```$listen``` array of your EventServiceProvider.
 
However, if you do that, then the '\\' doesn't get dropped and the namespace at the top of the generated listener for your event, will still have the starting '\\'.

## Solution
Simply ```trim``` the full event name when replacing the ```DummyFullEvent```.
