### PR TITLE
Add phpdoc disconnect method to db Facades

### DIFF
--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -23,6 +23,7 @@ namespace Illuminate\Support\Facades;
  * @method static void rollBack()
  * @method static int transactionLevel()
  * @method static array pretend(\Closure $callback)
+ * @method static void disconnect(string $string)
  *
  * @see \Illuminate\Database\DatabaseManager
  * @see \Illuminate\Database\Connection


### PR DESCRIPTION
Add phpdoc disconnect method to DB Facades to 'Disconnect from the given database'

I couldn't really figure out how to make a test for this. At least I know that it returns void and that it needs a string as the first parameter.

Illuminate\Database\DatabaseManager
```
    /**
     * Disconnect from the given database.
     *
     * @param  string  $name
     * @return void
     */
    public function disconnect($name = null)
    {
        if (isset($this->connections[$name = $name ?: $this->getDefaultConnection()])) {
            $this->connections[$name]->disconnect();
        }
    }
```

