### PR TITLE
[5.8] Fix the remaining issues with registering custom Doctrine types.

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -4,9 +4,9 @@ namespace Illuminate\Database\Schema;
 
 use Closure;
 use LogicException;
+use RuntimeException;
 use Doctrine\DBAL\Types\Type;
 use Illuminate\Database\Connection;
-use RuntimeException;
 
 class Builder
 {

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -6,6 +6,7 @@ use Closure;
 use LogicException;
 use Doctrine\DBAL\Types\Type;
 use Illuminate\Database\Connection;
+use RuntimeException;
 
 class Builder
 {
@@ -297,16 +298,20 @@ class Builder
      */
     public function registerCustomDoctrineType($class, $name, $type)
     {
-        if (Type::hasType($name)) {
-            return;
+        if (! $this->connection->isDoctrineAvailable()) {
+            throw new RuntimeException(
+                'Registering a custom Doctrine type requires Doctrine DBAL; install "doctrine/dbal".'
+            );
         }
 
-        Type::addType($name, $class);
+        if (! Type::hasType($name)) {
+            Type::addType($name, $class);
 
-        $this->connection
-            ->getDoctrineSchemaManager()
-            ->getDatabasePlatform()
-            ->registerDoctrineTypeMapping($type, $name);
+            $this->connection
+                ->getDoctrineSchemaManager()
+                ->getDatabasePlatform()
+                ->registerDoctrineTypeMapping($type, $name);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Database\Schema;
 
-use Illuminate\Database\Schema\Types\TinyInteger;
-
 class MySqlBuilder extends Builder
 {
     /**
@@ -112,21 +110,5 @@ class MySqlBuilder extends Builder
         return $this->connection->select(
             $this->grammar->compileGetAllViews()
         );
-    }
-
-    /**
-     * Register the custom Doctrine mapping types for the MySQL builder.
-     *
-     * @return void
-     *
-     * @throws \Doctrine\DBAL\DBALException
-     */
-    protected function registerCustomDoctrineTypes()
-    {
-        if ($this->connection->isDoctrineAvailable()) {
-            $this->registerCustomDoctrineType(
-                TinyInteger::class, TinyInteger::NAME, 'TINYINT'
-            );
-        }
     }
 }

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -11,7 +11,7 @@ namespace Illuminate\Support\Facades;
  * @method static void defaultStringLength(int $length)
  * @method static \Illuminate\Database\Schema\Builder disableForeignKeyConstraints()
  * @method static \Illuminate\Database\Schema\Builder enableForeignKeyConstraints()
- * @method static void registerCustomDBALType(string $class, string $name, string $type)
+ * @method static void registerCustomDoctrineType(string $class, string $name, string $type)
  *
  * @see \Illuminate\Database\Schema\Builder
  */

--- a/tests/Integration/Database/Fixtures/TinyInteger.php
+++ b/tests/Integration/Database/Fixtures/TinyInteger.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Database\Schema\Types;
+namespace Illuminate\Tests\Integration\Database\Fixtures;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -6,9 +6,9 @@ use Doctrine\DBAL\Types\Type;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Database\Schema\Types\TinyInteger;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use Illuminate\Tests\Integration\Database\Fixtures\TinyInteger;
 
 /**
  * @group integration


### PR DESCRIPTION
This PR removes the TinyInteger type from the core and allows the user to register their own custom Doctrine DBAL types. No connection wil be established by only instantiating the builder class, only as soon as you call the registerCustomDoctrineType method. Therefore it won't cause issues like #28282 anymore.