### PR TITLE
[5.9] Add --pivot option to MigrateMakeCommand

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -17,6 +17,7 @@ class MigrateMakeCommand extends BaseCommand
         {--create= : The table to be created}
         {--table= : The table to migrate}
         {--path= : The location where the migration file should be created}
+        {--pivot : The table to be created will be pivot}
         {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}';
 
     /**
@@ -71,6 +72,8 @@ class MigrateMakeCommand extends BaseCommand
 
         $create = $this->input->getOption('create') ?: false;
 
+        $tableType = $this->input->getOption('pivot') ? 'pivot' : null;
+
         // If no table was given as an option but a create option is given then we
         // will use the "create" option as the table name. This allows the devs
         // to pass a table name into this option as a short-cut for creating.
@@ -90,7 +93,7 @@ class MigrateMakeCommand extends BaseCommand
         // Now we are ready to write the migration out to disk. Once we've written
         // the migration out, we will dump-autoload for the entire framework to
         // make sure that the migrations are registered by the class loaders.
-        $this->writeMigration($name, $table, $create);
+        $this->writeMigration($name, $table, $create, $tableType);
 
         $this->composer->dumpAutoloads();
     }
@@ -103,10 +106,10 @@ class MigrateMakeCommand extends BaseCommand
      * @param  bool    $create
      * @return string
      */
-    protected function writeMigration($name, $table, $create)
+    protected function writeMigration($name, $table, $create, $tableType)
     {
         $file = pathinfo($this->creator->create(
-            $name, $this->getMigrationPath(), $table, $create
+            $name, $this->getMigrationPath(), $table, $create, $tableType
         ), PATHINFO_FILENAME);
 
         $this->line("<info>Created Migration:</info> {$file}");

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -98,7 +98,7 @@ class MigrationCreator
         // We also have stubs for creating new tables and modifying existing tables
         // to save the developer some typing when they are creating a new tables
         // or modifying existing tables. We'll grab the appropriate stub here.
-        $stub = $create ? ($tableType ? 'pivot.stub' :  'create.stub') : 'update.stub';
+        $stub = $create ? ($tableType ? 'pivot.stub' : 'create.stub') : 'update.stub';
 
         return $this->files->get($this->stubPath()."/{$stub}");
     }
@@ -122,12 +122,12 @@ class MigrationCreator
             $stub = str_replace('DummyTable', $table, $stub);
         }
 
-        if($create && $tableType == 'pivot') {
-            [$parent,$related] = [Str::before($table,'_'),Str::after($table,'_')];
-            $stub = str_replace('DummyParentKey', "{$parent}_id",$stub);
-            $stub = str_replace('DummyParentTable', Str::plural($parent),$stub);
-            $stub = str_replace('DummyRelatedKey', "{$related}_id",$stub);
-            $stub = str_replace('DummyRelatedTable', Str::plural($related),$stub);
+        if ($create && $tableType == 'pivot') {
+            [$parent,$related] = [Str::before($table, '_'), Str::after($table, '_')];
+            $stub = str_replace('DummyParentKey', "{$parent}_id", $stub);
+            $stub = str_replace('DummyParentTable', Str::plural($parent), $stub);
+            $stub = str_replace('DummyRelatedKey', "{$related}_id", $stub);
+            $stub = str_replace('DummyRelatedTable', Str::plural($related), $stub);
         }
 
         return $stub;

--- a/src/Illuminate/Database/Migrations/stubs/pivot.stub
+++ b/src/Illuminate/Database/Migrations/stubs/pivot.stub
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DummyClass extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('DummyTable', function (Blueprint $table) {
+            $table->unsignedBigInteger('DummyParentKey');
+            $table->foreign('DummyParentKey')->references('id')->on('DummyParentTable');
+
+            $table->unsignedBigInteger('DummyRelatedKey');
+            $table->foreign('DummyRelatedKey')->references('id')->on('DummyRelatedTable');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('DummyTable');
+    }
+}

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -91,6 +91,7 @@ class ModelMakeCommand extends GeneratorCommand
         $this->call('make:migration', [
             'name' => "create_{$table}_table",
             '--create' => $table,
+            '--pivot' => $this->option('pivot'),
         ]);
     }
 

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -27,7 +27,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app = new Application;
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
-        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true);
+        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, null);
         $composer->shouldReceive('dumpAutoloads')->once();
 
         $this->runCommand($command, ['name' => 'create_foo']);
@@ -42,7 +42,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app = new Application;
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
-        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true);
+        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, null);
 
         $this->runCommand($command, ['name' => 'create_foo']);
     }
@@ -56,7 +56,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app = new Application;
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
-        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true);
+        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, null);
 
         $this->runCommand($command, ['name' => 'CreateFoo']);
     }
@@ -70,7 +70,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app = new Application;
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
-        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true);
+        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, null);
 
         $this->runCommand($command, ['name' => 'create_foo', '--create' => 'users']);
     }
@@ -84,7 +84,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app = new Application;
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
-        $creator->shouldReceive('create')->once()->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true);
+        $creator->shouldReceive('create')->once()->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, null);
 
         $this->runCommand($command, ['name' => 'create_users_table']);
     }
@@ -98,8 +98,21 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app = new Application;
         $command->setLaravel($app);
         $app->setBasePath('/home/laravel');
-        $creator->shouldReceive('create')->once()->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true);
+        $creator->shouldReceive('create')->once()->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true, null);
         $this->runCommand($command, ['name' => 'create_foo', '--path' => 'vendor/laravel-package/migrations', '--create' => 'users']);
+    }
+
+    public function testCanSpecifyPivotToCreateMigrations()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock(MigrationCreator::class),
+            m::mock(Composer::class)->shouldIgnoreMissing()
+        );
+        $app = new Application;
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $creator->shouldReceive('create')->once()->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, 'pivot');
+        $this->runCommand($command, ['name' => 'create_users_table' , '--pivot' => true]);
     }
 
     protected function runCommand($command, $input = [])

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -112,7 +112,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, 'pivot');
-        $this->runCommand($command, ['name' => 'create_users_table' , '--pivot' => true]);
+        $this->runCommand($command, ['name' => 'create_users_table', '--pivot' => true]);
     }
 
     protected function runCommand($command, $input = [])


### PR DESCRIPTION
this **PR** adds the ability to do this

``` php artisan make:migration create_role_user_table --pivot```

``` php artisan make:model -mp```

which will generate the following migration 

```
 public function up()
    {
        Schema::create('role_user', function (Blueprint $table) {
            $table->unsignedBigInteger('role_id');
            $table->foreign('role_id')->references('id')->on('roles');

            $table->unsignedBigInteger('user_id');
            $table->foreign('user_id')->references('id')->on('users');
        });
    }

```

---------

this PR is based on this [Twitter Thread](https://twitter.com/maxalmonte14/status/1116898737379512320) , so it will help in less typing of this boilerplate migration for pivot tables .

my thoughts was first ,to make the developer write a migration like this ``` php artisan make:migration create_role_user_pivot_table``` but it  i think it's frustrating to force the developers to always postifx there migrations with _pivot .

so i changed  my approach to be **--pivot option** , and also **changed some of public methods api**  for sure this will be a breaking change if some one overrides **writeMigration** in there project , but i think it may adds some flexibility to allow handling other table migration types like **polymorphic migrations** for example with **--polymorphic** option

at the end am not quite sure if this is the **appropriate approach** to tackle the pivot migration 


