### PR TITLE
[5.8] Adds createForeign method to Blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema;
 use Closure;
 use BadMethodCallException;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
 use Illuminate\Database\Connection;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Database\SQLiteConnection;
@@ -1403,5 +1404,19 @@ class Blueprint
         return array_filter($this->columns, function ($column) {
             return (bool) $column->change;
         });
+    }
+
+    /**
+     * Specify a new column and foreign key for the table at the same tame.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Support\Fluent
+     */
+    public function createForeign($model)
+    {
+        $column = "{$model}_id";
+        $table = Str::snake(Str::pluralStudly($model));
+        $this->unsignedBigInteger($column);
+        return $this->foreign($column)->references('id')->on($table);
     }
 }

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -170,4 +170,18 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals(['alter table `users` add `foo` varchar(255) not null'], $blueprint->toSql($connection, new MySqlGrammar));
     }
+
+    public function testCreateForeign()
+    {
+        $fluent = m::mock(\Illuminate\Support\Fluent::class);
+        $fluent->shouldReceive('references')->once()->with('id')->andReturn($fluent);
+        $fluent->shouldReceive('on')->once()->with('jobs')->andReturn($fluent);
+
+        $blueprint = m::mock(Blueprint::class)->makePartial();
+
+        $blueprint->shouldReceive('unsignedBigInteger')->once()->with('job_id');
+        $blueprint->shouldReceive('foreign')->once()->with('job_id')->andReturn($fluent);
+
+        $blueprint->createForeign('job');
+    }
 }


### PR DESCRIPTION
I always set up a Macro with this code, almost all my migration who adds a foreign key use this. As a lot of the community follow rest/cruddy design I think a lot of people would love to have this shortcut.

I'm not sure if the name `createForeign` is the best choice. Also, I'm not sure if the Blueprint class is the best place to put this. It feels like the code doesn't belong there, other option would be to create a Service Provider and set up the macro for Blueprint there.