### PR TITLE
[5.8] Add foreign to fluent indexes

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -196,7 +196,7 @@ class Blueprint
     protected function addFluentIndexes()
     {
         foreach ($this->columns as $column) {
-            foreach (['primary', 'unique', 'index', 'spatialIndex'] as $index) {
+            foreach (['primary', 'unique', 'index', 'foreign', 'spatialIndex'] as $index) {
                 // If the index has been specified on the given column, but is simply equal
                 // to "true" (boolean), no name has been specified for this index so the
                 // index method can be called without a name and it will generate one.

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Fluent;
  * @method ColumnDefinition spatialIndex() Add a spatial index
  * @method ColumnDefinition storedAs(string $expression) Create a stored generated column (MySQL)
  * @method ColumnDefinition unique() Add a unique index
+ * @method ColumnDefinition foreign() Add a foreign key
  * @method ColumnDefinition unsigned() Set the INTEGER column as UNSIGNED (MySQL)
  * @method ColumnDefinition useCurrent() Set the TIMESTAMP column to use CURRENT_TIMESTAMP as default value
  * @method ColumnDefinition virtualAs(string $expression) Create a virtual generated column (MySQL)

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -99,7 +99,7 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
-     * Suggest a foreign
+     * Suggest a foreign.
      *
      * @param  \Illuminate\Support\Fluent  $command
      * @return void

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema\Grammars;
 
 use RuntimeException;
+use Illuminate\Support\Str;
 use Illuminate\Support\Fluent;
 use Doctrine\DBAL\Schema\TableDiff;
 use Illuminate\Database\Connection;
@@ -72,6 +73,8 @@ abstract class Grammar extends BaseGrammar
             $this->wrap($command->index)
         );
 
+        $this->suggestForeign($command);
+
         // Once we have the initial portion of the SQL statement we will add on the
         // key name, table name, and referenced columns. These will complete the
         // main portion of the SQL statement and this SQL will almost be done.
@@ -93,6 +96,21 @@ abstract class Grammar extends BaseGrammar
         }
 
         return $sql;
+    }
+
+    /**
+     * Suggest a foreign
+     *
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return void
+     */
+    protected function suggestForeign(Fluent $command)
+    {
+        if (count($command->columns) === 1 && is_null($command->on) && is_null($command->references)) {
+            $segments = explode('_', $command->columns[0]);
+            $command->references(array_pop($segments));
+            $command->on(Str::plural(implode('_', $segments)));
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -103,6 +103,8 @@ class SQLiteGrammar extends Grammar
      */
     protected function getForeignKey($foreign)
     {
+        $this->suggestForeign($foreign);
+
         // We need to columnize the columns that the foreign key is being defined for
         // so that it is a properly formatted list. Once we have done this, we can
         // return the foreign key SQL declaration to the calling method for use.

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -372,6 +372,17 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`)', $statements[0]);
     }
 
+    public function testAddingColumnWithForeignKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->integer('user_group_id')->foreign();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertEquals('alter table `users` add `user_group_id` int not null', $statements[0]);
+        $this->assertEquals('alter table `users` add constraint `users_user_group_id_foreign` foreign key (`user_group_id`) references `user_groups` (`id`)', $statements[1]);
+    }
+
     public function testAddingIncrementingID()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -738,6 +738,17 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable not valid', $statements[0]);
     }
 
+    public function testAddingColumnWithForeignKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->integer('user_group_id')->foreign();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertEquals('alter table "users" add column "user_group_id" integer not null', $statements[0]);
+        $this->assertEquals('alter table "users" add constraint "users_user_group_id_foreign" foreign key ("user_group_id") references "user_groups" ("id")', $statements[1]);
+    }
+
     public function testAddingGeometry()
     {
         $blueprint = new Blueprint('geo');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -211,6 +211,18 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('create table "users" ("foo" varchar not null, "order_id" varchar not null, foreign key("order_id") references "orders"("id"), primary key ("foo"))', $statements[0]);
     }
 
+    public function testAddingColumnWithForeignKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->string('foo')->primary();
+        $blueprint->string('order_id')->foreign();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('create table "users" ("foo" varchar not null, "order_id" varchar not null, foreign key("order_id") references "orders"("id"), primary key ("foo"))', $statements[0]);
+    }
+
     public function testAddingUniqueKey()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
Usually I write something like this in my migrations:

```php
Schema::table('users', function (Blueprint $table) {
    $table->unsignedInteger('group_id')->nullable();
    $table->foreign('group_id')->references('id')->on('groups');
});
```

This PR makes it a bit more simpler:

```php
Schema::table('users', function (Blueprint $table) {
    $table->unsignedInteger('group_id')->nullable()->foreign();
});
```