### PR TITLE
[5.8] Reset webpack file for none preset

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/None.php
+++ b/src/Illuminate/Foundation/Console/Presets/None.php
@@ -15,6 +15,7 @@ class None extends Preset
     {
         static::updatePackages();
         static::updateBootstrapping();
+        static::updateWebpackConfiguration();
 
         tap(new Filesystem, function ($filesystem) {
             $filesystem->deleteDirectory(resource_path('js/components'));
@@ -57,5 +58,15 @@ class None extends Preset
         file_put_contents(resource_path('sass/app.scss'), ''.PHP_EOL);
         copy(__DIR__.'/none-stubs/app.js', resource_path('js/app.js'));
         copy(__DIR__.'/none-stubs/bootstrap.js', resource_path('js/bootstrap.js'));
+    }
+
+    /**
+     * Update the Webpack configuration.
+     *
+     * @return void
+     */
+    protected static function updateWebpackConfiguration()
+    {
+        copy(__DIR__.'/none-stubs/webpack.mix.js', base_path('webpack.mix.js'));
     }
 }

--- a/src/Illuminate/Foundation/Console/Presets/none-stubs/webpack.mix.js
+++ b/src/Illuminate/Foundation/Console/Presets/none-stubs/webpack.mix.js
@@ -1,0 +1,15 @@
+const mix = require('laravel-mix');
+
+/*
+ |--------------------------------------------------------------------------
+ | Mix Asset Management
+ |--------------------------------------------------------------------------
+ |
+ | Mix provides a clean, fluent API for defining some Webpack build steps
+ | for your Laravel application. By default, we are compiling the Sass
+ | file for the application as well as bundling up all the JS files.
+ |
+ */
+
+mix.js('resources/js/app.js', 'public/js')
+   .sass('resources/sass/app.scss', 'public/css');


### PR DESCRIPTION
When using the none preset and previously react was chosen the webpack config file would still point to the react js compiler. Instead we should reset this file back to the JS compiler.

Fixes https://github.com/laravel/framework/issues/28461