### PR TITLE
[5.8] Handle database urls for database connections.

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -151,7 +151,7 @@ class DatabaseManager implements ConnectionResolverInterface
             throw new InvalidArgumentException("Database [{$name}] not configured.");
         }
 
-        return $config;
+        return $this->app->make(UrlParser::class)->parseDatabaseConfigWithUrl($config);
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -151,7 +151,9 @@ class DatabaseManager implements ConnectionResolverInterface
             throw new InvalidArgumentException("Database [{$name}] not configured.");
         }
 
-        return $this->app->make(UrlParser::class)->parseDatabaseConfigWithUrl($config);
+        $urlParser = new UrlParser;
+
+        return $urlParser->parseDatabaseConfigWithUrl($config);
     }
 
     /**

--- a/src/Illuminate/Database/UrlParser.php
+++ b/src/Illuminate/Database/UrlParser.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Illuminate\Database;
+
+use Illuminate\Support\Arr;
+use function array_map;
+use function array_merge;
+use function parse_str;
+use function parse_url;
+use function preg_replace;
+
+class UrlParser
+{
+    private static $driverAliases = [
+        'mssql' => 'sqlsrv',
+        'mysql2' => 'mysql', // Amazon RDS, for some weird reason
+        'postgres' => 'pgsql',
+        'postgresql' => 'pgsql',
+        'sqlite3' => 'sqlite',
+    ];
+
+    /**
+     * @var array
+     */
+    private $parsedUrl;
+
+    public static function getDriverAliases(): array
+    {
+        return self::$driverAliases;
+    }
+
+    public static function addDriverAlias(string $alias, string $driver)
+    {
+        self::$driverAliases[$alias] = $driver;
+    }
+
+    /**
+     * @param array|string $config
+     *
+     * @return array
+     */
+    public function parseDatabaseConfigWithUrl($config): array
+    {
+        if (is_string($config)) {
+            $config = ['url' => $config];
+        }
+
+        $url = $config['url'] ?? null;
+        $config = Arr::except($config, 'url');
+
+        if (!$url) {
+            return $config;
+        }
+
+        $this->parsedUrl = $this->parseUrl($url);
+
+        return array_merge(
+            $config,
+            $this->getMainAttributes(),
+            $this->getOtherOptions()
+        );
+    }
+
+    private function parseUrl(string $url): array
+    {
+        // sqlite3?:///... => sqlite3?://null/... or else the URL will be invalid
+        $url = preg_replace('#^(sqlite3?):///#', '$1://null/', $url);
+
+        $parsedUrl = parse_url($url);
+
+        if ($parsedUrl === false) {
+            throw new \InvalidArgumentException('Malformed parameter "url".');
+        }
+
+        return $this->parseStringsToNativeTypes(array_map('rawurldecode', $parsedUrl));
+    }
+
+    private function parseStringsToNativeTypes($value)
+    {
+        if (is_array($value)) {
+            return array_map([$this, 'parseStringsToNativeTypes'], $value);
+        }
+
+        if (!is_string($value)) {
+            return $value;
+        }
+
+        $parsedValue = json_decode($value, true);
+
+        if (json_last_error() === JSON_ERROR_NONE) {
+            return $parsedValue;
+        }
+
+        return $value;
+    }
+
+    private function getMainAttributes(): array
+    {
+        return array_filter([
+            'driver' => $this->getDriver(),
+            'database' => $this->getNormalizedPath(),
+            'host' => $this->getInUrl('host'),
+            'port' => $this->getInUrl('port'),
+            'username' => $this->getInUrl('user'),
+            'password' => $this->getInUrl('pass'),
+        ], function ($value) {
+            return $value !== null;
+        });
+    }
+
+    private function getDriver(): ?string
+    {
+        $alias = $this->getInUrl('scheme');
+
+        if (!$alias) {
+            return null;
+        }
+
+        return self::$driverAliases[$alias] ?? $alias;
+    }
+
+    private function getInUrl(string $key): ?string
+    {
+        return $this->parsedUrl[$key] ?? null;
+    }
+
+    private function getNormalizedPath(): ?string
+    {
+        $path = $this->getInUrl('path');
+
+        if (!$path) {
+            return null;
+        }
+
+        return substr($path, 1);
+    }
+
+    private function getOtherOptions(): array
+    {
+        $queryString = $this->getInUrl('query');
+
+        if (!$queryString) {
+            return [];
+        }
+
+        $query = [];
+
+        parse_str($queryString, $query);
+
+        return $this->parseStringsToNativeTypes($query);
+    }
+}

