### PR TITLE
[5.8] New helper function to instantiate a new class instance...

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -580,7 +580,7 @@ if (! function_exists('mix')) {
     }
 }
 
-if (! function_exists('newObj')) {
+if (! function_exists('new_obj')) {
     /**
      * Instantiate a new instance of $class, passing $args as constructor input.
      *
@@ -588,7 +588,7 @@ if (! function_exists('newObj')) {
      * @param  mixed $args
      * @return object
      */
-    function newObj($class, ...$args)
+    function new_obj($class, ...$args)
     {
         return new $class(...$args);
     }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -580,6 +580,20 @@ if (! function_exists('mix')) {
     }
 }
 
+if (! function_exists('newObj')) {
+    /**
+     * Instantiate a new instance of $class, passing $args as constructor input.
+     *
+     * @param  string $class
+     * @param  mixed $args
+     * @return object
+     */
+    function newObj($class, ...$args)
+    {
+        return new $class(...$args);
+    }
+}
+
 if (! function_exists('now')) {
     /**
      * Create a new Carbon instance for the current time.


### PR DESCRIPTION
(Edited with updated function name.)

This change adds a simple/basic helper that can serve to clean up some code a bit when dynamically instantiating.

Basically, instead of having two (or more...?) lines for dynamically instantiating an object like this:
```
$class = $this->getClassName();

$obj = new $class($arguments);
```

You can do this:
```
$obj = new_obj($this->getClassName(), $arguments);
```

It doesn't break anything because it's new.  Its value is that there's a bit less code and, many might say, it makes things a bit easier to read.

It would be nice to have a better name than `new_obj`, but I can't think of one that's short and sufficiently clear.  Although, the helpers already include such functions as `__`, `e`, and `dd`.  ;-)

Anyway, I'm looking forward to hearing how to improve this and/or why it doesn't belong in the framework.  Thanks in advance for your contribution(s)...!  :-)