### PR TITLE
Put use statements in alphabetical ordeer

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/blank.stub
+++ b/src/Illuminate/Database/Migrations/stubs/blank.stub
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class DummyClass extends Migration
 {

--- a/src/Illuminate/Database/Migrations/stubs/create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/create.stub
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class DummyClass extends Migration
 {

--- a/src/Illuminate/Database/Migrations/stubs/update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/update.stub
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class DummyClass extends Migration
 {


### PR DESCRIPTION
Fix once instead of every time when creating migrations.