### PR TITLE
[5.8] Added SET datatype on MySQL Grammar

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -857,6 +857,18 @@ class Blueprint
     }
 
     /**
+     * Create a new set column on the table.
+     *
+     * @param  string  $column
+     * @param  array  $allowed
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function set($column, array $allowed)
+    {
+        return $this->addColumn('set', $column, compact('allowed'));
+    }
+
+    /**
      * Create a new json column on the table.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -591,6 +591,17 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a set enumeration type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeSet(Fluent $column)
+    {
+        return sprintf('set(%s)', $this->quoteString($column->allowed));
+    }
+
+    /**
      * Create the column definition for a json type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -9,9 +9,6 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 
-/**
- * @group setTest
- */
 class DatabaseMySqlSchemaGrammarTest extends TestCase
 {
     protected function tearDown(): void

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -9,6 +9,9 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 
+/**
+ * @group setTest
+ */
 class DatabaseMySqlSchemaGrammarTest extends TestCase
 {
     protected function tearDown(): void
@@ -618,6 +621,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table `users` add `role` enum(\'member\', \'admin\') not null', $statements[0]);
+    }
+
+    public function testAddingSet()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->set('role', ['member', 'admin']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `role` set(\'member\', \'admin\') not null', $statements[0]);
     }
 
     public function testAddingJson()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This pull request adds the [MySQL's SET type](https://dev.mysql.com/doc/refman/8.0/en/set.html) into the migrations builder. It allows you to make: 

```php
    public function up()
    {
        Schema::create('table_name', function (Blueprint $table) {
            $table->bigIncrements('id');
            $table->set("field_name", [ "Possible", "Values" ]);
            $table->timestamps();
        });
    }
```

That will create a table with a `field_name` column with the `SET` dataType. Available only on MySQL.