### PR TITLE
Append 'Controller' automatically on create

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -212,6 +212,10 @@ abstract class GeneratorCommand extends Command
      */
     protected function getNameInput()
     {
+        if ($this->type == 'Controller' && !Str::endsWith(strtolower($this->argument('name')), 'controller')) {
+            return trim(sprintf("%sController", $this->argument('name')));
+        }
+
         return trim($this->argument('name'));
     }
 


### PR DESCRIPTION
As the title says, it automatically appends 'Controller'.

Example:

```php
php artisan make:controller Foo // App\Htpp\Controllers\FooController.
```

Because of `strtolower`, case with: 

```php
php artisan make:controller FoocontroLleR // App\Http\Controllers\FoocontroLleR
```

This is explicitly for the *Controller* but it is highly possible make pr for generating this automatically for all *make* commands, without hardcoding.
