### PR TITLE
[5.8] Make validation error message customizable

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -53,7 +53,7 @@ class ValidationException extends Exception
      */
     public function __construct($validator, $response = null, $errorBag = 'default')
     {
-        parent::__construct('The given data was invalid.');
+        parent::__construct($validator->getTranslator()->getFromJson('The given data was invalid.'));
 
         $this->response = $response;
         $this->errorBag = $errorBag;

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -20,6 +20,7 @@ use Illuminate\Config\Repository as Config;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Foundation\Exceptions\Handler;
 use Illuminate\Validation\ValidationException;
+use Illuminate\Contracts\Translation\Translator;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -181,6 +182,9 @@ class FoundationExceptionsHandlerTest extends TestCase
         $request = Request::create('/', 'POST', $argumentExpected, [], ['photo' => $file]);
 
         $validator = m::mock(Validator::class);
+        $translator = m::mock(Translator::class);
+        $translator->shouldReceive('getFromJson')->once()->andReturn('Custom message');
+        $validator->shouldReceive('getTranslator')->once()->andReturn($translator);
         $validator->shouldReceive('errors')->andReturn(new MessageBag(['error' => 'My custom validation exception']));
 
         $validationException = new ValidationException($validator);

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -160,6 +160,9 @@ class FoundationFormRequestTest extends TestCase
     {
         $translator = m::mock(Translator::class)->shouldReceive('trans')
                        ->zeroOrMoreTimes()->andReturn('error')->getMock();
+        $translator->shouldReceive('getFromJson')
+                   ->zeroOrMoreTimes()
+                   ->andReturn('error');
 
         return new ValidationFactory($translator, $container);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Validation errors always return 'The given data was invalid.' in the message field. This can be translated in other language now.
