### PR TITLE
[5.8] Add ability to drop types when running the migrate:fresh command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -47,6 +47,12 @@ class FreshCommand extends Command
 
         $this->info('Dropped all tables successfully.');
 
+        if ($this->option('drop-types')) {
+            $this->dropAllTypes($database);
+
+            $this->info('Dropped all types successfully.');
+        }
+
         $this->call('migrate', array_filter([
             '--database' => $database,
             '--path' => $this->input->getOption('path'),
@@ -87,6 +93,19 @@ class FreshCommand extends Command
     }
 
     /**
+     * Drop all of the database types.
+     *
+     * @param string $database
+     * @return void
+     */
+    protected function dropAllTypes($database)
+    {
+        $this->laravel['db']->connection($database)
+                    ->getSchemaBuilder()
+                    ->dropAllTypes();
+    }
+
+    /**
      * Determine if the developer has requested database seeding.
      *
      * @return bool
@@ -122,6 +141,8 @@ class FreshCommand extends Command
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
 
             ['drop-views', null, InputOption::VALUE_NONE, 'Drop all tables and views'],
+
+            ['drop-types', null, InputOption::VALUE_NONE, 'Drop all tables and types (Postgres only)'],
 
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
 

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -217,6 +217,18 @@ class Builder
     }
 
     /**
+     * Drop all types from the database.
+     *
+     * @return void
+     *
+     * @throws \LogicException
+     */
+    public function dropAllTypes()
+    {
+        throw new LogicException('This database driver does not support dropping all types.');
+    }
+
+    /**
      * Rename a table on the schema.
      *
      * @param  string  $from

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -220,6 +220,17 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile the SQL needed to drop all types.
+     *
+     * @param array $types
+     * @return string
+     */
+    public function compileDropAllTypes($types)
+    {
+        return 'drop type "'.implode('","', $types).'" cascade';
+    }
+
+    /**
      * Compile the SQL needed to retrieve all table names.
      *
      * @param  string  $schema
@@ -239,6 +250,16 @@ class PostgresGrammar extends Grammar
     public function compileGetAllViews($schema)
     {
         return "select viewname from pg_catalog.pg_views where schemaname = '{$schema}'";
+    }
+
+    /**
+     * Compile the SQL needed to retrieve all type names.
+     *
+     * @return string
+     */
+    public function compileGetAllTypes()
+    {
+        return "select distinct pg_type.typname from pg_type inner join pg_enum on pg_enum.enumtypid = pg_type.oid";
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -259,7 +259,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileGetAllTypes()
     {
-        return "select distinct pg_type.typname from pg_type inner join pg_enum on pg_enum.enumtypid = pg_type.oid";
+        return 'select distinct pg_type.typname from pg_type inner join pg_enum on pg_enum.enumtypid = pg_type.oid';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -76,6 +76,28 @@ class PostgresBuilder extends Builder
     }
 
     /**
+     * Drop all types from the database.
+     */
+    public function dropAllTypes()
+    {
+        $types = [];
+
+        foreach ($this->getAllTypes() as $row) {
+            $row = (array) $row;
+
+            $types[] = reset($row);
+        }
+
+        if (empty($types)) {
+            return;
+        }
+
+        $this->connection->statement(
+            $this->grammar->compileDropAllTypes($types)
+        );
+    }
+
+    /**
      * Get all of the table names for the database.
      *
      * @return array
@@ -96,6 +118,18 @@ class PostgresBuilder extends Builder
     {
         return $this->connection->select(
             $this->grammar->compileGetAllViews($this->connection->getConfig('schema'))
+        );
+    }
+
+    /**
+     * Get all of the type names for the database.
+     *
+     * @return array
+     */
+    protected function getAllTypes()
+    {
+        return $this->connection->select(
+            $this->grammar->compileGetAllTypes()
         );
     }
 

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -50,9 +50,10 @@ trait RefreshDatabase
     protected function refreshTestDatabase()
     {
         if (! RefreshDatabaseState::$migrated) {
-            $this->artisan('migrate:fresh', $this->shouldDropViews() ? [
-                '--drop-views' => true,
-            ] : []);
+            $this->artisan('migrate:fresh', [
+                '--drop-views' => $this->shouldDropViews(),
+                '--drop-types' => $this->shouldDropTypes(),
+            ]);
 
             $this->app[Kernel::class]->setArtisan(null);
 
@@ -113,5 +114,16 @@ trait RefreshDatabase
     {
         return property_exists($this, 'dropViews')
                             ? $this->dropViews : false;
+    }
+
+    /**
+     * Determine if types should be dropped when refreshing the database.
+     *
+     * @return bool
+     */
+    protected function shouldDropTypes()
+    {
+        return property_exists($this, 'dropTypes')
+            ? $this->dropTypes : false;
     }
 }

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -832,6 +832,13 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('drop view "alpha","beta","gamma" cascade', $statement);
     }
 
+    public function testDropAllTypesEscapesTableNames()
+    {
+        $statement = $this->getGrammar()->compileDropAllTypes(['alpha', 'beta', 'gamma']);
+
+        $this->assertEquals('drop type "alpha","beta","gamma" cascade', $statement);
+    }
+
     protected function getConnection()
     {
         return m::mock(Connection::class);


### PR DESCRIPTION
[PostgresSQL uses types for for enums](https://www.postgresql.org/docs/9.5/datatype-enum.html). Currently, when using the migrate:fresh command or the RefreshDatabase trait all the tables are dropped but the types used for enums remain. This causes an error when the migrations that created those types are rerun.

This change allows dropping database types when running the migrate:fresh command. It also adds the ability to drop types when using the RefreshDatabase trait in tests. 

This code change follows the same [pattern that was used to allow dropping views](https://github.com/laravel/framework/commit/23547e3a485eaa8fd15a6ac17b8e2310cca8c1fa). It adds an option to the migrate:fresh command that will drop types and allows adding a class property to have the RefreshDatabase trait drop types.