### PR TITLE
[5.8] Add retryAfter in Notification and Mailable object

### DIFF
--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -83,7 +83,7 @@ class SendQueuedMailable
     public function retryAfter()
     {
         if (! method_exists($this->mailable, 'retryAfter') && ! isset($this->mailable->retryAfter)) {
-            return null;
+            return;
         }
 
         return $this->mailable->retryAfter ?? $this->mailable->retryAfter();

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -76,6 +76,20 @@ class SendQueuedMailable
     }
 
     /**
+     * Get the retry delay for the mailable object.
+     *
+     * @return mixed
+     */
+    public function retryAfter()
+    {
+        if (! method_exists($this->mailable, 'retryAfter') && ! isset($this->mailable->retryAfter)) {
+            return null;
+        }
+
+        return $this->mailable->retryAfter ?? $this->mailable->retryAfter();
+    }
+
+    /**
      * Prepare the instance for cloning.
      *
      * @return void

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -97,6 +97,20 @@ class SendQueuedNotifications implements ShouldQueue
     }
 
     /**
+     * Get the retry delay for the notification.
+     *
+     * @return mixed
+     */
+    public function retryAfter()
+    {
+        if (! method_exists($this->notification, 'retryAfter') && ! isset($this->notification->retryAfter)) {
+            return null;
+        }
+
+        return $this->notification->retryAfter ?? $this->notification->retryAfter();
+    }
+
+    /**
      * Prepare the instance for cloning.
      *
      * @return void

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -104,7 +104,7 @@ class SendQueuedNotifications implements ShouldQueue
     public function retryAfter()
     {
         if (! method_exists($this->notification, 'retryAfter') && ! isset($this->notification->retryAfter)) {
-            return null;
+            return;
         }
 
         return $this->notification->retryAfter ?? $this->notification->retryAfter();


### PR DESCRIPTION
Since PR #28265 is merged, programmer can set `retryAfter` in Job property or method. However this is not possible to do with Notification and Mailable class. So I added simple methods, which do this.

Basically it acts as any other job, so `retryAfter()` method in `SendQueuedNotifications` and `SendQueuedMailable` check existence of `retryAfter` property or method in notification or mail class.

I tried to find tests to modify, but it looks there aren't any. Am I correct?