### PR TITLE
[5.8] Add renderable functionality to MailMessage

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -4,6 +4,7 @@ namespace Illuminate\Notifications\Messages;
 
 use Traversable;
 use Illuminate\Mail\Markdown;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 
@@ -281,6 +282,8 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function render()
     {
-        return app(Markdown::class)->render($this->markdown, $this->data());
+        return Container::getInstance()
+            ->make(Markdown::class)
+            ->render($this->markdown, $this->data());
     }
 }

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -4,8 +4,9 @@ namespace Illuminate\Notifications\Messages;
 
 use Traversable;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Renderable;
 
-class MailMessage extends SimpleMessage
+class MailMessage extends SimpleMessage implements Renderable
 {
     /**
      * The view to be rendered.
@@ -270,5 +271,15 @@ class MailMessage extends SimpleMessage
         return is_array($address) ||
                $address instanceof Arrayable ||
                $address instanceof Traversable;
+    }
+    
+    /**
+     * Render the mail object into an HTML string.
+     *
+     * @return string
+     */
+    public function render()
+    {
+        return app(\Illuminate\Mail\Markdown::class)->render($this->markdown, $this->data());
     }
 }

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Notifications\Messages;
 
 use Traversable;
+use Illuminate\Mail\Markdown;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 
@@ -272,7 +273,7 @@ class MailMessage extends SimpleMessage implements Renderable
                $address instanceof Arrayable ||
                $address instanceof Traversable;
     }
-    
+
     /**
      * Render the mail object into an HTML string.
      *
@@ -280,6 +281,6 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function render()
     {
-        return app(\Illuminate\Mail\Markdown::class)->render($this->markdown, $this->data());
+        return app(Markdown::class)->render($this->markdown, $this->data());
     }
 }


### PR DESCRIPTION
This PR adds the Renderable contract to the MailMessage class, allowing easier previewing of mail notifications in the browser. 

In your controller:
```php
return (new FooNotification())->toMail('example@example.com');
```

This is parallel with the current functionality of the Mailable class, and obviates the need to search for code snippets to accomplish the same for Notifications. This addresses Issue #24073.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
