### PR TITLE
[5.8] Fix fake dispatcher issue

### DIFF
--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -23,6 +23,8 @@ class AuthServiceProvider extends ServiceProvider
         $this->registerAccessGate();
 
         $this->registerRequestRebindHandler();
+
+        $this->registerEventRebindHandler();
     }
 
     /**
@@ -85,6 +87,21 @@ class AuthServiceProvider extends ServiceProvider
             $request->setUserResolver(function ($guard = null) use ($app) {
                 return call_user_func($app['auth']->userResolver(), $guard);
             });
+        });
+    }
+
+    /**
+     * Register a resolver for the 'events' rebinding.
+     *
+     * @return void
+     */
+    protected function registerEventRebindHandler()
+    {
+        $this->app->rebinding('events', function ($app, $dispatcher) {
+            $guard = $app['auth']->guard();
+            if (method_exists($guard, 'setDispatcher')) {
+                $guard->setDispatcher($dispatcher);
+            }
         });
     }
 }


### PR DESCRIPTION
Description:
Integration tests proof that it will work with both built-in session guard or any other custom guard whether it has a dispatcher or not.

Note : some build-in guards like Token guard does dispatch any events, hence there is no `setDispatcher ` method or any dispatcher on it.
So there are 2 types of guards.

which I think a contract (interface) is missing here, in order to mark the SessionGuard class or any other custom guard as an event dispatching guard, and enforce `setDispatcher` and `getDispatcher` methods on them.)

So the clunky `method_exists` check won't be needed.

Re-submit: https://github.com/laravel/framework/pull/28131
fixed: https://github.com/laravel/framework/issues/27451

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
