### PR TITLE
[5.8] Add @error blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -13,6 +13,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesComponents,
         Concerns\CompilesConditionals,
         Concerns\CompilesEchos,
+        Concerns\CompilesError,
         Concerns\CompilesHelpers,
         Concerns\CompilesIncludes,
         Concerns\CompilesInjections,

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -13,7 +13,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesComponents,
         Concerns\CompilesConditionals,
         Concerns\CompilesEchos,
-        Concerns\CompilesError,
+        Concerns\CompilesErrors,
         Concerns\CompilesHelpers,
         Concerns\CompilesIncludes,
         Concerns\CompilesInjections,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesError.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesError.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesError
+{
+    /**
+     * Compile the error statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileError($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        return '<?php if ($errors->has('.$expression.')) :
+if (isset($message)) { $messageCache = $message; }
+$message = $errors->first('.$expression.'); ?>';
+    }
+
+    /**
+     * Compile the enderror statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileEnderror($expression)
+    {
+        return '<?php unset($message);
+if (isset($messageCache)) { $message = $messageCache; }
+endif; ?>';
+    }
+}

--- a/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\View\Compilers\Concerns;
 
-trait CompilesError
+trait CompilesErrors
 {
     /**
      * Compile the error statements into valid PHP.

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeErrorTest extends AbstractBladeTestCase
+{
+    public function testErrorsAreCompiled()
+    {
+        $string = '
+@error(\'email\')
+    <span>{{ $message }}</span>
+@enderror';
+        $expected = '
+<?php if ($errors->has(\'email\')) :
+if (isset($message)) { $messageCache = $message; }
+$message = $errors->first(\'email\'); ?>
+    <span><?php echo e($message); ?></span>
+<?php unset($message);
+if (isset($messageCache)) { $message = $messageCache; }
+endif; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
This PR comes out of a popular tweet I wrote: https://twitter.com/calebporzio/status/1111366190444802048

```php
// Before
@if ($errors->has('email'))
    <span>{{ $errors->first('email') }}</span>
@endif
  
// After:
@error('email')
    <span>{{ $message }}</span>
@enderror
```