### PR TITLE
[5.8] Corrected test for supports

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1862,6 +1862,21 @@ class SupportCollectionTest extends TestCase
         ], $result->all());
     }
 
+    public function testKeyByObject()
+    {
+        $data = new Collection([
+            ['firstname' => 'Taylor', 'lastname' => 'Otwell', 'locale' => 'US'],
+            ['firstname' => 'Lucas', 'lastname' => 'Michot', 'locale' => 'FR'],
+        ]);
+        $result = $data->keyBy(function ($item, $key) {
+            return new Collection([$key, $item['firstname'], $item['lastname']]);
+        });
+        $this->assertEquals([
+            '[0,"Taylor","Otwell"]' => ['firstname' => 'Taylor', 'lastname' => 'Otwell', 'locale' => 'US'],
+            '[1,"Lucas","Michot"]' => ['firstname' => 'Lucas', 'lastname' => 'Michot', 'locale' => 'FR'],
+        ], $result->all());
+    }
+
     public function testContains()
     {
         $c = new Collection([1, 3, 5]);

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -133,6 +133,7 @@ class SupportMessageBagTest extends TestCase
     {
         $container = new MessageBag;
         $container->setFormat(':message');
+        $this->assertFalse($container->hasAny());
         $container->add('foo', 'bar');
         $container->add('bar', 'foo');
         $container->add('boom', 'baz');

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -30,6 +30,7 @@ class SupportPluralizerTest extends TestCase
         $this->assertEquals('Children', Str::plural('Child'));
         $this->assertEquals('CHILDREN', Str::plural('CHILD'));
         $this->assertEquals('Tests', Str::plural('Test'));
+        $this->assertEquals('children', Str::plural('cHiLd'));
     }
 
     public function testIfEndOfWordPlural()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
**Collection**
- If in keyBy key is Object

**MessageBag**
- If call to hasAny and MessageBag is empty

**Pluralizer**
- If attempt to match the case on two strings is fail