### PR TITLE
[5.8] in/not in operators

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -616,6 +616,17 @@ class Builder
             return $this->whereNested($column, $boolean);
         }
 
+        // If the operator is a literal string 'in' or 'not in', we will assume
+        // the developer wants to use the corresponding 'in' or 'not in' SQL
+        // operators. We will simply proxy to the query builder methods.
+        if ($operator == 'in') {
+            return $this->whereIn($column, $value, $boolean);
+        }
+
+        if ($operator == 'not in') {
+            return $this->whereNotIn($column, $value, $boolean);
+        }
+
         // If the given operator is not found in the list of valid operators we will
         // assume that the developer is just short-cutting the '=' operators and
         // we will set the operators to '=' and set the values appropriately.

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -645,6 +645,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
 
         $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 'in', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', [1, 2, 3]);
         $this->assertEquals('select * from "users" where "id" = ? or "id" in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
@@ -654,6 +659,11 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotIn('id', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 'not in', [1, 2, 3]);
         $this->assertEquals('select * from "users" where "id" not in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
 


### PR DESCRIPTION
This PR introduces the ability to pass `in` or `not in` strings as an operator to the query builder.

```php
// these two calls produce the same query
$query->where('foo', 'in', [1, 2]);
$query->whereIn('foo', [1, 2]);

// these two calls produce the same query
$query->where('foo', 'not in', [1, 2]);
$query->whereNotIn('foo', [1, 2]);
```

The reasons behind this PR:

- being able to pass-in these strings as operators allows for nicer query generation:

    ```php
    [$name, $operator, $value] = $filter->get(); // Filter model stored in the database

    // This PR allows for this
    $query->where($name, $operator, $value);

    // Instead of this
    if ($operator == 'in') {
        $query->whereIn($name, $value);
    } else if ($operator == 'not in') {
        $query->whereNotIn($name, $value);
    } else {
        $query->where($name, $operator, $value);
    }
    ```

- in the current implementation, it is kind of unintuitive that `$query->where('foo', 'in', [1, 2])` produces `where foo = "in"`

Thanks for reviewing this.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->