### PR TITLE
[5.8] Database migration - add schema foreign key definition meta class

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -520,7 +520,7 @@ class Blueprint
      *
      * @param  string|array  $columns
      * @param  string  $name
-     * @return \Illuminate\Support\Fluent
+     * @return \Illuminate\Support\Fluent|\Illuminate\Database\Schema\ForeignKeyDefinition
      */
     public function foreign($columns, $name = null)
     {

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Database\Schema;
+
+use Illuminate\Support\Fluent;
+
+/**
+ * @method ForeignKeyDefinition references(string $table) Specify the referenced table
+ * @method ForeignKeyDefinition on(string $column) Specify the referenced column
+ * @method ForeignKeyDefinition onDelete(string $action) Add an ON DELETE action
+ * @method ForeignKeyDefinition onUpdate(string $action) Add an ON UPDATE action
+ */
+class ForeignKeyDefinition extends Fluent
+{
+    //
+}


### PR DESCRIPTION
Illuminate\Database\Schema\ForeignKeyDefinition, will provide autocomplete support for the foreign key modifiers and prevent any IDE "undefined method" errors.

This class is created in the same way as Illuminate\Database\Schema\ColumnDefinition. Empty class with PHPDoc metadata.