### PR TITLE
Ignore NetBeans project directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Thumbs.db
 /.idea
 /.vscode
 .phpunit.result.cache
+/nbproject


### PR DESCRIPTION
Other popular IDEs like _VS Code_ and _IDEA_ already have their project directories ignored. So it'd be nice to extend the same treatment to _NetBeans_ as well.