### PR TITLE
[5.8] migrate command added support for multiple --path options

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -16,7 +16,7 @@ class MigrateCommand extends BaseCommand
      */
     protected $signature = 'migrate {--database= : The database connection to use}
                 {--force : Force the operation to run when in production}
-                {--path= : The path to the migrations files to be executed}
+                {--path=* : The path(s) to the migrations files to be executed}
                 {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
                 {--pretend : Dump the SQL queries that would be run}
                 {--seed : Indicates if the seed task should be re-run}


### PR DESCRIPTION
This pull request makes the --path option repeatable. This brings it in line with the migrate:reset command which has the same.

Similar to #28495