### PR TITLE
[5.8] Break out password reset credentials into a method

### DIFF
--- a/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
+++ b/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
@@ -31,7 +31,7 @@ trait SendsPasswordResetEmails
         // to send the link, we will examine the response then see the message we
         // need to show to the user. Finally, we'll send out a proper response.
         $response = $this->broker()->sendResetLink(
-            $request->only('email')
+            $this->credentials($request)
         );
 
         return $response == Password::RESET_LINK_SENT
@@ -48,6 +48,17 @@ trait SendsPasswordResetEmails
     protected function validateEmail(Request $request)
     {
         $request->validate(['email' => 'required|email']);
+    }
+
+    /**
+     * Get the needed authentication credentials from the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    protected function credentials(Request $request)
+    {
+        return $request->only('email');
     }
 
     /**


### PR DESCRIPTION
This breaks out the fetching of credentials from a password reset request into a separate method in a similar fashion to how it occurs in the `AuthenticatedUsers` trait. 

My use-case for this is that I'm using Postgres which is case-sensitive by default, so when a user attempts to reset their password but uses capitals then it tells them their account doesn't exist and leaves them confused.

I'm already overriding `credentials` for authentication in my own app for this. It might be nice to see Laravel `Str::lower` email addresses out of the box, but as it appears Postgres-specific it might be overkill.

This solution brings `SendsPasswordResetEmails` into line with `AuthenticatesUsers` and allows developers, where necessary, to support email normalization.