### PR TITLE
[5.8] Update docblock for connectionName

### DIFF
--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -48,6 +48,8 @@ abstract class Job
 
     /**
      * The name of the connection the job belongs to.
+     *
+     * @var string
      */
     protected $connectionName;
 


### PR DESCRIPTION
Just a small one - noticed there was no annotation for the base job's connection name.

This matches the variable type with the accessor method's return type.