### PR TITLE
[5.8] Pass extra data to an API Resource

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -23,6 +23,13 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public $resource;
 
     /**
+     * The additional data that can be used to construct the resource array.
+     *
+     * @var array
+     */
+    protected $extra = [];
+
+    /**
      * The additional data that should be added to the top-level resource array.
      *
      * @var array
@@ -118,6 +125,19 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
         return is_array($this->resource)
             ? $this->resource
             : $this->resource->toArray();
+    }
+
+    /**
+     * Add additional data to construct the resource array.
+     *
+     * @param array $data
+     * @return $this
+     */
+    public function using(array $data)
+    {
+        $this->extra = $data;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -23,7 +23,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public $resource;
 
     /**
-     * The additional data that can be used to construct the resource array.
+     * The extra data that can be used to construct the resource array.
      *
      * @var array
      */
@@ -128,7 +128,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
-     * Add additional data to construct the resource array.
+     * Add extra data to construct the resource array.
      *
      * @param array $data
      * @return $this

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -26,6 +26,13 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
     public $collection;
 
     /**
+     * The additional data that can be used to construct each of the resource arrays.
+     *
+     * @var array
+     */
+    protected $extra = [];
+
+    /**
      * Create a new resource instance.
      *
      * @param  mixed  $resource
@@ -36,6 +43,19 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
         parent::__construct($resource);
 
         $this->resource = $this->collectResource($resource);
+    }
+
+    /**
+     * Add additional data to construct each of the resource arrays.
+     *
+     * @param array $data
+     * @return $this
+     */
+    public function using(array $data)
+    {
+        $this->extra = $data;
+
+        return $this;
     }
 
     /**
@@ -56,6 +76,8 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
      */
     public function toArray($request)
     {
+        $this->collection->map->using($this->extra);
+
         return $this->collection->map->toArray($request)->all();
     }
 

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -26,7 +26,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
     public $collection;
 
     /**
-     * The additional data that can be used to construct each of the resource arrays.
+     * The extra data that can be used to construct each of the resource arrays.
      *
      * @var array
      */
@@ -46,7 +46,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
     }
 
     /**
-     * Add additional data to construct each of the resource arrays.
+     * Add extra data to construct each of the resource arrays.
      *
      * @param array $data
      * @return $this

--- a/tests/Integration/Http/Fixtures/PostResourceWithExtraData.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithExtraData.php
@@ -2,10 +2,15 @@
 
 namespace Illuminate\Tests\Integration\Http\Fixtures;
 
-class PostResourceWithExtraData extends PostResource
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResourceWithExtraData extends JsonResource
 {
-    public function with($request)
+    public function toArray($request)
     {
-        return ['foo' => 'bar'];
+        return [
+            'id' => $this->id,
+            'extra_value' => $this->extra['value'],
+        ];
     }
 }

--- a/tests/Integration/Http/Fixtures/PostResourceWithExtraMetaData.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithExtraMetaData.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+class PostResourceWithExtraMetaData extends PostResource
+{
+    public function with($request)
+    {
+        return ['foo' => 'bar'];
+    }
+}


### PR DESCRIPTION
## Explanation

API Resources are pretty powerful, but there's currently one thing not possible: passing extra data to a resource to alter the resource array.

This pull request adds a simple `using` function to API resources.

```php
UserResource::make($user)->using(['extra_value_key' => 'extra data that can be used to alter the array']);
UserResource::collection($user)->using(['extra_value_key' => 'it also works for a collection of an API resource']);

class UserResource extends JsonResource
{
    public function toArray($request)
    {
        return [
            'id' => $this->id,
            'extra_data' => $this->extra['extra_value_key'],
        ];
    }
}
```

## Example

But why would you want to do that? Let me give an example.

Let's say you have an organization model, and each organization has multiple users. A user has a role within the organization, but also a global role within the application.
If you want to create a JSON response of an organization and its users, you probably want to return the organizational role of every user, not the global role.
With the added ‘extra data’ option, you can pass that extra information to the child resources. Those child resources can then use that information to change the array correctly.

```php
class OrganizationResource extends JsonResource
{
    public function toArray($request)
    {
        return [
            'id' => $this->id,
            'users' => UserResource::collection($this->users)->using([
                'organization_id' => $this->id
            ]),
        ];
    }
}

class UserResource extends JsonResource
{
    public function toArray($request)
    {
        return [
            'id' => $this->id,
            'role' => $this->roles->where('pivot.organization_id', $this->extra['organization_id'] ?? null)->first()->name,
        ];
    }
}
```

That's just one simple example. I think there's a lot of use cases for this. Sometimes a child resource may be influenced by a parent resource.

## Remarks

- The implementation is not breaking and completely optionally to use.
- Other people have already discussed such a feature in the past (https://github.com/laravel/framework/issues/23826), so I think it will be useful for quite a lot of people.
- I added some basic tests. Tell me if more should be added.
- I renamed existing tests and a test fixture to indicate that those are about extra metadata. I did this to avoid naming collision with the tests and test fixture that are added by this pull request.
- If (or hopefully when 😛) this gets merged, I will create a pull request to update the docs.

_(This is my first open source pull request so tell me if I did something wrong)_