### PR TITLE
[5.8] Add RequiredIfAccepted rule to support implicit validation on another field being 'accepted'

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -361,6 +361,22 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the required_if_accepted rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceRequiredIfAccepted($message, $attribute, $rule, $parameters)
+    {
+        $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
+
+        return str_replace([':other'], $parameters, $message);
+    }
+
+    /**
      * Replace all place-holders for the same rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1340,6 +1340,28 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute exists when another attribute has been accepted (validateAccepted),
+     * this differs to RequiredIf as it supports all the values of the other field being accepted
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  mixed   $parameters
+     * @return bool
+     */
+    public function validateRequiredIfAccepted($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'required_if_accepted');
+
+        $other = Arr::get($this->data, $parameters[0]);
+        $otherAccepted = $this->validateAccepted($parameters[0], $other);
+        if (!$otherAccepted) {
+            return true;
+        }
+
+        return $this->validateRequired($attribute, $value);
+    }
+
+    /**
      * Convert the given values to boolean if they are string "true" / "false".
      *
      * @param  array  $values

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1341,7 +1341,7 @@ trait ValidatesAttributes
 
     /**
      * Validate that an attribute exists when another attribute has been accepted (validateAccepted),
-     * this differs to RequiredIf as it supports all the values of the other field being accepted
+     * this differs to RequiredIf as it supports all the values of the other field being accepted.
      *
      * @param  string  $attribute
      * @param  mixed   $value
@@ -1354,7 +1354,7 @@ trait ValidatesAttributes
 
         $other = Arr::get($this->data, $parameters[0]);
         $otherAccepted = $this->validateAccepted($parameters[0], $other);
-        if (!$otherAccepted) {
+        if (! $otherAccepted) {
             return true;
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -162,8 +162,8 @@ class Validator implements ValidatorContract
      * @var array
      */
     protected $implicitRules = [
-        'Required', 'Filled', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout',
-        'RequiredWithoutAll', 'RequiredIf', 'RequiredUnless', 'Accepted', 'Present',
+        'Required', 'Filled', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
+        'RequiredIf', 'RequiredUnless', 'Accepted', 'Present', 'RequiredIfAccepted',
     ];
 
     /**
@@ -172,9 +172,9 @@ class Validator implements ValidatorContract
      * @var array
      */
     protected $dependentRules = [
-        'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
-        'RequiredIf', 'RequiredUnless', 'Confirmed', 'Same', 'Different', 'Unique',
-        'Before', 'After', 'BeforeOrEqual', 'AfterOrEqual', 'Gt', 'Lt', 'Gte', 'Lte',
+        'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll', 'RequiredIf',
+        'RequiredUnless', 'Confirmed', 'Same', 'Different', 'Unique', 'Before', 'After',
+        'BeforeOrEqual', 'AfterOrEqual', 'Gt', 'Lt', 'Gte', 'Lte', 'RequiredIfAccepted',
     ];
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -989,7 +989,7 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines([
-            'validation.required_if_accepted' => 'The :attribute field is required when :other is accepted.'
+            'validation.required_if_accepted' => 'The :attribute field is required when :other is accepted.',
         ], 'en');
         $v = new Validator($trans, ['checked' => true], ['last' => 'required_if_accepted:checked']);
         $this->assertTrue($v->fails());
@@ -1021,7 +1021,7 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [
-            'checked' => $validChecked
+            'checked' => $validChecked,
         ], ['last' => 'required_if_accepted:checked']);
         $this->assertTrue($v->fails());
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -957,34 +957,6 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('The last field is required unless first is in taylor, sven.', $v->messages()->first('last'));
     }
 
-    public function requiredIfAcceptedNotAcceptedProvider()
-    {
-        return [
-            ['off'],
-            ['no'],
-            ['false'],
-            [false],
-            ['0'],
-            [0],
-        ];
-    }
-
-    public function requiredIfAcceptedAcceptedProvider()
-    {
-        return [
-            ['on'],
-            ['yes'],
-            ['true'],
-            [true],
-            ['1'],
-            [1],
-        ];
-    }
-
-    /**
-     * @dataProvider requiredIfAcceptedAcceptedProvider
-     * @param $validChecked
-     */
     public function testRequiredIfAcceptedReplacesAttributeAndOther()
     {
         $trans = $this->getIlluminateArrayTranslator();
@@ -1009,6 +981,16 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, [
             'checked' => $notAcceptedChecked,
             'last' => 'here',
+        ], ['last' => 'required_if_accepted:checked']);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testRequiredIfAcceptedNotPresent()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [
+            // Not present
+            'last' => null,
         ], ['last' => 'required_if_accepted:checked']);
         $this->assertTrue($v->passes());
     }
@@ -4603,5 +4585,30 @@ class ValidationValidatorTest extends TestCase
         return new Translator(
             new ArrayLoader, 'en'
         );
+    }
+
+    public function requiredIfAcceptedNotAcceptedProvider()
+    {
+        return [
+            ['off'],
+            ['no'],
+            ['false'],
+            [false],
+            ['0'],
+            [0],
+            [null],
+        ];
+    }
+
+    public function requiredIfAcceptedAcceptedProvider()
+    {
+        return [
+            ['on'],
+            ['yes'],
+            ['true'],
+            [true],
+            ['1'],
+            [1],
+        ];
     }
 }


### PR DESCRIPTION
The purpose of this validation rule is to support the use case where you will have a field that is required only if another field is 'accepted' (based on the current Laravel accepted rule).

I've created as a separate validation rule instead of using RequiredIf because I wanted to support all the permutations of an accepted value.

**Example usage:**
E.g with RequiredIf: `required_if:checked,true`, this will make the field under validation required if checked is a boolean true, but not if 1, '1', 'on' or 'yes' (as the accepted validation rule checks for.

Where as `required_if_accepted:checked`, this will make the field under validation required if checked is any of the possible accepted values, but not required if it's not.

**NB:** I didn't create the negative version of this rule as I wanted to run this past first, I'm happy to add the negative if this would be useful for others as it has been for me.