### PR TITLE
[5.8] Enable Pre-populated Collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -67,9 +67,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  mixed  $items
      * @return void
      */
-    public function __construct($items = [])
+    public function __construct($items = null)
     {
-        $this->items = $this->getArrayableItems($items);
+        if (isset($items)) {
+            $this->items = $this->getArrayableItems($items);
+        }
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3127,6 +3127,13 @@ class SupportCollectionTest extends TestCase
         $collection = new Collection([1, 2, 3]);
         $this->assertNull($collection->get(null));
     }
+
+    public function testPrePopulatedCollection()
+    {
+        $collection = new TestPrePopulatedCollection();
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertSame(['foo', 'bar', 'baz'], $collection->toArray());
+    }
 }
 
 class TestSupportCollectionHigherOrderItem
@@ -3247,4 +3254,9 @@ class TestCollectionMapIntoObject
 class TestCollectionSubclass extends Collection
 {
     //
+}
+
+class TestPrePopulatedCollection extends Collection
+{
+    protected $items = ['foo', 'bar', 'baz'];
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR updates the Collection class to enable pre-populated collections and would allow extracting Collections of pre-defined items to first-class objects. This should be a _non-breaking_ change. You would be able to define a pre-populated collection class like so:

```php
<?php

namespace App\Collections;

use Illuminate\Support\Collection;

final class PrePopulatedCollection extends Collection
{
    $items = [
        'foo',
        'bar',
        'baz'
    ];
}
```

And then use it from another file.

```php
use App\Collections\PrePopulatedCollection;

$collection = new PrePopulatedCollection();

$collection->toArray(); // Returns ['foo', 'bar', 'baz']
```

See my initial proposal here: https://github.com/laravel/ideas/issues/1608