### PR TITLE
[5.8] added `$params` argument to `resolve` helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -722,11 +722,12 @@ if (! function_exists('resolve')) {
      * Resolve a service from the container.
      *
      * @param  string  $name
+     * @param  array  $params
      * @return mixed
      */
-    function resolve($name)
+    function resolve($name, array $params = [])
     {
-        return app($name);
+        return app($name, $params);
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -722,12 +722,12 @@ if (! function_exists('resolve')) {
      * Resolve a service from the container.
      *
      * @param  string  $name
-     * @param  array  $params
+     * @param  array  $parameters
      * @return mixed
      */
-    function resolve($name, array $params = [])
+    function resolve($name, array $parameters = [])
     {
-        return app($name, $params);
+        return app($name, $parameters);
     }
 }
 


### PR DESCRIPTION
`$api = resolve('HelpSpot\API');` is an alias for `$api = $this->app->make('HelpSpot\API');`

So, may `$api = resolveWith('HelpSpot\API', ['id' => 1]);`
be an alias for `$api = $this->app->makeWith('HelpSpot\API', ['id' => 1]);`
