### PR TITLE
[5.8] Fix adding extra space/line that breaks content 

### DIFF
--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -3,8 +3,8 @@
 namespace Illuminate\View\Engines;
 
 use Exception;
-use Illuminate\Support\Str;
 use Throwable;
+use Illuminate\Support\Str;
 use Illuminate\Contracts\View\Engine;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
 
@@ -53,10 +53,11 @@ class PhpEngine implements Engine
         $ob_get_clean = ob_get_clean();
         if ($count > 0) {
             $last_line = $lines[$count - 1];
-            if (Str::startsWith($last_line, "<?php /*") && Str::endsWith($last_line, "*/ ?>")) {
-                $ob_get_clean = Str::replaceLast("\n", "", $ob_get_clean);
+            if (Str::startsWith($last_line, '<?php /*') && Str::endsWith($last_line, '*/ ?>')) {
+                $ob_get_clean = Str::replaceLast('\n', '', $ob_get_clean);
             }
         }
+
         return ltrim($ob_get_clean);
     }
 

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -49,11 +49,13 @@ class PhpEngine implements Engine
         }
 
         $lines = file($__path);
-        $last_line = $lines[count($lines)-1];
+        $count = count($lines);
         $ob_get_clean = ob_get_clean();
-
-        if (Str::startsWith($last_line, "<?php /*") && Str::endsWith($last_line, "*/ ?>")) {
-            $ob_get_clean =  Str::replaceLast("\n", "", $ob_get_clean);
+        if ($count > 0) {
+            $last_line = $lines[$count - 1];
+            if (Str::startsWith($last_line, "<?php /*") && Str::endsWith($last_line, "*/ ?>")) {
+                $ob_get_clean = Str::replaceLast("\n", "", $ob_get_clean);
+            }
         }
         return ltrim($ob_get_clean);
     }

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -53,7 +53,7 @@ class PhpEngine implements Engine
         $ob_get_clean = ob_get_clean();
 
         if (Str::startsWith($last_line, "<?php /*") && Str::endsWith($last_line, "*/ ?>")) {
-            $ob_get_clean =  substr_replace($ob_get_clean ,"", -1);
+            $ob_get_clean =  Str::replaceLast("\n", "", $ob_get_clean);
         }
         return ltrim($ob_get_clean);
     }

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -54,7 +54,7 @@ class PhpEngine implements Engine
         if ($count > 0) {
             $last_line = $lines[$count - 1];
             if (Str::startsWith($last_line, '<?php /*') && Str::endsWith($last_line, '*/ ?>')) {
-                $ob_get_clean = Str::replaceLast('\n', '', $ob_get_clean);
+                $ob_get_clean = Str::replaceLast("\n", '', $ob_get_clean);
             }
         }
 

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -3,6 +3,7 @@
 namespace Illuminate\View\Engines;
 
 use Exception;
+use Illuminate\Support\Str;
 use Throwable;
 use Illuminate\Contracts\View\Engine;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
@@ -47,7 +48,14 @@ class PhpEngine implements Engine
             $this->handleViewException(new FatalThrowableError($e), $obLevel);
         }
 
-        return ltrim(ob_get_clean());
+        $lines = file($__path);
+        $last_line = $lines[count($lines)-1];
+        $ob_get_clean = ob_get_clean();
+
+        if (Str::startsWith($last_line, "<?php /*") && Str::endsWith($last_line, "*/ ?>")) {
+            $ob_get_clean =  substr_replace($ob_get_clean ,"", -1);
+        }
+        return ltrim($ob_get_clean);
     }
 
     /**

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -34,4 +34,10 @@ class ViewPhpEngineTest extends TestCase
 
 ', $engine->get(__DIR__.'/fixtures/basicWithManyWhiteSpacesBeforePath.php'));
     }
+
+    public function testEmpty()
+    {
+        $engine = new PhpEngine;
+        $this->assertEquals('', $engine->get(__DIR__.'/fixtures/empty.php'));
+    }
 }

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -19,4 +19,19 @@ class ViewPhpEngineTest extends TestCase
         $this->assertEquals('Hello World
 ', $engine->get(__DIR__.'/fixtures/basic.php'));
     }
+
+    public function testTrimWhitespace()
+    {
+        $engine = new PhpEngine;
+        $this->assertEquals('Hello World', $engine->get(__DIR__.'/fixtures/basicWithPath.php'));
+    }
+
+    public function testTrimOnlyPathRelatedWhitespace()
+    {
+        $engine = new PhpEngine;
+        $this->assertEquals('Hello World
+
+
+', $engine->get(__DIR__.'/fixtures/basicWithManyWhiteSpacesBeforePath.php'));
+    }
 }

--- a/tests/View/fixtures/basicWithManyWhiteSpacesBeforePath.php
+++ b/tests/View/fixtures/basicWithManyWhiteSpacesBeforePath.php
@@ -1,0 +1,6 @@
+
+Hello World
+
+
+
+<?php /* template path */ ?>

--- a/tests/View/fixtures/basicWithPath.php
+++ b/tests/View/fixtures/basicWithPath.php
@@ -1,0 +1,3 @@
+
+Hello World
+<?php /* template path */ ?>


### PR DESCRIPTION
The pull-request contains the fix for #27996

The main idea is to remove extra line break related to the added path comment during view rendering.
This fix should not affect any line breaks which doesn't relate to added path comment.

I personally don't like the following things in the fix. 

1) If we change a form which is used to represent a path in compiled view, we should not forget to fix a rendering as well (I couldn't write a test for it, it looked quite complicated)

2) Totally we pass through a view 2 times, the first time when including the compiled view, and the second time when checking if it ends with path comment, probably it could be optimized and done with a single pass.

I appreciate if you could advise me how to improve it. 