### PR TITLE
[5.8] Add @is_localhost helper function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -528,7 +528,7 @@ if (! function_exists('is_localhost')) {
      */
     function is_localhost()
     {
-        return isset($_SERVER["SERVER_ADDR"]) && ($_SERVER["SERVER_ADDR"] == '127.0.0.1' || $_SERVER["SERVER_ADDR"] == '::1');
+        return isset($_SERVER['SERVER_ADDR']) && ($_SERVER['SERVER_ADDR'] == '127.0.0.1' || $_SERVER['SERVER_ADDR'] == '::1');
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -524,9 +524,10 @@ if (! function_exists('is_localhost')) {
     /**
      * Check if project is running on localhost or not.
      *
-     * @return boolean
+     * @return bool
      */
-    function is_localhost(){
+    function is_localhost()
+    {
         return isset($_SERVER["SERVER_ADDR"]) && ($_SERVER["SERVER_ADDR"] == '127.0.0.1' || $_SERVER["SERVER_ADDR"] == '::1');
     }
 }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -520,6 +520,17 @@ if (! function_exists('info')) {
     }
 }
 
+if (! function_exists('is_localhost')) {
+    /**
+     * Check if project is running on localhost or not.
+     *
+     * @return boolean
+     */
+    function is_localhost(){
+        return isset($_SERVER["SERVER_ADDR"]) && ($_SERVER["SERVER_ADDR"] == '127.0.0.1' || $_SERVER["SERVER_ADDR"] == '::1');
+    }
+}
+
 if (! function_exists('logger')) {
     /**
      * Log a debug message to the logs.


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR aims to provide a helper function (targeting mostly non-docker users) to those who want to check if their projects are running under a localhost server or not. This functionality is also important to create a generic_asset helper function which can call "asset" or "secure_asset" depending on the value returned by the is_localhost helper. (It will automatically call secure_asset if it is not localhost, for instance). 