### PR TITLE
[5.8] Handle duplicates method in eloquent collections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -306,6 +306,19 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Get the comparison function to detect duplicates.
+     *
+     * @param  bool  $strict
+     * @return \Closure
+     */
+    protected function duplicateComparator($strict)
+    {
+        return function ($a, $b) {
+            return $a->is($b);
+        };
+    }
+
+    /**
      * Intersect the collection with the given items.
      *
      * @param  \ArrayAccess|array  $items

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -420,12 +420,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $uniqueItems = $items->unique(null, $strict);
 
-        $compare = $strict ? function ($a, $b) {
-            return $a === $b;
-        }
-        : function ($a, $b) {
-            return $a == $b;
-        };
+        $compare = $this->duplicateComparator($strict);
 
         $duplicates = new static;
 
@@ -449,6 +444,25 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function duplicatesStrict($callback = null)
     {
         return $this->duplicates($callback, true);
+    }
+
+    /**
+     * Get the comparison function to detect duplicates.
+     *
+     * @param  bool  $strict
+     * @return \Closure
+     */
+    protected function duplicateComparator($strict)
+    {
+        if ($strict) {
+            return function ($a, $b) {
+                return $a === $b;
+            };
+        }
+
+        return function ($a, $b) {
+            return $a == $b;
+        };
     }
 
     /**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -245,6 +245,28 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(new Collection([$one]), $c1->diff($c2));
     }
 
+    public function testCollectionReturnsDuplicateBasedOnlyOnKeys()
+    {
+        $one = new TestEloquentCollectionModel();
+        $two = new TestEloquentCollectionModel();
+        $three = new TestEloquentCollectionModel();
+        $four = new TestEloquentCollectionModel();
+        $one->id = 1;
+        $one->someAttribute = '1';
+        $two->id = 1;
+        $two->someAttribute = '2';
+        $three->id = 1;
+        $three->someAttribute = '3';
+        $four->id = 2;
+        $four->someAttribute = '4';
+
+        $duplicates = Collection::make([$one, $two, $three, $four])->duplicates()->all();
+        $this->assertSame([1 => $two, 2 => $three], $duplicates);
+
+        $duplicates = Collection::make([$one, $two, $three, $four])->duplicatesStrict()->all();
+        $this->assertSame([1 => $two, 2 => $three], $duplicates);
+    }
+
     public function testCollectionIntersectsWithGivenCollection()
     {
         $one = m::mock(Model::class);


### PR DESCRIPTION
This PR handles the [new `$collection->duplicates()` method](https://github.com/laravel/framework/pull/28181) for eloquent collections.

The **eloquent** collection method compares entities with the `$a->is($b)` comparison. If you think it should just compare keys `$a->getKey() === $b->getKey()` than I can switch it over. The only time I see this being an issue is if a collection contains two models with the same key from different tables or something like that - which I can't imagine happening - but is something to consider.

**Note** that the eloquent method does not alter functionality with strict mode. I've written more about this below. It currently matches how `unique()` method works: https://github.com/laravel/framework/pull/28193

