### PR TITLE
[5.8] Support headers with notification mail message

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -134,6 +134,8 @@ class MailChannel
 
         $this->addAttachments($mailMessage, $message);
 
+        $this->addHeaders($mailMessage, $message);
+
         if (! is_null($message->priority)) {
             $mailMessage->setPriority($message->priority);
         }
@@ -223,6 +225,20 @@ class MailChannel
 
         foreach ($message->rawAttachments as $attachment) {
             $mailMessage->attachData($attachment['data'], $attachment['name'], $attachment['options']);
+        }
+    }
+
+    /**
+     * Add the headers to the message.
+     *
+     * @param  \Illuminate\Mail\Message  $mailMessage
+     * @param  \Illuminate\Notifications\Messages\MailMessage  $message
+     * @return void
+     */
+    protected function addHeaders($mailMessage, $message)
+    {
+        foreach ($message->headers as $name => $value) {
+            $mailMessage->getHeaders()->addTextHeader($name, $value);
         }
     }
 }

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -74,6 +74,13 @@ class MailMessage extends SimpleMessage implements Renderable
     public $rawAttachments = [];
 
     /**
+     * The headers for the message.
+     *
+     * @var array
+     */
+    public $headers = [];
+
+    /**
      * Priority level of the message.
      *
      * @var int
@@ -220,6 +227,20 @@ class MailMessage extends SimpleMessage implements Renderable
     public function attachData($data, $name, array $options = [])
     {
         $this->rawAttachments[] = compact('data', 'name', 'options');
+
+        return $this;
+    }
+
+    /**
+     * Set a header for the message.
+     *
+     * @param  string  $name
+     * @param  string  $value
+     * @return $this
+     */
+    public function header($name, $value)
+    {
+        $this->headers[$name] = $value;
 
         return $this;
     }

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -74,4 +74,12 @@ class NotificationMailMessageTest extends TestCase
 
         $this->assertSame([['test@example.com', null], ['test@example.com', 'Test']], $message->replyTo);
     }
+
+    public function testHeaderIsSetCorrectly()
+    {
+        $message = new Mailmessage;
+        $message->header('Name', 'Value');
+
+        $this->assertSame(['Name' => 'Value'], $message->headers);
+    }
 }


### PR DESCRIPTION
This extends the `MailMessage` used when creating basic mail notifications to support adding headers. It looks like this has been discussed before (see `laravel/ideas#475` and in a couple of other places) but there doesn't appear to be a stable solution, apart from creating mailables and returning those instead.

The common use-case for custom email headers is that they can be used for tracking purposes. For example, Mailgun uses headers to help breakdown emails sent for analytics purposes.