### PR TITLE
[5.8] Fix BelongsToMany read wrong parent key.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -214,7 +214,7 @@ trait InteractsWithPivotTable
     protected function updateExistingPivotUsingCustomClass($id, array $attributes, $touch)
     {
         $updated = $this->newPivot([
-            $this->foreignPivotKey => $this->parent->getKey(),
+            $this->foreignPivotKey => $this->parent->{$this->parentKey},
             $this->relatedPivotKey => $this->parseId($id),
         ], true)->fill($attributes)->save();
 
@@ -446,7 +446,7 @@ trait InteractsWithPivotTable
 
         foreach ($this->parseIds($ids) as $id) {
             $results += $this->newPivot([
-                $this->foreignPivotKey => $this->parent->getKey(),
+                $this->foreignPivotKey => $this->parent->{$this->parentKey},
                 $this->relatedPivotKey => $id,
             ], true)->delete();
         }


### PR DESCRIPTION
Sometimes we don't have primary id in pivot table. For example:
I have three tables.

```js
// users
[{
    id: 1,
    uuid: "c3b5c66a-aebe-4c76-9a51-9c305ff6dad1",
    name: "John"
}]

// shops
[{
    id: 1,
    uuid: "25adf508-8dff-4a7f-ad26-3320f4d23f15",
    name: "Nice Pizza"
}, {
    id: 1,
    uuid: "84a11000-0a09-4054-bc9c-c4e49e2f48c5",
    name: "Nice Flower"
}]

// user_shop(pivot table)
[{
    user_uuid: "c3b5c66a-aebe-4c76-9a51-9c305ff6dad1",
    shop_uuid: "25adf508-8dff-4a7f-ad26-3320f4d23f15"
}]
```

User extends Eloquent\Model
```php
    /**
     * Has many shops
     *
     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
     */
    public function shops()
    {
        return $this->belongsToMany(Shop::class, 'user_shop', 'user_uuid',
            'shop_uuid', 'uuid', 'uuid')
            ->using(UserShop::class);
    }
````

UserShop extends Eloquent\Relations\Pivot
```php
// Empty
```

```php
<?php
    $user = \App\Models\User::first();
    $user->shops()->sync(['84a11000-0a09-4054-bc9c-c4e49e2f48c5']);
    dd($user->shops->toArray());
```

expect
```sql
delete from `user_shop` where (`user_uuid` = 'c3b5c66a-aebe-4c76-9a51-9c305ff6dad1' and `shop_uuid` = '25adf508-8dff-4a7f-ad26-3320f4d23f15')
```

actual
```sql
delete from `user_shop` where (`user_uuid` = 1 and `shop_uuid` = '25adf508-8dff-4a7f-ad26-3320f4d23f15')
```

Because `user_uuid` read `$this->parent->getKey()`.