### PR TITLE
[5.8] Fixes clearing facades resolved instances after bootstrap app in testing

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -65,6 +65,8 @@ abstract class TestCase extends BaseTestCase
      */
     protected function setUp(): void
     {
+        Facade::clearResolvedInstances();
+
         if (! $this->app) {
             $this->refreshApplication();
         }
@@ -74,8 +76,6 @@ abstract class TestCase extends BaseTestCase
         foreach ($this->afterApplicationCreatedCallbacks as $callback) {
             call_user_func($callback);
         }
-
-        Facade::clearResolvedInstances();
 
         Model::setEventDispatcher($this->app['events']);
 


### PR DESCRIPTION
This pull request addresses this issue: https://github.com/laravel/framework/issues/28053.

**Note: I am not sure about the regressions this pull request can cause.**

**The problem**: Currently, using a service provider, if someone alters the a mutable object resolved by a  facade, the altered object will be reset **after** bootstrapping the application in the `setUp` in testing environments.

Service provider:
```php
    public function register()
    {
        \App\MyFacade::addData('foo');
    }
```

Test:
```php
    public function testBasicTest()
    {
        dd(\App\MyFacade::getData()); // empty array
    }
```

**The fix**: Clear the resolved facades before bootstrapping the application the mimic the http/console enviroments.