### PR TITLE
[5.8] fix MorphTo Relation ignores parent $timestamp when touching

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -294,6 +294,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $class = $class ?: static::class;
 
+        if (!get_class_vars($class)['timestamps']) {
+            return true;
+        }
+
         foreach (static::$ignoreOnTouch as $ignoredClass) {
             if ($class === $ignoredClass || is_subclass_of($class, $ignoredClass)) {
                 return true;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1886,6 +1886,18 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($called);
     }
 
+    public function testTouchingModelWithTimestamps() {
+        $this->assertFalse(
+            Model::isIgnoringTouch(Model::class)
+        );
+    }
+
+    public function testNotTouchingModelWithoutTimestamps() {
+        $this->assertTrue(
+            Model::isIgnoringTouch(EloquentModelWithoutTimestamps::class)
+        );
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock(ConnectionResolverInterface::class));
@@ -2302,4 +2314,10 @@ class EloquentModelEventObjectStub extends Model
     protected $dispatchesEvents = [
         'saving' => EloquentModelSavingEventStub::class,
     ];
+}
+
+class EloquentModelWithoutTimestamps extends Model
+{
+    protected $table = 'stub';
+    public $timestamps = false;
 }


### PR DESCRIPTION
Fixed bug with touching model which has $timestamps set to false resulting in `Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1 no such column: updated_at`

for source issue and more details see #28638 