### PR TITLE
[5.8] Fix belongsToMany->wherePivot condition for boolean columns

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -619,11 +619,11 @@ class Builder
         // If the operator is a literal string 'in' or 'not in', we will assume that
         // the developer wants to use the "whereIn / whereNotIn" methods for this
         // operation and proxy the query through those methods from this point.
-        if ($operator == 'in') {
+        if ($operator === 'in') {
             return $this->whereIn($column, $value, $boolean);
         }
 
-        if ($operator == 'not in') {
+        if ($operator === 'not in') {
             return $this->whereNotIn($column, $value, $boolean);
         }
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -604,6 +604,24 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $this->assertEquals(['id' => 1], $tags[0]->getAttributes());
     }
+
+    public function test_where_pivot_with_boolean_column_query()
+    {
+        Schema::table('posts_tags', function (Blueprint $table) {
+            $table->boolean('primary')->default(false)->after('flag');
+        });
+
+        $tag = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag->id, 'primary' => true]
+        ]);
+
+        $relationTag = $post->tags()->wherePivot('primary', true)->first();
+
+        $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
+    }
 }
 
 class Post extends Model


### PR DESCRIPTION
## Description

Fixes breaking change introduced in #28192, which used weak comparison which in turn caused searching for boolean values `belongsToManyRelation->wherePivot('primary', true)` (without specifying operator) (See #28251 for more details) in the pivot table to evaluate to true for the conditions [`$operator == 'in'`](https://github.com/laravel/framework/pull/28192/files#diff-cc3d43e01028390141596ae0da939930R622) / [`$operator == 'not in'`](https://github.com/laravel/framework/pull/28192/files#diff-cc3d43e01028390141596ae0da939930R626).

Switching to typed comparison takes care of this issue.