### PR TITLE
[5.9] Add the `resource` method to the Gate contract

### DIFF
--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -126,7 +126,7 @@ interface Gate
      * @return array
      */
     public function abilities();
-    
+
     /**
      * Define abilities for a resource.
      *

--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -126,4 +126,14 @@ interface Gate
      * @return array
      */
     public function abilities();
+    
+    /**
+     * Define abilities for a resource.
+     *
+     * @param  string  $name
+     * @param  string  $class
+     * @param  array|null   $abilities
+     * @return $this
+     */
+    public function resource($name, $class, array $abilities = null);
 }

--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -22,6 +22,16 @@ interface Gate
     public function define($ability, $callback);
 
     /**
+     * Define abilities for a resource.
+     *
+     * @param  string  $name
+     * @param  string  $class
+     * @param  array|null   $abilities
+     * @return $this
+     */
+    public function resource($name, $class, array $abilities = null);
+
+    /**
      * Define a policy class for a given class type.
      *
      * @param  string  $class
@@ -126,14 +136,4 @@ interface Gate
      * @return array
      */
     public function abilities();
-
-    /**
-     * Define abilities for a resource.
-     *
-     * @param  string  $name
-     * @param  string  $class
-     * @param  array|null   $abilities
-     * @return $this
-     */
-    public function resource($name, $class, array $abilities = null);
 }


### PR DESCRIPTION
this would need to be notes in the 5.9 upgrade guide (probably as a low priority).