### PR TITLE
[5.8] Add duplicates method to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -408,6 +408,49 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Retrieve duplicate items from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  bool  $strict
+     * @return static
+     */
+    public function duplicates($callback = null, $strict = false)
+    {
+        $items = $this->map($this->valueRetriever($callback));
+
+        $uniqueItems = $items->unique(null, $strict);
+
+        $compare = $strict ? function ($a, $b) {
+            return $a === $b;
+        } : function ($a, $b) {
+            return $a == $b;
+        };
+
+        $duplicates = new static;
+
+        foreach ($items as $key => $value) {
+            if ($uniqueItems->isNotEmpty() && $compare($value, $uniqueItems->first())) {
+                $uniqueItems->shift();
+            } else {
+                $duplicates[$key] = $value;
+            }
+        }
+
+        return $duplicates;
+    }
+
+    /**
+     * Retrieve duplicate items from the collection using strict comparison.
+     *
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public function duplicatesStrict($callback = null)
+    {
+        return $this->duplicates($callback, true);
+    }
+
+    /**
      * Execute a callback over each item.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -422,7 +422,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $compare = $strict ? function ($a, $b) {
             return $a === $b;
-        } : function ($a, $b) {
+        }
+        : function ($a, $b) {
             return $a == $b;
         };
 


### PR DESCRIPTION
This PR introduces the ability to get all the duplicate values from an `Illuminate\Support\Collection`.

## Usage

<img width="1385" alt="Screen Shot 2019-04-11 at 5 39 11 pm" src="https://user-images.githubusercontent.com/24803032/55939281-c3ad6200-5c80-11e9-9a80-af12ef086cd2.png">

## Loose and Strict

<img width="557" alt="Screen Shot 2019-04-11 at 5 09 23 pm" src="https://user-images.githubusercontent.com/24803032/55937561-95c61e80-5c7c-11e9-9ccf-140c4d85022c.png">

I've come at this from a bunch of different angles. I am more than happy to hear ways you think this could be improved - but please confirm it works with all the test cases (or I can for you), as I've found a lot of variations on this do not pass all the tests e.g. methods in the `array_diff` family don't play nice with multidimensional arrays.

I'd also like to hear if anyone thinks there are additional test cases I should account for.

### Does not work with integers and objects in loose comparison

[Loose comparison between integers and objects will trigger a notice and fail](https://3v4l.org/dlueJ). Good news is that the `unique` method actually triggers the notice when we call it from the `duplicates` method, so the issue already exists.

## Eloquent keys

If you are happy with this idea / approach for the base collection I will update this PR or do another to make it take model keys into account on the `Illuminate\Database\Eloquent\Collection`

---

Fingers crossed I never have to google "PHP how to find duplicates in an array" again 🤞