### PR TITLE
[5.8] Correctly escape single quotes in json paths

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1119,6 +1119,8 @@ class Grammar extends BaseGrammar
      */
     protected function wrapJsonPath($value, $delimiter = '->')
     {
+        $value = preg_replace("/([\\\\]+)?\\'/", "\\'", $value);
+
         return '\'$."'.str_replace($delimiter, '"."', $value).'"\'';
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2267,6 +2267,10 @@ SQL;
         $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
+        $builder->select("json->\\'))#");
+        $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
+
+        $builder = $this->getMySqlBuilder();
         $builder->select("json->\\\'))#");
         $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2252,6 +2252,25 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from `users` where json_extract(`items`, \'$."available"\') = true and json_extract(`items`, \'$."active"\') = false and json_unquote(json_extract(`items`, \'$."number_available"\')) = ?', $builder->toSql());
     }
 
+    public function testJsonPathEscaping()
+    {
+        $expectedJsonEscape = <<<SQL
+select json_unquote(json_extract(`json`, '$."\'))#"'))
+SQL;
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select("json->'))#");
+        $this->assertEquals($expectedJsonEscape, $builder->toSql());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select("json->\'))#");
+        $this->assertEquals($expectedJsonEscape, $builder->toSql());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select("json->\\\'))#");
+        $this->assertEquals($expectedJsonEscape, $builder->toSql());
+    }
+
     public function testMySqlWrappingJson()
     {
         $builder = $this->getMySqlBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2254,21 +2254,21 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testJsonPathEscaping()
     {
-        $expectedJsonEscape = <<<SQL
+        $expectedWithJsonEscaped = <<<SQL
 select json_unquote(json_extract(`json`, '$."\'))#"'))
 SQL;
 
         $builder = $this->getMySqlBuilder();
         $builder->select("json->'))#");
-        $this->assertEquals($expectedJsonEscape, $builder->toSql());
+        $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select("json->\'))#");
-        $this->assertEquals($expectedJsonEscape, $builder->toSql());
+        $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select("json->\\\'))#");
-        $this->assertEquals($expectedJsonEscape, $builder->toSql());
+        $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
     }
 
     public function testMySqlWrappingJson()


### PR DESCRIPTION
There's a potential SQL injection vulnerability with the JSON query syntax. This PR fixes that.

Laravel will parse JSON paths to `json_extract` functions. Say you've got the following:

```php
$builder->select('json_field->field');
```

This will be parsed to:

```SQL
json_extract(`json_field`, '$."field"')
```

The actual parsing is done in `\Illuminate\Database\Query\Grammars\Grammar::wrapJsonFieldAndPath()` 

It is however possible to provide a single quote as the "field" value, which will close the `json_extract` early. This gives an attacker the possibility to insert his own malicious SQL code. Take for example this input (indented for clarity):

```sql
lang->**"')), migrations.*

FROM users
    RIGHT OUTER JOIN migrations ON migrations.id <> null

#
```

By manually inserting `'` after `lang->**"`, we're able to break out of the `json_extract` function and inject our malicious code.

```sql
SELECT JSON_UNQUOTE(JSON_EXTRACT(`lang`, '$."**"')), migrations.*
FROM users
RIGHT OUTER JOIN migrations ON migrations.id <> null
#"')) from `users`
```

In this example we're joining on the migrations table, but it's possible to join on anything.

In order for this attack to work, two requirements have to be met:

- The attacker must control the columns of a query. Chances are not a lot of people are doing this manually in their projects. Though there are popular packages which expose this functionality to provide easy API endpoints. A popular example is the JSON API spec, which specifically allows for sparse fieldsets.
- The entry point table must have a column with JSON data. Otherwise the json_extract` function will fail, stopping the query. From the entry point though, you can access all other tables.

The solution is to escape all single quotes passed as `$value` in `\Illuminate\Database\Query\Grammars\Grammar::wrapJsonPath()`. Because attackers could potentially chain multiple backslashes, this PR will take all single quotes, with or without preceding backslashes, and replace it with `\'`. 

I decided to use a HEREDOC in the tests, for clarity. If this is not ok for Laravel, I'll be happy to change it.