### PR TITLE
[5.8] Provide support for the missing MySQL column types in Laravel migrations.

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -170,32 +170,6 @@ class Connection implements ConnectionInterface
     protected static $resolvers = [];
 
     /**
-     * The custom Doctrine DBAL types.
-     *
-     * @var array
-     */
-    private $doctrineTypes = [
-        TinyInteger::NAME           => TinyInteger::class,
-        MediumInteger::NAME         => MediumInteger::class,
-        Year::NAME                  => Year::class,
-        Char::NAME                  => Char::class,
-        Double::NAME                => Double::class,
-        Enum::NAME                  => Enum::class,
-        Uuid::NAME                  => Uuid::class,
-        Polygon::NAME               => Polygon::class,
-        MultiPolygon::NAME          => MultiPolygon::class,
-        Point::NAME                 => Point::class,
-        MultiPoint::NAME            => MultiPoint::class,
-        MultiLineString::NAME       => MultiLineString::class,
-        MacAddress::NAME            => MacAddress::class,
-        LineString::NAME            => LineString::class,
-        JsonB::NAME                 => JsonB::class,
-        IpAddress::NAME             => IpAddress::class,
-        GeometryCollection::NAME    => GeometryCollection::class,
-        Geometry::NAME              => Geometry::class
-    ];
-
-    /**
      * Create a new database connection instance.
      *
      * @param  \PDO|\Closure     $pdo
@@ -950,7 +924,9 @@ class Connection implements ConnectionInterface
                 'driver' => $driver->getName(),
             ], $driver);
 
-            $this->registerCustomDoctrineTypes();
+            $this->registerCustomDoctrineTypes(
+                $this->getDoctrineTypes()
+            );
         }
 
         return $this->doctrineConnection;
@@ -1310,17 +1286,17 @@ class Connection implements ConnectionInterface
         return static::$resolvers[$driver] ?? null;
     }
 
-
     /**
      * Register the custom Doctrine mapping types.
      *
+     * @param  array  $types
      * @return void
      *
      * @throws \Doctrine\DBAL\DBALException
      */
-    private function registerCustomDoctrineTypes()
+    private function registerCustomDoctrineTypes($types)
     {
-        foreach($this->doctrineTypes as $name => $class) {
+        foreach($types as $name => $class) {
             $this->registerCustomDoctrineType($class, $name, $name);
         }
     }
@@ -1348,5 +1324,34 @@ class Connection implements ConnectionInterface
             ->getDoctrineSchemaManager()
             ->getDatabasePlatform()
             ->registerDoctrineTypeMapping($type, $name);
+    }
+
+    /**
+     * Get a list of custom Doctrine DBAL types.
+     *
+     * @return array
+     */
+    private function getDoctrineTypes()
+    {
+        return [
+            TinyInteger::NAME           => TinyInteger::class,
+            MediumInteger::NAME         => MediumInteger::class,
+            Year::NAME                  => Year::class,
+            Char::NAME                  => Char::class,
+            Double::NAME                => Double::class,
+            Enum::NAME                  => Enum::class,
+            Uuid::NAME                  => Uuid::class,
+            Polygon::NAME               => Polygon::class,
+            MultiPolygon::NAME          => MultiPolygon::class,
+            Point::NAME                 => Point::class,
+            MultiPoint::NAME            => MultiPoint::class,
+            MultiLineString::NAME       => MultiLineString::class,
+            MacAddress::NAME            => MacAddress::class,
+            LineString::NAME            => LineString::class,
+            JsonB::NAME                 => JsonB::class,
+            IpAddress::NAME             => IpAddress::class,
+            GeometryCollection::NAME    => GeometryCollection::class,
+            Geometry::NAME              => Geometry::class
+        ];
     }
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -2,18 +2,11 @@
 
 namespace Illuminate\Database\Migrations;
 
-use Illuminate\Database\Schema\Types\Enum;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Doctrine\DBAL\Types\Type;
 use Illuminate\Support\Collection;
 use Illuminate\Console\OutputStyle;
