### PR TITLE
[5.8] Fix event:list command

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -48,7 +48,7 @@ class EventListCommand extends Command
         $events = [];
 
         foreach ($this->laravel->getProviders(EventServiceProvider::class) as $provider) {
-            $providerEvents = array_merge($provider->discoverEvents(), $provider->listens());
+            $providerEvents = array_merge_recursive($provider->discoverEvents(), $provider->listens());
 
             $events = array_merge_recursive($events, $providerEvents);
         }


### PR DESCRIPTION
When using a combination of manually registering events in the `EventServiceProvider` and event auto discovery, the output of `php artisan event:list` can be unexpected.

*Example*
If I have two listeners in the `app/Listeners` directory for the `VoteWasCast` event (e.g. `StoreVote` and `SendVote`), but I only have one of those manually registered in the `EventServiceProvider` as below, I would still expect both to be included in the output of `php artisan event:list`. 

```
class EventServiceProvider extends ServiceProvider
{
    protected $listen = [
        VoteWasCast::class => [
            StoreVote::class,
        ]
    ];
}
```

However, below is the output I get:

![Screenshot 2019-05-27 at 09 49 31](https://user-images.githubusercontent.com/3438564/58407978-c7e0e380-8064-11e9-873b-12284c679fa8.png)

This PR provides the following output which is in line with what I would expect.

![Screenshot 2019-05-27 at 09 51 01](https://user-images.githubusercontent.com/3438564/58408057-f494fb00-8064-11e9-894c-96e50ecc0fce.png)
