### PR TITLE
Extend Str:: helpers after/before and add new Str:: helpers afterLast/beforeLast

### DIFF
--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -8,9 +8,10 @@ use Illuminate\Support\Carbon;
 use Aws\DynamoDb\DynamoDbClient;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Contracts\Cache\LockProvider;
 use Aws\DynamoDb\Exception\DynamoDbException;
 
-class DynamoDbStore implements Store
+class DynamoDbStore implements Store, LockProvider
 {
     use InteractsWithTime;
 

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -46,12 +46,22 @@ class FactoryMakeCommand extends GeneratorCommand
      */
     protected function buildClass($name)
     {
-        $model = $this->option('model')
+        $namespaceModel = $this->option('model')
                         ? $this->qualifyClass($this->option('model'))
-                        : 'Model';
+                        : trim($this->rootNamespace(), '\\').'\\Model';
+
+        $model = class_basename($namespaceModel);
 
         return str_replace(
-            'DummyModel', $model, parent::buildClass($name)
+            [
+                'NamespacedDummyModel',
+                'DummyModel',
+            ],
+            [
+                $namespaceModel,
+                $model,
+            ],
+            parent::buildClass($name)
         );
     }
 

--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -2,8 +2,8 @@
 
 /* @var $factory \Illuminate\Database\Eloquent\Factory */
 
-use Faker\Generator as Faker;
 use NamespacedDummyModel;
+use Faker\Generator as Faker;
 
 $factory->define(DummyModel::class, function (Faker $faker) {
     return [

--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -1,6 +1,9 @@
 <?php
 
+/* @var $factory \Illuminate\Database\Eloquent\Factory */
+
 use Faker\Generator as Faker;
+use NamespacedDummyModel;
 
 $factory->define(DummyModel::class, function (Faker $faker) {
     return [

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -306,6 +306,19 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Get the comparison function to detect duplicates.
+     *
+     * @param  bool  $strict
+     * @return \Closure
+     */
+    protected function duplicateComparator($strict)
+    {
+        return function ($a, $b) {
+            return $a->is($b);
+        };
+    }
+
+    /**
      * Intersect the collection with the given items.
      *
      * @param  \ArrayAccess|array  $items

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -306,19 +306,6 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Get the comparison function to detect duplicates.
-     *
-     * @param  bool  $strict
-     * @return \Closure
-     */
-    protected function duplicateComparator($strict)
-    {
-        return function ($a, $b) {
-            return $a->is($b);
-        };
-    }
-
-    /**
      * Intersect the collection with the given items.
      *
      * @param  \ArrayAccess|array  $items
@@ -504,6 +491,19 @@ class Collection extends BaseCollection implements QueueableCollection
     public function pad($size, $value)
     {
         return $this->toBase()->pad($size, $value);
+    }
+
+    /**
+     * Get the comparison function to detect duplicates.
+     *
+     * @param  bool  $strict
+     * @return \Closure
+     */
+    protected function duplicateComparator($strict)
+    {
+        return function ($a, $b) {
+            return $a->is($b);
+        };
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -616,6 +616,17 @@ class Builder
             return $this->whereNested($column, $boolean);
         }
 
+        // If the operator is a literal string 'in' or 'not in', we will assume
+        // the developer wants to use the corresponding 'in' or 'not in' SQL
+        // operators. We will simply proxy to the query builder methods.
+        if ($operator == 'in') {
+            return $this->whereIn($column, $value, $boolean);
+        }
+
+        if ($operator == 'not in') {
+            return $this->whereNotIn($column, $value, $boolean);
+        }
+
         // If the given operator is not found in the list of valid operators we will
         // assume that the developer is just short-cutting the '=' operators and
         // we will set the operators to '=' and set the values appropriately.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -616,9 +616,9 @@ class Builder
             return $this->whereNested($column, $boolean);
         }
 
-        // If the operator is a literal string 'in' or 'not in', we will assume
-        // the developer wants to use the corresponding 'in' or 'not in' SQL
-        // operators. We will simply proxy to the query builder methods.
+        // If the operator is a literal string 'in' or 'not in', we will assume that
+        // the developer wants to use the "whereIn / whereNotIn" methods for this
+        // operation and proxy the query through those methods from this point.
         if ($operator == 'in') {
             return $this->whereIn($column, $value, $boolean);
         }

--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -15,7 +15,7 @@ class CreateSessionsTable extends Migration
     {
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->unique();
-            $table->unsignedInteger('user_id')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();
             $table->text('payload');

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -420,12 +420,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $uniqueItems = $items->unique(null, $strict);
 
-        $compare = $strict ? function ($a, $b) {
-            return $a === $b;
-        }
-        : function ($a, $b) {
-            return $a == $b;
-        };
+        $compare = $this->duplicateComparator($strict);
 
         $duplicates = new static;
 
@@ -449,6 +444,25 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function duplicatesStrict($callback = null)
     {
         return $this->duplicates($callback, true);
+    }
+
+    /**
+     * Get the comparison function to detect duplicates.
+     *
+     * @param  bool  $strict
+     * @return \Closure
+     */
+    protected function duplicateComparator($strict)
+    {
+        if ($strict) {
+            return function ($a, $b) {
+                return $a === $b;
+            };
+        }
+
+        return function ($a, $b) {
+            return $a == $b;
+        };
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -38,7 +38,7 @@ class Str
      *
      * @param  string  $subject
      * @param  string  $search
-     * @param  boolean $case_insensitive
+     * @param  bool $case_insensitive
      * @return string
      */
     public static function after($subject, $search, $case_insensitive = false)
@@ -55,10 +55,11 @@ class Str
      *
      * @param  string  $subject
      * @param  string  $search
-     * @param  boolean $case_insensitive
+     * @param  bool $case_insensitive
      * @return string
      */
-    public static function afterLast($subject, $search, $case_insensitive = false) {
+    public static function afterLast($subject, $search, $case_insensitive = false)
+    {
         $pos = $case_insensitive ? strripos($subject, $search) : strrpos($subject, $search);
         return $search === '' || $pos === false ? $subject : substr($subject, $pos + strlen($search));
     }
@@ -90,7 +91,7 @@ class Str
      *
      * @param  string  $subject
      * @param  string  $search
-     * @param  boolean $case_insensitive
+     * @param  bool $case_insensitive
      * @return string
      */
     public static function before($subject, $search, $case_insensitive = false)
@@ -107,10 +108,11 @@ class Str
      *
      * @param  string  $subject
      * @param  string  $search
-     * @param  boolean $case_insensitive
+     * @param  bool $case_insensitive
      * @return string
      */
-    public static function beforeLast($subject, $search, $case_insensitive = false) {
+    public static function beforeLast($subject, $search, $case_insensitive = false)
+    {
         $pos = $case_insensitive ? strripos($subject, $search) : strrpos($subject, $search);
         return $search === '' || $pos === false ? $subject : substr($subject, 0, $pos);
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -47,7 +47,7 @@ class Str
             return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
         }
         $pos = stripos($subject, $search);
-        
+
         return $pos === false ? $subject : substr($subject, $pos + strlen($search));
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -98,7 +98,8 @@ class Str
         if ($case_insensitive === false || $search === '') {
             return $search === '' ? $subject : explode($search, $subject, 2)[0];
         }
-        return stripos($subject, $search) === false ? $subject : substr($subject, 0, stripos($subject, $search));
+        $pos = stripos($subject, $search) === false;
+        return $pos ? $subject : substr($subject, 0, $pos);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -34,15 +34,33 @@ class Str
     protected static $studlyCache = [];
 
     /**
-     * Return the remainder of a string after a given value.
+     * Return the remainder of a string after the first occurence of a given value.
      *
      * @param  string  $subject
      * @param  string  $search
+     * @param  boolean $case_insensitive
      * @return string
      */
-    public static function after($subject, $search)
+    public static function after($subject, $search, $case_insensitive = false)
     {
-        return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
+        if ($case_insensitive === false || $subject === '') {
+            return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
+        }
+        $pos = stripos($subject, $search);
+        return $pos === false ? $subject : substr($subject, $pos + strlen($search));
+    }
+
+    /**
+     * Return the remainder of a string after the last occurrence of a given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @param  boolean $case_insensitive
+     * @return string
+     */
+    public static function afterLast($subject, $search, $case_insensitive = false) {
+        $pos = $case_insensitive ? strripos($subject, $search) : strrpos($subject, $search);
+        return $search === '' || $pos === false ? $subject : substr($subject, $pos + strlen($search));
     }
 
     /**
@@ -68,15 +86,32 @@ class Str
     }
 
     /**
-     * Get the portion of a string before a given value.
+     * Get the portion of a string before the first occurence of a given value.
      *
      * @param  string  $subject
      * @param  string  $search
+     * @param  boolean $case_insensitive
      * @return string
      */
-    public static function before($subject, $search)
+    public static function before($subject, $search, $case_insensitive = false)
     {
-        return $search === '' ? $subject : explode($search, $subject)[0];
+        if ($case_insensitive === false || $search === '') {
+            return $search === '' ? $subject : explode($search, $subject, 2)[0];
+        }
+        return stripos($subject, $search) === false ? $subject : substr($subject, 0, stripos($subject, $search));
+    }
+
+    /**
+     * Get the portion of a string before the last occurrence of a given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @param  boolean $case_insensitive
+     * @return string
+     */
+    public static function beforeLast($subject, $search, $case_insensitive = false) {
+        $pos = $case_insensitive ? strripos($subject, $search) : strrpos($subject, $search);
+        return $search === '' || $pos === false ? $subject : substr($subject, 0, $pos);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -122,6 +122,51 @@ class Str
     }
 
     /**
+     * Get the portion of a string between delimiters
+     *
+     * @param  string  $subject
+     * @param  string  $after
+     * @param  string  $before
+     * @param  bool    $case_insensitive
+     * @return string
+     */
+    public static function between($subject, $after, $before = null, $case_insensitive = false) {
+        $before = $before === null ? $after : $before;
+
+        return self::before(self::after($subject, $after, $case_insensitive), $before, $case_insensitive);
+    }
+
+    /**
+     * Get the largest portion of a string between delimiters
+     *
+     * @param  string  $subject
+     * @param  string  $after
+     * @param  string  $before
+     * @param  bool    $case_insensitive
+     * @return string
+     */
+    public static function betweenGreedy($subject, $after, $before = null, $case_insensitive = false) {
+        $before = $before === null ? $after : $before;
+
+        return self::beforeLast(self::after($subject, $after, $case_insensitive), $before, $case_insensitive);
+    }
+
+    /**
+     * Get the last portion of a string between delimiters
+     *
+     * @param  string  $subject
+     * @param  string  $after
+     * @param  string  $before
+     * @param  bool    $case_insensitive
+     * @return string
+     */
+    public static function betweenLazy($subject, $after, $before = null, $case_insensitive = false) {
+        $before = $before === null ? $after : $before;
+
+        return self::afterLast(self::beforeLast($subject, $before, $case_insensitive), $after, $case_insensitive);
+    }
+
+    /**
      * Convert a value to camel case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -122,7 +122,7 @@ class Str
     }
 
     /**
-     * Get the portion of a string between delimiters
+     * Get the portion of a string between delimiters.
      *
      * @param  string  $subject
      * @param  string  $after
@@ -130,14 +130,15 @@ class Str
      * @param  bool    $case_insensitive
      * @return string
      */
-    public static function between($subject, $after, $before = null, $case_insensitive = false) {
+    public static function between($subject, $after, $before = null, $case_insensitive = false)
+    {
         $before = $before === null ? $after : $before;
 
         return self::before(self::after($subject, $after, $case_insensitive), $before, $case_insensitive);
     }
 
     /**
-     * Get the largest portion of a string between delimiters
+     * Get the largest portion of a string between delimiters.
      *
      * @param  string  $subject
      * @param  string  $after
@@ -145,14 +146,15 @@ class Str
      * @param  bool    $case_insensitive
      * @return string
      */
-    public static function betweenGreedy($subject, $after, $before = null, $case_insensitive = false) {
+    public static function betweenGreedy($subject, $after, $before = null, $case_insensitive = false)
+    {
         $before = $before === null ? $after : $before;
 
         return self::beforeLast(self::after($subject, $after, $case_insensitive), $before, $case_insensitive);
     }
 
     /**
-     * Get the last portion of a string between delimiters
+     * Get the last portion of a string between delimiters.
      *
      * @param  string  $subject
      * @param  string  $after
@@ -160,7 +162,8 @@ class Str
      * @param  bool    $case_insensitive
      * @return string
      */
-    public static function betweenLazy($subject, $after, $before = null, $case_insensitive = false) {
+    public static function betweenLazy($subject, $after, $before = null, $case_insensitive = false)
+    {
         $before = $before === null ? $after : $before;
 
         return self::afterLast(self::beforeLast($subject, $before, $case_insensitive), $after, $case_insensitive);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -47,6 +47,7 @@ class Str
             return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
         }
         $pos = stripos($subject, $search);
+        
         return $pos === false ? $subject : substr($subject, $pos + strlen($search));
     }
 
@@ -61,6 +62,7 @@ class Str
     public static function afterLast($subject, $search, $case_insensitive = false)
     {
         $pos = $case_insensitive ? strripos($subject, $search) : strrpos($subject, $search);
+
         return $search === '' || $pos === false ? $subject : substr($subject, $pos + strlen($search));
     }
 
@@ -100,6 +102,7 @@ class Str
             return $search === '' ? $subject : explode($search, $subject, 2)[0];
         }
         $pos = stripos($subject, $search) === false;
+
         return $pos ? $subject : substr($subject, 0, $pos);
     }
 
@@ -114,6 +117,7 @@ class Str
     public static function beforeLast($subject, $search, $case_insensitive = false)
     {
         $pos = $case_insensitive ? strripos($subject, $search) : strrpos($subject, $search);
+
         return $search === '' || $pos === false ? $subject : substr($subject, 0, $pos);
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -46,9 +46,9 @@ class Str
         if ($case_insensitive === false || $subject === '') {
             return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
         }
-        $pos = stripos($subject, $search);
+        $pos = mb_stripos($subject, $search);
 
-        return $pos === false ? $subject : substr($subject, $pos + strlen($search));
+        return $pos === false ? $subject : mb_substr($subject, $pos + mb_strlen($search));
     }
 
     /**
@@ -61,9 +61,9 @@ class Str
      */
     public static function afterLast($subject, $search, $case_insensitive = false)
     {
-        $pos = $case_insensitive ? strripos($subject, $search) : strrpos($subject, $search);
+        $pos = $case_insensitive ? mb_strripos($subject, $search) : mb_strrpos($subject, $search);
 
-        return $search === '' || $pos === false ? $subject : substr($subject, $pos + strlen($search));
+        return $search === '' || $pos === false ? $subject : mb_substr($subject, $pos + mb_strlen($search));
     }
 
     /**
@@ -101,9 +101,9 @@ class Str
         if ($case_insensitive === false || $search === '') {
             return $search === '' ? $subject : explode($search, $subject, 2)[0];
         }
-        $pos = stripos($subject, $search) === false;
+        $pos = mb_stripos($subject, $search) === false;
 
-        return $pos ? $subject : substr($subject, 0, $pos);
+        return $pos ? $subject : mb_substr($subject, 0, $pos);
     }
 
     /**
@@ -116,9 +116,9 @@ class Str
      */
     public static function beforeLast($subject, $search, $case_insensitive = false)
     {
-        $pos = $case_insensitive ? strripos($subject, $search) : strrpos($subject, $search);
+        $pos = $case_insensitive ? mb_strripos($subject, $search) : mb_strrpos($subject, $search);
 
-        return $search === '' || $pos === false ? $subject : substr($subject, 0, $pos);
+        return $search === '' || $pos === false ? $subject : mb_substr($subject, 0, $pos);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -101,9 +101,9 @@ class Str
         if ($case_insensitive === false || $search === '') {
             return $search === '' ? $subject : explode($search, $subject, 2)[0];
         }
-        $pos = mb_stripos($subject, $search) === false;
+        $pos = mb_stripos($subject, $search);
 
-        return $pos ? $subject : mb_substr($subject, 0, $pos);
+        return $pos === false ? $subject : mb_substr($subject, 0, $pos);
     }
 
     /**

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -319,4 +319,14 @@ class FileViewFinder implements ViewFinderInterface
     {
         return $this->extensions;
     }
+
+    /**
+     * Get registered views.
+     *
+     * @return array
+     */
+    public function getViews()
+    {
+        return $this->views;
+    }
 }

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -301,6 +301,16 @@ class FileViewFinder implements ViewFinderInterface
     }
 
     /**
+     * Get the views that have been located.
+     *
+     * @return array
+     */
+    public function getViews()
+    {
+        return $this->views;
+    }
+
+    /**
      * Get the namespace to file path hints.
      *
      * @return array
@@ -318,15 +328,5 @@ class FileViewFinder implements ViewFinderInterface
     public function getExtensions()
     {
         return $this->extensions;
-    }
-
-    /**
-     * Get registered views.
-     *
-     * @return array
-     */
-    public function getViews()
-    {
-        return $this->views;
     }
 }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -245,6 +245,28 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(new Collection([$one]), $c1->diff($c2));
     }
 
+    public function testCollectionReturnsDuplicateBasedOnlyOnKeys()
+    {
+        $one = new TestEloquentCollectionModel();
+        $two = new TestEloquentCollectionModel();
+        $three = new TestEloquentCollectionModel();
+        $four = new TestEloquentCollectionModel();
+        $one->id = 1;
+        $one->someAttribute = '1';
+        $two->id = 1;
+        $two->someAttribute = '2';
+        $three->id = 1;
+        $three->someAttribute = '3';
+        $four->id = 2;
+        $four->someAttribute = '4';
+
+        $duplicates = Collection::make([$one, $two, $three, $four])->duplicates()->all();
+        $this->assertSame([1 => $two, 2 => $three], $duplicates);
+
+        $duplicates = Collection::make([$one, $two, $three, $four])->duplicatesStrict()->all();
+        $this->assertSame([1 => $two, 2 => $three], $duplicates);
+    }
+
     public function testCollectionIntersectsWithGivenCollection()
     {
         $one = m::mock(Model::class);

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -275,6 +275,28 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(new Collection([$one, $two]), $c->unique());
     }
 
+    public function testCollectionReturnsUniqueStrictBasedOnKeysOnly()
+    {
+        $one = new TestEloquentCollectionModel();
+        $two = new TestEloquentCollectionModel();
+        $three = new TestEloquentCollectionModel();
+        $four = new TestEloquentCollectionModel();
+        $one->id = 1;
+        $one->someAttribute = '1';
+        $two->id = 1;
+        $two->someAttribute = '2';
+        $three->id = 1;
+        $three->someAttribute = '3';
+        $four->id = 2;
+        $four->someAttribute = '4';
+
+        $uniques = Collection::make([$one, $two, $three, $four])->unique()->all();
+        $this->assertSame([$three, $four], $uniques);
+
+        $uniques = Collection::make([$one, $two, $three, $four])->unique(null, true)->all();
+        $this->assertSame([$three, $four], $uniques);
+    }
+
     public function testOnlyReturnsCollectionWithGivenModelKeys()
     {
         $one = m::mock(Model::class);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -645,6 +645,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
 
         $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 'in', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', [1, 2, 3]);
         $this->assertEquals('select * from "users" where "id" = ? or "id" in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
@@ -654,6 +659,11 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotIn('id', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 'not in', [1, 2, 3]);
         $this->assertEquals('select * from "users" where "id" not in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
 


### PR DESCRIPTION
Small but nice change. Non-breaking.

Add case-insensitive support for `Str::after` and `Str::before` allowing you to search before/after an occurrence of a substring, ignoring case, by passing `true` as the third argument.

And add new helpers `Str::afterLast` and `Str::beforeLast` which act similar to `Str::after` and `Str::before`, which find the the first occurrence of the substring, and instead find the last occurrence of the substring. This also has case-insensitive support by passing `true` as the third argument.

---

Ran some benchmarks for a million iterations (variance in results were ± 0.1s:

Context:
```php
$string = 'foo bar foo BAR foo bar foo BAR foo';
$find = 'BAR';
$wontFind = 'Whoops';
```

Current benchmarks:
- `Str::before($string, $find)`: 2.020s
- `Str::after($string, $find)`: 2.831s
- `Str::before($string, $wontFind)`: 1.912s
- `Str::after($string, $wontFind)`: 2.685s

Proposed-change benchmarks _(basically the same code for these)_:
- `Str::before($string, $find)`: 1.973s
- `Str::after($string, $find)`: 2.819s
- `Str::before($string, $wontFind)`: 1.890s
- `Str::after($string, $wontFind)`: 2.591s

New feature benchmarks:
- `Str::beforeLast($string, $find)`: 2.714s
- `Str::afterLast($string, $find)`: 2.786s
- `Str::beforeLast($string, $find, true)`: 2.957s
- `Str::afterLast($string, $find, true)`: 3.061s
- `Str::beforeLast($string, $wontFind)`: 1.930s
- `Str::afterLast($string, $wontFind)`: 1.881s
- `Str::before($string, $find, true)`: 3.916s
- `Str::after($string, $find, true)`: 3.022s

I tried a few different ways of supporting case-sensitive and case-insensitive lookups concurrently, by using `$case_insensitive ? stripos() : strpos()` (and `$case_insensitive ? strripos() : strrpos()`), however the "Current benchmarks" increased quite a bit -- because obviously the current code is optimal. This is why the code is split across a few lines using the existing code if case-sensitive (i.e. `explode`), otherwise `stripos()` if case-insensitive. Not as clean as it could be, but the benchmarks are comparable and is non-breaking.

--

Example Usage:

```php
// after (insensitive)
Str::after('This and this AND this', 'AND', true); // returns: ' this AND this'

// before (insensitive)
Str::after('This and this AND this', 'AND', true); // returns: 'This '

// afterLast
Str::afterLast('\\App\\Http\\Controllers\\UserController', '\\'); // returns: 'UserController'

// beforeLast
Str::beforeLast('\\App\\Http\\Controllers\\UserController', '\\'); // returns: '\\App\\Http\\Controllers'
```

I'm sure you can imagine what the insensitive versions of `afterLast` and `beforeLast` do.

Superseded by https://github.com/laravel/framework/pull/28218