### PR TITLE
Support deleting events when soft delete

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -82,7 +82,9 @@ trait SoftDeletes
 
         $time = $this->freshTimestamp();
 
-        $columns = [$this->getDeletedAtColumn() => $this->fromDateTime($time)];
+        $columns = $this->getDirty();
+
+        $columns[$this->getDeletedAtColumn()] = $this->fromDateTime($time);
 
         $this->{$this->getDeletedAtColumn()} = $time;
 

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -130,7 +130,7 @@ class DatabaseSoftDeletingTraitStub
 
         return $dirty;
     }
-    
+
     public function getAttributes()
     {
         return $this->attributes;

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -59,6 +59,7 @@ class DatabaseSoftDeletingTraitStub
     public $deleted_at;
     public $updated_at;
     public $timestamps = true;
+    protected $attributes = [];
 
     public function newQuery()
     {
@@ -115,5 +116,21 @@ class DatabaseSoftDeletingTraitStub
     protected function getKeyForSaveQuery()
     {
         return 1;
+    }
+
+    public function getDirty() {
+        $dirty = [];
+
+        foreach ($this->getAttributes() as $key => $value) {
+            if (! $this->originalIsEquivalent($key, $value)) {
+                $dirty[$key] = $value;
+            }
+        }
+
+        return $dirty;
+    }
+    public function getAttributes()
+    {
+        return $this->attributes;
     }
 }

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -118,7 +118,8 @@ class DatabaseSoftDeletingTraitStub
         return 1;
     }
 
-    public function getDirty() {
+    public function getDirty()
+    {
         $dirty = [];
 
         foreach ($this->getAttributes() as $key => $value) {
@@ -129,6 +130,7 @@ class DatabaseSoftDeletingTraitStub
 
         return $dirty;
     }
+    
     public function getAttributes()
     {
         return $this->attributes;


### PR DESCRIPTION
If you want to update other fields when you delete records softly, you need to implement them in the “deleted” event, so you need to do one more database operation(run save method), or customize a softDeletesTrait.

example：
I want to record the operator id in the deleted_by field when deleting data.

I just need to modify the Model and no extra database operations:
```php
    public static function boot()
    {
        parent::boot();
        static::deleting(function ($model) {
                $model->deleted_by = Auth::id();
        });
    }
```