### PR TITLE
[5.8] Handle DATABASE_URL env variable for database connection

### DIFF
--- a/src/Illuminate/Database/UrlParser.php
+++ b/src/Illuminate/Database/UrlParser.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Illuminate\Database;
+
+use function array_map;
+use function parse_str;
+use function parse_url;
+use function array_merge;
+use function preg_replace;
+use function array_key_exists;
+
+class UrlParser
+{
+    private const DRIVER_ALIASES = [
+        'mssql' => 'sqlsrv',
+        'sqlsrv' => 'sqlsrv',
+        'mysql' => 'mysql',
+        'mysql2' => 'mysql', // Amazon RDS, for some weird reason
+        'postgres' => 'pgsql',
+        'postgresql' => 'pgsql',
+        'pgsql' => 'pgsql',
+        'sqlite' => 'sqlite',
+        'sqlite3' => 'sqlite',
+    ];
+    /**
+     * @var array
+     */
+    private $url;
+
+    public function __construct(?string $url)
+    {
+        $this->url = $this->getParsedUrl($url);
+    }
+
+    private function getParsedUrl(?string $url)
+    {
+        // sqlite3?:///... => sqlite3?://localhost/... or else the URL will be invalid
+        $url = preg_replace('#^(sqlite3?):///#', '$1://localhost/', $url);
+
+        $parsedUrl = parse_url($url);
+
+        if ($parsedUrl === false) {
+            throw new \InvalidArgumentException('Malformed parameter "url".');
+        }
+
+        return array_map('rawurldecode', $parsedUrl);
+    }
+
+    public static function parse(?string $url): array
+    {
+        return (new self($url))->parseDatabaseUrl();
+    }
+
+    public function parseDatabaseUrl(): array
+    {
+        return array_merge(
+            $this->getMainAttributes(),
+            $this->parseDatabaseUrlQuery()
+        );
+    }
+
+    private function getMainAttributes(): array
+    {
+        return [
+            'driver' => $this->getDriverFromAlias($this->getInUrl('scheme')),
+            'database' => $this->normalizeDatabaseUrlPath($this->getInUrl('path')),
+            'host' => $this->getInUrl('host'),
+            'port' => $this->getInUrl('port'),
+            'username' => $this->getInUrl('user'),
+            'password' => $this->getInUrl('pass'),
+        ];
+    }
+
+    private function getDriverFromAlias(?string $alias): ?string
+    {
+        if (! $alias) {
+            return null;
+        }
+
+        if (! array_key_exists($alias, self::DRIVER_ALIASES)) {
+            throw new \InvalidArgumentException('No driver found with "'.$alias.'" scheme');
+        }
+
+        return self::DRIVER_ALIASES[$alias];
+    }
+
+    private function getInUrl(string $key): ?string
+    {
+        return $this->url[$key] ?? null;
+    }
+
+    private function normalizeDatabaseUrlPath(?string $urlPath): ?string
+    {
+        if (! $urlPath) {
+            return null;
+        }
+
+        return trim($urlPath, '/');
+    }
+
+    private function parseDatabaseUrlQuery(): array
+    {
+        $queryString = $this->getInUrl('query');
+
+        if (! $queryString) {
+            return [];
+        }
+
+        $query = [];
+
+        parse_str($queryString, $query);
+
+        return $query;
+    }
+}


### PR DESCRIPTION
Hi,
Many cloud providers use urls env var to configure the database connection (often DATABASE_URL), and many ORM (in many languages) handle them too.

The PR aims to handle those urls.

This is inspired by the Doctrine way to handle them.

This is just a draft, coming directly from my projects, feedback and comments are welcomed. 

If someone in the Laravel core team confirms me that this is a wanted feature and that it will be merged, I will be glad to spend more time on it.

**Roadmap**: 

- [ ] Add tests
- [ ] Edit `database.php` config file to use that class
- [ ] Add a redis part
- [ ] See something else?


**Ideas for usage** (to challenge, could be easier):
```php
// database.php
[
	'default' => env('DATABASE_URL') ? 'url' : env('DB_CONNECTION', 'pgsql'),
	'connections' => [
		// ....
		'url' => UrlParser::parse(env('DATABASE_URL')),
	],
	// ....
]
```


Thanks,
Matt'