### PR TITLE
[5.9] Return uuids as string

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -97,7 +97,7 @@ class NotificationSender
             }
 
             $this->withLocale($this->preferredLocale($notifiable, $notification), function () use ($viaChannels, $notifiable, $original) {
-                $notificationId = Str::uuid()->toString();
+                $notificationId = Str::uuid();
 
                 foreach ((array) $viaChannels as $channel) {
                     $this->sendToNotifiable($notifiable, $notificationId, clone $original, $channel);
@@ -177,7 +177,7 @@ class NotificationSender
         $original = clone $notification;
 
         foreach ($notifiables as $notifiable) {
-            $notificationId = Str::uuid()->toString();
+            $notificationId = Str::uuid();
 
             foreach ((array) $original->via($notifiable) as $channel) {
                 $notification = clone $original;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -544,17 +544,17 @@ class Str
     /**
      * Generate a UUID (version 4).
      *
-     * @return \Ramsey\Uuid\UuidInterface
+     * @return string
      */
     public static function uuid()
     {
-        return Uuid::uuid4();
+        return Uuid::uuid4()->toString();
     }
 
     /**
      * Generate a time-ordered UUID (version 4).
      *
-     * @return \Ramsey\Uuid\UuidInterface
+     * @return string
      */
     public static function orderedUuid()
     {
@@ -569,7 +569,7 @@ class Str
             $factory->getUuidBuilder()
         ));
 
-        return $factory->uuid4();
+        return $factory->uuid4()->toString();
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -203,7 +203,7 @@ class NotificationFake implements NotificationFactory, NotificationDispatcher
 
         foreach ($notifiables as $notifiable) {
             if (! $notification->id) {
-                $notification->id = Str::uuid()->toString();
+                $notification->id = Str::uuid();
             }
 
             $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)][] = [

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -342,8 +342,8 @@ class SupportStrTest extends TestCase
 
     public function testUuid()
     {
-        $this->assertIsString($uuid = Str::uuid());
-        $this->assertIsString($orderedUuid = Str::orderedUuid());
+        $this->assertIsString(Str::uuid());
+        $this->assertIsString(Str::orderedUuid());
     }
 }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -342,8 +342,8 @@ class SupportStrTest extends TestCase
 
     public function testUuid()
     {
-        $this->assertInstanceOf(UuidInterface::class, Str::uuid());
-        $this->assertInstanceOf(UuidInterface::class, Str::orderedUuid());
+        $this->assertIsString($uuid = Str::uuid());
+        $this->assertIsString($orderedUuid = Str::orderedUuid());
     }
 }
 


### PR DESCRIPTION
This PR makes `Str::uuid()` and `Str::orderedUuid()` return a string instead of an instance of `Ramsey\Uuid\Uuid`.

I ran into the issue that that when `Str::uuid()` is used in a factory, using that value in a test will fail the `uuid` validation rule:

![image](https://user-images.githubusercontent.com/7202674/57177990-58634400-6e6a-11e9-9b83-a2ddc8dc5d80.png)

The test above fails with the message `The user id must be a valid UUID.`, because the uuid attribute on the model is an object, not a string.

I couldn't think of a reason why you would want the object instead of the string when using `Str::uuid()`. All usages in the framework also instantly convert the object to a string. If you do actually need the uuid object, you can always directly call `\Ramsey\Uuid\Uuid::uuid4();`

This PR targets master because it is a breaking change. This PR will cause code that calls `Str::uuid()->toString()` or `Str::orderedUuid()->toString()` to fail.
