### PR TITLE
[5.8] Binding value as PDO::PARAM_INT has different behaviour in PHP 7.2 + MysqlConnection

### DIFF
--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -77,7 +77,7 @@ class MySqlConnection extends Connection
         foreach ($bindings as $key => $value) {
             $statement->bindValue(
                 is_string($key) ? $key : $key + 1, $value,
-                is_int($value) || is_float($value) ? PDO::PARAM_INT : PDO::PARAM_STR
+                is_int($value) ? PDO::PARAM_INT : PDO::PARAM_STR
             );
         }
     }

--- a/tests/Database/DatabaseMySqlConnectionTest.php
+++ b/tests/Database/DatabaseMySqlConnectionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\MySqlConnection;
+use PDO;
+use PDOStatement;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseMySqlConnectionTest extends TestCase
+{
+    public function testBindFloatValue()
+    {
+        $connection = new MySqlConnection(
+            function () {
+                throw new \UnexpectedValueException('Not expecting to really connect to database');
+            }
+        );
+
+        $statement = $this->createMock(PDOStatement::class);
+        $statement
+            ->expects($this->at(0))
+            ->method('bindValue')
+            ->with(1, 0.5, PDO::PARAM_STR);
+
+        $connection->bindValues($statement, [0 => 0.5]);
+    }
+
+    public function testBindStringValue()
+    {
+        $connection = new MySqlConnection(
+            function () {
+                throw new \UnexpectedValueException('Not expecting to really connect to database');
+            }
+        );
+
+        $statement = $this->createMock(PDOStatement::class);
+        $statement
+            ->expects($this->at(0))
+            ->method('bindValue')
+            ->with(1, 'test', PDO::PARAM_STR);
+
+        $connection->bindValues($statement, [0 => 'test']);
+    }
+
+    public function testBindIntegerValue()
+    {
+        $connection = new MySqlConnection(
+            function () {
+                throw new \UnexpectedValueException('Not expecting to really connect to database');
+            }
+        );
+
+        $statement = $this->createMock(PDOStatement::class);
+        $statement
+            ->expects($this->at(0))
+            ->method('bindValue')
+            ->with(1, 27, PDO::PARAM_INT);
+
+        $connection->bindValues($statement, [0 => 27]);
+    }
+}


### PR DESCRIPTION
When binding a value against a MySQL PDO statement, the behaviour between PHP 7.1 and PHP 7.2 differs. When you bind a value as integer while passing a float, this was no problem with PHP7.1. However, it became a problem in PHP7.2.

The problem is when executing the following. It inserts 0.5 in PHP7.1, and 0 in PHP7.2. I have tested this against MariaDB (10.1 and 10.2), not against MySQL. Another person also found difference in behaviour: https://stackoverflow.com/questions/54413798/pdoparam-int-behaviour-in-php-7-1-php-7-2.

```php
$stmt = $pdo->prepare('INSERT INTO tbl (val) VALUES (?)');
$stmt->bindValue(1, 0.5, PDO::PARAM_INT);
```

This PR fixes that issue. Moreover, it includes tests for the possible `PDO::PARAM_XXX` used my the `bindValue` method in `MysqlConnection`.

Because I am wondering if this is intended behaviour of PHP, I also opened [a PHP bug report](https://bugs.php.net/bug.php?id=77954) for it. Nonetheless, I think that using `PDO::PARAM_STR` is better for floating points than using `PDO::PARAM_INT`.