### PR TITLE
[5.8] Fix issue with is() and unpersisted models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1189,6 +1189,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function is($model)
     {
         return ! is_null($model) &&
+               $this->exists &&
+               $model->exists &&
                $this->getKey() === $model->getKey() &&
                $this->getTable() === $model->getTable() &&
                $this->getConnectionName() === $model->getConnectionName();

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -252,12 +252,16 @@ class DatabaseEloquentCollectionTest extends TestCase
         $three = new TestEloquentCollectionModel();
         $four = new TestEloquentCollectionModel();
         $one->id = 1;
+        $one->exists = 1;
         $one->someAttribute = '1';
         $two->id = 1;
+        $two->exists = 1;
         $two->someAttribute = '2';
         $three->id = 1;
+        $three->exists = 1;
         $three->someAttribute = '3';
         $four->id = 2;
+        $four->exists = 1;
         $four->someAttribute = '4';
 
         $duplicates = Collection::make([$one, $two, $three, $four])->duplicates()->all();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1513,7 +1513,9 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with('eloquent.replicating: '.get_class($model), m::on(function ($m) use ($model) {
-            return $model->is($m);
+            return $model->getKey() === $m->getKey()
+                && $model->getTable() === $m->getTable()
+                && $model->getConnectionName() === $m->getConnectionName();
         }));
 
         $model->replicate();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1821,15 +1821,35 @@ class DatabaseEloquentModelTest extends TestCase
     public function testIsWithNull()
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
+        $firstInstance->exists = true;
         $secondInstance = null;
 
         $this->assertFalse($firstInstance->is($secondInstance));
     }
 
+    public function testIsWithUnpersistedModelInstance()
+    {
+        $firstInstance = new EloquentModelStub(['id' => 1]);
+        $firstInstance->exists = true;
+        $secondInstance = new EloquentModelStub;
+        $result = $firstInstance->is($secondInstance);
+        $this->assertFalse($result);
+    }
+
+    public function testIsWithUnpersistedModelInstances()
+    {
+        $firstInstance = new EloquentModelStub;
+        $secondInstance = new EloquentModelStub;
+        $result = $firstInstance->is($secondInstance);
+        $this->assertFalse($result);
+    }
+
     public function testIsWithTheSameModelInstance()
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
+        $firstInstance->exists = true;
         $secondInstance = new EloquentModelStub(['id' => 1]);
+        $secondInstance->exists = true;
         $result = $firstInstance->is($secondInstance);
         $this->assertTrue($result);
     }
@@ -1837,7 +1857,9 @@ class DatabaseEloquentModelTest extends TestCase
     public function testIsWithAnotherModelInstance()
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
+        $firstInstance->exists = true;
         $secondInstance = new EloquentModelStub(['id' => 2]);
+        $secondInstance->exists = true;
         $result = $firstInstance->is($secondInstance);
         $this->assertFalse($result);
     }
@@ -1845,7 +1867,9 @@ class DatabaseEloquentModelTest extends TestCase
     public function testIsWithAnotherTable()
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
+        $firstInstance->exists = true;
         $secondInstance = new EloquentModelStub(['id' => 1]);
+        $secondInstance->exists = true;
         $secondInstance->setTable('foo');
         $result = $firstInstance->is($secondInstance);
         $this->assertFalse($result);
@@ -1854,7 +1878,9 @@ class DatabaseEloquentModelTest extends TestCase
     public function testIsWithAnotherConnection()
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
+        $firstInstance->exists = true;
         $secondInstance = new EloquentModelStub(['id' => 1]);
+        $secondInstance->exists = true;
         $secondInstance->setConnection('foo');
         $result = $firstInstance->is($secondInstance);
         $this->assertFalse($result);

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -553,6 +553,7 @@ class ResourceTest extends TestCase
     public function test_original_on_response_is_model_when_single_resource()
     {
         $createdPost = new Post(['id' => 5, 'title' => 'Test Title']);
+        $createdPost->exists = true;
         Route::get('/', function () use ($createdPost) {
             return new ReallyEmptyPostResource($createdPost);
         });


### PR DESCRIPTION
This fixes an issue with `is()` as described in #28172 where it would return `true` when given model instances that weren't actually persisted in the database. I think the expected functionality would be that it only returns true when comparing persisted database records.

I had to set `exists = true` for the test cases here to keep them valid - I did attempt to set it on the `EloquentModelStub` but it broke other tests, so felt it was more appropriate to be explicit on the relevant tests instead. Let me know if you'd prefer another approach.
