### PR TITLE
[5.5] Use the prefix as the parameter value when the resource route is empty

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -327,6 +327,12 @@ class ResourceRegistrar
      */
     public function getResourceWildcard($value)
     {
+        // If a null value is passed,
+        // we get it from the previous route prefix
+        if (empty($value)) {
+            $value = trim($this->router->getLastGroupPrefix(), '/');
+        }
+
         if (isset($this->parameters[$value])) {
             $value = $this->parameters[$value];
         } elseif (isset(static::$parameterMap[$value])) {

--- a/tests/Routing/RoutePrefixTest.php
+++ b/tests/Routing/RoutePrefixTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Mockery as m;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class RoutePrefixTest extends TestCase
+{
+    /**
+     * @var $router Router
+     */
+    protected $router;
+    protected $routes = [
+        'posts',
+        'posts/create',
+        'posts/{post}',
+        'posts/{post}/edit',
+    ];
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->router = new Router(m::mock(Dispatcher::class), Container::getInstance());
+    }
+
+    public function testCommonResource()
+    {
+        $this->router->resource('posts', 'PostController');
+
+        $allRoutes = collect($this->router->getRoutes())->pluck('uri')->toArray();
+
+
+        foreach ($allRoutes as $uri) {
+
+            $this->assertContains($uri, $this->routes);
+        }
+    }
+
+    public function testEmptyPrefix()
+    {
+        $this->router->prefix('posts')->group(function (Router $router) {
+
+            $router->resource('/', 'PostController');
+        });
+
+
+        $allRoutes = collect($this->router->getRoutes())->pluck('uri')->toArray();
+
+
+        foreach ($allRoutes as $uri) {
+
+            $this->assertContains($uri, $this->routes);
+        }
+    }
+}


### PR DESCRIPTION
Routing is as follows
```
Route::prefix('posts')->group(function () {


    Route::resource('/', 'PostController');
});
```

When the resource is routed to the root directory and has a prefix, as before, there is no parameter value
![image](https://user-images.githubusercontent.com/28035971/57291567-45fb3b80-70f2-11e9-8f25-aa673be0e292.png)
Now get the last route prefix as the parameter value
![image](https://user-images.githubusercontent.com/28035971/57291606-59a6a200-70f2-11e9-9c38-e08457dbf8c8.png)
please refer to.