### PR TITLE
[5.9] Fix Arr::isAssoc with empty array

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -348,6 +348,10 @@ class Arr
      */
     public static function isAssoc(array $array)
     {
+        if ($array === []) {
+            return true;
+        }
+
         $keys = array_keys($array);
 
         return array_keys($keys) !== $keys;

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -373,6 +373,7 @@ class SupportArrTest extends TestCase
         $this->assertTrue(Arr::isAssoc(['a' => 'a', 0 => 'b']));
         $this->assertTrue(Arr::isAssoc([1 => 'a', 0 => 'b']));
         $this->assertTrue(Arr::isAssoc([1 => 'a', 2 => 'b']));
+        $this->assertTrue(Arr::isAssoc([]));
         $this->assertFalse(Arr::isAssoc([0 => 'a', 1 => 'b']));
         $this->assertFalse(Arr::isAssoc(['a', 'b']));
     }


### PR DESCRIPTION
`Arr::isAssoc([])` currently returns `false` which is strange because an empty array is both associative and sequential (list), it should be `true`.

Breaking change with empty array.
