### PR TITLE
[5.8] Allow to call macros directly on Date

### DIFF
--- a/src/Illuminate/Support/DateFactory.php
+++ b/src/Illuminate/Support/DateFactory.php
@@ -212,7 +212,8 @@ class DateFactory
         $dateClass = static::$dateClass ?: $defaultClassName;
 
         // Check if date can be created using public class method...
-        if (method_exists($dateClass, $method)) {
+        if (method_exists($dateClass, $method) ||
+            method_exists($dateClass, 'hasMacro') && $dateClass::hasMacro($method)) {
             return $dateClass::$method(...$parameters);
         }
 

--- a/tests/Support/DateFacadeTest.php
+++ b/tests/Support/DateFacadeTest.php
@@ -92,4 +92,13 @@ class DateFacadeTest extends TestCase
     {
         DateFactory::use(42);
     }
+
+    public function testMacro()
+    {
+        Date::macro('returnNonDate', function () {
+            return 'string';
+        });
+
+        $this->assertSame('string', Date::returnNonDate());
+    }
 }


### PR DESCRIPTION
The following modification on DateFactory.php avoid the test below to throw an exception: allows macros that can be called statically and that return values that are note dates to be called directly on the Date facade.