### PR TITLE
[5.8] add assertValidationWithJsonResponse method  in TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -556,27 +556,32 @@ class TestResponse
      * @param  array $rules
      * @return $this
      */
-    public function assertValidationWithJsonResponse(Array $rules)
+    public function assertValidationWithJsonResponse(Array $rules, $wrapper)
     {
-        //Get First Array in json resopnse if not empty
-        $data = $this->json()['data'][0] ?? $this->json()['data'];
+        $data = data_get($this->json(), $wrapper);
         if (empty($data)) {
-            return PHPUnit::fail('Response Does not contain data');
-        }
-        $validator = Validator::make($data, $rules);
-        if (!$validator->fails()) {
-            return PHPUnit::assertTrue(true);
-        }
-        $errors = $validator->errors();
-        if (count($errors) > 0) {
-            PHPUnit::fail(
-                'Response has validation errors: ' . PHP_EOL . PHP_EOL .
-                json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+            return PHPUnit::fail(
+                "Response Dos not Have wrapper called  ${wrapper} "
             );
         }
+        $data = isset($data[0]) ? $data : [$data];
+        foreach ($data as $datum) {
+            $validator = Validator::make($datum, $rules);
+            if (!$validator->fails()) {
+                return PHPUnit::assertTrue(true);
+            }
+            $errors = $validator->errors();
+            if (count($errors) > 0) {
+                return PHPUnit::fail(
+                    'Response has validation errors: ' . PHP_EOL . PHP_EOL .
+                    json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+                );
+            }
 
+        }
         return $this;
     }
+
 
     /**
      * Get the strings we need to search for when examining the JSON.

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Foundation\Testing\Assert as PHPUnit;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Illuminate\Foundation\Testing\Constraints\SeeInOrder;
+use Illuminate\Support\Facades\Validator;
 
 /**
  * @mixin \Illuminate\Http\Response
@@ -548,6 +549,33 @@ class TestResponse
             'within'.PHP_EOL.PHP_EOL.
             "[{$actual}]."
         );
+    }
+    /**
+     * Assert that the response is pass validation rule.
+     *
+     * @param  array $rules
+     * @return $this
+     */
+    public function assertValidationWithJsonResponse(Array $rules)
+    {
+        //Get First Array in json resopnse if not empty
+        $data = $this->json()['data'][0] ?? $this->json()['data'];
+        if (empty($data)) {
+            return PHPUnit::fail('Response Does not contain data');
+        }
+        $validator = Validator::make($data, $rules);
+        if (!$validator->fails()) {
+            return PHPUnit::assertTrue(true);
+        }
+        $errors = $validator->errors();
+        if (count($errors) > 0) {
+            PHPUnit::fail(
+                'Response has validation errors: ' . PHP_EOL . PHP_EOL .
+                json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+            );
+        }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This PR adds assertValidationWithJsonResponse a new method to TestResponse class.
This allows developers to validate the JSON Response data type as we validate the request 
for example: 
`{
    "data": [
        {
            "id": 1,
            "name": "Athletic Shoe",
            "price": 895,
        },
        {
            "id": 2,
            "name": "Shoe",
            "price": "895",
        }
    ]
}`
in this case i want to validate that price attribute must be numeric value not string 
 `$this->json('get', 'api/products')
            ->assertValidationWithJsonResponse([
                'price'=>'numeric '
            ],'data');`