### PR TITLE
[5.8] Improve route:list command

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -236,6 +236,7 @@ class RouteListCommand extends Command
 
         return $results;
     }
+
     /**
      * Get the console command options.
      *

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -210,12 +210,32 @@ class RouteListCommand extends Command
         }
 
         if ($columns = $this->option('columns')) {
-            return array_intersect($availableColumns, $columns);
+            return array_intersect($availableColumns, $this->parseColumns($columns));
         }
 
         return $availableColumns;
     }
 
+    /**
+     * Parse the exact listing of columns.
+     *
+     * @param  array  $columns
+     * @return array
+     */
+    protected function parseColumns(array $columns)
+    {
+        $results = [];
+
+        foreach ($columns as $i => $column) {
+            if (Str::contains($column, ',')) {
+                $results = array_merge($results, explode(',', $column));
+            } else {
+                $results[] = $column;
+            }
+        }
+
+        return $results;
+    }
     /**
      * Get the console command options.
      *


### PR DESCRIPTION
Instead of always passing multiple "--columns" option if you need two or more columns:

    $ php artisan route:list --columns=method --columns=uri --columns=name

You can optionally use the way below:

    $ php artisan route:list --columns=method,uri,name
    $ php artisan route:list --columns=method --columns=uri,name

This PR doesn't break the existing behaviour of the `route:list` command. It just supports a bit more convenient way.