### PR TITLE
Allow setting the console command help with a property

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -62,6 +62,13 @@ class Command extends SymfonyCommand
     protected $description;
 
     /**
+     * The console command help.
+     *
+     * @var string
+     */
+    protected $help;
+
+    /**
      * Indicates whether the command should be shown in the Artisan command list.
      *
      * @var bool
@@ -108,6 +115,8 @@ class Command extends SymfonyCommand
         // related properties of the command. If a signature wasn't used to build
         // the command we'll set the arguments and the options on this command.
         $this->setDescription($this->description);
+
+        $this->setHelp($this->help);
 
         $this->setHidden($this->isHidden());
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR adds the ability to set the command's help text using the `help` property, similar to the way you can currently set the description with the `description` property.

The help text is not visible when you run `php artisan list` but is visible when you run `php artisan my:command --help`.

Usage looks like this (an example from my project):

```php
class AddCommand extends Command
{
    /**
     * @var string
     */
    protected $signature = 'add
        {project : The name of the project to add a frame to}
        {--f|from= : The start time of the frame}
        {--t|to= : the end time of the frame}
        {--i|interval= : An interval for the length of the frame}';

    /**
     * @var string
     */
    protected $description = 'Add a frame that happened in the past to the given project.';

    protected $help = <<<'HELP'
The start time of the frame must be specified with the --from option.  The start time may be any textual datetime format such as '2019-05-01 22:34:46' or a human readable difference such as '2 hours ago'.

You may specify an end time with the --to option.  The --to option accepts all of the same datetime formats as the --from option.

If you would rather specify an interval than a specific end time you can use the --interval option.  The --interval option accepts intervals such as '3h 12m' (meaning 3 hours, 12 minutes in this example).

If neither the --to or --interval options are specified the frame will end at the current time.
HELP;
```

Since all of the commands in my project add help text I currently have to either make my own base command or override the constructor in every command like this:

```php
public function __construct()
    {
        parent::__construct();

        $this->setHelp($this->help);
    }
```

I made this PR to the master branch because it's technically a breaking change if you happened to be using a `help` property in your command that wasn't null when the constructor was called.

I didn't add a test because it's a simple enough change and there isn't currently a test for the Command class.  I can add one if you would like, just let me know.