### PR TITLE
[5.8] Add @generic_asset helper function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -516,9 +516,9 @@ if (! function_exists('generic_asset')) {
      */
     function generic_asset($path, $env_value = 'local')
     {
-        if(env('APP_ENV', '') === $env_value){
+        if (env('APP_ENV', '') === $env_value) {
             return app('url')->asset($path);
-        }else{
+        } else {
             return app('url')->secure_asset($path);
         }
     }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -506,6 +506,24 @@ if (! function_exists('factory')) {
     }
 }
 
+if (! function_exists('generic_asset')) {
+    /**
+     * Generate an asset path for the application acording to the APP_ENV value used.
+     *
+     * @param  string  $path
+     * @param  string  $env_value
+     * @return string
+     */
+    function generic_asset($path, $env_value = 'local')
+    {
+        if(env('APP_ENV', '') === $env_value){
+            return app('url')->asset($path);
+        }else{
+            return app('url')->secure_asset($path);
+        }
+    }
+}
+
 if (! function_exists('info')) {
     /**
      * Write some information to the log.


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR aims to provide a helper function to those who want to load an asset generically i.e. being loaded as HTTP or HTTPS according to the APP_ENV value set currently. This functionality is important to help developers use only one call for asset loading no matter what kind of environment they are using.