### PR TITLE
[5.8] Replace only last occurrence to find class name from path on event discovery

### DIFF
--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -65,7 +65,7 @@ class DiscoverEvents
      */
     protected static function classFromFile(SplFileInfo $file, $basePath)
     {
-        $class = trim(str_replace($basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
+        $class = trim(Str::replaceLast($basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
 
         return str_replace(
             [DIRECTORY_SEPARATOR, 'App\\'],

--- a/tests/Foundation/DiscoverEventsTest.php
+++ b/tests/Foundation/DiscoverEventsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use Illuminate\Foundation\Events\DiscoverEvents;
+use Mockery;
+use Orchestra\Testbench\TestCase;
+use ReflectionClass;
+use Symfony\Component\Finder\SplFileInfo;
+
+class DiscoverEventsTest extends TestCase
+{
+    public function testDiscoverEventsClassFromFileWhenProjectDirectoryIsAppOnly(): void
+    {
+        $classFromFileMethod = (new ReflectionClass(DiscoverEvents::class))->getMethod('classFromFile');
+        $classFromFileMethod->setAccessible(true);
+
+        $splFileInfoMock = Mockery::mock(SplFileInfo::class);
+        $splFileInfoMock->shouldReceive('getRealPath')
+            ->once()
+            ->withNoArgs()
+            ->andReturn('/app/app/Listeners/FooListener');
+
+        $class = $classFromFileMethod->invoke(null, $splFileInfoMock, '/app');
+
+        $this->assertSame('App\\Listeners\\FooListener', $class);
+    }
+}

--- a/tests/Foundation/DiscoverEventsTest.php
+++ b/tests/Foundation/DiscoverEventsTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Foundation;
 
-use Illuminate\Foundation\Events\DiscoverEvents;
 use Mockery;
-use Orchestra\Testbench\TestCase;
 use ReflectionClass;
+use Orchestra\Testbench\TestCase;
 use Symfony\Component\Finder\SplFileInfo;
+use Illuminate\Foundation\Events\DiscoverEvents;
 
 class DiscoverEventsTest extends TestCase
 {


### PR DESCRIPTION
This PR fix the event discovery. When having a Laravel project within `/app` path (it is the case with Heroku PHP apps), Laravel will replace `/app` twice because the `str_replace` is used.

My fix is to use `Str::replaceLast` as it will only replace the last occurrence.
