### PR TITLE
[5.8] Add dumpHeaders

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -1021,6 +1021,16 @@ class TestResponse
     }
 
     /**
+     * Dump the headers from the response.
+     *
+     * @return void
+     */
+    public function dumpHeaders()
+    {
+        dd($this->headers->all());
+    }
+
+    /**
      * Get the streamed content from the response.
      *
      * @return string


### PR DESCRIPTION
`TestResponse` already allows us to `dump` content out, so why not headers too?