### PR TITLE
[5.8] Fix wrong relation parent key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -214,7 +214,7 @@ trait InteractsWithPivotTable
     protected function updateExistingPivotUsingCustomClass($id, array $attributes, $touch)
     {
         $updated = $this->newPivot([
-            $this->foreignPivotKey => $this->parent->getKey(),
+            $this->foreignPivotKey => $this->parent->{$this->parentKey},
             $this->relatedPivotKey => $this->parseId($id),
         ], true)->fill($attributes)->save();
 
@@ -446,7 +446,7 @@ trait InteractsWithPivotTable
 
         foreach ($this->parseIds($ids) as $id) {
             $results += $this->newPivot([
-                $this->foreignPivotKey => $this->parent->getKey(),
+                $this->foreignPivotKey => $this->parent->{$this->parentKey},
                 $this->relatedPivotKey => $id,
             ], true)->delete();
         }


### PR DESCRIPTION
Use parent->{$this->parentKey} instead of parent->getKey(). Sometimes we don't have primary key in pivot table.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
