### PR TITLE
Revert "[5.9] Add support for nullable unique indexes in SQL Server"

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -105,11 +105,10 @@ class SqlServerGrammar extends Grammar
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('create unique index %s on %s (%s) where %s is not null',
+        return sprintf('create unique index %s on %s (%s)',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
-            $this->columnize($command->columns),
-            implode(' is not null and ', $this->wrapArray($command->columns))
+            $this->columnize($command->columns)
         );
     }
 

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -233,14 +233,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create unique index "bar" on "users" ("foo") where "foo" is not null', $statements[0]);
-
-        $blueprint = new Blueprint('users');
-        $blueprint->unique(['foo', 'bar'], 'baz');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
-        $this->assertCount(1, $statements);
-        $this->assertEquals('create unique index "baz" on "users" ("foo", "bar") where "foo" is not null and "bar" is not null', $statements[0]);
+        $this->assertEquals('create unique index "bar" on "users" ("foo")', $statements[0]);
     }
 
     public function testAddingIndex()


### PR DESCRIPTION
Reverts laravel/framework#27938

See https://github.com/laravel/framework/issues/28587