### PR TITLE
[5.8] Add eloquent collection strict unique test

### DIFF
--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -275,6 +275,28 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(new Collection([$one, $two]), $c->unique());
     }
 
+    public function testCollectionReturnsUniqueStrictBasedOnKeysOnly()
+    {
+        $one = new TestEloquentCollectionModel();
+        $two = new TestEloquentCollectionModel();
+        $three = new TestEloquentCollectionModel();
+        $four = new TestEloquentCollectionModel();
+        $one->id = 1;
+        $one->someAttribute = '1';
+        $two->id = 1;
+        $two->someAttribute = '2';
+        $three->id = 1;
+        $three->someAttribute = '3';
+        $four->id = 2;
+        $four->someAttribute = '4';
+
+        $uniques = Collection::make([$one, $two, $three, $four])->unique()->all();
+        $this->assertSame([$three, $four], $uniques);
+
+        $uniques = Collection::make([$one, $two, $three, $four])->unique(null, true)->all();
+        $this->assertSame([$three, $four], $uniques);
+    }
+
     public function testOnlyReturnsCollectionWithGivenModelKeys()
     {
         $one = m::mock(Model::class);


### PR DESCRIPTION
Adding a test to the eloquent collection class to show that strict mode will only compare keys when the `$key` is null.

That is...

```php
$users = $users->unique($key = null, $strict = true);
```
will compare users like: `$userA->getKey() === $userB->getKey()` for both strict and non-strict comparisons, not like: `$userA === $userB` - which is how the base collection does a strict comparison.

This test is a proof for the implemented functionality of this PR: https://github.com/laravel/framework/pull/28194