### PR TITLE
[5.8] Deleted unnecessary check in pagination url window slider

### DIFF
--- a/src/Illuminate/Pagination/UrlWindow.php
+++ b/src/Illuminate/Pagination/UrlWindow.php
@@ -75,10 +75,6 @@ class UrlWindow
     {
         $window = $onEachSide * 2;
 
-        if (! $this->hasPages()) {
-            return ['first' => null, 'slider' => null, 'last' => null];
-        }
-
         // If the current page is very close to the beginning of the page range, we will
         // just render the beginning of the page range, followed by the last 2 of the
         // links in this list, since we will not have room to create a full slider.

--- a/tests/Pagination/UrlWindowTest.php
+++ b/tests/Pagination/UrlWindowTest.php
@@ -82,7 +82,7 @@ class UrlWindowTest extends TestCase
         for ($i = 1; $i <= 8; $i++) {
             $first[$i] = '/?page='.$i;
         }
-        $this->assertEquals(['first' => $first, 'slider' => null, 'last' => [12 => '/?page=12',13 => '/?page=13']], $window->get());
+        $this->assertEquals(['first' => $first, 'slider' => null, 'last' => [12 => '/?page=12', 13 => '/?page=13']], $window->get());
     }
 
     public function testMakeUrlWindow()

--- a/tests/Pagination/UrlWindowTest.php
+++ b/tests/Pagination/UrlWindowTest.php
@@ -68,4 +68,26 @@ class UrlWindowTest extends TestCase
 
         $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => $slider, 'last' => [12 => '/?page=12', 13 => '/?page=13']], $window->get());
     }
+
+    public function testGetUrlSliderTooCloseToBeginning()
+    {
+        $array = [];
+        for ($i = 1; $i <= 13; $i++) {
+            $array[$i] = 'item'.$i;
+        }
+        $p = new LengthAwarePaginator($array, count($array), 1, 1);
+        $window = new UrlWindow($p);
+
+        $first = [];
+        for ($i = 1; $i <= 8; $i++) {
+            $first[$i] = '/?page='.$i;
+        }
+        $this->assertEquals(['first' => $first, 'slider' => null, 'last' => [12 => '/?page=12',13 => '/?page=13']], $window->get());
+    }
+
+    public function testMakeUrlWindow()
+    {
+        $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
+        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => null, 'last' => null], UrlWindow::make($p));
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
UrlWindow `get()` check if has pages 

Also added tests
- call make in UrlWindow
- if slider too close to beginning