### PR TITLE
[5.8] Adds a throwing of an exception with an "Link has expired." label when signed link is expired

### DIFF
--- a/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
+++ b/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
@@ -15,4 +15,14 @@ class InvalidSignatureException extends HttpException
     {
         parent::__construct(403, 'Invalid signature.');
     }
+
+    public static function forInvalidSignature()
+    {
+        return new parent(403, 'Invalid signature.');
+    }
+
+    public static function forExpiredLink()
+    {
+        return new parent(403, 'Link has expired.');
+    }
 }

--- a/src/Illuminate/Routing/Middleware/ValidateSignature.php
+++ b/src/Illuminate/Routing/Middleware/ValidateSignature.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing\Middleware;
 
 use Closure;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Routing\Exceptions\InvalidSignatureException;
 
 class ValidateSignature
@@ -18,10 +19,14 @@ class ValidateSignature
      */
     public function handle($request, Closure $next)
     {
-        if ($request->hasValidSignature()) {
+        if (URL::hasValidSignature($request)) {
             return $next($request);
         }
 
-        throw new InvalidSignatureException;
+        if (URL::isExpired($request)) {
+            throw InvalidSignatureException::forExpiredLink();
+        }
+
+        throw InvalidSignatureException::forInvalidSignature();
     }
 }


### PR DESCRIPTION
I was really confused when I got an exception page with "Invalid signature." label (while the signature wasn't changed). After some investigation I discovered that expired link also causes an exception page with an "Invalid signature" label.
I've decided to place an "Link has expired." label instead of "Invalid signature." when signed link expires.

I'm open to a discussion because I'm not sure if the current implementation in the PR is the best one.