### PR TITLE
[5.8] Exclude non-existing directories from event discovery

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -89,6 +89,9 @@ class EventServiceProvider extends ServiceProvider
     public function discoverEvents()
     {
         return collect($this->discoverEventsWithin())
+                    ->reject(function ($directory) {
+                        return ! is_dir($directory);
+                    })
                     ->reduce(function ($discovered, $directory) {
                         return array_merge_recursive(
                             $discovered,


### PR DESCRIPTION
As reported in https://github.com/laravel/framework/issues/28092, if the listeners directory doesn't exist an error is thrown:

```
The ".../app/Listeners" directory does not exist.
```