### PR TITLE
[5.8] Adds a throwing of an exception with an "Link has expired." label when signed link is expired

### DIFF
--- a/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
+++ b/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
@@ -15,4 +15,14 @@ class InvalidSignatureException extends HttpException
     {
         parent::__construct(403, 'Invalid signature.');
     }
+
+    public static function forInvalidSignature()
+    {
+        return new parent(403, 'Invalid signature.');
+    }
+
+    public static function forExpiredLink()
+    {
+        return new parent(403, 'Link has expired.');
+    }
 }

--- a/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
+++ b/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
@@ -9,20 +9,30 @@ class InvalidSignatureException extends HttpException
     /**
      * Create a new exception instance.
      *
-     * @return void
+     * @param string $message
      */
-    public function __construct()
+    public function __construct($message = 'Invalid signature.')
     {
-        parent::__construct(403, 'Invalid signature.');
+        parent::__construct(403, $message);
     }
 
+    /**
+     * Create a new exception for an invalid signature.
+     *
+     * @return HttpException
+     */
     public static function forInvalidSignature()
     {
-        return new parent(403, 'Invalid signature.');
+        return new self('Invalid signature.');
     }
 
+    /**
+     * Create a new exception for an expired link.
+     *
+     * @return HttpException
+     */
     public static function forExpiredLink()
     {
-        return new parent(403, 'Link has expired.');
+        return new self('Link has expired.');
     }
 }

--- a/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
+++ b/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
@@ -19,7 +19,7 @@ class InvalidSignatureException extends HttpException
     /**
      * Create a new exception for an invalid signature.
      *
-     * @return HttpException
+     * @return InvalidSignatureException
      */
     public static function forInvalidSignature()
     {
@@ -29,7 +29,7 @@ class InvalidSignatureException extends HttpException
     /**
      * Create a new exception for an expired link.
      *
-     * @return HttpException
+     * @return InvalidSignatureException
      */
     public static function forExpiredLink()
     {

--- a/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
+++ b/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
@@ -19,7 +19,7 @@ class InvalidSignatureException extends HttpException
     /**
      * Create a new exception for an invalid signature.
      *
-     * @return InvalidSignatureException
+     * @return \Illuminate\Routing\Exceptions\InvalidSignatureException
      */
     public static function forInvalidSignature()
     {
@@ -29,7 +29,7 @@ class InvalidSignatureException extends HttpException
     /**
      * Create a new exception for an expired link.
      *
-     * @return InvalidSignatureException
+     * @return \Illuminate\Routing\Exceptions\InvalidSignatureException
      */
     public static function forExpiredLink()
     {

--- a/src/Illuminate/Routing/Middleware/ValidateSignature.php
+++ b/src/Illuminate/Routing/Middleware/ValidateSignature.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing\Middleware;
 
 use Closure;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Routing\Exceptions\InvalidSignatureException;
 
 class ValidateSignature
@@ -18,10 +19,14 @@ class ValidateSignature
      */
     public function handle($request, Closure $next)
     {
-        if ($request->hasValidSignature()) {
+        if (URL::hasValidSignature($request)) {
             return $next($request);
         }
 
-        throw new InvalidSignatureException;
+        if (URL::isExpired($request)) {
+            throw InvalidSignatureException::forExpiredLink();
+        }
+
+        throw InvalidSignatureException::forInvalidSignature();
     }
 }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -370,6 +370,19 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
+     * Determine if the given request has an expired timestamp.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function isExpired(Request $request)
+    {
+        $expires = $request->query('expires');
+
+        return $expires && Carbon::now()->getTimestamp() > $expires;
+    }
+
+    /**
      * Get the URL to a named route.
      *
      * @param  string  $name

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -361,12 +361,10 @@ class UrlGenerator implements UrlGeneratorContract
             Arr::except($request->query(), 'signature')
         ), '?');
 
-        $expires = $request->query('expires');
-
         $signature = hash_hmac('sha256', $original, call_user_func($this->keyResolver));
 
         return  hash_equals($signature, (string) $request->query('signature', '')) &&
-               ! ($expires && Carbon::now()->getTimestamp() > $expires);
+               ! $this->isExpired($request);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -14,7 +14,8 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Contracts\Routing\UrlGenerator setRootControllerNamespace(string $rootNamespace)
  * @method static string signedRoute(string $name, array $parameters = [], \DateTimeInterface|\DateInterval|int $expiration = null, bool $absolute = true)
  * @method static string temporarySignedRoute(string $name, \DateTimeInterface|\DateInterval|int $expiration, array $parameters = [], bool $absolute = true)
- * @method static string hasValidSignature(\Illuminate\Http\Request $request, bool $absolute = true)
+ * @method static bool hasValidSignature(\Illuminate\Http\Request $request, bool $absolute = true)
+ * @method static bool isExpired(\Illuminate\Http\Request $request)
  * @method static void defaults(array $defaults)
  *
  * @see \Illuminate\Routing\UrlGenerator

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -4,8 +4,8 @@ namespace Illuminate\Tests\Routing;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
-use Illuminate\Support\Carbon;
 use InvalidArgumentException;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Routing\RouteCollection;


### PR DESCRIPTION
I was really confused when I got an exception page with "Invalid signature." label (while the signature wasn't changed). After some investigation I discovered that expired link also causes an exception page with an "Invalid signature" label.
I've decided to place an "Link has expired." label instead of "Invalid signature." when signed link expires.

I'm open to a discussion because I'm not sure if the current implementation in the PR is the best one.