### PR TITLE
[5.9] Allow faking only specific jobs

### DIFF
--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -20,11 +20,12 @@ class Bus extends Facade
     /**
      * Replace the bound instance with a fake.
      *
+     * @param  array|string  $jobsToFake
      * @return \Illuminate\Support\Testing\Fakes\BusFake
      */
-    public static function fake()
+    public static function fake($jobsToFake = [])
     {
-        static::swap($fake = new BusFake);
+        static::swap($fake = new BusFake(static::getFacadeRoot(), $jobsToFake));
 
         return $fake;
     }

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -2,17 +2,47 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
+use Closure;
+use Illuminate\Support\Arr;
 use Illuminate\Contracts\Bus\Dispatcher;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class BusFake implements Dispatcher
 {
     /**
+     * The original bus dispatcher.
+     *
+     * @var \Illuminate\Contracts\Bus\Dispatcher
+     */
+    protected $dispatcher;
+
+    /**
+     * The job types that should be intercepted instead of dispatched.
+     *
+     * @var array
+     */
+    protected $jobsToFake;
+
+    /**
      * The commands that have been dispatched.
      *
      * @var array
      */
     protected $commands = [];
+
+    /**
+     * Create a new bus fake instance.
+     *
+     * @param  \Illuminate\Contracts\Bus\Dispatcher  $dispatcher
+     * @param  array|string  $jobsToFake
+     * @return void
+     */
+    public function __construct(Dispatcher $dispatcher, $jobsToFake = [])
+    {
+        $this->dispatcher = $dispatcher;
+
+        $this->jobsToFake = Arr::wrap($jobsToFake);
+    }
 
     /**
      * Assert if a job was dispatched based on a truth-test callback.
@@ -40,7 +70,7 @@ class BusFake implements Dispatcher
      * @param  int  $times
      * @return void
      */
-    protected function assertDispatchedTimes($command, $times = 1)
+    public function assertDispatchedTimes($command, $times = 1)
     {
         PHPUnit::assertTrue(
             ($count = $this->dispatched($command)->count()) === $times,
@@ -104,7 +134,11 @@ class BusFake implements Dispatcher
      */
     public function dispatch($command)
     {
-        return $this->dispatchNow($command);
+        if ($this->shouldFakeJob($command)) {
+            $this->commands[get_class($command)][] = $command;
+        } else {
+            return $this->dispatcher->dispatch($command);
+        }
     }
 
     /**
@@ -116,7 +150,32 @@ class BusFake implements Dispatcher
      */
     public function dispatchNow($command, $handler = null)
     {
-        $this->commands[get_class($command)][] = $command;
+        if ($this->shouldFakeJob($command)) {
+            $this->commands[get_class($command)][] = $command;
+        } else {
+            return $this->dispatcher->dispatchNow($command, $handler);
+        }
+    }
+
+    /**
+     * Determine if an command should be faked or actually dispatched.
+     *
+     * @param  mixed  $command
+     * @return bool
+     */
+    protected function shouldFakeJob($command)
+    {
+        if (empty($this->jobsToFake)) {
+            return true;
+        }
+
+        return collect($this->jobsToFake)
+            ->filter(function ($job) use ($command) {
+                return $job instanceof Closure
+                            ? $job($command)
+                            : $job === get_class($command);
+            })
+            ->isNotEmpty();
     }
 
     /**
@@ -127,7 +186,9 @@ class BusFake implements Dispatcher
      */
     public function pipeThrough(array $pipes)
     {
-        //
+        $this->dispatcher->pipeThrough($pipes);
+
+        return $this;
     }
 
     /**
@@ -138,7 +199,7 @@ class BusFake implements Dispatcher
      */
     public function hasCommandHandler($command)
     {
-        return false;
+        return $this->dispatcher->hasCommandHandler($command);
     }
 
     /**
@@ -149,7 +210,7 @@ class BusFake implements Dispatcher
      */
     public function getCommandHandler($command)
     {
-        return false;
+        return $this->dispatcher->getCommandHandler($command);
     }
 
     /**
@@ -160,6 +221,8 @@ class BusFake implements Dispatcher
      */
     public function map(array $map)
     {
+        $this->dispatcher->map($map);
+
         return $this;
     }
 }

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Support\Testing\Fakes\BusFake;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\Constraint\ExceptionMessage;
+
+class SupportTestingBusFakeTest extends TestCase
+{
+    /** @var \Illuminate\Support\Testing\Fakes\BusFake */
+    protected $fake;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fake = new BusFake(m::mock(Dispatcher::class));
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testAssertDispatched()
+    {
+        try {
+            $this->fake->assertDispatched(BusJobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\BusJobStub] job was not dispatched.'));
+        }
+
+        $this->fake->dispatch(new BusJobStub);
+
+        $this->fake->assertDispatched(BusJobStub::class);
+    }
+
+    public function testAssertDispatchedNow()
+    {
+        $this->fake->dispatchNow(new BusJobStub);
+
+        $this->fake->assertDispatched(BusJobStub::class);
+    }
+
+    public function testAssertDispatchedWithCallbackInt()
+    {
+        $this->fake->dispatch(new BusJobStub);
+        $this->fake->dispatchNow(new BusJobStub);
+
+        try {
+            $this->fake->assertDispatched(BusJobStub::class, 1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\BusJobStub] job was pushed 2 times instead of 1 times.'));
+        }
+
+        $this->fake->assertDispatched(BusJobStub::class, 2);
+    }
+
+    public function testAssertDispatchedWithCallbackFunction()
+    {
+        $this->fake->dispatch(new OtherBusJobStub);
+        $this->fake->dispatchNow(new OtherBusJobStub(1));
+
+        try {
+            $this->fake->assertDispatched(OtherBusJobStub::class, function ($job) {
+                return $job->id === 0;
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\OtherBusJobStub] job was not dispatched.'));
+        }
+
+        $this->fake->assertDispatched(OtherBusJobStub::class, function ($job) {
+            return $job->id === null;
+        });
+
+        $this->fake->assertDispatched(OtherBusJobStub::class, function ($job) {
+            return $job->id === 1;
+        });
+    }
+
+    public function testAssertDispatchedTimes()
+    {
+        $this->fake->dispatch(new BusJobStub);
+        $this->fake->dispatchNow(new BusJobStub);
+
+        try {
+            $this->fake->assertDispatchedTimes(BusJobStub::class, 1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\BusJobStub] job was pushed 2 times instead of 1 times.'));
+        }
+
+        $this->fake->assertDispatchedTimes(BusJobStub::class, 2);
+    }
+
+    public function testAssertNotDispatched()
+    {
+        $this->fake->assertNotDispatched(BusJobStub::class);
+
+        $this->fake->dispatch(new BusJobStub);
+        $this->fake->dispatchNow(new BusJobStub);
+
+        try {
+            $this->fake->assertNotDispatched(BusJobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\BusJobStub] job was dispatched.'));
+        }
+    }
+
+    public function testAssertDispatchedWithIgnoreClass()
+    {
+        $dispatcher = m::mock(Dispatcher::class);
+
+        $job = new BusJobStub;
+        $dispatcher->shouldReceive('dispatch')->once()->with($job);
+        $dispatcher->shouldReceive('dispatchNow')->once()->with($job, null);
+
+        $otherJob = new OtherBusJobStub;
+        $dispatcher->shouldReceive('dispatch')->never()->with($otherJob);
+        $dispatcher->shouldReceive('dispatchNow')->never()->with($otherJob, null);
+
+        $fake = new BusFake($dispatcher, OtherBusJobStub::class);
+
+        $fake->dispatch($job);
+        $fake->dispatchNow($job);
+
+        $fake->dispatch($otherJob);
+        $fake->dispatchNow($otherJob);
+
+        $fake->assertNotDispatched(BusJobStub::class);
+        $fake->assertDispatchedTimes(OtherBusJobStub::class, 2);
+    }
+
+    public function testAssertDispatchedWithIgnoreCallback()
+    {
+        $dispatcher = m::mock(Dispatcher::class);
+
+        $job = new BusJobStub;
+        $dispatcher->shouldReceive('dispatch')->once()->with($job);
+        $dispatcher->shouldReceive('dispatchNow')->once()->with($job, null);
+
+        $otherJob = new OtherBusJobStub;
+        $dispatcher->shouldReceive('dispatch')->once()->with($otherJob);
+        $dispatcher->shouldReceive('dispatchNow')->once()->with($otherJob, null);
+
+        $anotherJob = new OtherBusJobStub(1);
+        $dispatcher->shouldReceive('dispatch')->never()->with($anotherJob);
+        $dispatcher->shouldReceive('dispatchNow')->never()->with($anotherJob, null);
+
+        $fake = new BusFake($dispatcher, [
+            function ($command) {
+                return $command instanceof OtherBusJobStub && $command->id === 1;
+            },
+        ]);
+
+        $fake->dispatch($job);
+        $fake->dispatchNow($job);
+
+        $fake->dispatch($otherJob);
+        $fake->dispatchNow($otherJob);
+
+        $fake->dispatch($anotherJob);
+        $fake->dispatchNow($anotherJob);
+
+        $fake->assertNotDispatched(BusJobStub::class);
+        $fake->assertDispatchedTimes(OtherBusJobStub::class, 2);
+        $fake->assertNotDispatched(OtherBusJobStub::class, function ($job) {
+            return $job->id === null;
+        });
+        $fake->assertDispatched(OtherBusJobStub::class, function ($job) {
+            return $job->id === 1;
+        });
+    }
+}
+
+class BusJobStub
+{
+    //
+}
+
+class OtherBusJobStub
+{
+    public $id;
+
+    public function __construct($id = null)
+    {
+        $this->id = $id;
+    }
+}


### PR DESCRIPTION
Sometimes you need jobs to be dispatched as normal, but just want to make assertions on specific jobs. This feature works in the same fashion as the EventFake: Event::fake([OrderCreated::class])

Bonus: I have added tests for the whole BusFake class.

```php
public function testOrderShipping()
{
    // Fake only this type of job
    Bus::fake([ShipOrder::class]);

    // Or fake only these specific jobs
    Bus::fake([function ($job) {
        return $job instanceof ShipOrder
            && $job->order->hasFreeShipping();
    });

    // Perform order shipping...
    Bus::dispatch(new ShipOrder);

    // Dispatch another job as normal
    Bus::dispatch(new AnotherJob);

    // Assert a job was dispatched
    Bus::assertDispatched(ShipOrder::class);

    // Or assert a specific job was dispatched
    Bus::assertDispatched(ShipOrder::class, function ($job) {
        return $job->order->hasFreeShipping();
    });

    // Other jobs are dispatched as normal,
    // although they are **not** captured by the bus fake
    Bus::assertNotDispatched(AnotherJob::class);
}
```