### PR TITLE
[5.9] Added custom header for bearer token to TokenGuard

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -159,7 +159,8 @@ class AuthManager implements FactoryContract
             $this->app['request'],
             $config['input_key'] ?? 'api_token',
             $config['storage_key'] ?? 'api_token',
-            $config['hash'] ?? false
+            $config['hash'] ?? false,
+            $config['bearer_key'] ?? 'Authorization'
         );
 
         $this->app->refresh('request', $guard, 'setRequest');

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -39,6 +39,13 @@ class TokenGuard implements Guard
     protected $hash = false;
 
     /**
+     * The name of the header from the request containing the bearer token.
+     *
+     * @var string
+     */
+    protected $bearerKey;
+
+    /**
      * Create a new authentication guard.
      *
      * @param  \Illuminate\Contracts\Auth\UserProvider  $provider
@@ -46,6 +53,7 @@ class TokenGuard implements Guard
      * @param  string  $inputKey
      * @param  string  $storageKey
      * @param  bool  $hash
+     * @param  string  $bearerKey
      * @return void
      */
     public function __construct(
@@ -53,13 +61,15 @@ class TokenGuard implements Guard
         Request $request,
         $inputKey = 'api_token',
         $storageKey = 'api_token',
-        $hash = false)
+        $hash = false,
+        $bearerKey = 'Authorization')
     {
         $this->hash = $hash;
         $this->request = $request;
         $this->provider = $provider;
         $this->inputKey = $inputKey;
         $this->storageKey = $storageKey;
+        $this->bearerKey = $bearerKey;
     }
 
     /**
@@ -103,7 +113,7 @@ class TokenGuard implements Guard
         }
 
         if (empty($token)) {
-            $token = $this->request->bearerToken();
+            $token = $this->request->bearerToken($this->bearerKey);
         }
 
         if (empty($token)) {

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -48,11 +48,12 @@ trait InteractsWithInput
     /**
      * Get the bearer token from the request headers.
      *
+     * @param  string  $key
      * @return string|null
      */
-    public function bearerToken()
+    public function bearerToken($key = 'Authorization')
     {
-        $header = $this->header('Authorization', '');
+        $header = $this->header($key, '');
 
         if (Str::startsWith($header, 'Bearer ')) {
             return Str::substr($header, 7);

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -175,8 +175,8 @@ class AuthTokenGuardTest extends TestCase
     {
         $provider = m::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn((object) ['id' => 1]);
-        $request = Request::create('/', 'GET', [], [], [], ['HTTP_CUSTOM_BEARER' => 'Bearer foo']);
-        $guard = new TokenGuard($provider, $request, 'api_token', 'api_token', false, 'CUSTOM_BEARER');
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_X_CUSTOM_AUTH' => 'Bearer foo']);
+        $guard = new TokenGuard($provider, $request, 'api_token', 'api_token', false, 'x-custom-auth');
         $user = $guard->user();
         $this->assertEquals(1, $user->id);
     }

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -171,6 +171,16 @@ class AuthTokenGuardTest extends TestCase
         $this->assertEquals(1, $user->id);
     }
 
+    public function testUserCanBeRetrievedByBearerTokenWithCustomHeader()
+    {
+        $provider = m::mock(UserProvider::class);
+        $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn((object) ['id' => 1]);
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_CUSTOM_BEARER' => 'Bearer foo']);
+        $guard = new TokenGuard($provider, $request, 'api_token', 'api_token', false, 'CUSTOM_BEARER');
+        $user = $guard->user();
+        $this->assertEquals(1, $user->id);
+    }
+
     public function testValidateCanDetermineIfCredentialsAreValidWithCustomKey()
     {
         $provider = m::mock(UserProvider::class);


### PR DESCRIPTION
Currently, the TokenGuard is hard-coded to check for the Bearer Token in the standard 'Authorization' header. If a user wants to change this to a custom header name (for example, let's say my API requires the header name to be 'X-Custom-Auth') then the user would need to extend or implement a new guard.

This change allows the user to specify a custom header name by setting the 'bearer_key' value in the auth configuration.
For example, in the project config/auth.php:

    'guards' => [
        'api' => [
            'driver' => 'token',
            ...,
            'bearer_key' => 'X-Custom-Auth',
        ],
    ],

The above would cause the TokenGuard to check for the bearer token in the 'X-Custom-Auth' header.

This change should be backward-compatible since the header name will default to 'Authorization' which is the currently checked header. However, as pointed out by @devcircus the signature of the bearerToken function has changed, so anyone overriding this function will get an error.

Additional test cases added:

    In Illuminate\Tests\Auth\AuthTokenGuardTest::
    testUserCanBeRetrievedByBearerTokenWithCustomHeader()
    This test verifies that the custom bearer token header works properly.
