### PR TITLE
[5.8] Add class group to route

### DIFF
--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -40,7 +40,7 @@ class RouteGroup
      */
     protected static function formatClass($new, $old)
     {
-        return empty($new['class']) ? $old['class'] : $new['class'];
+        return $new['class'] ?? $old['class'] ?? null;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -30,7 +30,7 @@ class RouteGroup
             $old, ['namespace', 'prefix', 'where', 'as']
         ), $new);
     }
-    
+
     /**
      * Format the class for the new group attributes.
      *

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -20,6 +20,7 @@ class RouteGroup
         }
 
         $new = array_merge(static::formatAs($new, $old), [
+            'class' => static::formatClass($new, $old),
             'namespace' => static::formatNamespace($new, $old),
             'prefix' => static::formatPrefix($new, $old),
             'where' => static::formatWhere($new, $old),
@@ -28,6 +29,18 @@ class RouteGroup
         return array_merge_recursive(Arr::except(
             $old, ['namespace', 'prefix', 'where', 'as']
         ), $new);
+    }
+    
+    /**
+     * Format the class for the new group attributes.
+     *
+     * @param  array  $new
+     * @param  array  $old
+     * @return string|null
+     */
+    protected static function formatClass($new, $old)
+    {
+        return empty($new['class']) ? $old['class'] : $new['class'];
     }
 
     /**

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -19,6 +19,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\RouteRegistrar domain(string $value)
  * @method \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
  * @method \Illuminate\Routing\RouteRegistrar name(string $value)
+ * @method \Illuminate\Routing\RouteRegistrar class(string  $class)
  * @method \Illuminate\Routing\RouteRegistrar namespace(string $value)
  * @method \Illuminate\Routing\RouteRegistrar prefix(string  $prefix)
  * @method \Illuminate\Routing\RouteRegistrar where(array  $where)
@@ -54,7 +55,7 @@ class RouteRegistrar
      * @var array
      */
     protected $allowedAttributes = [
-        'as', 'domain', 'middleware', 'name', 'namespace', 'prefix', 'where',
+        'as', 'domain', 'middleware', 'name', 'class', 'namespace', 'prefix', 'where',
     ];
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -531,7 +531,7 @@ class Router implements RegistrarContract, BindingRegistrar
     {
         $group = end($this->groupStack);
 
-        return isset($group['class']) ? $group['class'] . '@' . $method_name : $method_name;
+        return isset($group['class']) ? $group['class'].'@'.$method_name : $method_name;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -520,7 +520,7 @@ class Router implements RegistrarContract, BindingRegistrar
 
         return $action;
     }
-    
+
     /**
      * Prepend the last group class onto the use clause.
      *

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -509,6 +509,7 @@ class Router implements RegistrarContract, BindingRegistrar
         // has the proper clause for this property. Then we can simply set the name
         // of the controller on the action and return the action array for usage.
         if (! empty($this->groupStack)) {
+            $action['uses'] = $this->prependGroupClass($action['uses']);
             $action['uses'] = $this->prependGroupNamespace($action['uses']);
         }
 
@@ -518,6 +519,19 @@ class Router implements RegistrarContract, BindingRegistrar
         $action['controller'] = $action['uses'];
 
         return $action;
+    }
+    
+    /**
+     * Prepend the last group class onto the use clause.
+     *
+     * @param  string  $method_name
+     * @return string
+     */
+    protected function prependGroupClass($method_name)
+    {
+        $group = end($this->groupStack);
+
+        return isset($group['class']) ? $group['class'] . '@' . $method_name : $method_name;
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -905,21 +905,21 @@ class RoutingRouteTest extends TestCase
     public function testGroupMerging()
     {
         $old = ['prefix' => 'foo/bar/'];
-        $this->assertEquals(['prefix' => 'foo/bar/baz', 'namespace' => null, 'where' => []], RouteGroup::merge(['prefix' => 'baz'], $old));
+        $this->assertEquals(['prefix' => 'foo/bar/baz', 'class' => null, 'namespace' => null, 'where' => []], RouteGroup::merge(['prefix' => 'baz'], $old));
 
         $old = ['domain' => 'foo'];
-        $this->assertEquals(['domain' => 'baz', 'prefix' => null, 'namespace' => null, 'where' => []], RouteGroup::merge(['domain' => 'baz'], $old));
+        $this->assertEquals(['domain' => 'baz', 'prefix' => null, 'class' => null, 'namespace' => null, 'where' => []], RouteGroup::merge(['domain' => 'baz'], $old));
 
         $old = ['as' => 'foo.'];
-        $this->assertEquals(['as' => 'foo.bar', 'prefix' => null, 'namespace' => null, 'where' => []], RouteGroup::merge(['as' => 'bar'], $old));
+        $this->assertEquals(['as' => 'foo.bar', 'prefix' => null, 'class' => null, 'namespace' => null, 'where' => []], RouteGroup::merge(['as' => 'bar'], $old));
 
         $old = ['where' => ['var1' => 'foo', 'var2' => 'bar']];
-        $this->assertEquals(['prefix' => null, 'namespace' => null, 'where' => [
+        $this->assertEquals(['prefix' => null, 'class' => null, 'namespace' => null, 'where' => [
             'var1' => 'foo', 'var2' => 'baz', 'var3' => 'qux',
         ]], RouteGroup::merge(['where' => ['var2' => 'baz', 'var3' => 'qux']], $old));
 
         $old = [];
-        $this->assertEquals(['prefix' => null, 'namespace' => null, 'where' => [
+        $this->assertEquals(['prefix' => null, 'class' => null, 'namespace' => null, 'where' => [
             'var1' => 'foo', 'var2' => 'bar',
         ]], RouteGroup::merge(['where' => ['var1' => 'foo', 'var2' => 'bar']], $old));
     }


### PR DESCRIPTION
This functionality will help to simplify writing of routes in cases where one controller has many methods that are tied behind the routes. We will be able to group routes by one controller.

Example:

```
Route::class('ItemController')->group(function () {
    Route::get('get-approved', 'getApproved');
    Route::post('approve/{item}', 'approve');
    Route::post('suspend/{item}', 'suspend');
});
```