### PR TITLE
[5.8] Maintain default db connection on migrate/seed call with db flag

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -49,6 +49,7 @@ class StatusCommand extends BaseCommand
      */
     public function handle()
     {
+        $previousConnection = $this->migrator->getConnection();
         $this->migrator->setConnection($this->option('database'));
 
         if (! $this->migrator->repositoryExists()) {
@@ -64,6 +65,8 @@ class StatusCommand extends BaseCommand
         } else {
             $this->error('No migrations found');
         }
+
+        $this->migrator->restorePriorConnection($previousConnection);
     }
 
     /**

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -57,11 +57,17 @@ class SeedCommand extends Command
             return;
         }
 
+        $previousConnection = $this->resolver->getDefaultConnection();
+
         $this->resolver->setDefaultConnection($this->getDatabase());
 
         Model::unguarded(function () {
             $this->getSeeder()->__invoke();
         });
+
+        if ($previousConnection) {
+            $this->resolver->setDefaultConnection($previousConnection);
+        }
 
         $this->info('Database seeding completed successfully.');
     }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -32,6 +32,11 @@ class DatabaseMigratorIntegrationTest extends TestCase
             'database'  => ':memory:',
         ]);
 
+        $db->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+        ], 'sqlite2');
+
         $db->setAsGlobal();
 
         $container = new Container;
@@ -52,6 +57,12 @@ class DatabaseMigratorIntegrationTest extends TestCase
 
         if (! $repository->repositoryExists()) {
             $repository->createRepository();
+        }
+
+        $repository2 = new DatabaseMigrationRepository($db->getDatabaseManager(), 'migrations');
+        $repository2->setSource('sqlite2');
+        if (! $repository2->repositoryExists()) {
+            $repository2->createRepository();
         }
     }
 
@@ -147,5 +158,46 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->assertFalse($this->db->schema()->hasTable('users'));
         $this->assertFalse($this->db->schema()->hasTable('password_resets'));
         $this->assertFalse($this->db->schema()->hasTable('flights'));
+    }
+
+    public function testConnectionPriorToMigrationIsNotChangedAfterMigration()
+    {
+        $this->migrator->setConnection('default');
+        $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->assertEquals('default', $this->migrator->getConnection());
+    }
+
+    public function testConnectionPriorToMigrationIsNotChangedAfterRollback()
+    {
+        $this->migrator->setConnection('default');
+        $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->migrator->rollback([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->assertEquals('default', $this->migrator->getConnection());
+    }
+
+    public function testConnectionPriorToMigrationIsNotChangedWhenNoOutstandingMigrationsExist()
+    {
+        $this->migrator->setConnection('default');
+        $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->migrator->setConnection('default');
+        $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->assertEquals('default', $this->migrator->getConnection());
+    }
+
+    public function testConnectionPriorToMigrationIsNotChangedWhenNothingToRollback()
+    {
+        $this->migrator->setConnection('default');
+        $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->migrator->rollback([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->migrator->rollback([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->assertEquals('default', $this->migrator->getConnection());
+    }
+
+    public function testConnectionPriorToMigrationIsNotChangedAfterMigrateReset()
+    {
+        $this->migrator->setConnection('default');
+        $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->migrator->reset([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->assertEquals('default', $this->migrator->getConnection());
     }
 }

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -25,6 +25,7 @@ class SeedCommandTest extends TestCase
         $seeder->shouldReceive('__invoke')->once();
 
         $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once();
         $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
 
         $container = m::mock(Container::class);


### PR DESCRIPTION
This pull request attempts to address issue #28253. The original problem is quoted below from this issue:

> The problem is that when Artisan is running any database related commands, it sets the option passed with'--database' flag as the framework's default connection. I guess that it was not meant to call such artisan commands somewhere in between while the framework is processing the request (like in my case).

But after [my initial PR attempt](https://github.com/laravel/framework/pull/28620), it was pointed out that there was some other situations not in the `Migrator` class where this issue came up such as:
- `migrate:status`
- `migrate:seed`

So I addressed those items as well. Also there was a [comment](https://github.com/laravel/framework/pull/28620#issuecomment-496039537) that said:
> Can we capture the "current/existing" DB connection as the migration starts, then set it back to that at the end?

That concept made more sense to me, so that's what I went for in this PR. Essentially the new `restorePriorConnection` method in the `Migrator` class captures the current connection, and then makes it the default connection after each point where a migration runs (or fails to run if there is nothing to migrate/rollback). 

The `restorePriorConnection` method is `public` because it is also called my the `StatusCommand` class (Database/Console/Migrations).  There was also a small update needed for the `SeedCommand` class (Database/Console/Seeds) so that its behavior would be similar. But there is no access to the `Migrator` class from that file, so I used its available methods as opposed to adding additional dependencies. 

Finally, I added several integration tests to the `DatabaseMigratorIntegrationTest` to assure the changes accomplish what they are supposed to.  

**All that being said, I'm not sure the ends justify the means in this case**. There are three files changed, new methods, etc. all in order to fix a problem that I would guess most developers never even noticed. Perhaps a more proper fix would be to update the `ConnectionResolverInterface` to have a `setTemporaryConnection` method. But because it's an interface,  that may have a substantial amount of ramifications. And probably isn't something that should be done in a minor release, in my opinion anyway. So if anyone has a better way to handle this or just thinks it should wait for a major release I would totally understand. It is a bug, but again I just don't think it's a major pain point for many devs. 