### PR TITLE
[5.8] Fixed the bindings for query exception

### DIFF
--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database;
 
-use Illuminate\Support\Str;
 use PDOException;
 
 class QueryException extends PDOException

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Database;
 
-use PDOException;
 use Illuminate\Support\Str;
+use PDOException;
 
 class QueryException extends PDOException
 {
@@ -53,7 +53,11 @@ class QueryException extends PDOException
      */
     protected function formatMessage($sql, $bindings, $previous)
     {
-        return $previous->getMessage().' (SQL: '.Str::replaceArray('?', $bindings, $sql).')';
+        $search = str_repeat('?, ', count($bindings) - 1).'?';
+        $replace = implode(', ', $bindings);
+        $query = ' (SQL: '.str_replace($search, $replace, $sql).')';
+
+        return $previous->getMessage().$query;
     }
 
     /**


### PR DESCRIPTION
# Overview

This PR fixes the bug that was reported in https://github.com/laravel/framework/issues/28245. When a `QueryException` is thrown with a `?` in the values of the bindings, the bindings are not properly assigned in the exception's message.

# Reproduction

Make Eloquent throw a column not found error:

    App\User::create(['foo' => '?', 'email' => 'someone@example.com']);

The SQL exception would be look like this:

> Illuminate/Database/QueryException with message 'SQLSTATE[42S22]: Column not found: 1054 Unknown column 'foo' in 'field list' (SQL: insert into `users` (`foo`, `email`, `updated_at`, `created_at`) values (someone@example.com, 2019-04-17 12:51:12, 2019-04-17 12:51:12, ?))'

# Proposed Solution

Use `str_replace` to replace all `?` in the query instead of using `Str::replaceArray` because the latter one goes through the bindings one by one and replace the first occurence. Therefore if the value of a binding is `?`, the rest of the values would be shifted to the left. Using this approach, the SQL exception would look like this:

> Illuminate/Database/QueryException with message 'SQLSTATE[42S22]: Column not found: 1054 Unknown column 'foo' in 'field list' (SQL: insert into `users` (`foo`, `email`, `updated_at`, `created_at`) values (?, someone@example.com, 2019-04-17 12:51:12, 2019-04-17 12:51:12))' 