### PR TITLE
[5.8] Improve output of "assertSessionDoesntHaveErrors" when called with no arguments

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -915,7 +915,7 @@ class TestResponse
         $keys = (array) $keys;
 
         if (empty($keys)) {
-            return $this->assertSessionMissing('errors');
+            return $this->assertSessionHasNoErrors();
         }
 
         if (is_null($this->session()->get('errors'))) {


### PR DESCRIPTION
This PR makes calling `assertSessionDoesntHaveErrors()` with no arguments forward the call to `assertSessionHasNoErrors()`. This makes the output more useful when the assertion fails:

Before:
![image](https://user-images.githubusercontent.com/7202674/56866690-9c72c680-69dc-11e9-87e5-87cb20fb2d00.png)

After:
![image](https://user-images.githubusercontent.com/7202674/56866697-ad233c80-69dc-11e9-98df-01b502c98daf.png)

Related PR: https://github.com/laravel/framework/pull/26039