### PR TITLE
[5.8] Fix fromSub() and joinSub() with table prefix

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -273,7 +273,7 @@ class Builder
     {
         [$query, $bindings] = $this->createSub($query);
 
-        return $this->fromRaw('('.$query.') as '.$this->grammar->wrap($as), $bindings);
+        return $this->fromRaw('('.$query.') as '.$this->grammar->wrapTable($as), $bindings);
     }
 
     /**
@@ -442,7 +442,7 @@ class Builder
     {
         [$query, $bindings] = $this->createSub($query);
 
-        $expression = '('.$query.') as '.$this->grammar->wrap($as);
+        $expression = '('.$query.') as '.$this->grammar->wrapTable($as);
 
         $this->addBinding($bindings, 'join');
 


### PR DESCRIPTION
The subquery alias in `fromSub()` and `joinSub()` has to include the table prefix:

```php
'sqlite' => [
    'driver' => 'sqlite',
    'database' => ':memory:',
    'prefix' => 'prefix_',
],

DB::table('users')->joinSub(DB::table('posts'), 'alias', 'alias.user_id', 'users.id')->get();

// expected
select * from "prefix_users"
inner join (select * from "prefix_posts") as "prefix_alias"
on "prefix_alias"."user_id" = "prefix_users"."id"

// actual
select * from "prefix_users"
inner join (select * from "prefix_posts") as "alias"
on "prefix_alias"."user_id" = "prefix_users"."id"
```

Fixes #28391.
