### PR TITLE
[5.8] Track the exit code of scheduled event commands

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -144,9 +144,9 @@ class Event
     public $mutex;
 
     /**
-     * The command exit status code.
+     * The exit status code of the command.
      *
-     * @var int
+     * @var int|null
      */
     public $exitCode;
 

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -144,6 +144,13 @@ class Event
     public $mutex;
 
     /**
+     * The command exit status code.
+     *
+     * @var int
+     */
+    public $exitCode;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
@@ -208,7 +215,7 @@ class Event
     {
         $this->callBeforeCallbacks($container);
 
-        Process::fromShellCommandline($this->buildCommand(), base_path(), null, null, null)->run();
+        $this->exitCode = Process::fromShellCommandline($this->buildCommand(), base_path(), null, null, null)->run();
 
         $this->callAfterCallbacks($container);
     }


### PR DESCRIPTION
Currently, there is no way to tell if a scheduled command failed without manually viewing the output.

This change will allow users to create the following `Illuminate\Console\Scheduling\Event` macros:

`$event->onFailureEmailOutputTo()`

`$event->pingOnSuccess()`

Perhaps these type of methods could be added to core later...