### PR TITLE
[5.8] Serialziation fix for date fields which have "empty" non-numerical values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -127,6 +127,10 @@ trait HasAttributes
                 continue;
             }
 
+            if (empty($attributes[$key]) && ! is_numeric($attributes[$key])) {
+                continue;
+            }
+
             $attributes[$key] = $this->serializeDate(
                 $this->asDateTime($attributes[$key])
             );

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -828,6 +828,40 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('boom', $array['namesList'][1]['bam']);
     }
 
+    public function testToArrayDates()
+    {
+        Carbon::setTestNow('2019-08-07 06:05:04');
+
+        $model = new EloquentDateModelStub;
+        $model->setDateFormat('Y-m-d H:i:s');
+
+        $model->setCreatedAt(now());
+        $this->assertSame(['created_at' => '2019-08-07 06:05:04'], $model->toArray());
+
+        $model->setCreatedAt(0);
+        $this->assertSame(['created_at' => '1970-01-01 00:00:00'], $model->toArray());
+
+        $model->setCreatedAt(null);
+        $this->assertSame(['created_at' => null], $model->toArray());
+
+        $model->setCreatedAt(false);
+        $this->assertSame(['created_at' => false], $model->toArray());
+
+        $model->setCreatedAt('');
+        $this->assertSame(['created_at' => ''], $model->toArray());
+
+        $model->setCreatedAt(now());
+        $model->setUpdatedAt(now());
+        $this->assertSame(
+            ['created_at' => '2019-08-07 06:05:04', 'updated_at' => '2019-08-07 06:05:04'],
+            $model->toArray()
+        );
+
+        $model->non_date_field = now();
+        $this->assertArrayHasKey('non_date_field', $model->toArray());
+        $this->assertIsNotString($model->toArray()['non_date_field']);
+    }
+
     public function testToArrayUsesMutators()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
Calling `toArray` on a model serializes its dates to a string. Currently, if the date value being serialized is `null` it gets _skipped_. However, if the date value is an empty string, attempting to create a Carbon object throws an `InvalidArgumentException`exception which cause the whole `toArray` call to fail.

In this PR, I simply check if the date value is not "empty" before attempting to serialize it. If so, it gets skipped, just like `null`. An exception is added to numeric values (i.e. 0) as it is can be a timestamp.

Date Value | Before | After
---------- | ---- | ------
null | null | null
0 | 1970-01-01 00:00:00 | 1970-01-01 00:00:00 
false | InvalidArgumentException | false
"" | InvalidArgumentException | ""
"abc" | InvalidArgumentException | InvalidArgumentException


Closes https://github.com/laravel/framework/issues/28047
