### PR TITLE
[5.8] Application::registerConfiguredProviders - Load Order Change

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -568,7 +568,15 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
                             return Str::startsWith($provider, 'Illuminate\\');
                         });
 
-        $providers->splice(1, 0, [$this->make(PackageManifest::class)->providers()]);
+        $appProviders = $providers->get(1)
+                            ->partition(function ($provider) {
+                                return Str::startsWith($provider, 'App\\');
+                            });
+
+        $providers->put(1, $appProviders[1]); // App\\
+        $providers->put(2, $appProviders[0]); // providers registered between Illuminate\\ and App\\
+
+        $providers->splice(2, 0, [$this->make(PackageManifest::class)->providers()]);
 
         (new ProviderRepository($this, new Filesystem, $this->getCachedServicesPath()))
                     ->load($providers->collapse()->toArray());


### PR DESCRIPTION

Why I am making this pull request:
--------------------------------

#### History/Reasons

I wrote StringBladeCompiler which adds to the functionality of the View class. The original way I replaced the View component was to remove the ServiceProvider reference in the config/app.php file and register the package ServiceProvider, which set up my extended view classes as the base View class.

This worked fine until the ServiceProvider auto load feature was implemented. Vendor packages that are registered with autoload are loaded before vendor packages referenced in the config/app.php file.

A example of the issue, I was messing around with https://github.com/the-control-group/voyager, a admin package. That package requires this package, https://github.com/larapack/voyager-hooks, which registers a view namespace in the register function, [#L40](https://github.com/larapack/voyager-hooks/blob/5de5a5f06c8359c7f09fb1bb9acd84b3f5379506/src/VoyagerHooksServiceProvider.php#L40)

Using my original method of replacing the View class, and the example above, this process will now cause an error as other package service providers load before mine. This results in the View class not existing, when the voyager-hooks register function tries to add a view namespace location. However, before the autoloading of service providers my process worked fine. 

I have since updated my code to not need the removal of the original View registration in config/app.php. So this is not a "issue" for me anymore.

#### The However
> I thought it was odd that vendor autoloaded service providers get priority over the vendor service providers I registered manually in the config/app.php file. I felt that the service providers that I specify in the config/app.php should get priority over any vendor package service provider that is autoloaded.

The pull request is to allow that ability.

#### The Existing Code

The existing code in ```Application::registerConfiguredProviders```, does the following.

- It gets the providers from ```$this->config['app.providers']```, splits them in to two groups. Those packages that start with ```Illuminate\\``` and everything else.
- It next prepends, the AutoLoaded vendor packages to the everything else group.

This results in the following registration order for Service Providers:

```php
array:38 [
  0 => "Illuminate\Auth\AuthServiceProvider"
  // trimed
  21 => "Illuminate\View\ViewServiceProvider"
  
  // autoloaded vendor packages
  22 => "Arrilot\Widgets\ServiceProvider"
  // trimed
  31 => "TCG\Voyager\Providers\VoyagerDummyServiceProvider"
  
  // config/app.php vendor and application providers.
  32 => "Wpb\String_Blade_Compiler\ViewServiceProvider"
  33 => "App\Providers\AppServiceProvider"
  34 => "App\Providers\AuthServiceProvider"
  35 => "App\Providers\EventServiceProvider"
  36 => "App\Providers\RouteServiceProvider"  
]
```

As you can see my directly registered package is not loaded until after all other vendor packages are loaded.

#### The code change

- It gets the providers from ```$this->config['app.providers']```, splits them in to two groups. Those packages that start with ```Illuminate\\``` and everything else.
- It then splits the everything else group extracting the ```App\\``` service providers.
- It then reassembles the group to be ```Illuminate\\```, ```config/app.php vendor```, and ```App\\```
- It next prepends, the AutoLoaded vendor packages to the ```App\\``` group.

This results in the following registration order for Service Providers:

```php
array:38 [
  0 => "Illuminate\Auth\AuthServiceProvider"
  // trimed
  21 => "Illuminate\View\ViewServiceProvider"
  
  // vendor packages registered in config/app.php
  22 => "Wpb\String_Blade_Compiler\ViewServiceProvider"
  
  // autoloaded vendor packages
  23 => "Arrilot\Widgets\ServiceProvider"
  // trimed
  32 => "TCG\Voyager\Providers\VoyagerDummyServiceProvider"
  
  // config/app.php application providers.
  33 => "App\Providers\AppServiceProvider"
  34 => "App\Providers\AuthServiceProvider"
  35 => "App\Providers\EventServiceProvider"
  36 => "App\Providers\RouteServiceProvider"
  37 => "App\Providers\CopyAssetsProvider"
]
```

As you can see the new registration order now give the vendor packages registered in config/app.php priority over the auto registered packages.

> Sorry about the book, but I wanted to provide enough information to show why I felt this change would be of benefit.

Thanks for reading. 