### PR TITLE
[5.8] Don't execute query when ids are empty Arrayable

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -338,7 +338,11 @@ class Builder
      */
     public function findMany($ids, $columns = ['*'])
     {
-        if (empty($ids)) {
+        $empty = $ids instanceOf Arrayable
+            ? empty($ids->toArray())
+            : empty($ids);
+
+        if ($empty) {
             return $this->model->newCollection();
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -338,7 +338,7 @@ class Builder
      */
     public function findMany($ids, $columns = ['*'])
     {
-        $empty = $ids instanceOf Arrayable
+        $empty = $ids instanceof Arrayable
             ? empty($ids->toArray())
             : empty($ids);
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -338,11 +338,9 @@ class Builder
      */
     public function findMany($ids, $columns = ['*'])
     {
-        $empty = $ids instanceof Arrayable
-            ? empty($ids->toArray())
-            : empty($ids);
+        $ids = $ids instanceof Arrayable ? $ids->toArray() : $ids;
 
-        if ($empty) {
+        if (empty($ids)) {
             return $this->model->newCollection();
         }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -39,6 +39,40 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('baz', $result);
     }
 
+    public function testFindManyMethod()
+    {
+        // ids are not empty
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($this->getMockModel());
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', ['one', 'two']);
+        $builder->shouldReceive('get')->with(['column'])->andReturn(['baz']);
+
+        $result = $builder->findMany(['one', 'two'], ['column']);
+        $this->assertEquals(['baz'], $result);
+
+        // ids are empty array
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $model = $this->getMockModel();
+        $model->shouldReceive('newCollection')->once()->withNoArgs()->andReturn('emptycollection');
+        $builder->setModel($model);
+        $builder->getQuery()->shouldNotReceive('whereIn');
+        $builder->shouldNotReceive('get');
+
+        $result = $builder->findMany([], ['column']);
+        $this->assertEquals('emptycollection', $result);
+
+        // ids are empty collection
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $model = $this->getMockModel();
+        $model->shouldReceive('newCollection')->once()->withNoArgs()->andReturn('emptycollection');
+        $builder->setModel($model);
+        $builder->getQuery()->shouldNotReceive('whereIn');
+        $builder->shouldNotReceive('get');
+
+        $result = $builder->findMany(collect(), ['column']);
+        $this->assertEquals('emptycollection', $result);
+    }
+
     public function testFindOrNewMethodModelFound()
     {
         $model = $this->getMockModel();

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -151,7 +151,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $ids = collect([1, 2]);
         $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
-        $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', $ids);
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', [1, 2]);
         $builder->setModel($this->getMockModel());
         $builder->shouldReceive('get')->with(['column'])->andReturn('baz');
 


### PR DESCRIPTION
Previous condition was met only if `$ids` were empty array. If they were empty instance of `Arrayable` (for example collection with no elements) condition was false and query was executed.