### PR TITLE
[5.8] Change navbar-laravel class for bootstrap classes

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -21,7 +21,7 @@
 </head>
 <body>
     <div id="app">
-        <nav class="navbar navbar-expand-md navbar-light navbar-laravel">
+        <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
             <div class="container">
                 <a class="navbar-brand" href="{{ url('/') }}">
                     {{ config('app.name', 'Laravel') }}


### PR DESCRIPTION
Bootstrap >=4.1 includes a `shadow-sm` class which looks pretty close to the one in the `navbar-laravel` class https://getbootstrap.com/docs/4.3/utilities/shadows/

You could then remove the `.navbar-laravel` class here:
https://github.com/laravel/laravel/blob/master/resources/sass/app.scss#L10-L13

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
