### PR TITLE
[5.8] - Use Name of Factory as Model

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -46,11 +46,18 @@ class FactoryMakeCommand extends GeneratorCommand
      */
     protected function buildClass($name)
     {
-        $namespaceModel = $this->option('model')
-                        ? $this->qualifyClass($this->option('model'))
-                        : trim($this->rootNamespace(), '\\').'\\Model';
+        $model = class_basename($this->option('model') ?? $name);
 
-        $model = class_basename($namespaceModel);
+        foreach(['factory', 'Factory'] as $name) {
+            if (strpos($model, $name)) {
+                $model = substr($model, 0,strpos($model, $name));
+                break;
+            }
+        }
+
+        $namespaceModel = ! $this->option('model')
+                ? trim($this->rootNamespace(), '\\').'\\'. $model
+                : $this->qualifyClass($this->option('model'));
 
         return str_replace(
             [

--- a/tests/Console/Factory/FactoryMakeCommandTest.php
+++ b/tests/Console/Factory/FactoryMakeCommandTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Illuminate\Tests\Console\Factory;
+
+use Illuminate\Database\Console\Factories\FactoryMakeCommand;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Input\ArrayInput;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Foundation\Application as LaravelApplication;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class FactoryMakeCommandTest extends TestCase
+{
+    protected $filesystem;
+
+    public function setUp() :void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem;
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+
+        $this->filesystem->deleteDirectory(__DIR__."/database");
+    }
+
+    /** @test */
+    public function it_is_giving_a_default_model_name_from_the_factory_name()
+    {
+        $command = $this->setupEnvironment();
+
+        $name = 'UserFactory';
+
+        $this->runCommand($command, ['name' => $name]);
+
+        $slug = $this->filesystem->get(__DIR__."/database/factories/{$name}.php");
+
+        $this->assertTrue(!! strpos($slug,'User::class'));
+        $this->assertTrue(!! strpos($slug,'App\\Models\\User'));
+    }
+
+    /** @test */
+    public function it_is_giving_the_specified_model_name()
+    {
+        $command = $this->setupEnvironment();
+
+        $name = 'UserFactory';
+
+        $this->runCommand($command, ['name' => $name, '--model' => 'ModelName']);
+
+        $slug = $this->filesystem->get(__DIR__."/database/factories/{$name}.php");
+
+        $this->assertFalse(!! strpos($slug,'User::class'));
+        $this->assertFalse(!! strpos($slug,'UserFactory::class'));
+
+        $this->assertTrue(!! strpos($slug,'ModelName::class'));
+        $this->assertTrue(!! strpos($slug,'App\\Models\\ModelName'));
+    }
+
+    /** @test */
+    public function it_is_giving_same_name_when_name_is_Factory_uppercase()
+    {
+        $command = $this->setupEnvironment();
+
+        $name = 'Factory';
+
+        $this->runCommand($command, ['name' => $name]);
+
+        $slug = $this->filesystem->get(__DIR__."/database/factories/{$name}.php");
+
+        $this->assertTrue(!! strpos($slug,'Factory::class'));
+        $this->assertTrue(!! strpos($slug,'App\\Models\\Factory'));
+    }
+
+    /** @test */
+    public function it_is_giving_same_name_when_factory_name_is_factory_lowercase()
+    {
+        $command = $this->setupEnvironment();
+
+        $name = 'factory';
+
+        $this->runCommand($command, ['name' => $name]);
+
+        $slug = $this->filesystem->get(__DIR__."/database/factories/{$name}.php");
+
+        $this->assertTrue(!! strpos($slug,'factory::class'));
+        $this->assertTrue(!! strpos($slug,'App\\Models\\factory'));
+    }
+
+    protected function setupEnvironment() {
+        $command = new FactoryMakeCommand($this->filesystem);
+
+        $app = new Application;
+
+        app()->singleton('config', function () {
+            return new Config([
+                'auth' => [
+                    'defaults' => ['guard' => 'default'],
+                    'guards' => [
+                        'default' => ['driver' => 'default'],
+                        'secondary' => ['driver' => 'secondary'],
+                    ],
+                ],
+            ]);
+        });
+
+        $app->basePath(__DIR__);
+
+        $app->useDatabasePath(__DIR__.'/database');
+
+        $command->setLaravel($app);
+
+        return $command;
+    }
+
+    protected function runCommand($command, $input = [])
+    {
+        return $command->run(new ArrayInput($input), new NullOutput);
+    }
+}
+
+class Application extends LaravelApplication {
+    public function getNamespace()
+    {
+        return 'App\\Models\\';
+    }
+}
+


### PR DESCRIPTION
Use the name of factory as the model if --model is not specified

```php artisan make:factory UserFactory```

the Model will be `User`