### PR TITLE
[5.8] Added `env()` default value tests

### DIFF
--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -572,6 +572,21 @@ class SupportHelpersTest extends TestCase
         $this->assertNull(env('foo'));
     }
 
+    public function testEnvDefault()
+    {
+        $_SERVER['foo'] = 'bar';
+        $this->assertEquals('bar', env('foo', 'default'));
+
+        $_SERVER['foo'] = '';
+        $this->assertEquals('', env('foo', 'default'));
+
+        unset($_SERVER['foo']);
+        $this->assertEquals('default', env('foo', 'default'));
+
+        $_SERVER['foo'] = null;
+        $this->assertEquals('default', env('foo', 'default'));
+    }
+
     public function testEnvEscapedString()
     {
         $_SERVER['foo'] = '"null"';


### PR DESCRIPTION
The `env()` default value tests covers:
- variable with value -> no fallback
- variable with empty string -> no fallback
- not existing variable -> fallback
- variable with null value -> fallback