### PR TITLE
[5.8] `Arr::has` for nested elements

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -333,13 +333,13 @@ class Arr
                             $subKeyArray = $subKeyArray[$index];
                         }
                     }
-                } else if ($segment == '**') {
+                } elseif ($segment == '**') {
                     foreach ($subKeyArray as $index => $subkey) {
                         if (static::accessible($subKeyArray) && static::exists($subKeyArray, $index)) {
                             $subKeyArray = $subKeyArray[$index];
                         }
                     }
-                } else if (static::accessible($subKeyArray) && static::exists($subKeyArray, $segment)) {
+                } elseif (static::accessible($subKeyArray) && static::exists($subKeyArray, $segment)) {
                     $subKeyArray = $subKeyArray[$segment];
                 } else {
                     return false;

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -327,7 +327,19 @@ class Arr
             }
 
             foreach (explode('.', $key) as $segment) {
-                if (static::accessible($subKeyArray) && static::exists($subKeyArray, $segment)) {
+                if ($segment == '*') {
+                    foreach ($subKeyArray as $index => $subkey) {
+                        if (static::accessible($subKeyArray) && static::exists($subKeyArray[$index], $index)) {
+                            $subKeyArray = $subKeyArray[$index];
+                        }
+                    }
+                } else if ($segment == '**') {
+                    foreach ($subKeyArray as $index => $subkey) {
+                        if (static::accessible($subKeyArray) && static::exists($subKeyArray, $index)) {
+                            $subKeyArray = $subKeyArray[$index];
+                        }
+                    }
+                } else if (static::accessible($subKeyArray) && static::exists($subKeyArray, $segment)) {
                     $subKeyArray = $subKeyArray[$segment];
                 } else {
                     return false;

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -358,7 +358,7 @@ class SupportArrTest extends TestCase
         ];
         $this->assertTrue(Arr::has($array, 'products.0.name'));
         $this->assertFalse(Arr::has($array, 'products.0.price'));
-                
+
         $this->assertTrue(Arr::has($array, 'products.**.id'));
         $this->assertFalse(Arr::has($array, 'products.*.id'));
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -352,11 +352,15 @@ class SupportArrTest extends TestCase
 
         $array = [
             'products' => [
+                ['id' => 1],
                 ['name' => 'desk'],
             ],
         ];
         $this->assertTrue(Arr::has($array, 'products.0.name'));
         $this->assertFalse(Arr::has($array, 'products.0.price'));
+                
+        $this->assertTrue(Arr::has($array, 'products.**.id'));
+        $this->assertFalse(Arr::has($array, 'products.*.id'));
 
         $this->assertFalse(Arr::has([], [null]));
         $this->assertFalse(Arr::has(null, [null]));


### PR DESCRIPTION
Update `Arr::has` to verify if nested elements have an attribute.

eg.: 

    // TRUE if in all elements
    App\Support\Arr::has([
        'items'=>[
            ['id'=>1],
            ['id'=>2]
        ]
    ], 'items.*.id');

    // FALSE if not in all elements
    App\Support\Arr::has([
        'items'=>[
            ['id'=>1],
            ['name'=>'laravel']
        ]
    ], 'items.*.id');

    // TRUE if at least one element
    App\Support\Arr::has([
        'items'=>[
            ['id'=>1],
            ['name'=>'laravel']
        ]
    ], 'items.**.id'); 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
