### PR TITLE
Use grouped usage statements for Illuminate/View/ namespace

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -2,9 +2,8 @@
 
 namespace Illuminate\View\Compilers;
 
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Illuminate\Support\{ Arr, Str };
 
 class BladeCompiler extends Compiler implements CompilerInterface
 {

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -2,9 +2,8 @@
 
 namespace Illuminate\View;
 
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Illuminate\Support\{ Arr, Str };
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -6,14 +6,10 @@ use Exception;
 use Throwable;
 use ArrayAccess;
 use BadMethodCallException;
-use Illuminate\Support\Str;
-use Illuminate\Support\MessageBag;
-use Illuminate\Contracts\View\Engine;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Renderable;
-use Illuminate\Contracts\Support\MessageProvider;
-use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Support\{ Str, MessageBag };
+use Illuminate\Contracts\View\{ Engine, View as ViewContract };
+use Illuminate\Contracts\Support\{ Arrayable, Renderable, MessageProvider };
 
 class View implements ArrayAccess, ViewContract
 {

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -2,12 +2,9 @@
 
 namespace Illuminate\View;
 
-use Illuminate\View\Engines\PhpEngine;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\View\Engines\FileEngine;
-use Illuminate\View\Engines\CompilerEngine;
-use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Compilers\BladeCompiler;
+use Illuminate\View\Engines\{ PhpEngine, FileEngine, CompilerEngine, EngineResolver};
 
 class ViewServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
The purpose of this PR is to start using grouped usage statements throughout the framework.

At the moment, this PR only covers the name space **Illuminate\View**

### Example in the Illuminate\Queue\QueueServiceProvider.php file

#### From
```
use Illuminate\Support\Str;
use Opis\Closure\SerializableClosure;
use Illuminate\Support\ServiceProvider;
use Illuminate\Queue\Connectors\SqsConnector;
use Illuminate\Queue\Connectors\NullConnector;
use Illuminate\Queue\Connectors\SyncConnector;
use Illuminate\Queue\Connectors\RedisConnector;
use Illuminate\Contracts\Debug\ExceptionHandler;
use Illuminate\Queue\Connectors\DatabaseConnector;
use Illuminate\Queue\Failed\NullFailedJobProvider;
use Illuminate\Contracts\Support\DeferrableProvider;
use Illuminate\Queue\Connectors\BeanstalkdConnector;
use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
```
#### To
```
use Opis\Closure\SerializableClosure;
use Illuminate\Support\{ Str, ServiceProvider };
use Illuminate\Contracts\Debug\ExceptionHandler;
use Illuminate\Contracts\Support\DeferrableProvider;
use Illuminate\Queue\Failed\{ NullFailedJobProvider, DatabaseFailedJobProvider };
use Illuminate\Queue\Connectors\{ SqsConnector, NullConnector, SyncConnector, RedisConnector, DatabaseConnector, BeanstalkdConnector };
```
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
