### PR TITLE
[5.8] Add custom message to thrown exception

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -79,7 +79,7 @@ class VerifyCsrfToken
             });
         }
 
-        throw new TokenMismatchException('Tokens mismatch');
+        throw new TokenMismatchException('CSRF token mismatch.');
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -79,7 +79,7 @@ class VerifyCsrfToken
             });
         }
 
-        throw new TokenMismatchException;
+        throw new TokenMismatchException('Tokens mismatch');
     }
 
     /**


### PR DESCRIPTION
TokenMismatchException throwed without message and stack trace was with empty message