### PR TITLE
[5.8] Add static `rename` method to facade docblocks

### DIFF
--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -7,6 +7,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Database\Schema\Builder drop(string $table)
  * @method static \Illuminate\Database\Schema\Builder dropIfExists(string $table)
  * @method static \Illuminate\Database\Schema\Builder table(string $table, \Closure $callback)
+ * @method static \Illuminate\Database\Schema\Builder rename(string $from, string $to)
  * @method static void defaultStringLength(int $length)
  * @method static \Illuminate\Database\Schema\Builder disableForeignKeyConstraints()
  * @method static \Illuminate\Database\Schema\Builder enableForeignKeyConstraints()


### PR DESCRIPTION
This method is statically accessible from the schema facade. But IDE's are not recognizing it.