-use Illuminate\Database\Connection;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Database\Schema\Types\Char;
-use Illuminate\Database\Schema\Types\Year;
-use Illuminate\Database\Schema\Types\Double;
-use Illuminate\Database\Schema\Types\TinyInteger;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 class Migrator
@@ -355,17 +348,12 @@ class Migrator
      * @param  object  $migration
      * @param  string  $method
      * @return void
-     *
-     * @throws \Doctrine\DBAL\DBALException
-     * @throws \Throwable
      */
     protected function runMigration($migration, $method)
     {
         $connection = $this->resolveConnection(
             $migration->getConnection()
         );
-
-        $this->registerCustomDoctrineTypes($connection);
 
         $callback = function () use ($migration, $method) {
             if (method_exists($migration, $method)) {
@@ -602,51 +590,5 @@ class Migrator
         if ($this->output) {
             $this->output->writeln($message);
         }
-    }
-
-    /**
-     * Register the custom Doctrine mapping types for the migrator.
-     *
-     * @param  Connection  $connection
-     * @return void
-     *
-     * @throws \Doctrine\DBAL\DBALException
-     */
-    private function registerCustomDoctrineTypes($connection)
-    {
-        if (! $connection->isDoctrineAvailable()) {
-            return;
-        }
-
-        $this->registerCustomDoctrineType($connection, TinyInteger::class, TinyInteger::NAME, 'TINYINT');
-        $this->registerCustomDoctrineType($connection, Year::class, Year::NAME, 'YEAR');
-        $this->registerCustomDoctrineType($connection, Char::class, Char::NAME, 'CHAR');
-        $this->registerCustomDoctrineType($connection, Double::class, Double::NAME, 'DOUBLE');
-        $this->registerCustomDoctrineType($connection, Enum::class, Enum::NAME, 'ENUM');
-    }
-
-    /**
-     * Register a custom Doctrine mapping type.
-     *
-     * @param  Connection  $connection
-     * @param  string  $class
-     * @param  string  $name
-     * @param  string  $type
-     * @return void
-     *
-     * @throws \Doctrine\DBAL\DBALException
-     */
-    private function registerCustomDoctrineType($connection, $class, $name, $type)
-    {
-        if (Type::hasType($name)) {
-            return;
-        }
-
-        Type::addType($name, $class);
-
-        $connection
-            ->getDoctrineSchemaManager()
-            ->getDatabasePlatform()
-            ->registerDoctrineTypeMapping($type, $name);
     }
 }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Schema;
 
 use Closure;
 use LogicException;
-use Doctrine\DBAL\Types\Type;
 use Illuminate\Database\Connection;
 
 class Builder

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -286,30 +286,6 @@ class Builder
     }
 
     /**
-     * Register a custom Doctrine mapping type.
-     *
-     * @param  string  $class
-     * @param  string  $name
-     * @param  string  $type
-     * @return void
-     *
-     * @throws \Doctrine\DBAL\DBALException
-     */
-    public function registerCustomDoctrineType($class, $name, $type)
-    {
-        if (Type::hasType($name)) {
-            return;
-        }
-
-        Type::addType($name, $class);
-
-        $this->connection
-            ->getDoctrineSchemaManager()
-            ->getDatabasePlatform()
-            ->registerDoctrineTypeMapping($type, $name);
-    }
-
-    /**
      * Get the database connection instance.
      *
      * @return \Illuminate\Database\Connection

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -82,7 +82,10 @@ class ChangeColumn
                 if (! is_null($option = static::mapFluentOptionToDoctrine($key))) {
                     if (method_exists($column, $method = 'set'.ucfirst($option))) {
                         $column->{$method}(static::mapFluentValueToDoctrine($option, $value));
+                        continue;
                     }
+
+                    $column->setCustomSchemaOption($option, static::mapFluentValueToDoctrine($option, $value));
                 }
             }
         }

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -422,6 +422,243 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * The SQL declaration for the "tinyint" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeTinyInteger($fieldDeclaration)
+    {
+        return $this->typeTinyInteger(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "mediumint" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeMediumInteger($fieldDeclaration)
+    {
+        return $this->typeMediumInteger(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "year" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeYear($fieldDeclaration)
+    {
+        return $this->typeYear(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "char" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeChar($fieldDeclaration)
+    {
+        return $this->typeChar(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "double" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeDouble($fieldDeclaration)
+    {
+        $fieldDeclaration['total'] = $fieldDeclaration['precision'];
+        $fieldDeclaration['places'] = $fieldDeclaration['scale'];
+
+        return $this->typeDouble(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "enum" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeEnum($fieldDeclaration)
+    {
+        return $this->typeEnum(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "uuid" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeUuid($fieldDeclaration)
+    {
+        return $this->typeUuid(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "polygon" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypePolygon($fieldDeclaration)
+    {
+        return $this->typePolygon(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "multiPolygon" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeMultiPolygon($fieldDeclaration)
+    {
+        return $this->typeMultiPolygon(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "point" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypePoint($fieldDeclaration)
+    {
+        return $this->typePoint(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "multiPoint" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeMultiPoint($fieldDeclaration)
+    {
+        return $this->typeMultiPoint(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "lineString" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeLineString($fieldDeclaration)
+    {
+        return $this->typeLineString(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "multiLineString" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeMultiLineString($fieldDeclaration)
+    {
+        return $this->typeMultiLineString(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "macAddress" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeMacAddress($fieldDeclaration)
+    {
+        return $this->typeMacAddress(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "jsonB" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeJsonB($fieldDeclaration)
+    {
+        return $this->typeJsonb(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "ipAddress" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeIpAddress($fieldDeclaration)
+    {
+        return $this->typeIpAddress(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "geometry" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeGeometry($fieldDeclaration)
+    {
+        return $this->typeGeometry(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
+     * The SQL declaration for the "geometryCollection" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeGeometryCollection($fieldDeclaration)
+    {
+        return $this->typeGeometryCollection(
+            new Fluent($fieldDeclaration)
+        );
+    }
+
+    /**
      * Create the column definition for a char type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -422,6 +422,61 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * The SQL declaration for the "tinyint" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeTinyInteger($fieldDeclaration)
+    {
+        return 'TINYINT';
+    }
+
+    /**
+     * The SQL declaration for the "year" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeYear($fieldDeclaration)
+    {
+        return 'YEAR';
+    }
+
+    /**
+     * The SQL declaration for the "char" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeChar($fieldDeclaration)
+    {
+        return "CHAR({$fieldDeclaration['length']})";
+    }
+
+    /**
+     * The SQL declaration for the "double" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeDouble($fieldDeclaration)
+    {
+        return "DOUBLE({$fieldDeclaration['precision']}, {$fieldDeclaration['scale']})";
+    }
+
+    /**
+     * The SQL declaration for the "enum" type.
+     *
+     * @param  array  $fieldDeclaration
+     * @return string
+     */
+    public function doctrineTypeEnum($fieldDeclaration)
+    {
+        return sprintf('enum(%s)', $this->quoteString($fieldDeclaration['allowed']));
+    }
+
+    /**
      * Create the column definition for a char type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -431,7 +431,7 @@ class MySqlGrammar extends Grammar
     {
         return $this->typeTinyInteger(
             new Fluent($fieldDeclaration)
-        );
+        ) . ($fieldDeclaration['unsigned'] === true ? ' UNSIGNED' : '');
     }
 
     /**
@@ -444,7 +444,7 @@ class MySqlGrammar extends Grammar
     {
         return $this->typeMediumInteger(
             new Fluent($fieldDeclaration)
-        );
+        )  . ($fieldDeclaration['unsigned'] === true ? ' UNSIGNED' : '');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -113,20 +113,4 @@ class MySqlBuilder extends Builder
             $this->grammar->compileGetAllViews()
         );
     }
-
-    /**
-     * Register the custom Doctrine mapping types for the MySQL builder.
-     *
-     * @return void
-     *
-     * @throws \Doctrine\DBAL\DBALException
-     */
-    protected function registerCustomDoctrineTypes()
-    {
-        if ($this->connection->isDoctrineAvailable()) {
-            $this->registerCustomDoctrineType(
-                TinyInteger::class, TinyInteger::NAME, 'TINYINT'
-            );
-        }
-    }
 }

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Database\Schema;
 
