### PR TITLE
[5.8] Enh: `FactoryMakeCommand` updated to generate more IDE friendly code

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -46,12 +46,22 @@ class FactoryMakeCommand extends GeneratorCommand
      */
     protected function buildClass($name)
     {
-        $model = $this->option('model')
+        $namespaceModel = $this->option('model')
                         ? $this->qualifyClass($this->option('model'))
-                        : 'Model';
+                        : trim($this->rootNamespace(), '\\').'\\Model';
+
+        $model = class_basename($namespaceModel);
 
         return str_replace(
-            'DummyModel', $model, parent::buildClass($name)
+            [
+                'NamespacedDummyModel',
+                'DummyModel',
+            ],
+            [
+                $namespaceModel,
+                $model,
+            ],
+            parent::buildClass($name)
         );
     }
 

--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -1,6 +1,9 @@
 <?php
 
+/* @var $factory \Illuminate\Database\Eloquent\Factory */
+
 use Faker\Generator as Faker;
+use NamespacedDummyModel;
 
 $factory->define(DummyModel::class, function (Faker $faker) {
     return [


### PR DESCRIPTION
Update  'make:factory' command to generate code, which is more consistent regardless to other generators: 
- import model via `use` statement instead of usage fully qualified class name inline.
- added PHPDoc hint for `$factory` variable, facilitating better IDE type-hinting and static analysis

With this patch command `php artisan make:factory -m Foo FooFactory` generates following code:

```php
<?php

/* @var $factory \Illuminate\Database\Eloquent\Factory */

use Faker\Generator as Faker;
use App\Foo;

$factory->define(Foo::class, function (Faker $faker) {
    return [
        //
    ];
});

```