### PR TITLE
Add 'pwned' validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6).",
         "filp/whoops": "Required for friendly error pages in development (^2.1.4).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (^1.4).",
-        "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers and the ping methods on schedules (^6.0).",
+        "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers, the ping methods on schedules, and the pwned validation rule (^6.0).",
         "laravel/tinker": "Required to use the tinker console command (^1.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^1.0).",
         "league/flysystem-cached-adapter": "Required to use the Flysystem cache (^1.0).",

--- a/src/Illuminate/Validation/PwnedVerifier.php
+++ b/src/Illuminate/Validation/PwnedVerifier.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Validation;
+
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\ClientInterface as HttpClientInterface;
+
+class PwnedVerifier
+{
+    /**
+     * The HaveIBeenPwned API URL.
+     */
+    public const PWNED_API = 'https://api.pwnedpasswords.com/range/%s';
+
+    /**
+     * @var HttpClientInterface
+     */
+    private $httpClient;
+
+    public function __construct(HttpClientInterface $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    /**
+     * Checks if password has been leaked from a data breach using the HaveIBeenPwned API.
+     *
+     * @param  string  $password
+     * @param  int     $threshold
+     * @param  bool    $skipOnError
+     * @return bool
+     * @throws GuzzleException
+     */
+    public function isPwned(string $password, int $threshold = 1, bool $skipOnError = false): bool
+    {
+        $hash = strtoupper(sha1($password));
+        $hashPrefix = substr($hash, 0, 5);
+        $hashSuffix = substr($hash, 5);
+
+        $url = sprintf(self::PWNED_API, $hashPrefix);
+
+        try {
+            $result = $this->httpClient->request('GET', $url)->getBody()->getContents();
+
+            foreach (explode("\r\n", $result) as $line) {
+                [$suffix, $count] = explode(':', $line);
+
+                if ($hashSuffix === $suffix && (int) $count >= $threshold) {
+                    return true;
+                }
+            }
+
+            return false;
+        } catch (GuzzleException $e) {
+            if ($skipOnError) {
+                return false;
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @param  string  $password
+     * @param  int     $threshold
+     * @param  bool    $skipOnError
+     * @return bool
+     * @throws GuzzleException
+     */
+    public function isNotPwned(string $password, int $threshold = 1, bool $skipOnError = false): bool
+    {
+        return ! $this->isPwned($password, $threshold, $skipOnError);
+    }
+}

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -63,6 +63,18 @@ class Rule
     }
 
     /**
+     * Get a pwned constraint builder instance.
+     *
+     * @param int $threshold
+     * @param bool $skipOnError
+     * @return \Illuminate\Validation\Rules\Pwned
+     */
+    public static function pwned($threshold = 1, $skipOnError = false)
+    {
+        return new Rules\Pwned($threshold, $skipOnError);
+    }
+
+    /**
      * Get a required_if constraint builder instance.
      *
      * @param  callable|bool  $callback

--- a/src/Illuminate/Validation/Rules/Pwned.php
+++ b/src/Illuminate/Validation/Rules/Pwned.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+class Pwned
+{
+    /**
+     * The number of times the password is allowed to appear.
+     *
+     * @var int
+     */
+    protected $threshold;
+
+    /**
+     * Ignore the error if the HaveIBeenPwned API fails to respond.
+     *
+     * @var bool
+     */
+    protected $skipOnError;
+
+    /**
+     * Pwned constructor.
+     * @param int $threshold
+     * @param bool $skipOnError
+     */
+    public function __construct(int $threshold = 1, bool $skipOnError = false)
+    {
+        $this->threshold = $threshold;
+        $this->skipOnError = $skipOnError;
+    }
+
+    /**
+     * @param int $threshold
+     * @return Pwned
+     */
+    public function threshold(int $threshold): Pwned
+    {
+        $this->threshold = $threshold;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $skipOnError
+     * @return Pwned
+     */
+    public function skipOnError(bool $skipOnError): Pwned
+    {
+        $this->skipOnError = $skipOnError;
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        $result = sprintf('pwned:threshold=%d', $this->threshold);
+
+        if ($this->skipOnError) {
+            $result .= ',skipOnError';
+        }
+
+        return $result;
+    }
+}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -163,7 +163,7 @@ class Validator implements ValidatorContract
      */
     protected $implicitRules = [
         'Required', 'Filled', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout',
-        'RequiredWithoutAll', 'RequiredIf', 'RequiredUnless', 'Accepted', 'Present',
+        'RequiredWithoutAll', 'RequiredIf', 'RequiredUnless', 'Accepted', 'Present', 'Pwned',
     ];
 
     /**

--- a/tests/Validation/ValidationPwnedRuleTest.php
+++ b/tests/Validation/ValidationPwnedRuleTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Rules\Pwned;
+
+class ValidationPwnedRuleTest extends TestCase
+{
+    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    {
+        $rule = new Pwned();
+
+        $this->assertEquals('pwned:threshold=1', (string) $rule);
+
+        $rule = new Pwned(3);
+
+        $this->assertEquals('pwned:threshold=3', (string) $rule);
+
+        $rule = new Pwned(3, true);
+
+        $this->assertEquals('pwned:threshold=3,skipOnError', (string) $rule);
+    }
+}

--- a/tests/Validation/ValidationPwnedVerifierTest.php
+++ b/tests/Validation/ValidationPwnedVerifierTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Mockery as m;
+use GuzzleHttp\ClientInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\ResponseInterface;
+use Illuminate\Validation\PwnedVerifier;
+use GuzzleHttp\Exception\TransferException;
+
+class ValidationPwnedVerifierTest extends TestCase
+{
+    private const PWNED_PASS = 'password';
+    private const PWNED_PASS_HASH_PREFIX = '5BAA6';
+    private const NOT_PWNED_PASS = 'ayfqM7YnNvkyNaF';
+    private const NOT_PWNED_PASS_HASH_PREFIX = '4D5EA';
+
+    private const HASH_LIST = [
+        '2471B4FBA2AC638B7E5F6F758F2D726D3BB:0', // not pwned
+        'D66A63D4BF1747940578EC3D0103530E21D:13',
+        '1E4C9B93F3F0682250B6CF8331B7EE68FD8:20', // pwned
+        'A43BB67901CC0CB207E6BCF13A606611CF7:4',
+        '4D75252D9788CE20300D00023FA1CCD4D19:5',
+    ];
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testItIsPwned()
+    {
+        $verifier = new PwnedVerifier($httpClient = m::mock(ClientInterface::class));
+
+        $httpClient->shouldReceive('request')
+                   ->once()
+                   ->with('GET', sprintf(PwnedVerifier::PWNED_API, self::PWNED_PASS_HASH_PREFIX))
+                   ->andReturn($response = m::mock(ResponseInterface::class));
+
+        $response->shouldReceive('getBody')
+                 ->once()
+                 ->andReturn($body = m::mock(StreamInterface::class));
+
+        $body->shouldReceive('getContents')
+             ->once()
+             ->andReturn($contents = implode("\r\n", self::HASH_LIST));
+
+        $this->assertEquals(true, $verifier->isPwned(self::PWNED_PASS));
+    }
+
+    public function testItIsNotPwned()
+    {
+        $verifier = new PwnedVerifier($httpClient = m::mock(ClientInterface::class));
+
+        $httpClient->shouldReceive('request')
+            ->once()
+            ->with('GET', sprintf(PwnedVerifier::PWNED_API, self::NOT_PWNED_PASS_HASH_PREFIX))
+            ->andReturn($response = m::mock(ResponseInterface::class));
+
+        $response->shouldReceive('getBody')
+            ->once()
+            ->andReturn($body = m::mock(StreamInterface::class));
+
+        $body->shouldReceive('getContents')
+            ->once()
+            ->andReturn($contents = implode("\r\n", self::HASH_LIST));
+
+        $this->assertEquals(false, $verifier->isPwned(self::NOT_PWNED_PASS));
+    }
+
+    public function testItIsNotPwnedUsingThreshold()
+    {
+        $verifier = new PwnedVerifier($httpClient = m::mock(ClientInterface::class));
+
+        $httpClient->shouldReceive('request')
+            ->once()
+            ->with('GET', sprintf(PwnedVerifier::PWNED_API, self::PWNED_PASS_HASH_PREFIX))
+            ->andReturn($response = m::mock(ResponseInterface::class));
+
+        $response->shouldReceive('getBody')
+            ->once()
+            ->andReturn($body = m::mock(StreamInterface::class));
+
+        $body->shouldReceive('getContents')
+            ->once()
+            ->andReturn($contents = implode("\r\n", self::HASH_LIST));
+
+        $this->assertEquals(false, $verifier->isPwned(self::PWNED_PASS, 21));
+    }
+
+    public function testItThrowsAnError()
+    {
+        $verifier = new PwnedVerifier($httpClient = m::mock(ClientInterface::class));
+
+        $httpClient->shouldReceive('request')
+            ->once()
+            ->with('GET', sprintf(PwnedVerifier::PWNED_API, self::PWNED_PASS_HASH_PREFIX))
+            ->andThrows(TransferException::class);
+
+        $this->expectException(TransferException::class);
+        $verifier->isPwned('password');
+    }
+
+    public function testItDoesNotThrowAnError()
+    {
+        $verifier = new PwnedVerifier($httpClient = m::mock(ClientInterface::class));
+
+        $httpClient->shouldReceive('request')
+                   ->once()
+                   ->with('GET', sprintf(PwnedVerifier::PWNED_API, self::PWNED_PASS_HASH_PREFIX))
+                   ->andThrows(TransferException::class);
+
+        $this->assertEquals(false, $verifier->isPwned('password', 1, true));
+    }
+}


### PR DESCRIPTION
This PR adds the ability to prevent the use of passwords that have been leaked in data breaches from being used by making use of the [Have I Been Pwned](https://haveibeenpwned.com/) API. 

Two options are available for configuration, which are:

- `threshold`: this allows one to configure how much times they wish for the password to be leaked before considering it pwned. The default is 1.

- `skipOnError`: this allows one to ignore any HTTP exceptions which may occur connecting to the Have I Been Pwned API. The default is `false`.

If any of the options are to be specified however, `threshold` should be first.