### PR TITLE
[5.8] Add ends_with validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -471,6 +471,24 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the ends_with rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceEndsWith($message, $attribute, $rule, $parameters)
+    {
+        foreach ($parameters as &$parameter) {
+            $parameter = $this->getDisplayableValue($attribute, $parameter);
+        }
+
+        return str_replace(':values', implode(', ', $parameters), $message);
+    }
+
+    /**
      * Replace all place-holders for the starts_with rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1535,6 +1535,19 @@ trait ValidatesAttributes
      * @param  array   $parameters
      * @return bool
      */
+    public function validateEndsWith($attribute, $value, $parameters)
+    {
+        return Str::endsWith($value, $parameters);
+    }
+
+    /**
+     * Validate the attribute starts with a given substring.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
     public function validateStartsWith($attribute, $value, $parameters)
     {
         return Str::startsWith($value, $parameters);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1235,6 +1235,33 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateEndsWith()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'hello world'], ['x' => 'ends_with:hello']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'hello world'], ['x' => 'ends_with:world']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'hello world'], ['x' => 'ends_with:world,hello']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.ends_with' => 'The :attribute must end with one of the following values :values'], 'en');
+        $v = new Validator($trans, ['url' => 'laravel.com'], ['url' => 'ends_with:http']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals('The url must end with one of the following values http', $v->messages()->first('url'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.ends_with' => 'The :attribute must end with one of the following values :values'], 'en');
+        $v = new Validator($trans, ['url' => 'laravel.com'], ['url' => 'ends_with:http,https']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals('The url must end with one of the following values http, https', $v->messages()->first('url'));
+    }
+
     public function testValidateStartsWith()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
A `starts_with` validation rule exists, however an `ends_with` does not. Given the symmetry between other validation rules as well as the `startsWith` and `endsWith` string helper methods, why not add it. Infinitely more expressive than the nasty` regex:/(foo|bar)$/` alternative.

Rule attributes are the same as `starts_with`, for example: 

```php
$rules = [
    'email' => 'required|ends_with:laravel.com,jasonmccreary.me',
];
```