### PR TITLE
[5.8] Update forever cache duration for database driver from minutes to seconds

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -202,7 +202,7 @@ class DatabaseStore implements Store
      */
     public function forever($key, $value)
     {
-        return $this->put($key, $value, 5256000);
+        return $this->put($key, $value, 315360000);
     }
 
     /**

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -106,7 +106,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testForeverCallsStoreItemWithReallyLongTime()
     {
         $store = $this->getMockBuilder(DatabaseStore::class)->setMethods(['put'])->setConstructorArgs($this->getMocks())->getMock();
-        $store->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(5256000))->willReturn(true);
+        $store->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(315360000))->willReturn(true);
         $result = $store->forever('foo', 'bar');
         $this->assertTrue($result);
     }


### PR DESCRIPTION
Updates forever cache method for database driver which was not changed after 5.8 update. It is now storing data for roughly 2 months instead of 10 years which it did previously.