### PR TITLE
[5.8] Fix collection valueRetriever dockblock

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1854,7 +1854,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get a value retrieving callback.
      *
-     * @param  string  $value
+     * @param  callable|string|null  $value
      * @return callable
      */
     protected function valueRetriever($value)


### PR DESCRIPTION
`\Illuminate\Support\Collection::valueRetriever` method accepts `callable|string|null` rather than only `string`.

For example,

```php
<?php

/**
 * Get the average value of a given key.
 *
 * @param  callable|string|null  $callback
 * @return mixed
 */
public function avg($callback = null)
{
    $callback = $this->valueRetriever($callback);

    $items = $this->map(function ($value) use ($callback) {
        return $callback($value);
    })->filter(function ($value) {
        return !is_null($value);
    });

    if ($count = $items->count()) {
        return $items->sum() / $count;
    }
}
```