### PR TITLE
[5.8] Fixed circular dependency - fix #28165

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -360,7 +360,7 @@ class QueueFake extends QueueManager implements Queue
     }
 
     /**
-     * Override the parent to prevent circular dependency.
+     * Override the QueueManager to prevent circular dependency.
      *
      * @param  string  $method
      * @param  array   $parameters

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -360,7 +360,7 @@ class QueueFake extends QueueManager implements Queue
     }
 
     /**
-     * Override the parent to prevent circular dependency
+     * Override the parent to prevent circular dependency.
      *
      * @param  string  $method
      * @param  array   $parameters

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
+use BadMethodCallException;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Contracts\Queue\Queue;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -356,5 +357,19 @@ class QueueFake extends QueueManager implements Queue
     public function setConnectionName($name)
     {
         return $this;
+    }
+
+    /**
+     * Override the parent to prevent circular dependency
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        throw new BadMethodCallException(sprintf(
+            'Call to undefined method %s::%s()', static::class, $method
+        ));
     }
 }

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use BadMethodCallException;
 use Illuminate\Bus\Queueable;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
@@ -225,6 +226,17 @@ class SupportTestingQueueFakeTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertThat($e, new ExceptionMessage('The expected chain was not pushed'));
+        }
+    }
+
+    public function testCallUndefinedMethodErrorHandling()
+    {
+        try {
+            $this->fake->undefinedMethod();
+        } catch (BadMethodCallException $e) {
+            $this->assertThat($e, new ExceptionMessage(sprintf(
+                'Call to undefined method %s::%s()', get_class($this->fake), 'undefinedMethod'
+            )));
         }
     }
 }


### PR DESCRIPTION
This PR fix the issue opened by me (#28165).

Basically, this code override the `QueueManager::__call` magic method when the Queue is mocked to prevend a circular dependency when calling a undefined method in the mock.

To prevent any break of existing feature i've made a simple test.