### PR TITLE
[5.8] Translating ValidationException message

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -53,7 +53,7 @@ class ValidationException extends Exception
      */
     public function __construct($validator, $response = null, $errorBag = 'default')
     {
-        parent::__construct('The given data was invalid.');
+        parent::__construct(__('The given data was invalid.'));
 
         $this->response = $response;
         $this->errorBag = $errorBag;

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -15,6 +15,7 @@ use Illuminate\Container\Container;
 use Illuminate\Validation\Validator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Translation\Translator;
 use Illuminate\Routing\ResponseFactory;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Contracts\Support\Responsable;
@@ -152,6 +153,16 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $argumentExpected = ['input' => 'My input value'];
         $argumentActual = null;
+
+        $this->container->singleton('translator', function () {
+            $translator = m::mock(Translator::class);
+
+            $translator->shouldReceive('getFromJson')->once()
+                ->with('The given data was invalid.', [], null)
+                ->andReturn('The given data was invalid.');
+
+            return $translator;
+        });
 
         $this->container->singleton('redirect', function () use (&$argumentActual) {
             $redirector = m::mock(Redirector::class);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -79,6 +79,16 @@ class ValidationValidatorTest extends TestCase
     {
         $this->expectException(ValidationException::class);
 
+        \Illuminate\Container\Container::getInstance()->singleton('translator', function () {
+            $translator = m::mock(Translator::class);
+
+            $translator->shouldReceive('getFromJson')->once()
+                ->with('The given data was invalid.', [], null)
+                ->andReturn('The given data was invalid.');
+
+            return $translator;
+        });
+
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar'], ['baz' => 'required']);
 


### PR DESCRIPTION
Instead of overriding the method `invalidJson` in `Illuminate\Foundation\Exceptions\Handler` class with:

```php
// App\Exceptions\Handler

/**
 * Convert a validation exception into a JSON response.
 *
 * @param  \Illuminate\Http\Request                    $request
 * @param  \Illuminate\Validation\ValidationException  $exception
 *
 * @return \Illuminate\Http\JsonResponse
 */
protected function invalidJson($request, ValidationException $exception)
{
    return response()->json([
        'message' => __($exception->getMessage()),
        'errors'  => $exception->errors(),
    ], $exception->status);
}
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
