### PR TITLE
[5.8] Adding toResponseArray to Resources

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -202,6 +202,17 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
+     * Create an array response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toResponseArray($request)
+    {
+        return (new ResourceResponse($this))->toArray($request);
+    }
+
+    /**
      * Prepare the resource for JSON serialization.
      *
      * @return array

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -15,20 +15,31 @@ class PaginatedResourceResponse extends ResourceResponse
     public function toResponse($request)
     {
         return tap(response()->json(
-            $this->wrap(
-                $this->resource->resolve($request),
-                array_merge_recursive(
-                    $this->paginationInformation($request),
-                    $this->resource->with($request),
-                    $this->resource->additional
-                )
-            ),
+            $this->toArray($request),
             $this->calculateStatus()
         ), function ($response) use ($request) {
             $response->original = $this->resource->resource->pluck('resource');
 
             $this->resource->withResponse($request, $response);
         });
+    }
+
+    /**
+     * Create an array that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return $this->wrap(
+            $this->resource->resolve($request),
+            array_merge_recursive(
+                $this->paginationInformation($request),
+                $this->resource->with($request),
+                $this->resource->additional
+            )
+        );
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -71,4 +71,17 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
                     ? (new PaginatedResourceResponse($this))->toResponse($request)
                     : parent::toResponse($request);
     }
+
+    /**
+     * Create an array that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toResponseArray($request)
+    {
+        return $this->resource instanceof AbstractPaginator
+                    ? (new PaginatedResourceResponse($this))->toArray($request)
+                    : parent::toResponseArray($request);
+    }
 }

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -35,17 +35,28 @@ class ResourceResponse implements Responsable
     public function toResponse($request)
     {
         return tap(response()->json(
-            $this->wrap(
-                $this->resource->resolve($request),
-                $this->resource->with($request),
-                $this->resource->additional
-            ),
+            $this->toArray($request),
             $this->calculateStatus()
         ), function ($response) use ($request) {
             $response->original = $this->resource->resource;
 
             $this->resource->withResponse($request, $response);
         });
+    }
+
+    /**
+     * Create an array that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return $this->wrap(
+            $this->resource->resolve($request),
+            $this->resource->with($request),
+            $this->resource->additional
+        );
     }
 
     /**

--- a/tests/Http/HttpResourceTest.php
+++ b/tests/Http/HttpResourceTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Illuminate\Tests\Http;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Request;
+
+class HttpResourceTest extends TestCase
+{
+    public function testToResourceArray()
+    {
+        $request = Request::create('https://example.com');
+        $resource = PostResource::make(new Post([
+            'id' => 5,
+            'title' => 'Test Title',
+        ]));
+
+        $this->assertEquals($resource->toResponseArray($request), [
+            'data' => [
+                'id' => 5,
+                'title' => 'Test Title',
+                'custom' => true,
+            ],
+        ]);
+    }
+
+    public function testCollectionToResourceArray()
+    {
+        $request = Request::create('https://example.com');
+        $resource = PostResource::collection(
+            collect([new Post(['id' => 5, 'title' => 'Test Title'])]),
+            10, 15, 1
+        );
+
+        $this->assertEquals($resource->toResponseArray($request), [
+            'data' => [
+                [
+                    'id' => 5,
+                    'title' => 'Test Title',
+                    'custom' => true,
+                ],
+            ],
+        ]);
+    }
+
+    public function testPaginatedCollectionToResourceArray()
+    {
+        $request = Request::create('https://example.com');
+        $resource = PostResource::collection(new LengthAwarePaginator(
+            collect([new Post(['id' => 5, 'title' => 'Test Title'])]),
+            10, 15, 1
+        ));
+
+        $this->assertEquals($resource->toResponseArray($request), [
+            'data' => [
+                [
+                    'id' => 5,
+                    'title' => 'Test Title',
+                    'custom' => true,
+                ]
+            ],
+            'links' => [
+                "first" => "/?page=1",
+                "last" => "/?page=1",
+                "prev" => null,
+                "next" => null,
+            ],
+            'meta' => [
+                "current_page" => 1,
+                "from" => 1,
+                "last_page" => 1,
+                "path" => "/",
+                "per_page" => 15,
+                "to" => 1,
+                "total" => 10,
+            ],
+        ]);
+    }
+}
+
+class Post extends Model
+{
+    protected $guarded = [];
+}
+
+class PostResource extends JsonResource
+{
+    public function toArray($request)
+    {
+        return ['id' => $this->id, 'title' => $this->title, 'custom' => true];
+    }
+
+    public function withResponse($request, $response)
+    {
+        $response->header('X-Resource', 'True');
+    }
+}

--- a/tests/Http/HttpResourceTest.php
+++ b/tests/Http/HttpResourceTest.php
@@ -60,7 +60,7 @@ class HttpResourceTest extends TestCase
                     'id' => 5,
                     'title' => 'Test Title',
                     'custom' => true,
-                ]
+                ],
             ],
             'links' => [
                 'first' => '/?page=1',

--- a/tests/Http/HttpResourceTest.php
+++ b/tests/Http/HttpResourceTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Http;
 
+use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Http\Resources\Json\JsonResource;
-use Illuminate\Http\Request;
 
 class HttpResourceTest extends TestCase
 {
@@ -63,19 +63,19 @@ class HttpResourceTest extends TestCase
                 ]
             ],
             'links' => [
-                "first" => "/?page=1",
-                "last" => "/?page=1",
-                "prev" => null,
-                "next" => null,
+                'first' => '/?page=1',
+                'last' => '/?page=1',
+                'prev' => null,
+                'next' => null,
             ],
             'meta' => [
-                "current_page" => 1,
-                "from" => 1,
-                "last_page" => 1,
-                "path" => "/",
-                "per_page" => 15,
-                "to" => 1,
-                "total" => 10,
+                'current_page' => 1,
+                'from' => 1,
+                'last_page' => 1,
+                'path' => '/',
+                'per_page' => 15,
+                'to' => 1,
+                'total' => 10,
             ],
         ]);
     }


### PR DESCRIPTION
In my use case i want to use Pagination with Resources but i want an Array instead of a JsonResponse, because i want to inject the data as props in a Vue Compoenent.

Currently there is no way of fetching the Pagination Data, only as `JsonResponse`.

My change doesn't change anything, it only introduces a new method for getting array instead of `JsonResponse`.
