### PR TITLE
[5.8] Improvements regarding arguments passed to the Gate callbacks

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -462,14 +462,12 @@ class Gate implements GateContract
      */
     protected function callBeforeCallbacks($user, $ability, array $arguments)
     {
-        $arguments = array_merge([$user, $ability], [$arguments]);
-
         foreach ($this->beforeCallbacks as $before) {
             if (! $this->canBeCalledWithUser($user, $before)) {
                 continue;
             }
 
-            if (! is_null($result = $before(...$arguments))) {
+            if (! is_null($result = $before($user, $ability, $arguments))) {
                 return $result;
             }
         }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -342,6 +342,11 @@ class AuthAccessGateTest extends TestCase
 
         $dummy = new AccessGateTestDummy;
 
+        $gate->before(function ($user, $ability, array $arguments) use ($dummy) {
+            $this->assertCount(1, $arguments);
+            $this->assertSame($dummy, $arguments[0]);
+        });
+
         $gate->define('foo', function ($user, $x) use ($dummy) {
             $this->assertEquals($dummy, $x);
 
@@ -357,6 +362,11 @@ class AuthAccessGateTest extends TestCase
 
         $dummy1 = new AccessGateTestDummy;
         $dummy2 = new AccessGateTestDummy;
+
+        $gate->before(function ($user, $ability, array $arguments) use ($dummy1, $dummy2) {
+            $this->assertCount(2, $arguments);
+            $this->assertSame([$dummy1, $dummy2], $arguments);
+        });
 
         $gate->define('foo', function ($user, $x, $y) use ($dummy1, $dummy2) {
             $this->assertEquals($dummy1, $x);

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -348,9 +348,14 @@ class AuthAccessGateTest extends TestCase
         });
 
         $gate->define('foo', function ($user, $x) use ($dummy) {
-            $this->assertEquals($dummy, $x);
+            $this->assertSame($dummy, $x);
 
             return true;
+        });
+
+        $gate->after(function ($user, $ability, $result, array $arguments) use ($dummy) {
+            $this->assertCount(1, $arguments);
+            $this->assertSame($dummy, $arguments[0]);
         });
 
         $this->assertTrue($gate->check('foo', $dummy));
@@ -369,10 +374,15 @@ class AuthAccessGateTest extends TestCase
         });
 
         $gate->define('foo', function ($user, $x, $y) use ($dummy1, $dummy2) {
-            $this->assertEquals($dummy1, $x);
-            $this->assertEquals($dummy2, $y);
+            $this->assertSame($dummy1, $x);
+            $this->assertSame($dummy2, $y);
 
             return true;
+        });
+
+        $gate->after(function ($user, $ability, $result, array $arguments) use ($dummy1, $dummy2) {
+            $this->assertCount(2, $arguments);
+            $this->assertSame([$dummy1, $dummy2], $arguments);
         });
 
         $this->assertTrue($gate->check('foo', [$dummy1, $dummy2]));


### PR DESCRIPTION
### Simplify the arguments passed to the before callbacks

This commit removes some legacy code that was laying around since #12305 was merged.

Before that PR, the arguments were spread out before being passed to the callbacks,
so the user and the ability were merged with the other arguments, before being passed to the callback.

Since then, the arguments are being passed as an array,
so instead of merging the user and the ability with the array of arguments, which is superfluous,
we can directly pass the user, the ability, and the arguments directly to the callback.

This commit doesn't change the existing functionality, and it keeps backwards compatibility.

I have also added some assertions to the tests, since the arguments in the before callbacks were never tested.

### Improve tests for arguments in ability checks

Use `assertSame` because `assertEquals` doesn't compare object references.

Add assertions that the arguments are passed to the after callbacks.