### PR TITLE
[5.9] Add Env class

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Support;
+
+use PhpOption\Option;
+use Dotenv\Environment\DotenvFactory;
+use Dotenv\Environment\Adapter\PutenvAdapter;
+use Dotenv\Environment\Adapter\EnvConstAdapter;
+use Dotenv\Environment\Adapter\ServerConstAdapter;
+
+class Env
+{
+    /**
+     * Gets the value of an environment variable.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return mixed
+     */
+    public static function get($key, $default = null)
+    {
+        static $variables;
+
+        if ($variables === null) {
+            $variables = (new DotenvFactory([new EnvConstAdapter, new PutenvAdapter, new ServerConstAdapter]))->createImmutable();
+        }
+
+        return Option::fromValue($variables->get($key))
+                     ->map(function ($value) {
+                         switch (strtolower($value)) {
+                             case 'true':
+                             case '(true)':
+                                 return true;
+                             case 'false':
+                             case '(false)':
+                                 return false;
+                             case 'empty':
+                             case '(empty)':
+                                 return '';
+                             case 'null':
+                             case '(null)':
+                                 return;
+                         }
+
+                         if (preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)) {
+                             return $matches[2];
+                         }
+
+                         return $value;
+                     })
+                     ->getOrCall(function () use ($default) {
+                         return value($default);
+                     });
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1,14 +1,11 @@
 <?php
 
-use PhpOption\Option;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Collection;
-use Dotenv\Environment\DotenvFactory;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HigherOrderTapProxy;
-use Dotenv\Environment\Adapter\EnvConstAdapter;
-use Dotenv\Environment\Adapter\ServerConstAdapter;
 
 if (! function_exists('append_config')) {
     /**
@@ -265,38 +262,7 @@ if (! function_exists('env')) {
      */
     function env($key, $default = null)
     {
-        static $variables;
-
-        if ($variables === null) {
-            $variables = (new DotenvFactory([new EnvConstAdapter, new ServerConstAdapter]))->createImmutable();
-        }
-
-        return Option::fromValue($variables->get($key))
-            ->map(function ($value) {
-                switch (strtolower($value)) {
-                    case 'true':
-                    case '(true)':
-                        return true;
-                    case 'false':
-                    case '(false)':
-                        return false;
-                    case 'empty':
-                    case '(empty)':
-                        return '';
-                    case 'null':
-                    case '(null)':
-                        return;
-                }
-
-                if (preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)) {
-                    return $matches[2];
-                }
-
-                return $value;
-            })
-            ->getOrCall(function () use ($default) {
-                return value($default);
-            });
+        return Env::get($key, $default);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -6,6 +6,7 @@ use stdClass;
 use ArrayAccess;
 use Mockery as m;
 use RuntimeException;
+use Illuminate\Support\Env;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Optional;
 use Illuminate\Contracts\Support\Htmlable;
@@ -531,6 +532,7 @@ class SupportHelpersTest extends TestCase
     {
         $_SERVER['foo'] = 'bar';
         $this->assertSame('bar', env('foo'));
+        $this->assertSame('bar', Env::get('foo'));
     }
 
     public function testEnvTrue()


### PR DESCRIPTION
Again.
https://github.com/laravel/framework/pull/28061

If other packages have global env(), the Laravel project will be broken. It actually happened. 
The dependency package may have env() even if I do not install it myself. 
This PR gives the option not to use env().

```php
<?php

use Illuminate\Support\Env;

return [
    'name' => Env::get('APP_NAME', 'Laravel'),
];
```

It is necessary to consider whether to deprecate env().

## Example of conflict
```
APP_DEBUG=false
```

Laravel env()
(bool)false

Another env()
(string)false
==(bool)true

Debug mode is enabled in production. Very dangerous.