### PR TITLE
Extending sql insertion to ignore duplicates

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -411,6 +411,12 @@ class Connection implements ConnectionInterface
         return $this->statement($query, $bindings);
     }
 
+    
+    public function upsert($query, $bindings = [])
+    {
+        return $this->statement($query, $bindings);
+    }
+
     /**
      * Run an update statement against the database.
      *

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -411,8 +411,17 @@ class Connection implements ConnectionInterface
         return $this->statement($query, $bindings);
     }
 
-    
-    public function upsert($query, $bindings = [])
+    /**
+     * Run an insert statement against the database, ignoring erronous rows.
+     * The rows with invalid data that cause the error are 
+     * ignored and the rows with valid data are inserted 
+     * into the table.
+     * 
+     * @param  string  $query
+     * @param  array   $bindings
+     * @return bool
+     */
+    public function insertOrIgnore($query, $bindings = [])
     {
         return $this->statement($query, $bindings);
     }

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -62,6 +62,16 @@ interface ConnectionInterface
     public function insert($query, $bindings = []);
 
     /**
+     * Run an insert statement against the database that updates rows if they exist,
+     * or inserts them if not.
+     *
+     * @param  string  $query
+     * @param  array   $bindings
+     * @return bool
+     */
+    public function upsert($query, $bindings = []);
+
+    /**
      * Run an update statement against the database.
      *
      * @param  string  $query

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -62,14 +62,13 @@ interface ConnectionInterface
     public function insert($query, $bindings = []);
 
     /**
-     * Run an insert statement against the database that updates rows if they exist,
-     * or inserts them if not.
+     * Run an insert statement against the database that ignores errors.
      *
      * @param  string  $query
      * @param  array   $bindings
      * @return bool
      */
-    public function upsert($query, $bindings = []);
+    public function insertOrIgnore($query, $bindings = []);
 
     /**
      * Run an update statement against the database.

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -71,7 +71,7 @@ class Builder
      * @var array
      */
     protected $passthru = [
-        'insert', 'insertGetId', 'getBindings', 'toSql',
+        'insert', 'insertOrIgnore', 'insertGetId', 'getBindings', 'toSql',
         'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection',
     ];
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2552,6 +2552,39 @@ class Builder
         );
     }
 
