### PR TITLE
[5.8] Fixed a bug of "Form Request Validation"

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -49,8 +49,8 @@ class FoundationServiceProvider extends AggregateServiceProvider
      */
     public function registerRequestValidation()
     {
-        Request::macro('validate', function (array $rules, ...$params) {
-            return validator()->validate($this->all(), $rules, ...$params);
+        Request::macro('validate', function (...$params) {
+            return validator()->validate($this->all(), ...$params);
         });
     }
 

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -39,7 +39,7 @@ trait ValidatesRequests
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function validate(Request $request, array $rules,
+    public function validate(Request $request, array $rules = [],
                              array $messages = [], array $customAttributes = [])
     {
         return $this->getValidationFactory()->make(

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -131,7 +131,7 @@ class Factory implements FactoryContract
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function validate(array $data, array $rules, array $messages = [], array $customAttributes = [])
+    public function validate(array $data, array $rules = [], array $messages = [], array $customAttributes = [])
     {
         return $this->make($data, $rules, $messages, $customAttributes)->validate();
     }


### PR DESCRIPTION
**This PR solved the below problem:**

Based on [this documentation](https://laravel.com/docs/5.8/validation#form-request-validation), if you create "Form Requests" and define $rules, to retrieve the validated input data you may call `$validated = $request->validated();`. If the rules are passed and there is no error you will see the below error:

`"Too few arguments to function App\Http\Requests\CustomRequest::Illuminate\Foundation\Providers\{closure}(), 0 passed and exactly 1 expected"`

Because it expects you to pass the $rules as an argument to the function validated like so `$validated = $request->validated($rules);` but you already defined $rules in App/Http/Requests/CustomRequest.php

This PR will solve the problem