### PR TITLE
[5.8] Custom app path in auto-discovery for events

### DIFF
--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -66,9 +66,10 @@ class DiscoverEvents
     protected static function classFromFile(SplFileInfo $file, $basePath)
     {
         $class = trim(Str::replaceFirst($basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
+        $appPath = ucfirst(basename(app()->path()));
 
         return str_replace(
-            [DIRECTORY_SEPARATOR, 'App\\'],
+            [DIRECTORY_SEPARATOR, "{$appPath}\\"],
             ['\\', app()->getNamespace()],
             ucfirst(Str::replaceLast('.php', '', $class))
         );


### PR DESCRIPTION
This PR adds support auto-discovery for events in a custom application directory, that sets via `Illuminate\Foundation\Application::useAppPath()` (this issue was reported in #28187 ).

It doesn't break compatibility with default `app` directory.