### PR TITLE
[5.9] Deferred resolving of scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
@@ -28,33 +28,14 @@ class ScheduleFinishCommand extends Command
     protected $hidden = true;
 
     /**
-     * The schedule instance.
-     *
-     * @var \Illuminate\Console\Scheduling\Schedule
-     */
-    protected $schedule;
-
-    /**
-     * Create a new command instance.
-     *
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
-     * @return void
-     */
-    public function __construct(Schedule $schedule)
-    {
-        $this->schedule = $schedule;
-
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
+     * @param  \Illuminate\Console\Scheduling\Schedule $schedule
      * @return void
      */
-    public function handle()
+    public function handle(Schedule $schedule)
     {
-        collect($this->schedule->events())->filter(function ($value) {
+        collect($schedule->events())->filter(function ($value) {
             return $value->mutexName() == $this->argument('id');
         })->each->callAfterCallbacks($this->laravel);
     }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -57,14 +57,14 @@ class ScheduleRunCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param  \Illuminate\Console\Scheduling\Schedule $schedule
+     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
      * @return void
      */
     public function handle(Schedule $schedule)
     {
         $this->schedule = $schedule;
 
-        foreach ($schedule->dueEvents($this->laravel) as $event) {
+        foreach ($this->schedule->dueEvents($this->laravel) as $event) {
             if (! $event->filtersPass($this->laravel)) {
                 continue;
             }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -22,13 +22,6 @@ class ScheduleRunCommand extends Command
     protected $description = 'Run the scheduled commands';
 
     /**
-     * The schedule instance.
-     *
-     * @var \Illuminate\Console\Scheduling\Schedule
-     */
-    protected $schedule;
-
-    /**
      * The 24 hour timestamp this scheduler command started running.
      *
      * @var \Illuminate\Support\Carbon;
@@ -45,13 +38,10 @@ class ScheduleRunCommand extends Command
     /**
      * Create a new command instance.
      *
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
      * @return void
      */
-    public function __construct(Schedule $schedule)
+    public function __construct()
     {
-        $this->schedule = $schedule;
-
         $this->startedAt = Date::now();
 
         parent::__construct();
@@ -60,17 +50,18 @@ class ScheduleRunCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param  \Illuminate\Console\Scheduling\Schedule $schedule
      * @return void
      */
-    public function handle()
+    public function handle(Schedule $schedule)
     {
-        foreach ($this->schedule->dueEvents($this->laravel) as $event) {
+        foreach ($schedule->dueEvents($this->laravel) as $event) {
             if (! $event->filtersPass($this->laravel)) {
                 continue;
             }
 
             if ($event->onOneServer) {
-                $this->runSingleServerEvent($event);
+                $this->runSingleServerEvent($schedule, $event);
             } else {
                 $this->runEvent($event);
             }
@@ -86,12 +77,13 @@ class ScheduleRunCommand extends Command
     /**
      * Run the given single server event.
      *
+     * @param  \Illuminate\Console\Scheduling\Schedule $schedule
      * @param  \Illuminate\Console\Scheduling\Event  $event
      * @return void
      */
-    protected function runSingleServerEvent($event)
+    protected function runSingleServerEvent($schedule, $event)
     {
-        if ($this->schedule->serverShouldRun($event, $this->startedAt)) {
+        if ($schedule->serverShouldRun($event, $this->startedAt)) {
             $this->runEvent($event);
         } else {
             $this->line('<info>Skipping command (has already run on another server):</info> '.$event->getSummaryForDisplay());

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -99,12 +99,10 @@ class Kernel implements KernelContract
     protected function defineConsoleSchedule()
     {
         $this->app->singleton(Schedule::class, function ($app) {
-            return new Schedule($this->scheduleTimezone());
+            return tap(new Schedule($this->scheduleTimezone()), function ($schedule) {
+                $this->schedule($schedule);
+            });
         });
-
-        $schedule = $this->app->make(Schedule::class);
-
-        $this->schedule($schedule);
     }
 
     /**

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Console;
 use Illuminate\Console\Command;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Console\Scheduling\Schedule;
 
 class ConsoleApplicationTest extends TestCase
 {
@@ -51,6 +52,19 @@ class ConsoleApplicationTest extends TestCase
         $this->assertSame(0, $exitCode);
         $mock->assertExitCode(0);
     }
+
+    public function test_artisan_instantiate_schedule_when_need()
+    {
+        $this->assertFalse($this->app->resolved(Schedule::class));
+
+        $this->app[Kernel::class]->registerCommand(new ScheduleCommandStub);
+
+        $this->assertFalse($this->app->resolved(Schedule::class));
+
+        $this->artisan('foo:schedule');
+
+        $this->assertTrue($this->app->resolved(Schedule::class));
+    }
 }
 
 class FooCommandStub extends Command
@@ -58,6 +72,16 @@ class FooCommandStub extends Command
     protected $signature = 'foo:bar {id}';
 
     public function handle()
+    {
+        //
+    }
+}
+
+class ScheduleCommandStub extends Command
+{
+    protected $signature = 'foo:schedule';
+
+    public function handle(Schedule $schedule)
     {
         //
     }


### PR DESCRIPTION
Scheduler is resolved if you use any artisan command.
This PR adds resolving of scheduler if it really needed(schedule:* commands).

#### Why?
I have package what populate scheduler from DB.
```php
        $this->app->afterResolving(Schedule::class, function (Schedule $scheduler) {
            Entities\Schedule::query()->whereNotNull('schedule')
                ->each(function (Entities\Schedule $schedule) use ($scheduler) {
                    (new ScheduleJob($schedule))->register($scheduler);
                });
        });
```
But I cannot to migrate DB. Scheduler is resolved before and try to read data from table what doesn't exists.
```
./artisan migrate

In Connection.php line 664:
                                                                                                                                                                                                                                                                                  
  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'scheduler' doesn't exist (SQL: select * from `scheduler` where `schedule` is not null and `scheduler`.`deleted_at` is null and `scheduler`.`enabled` = 1 order by `scheduler`.`id` asc limit 1000 offset 0)  
```