### PR TITLE
[5.8] move test classes to their own files

### DIFF
--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -14,13 +14,13 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Pagination\LengthAwarePaginator;
-use Illuminate\Tests\Integration\Database\Post;
-use Illuminate\Tests\Integration\Database\User;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Tests\Integration\Database\Fixtures\Post;
+use Illuminate\Tests\Integration\Database\Fixtures\User;
 use Illuminate\Pagination\AbstractPaginator as Paginator;
 
 class DatabaseEloquentIntegrationTest extends TestCase

--- a/tests/Integration/Database/EloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/EloquentCollectionFreshTest.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Tests\Integration\Database\Fixtures\User;
 
 /**
  * @group integration
@@ -34,9 +34,4 @@ class EloquentCollectionFreshTest extends DatabaseTestCase
 
         $this->assertEmpty($collection->fresh()->filter());
     }
-}
-
-class User extends Model
-{
-    protected $guarded = [];
 }

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Tests\Integration\Database\Fixtures\Post;
 
 /**
  * @group integration
@@ -78,11 +79,6 @@ class EloquentDeleteTest extends TestCase
 
         $this->assertEquals($role->id, RoleObserver::$model->id);
     }
-}
-
-class Post extends Model
-{
-    public $table = 'posts';
 }
 
 class Comment extends Model

--- a/tests/Integration/Database/Fixtures/Post.php
+++ b/tests/Integration/Database/Fixtures/Post.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    public $table = 'posts';
+}

--- a/tests/Integration/Database/Fixtures/User.php
+++ b/tests/Integration/Database/Fixtures/User.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $guarded = [];
+}


### PR DESCRIPTION
Fixing tests:
Currently running `phpunit tests\Database` fails because tests use classes that are not auto-loadable:
```
1) Illuminate\Tests\Database\DatabaseEloquentIntegrationTest::testWhenBaseModelIsIgnoredAllChildModelsAreIgnored
Error: Class 'Illuminate\Tests\Integration\Database\User' not found

/framework/tests/Database/DatabaseEloquentIntegrationTest.php:1526

2) Illuminate\Tests\Database\DatabaseEloquentIntegrationTest::testChildModelsAreIgnored
Error: Class 'Illuminate\Tests\Integration\Database\User' not found

/framework/tests/Database/DatabaseEloquentIntegrationTest.php:1540
```