### PR TITLE
[5.8] Request->expectsJson() handles multiple HTTP_ACCEPT items

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Concerns;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 trait InteractsWithContentTypes
@@ -53,7 +54,9 @@ trait InteractsWithContentTypes
     {
         $acceptable = $this->getAcceptableContentTypes();
 
-        return isset($acceptable[0]) && Str::contains($acceptable[0], ['/json', '+json']);
+        return Arr::first($acceptable, function ($value, $key) {
+			return Str::contains($value, ['/json', '+json']);
+		}, null);
     }
 
     /**
@@ -128,7 +131,7 @@ trait InteractsWithContentTypes
         $acceptable = $this->getAcceptableContentTypes();
 
         return count($acceptable) === 0 || (
-            isset($acceptable[0]) && ($acceptable[0] === '*/*' || $acceptable[0] === '*')
+            in_array('*/*', $acceptable) || in_array('*', $acceptable)
         );
     }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -54,9 +54,11 @@ trait InteractsWithContentTypes
     {
         $acceptable = $this->getAcceptableContentTypes();
 
-        return Arr::first($acceptable, function ($value, $key) {
-			return Str::contains($value, ['/json', '+json']);
-		}, null);
+        return !is_null(
+			Arr::first($acceptable, function ($value, $key) {
+				return Str::contains($value, ['/json', '+json']);
+			}, null)
+		);
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -732,6 +732,12 @@ class HttpRequestTest extends TestCase
 
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'text/html', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest', 'HTTP_X_PJAX' => 'true']);
         $this->assertFalse($request->expectsJson());
+
+		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'text/html, application/xhtml+xml, */*', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+		$this->assertTrue($request->expectsJson());
+
+		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'text/html, application/json, application/xhtml+xml']);
+		$this->assertTrue($request->expectsJson());
     }
 
     public function testFormatReturnsAcceptableFormat()


### PR DESCRIPTION
There can be several items in `HTTP_ACCEPT`, and `'*/*'` or `'application/json'` can be not in first item. 

For example `getAcceptableContentTypes()` can return `[
"text/html",
"application/xhtml+xml",
"application/xml",
"*/*"
]`, and beause of this `acceptsAnyContentType()` will return `false` instead of `true`.

