### PR TITLE
[5.8] Improve Error Messages on Gte, Lte, Gt and Lt Validations

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -259,11 +259,11 @@ trait ReplacesAttributes
      */
     protected function replaceGt($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
-            return str_replace(':value', $parameters[0], $message);
-        }
+	    if (is_null($value = $this->getValue($parameters[0])) && is_numeric($parameters[0])) {
+		    return str_replace(':value', $parameters[0], $message);
+	    }
 
-        return str_replace(':value', $this->getSize($attribute, $value), $message);
+	    return str_replace(':value', $this->getSize($attribute, $value ?? $parameters[0]), $message);
     }
 
     /**
@@ -277,11 +277,11 @@ trait ReplacesAttributes
      */
     protected function replaceLt($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
-            return str_replace(':value', $parameters[0], $message);
-        }
+	    if (is_null($value = $this->getValue($parameters[0])) && is_numeric($parameters[0])) {
+		    return str_replace(':value', $parameters[0], $message);
+	    }
 
-        return str_replace(':value', $this->getSize($attribute, $value), $message);
+	    return str_replace(':value', $this->getSize($attribute, $value ?? $parameters[0]), $message);
     }
 
     /**
@@ -293,14 +293,14 @@ trait ReplacesAttributes
      * @param  array   $parameters
      * @return string
      */
-    protected function replaceGte($message, $attribute, $rule, $parameters)
-    {
-        if (is_null($value = $this->getValue($parameters[0]))) {
-            return str_replace(':value', $parameters[0], $message);
-        }
+	protected function replaceGte($message, $attribute, $rule, $parameters)
+	{
+		if (is_null($value = $this->getValue($parameters[0])) && is_numeric($parameters[0])) {
+			return str_replace(':value', $parameters[0], $message);
+		}
 
-        return str_replace(':value', $this->getSize($attribute, $value), $message);
-    }
+		return str_replace(':value', $this->getSize($attribute, $value ?? $parameters[0]), $message);
+	}
 
     /**
      * Replace all place-holders for the lte rule.
@@ -313,11 +313,11 @@ trait ReplacesAttributes
      */
     protected function replaceLte($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
-            return str_replace(':value', $parameters[0], $message);
-        }
+	    if (is_null($value = $this->getValue($parameters[0])) && is_numeric($parameters[0])) {
+		    return str_replace(':value', $parameters[0], $message);
+	    }
 
-        return str_replace(':value', $this->getSize($attribute, $value), $message);
+	    return str_replace(':value', $this->getSize($attribute, $value ?? $parameters[0]), $message);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1097,12 +1097,28 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->fails());
 
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.string", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.numeric", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.array", $v->messages()->first('lhs'));
+
+	    $this->expectException(InvalidArgumentException::class);
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals(null, $v->messages()->first('lhs'));
+
         $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(3151));
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->passes());
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.file", $v->messages()->first('lhs'));
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gt:10']);
         $this->assertTrue($v->passes());
@@ -1126,12 +1142,28 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->passes());
 
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.string", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.numeric", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.array", $v->messages()->first('lhs'));
+
+	    $this->expectException(InvalidArgumentException::class);
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals(null, $v->messages()->first('lhs'));
+
         $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(3151));
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->fails());
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.file", $v->messages()->first('lhs'));
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lt:10']);
         $this->assertTrue($v->fails());
@@ -1155,12 +1187,28 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->fails());
 
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.string", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.numeric", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.array", $v->messages()->first('lhs'));
+
+	    $this->expectException(InvalidArgumentException::class);
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals(null, $v->messages()->first('lhs'));
+
         $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->passes());
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.file", $v->messages()->first('lhs'));
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gte:15']);
         $this->assertTrue($v->passes());
@@ -1184,12 +1232,28 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->passes());
 
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.string", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.numeric", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.array", $v->messages()->first('lhs'));
+
+	    $this->expectException(InvalidArgumentException::class);
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals(null, $v->messages()->first('lhs'));
+
         $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->passes());
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.file", $v->messages()->first('lhs'));
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lte:10']);
         $this->assertTrue($v->fails());


### PR DESCRIPTION
After reviewing issue https://github.com/laravel/framework/issues/28258, it seems that the error messages returned for the Gte, Lte, Gt and Lt validations can be incorrect or confusing with some edge cases. For example when the two fields under comparison were of different types. See [my comment on the issue](https://github.com/laravel/framework/issues/28258#issuecomment-489324103) for a more lengthy example. 

So, first I created a more robust `isSameType` method in the [ValidatesAttributes Class](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Validation/Concerns/ValidatesAttributes.php) to help catch some of these edge case errors. The prior method was good. But it caused the given validation to fail without very much feedback as to why (i.e. the fields under comparison did not match). 

The updated version throws an Exception if the field that is used as the base of comparison is not of one of the expected data types. And then if the types don't match, it add a new failure to the error messages (using the already available Validation methods). 

The `$comparedToValue` variable used in all of the [ValidatesAttributes Class](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Validation/Concerns/ValidatesAttributes.php) `validateGte`,` validateLte`, `validateGt` and `validateLt` methods, also sometimes returned confusing/misleading data when it was sent to the `getValue` method as `null`. So I used a null coalescing operator to check that and send an empty string instead, which returns more reliable/expected data. 

In the [ReplaceAttributes Class](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Validation/Concerns/ReplacesAttributes.php) I added a numeric check to the first `if` statement and a null coalescing operator on the default `return` statement to help provide more reliable Error messages in the `replaceGte`,` replaceLte`, `replaceGt` and `replaceLt` methods. Before it was returning things like "The :attribute must be greater than cat", due to what seemed to be assigning the numeric error message to non-numeric values. 

Finally I added some new tests to the `Validation` test cases to assure the changes were working properly. I also ran all of the tests and they passed except for the ones that were skipped, see below output from the console:

OK, but incomplete, skipped, or risky tests!
Tests: 4093, Assertions: 9500, Skipped: 87.

Please review to be sure that these changes make sense and that they don't break any existing functionality. **I only used the automated test suite** and did not do any browser testing. 