### PR TITLE
[5.9] Add optimistic locking feature to Eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/OptimisticLockingException.php
+++ b/src/Illuminate/Database/Eloquent/OptimisticLockingException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use RuntimeException;
+
+class OptimisticLockingException extends RuntimeException
+{
+    /**
+     * Instance of the locked Eloquent model.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $model;
+
+    /**
+     * Set the affected Eloquent model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model   $model
+     * @return $this
+     */
+    public function setModel($model)
+    {
+        $this->model = $model;
+
+        return $this;
+    }
+
+    /**
+     * Get the affected Eloquent model.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function getModel()
+    {
+        return $this->model;
+    }
+}

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -759,6 +759,16 @@ class Blueprint
     }
 
     /**
+     * Adds the `lock_version` column for optimistic locking to the table.
+     *
+     * @return \Illuminate\Support\Fluent
+     */
+    public function lockVersion()
+    {
+        return $this->integer('lock_version')->default(1);
+    }
+
+    /**
      * Create a new drop index command on the blueprint.
      *
      * @param  string  $command


### PR DESCRIPTION
This pull requests adds basic optimistic locking functionality to eloquent models.
This has been referenced on https://github.com/laravel/framework/issues/545

### What has changed?
- A new `Blueprint::lockVersion()` method has been added to allow developers to fluently add the needed field to their table to support optimistic locking.
- The `performUpdate` method has been overridden and holds the main logic for the feature. It is not so clean, it can be modified by discussion.
- Each time a new model is updated -if it is dirty- the `lock_version` field is incremented by **1**, so
if the **update** query returns **0**, we assume that the given lock version is old and throw an exception. 
- The optimistic locking check is only performed if the `$optimisticLocking` boolean is set to true in model - which is default set to false-.
