### PR TITLE
[5.8] Added message to EntryNotFoundException to give more insight

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -631,7 +631,7 @@ class Container implements ArrayAccess, ContainerContract
                 throw $e;
             }
 
-            throw new EntryNotFoundException;
+            throw new EntryNotFoundException($e->getMessage());
         }
     }
 


### PR DESCRIPTION
I had an interface resolution without a binding in one of my dependency injections. All i got was an `EntryNotFoundException`. This makes sense. But to figure out was wrong i had to actually dive into the Container to see what was going on.

The original exception being thrown was the `BindingResolutionException`. Because we throw a new EntryNotFoundException, this doesn't show up in the stacktrace. Which makes debugging a little bit difficult.

I'm not that experienced with Exception programming so i made this change with the feeling that it wasn't 'the right way'. Maybe we could use this PR to improve the exception handling of binding resolution in some other way.

Thanks for looking at my pull request and this amazing framework. 
