### PR TITLE
[5.8] Use Name of Factory as Model

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -48,7 +48,7 @@ class FactoryMakeCommand extends GeneratorCommand
     {
         $namespaceModel = $this->option('model')
                         ? $this->qualifyClass($this->option('model'))
-                        : trim($this->rootNamespace(), '\\').'\\'. ucfirst(str_replace('Factory', '', $name));
+                        : trim($this->rootNamespace(), '\\').'\\'. ! strpos($name, 'Factory') ? 'Model' : ucfirst(str_replace('Factory', '', $name));
 
         $model = class_basename($namespaceModel);
 

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -48,7 +48,7 @@ class FactoryMakeCommand extends GeneratorCommand
     {
         $namespaceModel = $this->option('model')
                         ? $this->qualifyClass($this->option('model'))
-                        : trim($this->rootNamespace(), '\\').'\\Model';
+                        : trim($this->rootNamespace(), '\\').'\\'. ucfirst(str_replace('Factory', '', $name));
 
         $model = class_basename($namespaceModel);
 


### PR DESCRIPTION
Use the name of factory as the model if `--model` is not specified
```
php artisan make:factory UserFactory
```

the Model will be `User` here