### PR TITLE
[5.8] Added missing docblock from ResponseFactory Interface to Response Facade

### DIFF
--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -6,12 +6,14 @@ use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 
 /**
  * @method static \Illuminate\Http\Response make(string $content = '', int $status = 200, array $headers = [])
+ * @method static \Illuminate\Http\Response noContent($status = 204, array $headers = [])
  * @method static \Illuminate\Http\Response view(string $view, array $data = [], int $status = 200, array $headers = [])
  * @method static \Illuminate\Http\JsonResponse json(string|array $data = [], int $status = 200, array $headers = [], int $options = 0)
  * @method static \Illuminate\Http\JsonResponse jsonp(string $callback, string|array $data = [], int $status = 200, array $headers = [], int $options = 0)
  * @method static \Symfony\Component\HttpFoundation\StreamedResponse stream(\Closure $callback, int $status = 200, array $headers = [])
  * @method static \Symfony\Component\HttpFoundation\StreamedResponse streamDownload(\Closure $callback, string|null $name = null, array $headers = [], string|null $disposition = 'attachment')
  * @method static \Symfony\Component\HttpFoundation\BinaryFileResponse download(\SplFileInfo|string $file, string|null $name = null, array $headers = [], string|null $disposition = 'attachment')
+ * @method static \Symfony\Component\HttpFoundation\BinaryFileResponse file($file, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse redirectTo(string $path, int $status = 302, array $headers = [], bool|null $secure = null)
  * @method static \Illuminate\Http\RedirectResponse redirectToRoute(string $route, array $parameters = [], int $status = 302, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse redirectToAction(string $action, array $parameters = [], int $status = 302, array $headers = [])


### PR DESCRIPTION
The `Response` Facade docblock list almost all the `ResponseFactory` Interface methods in its docblock, which is very useful for IDE auto-completion.

Currently the `noContent` and `file` methods were missing. This PR adds those missing methods to the `Response` Facade docblock

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