-use Illuminate\Database\Schema\Types\TinyInteger;
-
 class MySqlBuilder extends Builder
 {
     /**

--- a/src/Illuminate/Database/Schema/Types/Char.php
+++ b/src/Illuminate/Database/Schema/Types/Char.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class Char extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'char';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeChar')) {
+            throw DBALException::notSupported('doctrineTypeChar');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeChar(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/Double.php
+++ b/src/Illuminate/Database/Schema/Types/Double.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class Double extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'double';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeDouble')) {
+            throw DBALException::notSupported('doctrineTypeDouble');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeDouble(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/Enum.php
+++ b/src/Illuminate/Database/Schema/Types/Enum.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class Enum extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'enum';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeEnum')) {
+            throw DBALException::notSupported('doctrineTypeEnum');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeEnum(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/Geometry.php
+++ b/src/Illuminate/Database/Schema/Types/Geometry.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class Geometry extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'geometry';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeGeometry')) {
+            throw DBALException::notSupported('doctrineTypeGeometry');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeGeometry(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/GeometryCollection.php
+++ b/src/Illuminate/Database/Schema/Types/GeometryCollection.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class GeometryCollection extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'geometrycollection';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeGeometryCollection')) {
+            throw DBALException::notSupported('doctrineTypeGeometryCollection');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeGeometryCollection(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/IpAddress.php
+++ b/src/Illuminate/Database/Schema/Types/IpAddress.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class IpAddress extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'ipaddress';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeIpAddress')) {
+            throw DBALException::notSupported('doctrineTypeIpAddress');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeIpAddress(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/JsonB.php
+++ b/src/Illuminate/Database/Schema/Types/JsonB.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class JsonB extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'jsonb';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeJsonB')) {
+            throw DBALException::notSupported('doctrineTypeJsonB');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeJsonB(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/LineString.php
+++ b/src/Illuminate/Database/Schema/Types/LineString.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class LineString extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'linestring';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeLineString')) {
+            throw DBALException::notSupported('doctrineTypeLineString');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeLineString(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/MacAddress.php
+++ b/src/Illuminate/Database/Schema/Types/MacAddress.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class MacAddress extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'macaddress';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeMacAddress')) {
+            throw DBALException::notSupported('doctrineTypeMacAddress');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeMacAddress(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/MediumInteger.php
+++ b/src/Illuminate/Database/Schema/Types/MediumInteger.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class MediumInteger extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'mediuminteger';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeMediumInteger')) {
+            throw DBALException::notSupported('doctrineTypeMediumInteger');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeMediumInteger(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/MultiLineString.php
+++ b/src/Illuminate/Database/Schema/Types/MultiLineString.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class MultiLineString extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'multilinestring';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeMultiLineString')) {
+            throw DBALException::notSupported('doctrineTypeMultiLineString');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeMultiLineString(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/MultiPoint.php
+++ b/src/Illuminate/Database/Schema/Types/MultiPoint.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class MultiPoint extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'multipoint';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeMultiPoint')) {
+            throw DBALException::notSupported('doctrineTypeMultiPoint');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeMultiPoint(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/MultiPolygon.php
+++ b/src/Illuminate/Database/Schema/Types/MultiPolygon.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class MultiPolygon extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'multipolygon';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeMultiPolygon')) {
+            throw DBALException::notSupported('doctrineTypeMultiPolygon');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeMultiPolygon(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/Point.php
+++ b/src/Illuminate/Database/Schema/Types/Point.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class Point extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'point';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypePoint')) {
+            throw DBALException::notSupported('doctrineTypePoint');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypePoint(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/Polygon.php
+++ b/src/Illuminate/Database/Schema/Types/Polygon.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class Polygon extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'polygon';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypePolygon')) {
+            throw DBALException::notSupported('doctrineTypePolygon');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypePolygon(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/Type.php
+++ b/src/Illuminate/Database/Schema/Types/Type.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Database\Schema\Types;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Types\Type as DoctrineType;
+use Illuminate\Database\Schema\Grammars\MySqlGrammar;
+use Illuminate\Database\Schema\Grammars\PostgresGrammar;
+use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
+use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
+use Illuminate\Support\Arr;
+
+abstract class Type extends DoctrineType
+{
+    /**
+     * A mapping used to determine the grammar for the platform.
+     *
+     * @var array
+     */
+    protected $mapping = [
+        'mysql' => MySqlGrammar::class,
+        'postgresql' => PostgresGrammar::class,
+        'sqlite' => SQLiteGrammar::class,
+        'mssql' => SqlServerGrammar::class
+    ];
+
+    /**
+     * Get the schema grammar linked to this platform.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Database\Schema\Grammars\Grammar
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    protected function getSchemaGrammar($name)
+    {
+        if (Arr::exists($this->mapping, $name)) {
+            return new $this->mapping[$name];
+        }
+
+        throw DBALException::notSupported('getSchemaGrammar');
+    }
+}

--- a/src/Illuminate/Database/Schema/Types/Type.php
+++ b/src/Illuminate/Database/Schema/Types/Type.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Database\Schema\Types;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Types\Type as DoctrineType;
+use Illuminate\Database\Schema\Grammars\MySqlGrammar;
+use Illuminate\Database\Schema\Grammars\PostgresGrammar;
+use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
+use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
+use Illuminate\Support\Arr;
+
+abstract class Type extends DoctrineType
+{
+    /**
+     * A mapping used to determine the grammar for the platform.
+     *
+     * @var array
+     */
+    protected $mapping = [
+        'mysql' => MySqlGrammar::class,
+        'postgresql' => PostgresGrammar::class,
+        'sqlite' => SQLiteGrammar::class,
+        'mssql' => SqlServerGrammar::class
+    ];
+
+    /**
+     * Get the schema grammar linked to this platform.
+     *
+     * @param  string  $name
+     *
+     * @return \Illuminate\Database\Schema\Grammars\Grammar
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    protected function getSchemaGrammar($name)
+    {
+        if (Arr::exists($this->mapping, $name)) {
+            return new $this->mapping[$name];
+        }
+
+        throw DBALException::notSupported('getSchemaGrammar');
+    }
+}

--- a/src/Illuminate/Database/Schema/Types/Uuid.php
+++ b/src/Illuminate/Database/Schema/Types/Uuid.php
@@ -5,14 +5,14 @@ namespace Illuminate\Database\Schema\Types;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class Uuid extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'uuid';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +29,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeUuid')) {
+            throw DBALException::notSupported('doctrineTypeUuid');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeUuid(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Database/Schema/Types/Year.php
+++ b/src/Illuminate/Database/Schema/Types/Year.php
@@ -2,17 +2,16 @@
 
 namespace Illuminate\Database\Schema\Types;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-class TinyInteger extends Type
+class Year extends Type
 {
     /**
      * The name of the custom type.
      *
      * @var string
      */
-    const NAME = 'tinyinteger';
+    const NAME = 'year';
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -29,11 +28,11 @@ class TinyInteger extends Type
             $platform->getName()
         );
 
