### PR TITLE
[5.8] Update the phpdoc of methods to accept uuid

### DIFF
--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -28,7 +28,7 @@ interface Guard
     /**
      * Get the ID for the currently authenticated user.
      *
-     * @return int|null
+     * @return int|string|null
      */
     public function id();
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2078,7 +2078,7 @@ class Builder
     /**
      * Execute a query for a single record by ID.
      *
-     * @param  int    $id
+     * @param  int|string  $id
      * @param  array  $columns
      * @return mixed|static
      */


### PR DESCRIPTION
When using Uuid as primary key, the PHPStorm and static analysis tools like PHPStan catch the advertise that `auth()->id()` is not a string, but it is when using Uuid.

The find method of Builder also expect only int parameter, but it can be a string when using uuid.

<img width="838" alt="Screen Shot 2019-05-14 at 21 44 18" src="https://user-images.githubusercontent.com/4256471/57741085-6fd3d580-7691-11e9-99c5-7f33e982e2c1.png">