### PR TITLE
[5.8] Remove return type

### DIFF
--- a/src/Illuminate/Database/ConfigurationUrlParser.php
+++ b/src/Illuminate/Database/ConfigurationUrlParser.php
@@ -126,7 +126,7 @@ class ConfigurationUrlParser
      * @param  string  $url
      * @return array
      */
-    protected function parseUrl($url): array
+    protected function parseUrl($url)
     {
         $url = preg_replace('#^(sqlite3?):///#', '$1://null/', $url);
 


### PR DESCRIPTION
Since return types aren't used anywhere, we should be consistent.