### PR TITLE
[5.3] prevent counting null in addNestedWhereQuery

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -98,7 +98,7 @@ class Builder
      *
      * @var array
      */
-    public $wheres;
+    public $wheres = [];
 
     /**
      * The groupings for the query.


### PR DESCRIPTION
Fix counting null issue in `Illuminate\Database\Query\Builder::addNestedWhereQuery`