### PR TITLE
[5.8] Update URL facade documentation to comply with UrlGenerator

### DIFF
--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -12,9 +12,9 @@ namespace Illuminate\Support\Facades;
  * @method static string route(string $name, $parameters = [], bool $absolute = true)
  * @method static string action(string $action, $parameters = [], bool $absolute = true)
  * @method static \Illuminate\Contracts\Routing\UrlGenerator setRootControllerNamespace(string $rootNamespace)
- * @method static string signedRoute(string $name, array $parameters = [], \DateTimeInterface|\DateInterval|int $expiration = null)
- * @method static string temporarySignedRoute(string $name, \DateTimeInterface|\DateInterval|int $expiration, array $parameters = [])
- * @method static string hasValidSignature(\Illuminate\Http\Request $request, bool $absolute)
+ * @method static string signedRoute(string $name, array $parameters = [], \DateTimeInterface|\DateInterval|int $expiration = null, bool $absolute = true)
+ * @method static string temporarySignedRoute(string $name, \DateTimeInterface|\DateInterval|int $expiration, array $parameters = [], bool $absolute = true)
+ * @method static string hasValidSignature(\Illuminate\Http\Request $request, bool $absolute = true)
  * @method static void defaults(array $defaults)
  *
  * @see \Illuminate\Routing\UrlGenerator


### PR DESCRIPTION
The documentation of `URL` facade was not up to date with `UrlGenerator`.

This pull-request just update it.