### PR TITLE
[5.8] Fix validation with multiple passes() calls

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -267,6 +267,8 @@ class Validator implements ValidatorContract
 
         $this->distinctValues = [];
 
+        $this->failedRules = [];
+
         // We'll spin through each rule, validating the attributes attached to that
         // rule. Any error messages will be added to the containers with each of
         // the other error messages, returning true if we don't have messages.

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4413,6 +4413,14 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(1, $validateCount);
     }
 
+    public function testMultiplePassesCalls()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['foo' => 'string|required']);
+        $this->assertFalse($v->passes());
+        $this->assertFalse($v->passes());
+    }
+
     /**
      * @dataProvider validUuidList
      */


### PR DESCRIPTION
Validation incorrectly passes after the first time if `required` isn't the first rule:

```php
$v = Validator::make([], ['foo' => 'required|string']);
dump($v->passes()); // false
dump($v->passes()); // false

$v = Validator::make([], ['foo' => 'string|required']);
dump($v->passes()); // false
dump($v->passes()); // true
```

We have to reset the `$failedRules` property every time `passes()` gets called.

Fixes #28480.