### PR TITLE
[5.8] Improving the performance of a command running inside the Scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/CommandBuilder.php
+++ b/src/Illuminate/Console/Scheduling/CommandBuilder.php
@@ -49,7 +49,11 @@ class CommandBuilder
 
         $redirect = $event->shouldAppendOutput ? ' >> ' : ' > ';
 
-        $finished = Application::formatCommandString('schedule:finish').' "'.$event->mutexName().'"';
+        $finished = '';
+
+        if ($event->hasAfterCallbacks()) {
+            $finished = Application::formatCommandString('schedule:finish').' "'.$event->mutexName().'"';
+        }
 
         return $this->ensureCorrectUser($event,
             '('.$event->command.$redirect.$output.' 2>&1 '.(windows_os() ? '&' : ';').' '.$finished.') > '

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -810,4 +810,14 @@ class Event
 
         return $this;
     }
+    
+    /**
+     * Determine if there is any callback to run after
+     *
+     * @return bool
+     */
+    public function hasAfterCallbacks()
+    {
+      return !empty($this->afterCallbacks);
+    }
 }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -818,6 +818,6 @@ class Event
      */
     public function hasAfterCallbacks()
     {
-      return !empty($this->afterCallbacks);
+        return !empty($this->afterCallbacks);
     }
 }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -812,12 +812,12 @@ class Event
     }
     
     /**
-     * Determine if there is any callback to run after
+     * Determine if there's any callback to run after.
      *
      * @return bool
      */
     public function hasAfterCallbacks()
     {
-        return !empty($this->afterCallbacks);
+        return ! empty($this->afterCallbacks);
     }
 }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -810,7 +810,7 @@ class Event
 
         return $this;
     }
-    
+
     /**
      * Determine if there's any callback to run after.
      *

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -25,7 +25,8 @@ class EventTest extends TestCase
         $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1", $event->buildCommand());
 
         $event = new Event(m::mock(EventMutex::class), 'php -i');
-        $event->after(function(){});
+        $event->after(function () {
+        });
         $event->runInBackground();
 
         $commandSeparator = ($isWindows ? '&' : ';');

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -25,6 +25,7 @@ class EventTest extends TestCase
         $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1", $event->buildCommand());
 
         $event = new Event(m::mock(EventMutex::class), 'php -i');
+        $event->after(function(){});
         $event->runInBackground();
 
         $commandSeparator = ($isWindows ? '&' : ';');


### PR DESCRIPTION
I think we don't need to run the command schedule:finish when we don't have any after callback function in the event. the performance will be better. we will spend less CPU and the load will be lower.