### PR TITLE
[5.8] Add except method to Eloquent Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -998,6 +998,19 @@ trait HasAttributes
     }
 
     /**
+     * Returns all of the model's attributes except those with the specified keys
+     *
+     * @param  array|mixed  $attributes
+     * @return array
+     */
+    public function except($attributes)
+    {
+        $attributes = is_array($attributes) ? $attributes : func_get_args();
+
+        return Arr::except($this->toArray(),$attributes);
+    }
+
+    /**
      * Sync the original attributes with the current.
      *
      * @return $this

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -165,6 +165,18 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->only(['first_name', 'last_name']));
     }
 
+    public function testExcept()
+    {
+        $model = new EloquentModelStub;
+        $model->first_name = 'taylor';
+        $model->last_name = 'otwell';
+        $model->project = 'laravel';
+
+        $this->assertEquals(['first_name' => 'taylor','last_name' => 'otwell'], $model->except('project'));
+        $this->assertEquals(['project' => 'laravel'], $model->except('first_name', 'last_name'));
+        $this->assertEquals(['project' => 'laravel'], $model->except(['first_name', 'last_name']));
+    }
+
     public function testNewInstanceReturnsNewInstanceWithAttributesSet()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
**Summary**
This PR adds the `except` method to **Model** to perform the inverse of the `only` method. It returns all the attributes of a model except those specified.

**Example**
```
$model = new User;
$model->first_name = 'john';
$model->last_name = 'doe';
$model->email = 'john@example.com';

$model->except(['email']);
// returns ['first_name' => 'john', 'last_name' => 'doe']

$model->except('first_name','last_name');
// returns ['email' => 'john@example.com']

$model->except(['first_name','last_name']);
// returns ['email' => 'john@example.com']
```

**Use Case**
Sometimes it's cleaner to list the attributes to exclude rather than those to include. For example, if you needed to remove private user data from a large data export. You would pass a few attributes to `exclude` rather than potentially dozens to `only`. 

I'm aware that **Model** already has a way to exclude attributes using the `$hidden` property, but that's not context-sensitive enough for all use cases. This gives the developer more dynamic control of what to exclude.

**Further Justification**
This is a minor addition that does not change any existing code. I've also added a passing test for it.