### PR TITLE
Send through $columns when asking `getCountForPagination`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -745,7 +745,7 @@ class Builder
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = ($total = $this->toBase()->getCountForPagination())
+        $results = ($total = $this->toBase()->getCountForPagination($columns))
                                     ? $this->forPage($page, $perPage)->get($columns)
                                     : $this->model->newCollection();
 


### PR DESCRIPTION
When asking for a set of paginated results, and defining any colums, this should also be passed through to the `getCountForPagination` function.

I don't know how to test this with PHPUnit, but have tested with my example code. A simple test is to have a table with say multiple duplicate ID's, and then select a distinct paginated results on this duplicated ID.