### PR TITLE
[5.8] Refactor DiscoverEvents::within()

### DIFF
--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -19,17 +19,12 @@ class DiscoverEvents
      */
     public static function within($listenerPath, $basePath)
     {
-        $listenerEvents = collect(static::getListenerEvents((new Finder)
-                    ->files()
-                    ->in($listenerPath), $basePath));
-
-        return $listenerEvents->values()
-                ->zip($listenerEvents->keys()->all())
-                ->reduce(function ($carry, $listenerEventPair) {
-                    $carry[$listenerEventPair[0]][] = $listenerEventPair[1];
-
-                    return $carry;
-                }, []);
+        return collect(static::getListenerEvents((new Finder)
+            ->files()
+            ->in($listenerPath), $basePath))
+            ->mapToDictionary(function ($event, $listener) {
+                return [$event => $listener];
+            })->all();
     }
 
     /**


### PR DESCRIPTION
The pairs of listeners and events can be mapped to groups of listeners keyed by the event  name.

By using `mapToDictionary` we can void zipping the pairs and then unzipping them while reducing.