### PR TITLE
[5.8] Add redirect to intended url after registration

### DIFF
--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -35,7 +35,7 @@ trait RegistersUsers
         $this->guard()->login($user);
 
         return $this->registered($request, $user)
-                        ?: redirect($this->redirectPath());
+                        ?: redirect()->intended($this->redirectPath());
     }
 
     /**


### PR DESCRIPTION
When user clicks on protected link he will be redirected to login page, because he need to login\register. After login user redirects to intended URL, but after registration he will be redirected to the home page, what could be frustrating.

This PR adds to registration the same behavior as login. On success it tries to redirect user to intended URL first.