### PR TITLE
[5.8] Allow setting additional smtp config options

### DIFF
--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -53,6 +53,21 @@ class TransportManager extends Manager
         if (isset($config['stream'])) {
             $transport->setStreamOptions($config['stream']);
         }
+        
+        // Set the source ip for servers which have more than one ip address.
+        // This will cause Swift SMTP transport to make requests only via that 
+        // IP address, which is useful for firewalled smtp servers like gmail
+        // smtp relay.
+        if (isset($config['sourceip'])) {
+            $transport->setSourceIp($config['sourceip']);
+        }
+        
+        // Allow setting the local domain which Swift SMTP transport will use
+        // to identify the request domain to the smtp server, which is useful
+        // for shared smtp servers like gmail's smtp relay.
+        if (isset($config['localdomain'])) {
+            $transport->setLocalDomain($config['localdomain']);
+        }
 
         return $transport;
     }


### PR DESCRIPTION
https://github.com/laravel/ideas/issues/1661
Allows configuring the source IP address used by swift mailer. Useful on servers with multiple ip addresses, or servers with both IPv4 and IPv6 addresses. 

Allows configuring the localdomain sent by the swift mailer in the HELO or EHLO command. The default behavior is to send the server's name, but for sub-domain servers, it would be better to send the root domain (example.com instead of www.example.com).

Neither of these would change existing behavior unless config values were set. 

I couldn't find any existing tests around transport manager to base my tests around, and wasn't sure how to test the purpose of this.