### PR TITLE
[5.8] Allow ShouldDiscoverEvents to return a local property

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -23,7 +23,7 @@ class EventServiceProvider extends ServiceProvider
     protected $subscribe = [];
     
     /**
-     * Should automatically discover events and listeners
+     * Should automatically discover events and listeners.
      *
      * @var bool
      */

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -21,6 +21,13 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $subscribe = [];
+    
+    /**
+     * Should automatically discover events and listeners
+     *
+     * @var bool
+     */
+    protected $discover = false;
 
     /**
      * Register the application's event listeners.
@@ -78,7 +85,7 @@ class EventServiceProvider extends ServiceProvider
      */
     public function shouldDiscoverEvents()
     {
-        return false;
+        return $this->discover;
     }
 
     /**


### PR DESCRIPTION
This will allow the user to not override the method, but instead, just override the variable, since this method only needs to return a boolean.

This also allows to use logic inside the method.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
