### PR TITLE
[5.8] Allow lock to be configured in local filesystems

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -159,8 +159,10 @@ class FilesystemManager implements FactoryContract
             ? LocalAdapter::SKIP_LINKS
             : LocalAdapter::DISALLOW_LINKS;
 
+        $lock = $config['lock'] ?? LOCK_EX;
+
         return $this->adapt($this->createFlysystem(new LocalAdapter(
-            $config['root'], LOCK_EX, $links, $permissions
+            $config['root'], $lock, $links, $permissions
         ), $config));
     }
 


### PR DESCRIPTION
The Local adapter from Flysystem uses a lock for read/writes by default, but it allows this parameter to be changed in the constructor: https://flysystem.thephpleague.com/docs/adapter/local/

This commit allows developers to change this behavior in the `filesystems.php` configuration, because currently `LOCK_EX` is hardcoded:

```php
'local' => [
    'driver' => 'local',
    'root' => storage_path('app'),
    'lock' => 0,
],
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
