### PR TITLE
Create route through an iterator

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -113,7 +113,7 @@ class RouteRegistrar
     /**
      * Create a route group with shared attributes.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|iterable  $callback
      * @return void
      */
     public function group($callback)

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use Iterator;
 use Closure;
 use ArrayObject;
 use JsonSerializable;
@@ -360,7 +361,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * Create a route group with shared attributes.
      *
      * @param  array  $attributes
-     * @param  \Closure|string  $routes
+     * @param  \Closure|string|iterable  $routes
      * @return void
      */
     public function group(array $attributes, $routes)
@@ -370,8 +371,26 @@ class Router implements RegistrarContract, BindingRegistrar
         // Once we have updated the group stack, we'll load the provided routes and
         // merge in the group's attributes when the routes are created. After we
         // have created the routes, we will pop the attributes off the stack.
-        $this->loadRoutes($routes);
 
+        if($routes instanceof Iterator){
+            $this->groupIterable($routes);
+            return ;
+        }
+
+        $this->loadRoutes($routes);
+        array_pop($this->groupStack);
+    }
+
+    /**
+     * Create a route group from an iterator with shared attributes.
+     *
+     * @param Iterator $routes
+     * @return void
+     */
+    public function groupIterable(\Iterator $routes){
+        foreach($routes as $route) {
+            $this->loadRoutes($route);
+        }
         array_pop($this->groupStack);
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use Iterator
 use Closure;
 use ArrayObject;
 use JsonSerializable;
@@ -360,7 +361,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * Create a route group with shared attributes.
      *
      * @param  array  $attributes
-     * @param  \Closure|string  $routes
+     * @param  \Closure|string|iterable  $routes
      * @return void
      */
     public function group(array $attributes, $routes)
@@ -370,8 +371,26 @@ class Router implements RegistrarContract, BindingRegistrar
         // Once we have updated the group stack, we'll load the provided routes and
         // merge in the group's attributes when the routes are created. After we
         // have created the routes, we will pop the attributes off the stack.
-        $this->loadRoutes($routes);
 
+        if($routes instanceof Iterator){
+            $this->groupIterable($routes);
+            return ;
+        }
+
+        $this->loadRoutes($routes);
+        array_pop($this->groupStack);
+    }
+
+    /**
+     * Create a route group from an iterator with shared attributes.
+     *
+     * @param Iterator $routes
+     * @return void
+     */
+    public function groupIterable(\Iterator $routes){
+        foreach($routes as $route) {
+            $this->loadRoutes($route);
+        }
         array_pop($this->groupStack);
     }
 


### PR DESCRIPTION
Create a route group from an iterator.

So we can separate our routes into more files avoiding that they get too big:

./routes
├── api.php
├── api.posts.php
├── api.users.php
├── channels.php
├── web.php
├── web.posts.php
└── web.users.php

```
    protected function mapWebRoutes()
    {
        $directory = new \RecursiveDirectoryIterator(base_path('routes/'));
        $files = new \RegexIterator($directory, '/web(.*).php$/');

        Route::middleware('web')
            ->namespace($this->namespace)
            ->group($files);
    }
```

All the tests in the framework are passing and did not have any major modifications. 

