### PR TITLE
[5.8] Add app()->isProduction helper and tests

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -520,6 +520,16 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Determine if application is in production environment.
+     *
+     * @return bool
+     */
+    public function isProduction()
+    {
+        return $this['env'] === 'production';
+    }
+
+    /**
      * Detect the application's current environment.
      *
      * @param  \Closure  $callback

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -189,6 +189,30 @@ class FoundationApplicationTest extends TestCase
         $this->assertFalse($app->environment(['qux', 'bar']));
     }
 
+    public function testEnvironmentHelpers()
+    {
+        $local = new Application;
+        $local['env'] = 'local';
+
+        $this->assertTrue($local->isLocal());
+        $this->assertFalse($local->isProduction());
+        $this->assertFalse($local->runningUnitTests());
+
+        $production = new Application;
+        $production['env'] = 'production';
+
+        $this->assertTrue($production->isProduction());
+        $this->assertFalse($production->isLocal());
+        $this->assertFalse($production->runningUnitTests());
+
+        $testing = new Application;
+        $testing['env'] = 'testing';
+
+        $this->assertTrue($testing->runningUnitTests());
+        $this->assertFalse($testing->isLocal());
+        $this->assertFalse($testing->isProduction());
+    }
+
     public function testMethodAfterLoadingEnvironmentAddsClosure()
     {
         $app = new Application;


### PR DESCRIPTION
This PR adds an `isProduction()` helper to match the `isLocal` and `runningUnitTests` helpers as these are the most common environments in use. 

I also added tests for those three methods.