### PR TITLE
[5.8] Replace HTTP Response codes with named constants

### DIFF
--- a/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
+++ b/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Auth\Middleware;
 
 use Closure;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 
@@ -22,7 +23,7 @@ class EnsureEmailIsVerified
             ($request->user() instanceof MustVerifyEmail &&
             ! $request->user()->hasVerifiedEmail())) {
             return $request->expectsJson()
-                    ? abort(403, 'Your email address is not verified.')
+                    ? abort(Response::HTTP_FORBIDDEN, 'Your email address is not verified.')
                     : Redirect::route($redirectToRoute ?: 'verification.notice');
         }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -5,6 +5,7 @@ namespace Illuminate\Broadcasting\Broadcasters;
 use Pusher\Pusher;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Http\Response;
 use Illuminate\Broadcasting\BroadcastException;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -111,7 +112,7 @@ class PusherBroadcaster extends Broadcaster
             $this->formatChannels($channels), $event, $payload, $socket, true
         );
 
-        if ((is_array($response) && $response['status'] >= 200 && $response['status'] <= 299)
+        if ((is_array($response) && $response['status'] >= Response::HTTP_OK && $response['status'] <= 299)
             || $response === true) {
             return;
         }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -7,6 +7,7 @@ use RuntimeException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
@@ -978,7 +979,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function abort($code, $message = '', array $headers = [])
     {
-        if ($code == 404) {
+        if ($code == Response::HTTP_NOT_FOUND) {
             throw new NotFoundHttpException($message);
         }
 

--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Auth\Events\Lockout;
 use Illuminate\Support\Facades\Lang;
@@ -53,7 +54,7 @@ trait ThrottlesLogins
 
         throw ValidationException::withMessages([
             $this->username() => [Lang::get('auth.throttle', ['seconds' => $seconds])],
-        ])->status(429);
+        ])->status(Response::HTTP_TOO_MANY_REQUESTS);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/stubs/test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.stub
@@ -3,6 +3,7 @@
 namespace DummyNamespace;
 
 use Tests\TestCase;
+use Illuminate\Http\Response;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -17,6 +18,6 @@ class DummyClass extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
     }
 }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -217,7 +217,7 @@ class Handler implements ExceptionHandlerContract
     protected function unauthenticated($request, AuthenticationException $exception)
     {
         return $request->expectsJson()
-                    ? response()->json(['message' => $exception->getMessage()], 401)
+                    ? response()->json(['message' => $exception->getMessage()], Response::HTTP_UNAUTHORIZED)
                     : redirect()->guest($exception->redirectTo() ?? route('login'));
     }
 
