### PR TITLE
[5.8] Added Tappable trait

### DIFF
--- a/src/Illuminate/Support/Traits/Tappable.php
+++ b/src/Illuminate/Support/Traits/Tappable.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+trait Tappable
+{
+    /**
+     * Call the given Closure with this instance then return the instance.
+     *
+     * @param  callable|null  $callback
+     * @return mixed
+     */
+    public function tap($callback = null)
+    {
+        return tap($this, $callback);
+    }
+}

--- a/tests/Support/SupportTappableTest.php
+++ b/tests/Support/SupportTappableTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Support;
 
-use Illuminate\Support\Traits\Tappable;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Traits\Tappable;
 
 class SupportTappableTest extends TestCase
 {

--- a/tests/Support/SupportTappableTest.php
+++ b/tests/Support/SupportTappableTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Traits\Tappable;
+use PHPUnit\Framework\TestCase;
+
+class SupportTappableTest extends TestCase
+{
+    public function testTappableClassWithCallback()
+    {
+        $name = TappableClass::make()->tap(function ($tappable) {
+            $tappable->setName('MyName');
+        })->getName();
+
+        $this->assertEquals('MyName', $name);
+    }
+
+    public function testTappableClassWithoutCallback()
+    {
+        $name = TappableClass::make()->tap()->setName('MyName')->getName();
+
+        $this->assertEquals('MyName', $name);
+    }
+}
+
+class TappableClass
+{
+    use Tappable;
+
+    private $name;
+
+    public static function make()
+    {
+        return new static;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}


### PR DESCRIPTION
A little helper trait to add the `tap` function to any class and remove the need for temporary variables. I've used it in the case where `doSomething` and `doSomethingElse` don't return the instance :)

```php
$result = TappableClass::make()->tap(function ($tappable) {
    $tappable->doSomething();
    $tappable->doSomethingElse();
})->getResult();
```