### PR TITLE
[5.8] Support macros of grammars

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -123,7 +123,8 @@ class Blueprint
                 if (! is_null($sql = $grammar->$method($this, $command, $connection))) {
                     $statements = array_merge($statements, (array) $sql);
                 }
-            } catch (BadMethodCallException $e) {}
+            } catch (BadMethodCallException $e) {
+            }
         }
 
         return $statements;

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -119,11 +119,11 @@ class Blueprint
         foreach ($this->commands as $command) {
             $method = 'compile'.ucfirst($command->name);
 
-            if (method_exists($grammar, $method)) {
+            try {
                 if (! is_null($sql = $grammar->$method($this, $command, $connection))) {
                     $statements = array_merge($statements, (array) $sql);
                 }
-            }
+            } catch (BadMethodCallException $e) {}
         }
 
         return $statements;


### PR DESCRIPTION
In Blueprint `method_exists` is used. It cant find magic methods declared via macros. So if we will use "try catch", we can get around this. In most cases exception will not be thrown.
