### PR TITLE
[5.8] Arr::collapse better performance

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -55,10 +55,12 @@ class Arr
                 continue;
             }
 
-            $results[] = $values;
+            foreach ($values as $item) {
+                array_push($results, $item);
+            }
         }
 
-        return array_merge(...$results);
+        return $results;
     }
 
     /**

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -55,10 +55,10 @@ class Arr
                 continue;
             }
 
-            $results = array_merge($results, $values);
+            $results[] = $values;
         }
 
-        return $results;
+        return array_merge(...$results);
     }
 
     /**

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -56,7 +56,7 @@ class Arr
             }
 
             foreach ($values as $item) {
-                array_push($results, $item);
+                $results[] = $item;
             }
         }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -55,12 +55,10 @@ class Arr
                 continue;
             }
 
-            foreach ($values as $item) {
-                $results[] = $item;
-            }
+            $results[] = $values;
         }
 
-        return $results;
+        return array_merge([], [], ...$results);
     }
 
     /**


### PR DESCRIPTION
For large array to collapse() get better performance.

Ubuntu 14.04 Core™ i3-4130 CPU @ 3.40GHz × 4, 8GB

```
$arr = [];
for ($i = 0; $i < 20000; $i++) {
    $arr[] = [1, 2, 3];
}
Arr::collapse($arr);
```

**Before**: 6.88 s
**After**: 0.03 ms