### PR TITLE
[5.9] Add Optimistic Locking Feature to Eloquent Models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasOptimisticLocking.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasOptimisticLocking.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Eloquent\Concerns;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\OptimisticLockingException;
 
 trait HasOptimisticLocking
 {
@@ -55,17 +54,5 @@ trait HasOptimisticLocking
         $query->where(static::LOCK_VERSION, '=', $this->{static::LOCK_VERSION});
 
         return $query;
-    }
-
-    /**
-     * Throws optimistic locking exception of update failure.
-     *
-     * @throws \Illuminate\Database\Eloquent\OptimisticLockingException
-     */
-    public function throwOptimisticLockingException()
-    {
-        $this->rollbackLockVersion();
-
-        throw (new OptimisticLockingException('Model has been changed during update.'))->setModel($this);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasOptimisticLocking.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasOptimisticLocking.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\OptimisticLockingException;
+
+trait HasOptimisticLocking
+{
+    /**
+     * Indicates if the model should be optimistically lockable.
+     *
+     * @var bool
+     */
+    public $optimisticLocking = false;
+
+    /**
+     * Determine if the model has optimistic locking.
+     *
+     * @return bool
+     */
+    public function usesOptimisticLocking()
+    {
+        return $this->optimisticLocking;
+    }
+
+    /**
+     * Increment lock version for the new update query.
+     *
+     * @return void
+     */
+    public function incrementLockVersion()
+    {
+        $this->setAttribute(static::LOCK_VERSION, $this->getAttribute(static::LOCK_VERSION) + 1);
+    }
+
+    /**
+     * Set optimistic locking version to the original one.
+     *
+     * @return void
+     */
+    public function rollbackLockVersion()
+    {
+        $this->setAttribute(static::LOCK_VERSION, $this->getOriginal(static::LOCK_VERSION));
+    }
+
+    /**
+     * Set the keys for a save update query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function setKeysForOptimisticLocking(Builder $query)
+    {
+        $query->where(static::LOCK_VERSION, '=', $this->{static::LOCK_VERSION});
+
+        return $query;
+    }
+
+    /**
+     * Throws optimistic locking exception of update failure.
+     *
+     * @throws \Illuminate\Database\Eloquent\OptimisticLockingException
+     */
+    public function throwOptimisticLockingException()
+    {
+        $this->rollbackLockVersion();
+
+        throw (new OptimisticLockingException('Model has been changed during update.'))->setModel($this);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -755,7 +755,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $count = $this->setKeysForSaveQuery($query)->update($dirty);
 
             if ($this->usesOptimisticLocking() && $count === 0) {
-                $this->throwOptimisticLockingException();
+                $this->rollbackLockVersion();
+                throw (new OptimisticLockingException('Model has been changed during update.'))->setModel($this);
             }
 
             $this->syncChanges();

--- a/src/Illuminate/Database/Eloquent/OptimisticLockingException.php
+++ b/src/Illuminate/Database/Eloquent/OptimisticLockingException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use RuntimeException;
+
+class OptimisticLockingException extends RuntimeException
+{
+    /**
+     * Related model.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $model;
+
+    /**
+     * Set related model.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @return $this
+     */
+    public function setModel($model)
+    {
+        $this->model = $model;
+
+        return $this;
+    }
+
+    /**
+     * Get related model.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function getModel()
+    {
+        return $this->model;
+    }
+}

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1223,6 +1223,16 @@ class Blueprint
     }
 
     /**
+     * Adds the `lock_version` column to the table.
+     *
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function lockVersion()
+    {
+        return $this->integer('lock_version')->unsigned()->default(1);
+    }
+
+    /**
      * Add a new index command to the blueprint.
      *
      * @param  string  $type


### PR DESCRIPTION
This pull request adds basic optimistic locking functionality to Eloquent models.
This has been issued on https://github.com/laravel/framework/issues/545

### What has changed?
- A new `Blueprint::lockVersion()` method has been added to allow developers to fluently add the needed field to their table to support version based optimistic locking.
- The `performUpdate` method has been overridden and interacts with the `HasOptimisticLocking` concern to implement the feature.
- Each time a new model is updated -if it is dirty- the `lock_version` field is incremented by **1**, so
if the **update** query returns **0**, we assume that the given lock version is old and throw a specific exception. 
- The optimistic locking check is only performed if the `$optimisticLocking` boolean is set to true in the model - which is set to false by default-.

I have already created a package for this, but I thinks this is a functionality needed inside Eloquent itself. Overriding Eloquent methods from external traits may lead to conflicts with other packages, and also relying on model events may lead to unexpected behavior in case one of the listeners returns `false`. Also this seems to be a challenge several developers are facing whenever a single resource may be edited by several processes or users, Other ORMs like [ActiveRecord](https://api.rubyonrails.org/classes/ActiveRecord/Locking/Optimistic.html) and [Hibernate](https://docs.jboss.org/hibernate/orm/4.0/devguide/en-US/html/ch05.html#d0e2225) have already implemented optimistic locking using **Versioning**.

### Example Usage
```php
<?php

Schema::create('blog_posts', function(\Illuminate\Database\Schema\Blueprint $t) {
    $t->bigIncrements('id');
    $t->string('title');
    $t->longText('content');

    $t->lockVersion();

    $t->timestamps();
});

class BlogPost extends \Illuminate\Database\Eloquent\Model {
    public $optimisticLocking = true;
}

Route::put('blog-posts/{id}', function ($id) {

    $post = BlogPost::findOrFail($id);

    $post->lock_version = request('lock_version', 1);

    try {
        $post->title = request('title');
        $post->content = request('content');
        $post->save();
    } catch (\Illuminate\Database\Eloquent\OptimisticLockingException $e) {
        abort(400, $e->getMessage()); // merge / ask to retry / ignore.
    }

});


```