### PR TITLE
[5.9] Remove base controller usages

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -172,8 +172,8 @@ abstract class GeneratorCommand extends Command
     protected function replaceNamespace(&$stub, $name)
     {
         $stub = str_replace(
-            ['DummyNamespace', 'DummyRootNamespace', 'NamespacedDummyUserModel'],
-            [$this->getNamespace($name), $this->rootNamespace(), $this->userProviderModel()],
+            ['DummyNamespace', 'NamespacedDummyUserModel'],
+            [$this->getNamespace($name), $this->userProviderModel()],
             $stub
         );
 

--- a/src/Illuminate/Routing/Console/stubs/controller.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.api.stub
@@ -3,9 +3,8 @@
 namespace DummyNamespace;
 
 use Illuminate\Http\Request;
-use DummyRootNamespaceHttp\Controllers\Controller;
 
-class DummyClass extends Controller
+class DummyClass
 {
     /**
      * Display a listing of the resource.

--- a/src/Illuminate/Routing/Console/stubs/controller.invokable.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.invokable.stub
@@ -3,9 +3,8 @@
 namespace DummyNamespace;
 
 use Illuminate\Http\Request;
-use DummyRootNamespaceHttp\Controllers\Controller;
 
-class DummyClass extends Controller
+class DummyClass
 {
     /**
      * Handle the incoming request.

--- a/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
@@ -4,9 +4,8 @@ namespace DummyNamespace;
 
 use DummyFullModelClass;
 use Illuminate\Http\Request;
-use DummyRootNamespaceHttp\Controllers\Controller;
 
-class DummyClass extends Controller
+class DummyClass
 {
     /**
      * Display a listing of the resource.

--- a/src/Illuminate/Routing/Console/stubs/controller.model.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.stub
@@ -4,9 +4,8 @@ namespace DummyNamespace;
 
 use DummyFullModelClass;
 use Illuminate\Http\Request;
-use DummyRootNamespaceHttp\Controllers\Controller;
 
-class DummyClass extends Controller
+class DummyClass
 {
     /**
      * Display a listing of the resource.

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.api.stub
@@ -5,9 +5,8 @@ namespace DummyNamespace;
 use DummyFullModelClass;
 use ParentDummyFullModelClass;
 use Illuminate\Http\Request;
-use DummyRootNamespaceHttp\Controllers\Controller;
 
-class DummyClass extends Controller
+class DummyClass
 {
     /**
      * Display a listing of the resource.

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.stub
@@ -5,9 +5,8 @@ namespace DummyNamespace;
 use DummyFullModelClass;
 use ParentDummyFullModelClass;
 use Illuminate\Http\Request;
-use DummyRootNamespaceHttp\Controllers\Controller;
 
-class DummyClass extends Controller
+class DummyClass
 {
     /**
      * Display a listing of the resource.

--- a/src/Illuminate/Routing/Console/stubs/controller.plain.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.plain.stub
@@ -3,9 +3,8 @@
 namespace DummyNamespace;
 
 use Illuminate\Http\Request;
-use DummyRootNamespaceHttp\Controllers\Controller;
 
-class DummyClass extends Controller
+class DummyClass
 {
     //
 }

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -3,9 +3,8 @@
 namespace DummyNamespace;
 
 use Illuminate\Http\Request;
-use DummyRootNamespaceHttp\Controllers\Controller;
 
-class DummyClass extends Controller
+class DummyClass
 {
     /**
      * Display a listing of the resource.


### PR DESCRIPTION
This PR accompanies https://github.com/laravel/laravel/pull/5009 since the controller there is removed.