### PR TITLE
[5.8] Define router property of route:list command

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -27,11 +27,11 @@ class RouteListCommand extends Command
     protected $description = 'List all registered routes';
 
     /**
-     * An array of all the registered routes.
+     * The router instance.
      *
-     * @var \Illuminate\Routing\RouteCollection
+     * @var \Illuminate\Routing\Router
      */
-    protected $routes;
+    protected $router;
 
     /**
      * The table headers for the command.


### PR DESCRIPTION
The router property of `route:list` command was deleted in https://github.com/laravel/framework/pull/27532

 Now, we have to delete `routes` property and redefine `router` property due to this PR https://github.com/laravel/framework/pull/28460
