### PR TITLE
[5.8] Fix exception: The filename fallback must only contain ASCII characters.

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -138,7 +138,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     {
         $response = new StreamedResponse;
 
-        $disposition = $response->headers->makeDisposition($disposition, $name ?? basename($path));
+        $disposition = $response->headers->makeDisposition($disposition, $name ?? basename($path), Str::ascii($name));
 
         $response->headers->replace($headers + [
             'Content-Type' => $this->mimeType($path),

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -138,7 +138,8 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     {
         $response = new StreamedResponse;
 
-        $disposition = $response->headers->makeDisposition($disposition, $name ?? basename($path), Str::ascii($name));
+        $target_name = $name ?? basename($path);
+        $disposition = $response->headers->makeDisposition($disposition, $target_name, Str::ascii($target_name));
 
         $response->headers->replace($headers + [
             'Content-Type' => $this->mimeType($path),

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -138,8 +138,8 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     {
         $response = new StreamedResponse;
 
-        $target_name = $name ?? basename($path);
-        $disposition = $response->headers->makeDisposition($disposition, $target_name, Str::ascii($target_name));
+        $targetName = $name ?? basename($path);
+        $disposition = $response->headers->makeDisposition($disposition, $targetName, Str::ascii($targetName));
 
         $response->headers->replace($headers + [
             'Content-Type' => $this->mimeType($path),

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -58,7 +58,7 @@ class FilesystemAdapterTest extends TestCase
         $files = new FilesystemAdapter($this->filesystem);
         $response = $files->download('file.txt', 'пиздюк.txt');
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        // $this->assertEquals('attachment; filename="hello.txt"', $response->headers->get('content-disposition'));
+        $this->assertEquals('attachment; filename=pizdyuk.txt; filename*=utf-8\'\'%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt', $response->headers->get('content-disposition'));
     }
 
     public function testExists()

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -58,6 +58,17 @@ class FilesystemAdapterTest extends TestCase
         $files = new FilesystemAdapter($this->filesystem);
         $response = $files->download('file.txt', 'пиздюк.txt');
         $this->assertInstanceOf(StreamedResponse::class, $response);
+        $this->assertEquals("attachment; filename=pizdyuk.txt; filename*=utf-8''%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt", $response->headers->get('content-disposition'));
+    }
+
+    public function testDownloadNonAsciiEmptyFilename()
+    {
+        setlocale(LC_ALL,'en_US.UTF-8');
+
+        $this->filesystem->write('пиздюк.txt', 'Hello World');
+        $files = new FilesystemAdapter($this->filesystem);
+        $response = $files->download('пиздюк.txt');
+        $this->assertInstanceOf(StreamedResponse::class, $response);
         $this->assertEquals('attachment; filename=pizdyuk.txt; filename*=utf-8\'\'%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt', $response->headers->get('content-disposition'));
     }
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -52,6 +52,15 @@ class FilesystemAdapterTest extends TestCase
         // $this->assertEquals('attachment; filename="hello.txt"', $response->headers->get('content-disposition'));
     }
 
+    public function testDownloadNonAsciiFilename()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+        $files = new FilesystemAdapter($this->filesystem);
+        $response = $files->download('file.txt', 'пиздюк.txt');
+        $this->assertInstanceOf(StreamedResponse::class, $response);
+        // $this->assertEquals('attachment; filename="hello.txt"', $response->headers->get('content-disposition'));
+    }
+
     public function testExists()
     {
         $this->filesystem->write('file.txt', 'Hello World');

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -63,8 +63,6 @@ class FilesystemAdapterTest extends TestCase
 
     public function testDownloadNonAsciiEmptyFilename()
     {
-        setlocale(LC_ALL,'en_US.UTF-8');
-
         $this->filesystem->write('пиздюк.txt', 'Hello World');
         $files = new FilesystemAdapter($this->filesystem);
         $response = $files->download('пиздюк.txt');


### PR DESCRIPTION
Generate and pass `$filenameFallback` param to `\Symfony\Component\HttpFoundation\HeaderUtils::makeDisposition()`.

Problem: downloading files with Cyrillic names does not work. Test complete.
`\Illuminate\Tests\Filesystem\FilesystemAdapterTest::testDownloadNonAsciiFilename()`