### PR TITLE
[5.8] Fix PHPdoc for "retrieveByToken" in Illuminate\Contracts\Auth\UserProvider.php

### DIFF
--- a/src/Illuminate/Contracts/Auth/UserProvider.php
+++ b/src/Illuminate/Contracts/Auth/UserProvider.php
@@ -15,7 +15,7 @@ interface UserProvider
     /**
      * Retrieve a user by their unique identifier and "remember me" token.
      *
-     * @param  mixed   $identifier
+     * @param  mixed  $identifier
      * @param  string  $token
      * @return \Illuminate\Contracts\Auth\Authenticatable|null
      */


### PR DESCRIPTION
The "$identifier" parameter seems to have more than two spaces. According to [Coding Style](https://laravel.com/docs/5.8/contributions#coding-style) it should not be like that.

Regards!
John