### PR TITLE
[5.8] Arr:getFirst($array $keys...) | Get the first element in an array based on key where value is set

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -623,15 +623,16 @@ class Arr
     }
 
     /**
-     * Get the first element corresponding with the key and where value is set
+     * Get the first element corresponding with the key and where value is set.
      *
      * @param  mixed  $value
      * @return array
      */
-    public static function getFirst() {
+    public static function getFirst() 
+    {
         $args = func_get_args();
 
-        if(count($args) < 2) {
+        if (count($args) < 2) {
             return [];
         }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -628,7 +628,7 @@ class Arr
      * @param  mixed  $value
      * @return array
      */
-    public static function getFirst() 
+    public static function getFirst()
     {
         $args = func_get_args();
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -623,7 +623,7 @@ class Arr
     }
 
     /**
-     * Get the first element corresponding with the key which and has value set
+     * Get the first element corresponding with the key and where value is set
      *
      * @param  mixed  $value
      * @return array
@@ -640,9 +640,9 @@ class Arr
         }
 
         $array = self::first($args);
-        
+
         $keys = array_slice($args, 1);
-        
+
         for ($i = 0; $i < count($keys); $i++) {
             $value = self::only($array, $keys[$i]);
             if ($value) {

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -621,4 +621,35 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Get the first element corresponding with the key which and has value set
+     *
+     * @param  mixed  $value
+     * @return array
+     */
+    public static function getFirst() {
+        $args = func_get_args();
+
+        if(count($args) < 2) {
+            return [];
+        }
+
+        if (! self::accessible(self::first($args))) {
+            return [];
+        }
+
+        $array = self::first($args);
+        $keys = array_slice($args, 1);
+
+        for ($i = 0; $i < count($keys); $i++) {
+            $value = self::only($array, $keys[$i]);
+            if ($value) {
+                if (! is_null($value[$keys[$i]]) && ! empty($value[$keys[$i]])) {
+                    return $value;
+                }
+            }
+        }
+        return [];
+    }
 }

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -640,8 +640,9 @@ class Arr
         }
 
         $array = self::first($args);
+        
         $keys = array_slice($args, 1);
-
+        
         for ($i = 0; $i < count($keys); $i++) {
             $value = self::only($array, $keys[$i]);
             if ($value) {

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -652,6 +652,7 @@ class Arr
                 }
             }
         }
+        
         return [];
     }
 }

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -652,7 +652,7 @@ class Arr
                 }
             }
         }
-        
+
         return [];
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -815,4 +815,58 @@ class SupportArrTest extends TestCase
         $this->assertEquals([$obj], Arr::wrap($obj));
         $this->assertSame($obj, Arr::wrap($obj)[0]);
     }
+
+    public function testGetFirst()
+    {
+        $a = [
+            'lastName' => 'Doe',
+            'firstName' => 'John',
+            'phone' => '',
+            'email' => 'john.doe@example.com',
+            'mobile' => '85674634',
+            'city' => '',
+            'nested' => [
+                'first',
+                'second',
+                'third',
+            ],
+            'zipCode' => '1234',
+        ];
+                    
+        $result = Arr::getFirst();
+        $this->assertEquals($result, []);
+
+        $result = Arr::getFirst($a);
+        $this->assertEquals($result, []);
+
+        $result = Arr::getFirst($a, 'nested');
+        $this->assertEquals($result, [
+            'nested' => [
+                'first',
+                'second',
+                'third',
+            ]
+        ]);
+
+        $result = Arr::getFirst('not-an-array', 'city');
+        $this->assertEquals($result, []);
+
+        $result = Arr::getFirst($a, 'city');
+        $this->assertEquals($result, []);
+
+        $result = Arr::getFirst($a, 'email');
+        $this->assertEquals($result, ['email' => 'john.doe@example.com']);
+
+        $result = Arr::getFirst($a, 'phone', 'mobile');
+        $this->assertEquals($result, ['mobile' => '85674634']);
+
+        $result = Arr::getFirst($a, 'zipCode', 'phone', 'mobile');
+        $this->assertEquals($result, ['zipCode' => '1234']);
+
+        $result = Arr::getFirst($a, 'phone', 'zipCode', 'mobile');
+        $this->assertEquals($result, ['zipCode' => '1234']);
+        
+        $result = Arr::getFirst($a, 'phone',  'mobile', 'zipCode');
+        $this->assertEquals($result, ['mobile' => '85674634']);
+    }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -832,7 +832,7 @@ class SupportArrTest extends TestCase
             ],
             'zipCode' => '1234',
         ];
-                    
+
         $result = Arr::getFirst();
         $this->assertEquals($result, []);
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -865,8 +865,8 @@ class SupportArrTest extends TestCase
 
         $result = Arr::getFirst($a, 'phone', 'zipCode', 'mobile');
         $this->assertEquals($result, ['zipCode' => '1234']);
-        
-        $result = Arr::getFirst($a, 'phone',  'mobile', 'zipCode');
+
+        $result = Arr::getFirst($a, 'phone', 'mobile', 'zipCode');
         $this->assertEquals($result, ['mobile' => '85674634']);
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -845,7 +845,7 @@ class SupportArrTest extends TestCase
                 'first',
                 'second',
                 'third',
-            ]
+            ],
         ]);
 
         $result = Arr::getFirst('not-an-array', 'city');


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In a project i needed to get the values from a array passed down to a function where either value X,Y or Z was set.

```
$a = [
 'email' => '',
 'phone' => '',
 'mobile' => '12345678',
];
```

I wanted to pass this on to some other function in the same class with using the same structure ( 'mobile' => '12345678') not only the value. To both figure out which of the values is set and grab the whole $key => $value structure i created a helper as in this PR.

Also if there is a prioritized order of the values it will pick the first one. Let's say you are identifing a user by email, phone (office, home, etc.) or mobile, but you prefer email, can do it with phone, and it barely is sufficient with mobile, you could easily prioritize it like this and get the one which is set.

```
if ($identifier = Arr::getFirst($array, 'email', 'phone', 'mobile')) {
   // buisness..
}

```

Since this is a new function is does not break any existing projects. It is useful in the use case described above and it probably exists some other similar use case where it also can clean up code and be useful.

I really enjoy working with Laravel, it's a great framework!