### PR TITLE
[5.8] Add map() method to the query builders

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Database\Concerns;
 
-use Illuminate\Container\Container;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Pagination\Paginator;
-use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
+use Illuminate\Container\Container;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 trait BuildsQueries
 {
@@ -84,7 +84,7 @@ trait BuildsQueries
             $mapped = $callback($value, $key);
 
             // If we encounter a non-Model instance, we'll set the useEloquent flag to false
-            if ($useEloquent && !($mapped instanceof Model)) {
+            if ($useEloquent && ! $mapped instanceof Model) {
                 $useEloquent = false;
             }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -408,7 +408,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestUser::create(['name' => 'Third', 'email' => 'third@gmail.com']);
 
         $names = EloquentTestUser::query()->map(function (EloquentTestUser $user) {
-           return $user->name;
+            return $user->name;
         }, 2);
 
         $this->assertInstanceOf(\Illuminate\Support\Collection::class, $names);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -401,6 +401,41 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(2, $i);
     }
 
+    public function testMap()
+    {
+        EloquentTestUser::create(['name' => 'First', 'email' => 'first@gmail.com']);
+        EloquentTestUser::create(['name' => 'Second', 'email' => 'second@gmail.com']);
+        EloquentTestUser::create(['name' => 'Third', 'email' => 'third@gmail.com']);
+
+        $names = EloquentTestUser::query()->map(function (EloquentTestUser $user) {
+           return $user->name;
+        }, 2);
+
+        $this->assertInstanceOf(\Illuminate\Support\Collection::class, $names);
+        $this->assertEquals(3, $names->count());
+        $this->assertTrue($names->contains('First'));
+        $this->assertTrue($names->contains('Second'));
+        $this->assertTrue($names->contains('Third'));
+    }
+
+    public function testMapToModels()
+    {
+        EloquentTestUser::create(['name' => 'First', 'email' => 'first@gmail.com']);
+        EloquentTestUser::create(['name' => 'Second', 'email' => 'second@gmail.com']);
+        EloquentTestUser::create(['name' => 'Third', 'email' => 'third@gmail.com']);
+
+        $users = EloquentTestUser::query()->map(function (EloquentTestUser $user) {
+            $user->name = "Modified:{$user->name}";
+            return $user;
+        }, 2);
+
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertEquals(3, $users->count());
+        $this->assertTrue($users->contains('name', '=', 'Modified:First'));
+        $this->assertTrue($users->contains('name', '=', 'Modified:Second'));
+        $this->assertTrue($users->contains('name', '=', 'Modified:Third'));
+    }
+
     public function testPluck()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -426,6 +426,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $users = EloquentTestUser::query()->map(function (EloquentTestUser $user) {
             $user->name = "Modified:{$user->name}";
+
             return $user;
         }, 2);
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Database\Eloquent\Collection;
 use stdClass;
 use Mockery as m;
 use RuntimeException;
@@ -10,10 +9,11 @@ use BadMethodCallException;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Pagination\LengthAwarePaginator;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Expression as Raw;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;


### PR DESCRIPTION
I often find myself wanting to map query builder results, and I'd like to have the power of `chunk()`/`each()` rather than having to `get()` all the results and then perform my map operation. This adds that function to the `BuildsQueries` trait.

Before:

```php
// Load all users into memory at once
$summary = User::whereConfirmed(false)->get()->map(function(User $user) {
    return "{$user->name} <{$user->email}>";
});
```

After:

```php
// Only load 100 at a time
$summary = User::whereConfirmed(false)->map(function(User $user) {
    return "{$user->name} <{$user->email}>";
}, 100);
```

This implementation will return an Eloquent collection if all the mapped results are instances of `Model` or a base collection in all other cases.