--- a/src/Illuminate/Database/UrlParser.php
+++ b/src/Illuminate/Database/UrlParser.php
@@ -22,14 +22,14 @@ class UrlParser
     /**
      * @var array
      */
-    private $parsedUrl;
+    protected $parsedUrl;
 
     public static function getDriverAliases(): array
     {
         return self::$driverAliases;
     }
 
-    public static function addDriverAlias(string $alias, string $driver)
+    public static function addDriverAlias($alias, $driver)
     {
         self::$driverAliases[$alias] = $driver;
     }
@@ -61,7 +61,7 @@ class UrlParser
         );
     }
 
-    private function parseUrl(string $url): array
+    protected function parseUrl($url): array
     {
         // sqlite3?:///... => sqlite3?://null/... or else the URL will be invalid
         $url = preg_replace('#^(sqlite3?):///#', '$1://null/', $url);
@@ -75,7 +75,7 @@ class UrlParser
         return $this->parseStringsToNativeTypes(array_map('rawurldecode', $parsedUrl));
     }
 
-    private function parseStringsToNativeTypes($value)
+    protected function parseStringsToNativeTypes($value)
     {
         if (is_array($value)) {
             return array_map([$this, 'parseStringsToNativeTypes'], $value);
@@ -94,7 +94,7 @@ class UrlParser
         return $value;
     }
 
-    private function getMainAttributes(): array
+    protected function getMainAttributes(): array
     {
         return array_filter([
             'driver' => $this->getDriver(),
@@ -108,7 +108,7 @@ class UrlParser
         });
     }
 
-    private function getDriver(): ?string
+    protected function getDriver()
     {
         $alias = $this->getInUrl('scheme');
 
@@ -119,12 +119,12 @@ class UrlParser
         return self::$driverAliases[$alias] ?? $alias;
     }
 
-    private function getInUrl(string $key): ?string
+    protected function getInUrl($key)
     {
         return $this->parsedUrl[$key] ?? null;
     }
 
-    private function getNormalizedPath(): ?string
+    protected function getNormalizedPath()
     {
         $path = $this->getInUrl('path');
 
@@ -135,7 +135,7 @@ class UrlParser
         return substr($path, 1);
     }
 
-    private function getOtherOptions(): array
+    protected function getOtherOptions(): array
     {
         $queryString = $this->getInUrl('query');
 

--- a/src/Illuminate/Database/UrlParser.php
+++ b/src/Illuminate/Database/UrlParser.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Database;
 
-use Illuminate\Support\Arr;
 use function array_map;
-use function array_merge;
 use function parse_str;
 use function parse_url;
+use function array_merge;
 use function preg_replace;
+use Illuminate\Support\Arr;
 
 class UrlParser
 {
@@ -48,7 +48,7 @@ class UrlParser
         $url = $config['url'] ?? null;
         $config = Arr::except($config, 'url');
 
-        if (!$url) {
+        if (! $url) {
             return $config;
         }
 
@@ -81,7 +81,7 @@ class UrlParser
             return array_map([$this, 'parseStringsToNativeTypes'], $value);
         }
 
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             return $value;
         }
 
@@ -112,7 +112,7 @@ class UrlParser
     {
         $alias = $this->getInUrl('scheme');
 
-        if (!$alias) {
+        if (! $alias) {
             return null;
         }
 
@@ -128,7 +128,7 @@ class UrlParser
     {
         $path = $this->getInUrl('path');
 
-        if (!$path) {
+        if (! $path) {
             return null;
         }
 
@@ -139,7 +139,7 @@ class UrlParser
     {
         $queryString = $this->getInUrl('query');
 
-        if (!$queryString) {
+        if (! $queryString) {
             return [];
         }
 

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -13,7 +13,6 @@ use Illuminate\Database\Connectors\ConnectionFactory;
 
 class DatabaseConnectionFactoryTest extends TestCase
 {
-    /** @var DB */
     protected $db;
 
     protected function setUp(): void

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Connectors\ConnectionFactory;
 
 class DatabaseConnectionFactoryTest extends TestCase
 {
+    /** @var DB */
     protected $db;
 
     protected function setUp(): void
@@ -48,17 +49,47 @@ class DatabaseConnectionFactoryTest extends TestCase
 
     public function testConnectionCanBeCreated()
     {
-        $this->assertInstanceOf(PDO::class, $this->db->connection()->getPdo());
-        $this->assertInstanceOf(PDO::class, $this->db->connection()->getReadPdo());
-        $this->assertInstanceOf(PDO::class, $this->db->connection('read_write')->getPdo());
-        $this->assertInstanceOf(PDO::class, $this->db->connection('read_write')->getReadPdo());
-        $this->assertInstanceOf(PDO::class, $this->db->connection('url')->getPdo());
-        $this->assertInstanceOf(PDO::class, $this->db->connection('url')->getReadPdo());
+        $this->assertInstanceOf(PDO::class, $this->db->getConnection()->getPdo());
+        $this->assertInstanceOf(PDO::class, $this->db->getConnection()->getReadPdo());
+        $this->assertInstanceOf(PDO::class, $this->db->getConnection('read_write')->getPdo());
+        $this->assertInstanceOf(PDO::class, $this->db->getConnection('read_write')->getReadPdo());
+        $this->assertInstanceOf(PDO::class, $this->db->getConnection('url')->getPdo());
+        $this->assertInstanceOf(PDO::class, $this->db->getConnection('url')->getReadPdo());
+    }
+
+    public function testConnectionFromUrlHasProperConfig()
+    {
+        $this->db->addConnection([
+            'url' => 'mysql://root:pass@db/local?strict=true',
+            'unix_socket' => '',
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'strict' => false,
+            'engine' => null,
+        ], 'url-config');
+
+        $this->assertEquals([
+            'name' => 'url-config',
+            'driver' => 'mysql',
+            'database' => 'local',
+            'host' => 'db',
+            'username' => 'root',
+            'password' => 'pass',
+            'unix_socket' => '',
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'strict' => true,
+            'engine' => null,
+        ], $this->db->getConnection('url-config')->getConfig());
     }
 
     public function testSingleConnectionNotCreatedUntilNeeded()
     {
-        $connection = $this->db->connection();
+        $connection = $this->db->getConnection();
         $pdo = new ReflectionProperty(get_class($connection), 'pdo');
         $pdo->setAccessible(true);
         $readPdo = new ReflectionProperty(get_class($connection), 'readPdo');
@@ -70,7 +101,7 @@ class DatabaseConnectionFactoryTest extends TestCase
 
     public function testReadWriteConnectionsNotCreatedUntilNeeded()
     {
-        $connection = $this->db->connection('read_write');
+        $connection = $this->db->getConnection('read_write');
         $pdo = new ReflectionProperty(get_class($connection), 'pdo');
         $pdo->setAccessible(true);
         $readPdo = new ReflectionProperty(get_class($connection), 'readPdo');
@@ -114,8 +145,8 @@ class DatabaseConnectionFactoryTest extends TestCase
             'url' => 'sqlite:///:memory:?foreign_key_constraints=true',
         ], 'constraints_set');
 
-        $this->assertEquals(0, $this->db->connection()->select('PRAGMA foreign_keys')[0]->foreign_keys);
+        $this->assertEquals(0, $this->db->getConnection()->select('PRAGMA foreign_keys')[0]->foreign_keys);
 
-        $this->assertEquals(1, $this->db->connection('constraints_set')->select('PRAGMA foreign_keys')[0]->foreign_keys);
+        $this->assertEquals(1, $this->db->getConnection('constraints_set')->select('PRAGMA foreign_keys')[0]->foreign_keys);
     }
 }

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -25,6 +25,10 @@ class DatabaseConnectionFactoryTest extends TestCase
         ]);
 
         $this->db->addConnection([
+            'url' => 'sqlite:///:memory:',
+        ], 'url');
+
+        $this->db->addConnection([
             'driver' => 'sqlite',
             'read' => [
                 'database'  => ':memory:',
@@ -48,6 +52,8 @@ class DatabaseConnectionFactoryTest extends TestCase
         $this->assertInstanceOf(PDO::class, $this->db->connection()->getReadPdo());
         $this->assertInstanceOf(PDO::class, $this->db->connection('read_write')->getPdo());
         $this->assertInstanceOf(PDO::class, $this->db->connection('read_write')->getReadPdo());
+        $this->assertInstanceOf(PDO::class, $this->db->connection('url')->getPdo());
+        $this->assertInstanceOf(PDO::class, $this->db->connection('url')->getReadPdo());
     }
 
     public function testSingleConnectionNotCreatedUntilNeeded()
@@ -105,9 +111,7 @@ class DatabaseConnectionFactoryTest extends TestCase
     public function testSqliteForeignKeyConstraints()
     {
         $this->db->addConnection([
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'foreign_key_constraints' => true,
+            'url' => 'sqlite:///:memory:?foreign_key_constraints=true',
         ], 'constraints_set');
 
         $this->assertEquals(0, $this->db->connection()->select('PRAGMA foreign_keys')[0]->foreign_keys);

--- a/tests/Database/DatabaseUrlParserTest.php
+++ b/tests/Database/DatabaseUrlParserTest.php
@@ -301,7 +301,7 @@ class DatabaseUrlParserTest extends TestCase
 
             'Full example from doc with url overwriting parameters' => [
                 [
-                    'url' => 'pgsql://root:pass@db/local',
+                    'url' => 'mysql://root:pass@db/local',
                     'driver' => 'mysql',
                     'host' => '127.0.0.1',
                     'port' => '3306',
@@ -318,7 +318,7 @@ class DatabaseUrlParserTest extends TestCase
                     'options' => ['foo' => 'bar'],
                 ],
                 [
-                    'driver' => 'pgsql',
+                    'driver' => 'mysql',
                     'host' => 'db',
                     'port' => '3306',
                     'database' => 'local',

--- a/tests/Database/DatabaseUrlParserTest.php
+++ b/tests/Database/DatabaseUrlParserTest.php
@@ -1,0 +1,339 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\UrlParser;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseUrlParserTest extends TestCase
+{
+    /**
+     * @dataProvider databaseUrls
+     */
+    public function testDatabaseUrlsAreParsed($config, $expectedOutput)
+    {
+        $this->assertEquals($expectedOutput, (new UrlParser)->parseDatabaseConfigWithUrl($config));
+    }
+
+    public function testDriversAliases()
+    {
+        $this->assertEquals([
+            'mssql' => 'sqlsrv',
+            'mysql2' => 'mysql',
+            'postgres' => 'pgsql',
+            'postgresql' => 'pgsql',
+            'sqlite3' => 'sqlite',
+        ], UrlParser::getDriverAliases());
+
+        UrlParser::addDriverAlias('some-particular-alias', 'mysql');
+
+        $this->assertEquals([
+            'mssql' => 'sqlsrv',
+            'mysql2' => 'mysql',
+            'postgres' => 'pgsql',
+            'postgresql' => 'pgsql',
+            'sqlite3' => 'sqlite',
+            'some-particular-alias' => 'mysql',
+        ], UrlParser::getDriverAliases());
+
+        $this->assertEquals([
+            'driver' => 'mysql',
+        ], (new UrlParser)->parseDatabaseConfigWithUrl('some-particular-alias://null'));
+    }
+
+    public function databaseUrls()
+    {
+        return [
+            'simple URL' => [
+                'mysql://foo:bar@localhost/baz',
+                [
+                    'driver' => 'mysql',
+                    'username' => 'foo',
+                    'password' => 'bar',
+                    'host' => 'localhost',
+                    'database' => 'baz',
+                ],
+            ],
+            'simple URL with port' => [
+                'mysql://foo:bar@localhost:134/baz',
+                [
+                    'driver' => 'mysql',
+                    'username' => 'foo',
+                    'password' => 'bar',
+                    'host' => 'localhost',
+                    'port' => 134,
+                    'database' => 'baz',
+                ],
+            ],
+            'sqlite relative URL with host' => [
+                'sqlite://localhost/foo/database.sqlite',
+                [
+                    'database' => 'foo/database.sqlite',
+                    'driver' => 'sqlite',
+                    'host' => 'localhost',
+                ],
+            ],
+            'sqlite absolute URL with host' => [
+                'sqlite://localhost//tmp/database.sqlite',
+                [
+                    'database' => '/tmp/database.sqlite',
+                    'driver' => 'sqlite',
+                    'host' => 'localhost',
+                ],
+            ],
+            'sqlite relative URL without host' => [
+                'sqlite:///foo/database.sqlite',
+                [
+                    'database' => 'foo/database.sqlite',
+                    'driver' => 'sqlite',
+                ],
+            ],
+            'sqlite absolute URL without host' => [
+                'sqlite:////tmp/database.sqlite',
+                [
+                    'database' => '/tmp/database.sqlite',
+                    'driver' => 'sqlite',
+                ],
+            ],
+            'sqlite memory' => [
+                'sqlite:///:memory:',
+                [
+                    'database' => ':memory:',
+                    'driver' => 'sqlite',
+                ],
+            ],
+            'params parsed from URL override individual params' => [
+                [
+                    'url' => 'mysql://foo:bar@localhost/baz',
+                    'password' => 'lulz',
+                    'driver' => 'sqlite',
+                ],
+                [
+                    'username' => 'foo',
+                    'password' => 'bar',
+                    'host' => 'localhost',
+                    'database' => 'baz',
+                    'driver' => 'mysql',
+                ],
+            ],
+            'params not parsed from URL but individual params are preserved' => [
+                [
+                    'url' => 'mysql://foo:bar@localhost/baz',
+                    'port' => 134,
+                ],
+                [
+                    'username' => 'foo',
+                    'password' => 'bar',
+                    'host' => 'localhost',
+                    'port' => 134,
+                    'database' => 'baz',
+                    'driver' => 'mysql',
+                ],
+            ],
+            'query params from URL are used as extra params' => [
+                'url' => 'mysql://foo:bar@localhost/database?charset=UTF-8',
+                [
+                    'driver' => 'mysql',
+                    'database' => 'database',
+                    'host' => 'localhost',
+                    'username' => 'foo',
+                    'password' => 'bar',
+                    'charset' => 'UTF-8',
+                ],
+            ],
+            'simple URL with driver set apart' => [
+                [
+                    'url' => '//foo:bar@localhost/baz',
+                    'driver' => 'sqlsrv',
+                ],
+                [
+                    'username' => 'foo',
+                    'password' => 'bar',
+                    'host' => 'localhost',
+                    'database' => 'baz',
+                    'driver' => 'sqlsrv',
+                ],
+            ],
+            'simple URL with percent encoding' => [
+                'mysql://foo%3A:bar%2F@localhost/baz+baz%40',
+                [
+                    'username' => 'foo:',
+                    'password' => 'bar/',
+                    'host' => 'localhost',
+                    'database' => 'baz+baz@',
+                    'driver' => 'mysql',
+                ],
+            ],
+            'simple URL with percent sign in password' => [
+                'mysql://foo:bar%25bar@localhost/baz',
+                [
+                    'username' => 'foo',
+                    'password' => 'bar%bar',
+                    'host' => 'localhost',
+                    'database' => 'baz',
+                    'driver' => 'mysql',
+                ],
+            ],
+            'URL with mssql alias driver' => [
+                'mssql://null',
+                [
+                    'driver' => 'sqlsrv',
+                ],
+            ],
+            'URL with sqlsrv alias driver' => [
+                'sqlsrv://null',
+                [
+                    'driver' => 'sqlsrv',
+                ],
+            ],
+            'URL with mysql alias driver' => [
+                'mysql://null',
+                [
+                    'driver' => 'mysql',
+                ],
+            ],
+            'URL with mysql2 alias driver' => [
+                'mysql2://null',
+                [
+                    'driver' => 'mysql',
+                ],
+            ],
+            'URL with postgres alias driver' => [
+                'postgres://null',
+                [
+                    'driver' => 'pgsql',
+                ],
+            ],
+            'URL with postgresql alias driver' => [
+                'postgresql://null',
+                [
+                    'driver' => 'pgsql',
+                ],
+            ],
+            'URL with pgsql alias driver' => [
+                'pgsql://null',
+                [
+                    'driver' => 'pgsql',
+                ],
+            ],
+            'URL with sqlite alias driver' => [
+                'sqlite://null',
+                [
+                    'driver' => 'sqlite',
+                ],
+            ],
+            'URL with sqlite3 alias driver' => [
+                'sqlite3://null',
+                [
+                    'driver' => 'sqlite',
+                ],
+            ],
+
+            'URL with unknown driver' => [
+                'foo://null',
+                [
+                    'driver' => 'foo',
+                ],
+            ],
+            'Sqlite with foreign_key_constraints' => [
+                'sqlite:////absolute/path/to/database.sqlite?foreign_key_constraints=true',
+                [
+                    'driver' => 'sqlite',
+                    'database' => '/absolute/path/to/database.sqlite',
+                    'foreign_key_constraints' => true,
+                ],
+            ],
+
+            'Most complex example with read and write subarrays all in string' => [
+                'mysql://root:@null/database?read[host][]=192.168.1.1&write[host][]=196.168.1.2&sticky=true&charset=utf8mb4&collation=utf8mb4_unicode_ci&prefix=',
+                [
+                    'read' => [
+                        'host' => ['192.168.1.1'],
+                    ],
+                    'write' => [
+                        'host' => ['196.168.1.2'],
+                    ],
+                    'sticky' => true,
+                    'driver' => 'mysql',
+                    'database' => 'database',
+                    'username' => 'root',
+                    'password' => '',
+                    'charset' => 'utf8mb4',
+                    'collation' => 'utf8mb4_unicode_ci',
+                    'prefix' => '',
+                ],
+            ],
+
+            'Full example from doc that prove that there isn\'t any Breaking Change' => [
+                [
+                    'driver' => 'mysql',
+                    'host' => '127.0.0.1',
+                    'port' => '3306',
+                    'database' => 'forge',
+                    'username' => 'forge',
+                    'password' => '',
+                    'unix_socket' => '',
+                    'charset' => 'utf8mb4',
+                    'collation' => 'utf8mb4_unicode_ci',
+                    'prefix' => '',
+                    'prefix_indexes' => true,
+                    'strict' => true,
+                    'engine' => null,
+                    'options' => ['foo' => 'bar'],
+                ],
+                [
+                    'driver' => 'mysql',
+                    'host' => '127.0.0.1',
+                    'port' => '3306',
+                    'database' => 'forge',
+                    'username' => 'forge',
+                    'password' => '',
+                    'unix_socket' => '',
+                    'charset' => 'utf8mb4',
+                    'collation' => 'utf8mb4_unicode_ci',
+                    'prefix' => '',
+                    'prefix_indexes' => true,
+                    'strict' => true,
+                    'engine' => null,
+                    'options' => ['foo' => 'bar'],
+                ],
+            ],
+
+            'Full example from doc with url overwriting parameters' => [
+                [
+                    'url' => 'pgsql://root:pass@db/local',
+                    'driver' => 'mysql',
+                    'host' => '127.0.0.1',
+                    'port' => '3306',
+                    'database' => 'forge',
+                    'username' => 'forge',
+                    'password' => '',
+                    'unix_socket' => '',
+                    'charset' => 'utf8mb4',
+                    'collation' => 'utf8mb4_unicode_ci',
+                    'prefix' => '',
+                    'prefix_indexes' => true,
+                    'strict' => true,
+                    'engine' => null,
+                    'options' => ['foo' => 'bar'],
+                ],
+                [
+                    'driver' => 'pgsql',
+                    'host' => 'db',
+                    'port' => '3306',
+                    'database' => 'local',
+                    'username' => 'root',
+                    'password' => 'pass',
+                    'unix_socket' => '',
+                    'charset' => 'utf8mb4',
+                    'collation' => 'utf8mb4_unicode_ci',
+                    'prefix' => '',
+                    'prefix_indexes' => true,
+                    'strict' => true,
+                    'engine' => null,
+                    'options' => ['foo' => 'bar'],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Database/DatabaseUrlParserTest.php
+++ b/tests/Database/DatabaseUrlParserTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Database\UrlParser;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Database\UrlParser;
 
 class DatabaseUrlParserTest extends TestCase
 {


### PR DESCRIPTION
Following https://github.com/laravel/framework/pull/28096

I've directly integrated it in the connection process, so it's fully transparent for the user, and without any breaking change (see the tests about it).

### Usages

```php
[
	'default' => env('DB_CONNECTION', 'mysql'),
	'connections' => [
		'mysql' => [
			'url' => env('DATABASE_URL'), // will override other parameters
            'driver' => 'mysql',
            'host' => env('DB_HOST', '127.0.0.1'),
            'port' => env('DB_PORT', '3306'),
            'database' => env('DB_DATABASE', 'forge'),
            'username' => env('DB_USERNAME', 'forge'),
            'password' => env('DB_PASSWORD', ''),
            'unix_socket' => env('DB_SOCKET', ''),
            'charset' => 'utf8mb4',
            'collation' => 'utf8mb4_unicode_ci',
			// ...
		],

		// Or directly: 
		'url' => env('DATABASE_URL')
// ...

```


I've covered many cases and examples in tests, so I let you dig into them, and give me back your thoughts about it.

I'm also using it in a real project, and for now it works like a charm.

Thanks.
Matt'