### PR TITLE
[5.8] Corrected phpdoc for Filesystem append() and prepend()

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -91,7 +91,7 @@ interface Filesystem
      *
      * @param  string  $path
      * @param  string  $data
-     * @return int
+     * @return bool
      */
     public function prepend($path, $data);
 
@@ -100,7 +100,7 @@ interface Filesystem
      *
      * @param  string  $path
      * @param  string  $data
-     * @return int
+     * @return bool
      */
     public function append($path, $data);
 


### PR DESCRIPTION
A simple phpdoc correction as described in issue #28225
