### PR TITLE
[5.8] Fix session resolver in RoutingServiceProvider

### DIFF
--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -66,7 +66,7 @@ class RoutingServiceProvider extends ServiceProvider
             // get the information it needs to function. This just provides some of
             // the convenience features to this URL generator like "signed" URLs.
             $url->setSessionResolver(function () {
-                return $this->app['session'];
+                return $this->app['session'] ?? null;
             });
 
             $url->setKeyResolver(function () {

--- a/tests/Integration/Routing/PreviousUrlTest.php
+++ b/tests/Integration/Routing/PreviousUrlTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Session\SessionServiceProvider;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class PreviousUrlTest extends TestCase
+{
+    public function test_previous_url_without_session()
+    {
+        Route::post('/previous-url', function (DummyFormRequest $request) {
+            return 'OK';
+        });
+
+        $response = $this->postJson('/previous-url');
+
+        $this->assertEquals(422, $response->status());
+    }
+
+    protected function getApplicationProviders($app)
+    {
+        $providers = parent::getApplicationProviders($app);
+
+        return array_filter($providers, function ($provider) {
+            return $provider !== SessionServiceProvider::class;
+        });
+    }
+}
+
+class DummyFormRequest extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'foo' => [
+                'required',
+                'string',
+            ],
+        ];
+    }
+}

--- a/tests/Integration/Routing/PreviousUrlTest.php
+++ b/tests/Integration/Routing/PreviousUrlTest.php
@@ -6,8 +6,6 @@ use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Session\SessionServiceProvider;
-use Illuminate\Support\Facades\Route;
-use Orchestra\Testbench\TestCase;
 
 class PreviousUrlTest extends TestCase
 {

--- a/tests/Integration/Routing/PreviousUrlTest.php
+++ b/tests/Integration/Routing/PreviousUrlTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Routing;
 
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Session\SessionServiceProvider;
 use Illuminate\Support\Facades\Route;


### PR DESCRIPTION
Currently [on validation exception FormRequest](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Foundation/Http/FormRequest.php#L128-L153) tries to [resolve previous url from session](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Routing/UrlGenerator.php#L153-L178). But if we don't use SessionServiceProvider then application fails with exception `Class session does not exist`. 
The problem in sessionResolver that always tries to resolve session in application. 