### PR TITLE
[5.8] Add forPageBeforeId method to query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1939,6 +1939,26 @@ class Builder
     }
 
     /**
+     * Constrain the query to the previous "page" of results before a given ID.
+     *
+     * @param  int  $perPage
+     * @param  int|null  $lastId
+     * @param  string  $column
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function forPageBeforeId($perPage = 15, $lastId = 0, $column = 'id')
+    {
+        $this->orders = $this->removeExistingOrdersFor($column);
+
+        if (! is_null($lastId)) {
+            $this->where($column, '<', $lastId);
+        }
+
+        return $this->orderBy($column, 'desc')
+                    ->take($perPage);
+    }
+
+    /**
      * Constrain the query to the next "page" of results after a given ID.
      *
      * @param  int  $perPage

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1090,6 +1090,20 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertNotNull(EloquentTestUserWithGlobalScopeRemovingOtherScope::find($user->id));
     }
 
+    public function testForPageBeforeIdCorrectlyPaginates()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
+        $results = EloquentTestUser::forPageBeforeId(15, 2);
+        $this->assertInstanceOf(Builder::class, $results);
+        $this->assertEquals(1, $results->first()->id);
+
+        $results = EloquentTestUser::orderBy('id', 'desc')->forPageBeforeId(15, 2);
+        $this->assertInstanceOf(Builder::class, $results);
+        $this->assertEquals(1, $results->first()->id);
+    }
+
     public function testForPageAfterIdCorrectlyPaginates()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
On my current project, I have the need in the admin area to show a chat post in context of its surrounding posts. This allows admins to view a specific chat post that has been reported for abuse (or other potential issues) within context of the chat thread.

The following is a (terrible) example of what I mean just to illustrate the point. `Post 205` is "focused". The page shows a handful of posts before, and after the focused post to give context to the admin. 

```
-> ChatPost 202
-> ChatPost 203
-> ChatPost 204
=> ChatPost 205 👈 focused post
-> ChatPost 206
-> ChatPost 207
-> ChatPost 208
```

I stumbled upon the existing `forPageAfterId` method which is *mostly* sugar over some other methods. This is an undocumented method, and is perhaps meant for internal use (i.e. the chunkById method), however it is the perfect tool for retrieving the posts following the focused post. Unfortunately it only shows the page **after** the given ID, but I am also looking for the page **before** so I can show the post in context.

This PR introduces the complementary method `forPageBeforeId($perPage, $lastId, $column)`.

This allows a developer to do something like this...

```php
$posts = new Collection;

$posts = $posts->concat(ChatPost::forPageBeforeId(15, $focused->id)->get()->reverse());

$posts = $posts->push($focused);

$posts = $posts->concat(ChatPost::forPageAfterId(15, $focused->id)->get());
```

which results in a collection of posts that contain the focused post, with 15 posts on either side of the focused post, sorted chronologically.