### PR TITLE
[5.8] Fixed: SoftDelete::runSoftDelete and SoftDelete::performDeleteOnModel did not take into account overwrite Model::setKeysForSaveQuery

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -59,7 +59,7 @@ trait SoftDeletes
         if ($this->forceDeleting) {
             $this->exists = false;
 
-            return $this->newModelQuery()->where($this->getKeyName(), $this->getKey())->forceDelete();
+            return $this->setKeysForSaveQuery($this->newModelQuery())->forceDelete();
         }
 
         return $this->runSoftDelete();
@@ -72,7 +72,7 @@ trait SoftDeletes
      */
     protected function runSoftDelete()
     {
-        $query = $this->newModelQuery()->where($this->getKeyName(), $this->getKey());
+        $query = $this->setKeysForSaveQuery($this->newModelQuery());
 
         $time = $this->freshTimestamp();
 

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -104,4 +104,16 @@ class DatabaseSoftDeletingTraitStub
     {
         return defined('static::UPDATED_AT') ? static::UPDATED_AT : 'updated_at';
     }
+
+    public function setKeysForSaveQuery($query)
+    {
+        $query->where($this->getKeyName(), '=', $this->getKeyForSaveQuery());
+
+        return $query;
+    }
+
+    protected function getKeyForSaveQuery()
+    {
+        return 1;
+    }
 }

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -19,7 +19,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         $model = m::mock(DatabaseSoftDeletingTraitStub::class);
         $model->makePartial();
         $model->shouldReceive('newModelQuery')->andReturn($query = m::mock(stdClass::class));
-        $query->shouldReceive('where')->once()->with('id', 1)->andReturn($query);
+        $query->shouldReceive('where')->once()->with('id', '=', 1)->andReturn($query);
         $query->shouldReceive('update')->once()->with([
             'deleted_at' => 'date-time',
             'updated_at' => 'date-time',


### PR DESCRIPTION
- Laravel Version: 5.8.4
- PHP Version: 7.2.4
- Database Driver & Version: MySql
- Issue: #28022 

### Description:
SoftDelete::runSoftDelete and SoftDelete::performDeleteOnModel did not take into account overwrite Model::setKeysForSaveQuery.
I use this for multi-tenancy purposes. Or for use composite primary keys.

Model:
```
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;
use Illuminate\Database\Eloquent\SoftDeletes;

class Shop extends Model
{
    use SoftDeletes;

    public $primaryKey= 'shop_id';

    protected function setKeysForSaveQuery(Builder $query) {
        $query
            ->where('user_id', '=', $this->getAttribute('user_id'))
            ->where('shop_id', '=', $this->getAttribute('shop_id'));

        return $query;
    }
}
```
When running below code:

```
$shop = Shop::find(1);
$shop->delete();
```

Expected query:
`UPDATE shop SET deleted_at = ?, Shop.updated_at = ? WHERE  shop_id = ? AND user_id = ?`

Actual query:
`UPDATE shop SET deleted_at = ?, SHOP.updated_at = ? WHERE shop_id = ?`

Solution is to replace below lines

```
<?php

namespace Illuminate\Database\Eloquent;

trait SoftDeletes
{
     ...
     protected function performDeleteOnModel()
    {
        ...
            return $this->newModelQuery()->where($this->getKeyName(), $this->getKey())->forceDelete();
        }

        ...
    }
     ...
     protected function runSoftDelete()
    {
        $query = $this->newModelQuery()->where($this->getKeyName(), $this->getKey());
        ...
     }
     ...
}
```
To
`return $this->setKeysForSaveQuery($this->newModelQuery())->forceDelete();`
`$query = $this->setKeysForSaveQuery($this->newModelQuery());`