### PR TITLE
The route does not exist, and the exception message is an empty string.

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -176,7 +176,7 @@ class RouteCollection implements Countable, IteratorAggregate
             return $this->getRouteForMethods($request, $others);
         }
 
-        throw new NotFoundHttpException;
+        throw new NotFoundHttpException('Route not found');
     }
 
     /**


### PR DESCRIPTION
### Version
Laravel version: 5.8.16

### Description
When in api mode, if the route does not exist, it will throw `Symfony\Component\HttpKernel\Exception\NotFoundHttpException`, but there is no `message` prompt.

![2019-05-08 11-02-42 的屏幕截图](https://user-images.githubusercontent.com/22486914/57346385-dda76b00-7180-11e9-8604-48b457d7d6ad.png)
