### PR TITLE
Collection map() and transform() can function as replace for simple arrays

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -246,12 +246,14 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Run a map over each of the items.
      *
-     * @param  callable  $callback
+     * @param  mixed  $callback
+     * @param  mixed  $replace
+     * @param  bool  $strict
      * @return \Illuminate\Support\Collection|static
      */
-    public function map(callable $callback)
+    public function map($callback, $search = null, $replace = false)
     {
-        $result = parent::map($callback);
+        $result = parent::map(...func_get_args());
 
         return $result->contains(function ($item) {
             return ! $item instanceof Model;

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1110,11 +1110,23 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Run a map over each of the items.
      *
-     * @param  callable  $callback
+     * @param  mixed  $callback
+     * @param  mixed  $replace
+     * @param  bool  $strict
      * @return static
      */
-    public function map(callable $callback)
+    public function map($callback, $replace = null, $strict = false)
     {
+        if (! is_callable($callback)) {
+            $callback = function ($item) use ($callback, $replace, $strict) {
+                if ($strict) {
+                    return $item === $callback ? $replace : $item;
+                }
+
+                return $item == $callback ? $replace : $item;
+            };
+        }
+
         $keys = array_keys($this->items);
 
         $items = array_map($callback, $this->items, $keys);
@@ -1798,12 +1810,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Transform each item in the collection using a callback.
      *
-     * @param  callable  $callback
+     * @param  mixed  $callback
+     * @param  mixed  $replace
+     * @param  bool  $strict
      * @return $this
      */
-    public function transform(callable $callback)
+    public function transform($callback, $replace = null, $strict = false)
     {
-        $this->items = $this->map($callback)->all();
+        $this->items = $this->map(...func_get_args())->all();
 
         return $this;
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1521,6 +1521,14 @@ class SupportCollectionTest extends TestCase
             return $key.'-'.strrev($item);
         });
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
+
+        $data = new Collection(['1', 1, 2]);
+        $data = $data->map('1', null);
+        $this->assertEquals([null, null, 2], $data->all());
+
+        $data = new Collection(['1', 1, 2]);
+        $data = $data->map('1', null, true);
+        $this->assertEquals([null, 1, 2], $data->all());
     }
 
     public function testMapSpread()
@@ -1740,6 +1748,14 @@ class SupportCollectionTest extends TestCase
             return $key.'-'.strrev($item);
         });
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
+
+        $data = new Collection(['1', 1, 2]);
+        $data->transform('1', null);
+        $this->assertEquals([null, null, 2], $data->all());
+
+        $data = new Collection(['1', 1, 2]);
+        $data->transform('1', null, true);
+        $this->assertEquals([null, 1, 2], $data->all());
     }
 
     public function testGroupByAttribute()


### PR DESCRIPTION
## What it adds

This PR would make this possible with collection `map()` and `transform()` methods:

```php
collect([3, 2, 1])->transform('1', 2)->toArray();
// [3, 2, 2]
```

It introduces 2nd and 3rd optional arguments, making the signature `function map($search, $replace, $strict = false)`

## Why

Earlier today I came across something like this:

```php
// A collection with a simple array of IDs
$ids->transform(function ($item) use ($oldId, $newId) {
    if ($item === $oldId) {
        return $newId;
    }

    return $item;
};
```

The code made sense in the place where it was. But it wasn't pretty.
But this would be: 

```php
$ids->transform($oldId, $newId);
```

## Thoughts?

I can't think of a situation where this could be a breaking change since the first argument was `callable` before and here I specifically check with `is_callable()`. This is better than checking the number of arguments, as it doesn't break code where multiple arguments could've been passed in, for whatever reason.

I also thought about creating a new method, but it just seemed to be recreating `transform()`.

Thoughts? 