### PR TITLE
[5.8] Improved queue:retry command with filters

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -15,8 +15,8 @@ class RetryCommand extends Command
      */
     protected $signature = 'queue:retry 
         {id* : The ID of the failed job or "all" to retry all jobs}
-        {--limit=0 : The number of jobs to retry}
-        {--offset=0 : Offset}
+        {--limit= : The number of jobs to retry}
+        {--offset= : Offset}
         {--queue= : The name of the queue to retry}
         {--connection= : The name of the connection}
         {--order=asc : Order of jobs to execute}';
@@ -57,11 +57,11 @@ class RetryCommand extends Command
      */
     protected function getJobIds()
     {
+        $connection = $this->option('connection');
+        $queue = $this->option('queue');
+        $order = $this->option('order');
         $limit = $this->option('limit');
         $offset = $this->option('offset');
-        $queue = $this->option('queue');
-        $connection = $this->option('connection');
-        $order = $this->option('order');
 
         $ids = (array) $this->argument('id');
 
@@ -69,26 +69,7 @@ class RetryCommand extends Command
             $provider = $this->laravel['queue.failer'];
 
             if ($provider instanceof QueryableFailedJobProviderInterface) {
-                $query = $provider->getQuery()->orderBy('id', 'desc');
-
-                if ($limit != 0) {
-                    $query = $query->limit($limit);
-                }
-
-                if ($offset != 0) {
-                    $query = $query->offset($offset);
-                }
-
-                if ($queue) {
-                    $query = $query->where('queue', $queue);
-                }
-
-                if ($connection) {
-                    $query = $query->where('connection', $connection);
-                }
-
-                $query = $query->orderBy('id', $order);
-                $ids = $query->pluck('id');
+                $ids = $provider->getJobIds($connection, $queue, $order, $limit, $offset);
             } else {
                 $ids = Arr::pluck($provider->all(), 'id');
             }

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Queue\Console;
 
-use Illuminate\Queue\Failed\QueryableFailedJobProviderInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Console\Command;
+use Illuminate\Queue\Failed\QueryableFailedJobProviderInterface;
 
 class RetryCommand extends Command
 {
@@ -71,17 +71,21 @@ class RetryCommand extends Command
             if ($provider instanceof QueryableFailedJobProviderInterface) {
                 $query = $provider->getQuery()->orderBy('id', 'desc');
 
-                if ($limit != 0)
+                if ($limit != 0) {
                     $query = $query->limit($limit);
+                }
 
-                if ($offset != 0)
+                if ($offset != 0) {
                     $query = $query->offset($offset);
+                }
 
-                if ($queue)
+                if ($queue) {
                     $query = $query->where('queue', $queue);
+                }
 
-                if ($connection)
+                if ($connection) {
                     $query = $query->where('connection', $connection);
+                }
 
                 $query = $query->orderBy('id', $order);
                 $ids = $query->pluck('id');

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -66,7 +66,6 @@ class RetryCommand extends Command
         if (count($ids) === 1 && $ids[0] === 'all') {
             $query = $this->laravel['queue.failer2']->getQuery()->orderBy('id', 'desc');
 
-
             if ($limit != 0)
                 $query = $query->limit($limit);
 
@@ -77,7 +76,6 @@ class RetryCommand extends Command
                 $query= $query->where('queue', $queue);
 
             $query = $query->orderBy('id', $order);
-
 
             $data = $query->get('id');
 

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -120,7 +120,8 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
      *
      * @return \Illuminate\Database\Query\Builder
      */
-    public function getQuery() {
+    public function getQuery()
+    {
         return $this->getTable();
     }
 }

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -114,4 +114,13 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
     {
         return $this->resolver->connection($this->database)->table($this->table);
     }
+
+    /**
+     * Get a new query builder instance for the table.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function getQuery() {
+        return $this->getTable();
+    }
 }

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -146,6 +146,7 @@ class DatabaseFailedJobProvider implements QueryableFailedJobProviderInterface
         }
 
         $query = $query->orderBy('id', $order);
+
         return $query->pluck('id')->all();
     }
 }

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -116,7 +116,7 @@ class DatabaseFailedJobProvider implements QueryableFailedJobProviderInterface
     }
 
     /**
-     * Retrieve job ids from specific connection and queue
+     * Retrieve job ids from specific connection and queue.
      *
      * @param string|null $connection
      * @param string|null $queue

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -110,18 +110,42 @@ class DatabaseFailedJobProvider implements QueryableFailedJobProviderInterface
      *
      * @return \Illuminate\Database\Query\Builder
      */
-    protected function getTable()
+    public function getTable()
     {
         return $this->resolver->connection($this->database)->table($this->table);
     }
 
     /**
-     * Get a new query builder instance for the table.
+     * Retrieve job ids from specific connection and queue
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @param string|null $connection
+     * @param string|null $queue
+     * @param string|null $order
+     * @param int|null $limit
+     * @param int|null $offset
+     * @return array
      */
-    public function getQuery()
+    public function getJobIds($connection, $queue, $order, $limit, $offset)
     {
-        return $this->getTable();
+        $query = $this->getTable();
+
+        if ($connection) {
+            $query = $query->where('connection', $connection);
+        }
+
+        if ($queue) {
+            $query = $query->where('queue', $queue);
+        }
+
+        if ($limit) {
+            $query = $query->limit($limit);
+        }
+
+        if ($offset) {
+            $query = $query->offset($offset);
+        }
+
+        $query = $query->orderBy('id', $order);
+        return $query->pluck('id')->all();
     }
 }

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -5,7 +5,7 @@ namespace Illuminate\Queue\Failed;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Database\ConnectionResolverInterface;
 
-class DatabaseFailedJobProvider implements FailedJobProviderInterface
+class DatabaseFailedJobProvider implements QueryableFailedJobProviderInterface
 {
     /**
      * The connection resolver implementation.

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -44,11 +44,4 @@ interface FailedJobProviderInterface
      * @return void
      */
     public function flush();
-
-    /**
-     * Get a new query builder instance for the table.
-     *
-     * @return \Illuminate\Database\Query\Builder
-     */
-    public function getQuery();
 }

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -44,4 +44,11 @@ interface FailedJobProviderInterface
      * @return void
      */
     public function flush();
+
+    /**
+     * Get a new query builder instance for the table.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function getQuery();
 }

--- a/src/Illuminate/Queue/Failed/QueryableFailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/QueryableFailedJobProviderInterface.php
@@ -6,7 +6,7 @@ namespace Illuminate\Queue\Failed;
 interface QueryableFailedJobProviderInterface extends FailedJobProviderInterface
 {
     /**
-     * Retrieve job ids from specific connection and queue
+     * Retrieve job ids from specific connection and queue.
      *
      * @param string|null $connection
      * @param string|null $queue

--- a/src/Illuminate/Queue/Failed/QueryableFailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/QueryableFailedJobProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Queue\Failed;
+
+interface QueryableFailedJobProviderInterface extends FailedJobProviderInterface
+{
+    /**
+     * Get a new query builder instance for the table.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function getQuery();
+}

--- a/src/Illuminate/Queue/Failed/QueryableFailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/QueryableFailedJobProviderInterface.php
@@ -2,12 +2,18 @@
 
 namespace Illuminate\Queue\Failed;
 
+
 interface QueryableFailedJobProviderInterface extends FailedJobProviderInterface
 {
     /**
-     * Get a new query builder instance for the table.
+     * Retrieve job ids from specific connection and queue
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @param string|null $connection
+     * @param string|null $queue
+     * @param string|null $order
+     * @param int|null $limit
+     * @param int|null $offset
+     * @return array
      */
-    public function getQuery();
+    public function getJobIds($connection, $queue, $order, $limit, $offset);
 }

--- a/src/Illuminate/Queue/Failed/QueryableFailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/QueryableFailedJobProviderInterface.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue\Failed;
 
-
 interface QueryableFailedJobProviderInterface extends FailedJobProviderInterface
 {
     /**


### PR DESCRIPTION
Programs with heavy usages of queues may suffer from retrying jobs since retry command has only two options of retrying a job by its id, and retrying all jobs.
In this commit, changes are made to retry command to let the user retry jobs of a specific queue, with limit and offset options.