### PR TITLE
[5.8] Bugfix for self-referencing polymorphic relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -92,6 +92,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
     {
         if ($query->getQuery()->from == $parentQuery->getQuery()->from) {
             $query = parent::getRelationExistenceQuery($query, $parentQuery, $columns);
+
             return $query->where(
                 $query->getModel()->getTable().'.'.$this->getMorphType(), $this->morphClass
             );

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -90,6 +90,13 @@ abstract class MorphOneOrMany extends HasOneOrMany
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
+        if ($query->getQuery()->from == $parentQuery->getQuery()->from) {
+            $query = parent::getRelationExistenceQuery($query, $parentQuery, $columns);
+            return $query->where(
+                $query->getModel()->getTable().'.'.$this->getMorphType(), $this->morphClass
+            );
+        }
+        
         return parent::getRelationExistenceQuery($query, $parentQuery, $columns)->where(
             $this->morphType, $this->morphClass
         );

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -96,7 +96,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
                 $query->getModel()->getTable().'.'.$this->getMorphType(), $this->morphClass
             );
         }
-        
+
         return parent::getRelationExistenceQuery($query, $parentQuery, $columns)->where(
             $this->morphType, $this->morphClass
         );


### PR DESCRIPTION
Bug: When a model has a polymorphic relationship with itself the withCount() function always returns 0.

Analysis: The HasOneOrMany::getRelationExistenceQuery() method has separate logic for self referencing relationships, but the MorphOneOrMany::getRelationExistenceQuery() function doesn't. This causes part of the query to point to the Model itself instead of the relation leading to the resulting count being always 0.

Solution: Modified MorphOneOrMany::getRelationExistenceQuery() to accommodate self-referencing relationships.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
