### PR TITLE
Add typehints in favour of PHPDocs for TransformsRequest middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
 class TransformsRequest
@@ -10,11 +11,9 @@ class TransformsRequest
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
      * @return mixed
      */
-    public function handle($request, Closure $next)
+    public function handle(Request $request, Closure $next)
     {
         $this->clean($request);
 
@@ -23,11 +22,8 @@ class TransformsRequest
 
     /**
      * Clean the request's data.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
      */
-    protected function clean($request)
+    protected function clean(Request $request): void
     {
         $this->cleanParameterBag($request->query);
 
@@ -40,23 +36,16 @@ class TransformsRequest
 
     /**
      * Clean the data in the parameter bag.
-     *
-     * @param  \Symfony\Component\HttpFoundation\ParameterBag  $bag
-     * @return void
      */
-    protected function cleanParameterBag(ParameterBag $bag)
+    protected function cleanParameterBag(ParameterBag $bag): void
     {
         $bag->replace($this->cleanArray($bag->all()));
     }
 
     /**
      * Clean the data in the given array.
-     *
-     * @param  array  $data
-     * @param  string  $keyPrefix
-     * @return array
      */
-    protected function cleanArray(array $data, $keyPrefix = '')
+    protected function cleanArray(array $data, string $keyPrefix = ''): array
     {
         return collect($data)->map(function ($value, $key) use ($keyPrefix) {
             return $this->cleanValue($keyPrefix.$key, $value);


### PR DESCRIPTION
As a minor improvement (and since the project is only targeting >= PHP 7.1) I've updated the `TransformsRequest` middleware to use the type hints where possible and removing the (redundant) `@params` and `@return`.
This PR doesn't touch the `cleanValue` method as it is overloaded and contains support for mixed types.

Feel free to reply if this PR needs rework (Since this is my 1st PR on this project)