### PR TITLE
modified error handling in connection.php, if database connection failed it will return a error Database connection Error instead frustrating sql exception page.

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -667,7 +667,7 @@ class Connection implements ConnectionInterface
             /*Check for specific SQL Error Code. in this case 2002 means database connection error return a
               nice error page instead a frustrating exception page ( "nice page" construction needed, I've just passed a string )  */
             if(strpos($exc_r , "SQLSTATE[HY000] [2002]") !== false) {
-                $err ="DB Connection is Missing.";
+                $err ='DB Connection is Missing.';
                 echo $err;
                 die();
             }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -666,7 +666,7 @@ class Connection implements ConnectionInterface
            
             /*Check for specific SQL Error Code. in this case 2002 means database connection error return a
               nice error page instead a frustrating exception page ( "nice page" construction needed, I've just passed a string )  */
-              if (strpos($exc_r, 'SQLSTATE[HY000] [2002]') !== false) {
+            if (strpos($exc_r, 'SQLSTATE[HY000] [2002]') !== false) {
                 $err = 'DB Connection is Missing.';
                 echo $err;
                 die();

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -666,7 +666,7 @@ class Connection implements ConnectionInterface
            
             /*Check for specific SQL Error Code. in this case 2002 means database connection error return a
               nice error page instead a frustrating exception page ( "nice page" construction needed, I've just passed a string )  */
-            if(strpos($exc_r, "SQLSTATE[HY000] [2002]") !== false) {
+              if (strpos($exc_r, 'SQLSTATE[HY000] [2002]') !== false) {
                 $err = 'DB Connection is Missing.';
                 echo $err;
                 die();

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -663,7 +663,6 @@ class Connection implements ConnectionInterface
         catch (Exception $e) {
             $exc = ltrim($e, 'PDOException:');
             $exc_r = strtok($exc, 'No');
-           
             /*Check for specific SQL Error Code. in this case 2002 means database connection error return a
               nice error page instead a frustrating exception page ( "nice page" construction needed, I've just passed a string )  */
             if (strpos($exc_r, 'SQLSTATE[HY000] [2002]') !== false) {

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -661,6 +661,16 @@ class Connection implements ConnectionInterface
         // message to include the bindings with SQL, which will make this exception a
         // lot more helpful to the developer instead of just the database's errors.
         catch (Exception $e) {
+            $exc = ltrim($e, 'PDOException:');
+            $exc_r = strtok($exc, "No");
+           
+            /*Check for specific SQL Error Code. in this case 2002 means database connection error return a
+              nice error page instead a frustrating exception page ( "nice page" construction needed, I've just passed a string )  */
+            if(strpos($exc_r , "SQLSTATE[HY000] [2002]") !== false){
+                $err ="DB Connection is Missing.";
+                echo $err;
+                die();
+            }
             throw new QueryException(
                 $query, $this->prepareBindings($bindings), $e
             );

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -666,8 +666,8 @@ class Connection implements ConnectionInterface
            
             /*Check for specific SQL Error Code. in this case 2002 means database connection error return a
               nice error page instead a frustrating exception page ( "nice page" construction needed, I've just passed a string )  */
-            if(strpos($exc_r , "SQLSTATE[HY000] [2002]") !== false) {
-                $err ='DB Connection is Missing.';
+            if(strpos($exc_r, "SQLSTATE[HY000] [2002]") !== false) {
+                $err = 'DB Connection is Missing.';
                 echo $err;
                 die();
             }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -662,11 +662,11 @@ class Connection implements ConnectionInterface
         // lot more helpful to the developer instead of just the database's errors.
         catch (Exception $e) {
             $exc = ltrim($e, 'PDOException:');
-            $exc_r = strtok($exc, "No");
+            $exc_r = strtok($exc, 'No');
            
             /*Check for specific SQL Error Code. in this case 2002 means database connection error return a
               nice error page instead a frustrating exception page ( "nice page" construction needed, I've just passed a string )  */
-            if(strpos($exc_r , "SQLSTATE[HY000] [2002]") !== false){
+            if(strpos($exc_r , "SQLSTATE[HY000] [2002]") !== false) {
                 $err ="DB Connection is Missing.";
                 echo $err;
                 die();


### PR DESCRIPTION
I think sql exception page is not necessary when you forget to start server's DB.

A nice error page ( like 404 page ) with message "Database connection error. Please try to start/ restart Database connection"  will be fine. 

I've modified runQueryCallback function of connection.php file. just a glimpse of handling the error. Please suggest or edit the code if necessary. I guess it can be handled more efficiently.    take a look. 