### PR TITLE
[5.8] Fix memory leak in JOIN queries

### DIFF
--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -21,11 +21,32 @@ class JoinClause extends Builder
     public $table;
 
     /**
-     * The parent query builder instance.
+     * The connection of the parent query builder.
      *
-     * @var \Illuminate\Database\Query\Builder
+     * @var \Illuminate\Database\ConnectionInterface
      */
-    private $parentQuery;
+    protected $parentConnection;
+
+    /**
+     * The grammar of the parent query builder.
+     *
+     * @var \Illuminate\Database\Query\Grammars\Grammar
+     */
+    protected $parentGrammar;
+
+    /**
+     * The processor of the parent query builder.
+     *
+     * @var \Illuminate\Database\Query\Processors\Processor
+     */
+    protected $parentProcessor;
+
+    /**
+     * The class name of the parent query builder.
+     *
+     * @var string
+     */
+    protected $parentClass;
 
     /**
      * Create a new join clause instance.
@@ -39,10 +60,13 @@ class JoinClause extends Builder
     {
         $this->type = $type;
         $this->table = $table;
-        $this->parentQuery = $parentQuery;
+        $this->parentConnection = $parentQuery->getConnection();
+        $this->parentGrammar = $parentQuery->getGrammar();
+        $this->parentProcessor = $parentQuery->getProcessor();
+        $this->parentClass = get_class($parentQuery);
 
         parent::__construct(
-            $parentQuery->getConnection(), $parentQuery->getGrammar(), $parentQuery->getProcessor()
+            $this->parentConnection, $this->parentGrammar, $this->parentProcessor
         );
     }
 
@@ -95,7 +119,7 @@ class JoinClause extends Builder
      */
     public function newQuery()
     {
-        return new static($this->parentQuery, $this->type, $this->table);
+        return new static($this->newParentQuery(), $this->type, $this->table);
     }
 
     /**
@@ -105,6 +129,18 @@ class JoinClause extends Builder
      */
     protected function forSubQuery()
     {
-        return $this->parentQuery->newQuery();
+        return $this->newParentQuery()->newQuery();
+    }
+
+    /**
+     * Create a new parent query instance.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    protected function newParentQuery()
+    {
+        $class = $this->parentClass;
+
+        return new $class($this->parentConnection, $this->parentGrammar, $this->parentProcessor);
     }
 }


### PR DESCRIPTION
Every `JoinClause` instance receives and stores the parent query. The instance itself then gets stored in the parent query's `$joins` property. This [circular reference](https://medium.com/@johann.pardanaud/about-circular-references-in-php-10f71f811e9) causes a memory leak and can be an issue for long-running scripts. 

We can fix it by storing the parent query's connection, grammar, processor and class name separately instead of the whole query instance.

The removed `$parentQuery` property was private, so this shouldn't be a breaking change.

Fixes #28195.