### PR TITLE
[5.8] Allow logging out other devices without setting remember me cookie

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -550,7 +550,9 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             $attribute => Hash::make($password),
         ]))->save();
 
-        $this->queueRecallerCookie($this->user());
+        if ($this->recaller() || $this->getCookieJar()->hasQueued($this->getRecallerName())) {
+            $this->queueRecallerCookie($this->user());
+        }
 
         $this->fireOtherDeviceLogoutEvent($this->user());
 


### PR DESCRIPTION
Currently calling logoutOtherDevices sets a remember me cookie regardless that it existed originally or not, this pull request makes sure that it is only queued, when:

- A recaller cookie already exists or
- A recaller cookie is already queued