### PR TITLE
[5.8] Add fullpath option

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -17,7 +17,8 @@ class MigrateMakeCommand extends BaseCommand
         {--create= : The table to be created}
         {--table= : The table to migrate}
         {--path= : The location where the migration file should be created}
-        {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}';
+        {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
+        {--fullpath : Output the full path of the migration}';
 
     /**
      * The console command description.
@@ -105,9 +106,13 @@ class MigrateMakeCommand extends BaseCommand
      */
     protected function writeMigration($name, $table, $create)
     {
-        $file = pathinfo($this->creator->create(
+        $file = $this->creator->create(
             $name, $this->getMigrationPath(), $table, $create
-        ), PATHINFO_FILENAME);
+        );
+
+        if (!$this->option('fullpath')) {
+            $file = pathinfo($file, PATHINFO_FILENAME);
+        }
 
         $this->line("<info>Created Migration:</info> {$file}");
     }

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -110,7 +110,7 @@ class MigrateMakeCommand extends BaseCommand
             $name, $this->getMigrationPath(), $table, $create
         );
 
-        if (!$this->option('fullpath')) {
+        if (! $this->option('fullpath')) {
             $file = pathinfo($file, PATHINFO_FILENAME);
         }
 


### PR DESCRIPTION
This adds a `--fullpath` option to the `make:migration` command and is super useful when using a terminal or editor which lets you click links to jump straight to them.

![](https://cdn-std.dprcdn.net/files/acc_752453/tigCvf)