### PR TITLE
[5.9] fillable _underscore

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use Illuminate\Support\Str;
-
 trait GuardsAttributes
 {
     /**
@@ -151,8 +149,7 @@ trait GuardsAttributes
             return false;
         }
 
-        return empty($this->getFillable()) &&
-            ! Str::startsWith($key, '_');
+        return empty($this->getFillable());
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -956,11 +956,11 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelStub::unguard(false);
     }
 
-    public function testUnderscorePropertiesAreNotFilled()
+    public function testUnderscorePropertiesAreFilled()
     {
         $model = new EloquentModelStub;
         $model->fill(['_method' => 'PUT']);
-        $this->assertEquals([], $model->getAttributes());
+        $this->assertEquals(['_method' => 'PUT'], $model->getAttributes());
     }
 
     public function testGuarded()


### PR DESCRIPTION
Currently setting `$guarded` to an empty array doesn't unguard model fields that starts with underscore (_). This PR disables this special treatment for Laravel 5.9.

### Reasons
1. IMO, disabling this feature doesn't break a Laravel application that is protected against mass assignment. It can only breaks apps that are not guarded against mass assignment by setting $filleable and pass everything from user request to the model constructor.
2. When you don't need mass assignment protection, and you don't want to set `$fillable`,  the current behaviour breaks a few model functionalities, namely `firstOrCreate()` and `findOrNew()`. This is  especially important when working with mongodb, because in mongodb the primary key name is always `_id`.
3. The current behaviour has never been documented. I only happened to know that after it caused a bug in my code.