### PR TITLE
[5.8] Remove method call through constructor

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -2,26 +2,10 @@
 
 namespace Illuminate\Database\Schema;
 
-use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Types\TinyInteger;
 
 class MySqlBuilder extends Builder
 {
-    /**
-     * Create a new builder instance.
-     *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @return void
-     *
-     * @throws \Doctrine\DBAL\DBALException
-     */
-    public function __construct(Connection $connection)
-    {
-        parent::__construct($connection);
-
-        $this->registerCustomDoctrineTypes();
-    }
-
     /**
      * Determine if the given table exists.
      *


### PR DESCRIPTION
Couldn't fully revert but reverting the call in the constructor should do the trick for now.

See https://github.com/laravel/framework/issues/28282