### PR TITLE
[5.8] Remove unused variables passed to closures

### DIFF
--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -134,7 +134,7 @@ class AuthorizeMiddlewareTest extends TestCase
             return $post;
         });
 
-        $this->gate()->define('view-comments', function ($user, $model = null) use ($post) {
+        $this->gate()->define('view-comments', function ($user, $model = null) {
             return true;
         });
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1866,7 +1866,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $called = false;
 
-        EloquentModelStub::withoutTouching(function () use (&$called, $model) {
+        EloquentModelStub::withoutTouching(function () use (&$called) {
             $called = true;
         });
 
@@ -1879,7 +1879,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $called = false;
 
-        Model::withoutTouchingOn([EloquentModelStub::class], function () use (&$called, $model) {
+        Model::withoutTouchingOn([EloquentModelStub::class], function () use (&$called) {
             $called = true;
         });
 


### PR DESCRIPTION
There were a couple of unused variables passed to closures via `use`.