### PR TITLE
[5.8] Add parameter password for RedisCluster construct function

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -123,7 +123,8 @@ class PhpRedisConnector
             array_values($servers),
             $options['timeout'] ?? 0,
             $options['read_timeout'] ?? 0,
-            isset($options['persistent']) && $options['persistent']
+            isset($options['persistent']) && $options['persistent'],
+            $options['password'] ?? null
         );
     }
 }


### PR DESCRIPTION
https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#readme

// Connect with cluster using password.
$obj_cluster = new RedisCluster(NULL, Array("host:7000", "host:7001"), 1.5, 1.5, true, "password");


