### PR TITLE
[5.8] Add excepts variable and except function in Model.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -141,6 +141,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected static $ignoreOnTouch = [];
 
     /**
+     * The Array of Excepts will be remove or unset variables to escape from Insert/Update into table.
+     * 
+     * @var array
+     */
+    protected $excepts = [];
+
+    /**
      * The name of the "created at" column.
      *
      * @var string
@@ -674,6 +681,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         if ($saved) {
             $this->finishSave($options);
         }
+
+        if (count($this->excepts) > 0)
+            $this->except();
 
         return $saved;
     }
@@ -1644,5 +1654,20 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function __wakeup()
     {
         $this->bootIfNotBooted();
+    }
+
+    /**
+     * We can use this function to except the fields from Insert/Update into table.
+     * We can call this function directly from model or use $excepts variable.
+     * Note: All fields to except will be release to null or unset variables.
+     * @param array $fields
+     */
+    protected function except(array $fields = [])
+    {
+        $all_fields = array_merge($this->excepts, $fields);
+
+        foreach ($all_fields as $field) {
+            unset($this->$field);
+        }
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -141,6 +141,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected static $ignoreOnTouch = [];
 
     /**
+     * The Array of Excepts will be remove or unset variables to escape from Insert/Update into table.
+     * 
+     * @var array
+     */
+    protected $excepts = [];
+
+    /**
      * The name of the "created at" column.
      *
      * @var string
@@ -673,6 +680,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // we need to happen after a model gets successfully saved right here.
         if ($saved) {
             $this->finishSave($options);
+        }
+
+        if (count($this->excepts) > 0) {
+            $this->except();
         }
 
         return $saved;
@@ -1644,5 +1655,20 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function __wakeup()
     {
         $this->bootIfNotBooted();
+    }
+
+    /**
+     * We can use this function to except the fields from Insert/Update into table.
+     * We can call this function directly from model or use $excepts variable.
+     * Note: All fields to except will be release to null or unset variables.
+     * @param array $fields
+     */
+    protected function except(array $fields = [])
+    {
+        $all_fields = array_merge($this->excepts, $fields);
+
+        foreach ($all_fields as $field) {
+            unset($this->$field);
+        }
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1666,7 +1666,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * Note: All fields to except will be release to null or unset variables.
      * @param array $fields
      */
-    protected function except(array $fields = [])
+    public function except(array $fields = [])
     {
         $all_fields = array_merge($this->excepts, $fields);
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -682,6 +682,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $this->finishSave($options);
         }
 
+        // We need to check the excepts variable, if it have any values.
+        // If it is "passed", it must be call the except function to trigger the unset
+        // varaibles and remove it from the current model.
         if (count($this->excepts) > 0) {
             $this->except();
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -139,7 +139,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @var array
      */
     protected static $ignoreOnTouch = [];
-    
+
     /**
      * The Array of Excepts will be remove or unset variables to escape from Insert/Update into table.
      *


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Add except fields, when the model try to escape variables from insert / update in save function.

There are two ways to use except function:

- Using protected $excepts = ['var_1', 'var_2', 'var_n'];

- Using $this->except(['var_1', 'var_2', 'var_n']);

Why need this function?
Because this function can be using to escape the variables or fields to insert/update while we trying to add more fields by using it as temporary variables and then we need to escape those of it.