### PR TITLE
[5.8] Use Name of Factory as Model

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Database\Console\Factories;
 
-use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputOption;
 
 class FactoryMakeCommand extends GeneratorCommand

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -51,7 +51,7 @@ class FactoryMakeCommand extends GeneratorCommand
 
         foreach (['factory', 'Factory'] as $name) {
             if (Str::endsWith($model, $name) && strpos($model, $name)) {
-                $model = substr($model, 0, 4);
+                $model = substr($model, 0, -7);
                 break;
             }
         }

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -46,11 +46,18 @@ class FactoryMakeCommand extends GeneratorCommand
      */
     protected function buildClass($name)
     {
-        $namespaceModel = $this->option('model')
-                        ? $this->qualifyClass($this->option('model'))
-                        : trim($this->rootNamespace(), '\\').'\\Model';
+        $model = class_basename($this->option('model') ?? $name);
 
-        $model = class_basename($namespaceModel);
+        foreach (['factory', 'Factory'] as $name) {
+            if (strpos($model, $name)) {
+                $model = substr($model, 0, strpos($model, $name));
+                break;
+            }
+        }
+
+        $namespaceModel = ! $this->option('model')
+                ? trim($this->rootNamespace(), '\\').'\\'.$model
+                : $this->qualifyClass($this->option('model'));
 
         return str_replace(
             [

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Console\Factories;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
 
 class FactoryMakeCommand extends GeneratorCommand
@@ -49,8 +50,8 @@ class FactoryMakeCommand extends GeneratorCommand
         $model = class_basename($this->option('model') ?? $name);
 
         foreach (['factory', 'Factory'] as $name) {
-            if (strpos($model, $name)) {
-                $model = substr($model, 0, strpos($model, $name));
+            if (Str::endsWith($model, $name) && strpos($model, $name)) {
+                $model = substr($model, 0, 4);
                 break;
             }
         }

--- a/tests/Console/Factory/FactoryMakeCommandTest.php
+++ b/tests/Console/Factory/FactoryMakeCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Console\Factory;
 
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Config\Repository as Config;
@@ -24,8 +23,6 @@ class FactoryMakeCommandTest extends TestCase
 
     protected function tearDown(): void
     {
-        m::close();
-
         $this->filesystem->deleteDirectory(__DIR__.'/database');
     }
 

--- a/tests/Console/Factory/FactoryMakeCommandTest.php
+++ b/tests/Console/Factory/FactoryMakeCommandTest.php
@@ -92,6 +92,36 @@ class FactoryMakeCommandTest extends TestCase
         $this->assertTrue((bool) strpos($slug, 'App\\Models\\factory'));
     }
 
+    /** @test */
+    public function it_has_factory_lowercase_on_the_middle_of_the_name()
+    {
+        $command = $this->setupEnvironment();
+
+        $name = 'UserfactoryExample';
+
+        $this->runCommand($command, ['name' => $name]);
+
+        $slug = $this->filesystem->get(__DIR__."/database/factories/{$name}.php");
+
+        $this->assertTrue((bool) strpos($slug, 'UserfactoryExample::class'));
+        $this->assertTrue((bool) strpos($slug, 'App\\Models\\UserfactoryExample'));
+    }
+
+    /** @test */
+    public function it_has_Factory_uppercase_on_the_middle_of_the_name()
+    {
+        $command = $this->setupEnvironment();
+
+        $name = 'UserFactoryExample';
+
+        $this->runCommand($command, ['name' => $name]);
+
+        $slug = $this->filesystem->get(__DIR__."/database/factories/{$name}.php");
+
+        $this->assertTrue((bool) strpos($slug, 'UserFactoryExample::class'));
+        $this->assertTrue((bool) strpos($slug, 'App\\Models\\UserFactoryExample'));
+    }
+
     protected function setupEnvironment()
     {
         $command = new FactoryMakeCommand($this->filesystem);

--- a/tests/Console/Factory/FactoryMakeCommandTest.php
+++ b/tests/Console/Factory/FactoryMakeCommandTest.php
@@ -93,7 +93,7 @@ class FactoryMakeCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_has_factory_lowercase_on_the_middle_of_the_name()
+    public function it_has_factory_lowercase_in_the_middle_of_the_name()
     {
         $command = $this->setupEnvironment();
 
@@ -108,7 +108,7 @@ class FactoryMakeCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_has_Factory_uppercase_on_the_middle_of_the_name()
+    public function it_has_Factory_uppercase_in_the_middle_of_the_name()
     {
         $command = $this->setupEnvironment();
 

--- a/tests/Console/Factory/FactoryMakeCommandTest.php
+++ b/tests/Console/Factory/FactoryMakeCommandTest.php
@@ -42,7 +42,7 @@ class FactoryMakeCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_is_giving_a_default_model_name_from_the_factory_name_long_carachter()
+    public function it_is_giving_a_default_model_name_from_the_factory_name_long_character()
     {
         $command = $this->setupEnvironment();
 

--- a/tests/Console/Factory/FactoryMakeCommandTest.php
+++ b/tests/Console/Factory/FactoryMakeCommandTest.php
@@ -42,6 +42,21 @@ class FactoryMakeCommandTest extends TestCase
     }
 
     /** @test */
+    public function it_is_giving_a_default_model_name_from_the_factory_name_long_carachter()
+    {
+        $command = $this->setupEnvironment();
+
+        $name = 'UserExampleModelFactory';
+
+        $this->runCommand($command, ['name' => $name]);
+
+        $slug = $this->filesystem->get(__DIR__."/database/factories/{$name}.php");
+
+        $this->assertTrue((bool) strpos($slug, 'UserExampleModel::class'));
+        $this->assertTrue((bool) strpos($slug, 'App\\Models\\UserExampleModel'));
+    }
+
+    /** @test */
     public function it_is_giving_the_specified_model_name()
     {
         $command = $this->setupEnvironment();

--- a/tests/Console/Factory/FactoryMakeCommandTest.php
+++ b/tests/Console/Factory/FactoryMakeCommandTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Illuminate\Tests\Console\Factory;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Config\Repository as Config;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Illuminate\Foundation\Application as LaravelApplication;
+use Illuminate\Database\Console\Factories\FactoryMakeCommand;
+
+class FactoryMakeCommandTest extends TestCase
+{
+    protected $filesystem;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem;
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+
+        $this->filesystem->deleteDirectory(__DIR__.'/database');
+    }
+
+    /** @test */
+    public function it_is_giving_a_default_model_name_from_the_factory_name()
+    {
+        $command = $this->setupEnvironment();
+
+        $name = 'UserFactory';
+
+        $this->runCommand($command, ['name' => $name]);
+
+        $slug = $this->filesystem->get(__DIR__."/database/factories/{$name}.php");
+
+        $this->assertTrue((bool) strpos($slug, 'User::class'));
+        $this->assertTrue((bool) strpos($slug, 'App\\Models\\User'));
+    }
+
+    /** @test */
+    public function it_is_giving_the_specified_model_name()
+    {
+        $command = $this->setupEnvironment();
+
+        $name = 'UserFactory';
+
+        $this->runCommand($command, ['name' => $name, '--model' => 'ModelName']);
+
+        $slug = $this->filesystem->get(__DIR__."/database/factories/{$name}.php");
+
+        $this->assertFalse((bool) strpos($slug, 'User::class'));
+        $this->assertFalse((bool) strpos($slug, 'UserFactory::class'));
+
+        $this->assertTrue((bool) strpos($slug, 'ModelName::class'));
+        $this->assertTrue((bool) strpos($slug, 'App\\Models\\ModelName'));
+    }
+
+    /** @test */
+    public function it_is_giving_same_name_when_name_is_Factory_uppercase()
+    {
+        $command = $this->setupEnvironment();
+
+        $name = 'Factory';
+
+        $this->runCommand($command, ['name' => $name]);
+
+        $slug = $this->filesystem->get(__DIR__."/database/factories/{$name}.php");
+
+        $this->assertTrue((bool) strpos($slug, 'Factory::class'));
+        $this->assertTrue((bool) strpos($slug, 'App\\Models\\Factory'));
+    }
+
+    /** @test */
+    public function it_is_giving_same_name_when_factory_name_is_factory_lowercase()
+    {
+        $command = $this->setupEnvironment();
+
+        $name = 'factory';
+
+        $this->runCommand($command, ['name' => $name]);
+
+        $slug = $this->filesystem->get(__DIR__."/database/factories/{$name}.php");
+
+        $this->assertTrue((bool) strpos($slug, 'factory::class'));
+        $this->assertTrue((bool) strpos($slug, 'App\\Models\\factory'));
+    }
+
+    protected function setupEnvironment()
+    {
+        $command = new FactoryMakeCommand($this->filesystem);
+
+        $app = new Application;
+
+        app()->singleton('config', function () {
+            return new Config([
+                'auth' => [
+                    'defaults' => ['guard' => 'default'],
+                    'guards' => [
+                        'default' => ['driver' => 'default'],
+                        'secondary' => ['driver' => 'secondary'],
+                    ],
+                ],
+            ]);
+        });
+
+        $app->basePath(__DIR__);
+
+        $app->useDatabasePath(__DIR__.'/database');
+
+        $command->setLaravel($app);
+
+        return $command;
+    }
+
+    protected function runCommand($command, $input = [])
+    {
+        return $command->run(new ArrayInput($input), new NullOutput);
+    }
+}
+
+class Application extends LaravelApplication
+{
+    public function getNamespace()
+    {
+        return 'App\\Models\\';
+    }
+}


### PR DESCRIPTION
Use the name of factory as the model if --model is not specified

```php artisan make:factory UserFactory```

the Model will be `User`

