### PR TITLE
[5.8] Add keyBy to hasMany relation and Collection::mapToDictionary

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -29,6 +29,8 @@ abstract class HasOneOrMany extends Relation
      */
     protected static $selfJoinCount = 0;
 
+    protected $keyBy = null;
+
     /**
      * Create a new has one or many relationship instance.
      *
@@ -157,6 +159,19 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Set the key by with results of the relationship are returned.
+     *
+     * @param string|callable $keyBy
+     * @return $this
+     */
+    public function keyBy($keyBy)
+    {
+        $this->keyBy = $keyBy;
+
+        return $this;
+    }
+
+    /**
      * Build model dictionary keyed by the relation's foreign key.
      *
      * @param  \Illuminate\Database\Eloquent\Collection  $results
@@ -168,7 +183,7 @@ abstract class HasOneOrMany extends Relation
 
         return $results->mapToDictionary(function ($result) use ($foreign) {
             return [$result->{$foreign} => $result];
-        })->all();
+        }, $this->keyBy)->all();
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1086,10 +1086,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * The callback should return an associative array with a single key/value pair.
      *
-     * @param  callable  $callback
+     * @param callable $callback
+     * @param string|callable $keyBy
      * @return static
      */
-    public function mapToDictionary(callable $callback)
+    public function mapToDictionary(callable $callback, $keyBy = null)
     {
         $dictionary = [];
 
@@ -1104,7 +1105,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 $dictionary[$key] = [];
             }
 
-            $dictionary[$key][] = $value;
+            if ($keyBy) {
+                $innerKey = $this->useAsCallable($keyBy) ? $keyBy($item) : data_get($item, $keyBy);
+                $dictionary[$key][$innerKey] = $value;
+            } else {
+                $dictionary[$key][] = $value;
+            }
         }
 
         return new static($dictionary);

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -234,6 +234,84 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertNull($models[2]->foo);
     }
 
+    public function testModelsAreProperlyMatchedToParentsWithKeyByAsString()
+    {
+        $relation = $this->getRelation()
+            ->keyBy('keyByField');
+
+        $result1 = new EloquentHasManyModelStub;
+        $result1->foreign_key = 1;
+        $result1->keyByField = 3;
+        $result2 = new EloquentHasManyModelStub;
+        $result2->foreign_key = 2;
+        $result2->keyByField = 4;
+        $result3 = new EloquentHasManyModelStub;
+        $result3->foreign_key = 2;
+        $result3->keyByField = 5;
+
+        $model1 = new EloquentHasManyModelStub;
+        $model1->id = 1;
+        $model2 = new EloquentHasManyModelStub;
+        $model2->id = 2;
+        $model3 = new EloquentHasManyModelStub;
+        $model3->id = 3;
+
+        $relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function ($array) {
+            return new Collection($array);
+        });
+        $models = $relation->match([$model1, $model2, $model3], new Collection([$result1, $result2, $result3]), 'foo');
+
+        $this->assertEquals(1, $models[0]->foo[3]->foreign_key);
+        $this->assertEquals(3, $models[0]->foo[3]->keyByField);
+        $this->assertCount(1, $models[0]->foo);
+        $this->assertEquals(2, $models[1]->foo[4]->foreign_key);
+        $this->assertEquals(4, $models[1]->foo[4]->keyByField);
+        $this->assertEquals(2, $models[1]->foo[5]->foreign_key);
+        $this->assertEquals(5, $models[1]->foo[5]->keyByField);
+        $this->assertCount(2, $models[1]->foo);
+        $this->assertNull($models[2]->foo);
+    }
+
+    public function testModelsAreProperlyMatchedToParentsWithKeyByAsCallable()
+    {
+        $relation = $this->getRelation()
+            ->keyBy(function ($item) {
+                return 2 * $item->keyByField;
+            });
+
+        $result1 = new EloquentHasManyModelStub;
+        $result1->foreign_key = 1;
+        $result1->keyByField = 3;
+        $result2 = new EloquentHasManyModelStub;
+        $result2->foreign_key = 2;
+        $result2->keyByField = 4;
+        $result3 = new EloquentHasManyModelStub;
+        $result3->foreign_key = 2;
+        $result3->keyByField = 5;
+
+        $model1 = new EloquentHasManyModelStub;
+        $model1->id = 1;
+        $model2 = new EloquentHasManyModelStub;
+        $model2->id = 2;
+        $model3 = new EloquentHasManyModelStub;
+        $model3->id = 3;
+
+        $relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function ($array) {
+            return new Collection($array);
+        });
+        $models = $relation->match([$model1, $model2, $model3], new Collection([$result1, $result2, $result3]), 'foo');
+
+        $this->assertEquals(1, $models[0]->foo[6]->foreign_key);
+        $this->assertEquals(3, $models[0]->foo[6]->keyByField);
+        $this->assertCount(1, $models[0]->foo);
+        $this->assertEquals(2, $models[1]->foo[8]->foreign_key);
+        $this->assertEquals(4, $models[1]->foo[8]->keyByField);
+        $this->assertEquals(2, $models[1]->foo[10]->foreign_key);
+        $this->assertEquals(5, $models[1]->foo[10]->keyByField);
+        $this->assertCount(2, $models[1]->foo);
+        $this->assertNull($models[2]->foo);
+    }
+
     public function testCreateManyCreatesARelatedModelForEachRecord()
     {
         $records = [

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1525,6 +1525,50 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => [0, 4], 2 => [1, 3], 3 => [2]], $groups->toArray());
     }
 
