### PR TITLE
HigherOrderCollectionProxy is actually allowed

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -560,7 +560,7 @@ abstract class AbstractPaginator implements Htmlable
     /**
      * Set the paginator's underlying collection.
      *
-     * @param  \Illuminate\Support\Collection  $collection
+     * @param  \Illuminate\Support\Collection|\Illuminate\Support\HigherOrderCollectionProxy  $collection
      * @return $this
      */
     public function setCollection(Collection $collection)


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
makes Paginator accept HigherOrderCollectionProxy type collections.

likes: 
```php
/**
 * @var \Illuminate\Pagination\Paginator $result
 */
$result = $query->paginate();
$list = $result->getCollection();
$list = $list->map->setVisible(['id', 'text']);
$result->setCollection($list); // ide based phpDoc might show warnings before this patched.
```
