### PR TITLE
[5.9] Fix issue with is() and unpersisted models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1189,6 +1189,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function is($model)
     {
         return ! is_null($model) &&
+               $this->exists &&
+               $model->exists &&
                $this->getKey() === $model->getKey() &&
                $this->getTable() === $model->getTable() &&
                $this->getConnectionName() === $model->getConnectionName();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1513,7 +1513,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with('eloquent.replicating: '.get_class($model), m::on(function ($m) use ($model) {
-            return $model->is($m);
+            return $model->getKey() === $m->getKey();
         }));
 
         $model->replicate();
@@ -1821,15 +1821,35 @@ class DatabaseEloquentModelTest extends TestCase
     public function testIsWithNull()
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
+        $firstInstance->exists = true;
         $secondInstance = null;
 
         $this->assertFalse($firstInstance->is($secondInstance));
     }
 
+    public function testIsWithUnpersistedModelInstance()
+    {
+        $firstInstance = new EloquentModelStub(['id' => 1]);
+        $firstInstance->exists = true;
+        $secondInstance = new EloquentModelStub;
+        $result = $firstInstance->is($secondInstance);
+        $this->assertFalse($result);
+    }
+
+    public function testIsWithUnpersistedModelInstances()
+    {
+        $firstInstance = new EloquentModelStub;
+        $secondInstance = new EloquentModelStub;
+        $result = $firstInstance->is($secondInstance);
+        $this->assertFalse($result);
+    }
+
     public function testIsWithTheSameModelInstance()
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
+        $firstInstance->exists = true;
         $secondInstance = new EloquentModelStub(['id' => 1]);
+        $secondInstance->exists = true;
         $result = $firstInstance->is($secondInstance);
         $this->assertTrue($result);
     }
@@ -1837,7 +1857,9 @@ class DatabaseEloquentModelTest extends TestCase
     public function testIsWithAnotherModelInstance()
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
+        $firstInstance->exists = true;
         $secondInstance = new EloquentModelStub(['id' => 2]);
+        $secondInstance->exists = true;
         $result = $firstInstance->is($secondInstance);
         $this->assertFalse($result);
     }
@@ -1845,7 +1867,9 @@ class DatabaseEloquentModelTest extends TestCase
     public function testIsWithAnotherTable()
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
+        $firstInstance->exists = true;
         $secondInstance = new EloquentModelStub(['id' => 1]);
+        $secondInstance->exists = true;
         $secondInstance->setTable('foo');
         $result = $firstInstance->is($secondInstance);
         $this->assertFalse($result);
@@ -1854,7 +1878,9 @@ class DatabaseEloquentModelTest extends TestCase
     public function testIsWithAnotherConnection()
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
+        $firstInstance->exists = true;
         $secondInstance = new EloquentModelStub(['id' => 1]);
+        $secondInstance->exists = true;
         $secondInstance->setConnection('foo');
         $result = $firstInstance->is($secondInstance);
         $this->assertFalse($result);

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -559,7 +559,7 @@ class ResourceTest extends TestCase
         $response = $this->withoutExceptionHandling()->get(
             '/', ['Accept' => 'application/json']
         );
-        $this->assertTrue($createdPost->is($response->getOriginalContent()));
+        $this->assertEquals($createdPost->getKey(), $response->getOriginalContent()->getKey());
     }
 
     public function test_original_on_response_is_collection_of_model_when_collection_resource()


### PR DESCRIPTION
Following up from a #28240 which made this change against 5.8 this applies it to the next release. The commentary from the previous PR highlighted the breaking change of this bug fix and that perhaps it should be held off for now.

> This fixes an issue with is() as described in #28172 where it would return true when given model instances that weren't actually persisted in the database. I think the expected functionality would be that it only returns true when comparing persisted database records.

In updating other tests that used `is()` without taking into considering actual database persistence I've just relaxed them to a simple ID comparison - I think that's probably a better compromise than having to set `$exists = true` to get them to pass.