### PR TITLE
[5.8] Fix recursive replacements in Str::replaceArray()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -327,11 +327,15 @@ class Str
      */
     public static function replaceArray($search, array $replace, $subject)
     {
-        foreach ($replace as $value) {
-            $subject = static::replaceFirst($search, $value, $subject);
+        $segments = explode($search, $subject);
+
+        $result = array_shift($segments);
+
+        foreach ($segments as $segment) {
+            $result .= (array_shift($replace) ?? $search).$segment;
         }
 
-        return $subject;
+        return $result;
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -248,6 +248,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('foo/bar/baz/?', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?/?/?'));
         $this->assertEquals('foo/bar', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?'));
         $this->assertEquals('?/?/?', Str::replaceArray('x', ['foo', 'bar', 'baz'], '?/?/?'));
+        $this->assertEquals('foo?/bar/baz', Str::replaceArray('?', ['foo?', 'bar', 'baz'], '?/?/?'));
     }
 
     public function testReplaceFirst()


### PR DESCRIPTION
`Str::replaceArray()` recursively replaces the search value if it appears in the replacements:

```php
Str::replaceArray('?', ['foo?', 'bar'], '?, ?');

// expected: foo?, bar
// actual:   foobar, ?
```

Laravel uses the method in query exceptions to replace the `?` placeholders with the actual bindings. This causes incorrect results if a binding contains a `?`.

We can fix it splitting the string and gluing it back together.

Theoretically, this could be a breaking change for users who are relying on recursive replacements. But I don't a see case where you would want this behavior.

Fixes #28245.