### PR TITLE
Twice password mutation in ResetsPasswords.php

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -102,10 +102,9 @@ trait ResetsPasswords
      */
     protected function resetPassword($user, $password)
     {
-        if(!method_exists($user, 'setPasswordAttribute')) {
+        if (!method_exists($user, 'setPasswordAttribute')) {
             $user->password = Hash::make($password);
-        }
-        else {
+        } else {
             $user->password = $password;
         }
 

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -102,7 +102,12 @@ trait ResetsPasswords
      */
     protected function resetPassword($user, $password)
     {
-        $user->password = Hash::make($password);
+        if(!method_exists($user, 'setPasswordAttribute')) {
+            $user->password = Hash::make($password);
+        }
+        else {
+            $user->password = $password;
+        }
 
         $user->setRememberToken(Str::random(60));
 

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -102,7 +102,7 @@ trait ResetsPasswords
      */
     protected function resetPassword($user, $password)
     {
-        if (!method_exists($user, 'setPasswordAttribute')) {
+        if (! method_exists($user, 'setPasswordAttribute')) {
             $user->password = Hash::make($password);
         } else {
             $user->password = $password;


### PR DESCRIPTION
While resetting password, if **User** model has password mutator `setPasswordAttribute`, it will generate **hash** twice, because there is `Hash::make()` in `resetPassword()` for password and it will re-encrypt already encrypted password from password mutator in **User** model.