### PR TITLE
[5.8] Allow for objects to be passed to json and jsonp in the docblock

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -37,7 +37,7 @@ interface ResponseFactory
     /**
      * Create a new JSON response instance.
      *
-     * @param  string|array  $data
+     * @param  string|array|object  $data
      * @param  int  $status
      * @param  array  $headers
      * @param  int  $options
@@ -49,7 +49,7 @@ interface ResponseFactory
      * Create a new JSONP response instance.
      *
      * @param  string  $callback
-     * @param  string|array  $data
+     * @param  string|array|object  $data
      * @param  int  $status
      * @param  array  $headers
      * @param  int  $options


### PR DESCRIPTION
The doc block for json and jsonp functions in the response factory don't allow for objects to be passed in the content argument, this changes adds them to allow for that.

The code already works with objects, but static analysis tools throw errors.