### PR TITLE
[5.8] chunk preserve keys

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1568,9 +1568,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Chunk the underlying collection array.
      *
      * @param  int  $size
+     * @param  boolean $preserveKeys
      * @return static
      */
-    public function chunk($size)
+    public function chunk($size, $preserveKeys = true)
     {
         if ($size <= 0) {
             return new static;
@@ -1578,7 +1579,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $chunks = [];
 
-        foreach (array_chunk($this->items, $size, true) as $chunk) {
+        foreach (array_chunk($this->items, $size, $preserveKeys) as $chunk) {
             $chunks[] = new static($chunk);
         }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1568,7 +1568,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Chunk the underlying collection array.
      *
      * @param  int  $size
-     * @param  boolean $preserveKeys
+     * @param  bool $preserveKeys
      * @return static
      */
     public function chunk($size, $preserveKeys = true)

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1082,6 +1082,18 @@ class SupportCollectionTest extends TestCase
         );
     }
 
+    public function testChunkWhenNotPreserveKeys()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $data = $data->chunk(3, false);
+
+        $this->assertInstanceOf(Collection::class, $data);
+        $this->assertInstanceOf(Collection::class, $data[0]);
+        $this->assertCount(4, $data);
+        $this->assertEquals([1, 2, 3], $data[0]->toArray());
+        $this->assertEquals([0 => 10], $data[3]->toArray());
+    }
+
     public function testEvery()
     {
         $c = new Collection([]);


### PR DESCRIPTION
This PR adds the option of the chunk method to preserve the array keys

Before:
```php
$data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
$data = $data->chunk(3);

// output:
Illuminate\Support\Collection {
  #items: array:4 [
    0 => Illuminate\Support\Collection {
      #items: array:3 [
        0 => 1
        1 => 2
        2 => 3
      ]
    }
    1 => Illuminate\Support\Collection {
      #items: array:3 [
        3 => 4
        4 => 5
        5 => 6
      ]
    }
    2 => Illuminate\Support\Collection {
      #items: array:3 [
        6 => 7
        7 => 8
        8 => 9
      ]
    }
    3 => Illuminate\Support\Collection {
      #items: array:1 [
        9 => 10
      ]
    }
  ]
}
```

After:
```php
$data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
$data = $data->chunk(3, false);

Illuminate\Support\Collection {
  #items: array:4 [
    0 => Illuminate\Support\Collection {
      #items: array:3 [
        0 => 1
        1 => 2
        2 => 3
      ]
    }
    1 => Illuminate\Support\Collection {
      #items: array:3 [
        0 => 4
        1 => 5
        2 => 6
      ]
    }
    2 => Illuminate\Support\Collection {
      #items: array:3 [
        0 => 7
        1 => 8
        2 => 9
      ]
    }
    3 => Illuminate\Support\Collection {
      #items: array:1 [
        0 => 10
      ]
    }
  ]
}
```