@@ -282,7 +282,7 @@ class Handler implements ExceptionHandlerContract
         }
 
         if (! $this->isHttpException($e)) {
-            $e = new HttpException(500, $e->getMessage());
+            $e = new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getMessage());
         }
 
         return $this->toIlluminateResponse(
@@ -300,7 +300,7 @@ class Handler implements ExceptionHandlerContract
     {
         return SymfonyResponse::create(
             $this->renderExceptionContent($e),
-            $this->isHttpException($e) ? $e->getStatusCode() : 500,
+            $this->isHttpException($e) ? $e->getStatusCode() : Response::HTTP_INTERNAL_SERVER_ERROR,
             $this->isHttpException($e) ? $e->getHeaders() : []
         );
     }
@@ -430,7 +430,7 @@ class Handler implements ExceptionHandlerContract
     {
         return new JsonResponse(
             $this->convertExceptionToArray($e),
-            $this->isHttpException($e) ? $e->getStatusCode() : 500,
+            $this->isHttpException($e) ? $e->getStatusCode() : Response::HTTP_INTERNAL_SERVER_ERROR,
             $this->isHttpException($e) ? $e->getHeaders() : [],
             JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
         );

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -175,7 +175,7 @@ if (! function_exists('back')) {
      * @param  mixed  $fallback
      * @return \Illuminate\Http\RedirectResponse
      */
-    function back($status = 302, $headers = [], $fallback = false)
+    function back($status = Response::HTTP_FOUND, $headers = [], $fallback = false)
     {
         return app('redirect')->back($status, $headers, $fallback);
     }
@@ -645,7 +645,7 @@ if (! function_exists('redirect')) {
      * @param  bool    $secure
      * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
      */
-    function redirect($to = null, $status = 302, $headers = [], $secure = null)
+    function redirect($to = null, $status = Response::HTTP_FOUND, $headers = [], $secure = null)
     {
         if (is_null($to)) {
             return app('redirect');
@@ -753,7 +753,7 @@ if (! function_exists('response')) {
      * @param  array   $headers
      * @return \Illuminate\Http\Response|\Illuminate\Contracts\Routing\ResponseFactory
      */
-    function response($content = '', $status = 200, array $headers = [])
+    function response($content = '', $status = Response::HTTP_OK, array $headers = [])
     {
         $factory = app(ResponseFactory::class);
 

--- a/src/Illuminate/Http/Exceptions/PostTooLargeException.php
+++ b/src/Illuminate/Http/Exceptions/PostTooLargeException.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Exceptions;
 
 use Exception;
+use Illuminate\Http\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class PostTooLargeException extends HttpException
@@ -18,6 +19,6 @@ class PostTooLargeException extends HttpException
      */
     public function __construct($message = null, Exception $previous = null, array $headers = [], $code = 0)
     {
-        parent::__construct(413, $message, $previous, $headers, $code);
+        parent::__construct(Response::HTTP_REQUEST_ENTITY_TOO_LARGE, $message, $previous, $headers, $code);
     }
 }

--- a/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php
+++ b/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Exceptions;
 
 use Exception;
+use Illuminate\Http\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class ThrottleRequestsException extends HttpException
@@ -18,6 +19,6 @@ class ThrottleRequestsException extends HttpException
      */
     public function __construct($message = null, Exception $previous = null, array $headers = [], $code = 0)
     {
-        parent::__construct(429, $message, $previous, $headers, $code);
+        parent::__construct(Response::HTTP_TOO_MANY_REQUESTS, $message, $previous, $headers, $code);
     }
 }

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -24,7 +24,7 @@ class JsonResponse extends BaseJsonResponse
      * @param  int    $options
      * @return void
      */
-    public function __construct($data = null, $status = 200, $headers = [], $options = 0)
+    public function __construct($data = null, $status = Response::HTTP_OK, $headers = [], $options = 0)
     {
         $this->encodingOptions = $options;
 

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Resources\Json;
 
+use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Support\Responsable;
@@ -115,6 +116,6 @@ class ResourceResponse implements Responsable
     protected function calculateStatus()
     {
         return $this->resource->resource instanceof Model &&
-               $this->resource->resource->wasRecentlyCreated ? 201 : 200;
+               $this->resource->resource->wasRecentlyCreated ? Response::HTTP_CREATED : Response::HTTP_OK;
     }
 }

--- a/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
+++ b/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing\Exceptions;
 
+use Illuminate\Http\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class InvalidSignatureException extends HttpException
@@ -13,6 +14,6 @@ class InvalidSignatureException extends HttpException
      */
     public function __construct()
     {
-        parent::__construct(403, 'Invalid signature.');
+        parent::__construct(Response::HTTP_FORBIDDEN, 'Invalid signature.');
     }
 }

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Http\Response;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Session\Store as SessionStore;
@@ -41,7 +42,7 @@ class Redirector
      * @param  int  $status
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function home($status = 302)
+    public function home($status = Response::HTTP_FOUND)
     {
         return $this->to($this->generator->route('home'), $status);
     }
@@ -54,7 +55,7 @@ class Redirector
      * @param  mixed  $fallback
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function back($status = 302, $headers = [], $fallback = false)
+    public function back($status = Response::HTTP_FOUND, $headers = [], $fallback = false)
     {
         return $this->createRedirect($this->generator->previous($fallback), $status, $headers);
     }
@@ -66,7 +67,7 @@ class Redirector
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function refresh($status = 302, $headers = [])
+    public function refresh($status = Response::HTTP_FOUND, $headers = [])
     {
         return $this->to($this->generator->getRequest()->path(), $status, $headers);
     }
@@ -80,7 +81,7 @@ class Redirector
      * @param  bool    $secure
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function guest($path, $status = 302, $headers = [], $secure = null)
+    public function guest($path, $status = Response::HTTP_FOUND, $headers = [], $secure = null)
     {
         $request = $this->generator->getRequest();
 
@@ -104,7 +105,7 @@ class Redirector
      * @param  bool    $secure
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function intended($default = '/', $status = 302, $headers = [], $secure = null)
+    public function intended($default = '/', $status = Response::HTTP_FOUND, $headers = [], $secure = null)
     {
         $path = $this->session->pull('url.intended', $default);
 
@@ -131,7 +132,7 @@ class Redirector
      * @param  bool    $secure
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function to($path, $status = 302, $headers = [], $secure = null)
+    public function to($path, $status = Response::HTTP_FOUND, $headers = [], $secure = null)
     {
         return $this->createRedirect($this->generator->to($path, [], $secure), $status, $headers);
     }
@@ -144,7 +145,7 @@ class Redirector
      * @param  array   $headers
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function away($path, $status = 302, $headers = [])
+    public function away($path, $status = Response::HTTP_FOUND, $headers = [])
     {
         return $this->createRedirect($path, $status, $headers);
     }
@@ -157,7 +158,7 @@ class Redirector
      * @param  array   $headers
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function secure($path, $status = 302, $headers = [])
+    public function secure($path, $status = Response::HTTP_FOUND, $headers = [])
     {
         return $this->to($path, $status, $headers, true);
     }
@@ -171,7 +172,7 @@ class Redirector
      * @param  array   $headers
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function route($route, $parameters = [], $status = 302, $headers = [])
+    public function route($route, $parameters = [], $status = Response::HTTP_FOUND, $headers = [])
     {
         return $this->to($this->generator->route($route, $parameters), $status, $headers);
     }
@@ -185,7 +186,7 @@ class Redirector
      * @param  array   $headers
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function action($action, $parameters = [], $status = 302, $headers = [])
+    public function action($action, $parameters = [], $status = Response::HTTP_FOUND, $headers = [])
     {
         return $this->to($this->generator->action($action, $parameters), $status, $headers);
     }

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -50,7 +50,7 @@ class ResponseFactory implements FactoryContract
      * @param  array  $headers
      * @return \Illuminate\Http\Response
      */
-    public function make($content = '', $status = 200, array $headers = [])
+    public function make($content = '', $status = Response::HTTP_OK, array $headers = [])
     {
         return new Response($content, $status, $headers);
     }
@@ -62,7 +62,7 @@ class ResponseFactory implements FactoryContract
      * @param  array  $headers
      * @return \Illuminate\Http\Response
      */
-    public function noContent($status = 204, array $headers = [])
+    public function noContent($status = Response::HTTP_NO_CONTENT, array $headers = [])
     {
         return $this->make('', $status, $headers);
     }
@@ -76,7 +76,7 @@ class ResponseFactory implements FactoryContract
      * @param  array  $headers
      * @return \Illuminate\Http\Response
      */
-    public function view($view, $data = [], $status = 200, array $headers = [])
+    public function view($view, $data = [], $status = Response::HTTP_OK, array $headers = [])
     {
         return $this->make($this->view->make($view, $data), $status, $headers);
     }
@@ -90,7 +90,7 @@ class ResponseFactory implements FactoryContract
      * @param  int  $options
      * @return \Illuminate\Http\JsonResponse
      */
-    public function json($data = [], $status = 200, array $headers = [], $options = 0)
+    public function json($data = [], $status = Response::HTTP_OK, array $headers = [], $options = 0)
     {
         return new JsonResponse($data, $status, $headers, $options);
     }
@@ -105,7 +105,7 @@ class ResponseFactory implements FactoryContract
      * @param  int  $options
      * @return \Illuminate\Http\JsonResponse
      */
-    public function jsonp($callback, $data = [], $status = 200, array $headers = [], $options = 0)
+    public function jsonp($callback, $data = [], $status = Response::HTTP_OK, array $headers = [], $options = 0)
     {
         return $this->json($data, $status, $headers, $options)->setCallback($callback);
     }
@@ -118,7 +118,7 @@ class ResponseFactory implements FactoryContract
      * @param  array  $headers
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function stream($callback, $status = 200, array $headers = [])
+    public function stream($callback, $status = Response::HTTP_OK, array $headers = [])
     {
         return new StreamedResponse($callback, $status, $headers);
     }
@@ -134,7 +134,7 @@ class ResponseFactory implements FactoryContract
      */
     public function streamDownload($callback, $name = null, array $headers = [], $disposition = 'attachment')
     {
-        $response = new StreamedResponse($callback, 200, $headers);
+        $response = new StreamedResponse($callback, Response::HTTP_OK, $headers);
 
         if (! is_null($name)) {
             $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
@@ -158,7 +158,7 @@ class ResponseFactory implements FactoryContract
      */
     public function download($file, $name = null, array $headers = [], $disposition = 'attachment')
     {
-        $response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
+        $response = new BinaryFileResponse($file, Response::HTTP_OK, $headers, true, $disposition);
 
         if (! is_null($name)) {
             return $response->setContentDisposition($disposition, $name, $this->fallbackName($name));
@@ -187,7 +187,7 @@ class ResponseFactory implements FactoryContract
      */
     public function file($file, array $headers = [])
     {
-        return new BinaryFileResponse($file, 200, $headers);
+        return new BinaryFileResponse($file, Response::HTTP_OK, $headers);
     }
 
     /**
@@ -199,7 +199,7 @@ class ResponseFactory implements FactoryContract
      * @param  bool|null  $secure
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function redirectTo($path, $status = 302, $headers = [], $secure = null)
+    public function redirectTo($path, $status = Response::HTTP_FOUND, $headers = [], $secure = null)
     {
         return $this->redirector->to($path, $status, $headers, $secure);
     }
@@ -213,7 +213,7 @@ class ResponseFactory implements FactoryContract
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function redirectToRoute($route, $parameters = [], $status = 302, $headers = [])
+    public function redirectToRoute($route, $parameters = [], $status = Response::HTTP_FOUND, $headers = [])
     {
         return $this->redirector->route($route, $parameters, $status, $headers);
     }
@@ -227,7 +227,7 @@ class ResponseFactory implements FactoryContract
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function redirectToAction($action, $parameters = [], $status = 302, $headers = [])
+    public function redirectToAction($action, $parameters = [], $status = Response::HTTP_FOUND, $headers = [])
     {
         return $this->redirector->action($action, $parameters, $status, $headers);
     }
@@ -241,7 +241,7 @@ class ResponseFactory implements FactoryContract
      * @param  bool|null  $secure
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function redirectGuest($path, $status = 302, $headers = [], $secure = null)
+    public function redirectGuest($path, $status = Response::HTTP_FOUND, $headers = [], $secure = null)
     {
         return $this->redirector->guest($path, $status, $headers, $secure);
     }
@@ -255,7 +255,7 @@ class ResponseFactory implements FactoryContract
      * @param  bool|null  $secure
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function redirectToIntended($default = '/', $status = 302, $headers = [], $secure = null)
+    public function redirectToIntended($default = '/', $status = Response::HTTP_FOUND, $headers = [], $secure = null)
     {
         return $this->redirector->intended($default, $status, $headers, $secure);
     }

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -235,7 +235,7 @@ class RouteCollection implements Countable, IteratorAggregate
     {
         if ($request->method() === 'OPTIONS') {
             return (new Route('OPTIONS', $request->path(), function () use ($methods) {
-                return new Response('', 200, ['Allow' => implode(',', $methods)]);
+                return new Response('', Response::HTTP_OK, ['Allow' => implode(',', $methods)]);
             }))->bind($request);
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -239,7 +239,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  int  $status
      * @return \Illuminate\Routing\Route
      */
-    public function redirect($uri, $destination, $status = 302)
+    public function redirect($uri, $destination, $status = Response::HTTP_FOUND)
     {
         return $this->any($uri, '\Illuminate\Routing\RedirectController')
                 ->defaults('destination', $destination)
@@ -255,7 +255,7 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function permanentRedirect($uri, $destination)
     {
-        return $this->redirect($uri, $destination, 301);
+        return $this->redirect($uri, $destination, Response::HTTP_MOVED_PERMANENTLY);
     }
 
     /**
@@ -736,7 +736,7 @@ class Router implements RegistrarContract, BindingRegistrar
         if ($response instanceof PsrResponseInterface) {
             $response = (new HttpFoundationFactory)->createResponse($response);
         } elseif ($response instanceof Model && $response->wasRecentlyCreated) {
-            $response = new JsonResponse($response, 201);
+            $response = new JsonResponse($response, Response::HTTP_CREATED);
         } elseif (! $response instanceof SymfonyResponse &&
                    ($response instanceof Arrayable ||
                     $response instanceof Jsonable ||

--- a/src/Illuminate/Support/Facades/Redirect.php
+++ b/src/Illuminate/Support/Facades/Redirect.php
@@ -3,16 +3,16 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Http\RedirectResponse home(int $status = 302)
- * @method static \Illuminate\Http\RedirectResponse back(int $status = 302, array $headers = [], $fallback = false)
- * @method static \Illuminate\Http\RedirectResponse refresh(int $status = 302, array $headers = [])
- * @method static \Illuminate\Http\RedirectResponse guest(string $path, int $status = 302, array $headers = [], bool $secure = null)
- * @method static intended(string $default = '/', int $status = 302, array $headers = [], bool $secure = null)
- * @method static \Illuminate\Http\RedirectResponse to(string $path, int $status = 302, array $headers = [], bool $secure = null)
- * @method static \Illuminate\Http\RedirectResponse away(string $path, int $status = 302, array $headers = [])
- * @method static \Illuminate\Http\RedirectResponse secure(string $path, int $status = 302, array $headers = [])
- * @method static \Illuminate\Http\RedirectResponse route(string $route, array $parameters = [], int $status = 302, array $headers = [])
- * @method static \Illuminate\Http\RedirectResponse action(string $action, array $parameters = [], int $status = 302, array $headers = [])
+ * @method static \Illuminate\Http\RedirectResponse home(int $status = \Illuminate\Http\Response::HTTP_FOUND)
+ * @method static \Illuminate\Http\RedirectResponse back(int $status = \Illuminate\Http\Response::HTTP_FOUND, array $headers = [], $fallback = false)
+ * @method static \Illuminate\Http\RedirectResponse refresh(int $status = \Illuminate\Http\Response::HTTP_FOUND, array $headers = [])
+ * @method static \Illuminate\Http\RedirectResponse guest(string $path, int $status = \Illuminate\Http\Response::HTTP_FOUND, array $headers = [], bool $secure = null)
+ * @method static intended(string $default = '/', int $status = \Illuminate\Http\Response::HTTP_FOUND, array $headers = [], bool $secure = null)
+ * @method static \Illuminate\Http\RedirectResponse to(string $path, int $status = \Illuminate\Http\Response::HTTP_FOUND, array $headers = [], bool $secure = null)
+ * @method static \Illuminate\Http\RedirectResponse away(string $path, int $status = \Illuminate\Http\Response::HTTP_FOUND, array $headers = [])
+ * @method static \Illuminate\Http\RedirectResponse secure(string $path, int $status = \Illuminate\Http\Response::HTTP_FOUND, array $headers = [])
+ * @method static \Illuminate\Http\RedirectResponse route(string $route, array $parameters = [], int $status = \Illuminate\Http\Response::HTTP_FOUND, array $headers = [])
+ * @method static \Illuminate\Http\RedirectResponse action(string $action, array $parameters = [], int $status = \Illuminate\Http\Response::HTTP_FOUND, array $headers = [])
  * @method static \Illuminate\Routing\UrlGenerator getUrlGenerator()
  * @method static void setSession(\Illuminate\Session\Store $session)
  *

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -24,7 +24,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar name(string $value)
  * @method static \Illuminate\Routing\RouteRegistrar namespace(string $value)
  * @method static \Illuminate\Routing\Router|\Illuminate\Routing\RouteRegistrar group(array|\Closure|string $attributes, \Closure|string $routes)
- * @method static \Illuminate\Routing\Route redirect(string $uri, string $destination, int $status = 302)
+ * @method static \Illuminate\Routing\Route redirect(string $uri, string $destination, int $status = \Illuminate\Http\Response::HTTP_FOUND)
  * @method static \Illuminate\Routing\Route permanentRedirect(string $uri, string $destination)
  * @method static \Illuminate\Routing\Route view(string $uri, string $view, array $data = [])
  * @method static void bind(string $key, string|callable $binder)

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation;
 
 use Exception;
 use Illuminate\Support\Arr;
+use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
 
 class ValidationException extends Exception
@@ -27,7 +28,7 @@ class ValidationException extends Exception
      *
      * @var int
      */
-    public $status = 422;
+    public $status = Response::HTTP_UNPROCESSABLE_ENTITY;
 
     /**
      * The name of the error bag.

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -8,6 +8,7 @@ use Mockery as m;
 use RuntimeException;
 use Illuminate\Http\Request;
 use Psr\Log\LoggerInterface;
+use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Routing\Redirector;
 use Illuminate\Support\MessageBag;
@@ -123,7 +124,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(false);
         $this->request->shouldReceive('expectsJson')->once()->andReturn(true);
 
-        $response = $this->handler->render($this->request, new HttpException(403, 'My custom error message'))->getContent();
+        $response = $this->handler->render($this->request, new HttpException(Response::HTTP_FORBIDDEN, 'My custom error message'))->getContent();
 
         $this->assertStringContainsString('"message": "My custom error message"', $response);
         $this->assertStringNotContainsString('<!DOCTYPE html>', $response);

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Http;
 
 use stdClass;
 use JsonSerializable;
+use Illuminate\Http\Response;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Http\JsonResponse;
@@ -60,12 +61,12 @@ class HttpJsonResponseTest extends TestCase
 
     public function testSetAndRetrieveStatusCode()
     {
-        $response = new JsonResponse(['foo' => 'bar'], 404);
-        $this->assertSame(404, $response->getStatusCode());
+        $response = new JsonResponse(['foo' => 'bar'], Response::HTTP_NOT_FOUND);
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
 
         $response = new JsonResponse(['foo' => 'bar']);
-        $response->setStatusCode(404);
-        $this->assertSame(404, $response->getStatusCode());
+        $response->setStatusCode(Response::HTTP_NOT_FOUND);
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
     }
 
     /**
@@ -85,7 +86,7 @@ class HttpJsonResponseTest extends TestCase
      */
     public function testGracefullyHandledSomeJsonErrorsWithPartialOutputOnError($data)
     {
-        new JsonResponse(['data' => $data], 200, [], JSON_PARTIAL_OUTPUT_ON_ERROR);
+        new JsonResponse(['data' => $data], Response::HTTP_OK, [], JSON_PARTIAL_OUTPUT_ON_ERROR);
     }
 
     /**

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -109,8 +109,8 @@ class HttpResponseTest extends TestCase
     public function testSetAndRetrieveStatusCode()
     {
         $response = new Response('foo');
-        $response->setStatusCode(404);
-        $this->assertSame(404, $response->getStatusCode());
+        $response->setStatusCode(Response::HTTP_NOT_FOUND);
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
     }
 
     public function testOnlyInputOnRedirect()
@@ -170,7 +170,7 @@ class HttpResponseTest extends TestCase
 
     public function testWithHeaders()
     {
-        $response = new Response(null, 200, ['foo' => 'bar']);
+        $response = new Response(null, Response::HTTP_OK, ['foo' => 'bar']);
         $this->assertSame('bar', $response->headers->get('foo'));
 
         $response->withHeaders(['foo' => 'BAR', 'bar' => 'baz']);

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -71,7 +71,7 @@ class CacheTest extends TestCase
             return new Response('some content');
         }, 'etag;max_age=100;s_maxage=200');
 
-        $this->assertSame(304, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_NOT_MODIFIED, $response->getStatusCode());
     }
 
     public function testInvalidOption()

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Auth;
 
 use Illuminate\Support\Str;
+use Illuminate\Http\Response;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\SessionGuard;
 use Illuminate\Events\Dispatcher;
@@ -73,7 +74,7 @@ class AuthenticationTest extends TestCase
 
     public function test_basic_auth_protects_route()
     {
-        $this->get('basic')->assertStatus(401);
+        $this->get('basic')->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
 
     public function test_basic_auth_passes_on_correct_credentials()
@@ -82,7 +83,7 @@ class AuthenticationTest extends TestCase
             'Authorization' => 'Basic '.base64_encode('email:password'),
         ]);
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
         $this->assertEquals('email', $response->decodeResponseJson()['email']);
     }
 
@@ -97,18 +98,18 @@ class AuthenticationTest extends TestCase
 
         $this->get('basicWithCondition', [
             'Authorization' => 'Basic '.base64_encode('email2:password2'),
-        ])->assertStatus(401);
+        ])->assertStatus(Response::HTTP_UNAUTHORIZED);
 
         $this->get('basicWithCondition', [
             'Authorization' => 'Basic '.base64_encode('email:password'),
-        ])->assertStatus(200);
+        ])->assertStatus(Response::HTTP_OK);
     }
 
     public function test_basic_auth_fails_on_wrong_credentials()
     {
         $this->get('basic', [
             'Authorization' => 'Basic '.base64_encode('email:wrong_password'),
-        ])->assertStatus(401);
+        ])->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
 
     public function test_logging_in_fails_via_attempt()

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Http;
 
+use Illuminate\Http\Response;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Route;
@@ -45,7 +46,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson([
             'data' => [
@@ -86,7 +87,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson([
             'data' => [
@@ -111,7 +112,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertExactJson([
             'data' => [
@@ -134,7 +135,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertExactJson([
             'data' => [
@@ -160,7 +161,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertExactJson([
             'data' => [
@@ -188,7 +189,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertExactJson([
             'data' => [
@@ -211,7 +212,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertExactJson([
             'data' => [
@@ -235,7 +236,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertExactJson([
             'data' => [
@@ -260,7 +261,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertExactJson([
             'data' => [
@@ -311,7 +312,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson([
             'data' => [
@@ -333,7 +334,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
         $response->assertHeader('X-Resource', 'True');
     }
 
@@ -432,7 +433,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson([
             'data' => [
@@ -459,7 +460,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson([
             'data' => [
@@ -499,7 +500,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson([
             'data' => [
@@ -540,7 +541,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson([
             'data' => [
@@ -625,7 +626,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson(['data' => $data]);
     }
@@ -658,7 +659,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $response->assertStatus(200);
+        $response->assertStatus(Response::HTTP_OK);
 
         $response->assertJson(['data' => $data->toArray()]);
     }
@@ -975,7 +976,7 @@ class ResourceTest extends TestCase
 
         $this->withoutExceptionHandling()
             ->get('/', ['Accept' => 'application/json'])
-            ->assertStatus(200)
+            ->assertStatus(Response::HTTP_OK)
             ->assertExactJson($expectedJson);
     }
 }

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Http;
 
 use Throwable;
+use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
@@ -49,7 +50,7 @@ class ThrottleRequestsTest extends TestCase
             $this->withoutExceptionHandling()->get('/');
         } catch (Throwable $e) {
             $this->assertInstanceOf(ThrottleRequestsException::class, $e);
-            $this->assertEquals(429, $e->getStatusCode());
+            $this->assertEquals(Response::HTTP_TOO_MANY_REQUESTS, $e->getStatusCode());
             $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
             $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
             $this->assertEquals(2, $e->getHeaders()['Retry-After']);

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Http;
 
 use Throwable;
+use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
@@ -53,7 +54,7 @@ class ThrottleRequestsWithRedisTest extends TestCase
             try {
                 $this->withoutExceptionHandling()->get('/');
             } catch (Throwable $e) {
-                $this->assertEquals(429, $e->getStatusCode());
+                $this->assertEquals(Response::HTTP_TOO_MANY_REQUESTS, $e->getStatusCode());
                 $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
                 $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
                 // $this->assertTrue(in_array($e->getHeaders()['Retry-After'], [2, 3]));

--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Routing;
 
+use Illuminate\Http\Response;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
 
@@ -13,7 +14,7 @@ class FallbackRouteTest extends TestCase
     public function test_basic_fallback()
     {
         Route::fallback(function () {
-            return response('fallback', 404);
+            return response('fallback', Response::HTTP_NOT_FOUND);
         });
 
         Route::get('one', function () {
@@ -22,14 +23,14 @@ class FallbackRouteTest extends TestCase
 
         $this->assertStringContainsString('one', $this->get('/one')->getContent());
         $this->assertStringContainsString('fallback', $this->get('/non-existing')->getContent());
-        $this->assertEquals(404, $this->get('/non-existing')->getStatusCode());
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $this->get('/non-existing')->getStatusCode());
     }
 
     public function test_fallback_with_prefix()
     {
         Route::group(['prefix' => 'prefix'], function () {
             Route::fallback(function () {
-                return response('fallback', 404);
+                return response('fallback', Response::HTTP_NOT_FOUND);
             });
 
             Route::get('one', function () {
@@ -46,7 +47,7 @@ class FallbackRouteTest extends TestCase
     public function test_fallback_with_wildcards()
     {
         Route::fallback(function () {
-            return response('fallback', 404);
+            return response('fallback', Response::HTTP_NOT_FOUND);
         });
 
         Route::get('one', function () {
@@ -59,23 +60,23 @@ class FallbackRouteTest extends TestCase
 
         $this->assertStringContainsString('one', $this->get('/one')->getContent());
         $this->assertStringContainsString('wildcard', $this->get('/non-existing')->getContent());
-        $this->assertEquals(200, $this->get('/non-existing')->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $this->get('/non-existing')->getStatusCode());
     }
 
     public function test_no_routes()
     {
         Route::fallback(function () {
-            return response('fallback', 404);
+            return response('fallback', Response::HTTP_NOT_FOUND);
         });
 
         $this->assertStringContainsString('fallback', $this->get('/non-existing')->getContent());
-        $this->assertEquals(404, $this->get('/non-existing')->getStatusCode());
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $this->get('/non-existing')->getStatusCode());
     }
 
     public function test_respond_with_named_fallback_route()
     {
         Route::fallback(function () {
-            return response('fallback', 404);
+            return response('fallback', Response::HTTP_NOT_FOUND);
         })->name('testFallbackRoute');
 
         Route::get('one', function () {
@@ -93,6 +94,6 @@ class FallbackRouteTest extends TestCase
         });
 
         $this->assertStringContainsString('one', $this->get('/one')->getContent());
-        $this->assertEquals(200, $this->get('/one')->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $this->get('/one')->getStatusCode());
     }
 }

--- a/tests/Integration/Routing/PreviousUrlTest.php
+++ b/tests/Integration/Routing/PreviousUrlTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Routing;
 
+use Illuminate\Http\Response;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Http\FormRequest;
@@ -17,7 +18,7 @@ class PreviousUrlTest extends TestCase
 
         $response = $this->postJson('/previous-url');
 
-        $this->assertEquals(422, $response->status());
+        $this->assertEquals(Response::HTTP_UNPROCESSABLE_ENTITY, $response->status());
     }
 
     protected function getApplicationProviders($app)

--- a/tests/Integration/Routing/RouteApiResourceTest.php
+++ b/tests/Integration/Routing/RouteApiResourceTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Routing;
 
+use Illuminate\Http\Response;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Tests\Integration\Routing\Fixtures\ApiResourceTaskController;
@@ -17,26 +18,26 @@ class RouteApiResourceTest extends TestCase
         Route::apiResource('tests', ApiResourceTestController::class);
 
         $response = $this->get('/tests');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m index', $response->getContent());
 
         $response = $this->post('/tests');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m store', $response->getContent());
 
         $response = $this->get('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m show', $response->getContent());
 
         $response = $this->put('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m update', $response->getContent());
         $response = $this->patch('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m update', $response->getContent());
 
         $response = $this->delete('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m destroy', $response->getContent());
     }
 
@@ -45,17 +46,17 @@ class RouteApiResourceTest extends TestCase
         Route::apiResource('tests', ApiResourceTestController::class)->only(['index', 'store']);
 
         $response = $this->get('/tests');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m index', $response->getContent());
 
         $response = $this->post('/tests');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m store', $response->getContent());
 
-        $this->assertEquals(404, $this->get('/tests/1')->getStatusCode());
-        $this->assertEquals(404, $this->put('/tests/1')->getStatusCode());
-        $this->assertEquals(404, $this->patch('/tests/1')->getStatusCode());
-        $this->assertEquals(404, $this->delete('/tests/1')->getStatusCode());
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $this->get('/tests/1')->getStatusCode());
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $this->put('/tests/1')->getStatusCode());
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $this->patch('/tests/1')->getStatusCode());
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $this->delete('/tests/1')->getStatusCode());
     }
 
     public function test_api_resources()
@@ -66,50 +67,50 @@ class RouteApiResourceTest extends TestCase
         ]);
 
         $response = $this->get('/tests');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m index', $response->getContent());
 
         $response = $this->post('/tests');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m store', $response->getContent());
 
         $response = $this->get('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m show', $response->getContent());
 
         $response = $this->put('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m update', $response->getContent());
         $response = $this->patch('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m update', $response->getContent());
 
         $response = $this->delete('/tests/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m destroy', $response->getContent());
 
         /////////////////////
         $response = $this->get('/tasks');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m index tasks', $response->getContent());
 
         $response = $this->post('/tasks');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m store tasks', $response->getContent());
 
         $response = $this->get('/tasks/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m show tasks', $response->getContent());
 
         $response = $this->put('/tasks/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m update tasks', $response->getContent());
         $response = $this->patch('/tasks/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m update tasks', $response->getContent());
 
         $response = $this->delete('/tasks/1');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('I`m destroy tasks', $response->getContent());
     }
 }

--- a/tests/Integration/Routing/RouteRedirectTest.php
+++ b/tests/Integration/Routing/RouteRedirectTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Routing;
 
+use Illuminate\Http\Response;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
 
@@ -19,11 +20,11 @@ class RouteRedirectTest extends TestCase
      */
     public function testRouteRedirect($redirectFrom, $redirectTo, $responseUri)
     {
-        Route::redirect($redirectFrom, $redirectTo, 301);
+        Route::redirect($redirectFrom, $redirectTo, Response::HTTP_MOVED_PERMANENTLY);
 
         $response = $this->get($responseUri);
         $response->assertRedirect($redirectTo);
-        $response->assertStatus(301);
+        $response->assertStatus(Response::HTTP_MOVED_PERMANENTLY);
     }
 
     public function routeRedirectDataSets(): array

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Routing;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\URL;
@@ -70,7 +71,7 @@ class UrlSigningTest extends TestCase
         Carbon::setTestNow(Carbon::create(2018, 1, 1)->addMinutes(10));
 
         $response = $this->get($url);
-        $response->assertStatus(403);
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
 
     public function test_signed_middleware_with_routable_parameter()

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Routing;
 
 use Mockery as m;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Session\Store;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Routing\Redirector;
@@ -56,16 +57,16 @@ class RoutingRedirectorTest extends TestCase
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
         $this->assertEquals($this->session, $response->getSession());
     }
 
     public function testComplexRedirectTo()
     {
-        $response = $this->redirect->to('bar', 303, ['X-RateLimit-Limit' => 60, 'X-RateLimit-Remaining' => 59], true);
+        $response = $this->redirect->to('bar', Response::HTTP_SEE_OTHER, ['X-RateLimit-Limit' => 60, 'X-RateLimit-Remaining' => 59], true);
 
         $this->assertEquals('https://foo.com/bar', $response->getTargetUrl());
-        $this->assertEquals(303, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_SEE_OTHER, $response->getStatusCode());
         $this->assertEquals(60, $response->headers->get('X-RateLimit-Limit'));
         $this->assertEquals(59, $response->headers->get('X-RateLimit-Remaining'));
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -166,11 +166,11 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
         $router->get('test', function () {
-            return (new SymfonyResponse('test', 304, ['foo' => 'bar']))->setLastModified(new DateTime);
+            return (new SymfonyResponse('test', SymfonyResponse::HTTP_NOT_MODIFIED, ['foo' => 'bar']))->setLastModified(new DateTime);
         });
 
         $response = $router->dispatch(Request::create('test', 'GET'));
-        $this->assertSame(304, $response->getStatusCode());
+        $this->assertSame(SymfonyResponse::HTTP_NOT_MODIFIED, $response->getStatusCode());
         $this->assertEmpty($response->getContent());
         $this->assertSame('bar', $response->headers->get('foo'));
         $this->assertNull($response->getLastModified());
@@ -408,7 +408,7 @@ class RoutingRouteTest extends TestCase
         });
         $response = $router->dispatch(Request::create('foo/bar', 'OPTIONS'));
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('GET,HEAD,POST', $response->headers->get('Allow'));
     }
 
@@ -420,11 +420,11 @@ class RoutingRouteTest extends TestCase
         });
 
         $response = $router->dispatch(Request::create('foo', 'OPTIONS'));
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('GET,HEAD,POST', $response->headers->get('Allow'));
 
         $response = $router->dispatch(Request::create('foo', 'HEAD'));
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEmpty($response->getContent());
 
         $router = $this->getRouter();
@@ -433,7 +433,7 @@ class RoutingRouteTest extends TestCase
         });
 
         $response = $router->dispatch(Request::create('foo', 'OPTIONS'));
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('GET,HEAD', $response->headers->get('Allow'));
 
         $router = $this->getRouter();
@@ -442,7 +442,7 @@ class RoutingRouteTest extends TestCase
         });
 
         $response = $router->dispatch(Request::create('foo', 'OPTIONS'));
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('POST', $response->headers->get('Allow'));
     }
 
@@ -1568,7 +1568,7 @@ class RoutingRouteTest extends TestCase
 
         $response = $router->dispatch(Request::create('contact_us', 'GET'));
         $this->assertTrue($response->isRedirect('contact'));
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
     }
 
     public function testRouteRedirectWithCustomStatus()
@@ -1577,11 +1577,11 @@ class RoutingRouteTest extends TestCase
         $router->get('contact_us', function () {
             throw new Exception('Route should not be reachable.');
         });
-        $router->redirect('contact_us', 'contact', 301);
+        $router->redirect('contact_us', 'contact', Response::HTTP_MOVED_PERMANENTLY);
 
         $response = $router->dispatch(Request::create('contact_us', 'GET'));
         $this->assertTrue($response->isRedirect('contact'));
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_MOVED_PERMANENTLY, $response->getStatusCode());
     }
 
     public function testRoutePermanentRedirect()
@@ -1594,7 +1594,7 @@ class RoutingRouteTest extends TestCase
 
         $response = $router->dispatch(Request::create('contact_us', 'GET'));
         $this->assertTrue($response->isRedirect('contact'));
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_MOVED_PERMANENTLY, $response->getStatusCode());
     }
 
     protected function getRouter()


### PR DESCRIPTION
After seeing @systemovich sending in JeffreyWay/council#239, I thought this would be a good idea to implement in the framework itself too

> The named constants are named after the HTTP response reason phrases.
> This way, a programmer does not always have to look-up the reason phrase
for unfamiliar codes.