### PR TITLE
[5.8] Fix allow serialize igbinary

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -292,7 +292,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function serialize($value)
     {
-        return is_numeric($value) ? $value : serialize($value);
+        return is_numeric($value) ? $value : $this->connection()->serialize($value);
     }
 
     /**
@@ -303,6 +303,6 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function unserialize($value)
     {
-        return is_numeric($value) ? $value : unserialize($value);
+        return is_numeric($value) ? $value : $this->connection()->unserialize($value);
     }
 }

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -433,4 +433,26 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     {
         return parent::__call(strtolower($method), $parameters);
     }
+
+    /**
+     * Serialize the value. Using PhpRedis's native serialize methods
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function serialize($value)
+    {
+        return $this->client->_serialize($value);
+    }
+
+    /**
+     * Unserialize the value.  Using PhpRedis's native serialize methods
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function unserialize($value)
+    {
+        return $this->client->_unserialize($value);
+    }
 }

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -43,4 +43,26 @@ class PredisConnection extends Connection implements ConnectionContract
 
         unset($loop);
     }
+
+    /**
+     * Serialize the value.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function serialize($value)
+    {
+        return serialize($value);
+    }
+
+    /**
+     * Unserialize the value.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function unserialize($value)
+    {
+        return unserialize($value);
+    }
 }

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -80,6 +80,10 @@ class PhpRedisConnector
             if (! empty($config['read_timeout'])) {
                 $client->setOption(Redis::OPT_READ_TIMEOUT, $config['read_timeout']);
             }
+
+            if (! empty($config['serializer'])) {
+                $client->setOption(Redis::OPT_SERIALIZER, $config['serializer']);
+            }
         });
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR aims to fix #26186 adding the ability to configure the PredisConnector to use `igBinary` serializer.

## Backward compatible
It is backward compatible, or at least does not brake anything, by moving the `serialize`/`unserialize` functionality into the Connectors. That way, any connector without it's own serializer can use the native PHP one. Predis itself will use the native serialization if no specific one is set.