### PR TITLE
[5.8] Router name filtered for striping whitespaces

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -381,7 +381,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function route($name, $parameters = [], $absolute = true)
     {
-        if (! is_null($route = $this->routes->getByName($name))) {
+        if (! is_null($route = $this->routes->getByName(trim($name)))) {
             return $this->toRoute($route, $parameters, $absolute);
         }
 


### PR DESCRIPTION
While coding I faced with incorrect router name error. I have realized that there is whitespace on the beginning of my router name because of it I have filtered router name ignoring whitespaces. It irritates me a lot finding conflict if there is whitespace on the begin or end of my router name. I would like my PR to be accepted.