### PR TITLE
[5.8] Modified None And React presets to exclude vue-template-compiler

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/None.php
+++ b/src/Illuminate/Foundation/Console/Presets/None.php
@@ -38,6 +38,7 @@ class None extends Preset
             $packages['jquery'],
             $packages['popper.js'],
             $packages['vue'],
+            $packages['vue-template-compiler'],
             $packages['@babel/preset-react'],
             $packages['react'],
             $packages['react-dom']

--- a/src/Illuminate/Foundation/Console/Presets/React.php
+++ b/src/Illuminate/Foundation/Console/Presets/React.php
@@ -34,7 +34,7 @@ class React extends Preset
             '@babel/preset-react' => '^7.0.0',
             'react' => '^16.2.0',
             'react-dom' => '^16.2.0',
-        ] + Arr::except($packages, ['vue']);
+        ] + Arr::except($packages, ['vue', 'vue-template-compiler']);
     }
 
     /**


### PR DESCRIPTION
Submitting a pull request to fix the behavior of React and None frontend scaffolding presets as referenced in issue [#](https://github.com/laravel/framework/issues/28384).

Have added vue-template-compiler to the list of packages excluded by the two, but have refrained from adding vue-template-compiler into Vue Preset. Will amend it if the maintainers find it valuable for it to be included.