### PR TITLE
[5.8] [WIP] Request::valuesOfPresentKeys()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Thumbs.db
 /.idea
 /.vscode
 .phpunit.result.cache
+/nbproject

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ Thumbs.db
 /.idea
 /.vscode
 .phpunit.result.cache
-/nbproject

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -394,7 +394,7 @@ trait InteractsWithInput
 
         return $presentKeys;
     }
-    
+
     /**
      * Check the list of expected keys, and return the values of the keys that
      * are present in the request.

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -402,7 +402,7 @@ trait InteractsWithInput
      * @param  array  $expectedKeys
      * @return array
      */
-    public function valuesOfPresentKeys(array $expectedKeys): array
+    public function valuesOfPresentKeys(array $expectedKeys)
     {
         $presentKeys = $this->presentKeys($expectedKeys);
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -376,6 +376,27 @@ trait InteractsWithInput
     }
 
     /**
+     * Check the list of expected keys, and return the keys among them that are
+     * present in the request.
+     * 
+     * @param array $expectedKeys
+     */
+    public function presentKeys(array $expectedKeys)
+    {
+        $presentKeys = [];
+
+        foreach ($expectedKeys as $expectedKey) {
+            if($this->has($expectedKey)){
+                $presentKeys[] = $expectedKey;
+            }
+        }
+
+        return $presentKeys;
+    }
+    
+    
+
+    /**
      * Retrieve a parameter item from a given source.
      *
      * @param  string  $source

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -378,7 +378,7 @@ trait InteractsWithInput
     /**
      * Check the list of expected keys, and return the keys among them that are
      * present in the request.
-     * 
+     *
      * @param array $expectedKeys
      * @return array
      */
@@ -387,7 +387,7 @@ trait InteractsWithInput
         $presentKeys = [];
 
         foreach ($expectedKeys as $expectedKey) {
-            if($this->has($expectedKey)){
+            if ($this->has($expectedKey)) {
                 $presentKeys[] = $expectedKey;
             }
         }
@@ -398,14 +398,14 @@ trait InteractsWithInput
     /**
      * Check the list of expected keys, and return the values of the keys that
      * are present in the request.
-     * 
+     *
      * @param array $expectedKeys
      * @return array
      */
     public function valuesOfPresentKeys(array $expectedKeys): array
     {
         $presentKeys = $this->presentKeys($expectedKeys);
-        
+
         return $this->all($presentKeys);
     }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -399,7 +399,7 @@ trait InteractsWithInput
      * Check the list of expected keys, and return the values of the keys that
      * are present in the request.
      *
-     * @param array $expectedKeys
+     * @param  array  $expectedKeys
      * @return array
      */
     public function valuesOfPresentKeys(array $expectedKeys): array

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -380,8 +380,9 @@ trait InteractsWithInput
      * present in the request.
      * 
      * @param array $expectedKeys
+     * @return array
      */
-    public function presentKeys(array $expectedKeys)
+    public function presentKeys(array $expectedKeys): array
     {
         $presentKeys = [];
 
@@ -394,7 +395,19 @@ trait InteractsWithInput
         return $presentKeys;
     }
     
-    
+    /**
+     * Check the list of expected keys, and return the values of the keys that
+     * are present in the request.
+     * 
+     * @param array $expectedKeys
+     * @return array
+     */
+    public function valuesOfPresentKeys(array $expectedKeys): array
+    {
+        $presentKeys = $this->presentKeys($expectedKeys);
+        
+        return $this->all($presentKeys);
+    }
 
     /**
      * Retrieve a parameter item from a given source.

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -379,7 +379,7 @@ trait InteractsWithInput
      * Check the list of expected keys, and return the keys among them that are
      * present in the request.
      *
-     * @param array $expectedKeys
+     * @param  array  $expectedKeys
      * @return array
      */
     public function presentKeys(array $expectedKeys): array

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -382,7 +382,7 @@ trait InteractsWithInput
      * @param  array  $expectedKeys
      * @return array
      */
-    public function presentKeys(array $expectedKeys): array
+    public function presentKeys(array $expectedKeys)
     {
         $presentKeys = [];
 


### PR DESCRIPTION
 - In scenarios like `PATCH`ing a resource via a REST API, incoming `Request` might not always contain all the attributes the resource has.
 - In case like that, doing `Request::all()` returns `null` as the value for attributes that are not present in the `Request`.
 - That makes it hard to discern whether the `Request` had the attribute with the value `null`, or the request did not contain the attribute at all.

To overcome this hardship, I propose `Request::valuesOfPresentKeys()`.

Imagine that the `Request` has attributes as follows:

```php
[
 'key1' => 'value1',
 'key2' => '',
 'key3' => null,
]
```

If we did the following:
```php
$values = $request -> valuesOfPresentKeys([
 'key1',
 'key2',
 'key3',
 'key4', //Observe that this was not present in the `Request`.
])
```

`$value` should be:
```php
[
 'key1' => 'value1',
 'key2' => '',
 'key3' => null,
]
```
Notice that `key4` is dropped because it was not part of the `Request`.