### PR TITLE
[5.8] Fix Error Message issue for Missing Method with Alternative Route Registering Syntax

### DIFF
--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -28,7 +28,7 @@ class RouteAction
         // If the action is already a Closure instance, we will just set that instance
         // as the "uses" property, because there is nothing else we need to do when
         // it is available. Otherwise we will need to find it in the action list.
-        if (is_callable($action)) {
+        if (is_callable($action, true)) {
             return ! is_array($action) ? ['uses' => $action] : [
                 'uses' => $action[0].'@'.$action[1],
                 'controller' => $action[0].'@'.$action[1],


### PR DESCRIPTION
This PR was created to resolve issue https://github.com/laravel/framework/issues/27344. 

When working through the framework's Routing files it seems that the below `if` statement found [here](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Routing/RouteAction.php) on the `parse` method of `Routing/RouteAction.php`, caused a problem when registering a route with the new style added by [this PR](https://github.com/laravel/framework/pull/24385). For example: `Route::get('/test', [App\Http\Controllers\TestController::class, 'index']);`. 

```
if (is_callable($action)) {
            return ! is_array($action) ? ['uses' => $action] : [
                'uses' => $action[0].'@'.$action[1],
                'controller' => $action[0].'@'.$action[1],
            ];
        }
```

By passing `true` as the second argument to the `is_callable` function (reference to PHP built in `is_callable` function and its parameters can be found [here](https://php.net/manual/en/function.is-callable.php)), it performs a syntax only check on the `$var` that is passed as the first argument. 

This allows the $action variable that is sent through to the `parse` method to pass the above `if` statement, which then sets the `uses` and `controller` items in the Route's action array as intended by the original PR. 

Then when the route's uri is hit in the browser it returns the proper error message, like: "Method App\Http\Controllers\TestController::index does not exist." as opposed to the generic "Function () does not exist", that the original issue report mentioned. 

I ran PHPUnit and all of the tests were passing, except the ones that were skipped, see below from my console:
```
OK, but incomplete, skipped, or risky tests!
Tests: 4085, Assertions: 9471, Skipped: 87.
```

 **P.S.** This is my first PR to the Laravel Framework, apologies if there are any issues. 