### PR TITLE
[5.8] Fix the collation bug when changing columns in a migration.

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -82,7 +82,10 @@ class ChangeColumn
                 if (! is_null($option = static::mapFluentOptionToDoctrine($key))) {
                     if (method_exists($column, $method = 'set'.ucfirst($option))) {
                         $column->{$method}(static::mapFluentValueToDoctrine($option, $value));
+                        continue;
                     }
+
+                    $column->setCustomSchemaOption($option, static::mapFluentValueToDoctrine($option, $value));
                 }
             }
         }

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -78,14 +78,18 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         $this->db->connection()->getSchemaBuilder()->create('users', function ($table) {
             $table->string('age');
         });
+
         $blueprint = new Blueprint('users', function ($table) {
             $table->integer('age')->collation('RTRIM')->change();
         });
+
         $blueprint2 = new Blueprint('users', function ($table) {
             $table->integer('age')->collation('NOCASE')->change();
         });
+
         $queries = $blueprint->toSql($this->db->connection(), new SQLiteGrammar);
         $queries2 = $blueprint2->toSql($this->db->connection(), new SQLiteGrammar);
+
         $expected = [
             'CREATE TEMPORARY TABLE __temp__users AS SELECT age FROM users',
             'DROP TABLE users',
@@ -93,6 +97,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             'INSERT INTO users (age) SELECT age FROM __temp__users',
             'DROP TABLE __temp__users'
         ];
+
         $expected2 = [
             'CREATE TEMPORARY TABLE __temp__users AS SELECT age FROM users',
             'DROP TABLE users',
@@ -100,6 +105,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             'INSERT INTO users (age) SELECT age FROM __temp__users',
             'DROP TABLE __temp__users'
         ];
+
         $this->assertEquals($expected, $queries);
         $this->assertEquals($expected2, $queries2);
     }

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -95,7 +95,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             'DROP TABLE users',
             'CREATE TABLE users (age INTEGER NOT NULL COLLATE RTRIM)',
             'INSERT INTO users (age) SELECT age FROM __temp__users',
-            'DROP TABLE __temp__users'
+            'DROP TABLE __temp__users',
         ];
 
         $expected2 = [
@@ -103,7 +103,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             'DROP TABLE users',
             'CREATE TABLE users (age INTEGER NOT NULL COLLATE NOCASE)',
             'INSERT INTO users (age) SELECT age FROM __temp__users',
-            'DROP TABLE __temp__users'
+            'DROP TABLE __temp__users',
         ];
 
         $this->assertEquals($expected, $queries);


### PR DESCRIPTION
This allows the user to add custom schema options to the Doctrine DBAL column. This serves as a fix for #28487.