### PR TITLE
[5.8] Fix typo in variable name in try catch of `report` function

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -105,7 +105,7 @@ class Handler implements ExceptionHandlerContract
 
         try {
             $logger = $this->container->make(LoggerInterface::class);
-        } catch (Exception $ex) {
+        } catch (Exception $e) {
             throw $e;
         }
 


### PR DESCRIPTION

Perhaps I found a typing error in the variable name.
(Is this a mistake?)

```
        try {
            $logger = $this->container->make(LoggerInterface::class);
        } catch (Exception $ex) {
            throw $e;
        }
```

I corrected as follows

**`$ex`** → **`$e`**