### PR TITLE
[5.8] Pass email verification URL to callback

### DIFF
--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -37,17 +37,16 @@ class VerifyEmail extends Notification
      */
     public function toMail($notifiable)
     {
+        $verificationUrl = $this->verificationUrl($notifiable);
+
         if (static::$toMailCallback) {
-            return call_user_func(static::$toMailCallback, $notifiable);
+            return call_user_func(static::$toMailCallback, $notifiable, $verificationUrl);
         }
 
         return (new MailMessage)
             ->subject(Lang::getFromJson('Verify Email Address'))
             ->line(Lang::getFromJson('Please click the button below to verify your email address.'))
-            ->action(
-                Lang::getFromJson('Verify Email Address'),
-                $this->verificationUrl($notifiable)
-            )
+            ->action(Lang::getFromJson('Verify Email Address'), $verificationUrl)
             ->line(Lang::getFromJson('If you did not create an account, no further action is required.'));
     }
 


### PR DESCRIPTION
Just like the `ResetPassword` notification does: https://github.com/laravel/framework/blob/82d99106ffca125e5903cbef304f32c7a90ae9bc/src/Illuminate/Auth/Notifications/ResetPassword.php#L55-L57

Not having to generate the verification URL keeps the callback simpler.