### PR TITLE
get intended redirect before regenerating session

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -10,6 +10,8 @@ trait AuthenticatesUsers
 {
     use RedirectsUsers, ThrottlesLogins;
 
+    protected $intended_redirect = null;
+
     /**
      * Show the application's login form.
      *
@@ -102,12 +104,14 @@ trait AuthenticatesUsers
      */
     protected function sendLoginResponse(Request $request)
     {
+        $this->intended_redirect = redirect()->intended($this->redirectPath());
+
         $request->session()->regenerate();
 
         $this->clearLoginAttempts($request);
 
         return $this->authenticated($request, $this->guard()->user())
-                ?: redirect()->intended($this->redirectPath());
+                ?: $this->intended_redirect;
     }
 
     /**


### PR DESCRIPTION
In the `Illuminate\Foundation\Auth\AuthenticatesUsers` trait:

`protected function sendLoginResponse(Request $request)` 

The `redirect()->intended()` method needs to be called and stored as a variable before regenerating the session id to get the initial intended route before the middleware blocked it. Otherwise it always defaults to the `redirectPath` value. 

Making use of a class property vs. a local function variable just in case others would still like to check what that previous route was.

Troubleshooting used logs to check before and after the session regenerate call always returned the blocked route first, and then it reset itself after the regenerate call was made, resulting in never getting the true intended route at the bottom of the function.

```
/// before the regeneration we pull the variable
$this->intended_redirect = redirect()->intended($this->redirectPath());

// this always returned the 'blocked route'
\Log::info("session id BEFORE regenerate {$request->session()->getId()} - {$this->intended_redirect->getTargetUrl()}");

// regenerating the session
$request->session()->regenerate();

// log the same behavior after regeneration
$this->intended_redirect = redirect()->intended($this->redirectPath());

// this always returned the result from "redirectPath"
\Log::info("session id AFTER regenerate {$request->session()->getId()} - {$this->intended_redirect->getTargetUrl()}");

```

Was this the intended functionality of the framework for a reason that I'm not understanding? If so, just close this out and we can always document this as a typical use case for class extension.
