### PR TITLE
Automatically detect the make:command command option

### DIFF
--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
@@ -40,7 +41,7 @@ class ConsoleMakeCommand extends GeneratorCommand
     {
         $stub = parent::replaceClass($stub, $name);
 
-        return str_replace('dummy:command', $this->option('command'), $stub);
+        return str_replace('dummy:command', $this->option('command') ?? $this->getDefaultCommand($name), $stub);
     }
 
     /**
@@ -65,6 +66,17 @@ class ConsoleMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Get the default terminal command that should be assigned.
+     *
+     * @param  string $name
+     * @return string
+     */
+    protected function getDefaultCommand($name)
+    {
+        return Str::snake(Str::replaceLast('Command', '', class_basename($name)), ':');
+    }
+
+    /**
      * Get the console command arguments.
      *
      * @return array
@@ -84,7 +96,7 @@ class ConsoleMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['command', null, InputOption::VALUE_OPTIONAL, 'The terminal command that should be assigned', 'command:name'],
+            ['command', null, InputOption::VALUE_OPTIONAL, 'The terminal command that should be assigned'],
         ];
     }
 }


### PR DESCRIPTION
This PR updates the `make:command` command to default the `--command` option to the colon separated class name without the `Command` suffix.

It's pretty common for Laravel apps to use the same name for the class and the command `$name`, i.e.

- [`App\Console\Commands\Inspire`](https://github.com/monicahq/monica/blob/c4322e62b681bec348207ed984a2de673828e0e1/app/Console/Commands/Inspire.php) -> `inspire`
- [`App\Console\Commands\ImportCsv`](https://github.com/monicahq/monica/blob/c4322e62b681bec348207ed984a2de673828e0e1/app/Console/Commands/ImportCSV.php) -> `import:csv`

Some developers prefer to use a `Command` suffix on the class, i.e. [`App\Commands\InspiringCommand`](https://github.com/laravel-zero/laravel-zero/blob/71b7ac722937284659f1266a5810b48bb49e228c/app/Commands/InspiringCommand.php) -> `inspiring`.

Currently you have to specify the command option manually like this:

```
php artisan make:command Inspire --command inspire
```

This is pretty tiring if you are making a lot of commands. Since there isn't a default and it's up to the developer to decide on the name it's easy to end up with inconsistent names on larger projects.

This PR changes the `make:command` generator to default the `--command` to the colon separated class name of the command without the `Command` suffix.  For example:

- `SendCommand` -> `send`
- `Send` -> `send`
- `SendEmailCommand` -> `send:email`
- `SendEmail` -> `send:email`
- `SendEmailWelcomeCommand` -> `send:email:welcome`

You can still manually specify the `--command` option if you don't want to use the defaults.

I tried to add a test but there aren't any existing tests for generator commands and it's really difficult to set the test up.