### PR TITLE
Update 5.6 branch with #28160 security update

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -940,6 +940,8 @@ class Grammar extends BaseGrammar
      */
     protected function wrapJsonPath($value)
     {
+        $value = preg_replace("/([\\\\]+)?\\'/", "\\'", $value);
+        
         return '\'$."'.str_replace('->', '"."', $value).'"\'';
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2044,6 +2044,25 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertCount(1, $builder->getRawBindings()['where']);
         $this->assertEquals('foo-bar', $builder->getRawBindings()['where'][0]);
     }
+    
+    public function testJsonPathEscaping()
+    {
+        $expectedWithJsonEscaped = <<<SQL
+select json_unquote(json_extract(`json`, '$."\'))#"'))
+SQL;
+        $builder = $this->getMySqlBuilder();
+        $builder->select("json->'))#");
+        $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
+        $builder = $this->getMySqlBuilder();
+        $builder->select("json->\'))#");
+        $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
+        $builder = $this->getMySqlBuilder();
+        $builder->select("json->\\'))#");
+        $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
+        $builder = $this->getMySqlBuilder();
+        $builder->select("json->\\\'))#");
+        $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
+    }
 
     public function testMySqlWrappingJson()
     {


### PR DESCRIPTION
#28160 Correctly escapes single quotes in json paths. This pull request applies the same changes to the 5.6 branch