### PR TITLE
[5.8][POC] Added automatic method injection to facades

### DIFF
--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use stdClass;
 use ArrayAccess;
 use Mockery as m;
+use ArgumentCountError;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Facades\Facade;
@@ -70,6 +71,78 @@ class SupportFacadeTest extends TestCase
         FacadeStub::shouldReceive('foo')->once()->andReturn('bar');
         $this->assertEquals('bar', FacadeStub::foo());
     }
+
+    public function testDoesNotSwallowInternalTypeErrorOfTheTargetClass()
+    {
+        $app = new ApplicationStub;
+        $app->setAttributes([
+            'foo' => new ConcreteFacadeStub,
+            FacadeStub1::class => new FacadeStub1(),
+        ]);
+
+        FacadeStub::setFacadeApplication($app);
+
+        try {
+            FacadeStub::faulty();
+        } catch (ArgumentCountError $error) {
+            $this->assertRegExp('/Too few arguments to function .*?FacadeStub1::method\(\), 0 passed in .* and exactly 1 expected/', $error->getMessage());
+        }
+    }
+
+    public function testItCanInjectForFirstParam()
+    {
+        $app = new ApplicationStub;
+        $app->setAttributes([
+            'foo' => new ConcreteFacadeStub,
+            FacadeStub1::class => new FacadeStub1(),
+            FacadeStub2::class => new FacadeStub2(),
+        ]);
+
+        FacadeStub::setFacadeApplication($app);
+
+        $this->assertEquals('def1'.'ab'.'def3', FacadeStub::m3(new FacadeStub1(), 'ab'));
+        $this->assertEquals('def1'.'bb'.'def3', FacadeStub::m3('bb'));
+        $this->assertEquals('def1'.'bb'.'cc', FacadeStub::m3('bb', 'cc'));
+        $this->assertEquals('def1'.'bb'.'cc', FacadeStub::m3('bb', 'cc', 'dd'));
+        $this->assertEquals('val1'.'def2'.'def3', FacadeStub::m3(new FacadeStub1('val1')));
+        $this->assertEquals('def1'.'def2'.'def3', FacadeStub::m3());
+    }
+
+    public function testItCanInjectForSecondParam()
+    {
+        $app = new ApplicationStub;
+        $app->setAttributes([
+            'foo' => new ConcreteFacadeStub,
+            FacadeStub1::class => new FacadeStub1(),
+        ]);
+
+        FacadeStub::setFacadeApplication($app);
+
+        $this->assertEquals('abc'.FacadeStub1::class.'def3', FacadeStub::m5('abc'));
+        $this->assertEquals('abc'.FacadeStub1::class.'def3', FacadeStub::m5('abc', new FacadeStub1()));
+        $this->assertEquals('bb'.FacadeStub1::class.'cc', FacadeStub::m5('bb', 'cc'));
+        $this->assertEquals('bb'.FacadeStub1::class.'cc', FacadeStub::m5('bb', new FacadeStub1, 'cc'));
+    }
+
+    public function testItCanInjectTwoDependencies()
+    {
+        $app = new ApplicationStub;
+        $app->setAttributes([
+            'foo' => new ConcreteFacadeStub,
+            FacadeStub1::class => new FacadeStub1(),
+            FacadeStub2::class => new FacadeStub2(),
+        ]);
+
+        FacadeStub::setFacadeApplication($app);
+
+        $this->assertEquals('val1'.'def2'.'x_default', FacadeStub::m6(new FacadeStub1('val1'), 'x_'));
+        $this->assertEquals('def1'.'val2'.'x_default', FacadeStub::m6(new FacadeStub2('val2'), 'x_'));
+        $this->assertEquals('val1'.'val2'.'x_default', FacadeStub::m6(new FacadeStub1('val1'), new FacadeStub2('val2'), 'x_'));
+        $this->assertEquals('val1'.'def2'.'x_y', FacadeStub::m6(new FacadeStub1('val1'), 'x_', 'y'));
+        $this->assertEquals('def1'.'val2'.'x_y', FacadeStub::m6(new FacadeStub2('val2'), 'x_', 'y'));
+        $this->assertEquals('def1'.'def2'.'x_default', FacadeStub::m6('x_'));
+        $this->assertEquals('def1'.'def2'.'x_y', FacadeStub::m6('x_', 'y'));
+    }
 }
 
 class FacadeStub extends Facade
@@ -112,5 +185,57 @@ class ApplicationStub implements ArrayAccess
     public function offsetUnset($key)
     {
         unset($this->attributes[$key]);
+    }
+}
+
+class FacadeStub1
+{
+    public $a;
+
+    public function __construct($a = 'def1')
+    {
+        $this->a = $a;
+    }
+
+    public function method($param)
+    {
+    }
+}
+
+class FacadeStub2
+{
+    public $b;
+
+    public function __construct($b = 'def2')
+    {
+        $this->b = $b;
+    }
+}
+
+class ConcreteFacadeStub
+{
+    public function m3(FacadeStub1 $p1, $p2 = 'def2', $p3 = 'def3')
+    {
+        return ($p1->a).$p2.$p3;
+    }
+
+    public function m4($p1, $p2 = 'def2')
+    {
+        return get_class($p1).$p2;
+    }
+
+    public function m5($p1, FacadeStub1 $p2, $p3 = 'def3')
+    {
+        return $p1.get_class($p2).$p3;
+    }
+
+    public function m6(FacadeStub1 $p1, FacadeStub2 $p2, $p3, $p4 = 'default')
+    {
+        return ($p1->a).($p2->b).$p3.$p4;
+    }
+
+    public function faulty(FacadeStub1 $p1)
+    {
+        $p1->method();
     }
 }


### PR DESCRIPTION
This adds ability to enjoy automatic method injection when calling methods on POPOs (Plain Old Php Objects) WITHOUT any performance hit when you do not need it.

In fact, it only comes into play if there is any `TypeError` thrown from a Facade call, trying to handle it gracefully by providing injected dependencies right within the method input,
and retry the method call once again. (in the catch block)
And would be happy to know if something is missing...

Example :
```php
class Foo { ... }

class Bar {
    public function m1 (Foo $foo, LoggerInterface $logger, string $msg) {
        //...
    }
}
```

Calling `Bar` through a Facade :

Before : 
```php
MyFacade::m1(resolve(Foo::class), resolve(LoggerInterface::class), 'hey there !'); 
```

After :
```php
 // This will work and $foo, $logger would be auto-injected for us.

MyFacade::m1('hey there !');          // normal facade
\Facades\Bar::m1('hey there !');     // real-time facade

// or even :
\Facades\Bar::m1(new Foo('hey man!'), 'hey there !'); //Now only the Logger is injected
```

and as always, 
we may define the facade class like this:

```php
MyFacade extends Facade {
    protected static function getFacadeAccessor () {
        return Bar::class;
    }
}
```

I tried to implement it fully backward-compatible (avoid tampering with the current code as much as possible) while adding minimum amount of new code and provide a lot of tests. 