### PR TITLE
[5.8] Fix missed type declaration from base class (Fixes #28056)

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -269,7 +269,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * Get the client IP address.
      *
-     * @return string
+     * @return string|null
      */
     public function ip()
     {


### PR DESCRIPTION
Add null return type for Request::ip() method as it can be returned from base class. Fix for issue #28056 