### PR TITLE
[5.8] Fix assertJsonMissingValidationErrors() on empty response

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -668,6 +668,12 @@ class TestResponse
      */
     public function assertJsonMissingValidationErrors($keys = null)
     {
+        if (empty($this->getContent())) {
+            PHPUnit::assertTrue(true);
+
+            return $this;
+        }
+
         $json = $this->json();
 
         if (! array_key_exists('errors', $json)) {

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -668,7 +668,7 @@ class TestResponse
      */
     public function assertJsonMissingValidationErrors($keys = null)
     {
-        if (empty($this->getContent())) {
+        if (empty($this->getContent()) && $this->getStatusCode() == 204) {
             PHPUnit::assertTrue(true);
 
             return $this;

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -448,11 +448,18 @@ class FoundationTestResponseTest extends TestCase
 
     public function testAssertJsonMissingValidationErrorsOnAnEmptyResponse()
     {
-        $testResponse = TestResponse::fromBaseResponse(
+        $emptyTestResponse204 = TestResponse::fromBaseResponse(
             (new Response)->setContent('')
         );
+        $emptyTestResponse204->setStatusCode(204);
+        $emptyTestResponse204->assertJsonMissingValidationErrors();
 
-        $testResponse->assertJsonMissingValidationErrors();
+        $this->expectException(AssertionFailedError::class);
+
+        $emptyTestResponseNot204 = TestResponse::fromBaseResponse(
+            (new Response)->setContent('')
+        );
+        $emptyTestResponseNot204->assertJsonMissingValidationErrors();
     }
 
     public function testMacroable()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -446,6 +446,15 @@ class FoundationTestResponseTest extends TestCase
         $testResponse->assertJsonMissingValidationErrors();
     }
 
+    public function testAssertJsonMissingValidationErrorsOnAnEmptyResponse()
+    {
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent('')
+        );
+
+        $testResponse->assertJsonMissingValidationErrors();
+    }
+
     public function testMacroable()
     {
         TestResponse::macro('foo', function () {


### PR DESCRIPTION
I have an endpoint where i update a resource and return a http 204 (no content) if the update was successful.

Calling `->assertJsonMissingValidationErrors('some_field')` to check that there is no errors should pass the test, but i get this error.
`Invalid JSON was returned from the route.`

That is because the `TestResponse::json()` method will throw this error when trying to decode a response that is not a valid json.