### PR TITLE
[5.9] WithFaker Trait should use 'faker_locale' Config

### DIFF
--- a/src/Illuminate/Foundation/Testing/WithFaker.php
+++ b/src/Illuminate/Foundation/Testing/WithFaker.php
@@ -42,6 +42,6 @@ trait WithFaker
      */
     protected function makeFaker($locale = null)
     {
-        return Factory::create($locale ?? Factory::DEFAULT_LOCALE);
+        return Factory::create($locale ?? config('app.faker_locale', Factory::DEFAULT_LOCALE));
     }
 }


### PR DESCRIPTION
Before this PR, `WithFaker.php` Trait didn't use the config variable `faker_locale` from `config/app.php`.

With this fix, it doesn't need to set faker locale elsewhere, as expected.