### PR TITLE
[5.8] Make NotificationFake macroable

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
@@ -11,6 +12,8 @@ use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;
 
 class NotificationFake implements NotificationFactory, NotificationDispatcher
 {
+    use Macroable;
+
     /**
      * All of the notifications that have been sent.
      *


### PR DESCRIPTION
I need to perform some custom assertions on the notifications being sent. Rather than adding these specific assertions, let's make it easy for everybody to add custom assertions.