### PR TITLE
[5.8] Added support of 'OPTIONS' method for `Route::apiResource()`

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -18,7 +18,7 @@ class ResourceRegistrar
      *
      * @var array
      */
-    protected $resourceDefaults = ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy'];
+    protected $resourceDefaults = ['options', 'index', 'create', 'store', 'show', 'edit', 'update', 'destroy'];
 
     /**
      * The parameters set for this resource instance.
@@ -289,6 +289,24 @@ class ResourceRegistrar
         $action = $this->getResourceAction($name, $controller, 'destroy', $options);
 
         return $this->router->delete($uri, $action);
+    }
+
+    /**
+     * Add the 'options' method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Illuminate\Routing\Route
+     */
+    protected function addResourceOptions($name, $base, $controller, $options)
+    {
+        $uri = $this->getResourceUri($name);
+
+        $action = $this->getResourceAction($name, $controller, 'options', $options);
+
+        return $this->router->options($uri, $action);
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -238,7 +238,7 @@ class RouteRegistrarTest extends TestCase
             'resource-three'    => RouteRegistrarControllerStubThree::class,
         ], ['except' => ['create', 'show']]);
 
-        $this->assertCount(15, $this->router->getRoutes());
+        $this->assertCount(18, $this->router->getRoutes());
 
         foreach (['one', 'two', 'three'] as $resource) {
             $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.index'));
@@ -282,7 +282,7 @@ class RouteRegistrarTest extends TestCase
             'resource-three'    => RouteRegistrarControllerStubThree::class,
         ]);
 
-        $this->assertCount(21, $this->router->getRoutes());
+        $this->assertCount(24, $this->router->getRoutes());
 
         foreach (['one', 'two', 'three'] as $resource) {
             $this->assertTrue($this->router->getRoutes()->hasNamedRoute('resource-'.$resource.'.index'));
@@ -301,7 +301,7 @@ class RouteRegistrarTest extends TestCase
                      ->resource('users', RouteRegistrarControllerStub::class)
                      ->register();
 
-        $this->assertCount(7, $resource->getRoutes());
+        $this->assertCount(8, $resource->getRoutes());
 
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.index'));
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.create'));
@@ -329,7 +329,7 @@ class RouteRegistrarTest extends TestCase
         $this->router->resource('users', RouteRegistrarControllerStub::class)
                      ->except(['index', 'create', 'store', 'show', 'edit']);
 
-        $this->assertCount(2, $this->router->getRoutes());
+        $this->assertCount(3, $this->router->getRoutes());
 
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.update'));
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
@@ -443,6 +443,22 @@ class RouteRegistrarTest extends TestCase
 
         $this->assertCount(2, $this->router->getRoutes());
 
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.index'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.show'));
+    }
+
+    /**
+     * @depends testUserCanRegisterApiResourceWithOnlyOption
+     */
+    public function testCanRegisterApiResourceWithOptionsMethod()
+    {
+        $this->router->apiResource('users', RouteRegistrarControllerStub::class, [
+            'only' => ['index', 'show', 'store', 'update', 'destroy', 'options'],
+        ]);
+
+        $this->assertCount(6, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.options'));
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.index'));
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.show'));
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1164,7 +1164,7 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->resource('foo', 'FooController');
         $routes = $router->getRoutes();
-        $this->assertCount(7, $routes);
+        $this->assertCount(8, $routes);
 
         $router = $this->getRouter();
         $router->resource('foo', 'FooController', ['only' => ['update']]);
@@ -1182,7 +1182,7 @@ class RoutingRouteTest extends TestCase
         $router->resource('foo', 'FooController', ['except' => ['show', 'destroy']]);
         $routes = $router->getRoutes();
 
-        $this->assertCount(5, $routes);
+        $this->assertCount(6, $routes);
 
         $router = $this->getRouter();
         $router->resource('foo-bars', 'FooController', ['only' => ['show']]);
@@ -1228,8 +1228,8 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foos/{foo}', $routes[3]->uri());
-        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[10]->uri());
+        $this->assertEquals('foos/{foo}', $routes[4]->uri());
+        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[12]->uri());
 
         ResourceRegistrar::setParameters(['foos' => 'oof', 'bazs' => 'b']);
 
@@ -1238,7 +1238,7 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('bars/{bar}/foos/{oof}/bazs/{b}', $routes[3]->uri());
+        $this->assertEquals('bars/{bar}/foos/{oof}/bazs/{b}', $routes[4]->uri());
 
         ResourceRegistrar::setParameters();
         ResourceRegistrar::singularParameters(false);
@@ -1249,22 +1249,22 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foos/{foo}', $routes[3]->uri());
-        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[10]->uri());
+        $this->assertEquals('foos/{foo}', $routes[4]->uri());
+        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[12]->uri());
 
         $router = $this->getRouter();
         $router->resource('foos.bars', 'FooController', ['parameters' => ['foos' => 'foo', 'bars' => 'bar']]);
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[3]->uri());
+        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[4]->uri());
 
         $router = $this->getRouter();
         $router->resource('foos.bars', 'FooController')->parameter('foos', 'foo')->parameter('bars', 'bar');
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[3]->uri());
+        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[4]->uri());
     }
 
     public function testResourceRouteNaming()


### PR DESCRIPTION
Fixes #28018: `ResourceRegistrar` now supports 'OPTIONS' request method for API resources.