### PR TITLE
[5.8] Maintain default db connection on migrate call with db flag

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -168,6 +168,8 @@ class Migrator
             }
         }
 
+        $this->restoreDefaultConnection();
+
         $this->fireMigrationEvent(new MigrationsEnded);
     }
 
@@ -279,6 +281,8 @@ class Migrator
                 $options['pretend'] ?? false
             );
         }
+
+	    $this->restoreDefaultConnection();
 
         $this->fireMigrationEvent(new MigrationsEnded);
 
@@ -545,6 +549,18 @@ class Migrator
     {
         return $this->resolver->connection($connection ?: $this->connection);
     }
+
+	/**
+	 * Restore connection to default instance from .env file.
+	 *
+	 * @return void
+	 */
+	public function restoreDefaultConnection()
+	{
+		if ($defaultConnection = env('DB_CONNECTION')) {
+			$this->resolver->setDefaultConnection($defaultConnection);
+		}
+	}
 
     /**
      * Get the schema grammar out of a migration connection.

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -282,7 +282,7 @@ class Migrator
             );
         }
 
-	    $this->restoreDefaultConnection();
+        $this->restoreDefaultConnection();
 
         $this->fireMigrationEvent(new MigrationsEnded);
 
@@ -550,17 +550,17 @@ class Migrator
         return $this->resolver->connection($connection ?: $this->connection);
     }
 
-	/**
-	 * Restore connection to default instance from .env file.
-	 *
-	 * @return void
-	 */
-	public function restoreDefaultConnection()
-	{
-		if ($defaultConnection = env('DB_CONNECTION')) {
-			$this->resolver->setDefaultConnection($defaultConnection);
-		}
-	}
+    /**
+     * Restore connection to default instance from .env file.
+     *
+     * @return void
+     */
+    protected function restoreDefaultConnection()
+    {
+        if ($defaultConnection = env('DB_CONNECTION')) {
+            $this->resolver->setDefaultConnection($defaultConnection);
+        }
+    }
 
     /**
      * Get the schema grammar out of a migration connection.


### PR DESCRIPTION
This pull request attempts to address issue https://github.com/laravel/framework/issues/28253. The main problem is quoted below from this issue:

> The problem is that when Artisan is running any database related commands, it sets the option passed with'--database' flag as the framework's default connection. I guess that it was not meant to call such artisan commands somewhere in between while the framework is processing the request (like in my case).

To remedy this, the PR creates a new `restoreDefaultConnection` method. If the `DB_CONNECTION` is set in the `.env` file, it resets the default connection to this instance after a migration is completed.

All of the tests in the automated test suite passed, except the ones that were skipped, console output below:

```
OK, but incomplete, skipped, or risky tests!
Tests: 4093, Assertions: 9492, Skipped: 87.
```

**P.S.** Not sure if it is appropriate to use the `env` helper in this case. If this is considered a bad practice, I apologize.  

