### PR TITLE
Use `Arr::has` in nested elements

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -327,7 +327,13 @@ class Arr
             }
 
             foreach (explode('.', $key) as $segment) {
-                if (static::accessible($subKeyArray) && static::exists($subKeyArray, $segment)) {
+                if ($segment == '*') {
+                    foreach($subKeyArray as $index => $subkey) {
+                        if (static::accessible($subKeyArray) && static::exists($subKeyArray, $index)) {
+                            $subKeyArray = $subKeyArray[$index];
+                        }
+                    }
+                } else if (static::accessible($subKeyArray) && static::exists($subKeyArray, $segment)) {
                     $subKeyArray = $subKeyArray[$segment];
                 } else {
                     return false;


### PR DESCRIPTION
Update `Arr::has` to permit verify if all nested elements has an attribute.

eg.: 
    App\Support\Arr::has(['items'=>[['id'=>1], ['id'=>2]]], 'items.*.id'); // true
    App\Support\Arr::has(['items'=>[['id'=>1],['name'=>'test']]], 'items.*.id'); // false

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
