### PR TITLE
[5.8] Allow rescued exception reporting to be disabled

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -703,14 +703,17 @@ if (! function_exists('rescue')) {
      *
      * @param  callable  $callback
      * @param  mixed  $rescue
+     * @param  bool  $report
      * @return mixed
      */
-    function rescue(callable $callback, $rescue = null)
+    function rescue(callable $callback, $rescue = null, $report = true)
     {
         try {
             return $callback();
         } catch (Throwable $e) {
-            report($e);
+            if ($report) {
+                report($e);
+            }
 
             return value($rescue);
         }


### PR DESCRIPTION
The `rescue` helper is definitely one of my favorites and use it a lot for parsing of request query values like dates for example. It's just quite annoying that the exceptions get reported even if I don't care about them at that specific location in my application logic. 

I know that I can ignore the exception class in the handler, but sometimes the thrown exception still makes sense at other places.

This PR adds an optional boolean to the helper to allow exceptions to be just ignored instead of reporting them by default.