### PR TITLE
[5.8] Add Env class

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Support;
+
+use PhpOption\Option;
+use Dotenv\Environment\DotenvFactory;
+use Dotenv\Environment\Adapter\PutenvAdapter;
+use Dotenv\Environment\Adapter\EnvConstAdapter;
+use Dotenv\Environment\Adapter\ServerConstAdapter;
+
+class Env
+{
+    /**
+     * Gets the value of an environment variable.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return mixed
+     */
+    public static function get($key, $default = null)
+    {
+        static $variables;
+
+        if ($variables === null) {
+            $variables = (new DotenvFactory([new EnvConstAdapter, new PutenvAdapter, new ServerConstAdapter]))->createImmutable();
+        }
+
+        return Option::fromValue($variables->get($key))
+                     ->map(function ($value) {
+                         switch (strtolower($value)) {
+                             case 'true':
+                             case '(true)':
+                                 return true;
+                             case 'false':
+                             case '(false)':
+                                 return false;
+                             case 'empty':
+                             case '(empty)':
+                                 return '';
+                             case 'null':
+                             case '(null)':
+                                 return;
+                         }
+
+                         if (preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)) {
+                             return $matches[2];
+                         }
+
+                         return $value;
+                     })
+                     ->getOrCall(function () use ($default) {
+                         return value($default);
+                     });
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1,16 +1,12 @@
 <?php
 
-use PhpOption\Option;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Env;
 use Illuminate\Support\Str;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Collection;
-use Dotenv\Environment\DotenvFactory;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HigherOrderTapProxy;
-use Dotenv\Environment\Adapter\PutenvAdapter;
-use Dotenv\Environment\Adapter\EnvConstAdapter;
-use Dotenv\Environment\Adapter\ServerConstAdapter;
 
 if (! function_exists('append_config')) {
     /**
@@ -640,38 +636,7 @@ if (! function_exists('env')) {
      */
     function env($key, $default = null)
     {
-        static $variables;
-
-        if ($variables === null) {
-            $variables = (new DotenvFactory([new EnvConstAdapter, new PutenvAdapter, new ServerConstAdapter]))->createImmutable();
-        }
-
-        return Option::fromValue($variables->get($key))
-            ->map(function ($value) {
-                switch (strtolower($value)) {
-                    case 'true':
-                    case '(true)':
-                        return true;
-                    case 'false':
-                    case '(false)':
-                        return false;
-                    case 'empty':
-                    case '(empty)':
-                        return '';
-                    case 'null':
-                    case '(null)':
-                        return;
-                }
-
-                if (preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)) {
-                    return $matches[2];
-                }
-
-                return $value;
-            })
-            ->getOrCall(function () use ($default) {
-                return value($default);
-            });
+        return Env::get($key, $default);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -6,8 +6,8 @@ use stdClass;
 use ArrayAccess;
 use Mockery as m;
 use RuntimeException;
-use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Env;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Optional;
 use Illuminate\Contracts\Support\Htmlable;
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -7,6 +7,7 @@ use ArrayAccess;
 use Mockery as m;
 use RuntimeException;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
 use Illuminate\Contracts\Support\Htmlable;
 
@@ -531,6 +532,7 @@ class SupportHelpersTest extends TestCase
     {
         $_SERVER['foo'] = 'bar';
         $this->assertSame('bar', env('foo'));
+        $this->assertSame('bar', Env::get('foo'));
     }
 
     public function testEnvTrue()


### PR DESCRIPTION
https://github.com/laravel/ideas/issues/1580

Still no breaking change.
This is for users who do not want to use env().

```php
<?php

use Illuminate\Support\Env;

return [
    'name' => Env::get('APP_NAME', 'Laravel'),
];
```

future plan
- Replace all env()
- Deprecate env() and move to `laravel/helpers`