### PR TITLE
[5.8] Add a 'manage' default policy

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -11,12 +11,12 @@ class DummyClass
     use HandlesAuthorization;
     
     /**
-     * Determine whether the user can manage the DocDummyModel.
+     * Determine whether the user can list the DocDummyPluralModel.
      *
      * @param  \NamespacedDummyUserModel  $user
      * @return mixed
      */
-    public function manage(DummyUser $user)
+    public function list(DummyUser $user)
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -11,12 +11,12 @@ class DummyClass
     use HandlesAuthorization;
     
     /**
-     * Determine whether the user can list the DocDummyPluralModel.
+     * Determine whether the user can view any DocDummyPluralModel.
      *
      * @param  \NamespacedDummyUserModel  $user
      * @return mixed
      */
-    public function list(DummyUser $user)
+    public function viewAny(DummyUser $user)
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -9,6 +9,17 @@ use Illuminate\Auth\Access\HandlesAuthorization;
 class DummyClass
 {
     use HandlesAuthorization;
+    
+    /**
+     * Determine whether the user can manage the DocDummyModel.
+     *
+     * @param  \NamespacedDummyUserModel  $user
+     * @return mixed
+     */
+    public function manage(DummyUser $user)
+    {
+        //
+    }
 
     /**
      * Determine whether the user can view the DocDummyModel.


### PR DESCRIPTION
In our normal resource controller, we have `index`, `create`, `store`, `edit`, `show`, `update`, and `destroy`.

Our default policy has methods that correspond to most of these methods.

`view` --> `show`
`create` --> `create` and `store`
`update` --> `edit` and `update`
`delete` --> `destroy`

The one clear omission is we have no default policy that corresponds to the `index` method. The `index` method traditionally contains a list of all items of a particular Model.

I'm proposing a new default policy called `manage` that can be used to determine if a `User` is allowed to access the `index` resource route.
