### PR TITLE
[5.8] `whereDay` and `whereMonth` inconsistent when passing `int` values

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1198,6 +1198,8 @@ class Builder
             $value = $value->format('d');
         }
 
+        $value = str_pad($value, 2, '0', STR_PAD_LEFT);
+
         return $this->addDateBasedWhere('Day', $column, $operator, $value, $boolean);
     }
 
@@ -1236,6 +1238,8 @@ class Builder
         if ($value instanceof DateTimeInterface) {
             $value = $value->format('m');
         }
+
+        $value = str_pad($value, 2, '0', STR_PAD_LEFT);
 
         return $this->addDateBasedWhere('Month', $column, $operator, $value, $boolean);
     }

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -36,12 +36,14 @@ class QueryBuilderTest extends DatabaseTestCase
     public function testWhereDay()
     {
         $this->assertSame(1, DB::table('posts')->whereDay('created_at', '02')->count());
+        $this->assertSame(1, DB::table('posts')->whereDay('created_at', 2)->count());
         $this->assertSame(1, DB::table('posts')->whereDay('created_at', new Carbon('2018-01-02'))->count());
     }
 
     public function testWhereMonth()
     {
         $this->assertSame(1, DB::table('posts')->whereMonth('created_at', '01')->count());
+        $this->assertSame(1, DB::table('posts')->whereMonth('created_at', 1)->count());
         $this->assertSame(1, DB::table('posts')->whereMonth('created_at', new Carbon('2018-01-02'))->count());
     }
 


### PR DESCRIPTION
Fixes #28184

- Laravel Version: 5.8.11
- PHP Version: 7.3.2
- Database Driver & Version: MySQL 5.7.25

### Description:
When using `whereDay`, or `whereMonth`, passing an integer produces mixed results based on the current date

### Steps To Reproduce:
add a `whereDay`, or `whereMonth` to a builder instance, when the date is less than 10th of the month, or the month is less than 10.
Easiest replication is to use `now()->month`, or `now()->day`