### PR TITLE
[5.8] Avoid errors when using ->onOneServer()

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -635,6 +635,8 @@ class Event
     {
         $this->onOneServer = true;
 
+        $this->description($this->mutexName());
+
         return $this;
     }
 


### PR DESCRIPTION
Here's the deal: when you are using `->onOneServer()` in `app/Console/Kernel.php`, at glance, you will see that will throw an error that tells you to use the `->name()` method before it. Something like this:
```php
$schedule->command('generate:reports')->onOneServer()->daily(); // nope

$schedule->command('generate:reports')->name('unique-mutex-name')->onOneServer()->daily(); // yes!
```

Basically, the `onOneServer()` method will add the mutex name by default unless you want to set another mutex name with the `->name()` method.

PR for docs: https://github.com/laravel/docs/pull/5161