### PR TITLE
Made first parameter of every optional

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -503,8 +503,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  mixed  $value
      * @return bool
      */
-    public function every($key, $operator = null, $value = null)
+    public function every($key = null, $operator = null, $value = null)
     {
+        if (is_null($key)) {
+            foreach ($this->items as $v) {
+                if (! $v) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         if (func_num_args() === 1) {
             $callback = $this->valueRetriever($key);
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1163,6 +1163,19 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue($c->every('active'));
         $this->assertTrue($c->every->active);
         $this->assertFalse($c->push(['active' => false])->every->active);
+
+        $c = new Collection([true, true]);
+        $this->assertTrue($c->every());
+        $this->assertFalse($c->push(false)->every());
+
+        $c = new Collection([null, true]);
+        $this->assertFalse($c->every());
+
+        $c = new Collection([[], []]);
+        $this->assertFalse($c->every());
+
+        $c = new Collection([null, 1, []]);
+        $this->assertFalse($c->every());
     }
 
     public function testExcept()


### PR DESCRIPTION
Through this change the usage of every gets a bit easier.  

```(php)
// current process
Collection::make([true, true, true])->every(function ($value) => return $value);

// After making the first parameter optional
Collection::make([true, true, true])->every();
```

In my Opinion this change would be beneficial for most developers.
