### PR TITLE
[5.8] Fix enum definition not producing N-quoted string on Sql Server

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -824,4 +824,19 @@ class SqlServerGrammar extends Grammar
 
         return parent::wrapTable($table);
     }
+
+    /**
+     * Quote the given string literal.
+     *
+     * @param  string|array  $value
+     * @return string
+     */
+    public function quoteString($value)
+    {
+        if (is_array($value)) {
+            return implode(', ', array_map([$this, __FUNCTION__], $value));
+        }
+
+        return "N'$value'";
+    }
 }

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -472,7 +472,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "role" nvarchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "role" nvarchar(255) check ("role" in (N\'member\', N\'admin\')) not null', $statements[0]);
     }
 
     public function testAddingJson()
@@ -791,6 +791,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $c = $this->getGrammar()::compileReplace();
 
         $this->assertTrue($c);
+    }
+
+    public function testQuoteString()
+    {
+        $this->assertSame("N'中文測試'", $this->getGrammar()->quoteString('中文測試'));
+    }
+
+    public function testQuoteStringOnArray()
+    {
+        $this->assertSame("N'中文', N'測試'", $this->getGrammar()->quoteString(['中文', '測試']));
     }
 
     protected function getConnection()


### PR DESCRIPTION
When I tried to use some Chinese characters in an enum definition in schema builder in Sql Server, the check constraint created was wrong, the Chinese characters turned into ? inside the Sql Server.

The check constraint should be created with the values quoted in `N'中文測試'` form (note the letter N before the quotation mark).

Reference:
https://social.msdn.microsoft.com/Forums/sqlserver/en-US/5d2ea1a2-32e1-4a82-b6e3-17d2b898babc/chinese-characters-issue-with-tsql?forum=transactsql

