### PR TITLE
[5.8] Fix type hint for Illuminate\Filesystem\ FilesystemAdapter#put()

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -174,7 +174,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      * @param  string  $path
      * @param  string|resource  $contents
      * @param  mixed  $options
-     * @return bool
+     * @return bool|string
      */
     public function put($path, $contents, $options = [])
     {


### PR DESCRIPTION
Doc comment in Illuminate\Filesystem\ FilesystemAdapter#put() said return type is `@return bool`.
But, In some cases, This method seems to me that returns the string $path.
This PR changed Doc comment `@return bool` to `@return bool|string`.
I think this PR will help developers understand the method.
