### PR TITLE
[5.8] Fix the usage of unused private property

### DIFF
--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -65,22 +65,20 @@ class SupportTestingNotificationFakeTest extends TestCase
 
     public function testResettingNotificationId()
     {
-        $notification = new NotificationStub;
+        $this->fake->send($this->user, $this->notification);
 
-        $this->fake->send($this->user, $notification);
+        $id = $this->notification->id;
 
-        $id = $notification->id;
+        $this->fake->send($this->user, $this->notification);
 
-        $this->fake->send($this->user, $notification);
+        $this->assertSame($id, $this->notification->id);
 
-        $this->assertSame($id, $notification->id);
+        $this->notification->id = null;
 
-        $notification->id = null;
+        $this->fake->send($this->user, $this->notification);
 
-        $this->fake->send($this->user, $notification);
-
-        $this->assertNotNull($notification->id);
-        $this->assertNotSame($id, $notification->id);
+        $this->assertNotNull($this->notification->id);
+        $this->assertNotSame($id, $this->notification->id);
     }
 
     public function testAssertTimesSent()


### PR DESCRIPTION
The private property `$notification` was previously set, but not used.
