### PR TITLE
WIP: use contraints on relation declarations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -49,6 +49,20 @@ abstract class Relation
     protected static $constraints = true;
 
     /**
+     * All callables to apply on query relations.
+     *
+     * @var array
+     */
+    protected $queryConstraints = [];
+
+    /**
+     * All constraints to apply on eager loading.
+     *
+     * @var array
+     */
+    protected $eagerConstraints = [];
+
+    /**
      * An array to map class names to their morph names in database.
      *
      * @var array
@@ -107,6 +121,61 @@ abstract class Relation
      * @return void
      */
     abstract public function addEagerConstraints(array $models);
+
+    /**
+     * Add a constraint on the relation query.
+     *
+     * @param Closure $constraint
+     * @return static
+     */
+    public function addConstraint(Closure $constraint)
+    {
+        $this->queryConstraints[] = $constraint;
+        return $this;
+    }
+
+    /**
+     * Add a constraint on the eager load of the relation.
+     *
+     * @param Closure $constraint
+     * @return static
+     */
+    public function addEagerConstraint(Closure $constraint)
+    {
+        $this->eagerConstraints[] = $constraint;
+        return $this;
+    }
+
+    /**
+     * Add a constraint on the relation query.
+     *
+     * @param Builder $query
+     * @return Builder
+     */
+    public function applyQueryConstraints(Builder $query)
+    {
+        foreach ($this->queryConstraints as $constraint) {
+            call_user_func($constraint, $query);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Add a constraint on the relation query.
+     *
+     * @param Builder $query
+     * @param array $models
+     * @return Builder
+     */
+    public function applyEagerConstraints(Builder $query, array $models)
+    {
+        foreach ($this->eagerConstraints as $constraint) {
+            call_user_func($constraint, $query, $models);
+        }
+
+        return $query;
+    }
 
     /**
      * Initialize the relation on a set of models.

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -131,6 +131,7 @@ abstract class Relation
     public function addConstraint(Closure $constraint)
     {
         $this->queryConstraints[] = $constraint;
+
         return $this;
     }
 
@@ -143,6 +144,7 @@ abstract class Relation
     public function addEagerConstraint(Closure $constraint)
     {
         $this->eagerConstraints[] = $constraint;
+
         return $this;
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
We may can define constraints on eager or query relationships call.
This can be usefull to complete query scopes wich depend of the parent model.

This will be apply in addEagerConstraints by the Relation method :

```
public function myRelation()
{
    return $this->hasMany('App\User')->addEagerConstraint(function ($query, $models) {
            // add constraints depending of returned models
    });
}
```


This will be apply in addEagerConstraints by the Relation method :
```
public function myRelation()
{
    return $this->hasMany('App\User')->addConstraint(function ($query) {
            // add constraints only on query relations (not in eagers loading)
    });
}
```