### PR TITLE
[5.8] Support creation and update dateTimes

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -408,6 +408,26 @@ class Blueprint
     }
 
     /**
+     * Indicate that the timestamp columns should be dropped.
+     *
+     * @return void
+     */
+    public function dropDateTimes()
+    {
+        $this->dropTimestamps();
+    }
+
+    /**
+     * Indicate that the timestamp columns should be dropped.
+     *
+     * @return void
+     */
+    public function dropDateTimesTz()
+    {
+        $this->dropTimestamps();
+    }
+
+    /**
      * Indicate that the soft delete column should be dropped.
      *
      * @param  string  $column
@@ -923,6 +943,32 @@ class Blueprint
     public function dateTimeTz($column, $precision = 0)
     {
         return $this->addColumn('dateTimeTz', $column, compact('precision'));
+    }
+
+    /**
+     * Add nullable creation and update dateTimes to the table.
+     *
+     * @param  int  $precision
+     * @return void
+     */
+    public function dateTimes($precision = 0)
+    {
+        $this->dateTime('created_at', $precision)->nullable();
+
+        $this->dateTime('updated_at', $precision)->nullable();
+    }
+
+    /**
+     * Add creation and update dateTimeTz columns to the table.
+     *
+     * @param  int  $precision
+     * @return void
+     */
+    public function dateTimesTz($precision = 0)
+    {
+        $this->dateTimeTz('created_at', $precision)->nullable();
+
+        $this->dateTimeTz('updated_at', $precision)->nullable();
     }
 
     /**


### PR DESCRIPTION
This PR adds a `dateTimes()` methods for generating `created_at` and `updated_at` columns using `dateTime()` instead of `timestamp()`.

```php
// Adding timestamps as dateTimes.
$table->dateTimes();
$table->dateTimesTz();

// Dropping dateTimes columns.
$table->dropDateTimes();
$table->dropDateTimesTz();

```

This change was originally suggested by Taylor Otwell in a [PR from 2014](https://github.com/laravel/framework/pull/3957#issuecomment-38355678).

5 years later, I am not sure if this addition is still welcome but I would be more than happy to continue working on it if it is (writing tests, etc.).

🍀 