### PR TITLE
[5.8] Arr::flatten performance

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -213,10 +213,14 @@ class Arr
 
             if (! is_array($item)) {
                 $result[] = $item;
-            } elseif ($depth === 1) {
-                $result = array_merge($result, array_values($item));
             } else {
-                $result = array_merge($result, static::flatten($item, $depth - 1));
+                $values = $depth === 1
+                    ? array_values($item)
+                    : static::flatten($item, $depth - 1);
+
+                foreach ($values as $value) {
+                    $result[] = $value;
+                }
             }
         }
 


### PR DESCRIPTION
MacBook Pro (2017), i5, 16 GB

**Before**: 1.92s
**After**: 6.5ms
```php
$arr = [];
for ($i = 0; $i < 20000; $i++) {
    $arr[] = ['test'];
}
Arr::flatten($arr);
```

**Before**: 6.33s
**After**: 87ms
```php
$arr = [];
for ($i = 0; $i < 20000; $i++) {
    $arr[] = ['name' => 'John', 'email' => 'john@me.com'];
}
app('db')->table('users')->insert($arr);
```

**Before**: 5.7s
**After**: 88.93ms
```php
$arr = [];
for ($i = 0; $i < 20000; $i++) {
    $arr[] = ['name' => 'John', 'email' => 'john@me.com'];;
}
User::insert($arr);
```