### PR TITLE
[5.8] Fix return type doc on NullStore.php

### DIFF
--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -42,7 +42,7 @@ class NullStore extends TaggableStore
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return int|bool
+     * @return bool
      */
     public function increment($key, $value = 1)
     {
@@ -54,7 +54,7 @@ class NullStore extends TaggableStore
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return int|bool
+     * @return bool
      */
     public function decrement($key, $value = 1)
     {


### PR DESCRIPTION
These methods returns `bool` value only