### PR TITLE
[5.8] Add support for typed eager loads

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -266,7 +266,7 @@ class MorphTo extends BelongsTo
     /**
      * Specify which relations to load for a given morph type.
      *
-     * @param array $with
+     * @param  array  $with
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
     public function withMorph(array $with)

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -38,7 +38,7 @@ class MorphTo extends BelongsTo
     protected $macroBuffer = [];
 
     /**
-     * A map of relations to load for each individual morph type
+     * A map of relations to load for each individual morph type.
      *
      * @var array
      */
@@ -264,7 +264,7 @@ class MorphTo extends BelongsTo
     }
 
     /**
-     * Specify which relations to load for a given morph type
+     * Specify which relations to load for a given morph type.
      *
      * @param string $modelClass
      * @param array $with

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -271,7 +271,7 @@ class MorphTo extends BelongsTo
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function withMorph(string $modelClass, array $with): self
+    public function withMorph(string $modelClass, array $with)
     {
         $this->typedEagerLoads[$modelClass] = array_merge(
             $this->typedEagerLoads[$modelClass] ?? [],

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -271,10 +271,10 @@ class MorphTo extends BelongsTo
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function withMorph(string $modelClass, array $with)
+    public function withMorph(array $with)
     {
-        $this->typedEagerLoads[$modelClass] = array_merge(
-            $this->typedEagerLoads[$modelClass] ?? [],
+        $this->typedEagerLoads = array_merge(
+            $this->typedEagerLoads,
             $with
         );
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -120,7 +120,7 @@ class MorphTo extends BelongsTo
                             ->mergeConstraintsFrom($this->getQuery())
                             ->with(array_merge(
                                 $this->getQuery()->getEagerLoads(),
-                                $this->typedEagerLoads[get_class($instance)] ?? []
+                                (array) ($this->typedEagerLoads[get_class($instance)] ?? [])
                             ));
 
         return $query->whereIn(
@@ -266,9 +266,7 @@ class MorphTo extends BelongsTo
     /**
      * Specify which relations to load for a given morph type.
      *
-     * @param string $modelClass
      * @param array $with
-     *
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
     public function withMorph(array $with)

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphToLazyEagerLoadingTest;
+
+use DB;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphToLazyEagerLoadingTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('post_id');
+            $table->unsignedInteger('user_id');
+        });
+
+        Schema::create('videos', function (Blueprint $table) {
+            $table->increments('video_id');
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('commentable_type');
+            $table->integer('commentable_id');
+        });
+
+        $user = User::create();
+
+        $post = tap((new Post)->user()->associate($user))->save();
+
+        $video = Video::create();
+
+        (new Comment)->commentable()->associate($post)->save();
+        (new Comment)->commentable()->associate($video)->save();
+    }
+
+    public function test_with_morph_loading()
+    {
+        $comments = Comment::query()
+            ->with(['commentable' => function (MorphTo $morphTo) {
+                $morphTo->withMorph(Post::class, ['user']);
+            }])
+            ->get();
+
+        $this->assertTrue($comments[0]->relationLoaded('commentable'));
+        $this->assertTrue($comments[0]->commentable->relationLoaded('user'));
+        $this->assertTrue($comments[1]->relationLoaded('commentable'));
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Post extends Model
+{
+    public $timestamps = false;
+    protected $primaryKey = 'post_id';
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}
+
+class User extends Model
+{
+    public $timestamps = false;
+}
+
+class Video extends Model
+{
+    public $timestamps = false;
+    protected $primaryKey = 'video_id';
+}

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -2,17 +2,16 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentMorphToLazyEagerLoadingTest;
 
-use DB;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 /**
  * @group integration
  */
-class EloquentMorphToLazyEagerLoadingTest extends DatabaseTestCase
+class EloquentMorphEagerLoadingTest extends DatabaseTestCase
 {
     protected function setUp(): void
     {

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -50,7 +50,7 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
     {
         $comments = Comment::query()
             ->with(['commentable' => function (MorphTo $morphTo) {
-                $morphTo->withMorph(Post::class, ['user']);
+                $morphTo->withMorph([Post::class =>['user']]);
             }])
             ->get();
 

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -50,13 +50,25 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
     {
         $comments = Comment::query()
             ->with(['commentable' => function (MorphTo $morphTo) {
-                $morphTo->withMorph([Post::class =>['user']]);
+                $morphTo->withMorph([Post::class => ['user']]);
             }])
             ->get();
 
         $this->assertTrue($comments[0]->relationLoaded('commentable'));
         $this->assertTrue($comments[0]->commentable->relationLoaded('user'));
         $this->assertTrue($comments[1]->relationLoaded('commentable'));
+    }
+
+    public function test_with_morph_loading_with_single_relation()
+    {
+        $comments = Comment::query()
+            ->with(['commentable' => function (MorphTo $morphTo) {
+                $morphTo->withMorph([Post::class => 'user']);
+            }])
+            ->get();
+
+        $this->assertTrue($comments[0]->relationLoaded('commentable'));
+        $this->assertTrue($comments[0]->commentable->relationLoaded('user'));
     }
 }
 


### PR DESCRIPTION
This PR adds support for eagerly loading relations of morphed models, based on their type.

An example:

- `Comment` has a morph relation to `commentable` to `Video` or `Post`
- `Post` has a relation to `User` 

With this PR, you can load all these specific relation via queries, instead of using `loadMorph` on collections (#23626). Here's what the above example would look like:

```php
Comment::query()
    ->with(['commentable' => function (MorphTo $morphTo) {
        $morphTo->withMorph(Post::class, ['user']);
    }])
    ->get();
```

The advantage of using this approach compared to `loadMorph`, is that nested relations are supported when using `with` on the query builder.

This PR is in draft, because I've got two questions still:

- I chose the name `withMorph` to be similar to `loadMorph`, though maybe someone has a better idea?
- ~Can someone point me into the right direction on how to test this. I'm getting these errors: `Call to a member function connection()` when running `DatabaseEloquentMorphToTest` on its own, so I'm unable to try things out myself right now.~ Edit: figured out the right place to test this.