### PR TITLE
[5.9] Make FormRequest::validationData() public

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -112,7 +112,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      *
      * @return array
      */
-    protected function validationData()
+    public function validationData()
     {
         return $this->all();
     }


### PR DESCRIPTION
I have action classes something like `SaveCreditCourseAction($request)` that will accept the form request and creates or updates a course from the form request.

I'm also overriding the validationData() method on my form requests, and i have quite a few changes that i'm making to the data.

Within the action i want to use the $this->request->validationData().
Since it's protected i cannot do that.

This PR is targeted for 5.9, to avoid breaking applications on 5.8 that are overriding the validationData() on their form requests.

A note should be added to the upgrade guide from 5.8 to 5.9 about updating the visibility of validationData() from protected to public