-        if (! method_exists($grammar, 'doctrineTypeTinyInteger')) {
-            throw DBALException::notSupported('doctrineTypeTinyInteger');
+        if (! method_exists($grammar, 'doctrineTypeYear')) {
+            throw DBALException::notSupported('doctrineTypeYear');
         }
 
-        return $grammar->doctrineTypeTinyInteger(
+        return $grammar->doctrineTypeYear(
             $fieldDeclaration
         );
     }

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -11,7 +11,6 @@ namespace Illuminate\Support\Facades;
  * @method static void defaultStringLength(int $length)
  * @method static \Illuminate\Database\Schema\Builder disableForeignKeyConstraints()
  * @method static \Illuminate\Database\Schema\Builder enableForeignKeyConstraints()
- * @method static void registerCustomDBALType(string $class, string $name, string $type)
  *
  * @see \Illuminate\Database\Schema\Builder
  */

--- a/tests/Integration/Database/MySQLSchemaBuilderTest.php
+++ b/tests/Integration/Database/MySQLSchemaBuilderTest.php
@@ -1,0 +1,335 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Grammars\MySqlGrammar;
+use PHPUnit\Framework\TestCase;
+
+class MySQLSchemaBuilderTest extends TestCase
+{
+    /**
+     * The "MySQL" connection.
+     *
+     * @var DB
+     */
+    private $db;
+
+    /**
+     * Start a "MySQL" connection and create the "test" table.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->startConnection();
+        $this->createTestTable();
+    }
+
+    /**
+     * Delete the "test" table.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->deleteTestTable();
+    }
+
+    public function test_if_changing_column_to_char_works()
+    {
+        $b = new Blueprint('table');
+        $b->char('test_column', 121)->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column char(121) NOT NULL COLLATE utf8mb4_unicode_ci',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_double_works()
+    {
+        $b = new Blueprint('table');
+        $b->double('test_column', 3, 8)->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column double(3, 8) NOT NULL COLLATE utf8mb4_unicode_ci',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_enum_works()
+    {
+        $b = new Blueprint('table');
+        $b->enum('test_column', ['yes', 'no'])->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column enum(\'yes\', \'no\') NOT NULL COLLATE utf8mb4_unicode_ci',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_geometry_works()
+    {
+        $b = new Blueprint('table');
+        $b->geometry('test_column')->collation('')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column geometry NOT NULL',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_geometrycollection_works()
+    {
+        $b = new Blueprint('table');
+        $b->geometryCollection('test_column')->collation('')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column geometrycollection NOT NULL',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_ipaddress_works()
+    {
+        $b = new Blueprint('table');
+        $b->ipAddress('test_column')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column varchar(45) NOT NULL COLLATE utf8mb4_unicode_ci',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_jsonb_works()
+    {
+        $b = new Blueprint('table');
+        $b->jsonb('test_column')->collation('')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column json NOT NULL',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_linestring_works()
+    {
+        $b = new Blueprint('table');
+        $b->lineString('test_column')->collation('')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column linestring NOT NULL',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_macaddress_works()
+    {
+        $b = new Blueprint('table');
+        $b->macAddress('test_column')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column varchar(17) NOT NULL COLLATE utf8mb4_unicode_ci',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_mediuminteger_works()
+    {
+        $b = new Blueprint('table');
+        $b->mediumInteger('test_column')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column mediumint NOT NULL COLLATE utf8mb4_unicode_ci',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_multilinestring_works()
+    {
+        $b = new Blueprint('table');
+        $b->multiLineString('test_column')->collation('')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column multilinestring NOT NULL',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_multipoint_works()
+    {
+        $b = new Blueprint('table');
+        $b->multiPoint('test_column')->collation('')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column multipoint NOT NULL',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_multipolygon_works()
+    {
+        $b = new Blueprint('table');
+        $b->multiPolygon('test_column')->collation('')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column multipolygon NOT NULL',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_point_works()
+    {
+        $b = new Blueprint('table');
+        $b->point('test_column')->collation('')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column point NOT NULL',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_polygon_works()
+    {
+        $b = new Blueprint('table');
+        $b->polygon('test_column')->collation('')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column polygon NOT NULL',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_tinyinteger_works()
+    {
+        $b = new Blueprint('table');
+        $b->tinyInteger('test_column')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column tinyint NOT NULL COLLATE utf8mb4_unicode_ci',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_uuid_works()
+    {
+        $b = new Blueprint('table');
+        $b->uuid('test_column')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column char(36) NOT NULL COLLATE utf8mb4_unicode_ci',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_year_works()
+    {
+        $b = new Blueprint('table');
+        $b->year('test_column')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column year NOT NULL COLLATE utf8mb4_unicode_ci',
+            $statements[0]
+        );
+    }
+
+    /**
+     * Start a "MySQL" connection.
+     *
+     * @return void
+     */
+    private function startConnection()
+    {
+        $this->db = $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'mysql',
+            'database' => 'laravel',
+            'prefix' => '',
+            'host' => 'localhost',
+            'username' => 'homestead',
+            'password' => 'secret'
+        ]);
+
+        $db->setAsGlobal();
+    }
+
+    /**
+     * Create the "test" table.
+     *
+     * @return void
+     */
+    private function createTestTable()
+    {
+        $this->db->connection()->getSchemaBuilder()->create('table', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('test_column');
+        });
+    }
+
+    /**
+     * Delete the "test" table.
+     *
+     * @return void
+     */
+    private function deleteTestTable()
+    {
+        $this->db->connection()->getSchemaBuilder()->drop('table');
+    }
+}

