### PR TITLE
[5.8] Fix many to many sync results with custom pivot model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -237,20 +237,6 @@ trait InteractsWithPivotTable
     }
 
     /**
-     * Get the existing records.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    protected function getCurrent()
-    {
-        return $this->current ?: $this->newPivotQuery()->get()->map(function($record){
-            $class = $this->using ? $this->using : Pivot::class;
-
-            return (new $class)->setRawAttributes((array) $record, true);
-        });
-    }
-
-    /**
      * Attach a model to the parent.
      *
      * @param  mixed  $id
@@ -658,5 +644,19 @@ trait InteractsWithPivotTable
             default:
                 return $value;
         }
+    }
+
+    /**
+     * Get the existing records.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getCurrent()
+    {
+        return $this->current ?: $this->newPivotQuery()->get()->map(function ($record) {
+            $class = $this->using ? $this->using : Pivot::class;
+
+            return (new $class)->setRawAttributes((array) $record, true);
+        });
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -213,7 +213,12 @@ trait InteractsWithPivotTable
      */
     protected function updateExistingPivotUsingCustomClass($id, array $attributes, $touch)
     {
-        $updated = $this->newPivot([
+        $updated = (new $this->using)->setTable($this->table)->where([
+            $this->foreignPivotKey => $this->parent->{$this->parentKey},
+            $this->relatedPivotKey => $this->parseId($id),
+        ])->first()->fill($attributes)->isDirty();
+
+        $this->newPivot([
             $this->foreignPivotKey => $this->parent->{$this->parentKey},
             $this->relatedPivotKey => $this->parseId($id),
         ], true)->fill($attributes)->save();

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -217,12 +217,12 @@ trait InteractsWithPivotTable
      */
     protected function updateExistingPivotUsingCustomClass($id, array $attributes, $touch)
     {
-        $current = $this->getCurrent()
-            ->where($this->foreignPivotKey, $this->parent->{$this->parentKey})
-            ->where($this->relatedPivotKey, $this->parseId($id))
-            ->first();
-
-        $updated = $current->fill($attributes)->isDirty();
+        $updated = $this->getCurrent()
+                    ->where($this->foreignPivotKey, $this->parent->{$this->parentKey})
+                    ->where($this->relatedPivotKey, $this->parseId($id))
+                    ->first()
+                    ->fill($attributes)
+                    ->isDirty();
 
         $this->newPivot([
             $this->foreignPivotKey => $this->parent->{$this->parentKey},

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -94,9 +94,9 @@ trait InteractsWithPivotTable
         // First we need to attach any of the associated models that are not currently
         // in this joining table. We'll spin through the given IDs, checking to see
         // if they exist in the array of current ones, and if not we will insert.
-        $currentKeys = $this->getCurrent()->pluck($this->relatedPivotKey)->all();
+        $current = $this->getCurrent()->pluck($this->relatedPivotKey)->all();
 
-        $detach = array_diff($currentKeys, array_keys(
+        $detach = array_diff($current, array_keys(
             $records = $this->formatRecordsList($this->parseIds($ids))
         ));
 
@@ -113,7 +113,7 @@ trait InteractsWithPivotTable
         // touching until after the entire operation is complete so we don't fire a
         // ton of touch operations until we are totally done syncing the records.
         $changes = array_merge(
-            $changes, $this->attachNew($records, $currentKeys, false)
+            $changes, $this->attachNew($records, $current, false)
         );
 
         // Once we have finished attaching or detaching the records, we will see if we

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -163,13 +163,13 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $tag = TagWithCustomPivot::create(['name' => Str::random()]);
 
         $results = $post->tagsWithCustomPivot()->sync([
-            $tag->id => ['flag' => 1]
+            $tag->id => ['flag' => 1],
         ]);
 
         $this->assertNotEmpty($results['attached']);
 
         $results = $post->tagsWithCustomPivot()->sync([
-            $tag->id => ['flag' => 1]
+            $tag->id => ['flag' => 1],
         ]);
 
         $this->assertEmpty($results['updated']);

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -154,6 +154,31 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals(2, PostTagPivot::first()->tag_id);
     }
 
+    public function test_custom_pivot_class_using_sync()
+    {
+        Carbon::setTestNow('2017-10-10 10:10:10');
+
+        $post = Post::create(['title' => Str::random()]);
+
+        $tag = TagWithCustomPivot::create(['name' => Str::random()]);
+
+        $results = $post->tagsWithCustomPivot()->sync([
+            $tag->id => ['flag' => 1]
+        ]);
+
+        $this->assertNotEmpty($results['attached']);
+
+        $results = $post->tagsWithCustomPivot()->sync([
+            $tag->id => ['flag' => 1]
+        ]);
+
+        $this->assertEmpty($results['updated']);
+
+        $results = $post->tagsWithCustomPivot()->sync([]);
+
+        $this->assertNotEmpty($results['detached']);
+    }
+
     public function test_attach_method()
     {
         $post = Post::create(['title' => Str::random()]);


### PR DESCRIPTION
This PR fixes an issue (https://github.com/laravel/framework/issues/28150) where the results of `sync()` while updating "Custom Pivot Model" attributes always show the record as updated even if it's not.

The reason was that we weren't loading the actual pivot model from the database and thus we didn't have any way to compare the newly provided data with the existing one.

My solution here is that we load the model from the database first, and use `isDirty()` to check if the attributes were update or not.

