### PR TITLE
[5.8] Add missing dependency to illuminate/support

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -19,7 +19,8 @@
         "ext-mbstring": "*",
         "doctrine/inflector": "^1.1",
         "illuminate/contracts": "5.8.*",
-        "nesbot/carbon": "^1.26.3 || ^2.0"
+        "nesbot/carbon": "^1.26.3 || ^2.0",
+        "vlucas/phpdotenv": "^3.3"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"


### PR DESCRIPTION
As of https://github.com/illuminate/support/commit/5a4a347705d9b3665fd948ed83c6deb6fc08e81a [5.8] illuminate/support now depends on vlucas/phpdotenv directly. This breaks Lumen projects that do not them self depend on it.