### PR TITLE
[5.8] Replace first occurrence instead of last for event discovery

### DIFF
--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -65,7 +65,7 @@ class DiscoverEvents
      */
     protected static function classFromFile(SplFileInfo $file, $basePath)
     {
-        $class = trim(Str::replaceLast($basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
+        $class = trim(Str::replaceFirst($basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
 
         return str_replace(
             [DIRECTORY_SEPARATOR, 'App\\'],


### PR DESCRIPTION
This PR fix the previous PR about event discovery : #28421.

The goal is to replace only the first occurrence instead of the last one because this is not the correct behavior.
Here is an example where the previous PR will create a bug :
`/app` is the project directory.
`/app/app/Listeners/app/FooListener.php` is the listener file path.
In this example, the resolved class path was `/app/app/Listeners/FooListener.php` with the previous PR. This is incorrect as a namespace part is missing.

With this PR, the class is correctly resolved as `/app/Listeners/app/FooListener.php`.