### PR TITLE
[5.8]Protected `FileLoader::loadJsonPaths()` method to public

### DIFF
--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -134,7 +134,7 @@ class FileLoader implements Loader
      *
      * @throws \RuntimeException
      */
-    protected function loadJsonPaths($locale)
+    public function loadJsonPaths($locale)
     {
         return collect(array_merge($this->jsonPaths, [$this->path]))
             ->reduce(function ($output, $path) use ($locale) {


### PR DESCRIPTION
load json from current location.

```php

app('translator')
	->getLoader()
	->loadJsonPaths(app()->getLocale())
```