### PR TITLE
[5.8] Option to configure endpoint for DynamoDB

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -229,6 +229,7 @@ class CacheManager implements FactoryContract
         $dynamoConfig = [
             'region' => $config['region'],
             'version' => 'latest',
+            'endpoint' => $config['endpoint'] ?? null,
         ];
 
         if ($config['key'] && $config['secret']) {

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -82,6 +82,7 @@ class DynamoDbStoreTest extends TestCase
             'secret' => env('AWS_SECRET_ACCESS_KEY'),
             'region' => 'us-east-1',
             'table' => env('DYNAMODB_CACHE_TABLE', 'laravel_test'),
+            'endpoint' => env('DYNAMODB_ENDPOINT'),
         ]);
     }
 }


### PR DESCRIPTION
This commit adds the option to configure the `\Aws\DynamoDb\DynamoDbClient` that is used for cache (and session) when using the `dynamodb` driver.

This is done by passing the `endpoint` property in the config for cache stores.
When passing `null` or not passing the property at all the default AWS endpoint is used.
A config for this could look like this:

```php
'dynamodb' => [
    'driver' => 'dynamodb',
    'key' => env('AWS_KEY'),
    'secret' => env('AWS_SECRET'),
    'region' => env('AWS_DEFAULT_REGION', 'eu-north-1'),
    'table' => env('DYNAMODB_CACHE_TABLE', 'cache'),
    'endpoint' => env('DYNAMODB_ENDPOINT', null),
],
```

The reason for this is to be able to use a [local version of DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) for local development and testing.

This does not break any backward compatibility since its an optional property with defaults built into the AWS SDK.

This solves https://github.com/laravel/ideas/issues/1654