### PR TITLE
[5.8] Fix route:list command when routes were dynamically modified

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -57,7 +57,7 @@ class RouteListCommand extends Command
     {
         parent::__construct();
 
-        $this->routes = $router->getRoutes();
+        $this->router = $router;
     }
 
     /**
@@ -67,7 +67,7 @@ class RouteListCommand extends Command
      */
     public function handle()
     {
-        if (empty($this->routes)) {
+        if (empty($this->router->getRoutes())) {
             return $this->error("Your application doesn't have any routes.");
         }
 
@@ -85,7 +85,7 @@ class RouteListCommand extends Command
      */
     protected function getRoutes()
     {
-        $routes = collect($this->routes)->map(function ($route) {
+        $routes = collect($this->router->getRoutes())->map(function ($route) {
             return $this->getRouteInformation($route);
         })->filter()->all();
 


### PR DESCRIPTION
When routes are modified by a custom service (like a Tenant service which modifies the routes domain, for example), the routes list displayed by this command remained unchanged.

Should be fixed in all actives versions.