### PR TITLE
[5.8] Prevent unnecessary JSON UPDATE queries on MySQL

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1145,7 +1145,7 @@ trait HasAttributes
     /**
      * Determine if the new and old values for a given key are equivalent.
      *
-     * @param  string $key
+     * @param  string  $key
      * @param  mixed  $current
      * @return bool
      */
@@ -1165,12 +1165,36 @@ trait HasAttributes
             return $this->fromDateTime($current) ===
                    $this->fromDateTime($original);
         } elseif ($this->hasCast($key)) {
-            return $this->castAttribute($key, $current) ===
-                   $this->castAttribute($key, $original);
+            return $this->originalWithCastIsEquivalent($key, $current, $original);
         }
 
         return is_numeric($current) && is_numeric($original)
                 && strcmp((string) $current, (string) $original) === 0;
+    }
+
+    /**
+     * Determine if the new and old values for a given key with cast are equivalent.
+     *
+     * @param  string  $key
+     * @param  mixed  $current
+     * @param  mixed  $original
+     * @return bool
+     */
+    protected function originalWithCastIsEquivalent($key, $current, $original)
+    {
+        $current = $this->castAttribute($key, $current);
+        $original = $this->castAttribute($key, $original);
+
+        if ($current === $original) {
+            return true;
+        } elseif (! $this->isJsonCastable($key)) {
+            return false;
+        }
+
+        $current = collect($current)->sortKeysRecursively()->all();
+        $original = collect($original)->sortKeysRecursively()->all();
+
+        return $current === $original;
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1667,12 +1667,43 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Sort the collection keys in descending order.
      *
-     * @param  int $options
+     * @param  int  $options
      * @return static
      */
     public function sortKeysDesc($options = SORT_REGULAR)
     {
         return $this->sortKeys($options, true);
+    }
+
+    /**
+     * Sort the collection keys recursively.
+     *
+     * @param  int  $options
+     * @param  bool  $descending
+     * @return static
+     */
+    public function sortKeysRecursively($options = SORT_REGULAR, $descending = false)
+    {
+        $items = $this->sortKeys($options, $descending)->all();
+
+        foreach ($items as $key => $value) {
+            if (is_array($value)) {
+                $items[$key] = (new static($value))->sortKeysRecursively($options, $descending)->all();
+            }
+        }
+
+        return new static($items);
+    }
+
+    /**
+     * Sort the collection keys recursively in descending order.
+     *
+     * @param  int  $options
+     * @return static
+     */
+    public function sortKeysRecursivelyDesc($options = SORT_REGULAR)
+    {
+        return $this->sortKeysRecursively($options, true);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -108,6 +108,29 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty('datetimeAttribute'));
     }
 
+    public function testDirtyOnJsonAttributes()
+    {
+        $array = ['a' => 'foo', 'b' => ['c' => 'bar', 'd' => 'baz']];
+        $model = new EloquentModelCastingStub;
+        $model->setRawAttributes(['objectAttribute' => '{"a": "foo"}']);
+        $model->arrayAttribute = $array;
+        $model->jsonAttribute = $array;
+        $model->collectionAttribute = $array;
+        $model->syncOriginal();
+
+        $array = ['b' => ['d' => 'baz', 'c' => 'bar'], 'a' => 'foo'];
+        $model->objectAttribute = ['a' => 'foo'];
+        $model->arrayAttribute = $array;
+        $model->jsonAttribute = $array;
+        $model->collectionAttribute = $array;
+
+        $this->assertFalse($model->isDirty());
+
+        $model->objectAttribute = ['a' => 'bar'];
+
+        $this->assertTrue($model->isDirty());
+    }
+
     public function testCleanAttributes()
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);
@@ -2230,6 +2253,7 @@ class EloquentModelCastingStub extends Model
         'objectAttribute' => 'object',
         'arrayAttribute' => 'array',
         'jsonAttribute' => 'json',
+        'collectionAttribute' => 'collection',
         'dateAttribute' => 'date',
         'datetimeAttribute' => 'datetime',
         'timestampAttribute' => 'timestamp',

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1031,6 +1031,20 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['b' => 'dayle', 'a' => 'taylor'], $data->sortKeys()->all());
     }
 
+    public function testSortKeysRecursively()
+    {
+        $data = new Collection(['b' => ['d' => 'baz', 'c' => 'bar'], 'a' => 'foo']);
+
+        $this->assertEquals(['a' => 'foo', 'b' => ['c' => 'bar', 'd' => 'baz']], $data->sortKeysRecursively()->all());
+    }
+
+    public function testSortKeysRecursivelyDesc()
+    {
+        $data = new Collection(['a' => 'foo', 'b' => ['c' => 'bar', 'd' => 'baz']]);
+
+        $this->assertEquals(['b' => ['d' => 'baz', 'c' => 'bar'], 'a' => 'foo'], $data->sortKeysRecursivelyDesc()->all());
+    }
+
     public function testReverse()
     {
         $data = new Collection(['zaeed', 'alan']);


### PR DESCRIPTION
MySQL [normalizes](https://dev.mysql.com/doc/refman/en/json.html#json-normalization) JSON strings by adding a space between key and value (`"foo":"bar"` → `"foo": "bar"`) and sorting the keys. This can prevent Eloquent from detecting equivalent values and causes unnecessary `UPDATE` queries:

```php
class User extends Model
{
    protected $casts = ['options' => 'array'];

    protected $guarded = [];
}

Schema::create('users', function ($table) {
    $table->increments('id');
    $table->json('options');
    $table->timestamps();
});

$options = ['b' => 'bar', 'a' => 'foo'];

$user = User::create(['options' => $options]);
$user->refresh();

$user->options = $options;
$user->save(); // Executes unnecessary UPDATE query.
```

For `collection` and `object` casts, a simple value like `['a' => 'foo']` already causes this issue: Due to the additional whitespace, `$current === $original` fails and the created `stdClass`/`Collection` objects aren't identical.

We can fix this by recursively sorting the keys on the current and original value before comparing them. To minimize the overhead, this only happens when the previous comparisons fail.

This PR doesn't apply to nested objects, but they are probably rather rare. 

In Laravel 5.9, we could make `sortKeys()` (optionally) recursive and remove `sortKeysRecursively()`.

Fixes #27946.