### PR TITLE
[5.8] Specify client charset in PDO_MYSQL DSN and PDO_PGSQL DSN

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -116,7 +116,15 @@ class MySqlConnector extends Connector implements ConnectorInterface
      */
     protected function getSocketDsn(array $config)
     {
-        return "mysql:unix_socket={$config['unix_socket']};dbname={$config['database']}";
+        $dsn = "mysql:unix_socket={$config['unix_socket']};dbname={$config['database']}";
+
+        // "set names" has only effect on server charset.
+        // We should specify client charset on DSN for security reason.
+        if (isset($config['charset'])) {
+            $dsn .= ";charset={$config['charset']}";
+        }
+
+        return $dsn;
     }
 
     /**
@@ -127,11 +135,19 @@ class MySqlConnector extends Connector implements ConnectorInterface
      */
     protected function getHostDsn(array $config)
     {
-        extract($config, EXTR_SKIP);
+        $dsn = "mysql:host={$config['host']};dbname={$config['database']}";
 
-        return isset($port)
-                    ? "mysql:host={$host};port={$port};dbname={$database}"
-                    : "mysql:host={$host};dbname={$database}";
+        if (isset($config['port'])) {
+            $dsn .= ";port={$config['port']}";
+        }
+
+        // "set names" has only effect on server charset.
+        // We should specify client charset on DSN for security reason.
+        if (isset($config['charset'])) {
+            $dsn .= ";charset={$config['charset']}";
+        }
+
+        return $dsn;
     }
 
     /**

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -140,17 +140,24 @@ class PostgresConnector extends Connector implements ConnectorInterface
         // First we will create the basic DSN setup as well as the port if it is in
         // in the configuration options. This will give us the basic DSN we will
         // need to establish the PDO connections and return them back for use.
-        extract($config, EXTR_SKIP);
 
-        $host = isset($host) ? "host={$host};" : '';
+        $dsn = "pgsql:dbname={$config['database']}";
 
-        $dsn = "pgsql:{$host}dbname={$database}";
+        if (isset($config['host'])) {
+            $dsn .= ";host={$config['host']}";
+        }
 
         // If a port was specified, we will add it to this Postgres DSN connections
         // format. Once we have done that we are ready to return this connection
         // string back out for usage, as this has been fully constructed here.
         if (isset($config['port'])) {
-            $dsn .= ";port={$port}";
+            $dsn .= ";port={$config['port']}";
+        }
+
+        // "set names" has only effect on server charset.
+        // We should specify client charset on DSN for security reason.
+        if (isset($config['charset'])) {
+            $dsn .= ";options='--client_encoding={$config['charset']}'";
         }
 
         return $this->addSslOptions($dsn, $config);

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -45,9 +45,9 @@ class DatabaseConnectorTest extends TestCase
     public function mySqlConnectProvider()
     {
         return [
-            ['mysql:host=foo;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
-            ['mysql:host=foo;port=111;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
-            ['mysql:unix_socket=baz;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'unix_socket' => 'baz', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
+            ['mysql:host=foo;dbname=bar;charset=utf8', ['host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
+            ['mysql:host=foo;dbname=bar;port=111;charset=utf8', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
+            ['mysql:unix_socket=baz;dbname=bar;charset=utf8', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'unix_socket' => 'baz', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
         ];
     }
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -53,7 +53,7 @@ class DatabaseConnectorTest extends TestCase
 
     public function testPostgresConnectCallsCreateConnectionWithProperArguments()
     {
-        $dsn = 'pgsql:host=foo;dbname=bar;port=111';
+        $dsn = "pgsql:dbname=bar;host=foo;port=111;options='--client_encoding=utf8'";
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
@@ -68,7 +68,7 @@ class DatabaseConnectorTest extends TestCase
 
     public function testPostgresSearchPathIsSet()
     {
-        $dsn = 'pgsql:host=foo;dbname=bar';
+        $dsn = "pgsql:dbname=bar;host=foo;options='--client_encoding=utf8'";
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => 'public', 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
@@ -84,7 +84,7 @@ class DatabaseConnectorTest extends TestCase
 
     public function testPostgresSearchPathArraySupported()
     {
-        $dsn = 'pgsql:host=foo;dbname=bar';
+        $dsn = "pgsql:dbname=bar;host=foo;options='--client_encoding=utf8'";
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => ['public', 'user'], 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
@@ -100,7 +100,7 @@ class DatabaseConnectorTest extends TestCase
 
     public function testPostgresApplicationNameIsSet()
     {
-        $dsn = 'pgsql:host=foo;dbname=bar';
+        $dsn = "pgsql:dbname=bar;host=foo;options='--client_encoding=utf8'";
         $config = ['host' => 'foo', 'database' => 'bar', 'charset' => 'utf8', 'application_name' => 'Laravel App'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);


### PR DESCRIPTION
Reopened PR of #28126 

-----

Currently, charset is set by the `set names` statement. This affects server but not client. If there is a difference between charsets recognized by server and client, we may get a security risk especially on `sjis` and `cp932` while enabling prepared statement emulation.
Official PHP manual suggests changing client charset:
[PHP: Character sets - Manual](https://www.php.net/manual/en/mysqlinfo.concepts.charset.php)

As far as I know:

- PDO_MYSQL has `"charset"` option on DSN
- PDO_PGSQL has `"options"` option on DSN which can include the argument `"--client_encoding=..."`
- PDO_SQLITE has no options but implicitly uses UTF-8

I changed PDO_MYSQL DSN and PDO_PGSQL DSN in this Pull Request.
Also PDO_ODBC DSN should be changed but I'm not familiar with it.