### PR TITLE
[5.8] Added view:cache to the optimize command

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -29,6 +29,7 @@ class OptimizeCommand extends Command
     {
         $this->call('config:cache');
         $this->call('route:cache');
+        $this->call('view:cache');
 
         $this->info('Files cached successfully!');
     }


### PR DESCRIPTION
I saw that the `view:cache` command was missing in the `optimize` command while the `view:clear` exists in the `optimize:clear` command