### PR TITLE
[5.8] Update Queue.php, update all $data vars datatype

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -6,12 +6,12 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
 
 /**
  * @method static int size(string $queue = null)
- * @method static mixed push(string|object $job, string $data = '', $queue = null)
- * @method static mixed pushOn(string $queue, string|object $job, $data = '')
+ * @method static mixed push(string|object $job, mixed $data = '', $queue = null)
+ * @method static mixed pushOn(string $queue, string|object $job, mixed $data = '')
  * @method static mixed pushRaw(string $payload, string $queue = null, array $options = [])
- * @method static mixed later(\DateTimeInterface|\DateInterval|int $delay, string|object $job, $data = '', string $queue = null)
- * @method static mixed laterOn(string $queue, \DateTimeInterface|\DateInterval|int $delay, string|object $job, $data = '')
- * @method static mixed bulk(array $jobs, $data = '', string $queue = null)
+ * @method static mixed later(\DateTimeInterface|\DateInterval|int $delay, string|object $job, mixed $data = '', string $queue = null)
+ * @method static mixed laterOn(string $queue, \DateTimeInterface|\DateInterval|int $delay, string|object $job, mixed $data = '')
+ * @method static mixed bulk(array $jobs, mixed $data = '', string $queue = null)
  * @method static \Illuminate\Contracts\Queue\Job|null pop(string $queue = null)
  * @method static string getConnectionName()
  * @method static \Illuminate\Contracts\Queue\Queue setConnectionName(string $name)


### PR DESCRIPTION
$data var should support multi datatype, not only string.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
