### PR TITLE
[5.8] Add wherePivot, wherePivotIn Tests

### DIFF
--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -518,6 +518,38 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertNotEquals('2017-10-10 10:10:10', Tag::find(300)->updated_at);
     }
 
+    public function test_where_pivot_on_string()
+    {
+        $tag = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'empty'],
+        ]);
+
+        $relationTag = $post->tags()->wherePivot('flag', 'empty')->first();
+        $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
+
+        $relationTag = $post->tags()->wherePivot('flag', '=', 'empty')->first();
+        $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
+    }
+
+    public function test_where_pivot_on_boolean()
+    {
+        $tag = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => true],
+        ]);
+
+        $relationTag = $post->tags()->wherePivot('flag', true)->first();
+        $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
+
+        $relationTag = $post->tags()->wherePivot('flag', '=', true)->first();
+        $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
+    }
+
     public function test_can_update_existing_pivot()
     {
         $tag = Tag::create(['name' => Str::random()]);

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -524,13 +524,13 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post = Post::create(['title' => Str::random()]);
 
         DB::table('posts_tags')->insert([
-            ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'empty'],
+            ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'foo'],
         ]);
 
-        $relationTag = $post->tags()->wherePivot('flag', 'empty')->first();
+        $relationTag = $post->tags()->wherePivot('flag', 'foo')->first();
         $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
 
-        $relationTag = $post->tags()->wherePivot('flag', '=', 'empty')->first();
+        $relationTag = $post->tags()->wherePivot('flag', '=', 'foo')->first();
         $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
     }
 
@@ -547,6 +547,19 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
 
         $relationTag = $post->tags()->wherePivot('flag', '=', true)->first();
+        $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
+    }
+
+    public function test_where_pivot_in_method()
+    {
+        $tag = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'foo'],
+        ]);
+
+        $relationTag = $post->tags()->wherePivotIn('flag', ['foo'])->first();
         $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
     }
 


### PR DESCRIPTION
This PR adds tests to `wherePivot` to prevent future issues such as problems (#28251) unintentionally introduced in #28192 (later reverted in 04a547ee25f78ddd738610cdbda2cb393c6795e9)

Also adds tests to the untested `wherePivotIn` method.