### PR TITLE
[5.9] Make Session contract independent of the specific implementations

### DIFF
--- a/src/Illuminate/Contracts/Session/Session.php
+++ b/src/Illuminate/Contracts/Session/Session.php
@@ -147,19 +147,4 @@ interface Session
      * @return \SessionHandlerInterface
      */
     public function getHandler();
-
-    /**
-     * Determine if the session handler needs a request.
-     *
-     * @return bool
-     */
-    public function handlerNeedsRequest();
-
-    /**
-     * Set the request on the handler instance.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
-     */
-    public function setRequestOnHandler($request);
 }

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -35,12 +35,14 @@ class CookieSessionHandler implements SessionHandlerInterface
     /**
      * Create a new cookie driven handler instance.
      *
+     * @param  \Symfony\Component\HttpFoundation\Request  $request
      * @param  \Illuminate\Contracts\Cookie\QueueingFactory  $cookie
      * @param  int  $minutes
      * @return void
      */
-    public function __construct(CookieJar $cookie, $minutes)
+    public function __construct(Request $request, CookieJar $cookie, $minutes)
     {
+        $this->request = $request;
         $this->cookie = $cookie;
         $this->minutes = $minutes;
     }
@@ -106,16 +108,5 @@ class CookieSessionHandler implements SessionHandlerInterface
     public function gc($lifetime)
     {
         return true;
-    }
-
-    /**
-     * Set the request instance.
-     *
-     * @param  \Symfony\Component\HttpFoundation\Request  $request
-     * @return void
-     */
-    public function setRequest(Request $request)
-    {
-        $this->request = $request;
     }
 }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -75,9 +75,7 @@ class StartSession
      */
     protected function startSession(Request $request)
     {
-        return tap($this->getSession($request), function ($session) use ($request) {
-            $session->setRequestOnHandler($request);
-
+        return tap($this->getSession($request), function ($session) {
             $session->start();
         });
     }

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -35,7 +35,7 @@ class SessionManager extends Manager
     protected function createCookieDriver()
     {
         return $this->buildSession(new CookieSessionHandler(
-            $this->app['cookie'], $this->app['config']['session.lifetime']
+            $this->app['request'], $this->app['cookie'], $this->app['config']['session.lifetime']
         ));
     }
 

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -635,27 +635,4 @@ class Store implements Session
     {
         return $this->handler;
     }
-
-    /**
-     * Determine if the session handler needs a request.
-     *
-     * @return bool
-     */
-    public function handlerNeedsRequest()
-    {
-        return $this->handler instanceof CookieSessionHandler;
-    }
-
-    /**
-     * Set the request on the handler instance.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
-     */
-    public function setRequestOnHandler($request)
-    {
-        if ($this->handlerNeedsRequest()) {
-            $this->handler->setRequest($request);
-        }
-    }
 }

--- a/src/Illuminate/Support/Facades/Session.php
+++ b/src/Illuminate/Support/Facades/Session.php
@@ -23,8 +23,6 @@ namespace Illuminate\Support\Facades;
  * @method static string|null previousUrl()
  * @method static void setPreviousUrl(string $url)
  * @method static \SessionHandlerInterface getHandler()
- * @method static bool handlerNeedsRequest()
- * @method static void setRequestOnHandler(\Illuminate\Http\Request $request)
  *
  * @see \Illuminate\Session\SessionManager
  * @see \Illuminate\Session\Store

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -7,9 +7,6 @@ use ReflectionClass;
 use SessionHandlerInterface;
 use Illuminate\Session\Store;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Cookie\CookieJar;
-use Illuminate\Session\CookieSessionHandler;
-use Symfony\Component\HttpFoundation\Request;
 
 class SessionStoreTest extends TestCase
 {
@@ -286,19 +283,6 @@ class SessionStoreTest extends TestCase
 
         $session->flashInput(['foo' => 'bar']);
         $this->assertTrue($session->hasOldInput());
-    }
-
-    public function testHandlerNeedsRequest()
-    {
-        $session = $this->getSession();
-        $this->assertFalse($session->handlerNeedsRequest());
-        $session->getHandler()->shouldReceive('setRequest')->never();
-
-        $session = new Store('test', m::mock(new CookieSessionHandler(new CookieJar, 60)));
-        $this->assertTrue($session->handlerNeedsRequest());
-        $session->getHandler()->shouldReceive('setRequest')->once();
-        $request = new Request;
-        $session->setRequestOnHandler($request);
     }
 
     public function testToken()


### PR DESCRIPTION
Remove a "Request" dependency from the Session contract. Since it is used only for the `CookieSessionHandler`.

Request is a required option for the `CookieSessionHandler`, so now it is passed using the constructor.