### PR TITLE
[5.8] Fix doc block

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -76,7 +76,7 @@ abstract class Queue
     /**
      * Create a payload string from the given job and data.
      *
-     * @param  string  $job
+     * @param  mixed  $job
      * @param  string  $queue
      * @param  mixed   $data
      * @return string


### PR DESCRIPTION
`$job` can be a string or an object.