### PR TITLE
[5.8] Optimize Str::replaceArray()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -331,8 +331,8 @@ class Str
 
         $result = array_shift($segments);
 
-        foreach ($segments as $segment) {
-            $result .= (array_shift($replace) ?? $search).$segment;
+        foreach ($segments as $i => $segment) {
+            $result .= ($replace[$i] ?? $search).$segment;
         }
 
         return $result;


### PR DESCRIPTION
[`array_shift()`](https://www.php.net/manual/en/function.array-shift.php) can be costly as it involves building a new array every time. Of course it worsens with large arrays. The local benchmarks I ran showed a 30% speedup.

Follow-up to #28338.

ping @staudenmeir @laurencei