### PR TITLE
[5.8] Add missing LockProvider interface on DynamoDbStore

### DIFF
--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -8,9 +8,10 @@ use Illuminate\Support\Carbon;
 use Aws\DynamoDb\DynamoDbClient;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Contracts\Cache\LockProvider;
 use Aws\DynamoDb\Exception\DynamoDbException;
 
-class DynamoDbStore implements Store
+class DynamoDbStore implements Store, LockProvider
 {
     use InteractsWithTime;
 


### PR DESCRIPTION
I noticed this interface was missing from the `DynamoDbStore` even though it implements the methods like `RedisStore` & `MemcachedStore` do.