+    public function testMapToDictionaryWithKeyByAsString()
+    {
+        $data = new Collection([
+            ['id' => 1, 'name' => 'A', 'key' => 4],
+            ['id' => 2, 'name' => 'B', 'key' => 3],
+            ['id' => 3, 'name' => 'C', 'key' => 2],
+            ['id' => 4, 'name' => 'B', 'key' => 1],
+        ]);
+
+        $groups = $data->mapToDictionary(
+            function ($item, $key) {
+                return [$item['name'] => $item['id']];
+            },
+            'key'
+        );
+
+        $this->assertInstanceOf(Collection::class, $groups);
+        $this->assertEquals(['A' => [4 => 1], 'B' => [3 => 2, 1 => 4], 'C' => [2 => 3]], $groups->toArray());
+        $this->assertIsArray($groups['A']);
+    }
+
+    public function testMapToDictionaryWithKeyByAsCallable()
+    {
+        $data = new Collection([
+            ['id' => 1, 'name' => 'A'],
+            ['id' => 2, 'name' => 'B'],
+            ['id' => 3, 'name' => 'C'],
+            ['id' => 4, 'name' => 'B'],
+        ]);
+
+        $groups = $data->mapToDictionary(
+            function ($item, $key) {
+                return [$item['name'] => $item['id']];
+            },
+            function ($item) {
+                return 2 * $item['id'];
+            }
+        );
+
+        $this->assertInstanceOf(Collection::class, $groups);
+        $this->assertEquals(['A' => [2 => 1], 'B' => [4 => 2, 8 => 4], 'C' => [6 => 3]], $groups->toArray());
+        $this->assertIsArray($groups['A']);
+    }
+
     public function testMapToGroups()
     {
         $data = new Collection([


### PR DESCRIPTION
This adds possibility to have related models in many-to-many relationship attached to the parent model by defined key values. Usually it would be related model `id`.

call: `$users = User::with('groups')->all()`

current: `$user->groups = [0 => $group];`

New usage with keyBy:
```
public function groups()
{
return $this->hasMany(Group::class)->keyBy('id'); // can be string or callable
}
```
result: `$user->groups = [$group->id => $group];`

This is useful in case there is a need to manipulate pivot records in mass.
Ex: users/groups grid where grid fields are some value in pivot record and not all pivot records exist

This implementation does not change current behaviour. 
It can be changed to use related model primary key (`id`) by default but that would change current behaviour.

Breaking change in case someone has overridden `Collection::mapToDictionary` method as there is new method parameter `$keyBy`.

It would be nice to have ability to specify keyBy dynamically within `with(...)` call, but this goes beyond my knowledge at the moment.