### PR TITLE
[5.8] adds regular expression matching to TrimStrings middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -5,7 +5,7 @@ namespace Illuminate\Foundation\Http\Middleware;
 class TrimStrings extends TransformsRequest
 {
     /**
-     * The attributes that should not be trimmed.
+     * The exact attributes that should not be trimmed.
      *
      * @var array
      */
@@ -14,18 +14,80 @@ class TrimStrings extends TransformsRequest
     ];
 
     /**
+     * The regular expressions matching attributes that should not be trimmed.
+     *
+     * @var array
+     */
+    protected $exceptPattern = [
+        //
+    ];
+
+    /**
+     * The regular expression generated from the exceptPattern.
+     *
+     * @var string
+     */
+    protected $patternString;
+
+    public function __construct()
+    {
+        $this->generatePatternString();
+    }
+
+    /**
+     * Generate the regular expression pattern from the exceptPattern.
+     *
+     * @return void
+     */
+    protected function generatePatternString()
+    {
+        if (count($this->exceptPattern) > 0) {
+            $this->patternString = sprintf('/(%s)/', implode('|', $this->exceptPattern));
+        }
+    }
+
+    /**
      * Transform the given value.
      *
-     * @param  string  $key
-     * @param  mixed  $value
+     * @param string $key
+     * @param mixed  $value
+     *
      * @return mixed
      */
     protected function transform($key, $value)
     {
-        if (in_array($key, $this->except, true)) {
+        if ($this->matchesExact($key) || $this->matchesPattern($key)) {
             return $value;
         }
 
         return is_string($value) ? trim($value) : $value;
+    }
+
+    /**
+     * Validate if the key is in the except array.
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    protected function matchesExact($key)
+    {
+        return in_array($key, $this->except, true);
+    }
+
+    /**
+     * Validate if the key matches the except regular expression.
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    protected function matchesPattern($key)
+    {
+        if (!$this->patternString) {
+            return false;
+        }
+
+        return preg_match($this->patternString, $key) !== 0;
     }
 }

--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\TrimStrings as TransformsRequest;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+class TrimStringsTest extends TestCase
+{
+    public function testTrimmingWhenDataIsPlain()
+    {
+        $middleware = new TrimStrings;
+
+        $symfonyRequest = new SymfonyRequest([
+            'foo' => 'foz  ',
+            'bar' => 'baz',
+        ]);
+
+        $symfonyRequest->server->set('REQUEST_METHOD', 'POST');
+        $request = Request::createFromBase($symfonyRequest);
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals('foz', $request->get('foo'));
+            $this->assertEquals('baz', $request->get('bar'));
+        });
+    }
+
+    public function testTrimmingExactExceptionsWhenDataIsPlain()
+    {
+        $middleware = new TrimStrings;
+
+        $symfonyRequest = new SymfonyRequest([
+            'foo' => 'foz  ',
+            'for' => 'baz  ',
+        ]);
+
+        $symfonyRequest->server->set('REQUEST_METHOD', 'POST');
+        $request = Request::createFromBase($symfonyRequest);
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals('foz', $request->get('foo'));
+            $this->assertEquals('baz  ', $request->get('for'));
+        });
+    }
+
+    public function testTrimmingPatternExceptionsWhenDataIsPlain()
+    {
+        $middleware = new TrimStrings;
+
+        $symfonyRequest = new SymfonyRequest([
+            'foo_pat' => 'foz  ',
+            'foo_pattern' => 'far  ',
+            'foo_123' => 'bar  '
+        ]);
+
+        $symfonyRequest->server->set('REQUEST_METHOD', 'POST');
+        $request = Request::createFromBase($symfonyRequest);
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals('foz  ', $request->get('foo_pat'));
+            $this->assertEquals('far  ', $request->get('foo_pattern'));
+            $this->assertEquals('bar', $request->get('foo_123'));
+        });
+    }
+
+    public function testTrimmingWhenDataIsNested()
+    {
+        $middleware = new TrimStrings;
+
+        $symfonyRequest = new SymfonyRequest([
+            'foo' => [['for' => 'foz  ']],
+            'for' => [['foo' => 'foz  ']],
+            'bar' => ['baz'],
+        ]);
+
+        $symfonyRequest->server->set('REQUEST_METHOD', 'POST');
+        $request = Request::createFromBase($symfonyRequest);
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals([['for' => 'foz']], $request->get('foo'));
+            $this->assertEquals([['foo' => 'foz']], $request->get('for'));
+            $this->assertEquals(['baz'], $request->get('bar'));
+        });
+    }
+
+    public function testTrimmingPatternExceptionsWhenDataIsNested()
+    {
+        $middleware = new TrimStrings;
+
+        $symfonyRequest = new SymfonyRequest([
+            'for' => [['for' => 'foz  ']],
+            'bar' => ['baz  '],
+        ]);
+
+        $symfonyRequest->server->set('REQUEST_METHOD', 'POST');
+        $request = Request::createFromBase($symfonyRequest);
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals([['for' => 'foz  ']], $request->get('for'));
+            $this->assertEquals(['baz  '], $request->get('bar'));
+        });
+    }
+}
+
+class TrimStrings extends TransformsRequest
+{
+    /**
+     * The exact attributes that should not be trimmed.
+     *
+     * @var array
+     */
+    protected $except = [
+        'for'
+    ];
+
+    /**
+     * The regular expressions matching attributes that should not be trimmed.
+     *
+     * @var array
+     */
+    protected $exceptPattern = [
+        '^foo_[a-z]+$',
+        '^for\.[0-9]\.for$',
+        '^bar\.[0-9]$',
+    ];
+}


### PR DESCRIPTION
When using the `TrimStrings` middleware, we cannot exclude fields that are nested or those that match a given pattern. For example, having a payload of selected text, of which the number of highlights vary, might be just one or fifty :

```
{
  "highlights": [
    {
      "first_characters": "this is a ",
      "last_characters": "simple test"
    },
    {
      "first_characters": "this is another",
      "last_characters": " simple test"
    }
  ]
}
```

Adding any of the keys to `protected $except` of the `TrimStrings` middleware will not work, but adding the regular expression `'^highlights\.[0-9]+\.(first|last)_characters$'` to the new `protected $exceptPattern` array should work.