### PR TITLE
[5.8] Prefer usage of Container Contract

### DIFF
--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Traits\CapsuleManagerTrait;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Connectors\ConnectionFactory;
+use Illuminate\Contracts\Container\Container as ContainerContract;
 
 class Manager
 {
@@ -24,10 +25,10 @@ class Manager
     /**
      * Create a new database capsule manager.
      *
-     * @param  \Illuminate\Container\Container|null  $container
+     * @param  \Illuminate\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Container $container = null)
+    public function __construct(ContainerContract $container = null)
     {
         $this->setupContainer($container ?: new Container);
 

--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -6,6 +6,7 @@ use Illuminate\Queue\QueueManager;
 use Illuminate\Container\Container;
 use Illuminate\Queue\QueueServiceProvider;
 use Illuminate\Support\Traits\CapsuleManagerTrait;
+use Illuminate\Contracts\Container\Container as ContainerContract;
 
 /**
  * @mixin \Illuminate\Queue\QueueManager
@@ -25,10 +26,10 @@ class Manager
     /**
      * Create a new queue capsule manager.
      *
-     * @param  \Illuminate\Container\Container  $container
+     * @param  \Illuminate\Contracts\Container\Container  $container
      * @return void
      */
-    public function __construct(Container $container = null)
+    public function __construct(ContainerContract $container = null)
     {
         $this->setupContainer($container ?: new Container);
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Queue;
 
 use DateTimeInterface;
-use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Contracts\Container\Container;
 
 abstract class Queue
 {

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Queue;
 
 use DateTimeInterface;
-use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\InteractsWithTime;
 
 abstract class Queue
@@ -250,7 +250,7 @@ abstract class Queue
     /**
      * Set the IoC container instance.
      *
-     * @param  \Illuminate\Container\Container  $container
+     * @param  \Illuminate\Contracts\Container\Container  $container
      * @return void
      */
     public function setContainer(Container $container)

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -12,7 +12,7 @@ abstract class Facade
     /**
      * The application instance being facaded.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var \Illuminate\Contracts\Container\Container
      */
     protected static $app;
 
@@ -199,7 +199,7 @@ abstract class Facade
     /**
      * Get the application instance behind the facade.
      *
-     * @return \Illuminate\Contracts\Foundation\Application
+     * @return \Illuminate\Contracts\Container\Container
      */
     public static function getFacadeApplication()
     {
@@ -209,7 +209,7 @@ abstract class Facade
     /**
      * Set the application instance.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Container\Container  $app
      * @return void
      */
     public static function setFacadeApplication($app)

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -10,7 +10,7 @@ abstract class ServiceProvider
     /**
      * The application instance.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var \Illuminate\Contracts\Container\Container
      */
     protected $app;
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -40,7 +40,7 @@ abstract class ServiceProvider
     /**
      * Create a new service provider instance.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Container\Container  $app
      * @return void
      */
     public function __construct($app)


### PR DESCRIPTION
This PR changes some typehints and docblock annotations to `\Illuminate\Contracts\Container\Container`, to make it easier for people to use Illuminate components outside of Laravel. Swapping out the direct `Container` implementation or the `Foundation\Application` contract with the `Container` Contract will allow people to use their own implementation of the contract without their IDE showing warnings or errors because they aren't providing the correct implementation or contract.

This PR will specifically affect `Database\Capsule\Manager`, `Queue\Capsule\Manager`, `Queue\Queue`, `Support\Facades\Facade`, and `Support\ServiceProvider`.