--- a/tests/Integration/Database/MySQLSchemaBuilderTest.php
+++ b/tests/Integration/Database/MySQLSchemaBuilderTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-use Illuminate\Database\Capsule\Manager as DB;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 
 class MySQLSchemaBuilderTest extends TestCase
 {
@@ -177,6 +177,48 @@ class MySQLSchemaBuilderTest extends TestCase
         );
     }
 
+    public function test_if_changing_column_to_unsigned_mediuminteger_works()
+    {
+        $b = new Blueprint('table');
+        $b->unsignedMediumInteger('test_column')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column mediumint UNSIGNED NOT NULL COLLATE utf8mb4_unicode_ci',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_unsigned_biginteger_works()
+    {
+        $b = new Blueprint('table');
+        $b->unsignedBigInteger('test_column')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column BIGINT UNSIGNED NOT NULL COLLATE utf8mb4_unicode_ci',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_unsigned_smallinteger_works()
+    {
+        $b = new Blueprint('table');
+        $b->unsignedSmallInteger('test_column')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column SMALLINT UNSIGNED NOT NULL COLLATE utf8mb4_unicode_ci',
+            $statements[0]
+        );
+    }
+
     public function test_if_changing_column_to_multilinestring_works()
     {
         $b = new Blueprint('table');
@@ -257,6 +299,20 @@ class MySQLSchemaBuilderTest extends TestCase
         $this->assertCount(1, $statements);
         $this->assertEquals(
             'ALTER TABLE `table` CHANGE test_column test_column tinyint NOT NULL COLLATE utf8mb4_unicode_ci',
+            $statements[0]
+        );
+    }
+
+    public function test_if_changing_column_to_unsigned_tinyinteger_works()
+    {
+        $b = new Blueprint('table');
+        $b->unsignedTinyInteger('test_column')->change();
+
+        $statements = $b->toSql($this->db->connection(), new MySqlGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'ALTER TABLE `table` CHANGE test_column test_column tinyint UNSIGNED NOT NULL COLLATE utf8mb4_unicode_ci',
             $statements[0]
         );
     }

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -2,12 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Database\SchemaTest;
 
-use Doctrine\DBAL\Types\Type;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Database\Schema\Types\TinyInteger;
-use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 /**
@@ -39,34 +36,5 @@ class SchemaBuilderTest extends DatabaseTestCase
         DB::statement('create view "view"("id") as select 1');
 
         $this->assertTrue(true);
-    }
-
-    public function test_register_custom_doctrine_type()
-    {
-        Schema::registerCustomDoctrineType(TinyInteger::class, TinyInteger::NAME, 'TINYINT');
-
-        Schema::create('test', function (Blueprint $table) {
-            $table->string('test_column');
-        });
-
-        $blueprint = new Blueprint('test', function (Blueprint $table) {
-            $table->tinyInteger('test_column')->change();
-        });
-
-        $expected = [
-            'CREATE TEMPORARY TABLE __temp__test AS SELECT test_column FROM test',
-            'DROP TABLE test',
-            'CREATE TABLE test (test_column TINYINT NOT NULL COLLATE BINARY)',
-            'INSERT INTO test (test_column) SELECT test_column FROM __temp__test',
-            'DROP TABLE __temp__test',
-        ];
-
-        $statements = $blueprint->toSql($this->getConnection(), new SQLiteGrammar());
-
-        $blueprint->build($this->getConnection(), new SQLiteGrammar());
-
-        $this->assertArrayHasKey(TinyInteger::NAME, Type::getTypesMap());
-        $this->assertEquals('tinyinteger', Schema::getColumnType('test', 'test_column'));
-        $this->assertEquals($expected, $statements);
     }
 }


### PR DESCRIPTION
### Overview

The ability to change columns, in contrast to creating columns, within Laravel migrations requires the use of the Doctrine DBAL package. However, the Doctrine DBAL package doesn't include support for columns types which are not supported across every database platform. Therefore, in order for some column types to be changed in a migration, custom types will need to be registered in the Doctrine DBAL types map.

This pull request aims to provide support for the missing MySQL column types. While some column types might be supported on other platforms, i don't have enough time to include these right now. A mapping has been made however, so adding these missing columns shouldn't should be doable in the future.

### Reproduction

In order to reproduce the issues, you'll need to run two migrations. One should create a column and the other one should should change the column with a column type that's not universally supported:

```php
// The first migration.
Schema::create('test_migration', function($table) {
    $table->char('test_column');
});
```
```php
// The second migration.
Schema::table('test_migration', function($table) {
    $table->tinyInteger('test_column')->change();
});
```

### What's included in this pull request?

Support for the following column types have been added:

| Column Type | MySQL | PostgreSQL | SQLite | Microsoft SQL Server |
| --- | --- | --- | --- | --- |
| Char | Yes | No | No | No |
| Double | Yes | No | No | No |
| Enum | Yes | No | No | No |
| Geometry | Yes | No | No | No |
| Geometry Collection | Yes | No | No | No |
| IP Address | Yes | No | No | No |
| JSONB | Yes | No | No | No |
| Line String| Yes | No | No | No |
| MAC Address| Yes | No | No | No |
| Medium Integer| Yes | No | No | No |
| Unsigned Medium Integer| Yes | No | No | No |
| Multi Line String | Yes | No | No | No |
| Multi Point | Yes | No | No | No |
| Multi Polygon| Yes | No | No | No |
| Point | Yes | No | No | No |
| Polygon | Yes | No | No | No |
| Tiny Integer | Yes | No | No | No |
| Unsigned Tiny Integer | Yes | No | No | No |
| UUID | Yes | No | No | No |
| Year | Yes | No | No | No |

Furthermore, i reverted the changes i made in pull request #28214 because they've become redundant.

### What's still left to do?

In order to ensure backwards compatibility i added doctrine column type methods to the "MySQL" grammar class. The regular type methods could not be used in the custom Doctrine type because they have protected visibility. This could eventually be changed to "public" in version 5.9 to avoid code duplication. I'd like to hear your thoughts on this.

Furthermore, like i mentioned earlier, this pull request lacks support for PostgreSQL, SQLite and Microsoft SQL Server. 

### Running the tests

I've added tests for every column type i added support for. These tests require a working MySQL database but i don't know how TravisCI is configured to handle MySQL specifics tests. If there's anything i need to change within the test's connection configurations, please let me know.