### PR TITLE
[5.8] Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,16 +2,16 @@
 
 ## Supported Versions
 
-Version |	Security Fixes Until
+Version | Security Fixes Until
 --- | ---
 5.8	| February 26th, 2020
 5.7	| September 4th, 2019
 5.6	| February 7th, 2019
-5.5 (LTS)	| August 30th, 2020
+5.5 (LTS) | August 30th, 2020
 5.4	| January 24th, 2018
 5.3	| August 23rd, 2017
 5.2	| December 21st, 2016
-5.1 (LTS)	| June 9th, 2018
+5.1 (LTS) | June 9th, 2018
 5.0	| February 4th, 2016
 
 ## Reporting a Vulnerability

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+Version |	Security Fixes Until
+--- | ---
+5.8	| February 26th, 2020
+5.7	| September 4th, 2019
+5.6	| February 7th, 2019
+5.5 (LTS)	| August 30th, 2020
+5.4	| January 24th, 2018
+5.3	| August 23rd, 2017
+5.2	| December 21st, 2016
+5.1 (LTS)	| June 9th, 2018
+5.0	| February 4th, 2016
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability within Laravel, please send an email to Taylor Otwell at taylor@laravel.com. All security vulnerabilities will be promptly addressed.


### PR DESCRIPTION
Add the newly supported SECURITY.md file. This takes over the versions and dates from https://laravel.com/docs/5.8/releases#support-policy

FYI: in contrary to the other PRs I created just now this file resides in the root of the repo and not in the `.github` folder to make it explicit. I also didn't add this to the `.gitattributes` file because I believe it always has value to be cloned along with the source code.