### PR TITLE
[5.8] Add TestResponse::dumpValidationErrors()

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -1031,6 +1031,21 @@ class TestResponse
     }
 
     /**
+     * Dump the validation errors.
+     *
+     * @param string $errorBag
+     */
+    public function dumpValidationErrors($errorBag = 'default')
+    {
+        if ($this->session()->get('errors')) {
+            dd($this->session()->get('errors')->getBag($errorBag)->messages());
+        }
+
+        $json = json_decode($this->getContent(), true);
+        dd($json['errors'] ?? []);
+    }
+
+    /**
      * Get the streamed content from the response.
      *
      * @return string


### PR DESCRIPTION
When writing tests for validation, and especially for complex validation logic, it's useful to see what errors we are getting.
This PR add the `dumpValidationErrors()` method to the `TestResponse` class to allow dumping the validation errors supporting both session and json errors.