### PR TITLE
[5.8] Provide notification callback with Swift message

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -137,6 +137,8 @@ class MailChannel
         if (! is_null($message->priority)) {
             $mailMessage->setPriority($message->priority);
         }
+
+        $this->runCallbacks($mailMessage, $message);
     }
 
     /**
@@ -224,5 +226,21 @@ class MailChannel
         foreach ($message->rawAttachments as $attachment) {
             $mailMessage->attachData($attachment['data'], $attachment['name'], $attachment['options']);
         }
+    }
+
+    /**
+     * Run the callbacks for the message.
+     *
+     * @param  \Illuminate\Mail\Message  $mailMessage
+     * @param  \Illuminate\Notifications\Messages\MailMessage  $message
+     * @return $this
+     */
+    protected function runCallbacks($mailMessage, $message)
+    {
+        foreach ($message->callbacks as $callback) {
+            $callback($mailMessage->getSwiftMessage());
+        }
+
+        return $this;
     }
 }

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -74,6 +74,13 @@ class MailMessage extends SimpleMessage implements Renderable
     public $rawAttachments = [];
 
     /**
+     * The callbacks for the message.
+     *
+     * @var array
+     */
+    public $callbacks = [];
+
+    /**
      * Priority level of the message.
      *
      * @var int
@@ -220,6 +227,19 @@ class MailMessage extends SimpleMessage implements Renderable
     public function attachData($data, $name, array $options = [])
     {
         $this->rawAttachments[] = compact('data', 'name', 'options');
+
+        return $this;
+    }
+
+    /**
+     * Add a callback for the message.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function withSwiftMessage($callback)
+    {
+        $this->callbacks[] = $callback;
 
         return $this;
     }

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -74,4 +74,16 @@ class NotificationMailMessageTest extends TestCase
 
         $this->assertSame([['test@example.com', null], ['test@example.com', 'Test']], $message->replyTo);
     }
+
+    public function testCallbackIsSetCorrectly()
+    {
+        $callback = function () {
+            //
+        };
+
+        $message = new MailMessage;
+        $message->withSwiftMessage($callback);
+
+        $this->assertSame([$callback], $message->callbacks);
+    }
 }


### PR DESCRIPTION
This is an improved approach to #28534 which provides developers direct access to the underlying Swift message before it is fired off. The use-case for the earlier PR was to allow adding headers to the message (for tracking/analytics) but this is a more flexible solution with greater control.

In addition, this approach mimics `withSwiftMessage($callback)` which mailables have, so it should be familiar for people who are already using that for those reasons. As mentioned in the other PR there has been chatter about supporting custom headers for notification mail (laravel/ideas#475) and this provides that functionality.