### PR TITLE
[5.8] Improve Error Messages on Validations for Gte, Lte, Gt and Lt

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -259,11 +259,11 @@ trait ReplacesAttributes
      */
     protected function replaceGt($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
+        if (is_null($value = $this->getValue($parameters[0])) && is_numeric($parameters[0])) {
             return str_replace(':value', $parameters[0], $message);
         }
 
-        return str_replace(':value', $this->getSize($attribute, $value), $message);
+        return str_replace(':value', $this->getSize($attribute, $value ?? $parameters[0]), $message);
     }
 
     /**
@@ -277,11 +277,11 @@ trait ReplacesAttributes
      */
     protected function replaceLt($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
+	    if (is_null($value = $this->getValue($parameters[0])) && is_numeric($parameters[0])) {
             return str_replace(':value', $parameters[0], $message);
         }
 
-        return str_replace(':value', $this->getSize($attribute, $value), $message);
+        return str_replace(':value', $this->getSize($attribute, $value ?? $parameters[0]), $message);
     }
 
     /**
@@ -295,11 +295,11 @@ trait ReplacesAttributes
      */
     protected function replaceGte($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
+	    if (is_null($value = $this->getValue($parameters[0])) && is_numeric($parameters[0])) {
             return str_replace(':value', $parameters[0], $message);
         }
 
-        return str_replace(':value', $this->getSize($attribute, $value), $message);
+        return str_replace(':value', $this->getSize($attribute, $value ?? $parameters[0]), $message);
     }
 
     /**
@@ -313,11 +313,11 @@ trait ReplacesAttributes
      */
     protected function replaceLte($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
+	    if (is_null($value = $this->getValue($parameters[0])) && is_numeric($parameters[0])) {
             return str_replace(':value', $parameters[0], $message);
         }
 
-        return str_replace(':value', $this->getSize($attribute, $value), $message);
+        return str_replace(':value', $this->getSize($attribute, $value ?? $parameters[0]), $message);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -277,7 +277,7 @@ trait ReplacesAttributes
      */
     protected function replaceLt($message, $attribute, $rule, $parameters)
     {
-	    if (is_null($value = $this->getValue($parameters[0])) && is_numeric($parameters[0])) {
+        if (is_null($value = $this->getValue($parameters[0])) && is_numeric($parameters[0])) {
             return str_replace(':value', $parameters[0], $message);
         }
 
@@ -295,7 +295,7 @@ trait ReplacesAttributes
      */
     protected function replaceGte($message, $attribute, $rule, $parameters)
     {
-	    if (is_null($value = $this->getValue($parameters[0])) && is_numeric($parameters[0])) {
+        if (is_null($value = $this->getValue($parameters[0])) && is_numeric($parameters[0])) {
             return str_replace(':value', $parameters[0], $message);
         }
 
@@ -313,7 +313,7 @@ trait ReplacesAttributes
      */
     protected function replaceLte($message, $attribute, $rule, $parameters)
     {
-	    if (is_null($value = $this->getValue($parameters[0])) && is_numeric($parameters[0])) {
+        if (is_null($value = $this->getValue($parameters[0])) && is_numeric($parameters[0])) {
             return str_replace(':value', $parameters[0], $message);
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -895,7 +895,7 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) > $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
         }
 
-        return true;
+        return $this->validateBail();
     }
 
     /**
@@ -922,7 +922,7 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) < $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
         }
 
-        return true;
+	    return $this->validateBail();
     }
 
     /**
@@ -949,7 +949,7 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) >= $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
         }
 
-        return true;
+	    return $this->validateBail();
     }
 
     /**
@@ -976,7 +976,7 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) <= $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
         }
 
-        return true;
+	    return $this->validateBail();
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -883,7 +883,7 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'gt');
 
-	    $comparedToValue = $this->getValue($parameters[0] ?? '');
+        $comparedToValue = $this->getValue($parameters[0] ?? '');
 
         $this->shouldBeNumeric($attribute, 'Gt');
 
@@ -891,8 +891,8 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) > $parameters[0];
         }
 
-	    if ($this->isSameType($attribute, $value, $comparedToValue ?? $parameters[0])) {
-	        return $this->getSize($attribute, $value) > $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
+        if ($this->isSameType($attribute, $value, $comparedToValue ?? $parameters[0])) {
+            return $this->getSize($attribute, $value) > $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
         }
 
         return true;
@@ -910,7 +910,7 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'lt');
 
-	    $comparedToValue = $this->getValue($parameters[0] ?? '');
+        $comparedToValue = $this->getValue($parameters[0] ?? '');
 
         $this->shouldBeNumeric($attribute, 'Lt');
 
@@ -918,8 +918,8 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) < $parameters[0];
         }
 
-	    if ($this->isSameType($attribute, $value, $comparedToValue ?? $parameters[0])) {
-		    return $this->getSize($attribute, $value) < $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
+        if ($this->isSameType($attribute, $value, $comparedToValue ?? $parameters[0])) {
+            return $this->getSize($attribute, $value) < $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
         }
 
         return true;
@@ -937,7 +937,7 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'gte');
 
-	    $comparedToValue = $this->getValue($parameters[0] ?? '');
+        $comparedToValue = $this->getValue($parameters[0] ?? '');
 
         $this->shouldBeNumeric($attribute, 'Gte');
 
@@ -945,8 +945,8 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) >= $parameters[0];
         }
 
-	    if ($this->isSameType($attribute, $value, $comparedToValue ?? $parameters[0])) {
-		    return $this->getSize($attribute, $value) >= $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
+        if ($this->isSameType($attribute, $value, $comparedToValue ?? $parameters[0])) {
+            return $this->getSize($attribute, $value) >= $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
         }
 
         return true;
@@ -964,7 +964,7 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'lte');
 
-	    $comparedToValue = $this->getValue($parameters[0] ?? '');
+        $comparedToValue = $this->getValue($parameters[0] ?? '');
 
         $this->shouldBeNumeric($attribute, 'Lte');
 
@@ -972,8 +972,8 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) <= $parameters[0];
         }
 
-	    if ($this->isSameType($attribute, $value, $comparedToValue ?? $parameters[0])) {
-		    return $this->getSize($attribute, $value) <= $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
+        if ($this->isSameType($attribute, $value, $comparedToValue ?? $parameters[0])) {
+            return $this->getSize($attribute, $value) <= $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
         }
 
         return true;
@@ -1741,37 +1741,36 @@ trait ValidatesAttributes
         }
     }
 
-	/**
-	 * Check if the values to be compared are of the same type.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed  $value
-	 * @param  mixed  $comparedToValue
-	 * @return bool
-	 */
-	protected function isSameType($attribute, $value, $comparedToValue)
-	{
-		$requiredType = gettype($comparedToValue);
+    /**
+     * Check if the values to be compared are of the same type.
+     *
+     * @param  string $attribute
+     * @param  mixed  $value
+     * @param  mixed  $comparedToValue
+     * @return bool
+     */
+    protected function isSameType($attribute, $value, $comparedToValue)
+    {
+        $requiredType = gettype($comparedToValue);
 
-		if (is_numeric($comparedToValue) && ! is_numeric($value)) {
-			$requiredType = 'numeric';
-		} elseif ($comparedToValue instanceof File && ! $value instanceof File) {
-			$requiredType = 'file';
-		}
+        if (is_numeric($comparedToValue) && ! is_numeric($value)) {
+            $requiredType = 'numeric';
+        } elseif ($comparedToValue instanceof File && ! $value instanceof File) {
+            $requiredType = 'file';
+        }
 
-		if (gettype($value) != $requiredType) {
+        if (gettype($value) != $requiredType) {
+            if (! in_array($requiredType, ['array', 'file', 'numeric', 'string'])) {
+                throw new InvalidArgumentException('The field under comparison must be an array, file, number or string.');
+            }
 
-			if (! in_array($requiredType, ['array', 'file', 'numeric', 'string'])) {
-				throw new InvalidArgumentException('The field under comparison must be an array, file, number or string.');
-			}
+            $this->addFailure($attribute, $requiredType);
 
-			$this->addFailure($attribute, $requiredType);
+            return false;
+        }
 
-			return false;
-		}
-
-		return true;
-	}
+        return true;
+    }
 
     /**
      * Adds the existing rule to the numericRules array if the attribute's value is numeric.

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -922,7 +922,7 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) < $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
         }
 
-	    return $this->validateBail();
+        return $this->validateBail();
     }
 
     /**
@@ -949,7 +949,7 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) >= $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
         }
 
-	    return $this->validateBail();
+        return $this->validateBail();
     }
 
     /**
@@ -976,7 +976,7 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) <= $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
         }
 
-	    return $this->validateBail();
+        return $this->validateBail();
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -891,12 +891,13 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) > $parameters[0];
         }
 
-	    if ($requiredType = $this->compareTypes($value, $comparedToValue ?? $parameters[0])) {
-		    $this->addIncorrectTypeFailureMessage($attribute, $requiredType);
-		    return $this->validateBail();
-	    }
+        if ($requiredType = $this->compareTypes($value, $comparedToValue ?? $parameters[0])) {
+            $this->addIncorrectTypeFailureMessage($attribute, $requiredType);
 
-	    return $this->getSize($attribute, $value) > $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
+            return $this->validateBail();
+        }
+
+        return $this->getSize($attribute, $value) > $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
     }
 
     /**
@@ -919,12 +920,13 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) < $parameters[0];
         }
 
-	    if ($requiredType = $this->compareTypes($value, $comparedToValue ?? $parameters[0])) {
-		    $this->addIncorrectTypeFailureMessage($attribute, $requiredType);
-		    return $this->validateBail();
-	    }
+        if ($requiredType = $this->compareTypes($value, $comparedToValue ?? $parameters[0])) {
+            $this->addIncorrectTypeFailureMessage($attribute, $requiredType);
 
-	    return $this->getSize($attribute, $value) < $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
+            return $this->validateBail();
+        }
+
+        return $this->getSize($attribute, $value) < $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
     }
 
     /**
@@ -948,8 +950,9 @@ trait ValidatesAttributes
         }
 
         if ($requiredType = $this->compareTypes($value, $comparedToValue ?? $parameters[0])) {
-        	$this->addIncorrectTypeFailureMessage($attribute, $requiredType);
-	        return $this->validateBail();
+            $this->addIncorrectTypeFailureMessage($attribute, $requiredType);
+
+            return $this->validateBail();
         }
 
         return $this->getSize($attribute, $value) >= $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
@@ -975,12 +978,13 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) <= $parameters[0];
         }
 
-	    if ($requiredType = $this->compareTypes($value, $comparedToValue ?? $parameters[0])) {
-		    $this->addIncorrectTypeFailureMessage($attribute, $requiredType);
-		    return $this->validateBail();
-	    }
+        if ($requiredType = $this->compareTypes($value, $comparedToValue ?? $parameters[0])) {
+            $this->addIncorrectTypeFailureMessage($attribute, $requiredType);
 
-	    return $this->getSize($attribute, $value) <= $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
+            return $this->validateBail();
+        }
+
+        return $this->getSize($attribute, $value) <= $this->getSize($attribute, $comparedToValue ?? $parameters[0]);
     }
 
     /**
@@ -1745,30 +1749,28 @@ trait ValidatesAttributes
         }
     }
 
-	/**
-	 * Check if the values to be compared are of the same
-	 * type, and if not return the required type.
-	 *
-	 * @param  mixed  $value
-	 * @param  mixed  $comparedToValue
-	 * @return mixed
-	 */
-	protected function compareTypes($value, $comparedToValue)
-	{
-		$requiredType = gettype($comparedToValue);
+    /**
+     * Check if the values to be compared are of the same
+     * type, and if not return the required type.
+     *
+     * @param  mixed  $value
+     * @param  mixed  $comparedToValue
+     * @return mixed
+     */
+    protected function compareTypes($value, $comparedToValue)
+    {
+        $requiredType = gettype($comparedToValue);
 
-		if (is_numeric($comparedToValue) && ! is_numeric($value)) {
-			$requiredType = 'numeric';
-		} elseif ($comparedToValue instanceof File && ! $value instanceof File) {
-			$requiredType = 'file';
-		}
+        if (is_numeric($comparedToValue) && ! is_numeric($value)) {
+            $requiredType = 'numeric';
+        } elseif ($comparedToValue instanceof File && ! $value instanceof File) {
+            $requiredType = 'file';
+        }
 
-		if (gettype($value) != $requiredType) {
-			return $requiredType;
-		}
-
-		return null;
-	}
+        if (gettype($value) != $requiredType) {
+            return $requiredType;
+        }
+    }
 
     /**
      * Add a failure message to the validator specifying the

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1097,12 +1097,28 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->fails());
 
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.string", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.numeric", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.array", $v->messages()->first('lhs'));
+
+	    $this->expectException(InvalidArgumentException::class);
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals(null, $v->messages()->first('lhs'));
+
         $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(3151));
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->passes());
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.file", $v->messages()->first('lhs'));
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gt:10']);
         $this->assertTrue($v->passes());
@@ -1126,12 +1142,28 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->passes());
 
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.string", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.numeric", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.array", $v->messages()->first('lhs'));
+
+	    $this->expectException(InvalidArgumentException::class);
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals(null, $v->messages()->first('lhs'));
+
         $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(3151));
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->fails());
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.file", $v->messages()->first('lhs'));
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lt:10']);
         $this->assertTrue($v->fails());
@@ -1155,12 +1187,28 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->fails());
 
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.string", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.numeric", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.array", $v->messages()->first('lhs'));
+
+	    $this->expectException(InvalidArgumentException::class);
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals(null, $v->messages()->first('lhs'));
+
         $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->passes());
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.file", $v->messages()->first('lhs'));
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gte:15']);
         $this->assertTrue($v->passes());
@@ -1184,12 +1232,28 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->passes());
 
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.string", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.numeric", $v->messages()->first('lhs'));
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.array", $v->messages()->first('lhs'));
+
+	    $this->expectException(InvalidArgumentException::class);
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals(null, $v->messages()->first('lhs'));
+
         $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $fileTwo = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->will($this->returnValue(5472));
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->passes());
+
+	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
+	    $this->assertEquals("validation.file", $v->messages()->first('lhs'));
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lte:10']);
         $this->assertTrue($v->fails());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1097,18 +1097,18 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->fails());
 
-	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.string", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.string', $v->messages()->first('lhs'));
 
-	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.numeric", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.numeric', $v->messages()->first('lhs'));
 
-	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.array", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.array', $v->messages()->first('lhs'));
 
-	    $this->expectException(InvalidArgumentException::class);
-	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals(null, $v->messages()->first('lhs'));
+        $this->expectException(InvalidArgumentException::class);
+        $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
+        $this->assertEquals(null, $v->messages()->first('lhs'));
 
         $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
@@ -1117,8 +1117,8 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->passes());
 
-	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.file", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.file', $v->messages()->first('lhs'));
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gt:10']);
         $this->assertTrue($v->passes());
@@ -1142,18 +1142,18 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->passes());
 
-	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.string", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.string', $v->messages()->first('lhs'));
 
-	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.numeric", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.numeric', $v->messages()->first('lhs'));
 
-	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.array", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.array', $v->messages()->first('lhs'));
 
-	    $this->expectException(InvalidArgumentException::class);
-	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals(null, $v->messages()->first('lhs'));
+        $this->expectException(InvalidArgumentException::class);
+        $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
+        $this->assertEquals(null, $v->messages()->first('lhs'));
 
         $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
@@ -1162,8 +1162,8 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->fails());
 
-	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.file", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.file', $v->messages()->first('lhs'));
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lt:10']);
         $this->assertTrue($v->fails());
@@ -1187,18 +1187,18 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->fails());
 
-	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.string", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.string', $v->messages()->first('lhs'));
 
-	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.numeric", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.numeric', $v->messages()->first('lhs'));
 
-	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.array", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.array', $v->messages()->first('lhs'));
 
-	    $this->expectException(InvalidArgumentException::class);
-	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals(null, $v->messages()->first('lhs'));
+        $this->expectException(InvalidArgumentException::class);
+        $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
+        $this->assertEquals(null, $v->messages()->first('lhs'));
 
         $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
@@ -1207,8 +1207,8 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->passes());
 
-	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.file", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.file', $v->messages()->first('lhs'));
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gte:15']);
         $this->assertTrue($v->passes());
@@ -1232,18 +1232,18 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->passes());
 
-	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.string", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.string', $v->messages()->first('lhs'));
 
-	    $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.numeric", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => '12'], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.numeric', $v->messages()->first('lhs'));
 
-	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.array", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => 'string', 'rhs' => ['string']], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.array', $v->messages()->first('lhs'));
 
-	    $this->expectException(InvalidArgumentException::class);
-	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals(null, $v->messages()->first('lhs'));
+        $this->expectException(InvalidArgumentException::class);
+        $v = new Validator($trans, ['lhs' => 'string', 'rhs' => (object) ['string']], ['lhs' => 'gt:rhs']);
+        $this->assertEquals(null, $v->messages()->first('lhs'));
 
         $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->will($this->returnValue(5472));
@@ -1252,8 +1252,8 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->passes());
 
-	    $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
-	    $this->assertEquals("validation.file", $v->messages()->first('lhs'));
+        $v = new Validator($trans, ['lhs' => 'string', 'rhs' => $fileOne], ['lhs' => 'gt:rhs']);
+        $this->assertEquals('validation.file', $v->messages()->first('lhs'));
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lte:10']);
         $this->assertTrue($v->fails());


### PR DESCRIPTION
**Attempted to fix styling issues on previous PR, resubmitting**

After reviewing issue https://github.com/laravel/framework/issues/28258, it seems that the error messages returned for the Gte, Lte, Gt and Lt validations can be incorrect or confusing with some edge cases. For example when the two fields under comparison were of different types. See [my comment on the issue](https://github.com/laravel/framework/issues/28258#issuecomment-489324103) for a more lengthy example. 

So, first I created a more robust `isSameType` method in the [ValidatesAttributes Class](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Validation/Concerns/ValidatesAttributes.php) to help catch some of these edge case errors. The prior method was good. But it caused the given validation to fail without very much feedback as to why (i.e. the fields under comparison did not match). 

The updated version throws an Exception if the field that is used as the base of comparison is not of one of the expected data types. And then if the types don't match, it add a new failure to the error messages (using the already available Validation methods). 

The `$comparedToValue` variable used in all of the [ValidatesAttributes Class](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Validation/Concerns/ValidatesAttributes.php) `validateGte`,` validateLte`, `validateGt` and `validateLt` methods, also sometimes returned confusing/misleading data when it was sent to the `getValue` method as `null`. So I used a null coalescing operator to check that and send an empty string instead, which returns more reliable/expected data. 

In the [ReplaceAttributes Class](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Validation/Concerns/ReplacesAttributes.php) I added a numeric check to the first `if` statement and a null coalescing operator on the default `return` statement to help provide more reliable Error messages in the `replaceGte`,` replaceLte`, `replaceGt` and `replaceLt` methods. Before it was returning things like "The :attribute must be greater than cat", due to what seemed to be assigning the numeric error message to non-numeric values. 

Finally I added some new tests to the `Validation` test cases to assure the changes were working properly. I also ran all of the tests and they passed except for the ones that were skipped, see below output from the console:

OK, but incomplete, skipped, or risky tests!
Tests: 4093, Assertions: 9500, Skipped: 87.

Please review to be sure that these changes make sense and that they don't break any existing functionality. **I only used the automated test suite** and did not do any browser testing. 