+    public function upsert(array $values)
+    {
+        // Since every insert gets treated like a batch insert, we will make sure the
+        // bindings are structured in a way that is convenient when building these
+        // inserts statements by verifying these elements are actually an array.
+        if (empty($values)) {
+            return true;
+        }
+
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        }
+
+        // Here, we will sort the insert keys for every record so that each insert is
+        // in the same order for the record. We need to make sure this is the case
+        // so there are not any errors or problems when inserting these records.
+        else {
+            foreach ($values as $key => $value) {
+                ksort($value);
+
+                $values[$key] = $value;
+            }
+        }
+
+        // Finally, we will run this query against the database connection and return
+        // the results. We will need to also flatten these bindings before running
+        // the query so they are all in one huge, flattened array for execution.
+        return $this->connection->upsert(
+            $this->grammar->compileUpsert($this, $values),
+            $this->cleanBindings(Arr::flatten($values, 1))
+        );
+    }
+
     /**
      * Insert a new record and get the value of the primary key.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2552,7 +2552,13 @@ class Builder
         );
     }
 
-    public function upsert(array $values)
+    /**
+     * Insert a new record into the database.
+     *
+     * @param  array  $values
+     * @return bool
+     */
+    public function insertOrIgnore(array $values)
     {
         // Since every insert gets treated like a batch insert, we will make sure the
         // bindings are structured in a way that is convenient when building these
@@ -2579,8 +2585,8 @@ class Builder
         // Finally, we will run this query against the database connection and return
         // the results. We will need to also flatten these bindings before running
         // the query so they are all in one huge, flattened array for execution.
-        return $this->connection->upsert(
-            $this->grammar->compileUpsert($this, $values),
+        return $this->connection->insertOrIgnore(
+            $this->grammar->compileInsertOrIgnore($this, $values),
             $this->cleanBindings(Arr::flatten($values, 1))
         );
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -849,6 +849,17 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * 
+     */
+    public function compileUpsert(Builder $query, array $values)
+    {
+        $insert = $this->compileInsert($query, $values);
+
+        $insert = str_replace('insert', 'insert ignore', $insert);
+        return $insert;
+    }
+
+    /**
      * Compile an insert and get ID statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -849,9 +849,10 @@ class Grammar extends BaseGrammar
     }
 
     /**
-     * 
+     * Compile an insert statement, that ignore errors and silently skips erronous rows, 
+     * into SQL.
      */
-    public function compileUpsert(Builder $query, array $values)
+    public function compileInsertOrIgnore(Builder $query, array $values)
     {
         $insert = $this->compileInsert($query, $values);
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -849,6 +849,32 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * 
+     */
+    public function compileUpsert(Builder $query, array $values)
+    {
+        // Essentially we will force every insert to be treated as a batch insert which
+        // simply makes creating the SQL easier for us since we can utilize the same
+        // basic routine regardless of an amount of records given to us to insert.
+        $table = $this->wrapTable($query->from);
+
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        }
+
+        $columns = $this->columnize(array_keys(reset($values)));
+
+        // We need to build a list of parameter place-holders of values that are bound
+        // to the query. Each insert should have the exact same amount of parameter
+        // bindings so we will loop through the record and parameterize them all.
+        $parameters = collect($values)->map(function ($record) {
+            return '('.$this->parameterize($record).')';
+        })->implode(', ');
+
+        return "insert ignore into $table ($columns) values $parameters";
+    }
+
+    /**
      * Compile an insert and get ID statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -853,25 +853,10 @@ class Grammar extends BaseGrammar
      */
     public function compileUpsert(Builder $query, array $values)
     {
-        // Essentially we will force every insert to be treated as a batch insert which
-        // simply makes creating the SQL easier for us since we can utilize the same
-        // basic routine regardless of an amount of records given to us to insert.
-        $table = $this->wrapTable($query->from);
+        $insert = $this->compileInsert($query, $values);
 
-        if (! is_array(reset($values))) {
-            $values = [$values];
-        }
-
-        $columns = $this->columnize(array_keys(reset($values)));
-
-        // We need to build a list of parameter place-holders of values that are bound
-        // to the query. Each insert should have the exact same amount of parameter
-        // bindings so we will loop through the record and parameterize them all.
-        $parameters = collect($values)->map(function ($record) {
-            return '('.$this->parameterize($record).')';
-        })->implode(', ');
-
-        return "insert ignore into $table ($columns) values $parameters";
+        $insert = str_replace('insert', 'insert ignore', $insert);
+        return $insert;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -109,6 +109,14 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * @todo Remove here if deemed OK to have in the base Grammar class
+     */
+    public function compileUpsert(Builder $query, array $values)
+    {
+        return parent::compileUpsert($query, $values);
+    }
+
+    /**
      * Compile the lock into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -109,6 +109,14 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * @todo Remove here if deemed OK to have in the base Grammar class
+     */
+    public function compileUpsert(Builder $query, array $values)
+    {
+        return parent::compileUpsert($query, $values);
+    }
+
+    /**
      * Compile the lock into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -203,6 +211,7 @@ class MySqlGrammar extends Grammar
 
         return "{$field} = json_set({$field}{$path}, {$value->getValue()})";
     }
+    
 
     /**
      * Prepare the bindings for an update statement.

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -111,9 +111,9 @@ class MySqlGrammar extends Grammar
     /**
      * @todo Remove here if deemed OK to have in the base Grammar class
      */
-    public function compileUpsert(Builder $query, array $values)
+    public function compileInsertOrIgnore(Builder $query, array $values)
     {
-        return parent::compileUpsert($query, $values);
+        return parent::compileInsertOrIgnore($query, $values);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -203,6 +203,7 @@ class MySqlGrammar extends Grammar
 
         return "{$field} = json_set({$field}{$path}, {$value->getValue()})";
     }
+    
 
     /**
      * Prepare the bindings for an update statement.

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -198,10 +198,9 @@ class PostgresGrammar extends Grammar
     /**
      * {@inheritdoc}
      */
-    public function compileUpsert(Builder $query, array $values)
+    public function compileInsertOrIgnore(Builder $query, array $values)
     {
         $insert = $this->compileInsert($query, $values);
-
         return $insert." on conflict do nothing";
     }
 

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -196,6 +196,16 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function compileUpsert(Builder $query, array $values)
+    {
+        $insert = $this->compileInsert($query, $values);
+
+        return $insert." on conflict do nothing";
+    }
+
+    /**
      * Compile an insert and get ID statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -179,6 +179,17 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * 
+     */
+    public function compileUpsert(Builder $query, array $values)
+    {
+        $insert = $this->compileInsert($query, $values);
+        $insert = str_replace('insert', 'insert or ignore', $insert);
+
+        return $insert;
+    }
+
+    /**
      * Compile an update statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -179,11 +179,13 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * 
+     * {@inheritdoc}
      */
-    public function compileUpsert(Builder $query, array $values)
+    public function compileInsertOrIgnore(Builder $query, array $values)
     {
+        // "upserts" are insert statements with additional "modifiers" to the insert.
         $insert = $this->compileInsert($query, $values);
+        // We don't need to do more work than adding 'or ignore' to the typical 'insert' statement.
         $insert = str_replace('insert', 'insert or ignore', $insert);
 
         return $insert;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -36,22 +36,17 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users"', $builder->toSql());
     }
 
-    public function testUpsertMethod()
+    public function testInsertOrIgnoreMethod()
     {
-        // -----------------------------------------------------------------
         $builder = $this->getBuilder();
         $builder->getConnection()
-            ->shouldReceive('upsert')
+            ->shouldReceive('insertOrIgnore')
             ->once()
             ->with('insert ignore into "users" ("email") values (?), (?)', ['foo', 'foo'])
             ->andReturn(true);
 
-        $result = $builder->from('users')->upsert([['email' => 'foo'], ['email' => 'foo']]);
+        $result = $builder->from('users')->insertOrIgnore([['email' => 'foo'], ['email' => 'foo']]);
         $this->assertTrue($result);
-    }
-
-    public function testUpsert()
-    {
     }
 
     public function testBasicSelectWithGetColumns()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -36,6 +36,24 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users"', $builder->toSql());
     }
 
+    public function testUpsertMethod()
+    {
+        // -----------------------------------------------------------------
+        $builder = $this->getBuilder();
+        $builder->getConnection()
+            ->shouldReceive('upsert')
+            ->once()
+            ->with('insert ignore into "users" ("email") values (?), (?)', ['foo', 'foo'])
+            ->andReturn(true);
+
+        $result = $builder->from('users')->upsert([['email' => 'foo'], ['email' => 'foo']]);
+        $this->assertTrue($result);
+    }
+
+    public function testUpsert()
+    {
+    }
+
     public function testBasicSelectWithGetColumns()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
**Description of proposal**
Added ignore modifier to inserts for the MySql, Postgresql and Sqlite drivers to accomodate batch-insertion without throwing errors on i.e: duplicate entries on unique columns.
It's not exhaustive, nor by definition an upsert (hence "insertOrIgnore"), as this only makes it possible to insert over duplicates without exceptions being thrown.

Tested against current Homestead setup (MySql, sqlite, postgresql).

**Use cases**
could import large CSV files that often conflict with existing entries that has unique columns, without it throwing an exception for duplicate entry. Editing the input data for thousands of rows and checking up against existing data makes for a lot of requests.

**Further Improvements**
I'd like to also be able to "insertOrUpdate", so that entries with a conflict on a certain column, could be updated with new data from the new insert (i.e: products in a table with unique code, but updated prices, for instance).

If anyone have tips for improvements, more exhaustive implementation etc, It's very welcome.

