### PR TITLE
[5.9] Fix Session contract

### DIFF
--- a/src/Illuminate/Contracts/Session/Session.php
+++ b/src/Illuminate/Contracts/Session/Session.php
@@ -147,19 +147,4 @@ interface Session
      * @return \SessionHandlerInterface
      */
     public function getHandler();
-
-    /**
-     * Determine if the session handler needs a request.
-     *
-     * @return bool
-     */
-    public function handlerNeedsRequest();
-
-    /**
-     * Set the request on the handler instance.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
-     */
-    public function setRequestOnHandler($request);
 }

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -35,12 +35,14 @@ class CookieSessionHandler implements SessionHandlerInterface
     /**
      * Create a new cookie driven handler instance.
      *
+     * @param  \Symfony\Component\HttpFoundation\Request  $request
      * @param  \Illuminate\Contracts\Cookie\QueueingFactory  $cookie
      * @param  int  $minutes
      * @return void
      */
-    public function __construct(CookieJar $cookie, $minutes)
+    public function __construct(Request $request, CookieJar $cookie, $minutes)
     {
+        $this->request = $request;
         $this->cookie = $cookie;
         $this->minutes = $minutes;
     }
@@ -106,16 +108,5 @@ class CookieSessionHandler implements SessionHandlerInterface
     public function gc($lifetime)
     {
         return true;
-    }
-
-    /**
-     * Set the request instance.
-     *
-     * @param  \Symfony\Component\HttpFoundation\Request  $request
-     * @return void
-     */
-    public function setRequest(Request $request)
-    {
-        $this->request = $request;
     }
 }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -75,9 +75,7 @@ class StartSession
      */
     protected function startSession(Request $request)
     {
-        return tap($this->getSession($request), function ($session) use ($request) {
-            $session->setRequestOnHandler($request);
-
+        return tap($this->getSession($request), function ($session) {
             $session->start();
         });
     }

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -35,7 +35,7 @@ class SessionManager extends Manager
     protected function createCookieDriver()
     {
         return $this->buildSession(new CookieSessionHandler(
-            $this->app['cookie'], $this->app['config']['session.lifetime']
+            $this->app['request'], $this->app['cookie'], $this->app['config']['session.lifetime']
         ));
     }
 

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -635,27 +635,4 @@ class Store implements Session
     {
         return $this->handler;
     }
-
-    /**
-     * Determine if the session handler needs a request.
-     *
-     * @return bool
-     */
-    public function handlerNeedsRequest()
-    {
-        return $this->handler instanceof CookieSessionHandler;
-    }
-
-    /**
-     * Set the request on the handler instance.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
-     */
-    public function setRequestOnHandler($request)
-    {
-        if ($this->handlerNeedsRequest()) {
-            $this->handler->setRequest($request);
-        }
-    }
 }

--- a/src/Illuminate/Support/Facades/Session.php
+++ b/src/Illuminate/Support/Facades/Session.php
@@ -23,8 +23,6 @@ namespace Illuminate\Support\Facades;
  * @method static string|null previousUrl()
  * @method static void setPreviousUrl(string $url)
  * @method static \SessionHandlerInterface getHandler()
- * @method static bool handlerNeedsRequest()
- * @method static void setRequestOnHandler(\Illuminate\Http\Request $request)
  *
  * @see \Illuminate\Session\SessionManager
  * @see \Illuminate\Session\Store

--- a/tests/Integration/Http/MiddlewareTest.php
+++ b/tests/Integration/Http/MiddlewareTest.php
@@ -2,16 +2,15 @@
 
 namespace Illuminate\Tests\Integration\Http;
 
+use Orchestra\Testbench\TestCase;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Route;
-use Orchestra\Testbench\TestCase;
 
 /**
  * @group integration
  */
 class MiddlewareTest extends TestCase
 {
-
     public function test_request_in_middleware_is_shared()
     {
         $this->app[Kernel::class]->prependMiddleware(MiddlewareStub::class);
@@ -31,7 +30,6 @@ class MiddlewareTest extends TestCase
 
 class MiddlewareStub
 {
-
     public function handle($request, $next)
     {
         $request->attributes->set('middleware', 'yes');

--- a/tests/Integration/Http/MiddlewareTest.php
+++ b/tests/Integration/Http/MiddlewareTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Http;
 
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
@@ -13,13 +14,14 @@ class MiddlewareTest extends TestCase
 
     public function test_request_in_middleware_is_shared()
     {
+        $this->app[Kernel::class]->prependMiddleware(MiddlewareStub::class);
         $this->app->singleton('service', function ($app) {
             return $app['request']->attributes->get('middleware');
         });
 
         Route::get('/', function () {
             return app('service');
-        })->middleware(MiddlewareStub::class);
+        });
 
         $response = $this->get('/');
 

--- a/tests/Integration/Http/MiddlewareTest.php
+++ b/tests/Integration/Http/MiddlewareTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http;
+
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class MiddlewareTest extends TestCase
+{
+
+    public function test_request_in_middleware_is_shared()
+    {
+        $this->app->singleton('service', function ($app) {
+            return $app['request']->attributes->get('middleware');
+        });
+
+        Route::get('/', function () {
+            return app('service');
+        })->middleware(MiddlewareStub::class);
+
+        $response = $this->get('/');
+
+        $this->assertEquals('yes', $response->getContent());
+    }
+}
+
+class MiddlewareStub
+{
+
+    public function handle($request, $next)
+    {
+        $request->attributes->set('middleware', 'yes');
+
+        return $next($request);
+    }
+}

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -7,9 +7,6 @@ use ReflectionClass;
 use SessionHandlerInterface;
 use Illuminate\Session\Store;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Cookie\CookieJar;
-use Illuminate\Session\CookieSessionHandler;
-use Symfony\Component\HttpFoundation\Request;
 
 class SessionStoreTest extends TestCase
 {
@@ -286,19 +283,6 @@ class SessionStoreTest extends TestCase
 
         $session->flashInput(['foo' => 'bar']);
         $this->assertTrue($session->hasOldInput());
-    }
-
-    public function testHandlerNeedsRequest()
-    {
-        $session = $this->getSession();
-        $this->assertFalse($session->handlerNeedsRequest());
-        $session->getHandler()->shouldReceive('setRequest')->never();
-
-        $session = new Store('test', m::mock(new CookieSessionHandler(new CookieJar, 60)));
-        $this->assertTrue($session->handlerNeedsRequest());
-        $session->getHandler()->shouldReceive('setRequest')->once();
-        $request = new Request;
-        $session->setRequestOnHandler($request);
     }
 
     public function testToken()


### PR DESCRIPTION
Related issue https://github.com/laravel/ideas/issues/1456

**Preamble**
As I understood the `illuminate/contracts` package should contain only abstract things fully decoupled of framework components, but a framework components should depend on contracts. In the related issue I have specified the contracts that break this agreement.

**Overview**
This PR focused on the only `Session` contract. This contract depends on the `Request` from the `illuminate/http` package. As we can see in [Store](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Session/Store.php#L646) only the [CookieSessionHandler](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Session/CookieSessionHandler.php#L117) uses this feature.

Also we can see ([CookieSessionHandler line 69](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Session/CookieSessionHandler.php#L69)) that the `Request` is required, so it should be provided through the constructor instead of a setter.

`setRequestOnHandler` method is used in [StartSession](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Session/Middleware/StartSession.php#L79) middleware.

I have removed extra methods from the contract and its implementation. Now the Request is specified through the constructor in the factory method.

**Tests**
Test related to old methods was removed. The new integration test proofs that the `Request` is a shared instance, so any changes inside Middleware affects global object. It means the new code have the same behavior related to the request object.

**Pros and cons**
Now `Session` contract fully decoupled of the other illuminate components. It is how the every contracts should look (as I understood about whole contracts idea)

Any changes in the contracts is a BC. So it should go to the next release with a description in the changelog.

Rejected https://github.com/laravel/framework/pull/28326