### PR TITLE
[5.8] fix container resolveDependencies method

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -848,9 +848,11 @@ class Container implements ArrayAccess, ContainerContract
             // If the class is null, it means the dependency is a string or some other
             // primitive type which we can not resolve since it is not a class and
             // we will just bomb out with an error since we have no-where to go.
-            $results[] = is_null($dependency->getClass())
-                            ? $this->resolvePrimitive($dependency)
-                            : $this->resolveClass($dependency);
+            if (! is_null($dependency->getClass())) {
+                $results[] = $this->resolveClass($dependency);
+            } elseif (! $dependency->isOptional()) {
+                $results[] = $this->resolvePrimitive($dependency);
+            }
         }
 
         return $results;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

some php predefined class constructor parameter is optional and has not default value

but container's resolveDependencies method not support this case.

so currently below code will cause an error.

```
app(\DateTime::class) // Error
app(\ArrayObject::class) //Error
```

ps)
I use laravel cointainer's object resolver instead of php new keyword.
because I use it when testing(mock)
