### PR TITLE
[5.8] MailFake::failures() returns an empty array

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -331,6 +331,6 @@ class MailFake implements Mailer, MailQueue
      */
     public function failures()
     {
-        //
+        return [];
     }
 }


### PR DESCRIPTION
When there is no failures, calling the `failures()` method on the real `Mailer` returns an empty array.
The fake mailer should do the same.

In my application i'm using the `failures()` method this way.
```php
if (in_array($some_email, $mailer->failures())) {
    // Do something
}
```

When running my tests and using the `Mail::fake()` i get this error
`ErrorException : in_array() expects parameter 2 to be array, null given`