### PR TITLE
[5.8] Add event:list command

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider;
+
+class EventListCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'event:list';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "List the application's events and listeners";
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->table(['Event', 'Listeners'], $this->getEvents());
+    }
+
+    /**
+     * Get all of the events and listeners configured for the application.
+     *
+     * @return array
+     */
+    protected function getEvents()
+    {
+        $events = [];
+
+        foreach ($this->laravel->getProviders(EventServiceProvider::class) as $provider) {
+            $providerEvents = array_merge($provider->discoverEvents(), $provider->listens());
+
+            $events = array_merge_recursive($events, $providerEvents);
+        }
+
+        return collect($events)->map(function ($value, $key) {
+            return ['Event' => $key, 'Listeners' => implode("\n", $value)];
+        })->values()->toArray();
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Providers;
 
-use Illuminate\Foundation\Console\EventListCommand;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Console\TableCommand;
 use Illuminate\Auth\Console\AuthMakeCommand;
@@ -20,6 +19,7 @@ use Illuminate\Foundation\Console\MailMakeCommand;
 use Illuminate\Foundation\Console\OptimizeCommand;
 use Illuminate\Foundation\Console\RuleMakeCommand;
 use Illuminate\Foundation\Console\TestMakeCommand;
+use Illuminate\Foundation\Console\EventListCommand;
 use Illuminate\Foundation\Console\EventMakeCommand;
 use Illuminate\Foundation\Console\ModelMakeCommand;
 use Illuminate\Foundation\Console\RouteListCommand;

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Providers;
 
+use Illuminate\Foundation\Console\EventListCommand;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Console\TableCommand;
 use Illuminate\Auth\Console\AuthMakeCommand;
@@ -93,6 +94,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'Environment' => 'command.environment',
         'EventCache' => 'command.event.cache',
         'EventClear' => 'command.event.clear',
+        'EventList' => 'command.event.list',
         'KeyGenerate' => 'command.key.generate',
         'Migrate' => 'command.migrate',
         'MigrateFresh' => 'command.migrate.fresh',
@@ -427,6 +429,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.event.clear', function ($app) {
             return new EventClearCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerEventListCommand()
+    {
+        $this->app->singleton('command.event.list', function () {
+            return new EventListCommand();
         });
     }
 


### PR DESCRIPTION
This PR adds a `event:list` artisan command which lists all the events discovered in your application and the list of listeners.

<img width="708" alt="Screen Shot 2019-04-01 at 8 27 40 PM" src="https://user-images.githubusercontent.com/4332182/55350440-65cc8d80-54bc-11e9-811b-b354656fcb15.png">
