### PR TITLE
Update PaginationServiceProvider.php

### DIFF
--- a/src/Illuminate/Pagination/PaginationServiceProvider.php
+++ b/src/Illuminate/Pagination/PaginationServiceProvider.php
@@ -34,7 +34,12 @@ class PaginationServiceProvider extends ServiceProvider
         });
 
         Paginator::currentPathResolver(function () {
-            return $this->app['request']->url();
+            $http_type = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')) ? 'https://' : 'http://';
+            $url = $this->app['request']->url();
+            if($http_type=='https://'){
+                $url = str_replace('http', 'https', $url);
+            }
+            return $url;
         });
 
         Paginator::currentPageResolver(function ($pageName = 'page') {


### PR DESCRIPTION
The next page' url cannot be fixed to http. If the server forces https, the next page will not be found.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
