### PR TITLE
[5.8] Fix appending path to inline Blade views

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -123,6 +123,15 @@ class BladeCompiler extends Compiler implements CompilerInterface
             );
 
             if (! empty($this->getPath())) {
+                $tokens = $this->getOpenAndClosingPHPTokens($contents);
+
+                // If the tokens we retrieved from the compiled contents have at least
+                // one opening tag and if that last token isn't the closing tag, we
+                // need to close the statement before adding the path at the end.
+                if ($tokens->isNotEmpty() && $tokens->last() !== T_CLOSE_TAG) {
+                    $contents .= ' ?>';
+                }
+
                 $contents .= "<?php /**PATH {$this->getPath()} ENDPATH**/ ?>";
             }
 
@@ -130,6 +139,21 @@ class BladeCompiler extends Compiler implements CompilerInterface
                 $this->getCompiledPath($this->getPath()), $contents
             );
         }
+    }
+
+    /**
+     * Returns the open and closing PHP tag tokens which are present in the compiled contents.
+     *
+     * @param  string  $contents
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getOpenAndClosingPHPTokens($contents)
+    {
+        return collect(token_get_all($contents))
+            ->pluck($tokenNumber = 0)
+            ->filter(function ($token) {
+                return in_array($token, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, T_CLOSE_TAG]);
+            });
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -123,7 +123,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
             );
 
             if (! empty($this->getPath())) {
-                $tokens = $this->getOpenAndClosingPHPTokens($contents);
+                $tokens = $this->getOpenAndClosingPhpTokens($contents);
 
                 // If the tokens we retrieved from the compiled contents have at least
                 // one opening tag and if that last token isn't the closing tag, we
@@ -142,12 +142,12 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
-     * Returns the open and closing PHP tag tokens which are present in the compiled contents.
+     * Get the open and closing PHP tag tokens from the given string.
      *
      * @param  string  $contents
      * @return \Illuminate\Support\Collection
      */
-    protected function getOpenAndClosingPHPTokens($contents)
+    protected function getOpenAndClosingPhpTokens($contents)
     {
         return collect(token_get_all($contents))
             ->pluck($tokenNumber = 0)


### PR DESCRIPTION
When appending the view path to Blade views with only one line and opening tags we should take into consideration for closing the PHP tag first before appending the path. I've added tests which should cover quite a few situations.

Thanks to Sisve for making me aware of this: https://github.com/laravel/framework/pull/28117#issuecomment-480473139
