### PR TITLE
Fix comment on \Illuminate\Broadcasting\BroadcastManager::resolve

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -165,7 +165,7 @@ class BroadcastManager implements FactoryContract
     }
 
     /**
-     * Resolve the given store.
+     * Resolve the given broadcaster.
      *
      * @param  string  $name
      * @return \Illuminate\Contracts\Broadcasting\Broadcaster


### PR DESCRIPTION
Seems to have been copypasted from `\Illuminate\Cache\CacheManager::resolve`:
```php
    /**
     * Resolve the given store.
     *
```