### PR TITLE
[5.8] Use Null Coalesce Operator

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1287,9 +1287,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getTable()
     {
-        return isset($this->table)
-            ? $this->table
-            : Str::snake(Str::pluralStudly(class_basename($this)));
+        return $this->table ?? Str::snake(Str::pluralStudly(class_basename($this)));
     }
 
     /**


### PR DESCRIPTION
Following #25013, #24466, #22383 and #18637, this PR enforces the usage of the Null Coalesce Operator (`??`) when possible.