### PR TITLE
[5.8] Improved retry command to handle queue specific retries with limit an…

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -66,7 +66,6 @@ class RetryCommand extends Command
         if (count($ids) === 1 && $ids[0] === 'all') {
             $query = $this->laravel['queue.failer2']->getQuery()->orderBy('id', 'desc');
 
-
             if ($limit != 0)
                 $query = $query->limit($limit);
 
@@ -77,7 +76,6 @@ class RetryCommand extends Command
                 $query= $query->where('queue', $queue);
 
             $query = $query->orderBy('id', $order);
-
 
             $data = $query->get('id');
 

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -120,7 +120,8 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
      *
      * @return \Illuminate\Database\Query\Builder
      */
-    public function getQuery() {
+    public function getQuery()
+    {
         return $this->getTable();
     }
 }

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -114,4 +114,13 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
     {
         return $this->resolver->connection($this->database)->table($this->table);
     }
+
+    /**
+     * Get a new query builder instance for the table.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function getQuery() {
+        return $this->getTable();
+    }
 }

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -5,7 +5,7 @@ namespace Illuminate\Queue\Failed;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Database\ConnectionResolverInterface;
 
-class DatabaseFailedJobProvider implements FailedJobProviderInterface
+class DatabaseFailedJobProvider implements QueryableFailedJobProviderInterface
 {
     /**
      * The connection resolver implementation.

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -44,11 +44,4 @@ interface FailedJobProviderInterface
      * @return void
      */
     public function flush();
-
-    /**
-     * Get a new query builder instance for the table.
-     *
-     * @return \Illuminate\Database\Query\Builder
-     */
-    public function getQuery();
 }

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -44,4 +44,11 @@ interface FailedJobProviderInterface
      * @return void
      */
     public function flush();
+
+    /**
+     * Get a new query builder instance for the table.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function getQuery();
 }

--- a/src/Illuminate/Queue/Failed/QueryableFailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/QueryableFailedJobProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Queue\Failed;
+
+interface QueryableFailedJobProviderInterface extends FailedJobProviderInterface
+{
+    /**
+     * Get a new query builder instance for the table.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function getQuery();
+}


### PR DESCRIPTION
Programs with heavy usages of queues may suffer from retrying jobs since retry command has only two options of retrying a job by its id, and retrying all jobs.
In this commit, changes are made to retry command to let the user retry jobs of a specific queue, with limit and offset options.