### PR TITLE
[5.8] Add validation rule to verify if attribute is multiple of given number

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -498,8 +498,8 @@ trait ValidatesAttributes
         $this->requireParameterCount(1, $parameters, 'multiple_of');
         $this->shouldBeNumeric($attribute, 'multiple_of');
 
-        if ((float) $parameters[0] === 0) {
-            return (float) $value === 0;
+        if ((float) $parameters[0] === 0.0) {
+            return (float) $value === 0.0;
         }
 
         return fmod($value, $parameters[0]) === 0.0;

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -486,6 +486,26 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is a multiple of given number.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateMultipleOf($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'multiple_of');
+        $this->shouldBeNumeric($attribute, 'multiple_of');
+
+        if ((int) $parameters[0] === 0) {
+            return (int) $value === 0;
+        }
+
+        return $parameters[0] !== 0 &&  $value % $parameters[0] === 0;
+    }
+
+    /**
      * Validate the dimensions of an image matches the given values.
      *
      * @param  string $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -498,11 +498,11 @@ trait ValidatesAttributes
         $this->requireParameterCount(1, $parameters, 'multiple_of');
         $this->shouldBeNumeric($attribute, 'multiple_of');
 
-        if ((int) $parameters[0] === 0) {
-            return (int) $value === 0;
+        if ((float) $parameters[0] === 0) {
+            return (float) $value === 0;
         }
 
-        return $value % $parameters[0] === 0;
+        return fmod($value, $parameters[0]) === 0.0;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -502,7 +502,7 @@ trait ValidatesAttributes
             return (int) $value === 0;
         }
 
-        return $parameters[0] !== 0 &&  $value % $parameters[0] === 0;
+        return $value % $parameters[0] === 0;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1413,6 +1413,29 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => '+12.3'], ['foo' => 'digits_between:1,6']);
         $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['foo' => '24'], ['foo' => 'multiple_of:5']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '24'], ['foo' => 'multiple_of:0']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '24'], ['foo' => 'multiple_of:-4']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '24'], ['foo' => 'multiple_of:4']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '-24'], ['foo' => 'multiple_of:-4']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '0'], ['foo' => 'multiple_of:0']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '0'], ['foo' => 'multiple_of:5']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateSize()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1422,8 +1422,11 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '24'], ['foo' => 'multiple_of:0']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => '24'], ['foo' => 'multiple_of:-4']);
+        $v = new Validator($trans, ['foo' => '24'], ['foo' => 'multiple_of:4.1']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '24'], ['foo' => 'multiple_of:-4']);
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => '24'], ['foo' => 'multiple_of:4']);
         $this->assertTrue($v->passes());


### PR DESCRIPTION
This PR adds a "multipleOf" validation rule. We verify if attribute is a multiple of given number. This is currently not achieved by available validation rules.

Example of how to use it.

```
    protected function create(Request $request)
    {
        $request->validate([
            'num' => 'multiple_of:15',
        ]);
    }
```

End users could benefit from it if they are working with currency, time, distance etc where they need to validate if attribute is a multiple of certain number. For example: When working with calendar, user needs to only accept appointments of length that are multiple of 15. (15 min, 30 mins etc)