### PR TITLE
[5.8] Accept throwable in report helper typehint

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -659,7 +659,7 @@ if (! function_exists('report')) {
     /**
      * Report an exception.
      *
-     * @param  \Exception  $exception
+     * @param  \Throwable  $exception
      * @return void
      */
     function report($exception)


### PR DESCRIPTION
Since the `report` helper function can handle `Throwable`s, this PR changes the `$exception` param typehint from `Exception` to `Throwable`.