### PR TITLE
[5.8] BusFake::pipeThrough() returns $this

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -127,7 +127,7 @@ class BusFake implements Dispatcher
      */
     public function pipeThrough(array $pipes)
     {
-        //
+        return $this;
     }
 
     /**


### PR DESCRIPTION
The real implementation returns `$this` to allow chaining.
The fake one should do the same to avoid breaking tests when using the fake dispatcher. 