### PR TITLE
[5.8] Improve ForeignKeyDefinition meta class

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -5,10 +5,12 @@ namespace Illuminate\Database\Schema;
 use Illuminate\Support\Fluent;
 
 /**
- * @method ForeignKeyDefinition references(string $table) Specify the referenced table
- * @method ForeignKeyDefinition on(string $column) Specify the referenced column
+ * @method ForeignKeyDefinition references(string|array $columns) Specify the referenced column(s)
+ * @method ForeignKeyDefinition on(string $table) Specify the referenced table
  * @method ForeignKeyDefinition onDelete(string $action) Add an ON DELETE action
  * @method ForeignKeyDefinition onUpdate(string $action) Add an ON UPDATE action
+ * @method ForeignKeyDefinition deferrable(bool $value = true) Set the foreign key as deferrable (PostgreSQL)
+ * @method ForeignKeyDefinition initiallyImmediate(bool $value = true) Set the default time to check the constraint (PostgreSQL)
  */
 class ForeignKeyDefinition extends Fluent
 {


### PR DESCRIPTION
Fixes `references()` and `on()` and adds PostgreSQL-specific modifiers.